### PR TITLE
treewide: go: inherit platforms instead of using platforms.all

### DIFF
--- a/pkgs/applications/editors/gophernotes/default.nix
+++ b/pkgs/applications/editors/gophernotes/default.nix
@@ -21,6 +21,5 @@ buildGoModule rec {
     homepage = "https://github.com/gopherdata/gophernotes";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-diff.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-diff.nix
@@ -30,6 +30,5 @@ buildGoModule rec {
     inherit (src.meta) homepage;
     license = licenses.apsl20;
     maintainers = with maintainers; [ yurrriq ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-s3.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-s3.nix
@@ -33,6 +33,5 @@ buildGoModule rec {
     inherit (src.meta) homepage;
     license = licenses.apsl20;
     maintainers = with maintainers; [ yurrriq ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/ghorg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghorg/default.nix
@@ -32,6 +32,5 @@ buildGoModule rec {
     homepage = "https://github.com/gabrie30/ghorg";
     license = licenses.asl20;
     maintainers = with maintainers; [ vidbina ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -52,7 +52,6 @@ buildGoModule {
   meta = with lib; {
     description = "Free TLS/SSL implementation";
     homepage    = "https://boringssl.googlesource.com";
-    platforms   = platforms.all;
     maintainers = [ maintainers.thoughtpolice ];
     license = with licenses; [ openssl isc mit bsd3 ];
   };

--- a/pkgs/development/tools/protoc-gen-go-grpc/default.nix
+++ b/pkgs/development/tools/protoc-gen-go-grpc/default.nix
@@ -24,6 +24,5 @@ buildGoPackage rec {
     description = "The Go language implementation of gRPC. HTTP/2 based RPC";
     license = licenses.asl20;
     maintainers = [ maintainers.raboof ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/irc/robustirc-bridge/default.nix
+++ b/pkgs/servers/irc/robustirc-bridge/default.nix
@@ -24,6 +24,5 @@ buildGoModule rec {
     homepage = "https://robustirc.net/";
     license = licenses.bsd3;
     maintainers = [ maintainers.hax404 ];
-    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/monitoring/mackerel-agent/default.nix
+++ b/pkgs/servers/monitoring/mackerel-agent/default.nix
@@ -37,6 +37,5 @@ buildGoModule rec {
     homepage = "https://github.com/mackerelio/mackerel-agent";
     license = licenses.asl20;
     maintainers = with maintainers; [ midchildan ];
-    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`buildGoModule` and `buildGoPackage` by default inherit the `platforms`
from go. That seems better than explicitly configuring `platforms.all`.
    
There are also many packages that specify 'linux + darwin' - this is
even suggested in the documentation. We might also want to update those,
but let's do the noncontroversial change first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).