### PR TITLE
[20.09] nvidia-x11: 455.38 -> 460.67

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -22,10 +22,10 @@ rec {
   # Policy: use the highest stable version as the default (on our master).
   stable = if stdenv.hostPlatform.system == "x86_64-linux"
     then generic {
-      version = "455.38";
-      sha256_64bit = "0x6w2kcjm5q9z9l6rkxqabway4qq4h3ynngn36i8ky2dpxc1wzfq";
-      settingsSha256 = "1hk4yvbb7xhfwm8jiwq6fj5m7vg3w7yvgglhfyhq7bbrlklfb4hm";
-      persistencedSha256 = "00mmazv8sy93jvp60v7p954n250f4q3kxc13l4f8fmi28lgv0844";
+      version = "460.67";
+      sha256_64bit = "L2cRySVw7mgYSN25mJV+b4uOeHTdjLGvFPEkwyFgtec=";
+      settingsSha256 = "DB+ZeKm6cYQuVkJWjVd71qOTOmwIcRqx1CxfkgMbDpg=";
+      persistencedSha256 = "HCmZZRlNhOHi5yN2lNHhBILZkdng73q0vCbv7CIX/8s=";
     }
     else legacy_390;
 


### PR DESCRIPTION
Resolves #114075

(cherry picked from commit dbb4c63de60d7885f88ba4236e2d569647f0473c)

Reason: compiling with linuxPackages_latest package fails with nvidia
455.38 driver.

* 455.45 introduced support for kernel 5.9 and 5.10
    * Previous versions will fail to due to "get_dma_ops" being
      refactored to a different include in kernel 5.10
        * "get_dma_ops" in kernel 5.9 tree: https://elixir.bootlin.com/linux/v5.9.16/A/ident/get_dma_ops
        * "get_dma_ops" in kernel 5.10 tree: https://elixir.bootlin.com/linux/v5.10/A/ident/get_dma_ops
    * Relevant Gentoo issue: https://bugs.gentoo.org/755722#c2
    * Release Highlights: https://www.nvidia.com/Download/driverResults.aspx/166883/en-us
* 460.67 introduced support for kernel 5.11
    * Previous versions will fail to find include file "asm/kmap_types.h"
        * Include in kernel 5.10 tree: https://elixir.bootlin.com/linux/v5.10.32/source/include/asm-generic/kmap_types.h
        * Include missing in kernel 5.11 tree: https://elixir.bootlin.com/linux/v5.11/source/include/asm-generic/kmap_types.h
    * Release Highlights: https://www.nvidia.com/download/driverResults.aspx/171392/en-us

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 120655"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
