### PR TITLE
python3.pkgs.signedjson: fix build

### DIFF
--- a/pkgs/development/python-modules/signedjson/default.nix
+++ b/pkgs/development/python-modules/signedjson/default.nix
@@ -1,24 +1,36 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
+, fetchpatch
 , canonicaljson
 , unpaddedbase64
 , pynacl
 , typing-extensions
+, setuptools-scm
+, importlib-metadata
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "signedjson";
   version = "1.1.1";
 
-  src = fetchFromGitHub {
-    owner = "matrix-org";
-    repo = "python-${pname}";
-    rev = "v${version}";
-    sha256 = "0y5c9v4vx9hqpnca892gc9b4xgs4gp5xk6l1wma5ciz8zswp9yfs";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0280f8zyycsmd7iy65bs438flm7m8ffs1kcxfbvhi8hbazkqc19m";
   };
 
-  propagatedBuildInputs = [ canonicaljson unpaddedbase64 pynacl typing-extensions ];
+  patches = [
+    # Do not require importlib_metadata on python 3.8
+    (fetchpatch {
+      url = "https://github.com/matrix-org/python-signedjson/commit/c40c83f844fee3c1c7b0c5d1508f87052334b4e5.patch";
+      sha256 = "109f135zn9azg5h1ljw3v94kpvnzmlqz1aiknpl5hsqfa3imjca1";
+    })
+  ];
+
+  nativeBuildInputs = [ setuptools-scm ];
+  propagatedBuildInputs = [ canonicaljson unpaddedbase64 pynacl typing-extensions ]
+    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   meta = with lib; {
     homepage = "https://pypi.org/project/signedjson/";


### PR DESCRIPTION
###### Motivation for this change
It doesn't build right now (on 8931b66733af0c4048f8fda19c63651017cd7d54).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s): `matrix-synapse`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
