### PR TITLE
kubesec: init at 2.11.0

### DIFF
--- a/pkgs/tools/security/kubesec/default.nix
+++ b/pkgs/tools/security/kubesec/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "kubesec";
+  version = "2.11.0";
+
+  src = fetchFromGitHub {
+    owner = "controlplaneio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rv5qywh8107rqdly1x7wkb6dljalyn9abrkm12bxa7cqscp9b4z";
+  };
+
+  vendorSha256 = "0xngnx67giwp0g7c19xhb6kmc9m3bjlwk2wwp9bn9vwkmss3ysyp";
+
+  # Tests wants to download additional files
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Security risk analysis tool for Kubernetes resources";
+    homepage = "https://github.com/controlplaneio/kubesec";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13065,6 +13065,8 @@ in
 
   kubeprompt = callPackage ../development/tools/kubeprompt { };
 
+  kubesec = callPackage ../tools/security/kubesec { };
+
   kubespy = callPackage ../applications/networking/cluster/kubespy { };
 
   kubicorn = callPackage ../development/tools/kubicorn {  };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Security risk analysis for Kubernetes resources

https://github.com/controlplaneio/kubesec

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
