### PR TITLE
[20.09] subversion: add patch for CVE-2020-17525

### DIFF
--- a/pkgs/applications/version-management/subversion/CVE-2020-17525.patch
+++ b/pkgs/applications/version-management/subversion/CVE-2020-17525.patch
@@ -1,0 +1,15 @@
+Patch included in advisory @ https://subversion.apache.org/security/CVE-2020-17525-advisory.txt
+
+--- a/subversion/libsvn_repos/config_file.c
++++ b/subversion/libsvn_repos/config_file.c
+@@ -237,6 +237,10 @@ get_repos_config(svn_stream_t **stream,
+     {
+       /* Search for a repository in the full path. */
+       repos_root_dirent = svn_repos_find_root_path(dirent, scratch_pool);
++      if (repos_root_dirent == NULL)
++        return svn_error_trace(handle_missing_file(stream, checksum, access,
++                                                   url, must_exist,
++                                                   svn_node_none));
+ 
+       /* Attempt to open a repository at repos_root_dirent. */
+       SVN_ERR(svn_repos_open3(&access->repos, repos_root_dirent, NULL,

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -17,7 +17,7 @@ assert javahlBindings -> jdk != null && perl != null;
 
 let
 
-  common = { version, sha256, extraBuildInputs ? [ ], knownVulnerabilities ? [ ] }: stdenv.mkDerivation (rec {
+  common = { version, sha256, extraBuildInputs ? [ ], extraPatches ? [ ], knownVulnerabilities ? [ ] }: stdenv.mkDerivation (rec {
     inherit version;
     pname = "subversion";
 
@@ -36,7 +36,7 @@ let
       ++ stdenv.lib.optional perlBindings perl
       ++ stdenv.lib.optional saslSupport sasl;
 
-    patches = [ ./apr-1.patch ];
+    patches = [ ./apr-1.patch ] ++ extraPatches;
 
     # We are hitting the following issue even with APR 1.6.x
     # -> https://issues.apache.org/jira/browse/SVN-4813
@@ -130,5 +130,6 @@ in {
     version = "1.12.2";
     sha256 = "0wgpw3kzsiawzqk4y0xgh1z93kllxydgv4lsviim45y5wk4bbl1v";
     extraBuildInputs = [ lz4 utf8proc ];
+    extraPatches = [ ./CVE-2020-17525.patch ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/120419

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
