### PR TITLE
ocamlPackages.paf: init at 0.8.0; ocamlPackages.letsencrypt: init at 0.2.4

### DIFF
--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -1,0 +1,84 @@
+{ buildDunePackage
+, lib
+, fetchurl
+, astring
+, asn1-combinators
+, uri
+, rresult
+, base64
+, cmdliner
+, cohttp
+, cohttp-lwt
+, cohttp-lwt-unix
+, zarith
+, logs
+, fmt
+, lwt
+, mirage-crypto
+, mirage-crypto-pk
+, mirage-crypto-rng
+, x509
+, yojson
+, ounit
+, dns
+, dns-tsig
+, ptime
+, bos
+, fpath
+, randomconv
+, domain-name
+}:
+
+buildDunePackage rec {
+  pname = "letsencrypt";
+  version = "0.2.4";
+
+  src = fetchurl {
+    url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-v${version}.tbz";
+    sha256 = "91c79828a50243804da29c17563c54d2d528a79207e5b874dce6a3e7fedf7567";
+  };
+
+  minimumOCamlVersion = "4.08";
+  useDune2 = true;
+
+  buildInputs = [
+    cmdliner
+    cohttp
+    cohttp-lwt-unix
+    zarith
+    fmt
+    mirage-crypto-rng
+    ptime
+    bos
+    fpath
+    randomconv
+    domain-name
+  ];
+
+  propagatedBuildInputs = [
+    logs
+    yojson
+    lwt
+    base64
+    mirage-crypto
+    mirage-crypto-pk
+    asn1-combinators
+    x509
+    uri
+    dns
+    dns-tsig
+    rresult
+    astring
+    cohttp-lwt
+  ];
+
+  doCheck = true;
+  checkInputs = [ ounit ];
+
+  meta = {
+    description = "ACME implementation in OCaml";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.sternenseemann ];
+    homepage = "https://github.com/mmaker/ocaml-letsencrypt";
+  };
+}

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -1,0 +1,82 @@
+{ buildDunePackage
+, lib
+, fetchurl
+, fetchpatch
+, mirage-stack
+, mirage-time
+, httpaf
+, tls-mirage
+, mimic
+, cohttp-lwt
+, letsencrypt
+, emile
+, ke
+, bigstringaf
+, domain-name
+, duration
+, faraday
+, ipaddr
+, tls
+, x509
+, lwt
+, logs
+, fmt
+, mirage-crypto-rng
+, tcpip
+, mirage-time-unix
+, ptime
+, uri
+, alcotest-lwt
+}:
+
+buildDunePackage rec {
+  pname = "paf";
+  version = "0.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/dinosaure/paf-le-chien/releases/download/${version}/paf-${version}.tbz";
+    sha256 = "7a794c21ce458bda302553b0f5ac128c067579fbb3b7b8fba9b410446c43e790";
+  };
+
+  useDune2 = true;
+  minimumOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [
+    mirage-stack
+    mirage-time
+    httpaf
+    tls-mirage
+    mimic
+    cohttp-lwt
+    letsencrypt
+    emile
+    ke
+    bigstringaf
+    domain-name
+    ipaddr
+    duration
+    faraday
+    tls
+    x509
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    lwt
+    logs
+    fmt
+    mirage-crypto-rng
+    tcpip
+    mirage-time-unix
+    ptime
+    uri
+    alcotest-lwt
+  ];
+
+  meta = {
+    description = "HTTP/AF and MirageOS";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sternenseemann ];
+    homepage = "https://github.com/dinosaure/paf-le-chien";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -580,6 +580,8 @@ let
 
     lens = callPackage ../development/ocaml-modules/lens { };
 
+    letsencrypt = callPackage ../development/ocaml-modules/letsencrypt { };
+
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
     llvm = callPackage ../development/ocaml-modules/llvm {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -944,6 +944,8 @@ let
 
     ounit2 = callPackage ../development/ocaml-modules/ounit2 { };
 
+    paf = callPackage ../development/ocaml-modules/paf { };
+
     parse-argv = callPackage ../development/ocaml-modules/parse-argv { };
 
     path_glob = callPackage ../development/ocaml-modules/path_glob { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Dependencies of `git-paf` 3.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
