### PR TITLE
nvi: 1.79 -> 1.81.6; unbreak; name -> pname

### DIFF
--- a/pkgs/applications/editors/nvi/default.nix
+++ b/pkgs/applications/editors/nvi/default.nix
@@ -1,56 +1,39 @@
-{ fetchurl, lib, stdenv, ncurses }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, db }:
 
-stdenv.mkDerivation {
-  name = "nvi-1.79";
+stdenv.mkDerivation rec {
+  pname = "nvi";
+  version = "1.81.6";
 
   src = fetchurl {
-    urls =
-      [ "ftp://ftp.eenet.ee/pub/cpan/src/misc/nvi-1.79.tar.gz"
-        "ftp://ftp.saintjoe.edu/pub/CPAN/src/misc/nvi-1.79.tar.gz"
-        "ftp://ftp.free.fr/.mirrors1/ftp.netbsd.org/packages/distfiles/nvi-1.79.tar.gz"
-      ];
-    sha256 = "0cvf56rbylz7ksny6g2256sjg8yrsxrmbpk82r64rhi53sm8fnvm";
+    url = "https://deb.debian.org/debian/pool/main/n/nvi/nvi_${version}.orig.tar.gz";
+    sha256 = "13cp9iz017bk6ryi05jn7drbv7a5dyr201zqd3r4r8srj644ihwb";
   };
 
-  buildInputs = [ ncurses ];
+  patches = [
+    # Fix runtime error with modern versions of db.
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/nvi/raw/f33/f/nvi-03-db4.patch";
+      sha256 = "1vpnly3dcldwl8gwl0jrh5yh0vhgbdhsh6xn7lnwhrawlvk6d55y";
+    })
 
-  # nvi tries to write to a usual tmp directory (/var/tmp),
-  # so we will force it to use /tmp.
-  patchPhase = ''
-    sed -i build/configure \
-      -e s@vi_cv_path_preserve=no@vi_cv_path_preserve=/tmp/vi.recover@ \
-      -e s@/var/tmp@@ \
-      -e s@-lcurses@-lncurses@
+    # Fix build with Glibc.
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/nvi/raw/f33/f/nvi-20-glibc_has_grantpt.patch";
+      sha256 = "1ypqj263wh53m5rgiag5c4gy1rksj2waginny1lcj34n72p2dsml";
+    })
+  ];
+
+  buildInputs = [ ncurses db ];
+
+  preConfigure = ''
+    cd build.unix
   '';
+  configureScript = "../dist/configure";
+  configureFlags = [ "vi_cv_path_preserve=/tmp" ];
 
-  configurePhase = ''
-    mkdir mybuild
-    cd mybuild
-    ../build/configure --prefix=$out --disable-curses
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share/vi/catalog
-    for a in dutch english french german ru_SU.KOI8-R spanish swedish; do
-      cp ../catalog/$a $out/share/vi/catalog
-    done
-    cp nvi $out/bin/nvi
-    ln -s $out/bin/nvi $out/bin/vi
-    ln -s $out/bin/nvi $out/bin/ex
-    ln -s $out/bin/nvi $out/bin/view
-
-    mkdir -p $out/share/man/man1
-    cp ../docs/USD.doc/vi.man/vi.1 $out/share/man/man1/nvi.1
-    ln -s $out/share/man/man1/nvi.1 $out/share/man/man1/vi
-    ln -s $out/share/man/man1/nvi.1 $out/share/man/man1/ex
-    ln -s $out/share/man/man1/nvi.1 $out/share/man/man1/view
-    ln -s $out/bin/{,vi-}nvi # create a symlink so that all vi(m) users will find it
-  '';
-
-  meta = {
-    homepage = "http://www.bostic.com/vi/";
+  meta = with lib; {
     description = "The Berkeley Vi Editor";
-    license = lib.licenses.free;
-    broken = true; # since 2020-02-08
+    license = licenses.free;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Most other distributions seem to use Debian as upstream, so let's do
that too.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
