### PR TITLE
pythonPackages.btrfs: 12 -> 13

### DIFF
--- a/pkgs/development/python-modules/btrfs/default.nix
+++ b/pkgs/development/python-modules/btrfs/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/knorrie/python-btrfs";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.evils ];
+    maintainers = with maintainers; [ evils Luflosi ];
   };
 }

--- a/pkgs/development/python-modules/btrfs/default.nix
+++ b/pkgs/development/python-modules/btrfs/default.nix
@@ -1,17 +1,15 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 }:
 
 buildPythonPackage rec {
   pname = "btrfs";
-  version = "12";
+  version = "13";
 
-  src = fetchFromGitHub {
-    owner = "knorrie";
-    repo = "python-btrfs";
-    rev = "v${version}";
-    sha256 = "sha256-ZQSp+pbHABgBTrCwC2YsUUXAf/StP4ny7MEhBgCRqgE=";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-NSyzhpHYDkunuU104XnbVCcVRNDoVBz4KuJRrE7WMO0=";
   };
 
   # no tests (in v12)


### PR DESCRIPTION
###### Motivation for this change
Version 12 is not available on PyPi, so fetch directly from GitHub instead.
Also install the various python scripts like btrfs-space-calculator.
Test if importing the Python module works fine with `pythonImportsCheck`.
While this library can't be used on macOS to interact with a btrfs filesystem because it is only supported on Linux, btrfs-space-calculator works perfectly fine on macOS. Because of this, I added platforms.darwin to the list of supported platforms.
Also add myself as a maintainer.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).