### PR TITLE
nxdomain: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/tools/networking/nxdomain/default.nix
+++ b/pkgs/tools/networking/nxdomain/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonApplication rec {
   pname = "nxdomain";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1z9iffggqq2kw6kpnj30shi98cg0bkvkwpglmhnkgwac6g55n2zn";
+    sha256 = "0va7nkbdjgzrf7fnbxkh1140pbc62wyj86rdrrh5wmg3phiziqkb";
   };
 
   propagatedBuildInputs = [ dnspython ];
@@ -23,7 +23,7 @@ buildPythonApplication rec {
     homepage = "https://github.com/zopieux/nxdomain";
     description = "A domain (ad) block list creator";
     platforms = platforms.all;
-    license = licenses.gpl3Plus;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ zopieux ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New version (bug fix).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
