### PR TITLE
mcomix3: 2020-11-23 -> 2021-04-23

### DIFF
--- a/pkgs/applications/graphics/mcomix3/default.nix
+++ b/pkgs/applications/graphics/mcomix3/default.nix
@@ -17,13 +17,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "mcomix3";
-  version = "unstable-2020-11-23";
+  version = "unstable-2021-04-23";
 
   # no official release on pypi/github and no build system
   src = fetchFromGitHub {
     repo   = "${pname}";
     owner  = "multiSnow";
-    rev = "cdcb27533dc7ee2ebf7b0a8ab5ba10e61c0b8ff8";
+    rev = "139344e23898c28484328fc29fd0c6659affb12d";
     sha256 = "0q9xgl60ryf7qmy5vgzgfry4rvw5j9rb4d1ilxmpjmvm7dd3fm2k";
   };
 
@@ -46,6 +46,8 @@ python3.pkgs.buildPythonApplication rec {
   installPhase = ''
     runHook preInstall
 
+    substituteInPlace mime/*.desktop \
+      --replace "Exec=mcomix" "Exec=mcomix3"
     ${python3.executable} installer.py --srcdir=mcomix --target=$libdir
     mv $libdir/mcomix/mcomixstarter.py $out/bin/${pname}
     mv $libdir/mcomix/comicthumb.py $out/bin/comicthumb


### PR DESCRIPTION
closes #119936

###### Motivation for this change
* Version update
* Fix Desktop File

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
