### PR TITLE
python3Packages.black: 20.8b1 -> 21.4b2

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -8,6 +8,7 @@
 , dataclasses
 , mypy-extensions
 , pathspec
+, parameterized
 , regex
 , toml
 , typed-ast
@@ -15,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "20.8b1";
+  version = "21.5b1";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1spv6sldp3mcxr740dh3ywp25lly9s8qlvs946fin44rl1x5a0hw";
+    sha256 = "1cdkrl5vw26iy7s23v2zpr39m6g5xsgxhfhagzzflgfbvdc56s93";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
@@ -30,19 +31,19 @@ buildPythonPackage rec {
   # Black starts a local server and needs to bind a local address.
   __darwinAllowLocalNetworking = true;
 
-  checkInputs =  [ pytestCheckHook ];
+  checkInputs =  [ pytestCheckHook parameterized ];
 
   preCheck = ''
     export PATH="$PATH:$out/bin"
+
+    # The top directory /build matches black's DEFAULT_EXCLUDE regex.
+    # Make /build the project root for black tests to avoid excluding files.
+    touch ../.git
   '';
 
   disabledTests = [
-    # Don't know why these tests fails
-    "test_cache_multiple_files"
-    "test_failed_formatting_does_not_get_cached"
     # requires network access
     "test_gen_check_output"
-    "test_process_queue"
   ] ++ lib.optionals stdenv.isDarwin [
     # fails on darwin
     "test_expression_diff"

--- a/pkgs/development/python-modules/pyls-black/default.nix
+++ b/pkgs/development/python-modules/pyls-black/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch
 , black, toml, pytest, python-language-server, isPy3k
 }:
 
@@ -12,6 +12,15 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "0cjf0mjn156qp0x6md6mncs31hdpzfim769c2lixaczhyzwywqnj";
   };
+
+  # Fix test failure with black 21.4b0+
+  # Remove if https://github.com/rupert/pyls-black/pull/39 merged.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/rupert/pyls-black/commit/728207b540d9c25eb0d1cd96419ebfda2e257f63.patch";
+      sha256 = "0i3w5myhjl5lq1lpkizagnmk6m8fkn3igfyv5f2qcrn5n7f119ak";
+    })
+  ];
 
   disabled = !isPy3k;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package update. 

There are 2 new persistently failing tests (currently disabled) where I don't know why they fail.

```
=================================== FAILURES ===================================
_________ BlackTestCase.test_output_locking_when_writeback_color_diff __________

self = <tests.test_black.BlackTestCase testMethod=test_output_locking_when_writeback_color_diff>

    @event_loop()
    def test_output_locking_when_writeback_color_diff(self) -> None:
        with cache_dir() as workspace:
            for tag in range(0, 4):
                src = (workspace / f"test{tag}.py").resolve()
                with src.open("w") as fobj:
                    fobj.write("print('hello')")
            with patch("black.Manager", wraps=multiprocessing.Manager) as mgr:
                self.invokeBlack(["--diff", "--color", str(workspace)], exit_code=0)
                # this isn't quite doing what we want, but if it _isn't_
                # called then we cannot be using the lock it provides
>               mgr.assert_called()

tests/test_black.py:1125:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <MagicMock name='Manager' id='140737305834208'>

    def assert_called(self):
        """assert that the mock was called at least once
        """
        if self.call_count == 0:
            msg = ("Expected '%s' to have been called." %
                   (self._mock_name or 'mock'))
>           raise AssertionError(msg)
E           AssertionError: Expected 'Manager' to have been called.

/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/lib/python3.8/unittest/mock.py:882: AssertionError
____________ BlackTestCase.test_output_locking_when_writeback_diff _____________

self = <tests.test_black.BlackTestCase testMethod=test_output_locking_when_writeback_diff>

    @event_loop()
    def test_output_locking_when_writeback_diff(self) -> None:
        with cache_dir() as workspace:
            for tag in range(0, 4):
                src = (workspace / f"test{tag}.py").resolve()
                with src.open("w") as fobj:
                    fobj.write("print('hello')")
            with patch("black.Manager", wraps=multiprocessing.Manager) as mgr:
                self.invokeBlack(["--diff", str(workspace)], exit_code=0)
                # this isn't quite doing what we want, but if it _isn't_
                # called then we cannot be using the lock it provides
>               mgr.assert_called()

tests/test_black.py:1112:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <MagicMock name='Manager' id='140737305116240'>

    def assert_called(self):
        """assert that the mock was called at least once
        """
        if self.call_count == 0:
            msg = ("Expected '%s' to have been called." %
                   (self._mock_name or 'mock'))
>           raise AssertionError(msg)
E           AssertionError: Expected 'Manager' to have been called.

/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/lib/python3.8/unittest/mock.py:882: AssertionError
=========================== short test summary info ============================
FAILED tests/test_black.py::BlackTestCase::test_output_locking_when_writeback_color_diff
FAILED tests/test_black.py::BlackTestCase::test_output_locking_when_writeback_diff
=========== 2 failed, 174 passed, 4 deselected, 3 xfailed in 34.59s ============
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
