### PR TITLE
kubei: init at 1.0.11

### DIFF
--- a/pkgs/tools/security/kubei/default.nix
+++ b/pkgs/tools/security/kubei/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "kubei";
+  version = "1.0.11";
+
+  src = fetchFromGitHub {
+    owner = "Portshift";
+    repo = pname;
+    rev = version;
+    sha256 = "0n9kzlw7wlzkc3yhq68jgjhnvig817kz0q81ydkjxp4snwc1kvw8";
+  };
+
+  vendorSha256 = "0q0vkajn5n1aqb8wwdkvg8jv6j98l70g4hb399ickamhnirk69g4";
+
+  meta = with lib; {
+    description = "Kubernetes runtime scanner";
+    longDescription = ''
+      Kubei is a vulnerabilities scanning and CIS Docker benchmark tool that
+      allows users to get an accurate and immediate risk assessment of their
+      kubernetes clusters. Kubei scans all images that are being used in a
+      Kubernetes cluster, including images of application pods and system pods.
+    '';
+    homepage = "https://github.com/Portshift/kubei";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13063,6 +13063,8 @@ in
 
   kube-prompt = callPackage ../development/tools/kube-prompt { };
 
+  kubei = callPackage ../tools/security/kubei { };
+
   kubeprompt = callPackage ../development/tools/kubeprompt { };
 
   kubespy = callPackage ../applications/networking/cluster/kubespy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Kubei is a vulnerabilities scanning and CIS Docker benchmark tool that
allows users to get an accurate and immediate risk assessment of their
Kubernetes clusters. Kubei scans all images that are being used in a
Kubernetes cluster, including images of application pods and system pods.

https://github.com/Portshift/kubei

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
