### PR TITLE
gsocket: init at 1.4.29

### DIFF
--- a/pkgs/tools/networking/gsocket/default.nix
+++ b/pkgs/tools/networking/gsocket/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "gsocket";
+  version = "1.4.29";
+
+  src = fetchFromGitHub {
+    owner = "hackerschoice";
+    repo = "gsocket";
+    rev = "v${version}";
+    sha256 = "sha256-8NhTbXWacWB+LAapAW2e4ONWAgfeExyu6XIrCvWvOxE=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ openssl ];
+  dontDisableStatic = true;
+
+  meta = with lib; {
+    description = "Connect like there is no firewall, securely";
+    homepage = "https://www.gsocket.io";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2645,6 +2645,8 @@ in
 
   gsctl = callPackage ../applications/misc/gsctl { };
 
+  gsocket = callPackage ../tools/networking/gsocket { };
+
   gthree = callPackage ../development/libraries/gthree { };
 
   gtg = callPackage ../applications/office/gtg { };


### PR DESCRIPTION
###### Motivation for this change
In case anyone wants it

###### Things done
package gsocket

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
