### PR TITLE
scribusUnstable: 1.5.6.1 -> 1.5.7

### DIFF
--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -2,7 +2,6 @@
 , cairo
 , cmake
 , cups
-, fetchpatch
 , fetchurl
 , fontconfig
 , freetype
@@ -36,19 +35,12 @@ in
 mkDerivation rec {
   pname = "scribus";
 
-  version = "1.5.6.1";
+  version = "1.5.7";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${pname}-devel/${pname}-${version}.tar.xz";
-    sha256 = "sha256-1CV2lVOc+kDerYq9rwTFHjTU10vK1aLJNNCObp1Dt6s=";
+    sha256 = "sha256-MYMWss/Hp2GR0+DT+MImUUfa6gVwFiAo4kPCktgm+M4=";
   };
-
-  patches = [
-    (fetchpatch {  # fix build with podofo 0.9.7
-      url = "https://github.com/scribusproject/scribus/commit/c6182ef92820b422d61c904e40e9fed865458eb5.patch";
-      sha256 = "0vp275xfbd4xnj5s55cgzsihgihby5mmjlbmrc7sa6jbrsm8aa2c";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
