### PR TITLE
xineLib: 1.2.9 -> 1.2.11

### DIFF
--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -1,15 +1,16 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, xorg, alsaLib, libGLU, libGL, aalib
+{ lib, stdenv, fetchurl, pkg-config, xorg, alsaLib, libGLU, libGL, aalib
 , libvorbis, libtheora, speex, zlib, perl, ffmpeg_3
 , flac, libcaca, libpulseaudio, libmng, libcdio, libv4l, vcdimager
-, libmpcdec
+, libmpcdec, ncurses
 }:
 
 stdenv.mkDerivation rec {
-  name = "xine-lib-1.2.9";
+  pname = "xine-lib";
+  version = "1.2.11";
 
   src = fetchurl {
-    url = "mirror://sourceforge/xine/${name}.tar.xz";
-    sha256 = "13clir4qxl2zvsvvjd9yv3yrdhsnvcn5s7ambbbn5dzy9604xcrj";
+    url = "mirror://sourceforge/xine/xine-lib-${version}.tar.xz";
+    sha256 = "01bhq27g5zbgy6y36hl7lajz1nngf68vs4fplxgh98fx20fv4lgg";
   };
 
   nativeBuildInputs = [ pkg-config perl ];
@@ -17,15 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     xorg.libX11 xorg.libXv xorg.libXinerama xorg.libxcb xorg.libXext
     alsaLib libGLU libGL aalib libvorbis libtheora speex perl ffmpeg_3 flac
-    libcaca libpulseaudio libmng libcdio libv4l vcdimager libmpcdec
-  ];
-
-  patches = [
-    (fetchpatch {
-      name = "0001-fix-XINE_PLUGIN_PATH-splitting.patch";
-      url = "https://sourceforge.net/p/xine/mailman/attachment/32394053-5e27-6558-f0c9-49e0da0bc3cc%40gmx.de/1/";
-      sha256 = "0nrsdn7myvjs8fl9rj6k4g1bnv0a84prsscg1q9n49gwn339v5rc";
-    })
+    libcaca libpulseaudio libmng libcdio libv4l vcdimager libmpcdec ncurses
   ];
 
   NIX_LDFLAGS = "-lxcb-shm";
@@ -35,9 +28,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "http://www.xine-project.org/";
+    homepage = "http://xine.sourceforge.net/home";
     description = "A high-performance, portable and reusable multimedia playback engine";
     platforms = platforms.linux;
-    license = with licenses; [ gpl2 lgpl2 ];
+    license = with licenses; [ gpl2Plus lgpl2Plus ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix [build error](https://hydra.nixos.org/build/141674048) caused by f31864112f27d7a168f285b3147307649e68cca6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
