### PR TITLE
openboard: init at 1.6.1

### DIFF
--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -107,8 +107,7 @@ in mkDerivation rec {
   '';
 
   meta = with lib; {
-    description =
-      "Cross-platform interactive whiteboard application intended for use in a classroom setting";
+    description = "Interactive whiteboard application";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ fufexan ];
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -96,7 +96,7 @@ in mkDerivation rec {
     install -m644 resources/linux/openboard-ubz.xml $out/opt/openboard/etc/
     install -Dm644 resources/images/OpenBoard.png $out/share/icons/hicolor/64x64/apps/OpenBoard.png
 
-    runHook postBuild
+    runHook postInstall
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -85,7 +85,7 @@ in mkDerivation rec {
   ];
 
   installPhase = ''
-    runHook preBuild
+    runHook preInstall
 
     lrelease OpenBoard.pro
 

--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -1,0 +1,116 @@
+{ mkDerivation, lib, fetchFromGitHub, copyDesktopItems, makeDesktopItem, qmake
+, qtbase, qtxmlpatterns, qttools, qtwebkit, libGL, fontconfig, openssl, poppler
+, ffmpeg, libva, alsaLib, SDL, x264, libvpx, libvorbis, libtheora, libogg
+, libopus, lame, fdk_aac, libass, quazip, libXext, libXfixes }:
+
+let
+  importer = mkDerivation rec {
+    pname = "openboard-importer";
+    version = "unstable-2016-10-08";
+
+    src = fetchFromGitHub {
+      owner = "OpenBoard-org";
+      repo = "OpenBoard-Importer";
+      rev = "47927bda021b4f7f1540b794825fb0d601875e79";
+      sha256 = "19zhgsimy0f070caikc4vrrqyc8kv2h6rl37sy3iggks8z0g98gf";
+    };
+
+    nativeBuildInputs = [ qmake ];
+
+    installPhase = ''
+      install -Dm755 OpenBoardImporter $out/bin/OpenBoardImporter
+    '';
+  };
+in mkDerivation rec {
+  pname = "openboard";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "OpenBoard-org";
+    repo = "OpenBoard";
+    rev = "v${version}";
+    sha256 = "sha256-OlGXGIMghil/GG6eso20+CWo/hCjarXGs6edXX9pc/M=";
+  };
+
+  postPatch = ''
+    substituteInPlace OpenBoard.pro \
+      --replace '/usr/include/quazip' '${quazip}/include/quazip5' \
+      --replace '/usr/include/poppler' '${poppler.dev}/include/poppler'
+  '';
+
+  nativeBuildInputs = [ qmake copyDesktopItems ];
+
+  buildInputs = [
+    qtbase
+    qtxmlpatterns
+    qttools
+    qtwebkit
+    libGL
+    fontconfig
+    openssl
+    poppler
+    ffmpeg
+    libva
+    alsaLib
+    SDL
+    x264
+    libvpx
+    libvorbis
+    libtheora
+    libogg
+    libopus
+    lame
+    fdk_aac
+    libass
+    quazip
+    libXext
+    libXfixes
+  ];
+
+  propagatedBuildInputs = [ importer ];
+
+  makeFlags = [ "release-install" ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "OpenBoard";
+      exec = "OpenBoard %f";
+      icon = "OpenBoard";
+      comment = "";
+      desktopName = "OpenBoard";
+      mimeType = "application/ubz";
+      categories = "Education;";
+      startupNotify = true;
+    })
+  ];
+
+  installPhase = ''
+    runHook preBuild
+
+    lrelease OpenBoard.pro
+
+    # Replicated release_scripts/linux/package.sh
+    mkdir -p $out/opt/openboard/i18n
+    cp -R resources/customizations build/linux/release/product/* $out/opt/openboard/
+    cp resources/i18n/*.qm $out/opt/openboard/i18n/
+    install -m644 resources/linux/openboard-ubz.xml $out/opt/openboard/etc/
+    install -Dm644 resources/images/OpenBoard.png $out/share/icons/hicolor/64x64/apps/OpenBoard.png
+
+    runHook postBuild
+  '';
+
+  dontWrapQtApps = true;
+
+  postFixup = ''
+    makeWrapper $out/opt/openboard/OpenBoard $out/bin/OpenBoard \
+      "''${qtWrapperArgs[@]}"
+  '';
+
+  meta = with lib; {
+    description =
+      "Cross-platform interactive whiteboard application intended for use in a classroom setting";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fufexan ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -76,7 +76,7 @@ in mkDerivation rec {
       name = "OpenBoard";
       exec = "OpenBoard %f";
       icon = "OpenBoard";
-      comment = "";
+      comment = "OpenBoard, an interactive white board application";
       desktopName = "OpenBoard";
       mimeType = "application/ubz";
       categories = "Education;";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7120,6 +7120,8 @@ in
   openbazaar = callPackage ../applications/networking/openbazaar { };
   openbazaar-client = callPackage ../applications/networking/openbazaar/client.nix { };
 
+  openboard = libsForQt5.callPackage ../applications/graphics/openboard { };
+
   opencc = callPackage ../tools/text/opencc { };
 
   opencl-info = callPackage ../tools/system/opencl-info { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add OpenBoard to Nixpkgs. The derivation was written by @OPNA2608, who also gave me permission to use it in this PR.
Darwin support is coming soon™.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
