### PR TITLE
octoprint.python.pkgs.octoprint-ldap: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1486,6 +1486,12 @@
     githubId = 7214361;
     name = "Roman Gerasimenko";
   };
+  busti = {
+    email = "nixos@busti.cool";
+    github = "busti";
+    githubId = 3575167;
+    name = "Moritz Bust";
+  };
   bburdette = {
     email = "bburdette@protonmail.com";
     github = "bburdette";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -206,6 +206,27 @@ in {
     };
   };
 
+  octoprint-ldap = buildPlugin rec {
+    pname = "OctoPrint-LDAP";
+    version = "1.1.0";
+
+    src = fetchFromGitHub {
+      owner = "gillg";
+      repo = pname;
+      rev = "01016c2";
+      sha256 = "0y3v0zpw6pj3gmb7h54402cl2rh0zhv4y31cwfqf1yxhs7bqvzwf";
+    };
+
+    propagatedBuildInputs = with super; [ ldap ];
+
+    meta = with lib; {
+      description = "Octoprint LDAP auth plugin";
+      homepage = "https://github.com/gillg/OctoPrint-LDAP";
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ busti ];
+    };
+  };
+
   printtimegenius = buildPlugin rec {
     pname = "PrintTimeGenius";
     version = "2.2.6";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -222,7 +222,7 @@ in {
     meta = with lib; {
       description = "Octoprint LDAP auth plugin";
       homepage = "https://github.com/gillg/OctoPrint-LDAP";
-      license = licenses.agpl3;
+      license = licenses.agpl3Only;
       maintainers = with maintainers; [ busti ];
     };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I would like to use ldap auth in octoprint

###### Things done
Add a plugin for ldap authentication in octoprint

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
