### PR TITLE
ocamlPackages.dtoa: disable hardening feature based on more accurate condition

### DIFF
--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
     sha256 = "0zkhn0rdq82g6gamsv6nkx6i44s8104nh6jg5xydazl9jl1704xn";
   };
 
-  hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
+  hardeningDisable = lib.optional stdenv.cc.isClang "strictoverflow";
 
   meta = with lib; {
     homepage = "https://github.com/flowtype/ocaml-dtoa";


### PR DESCRIPTION
###### Motivation for this change
The `strictoverflow` hardening feature causes a build failure when using Clang as the compiler, not just on Darwin.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).