### PR TITLE
php.extensions.snuffleupagus: init at 0.7.0

### DIFF
--- a/pkgs/development/php-packages/snuffleupagus/default.nix
+++ b/pkgs/development/php-packages/snuffleupagus/default.nix
@@ -1,0 +1,53 @@
+{ buildPecl
+, lib
+, php
+, fetchFromGitHub
+, pcre'
+, fetchpatch
+}:
+
+buildPecl rec {
+  pname = "snuffleupagus";
+  version = "0.7.0";
+  src = fetchFromGitHub {
+    owner = "jvoisin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1la6wa9xznc110b7isiy502x71mkvhisq6m8llhczpq4rs4nbcw2";
+  };
+
+  buildInputs = [
+    pcre'
+  ];
+
+  internalDeps = with php.extensions; [
+    session
+  ] ++ lib.optionals (lib.versionOlder php.version "7.4") [
+    hash
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/jvoisin/snuffleupagus/commit/3c528d9d03cec872382a6f400b5701a8fbfd59b4.patch";
+      sha256 = "0lnj4xcl867f477mha697d1py1nwxhl18dvvg40qgflpdbywlzns";
+      stripLen = 1;
+    })
+  ];
+
+  sourceRoot = "source/src";
+
+  configureFlags = [
+    "--enable-snuffleupagus"
+  ];
+
+  postPhpize = ''
+    ./configure --enable-snuffleupagus
+  '';
+
+  meta = with lib; {
+    description = "Security module for php7 and php8 - Killing bugclasses and virtual-patching the rest!";
+    license = licenses.lgpl3Only;
+    homepage = "https://github.com/jvoisin/snuffleupagus";
+    maintainers = teams.php.members ++ [ maintainers.zupo ];
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -136,6 +136,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     smbclient = callPackage ../development/php-packages/smbclient { };
 
+    snuffleupagus = callPackage ../development/php-packages/snuffleupagus { };
+
     sqlsrv = callPackage ../development/php-packages/sqlsrv { };
 
     swoole = callPackage ../development/php-packages/swoole { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/120163


###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

I ran this, but have no idea what it does or what I should see. It succeeded .. :shrug: 

- [X] Tested execution of all binary files (usually in `./result/bin/`):

```
result/bin/php -m | grep snuffleupagus
snuffleupagus
```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
