### PR TITLE
frugal: init at 3.14.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2433,6 +2433,12 @@
     githubId = 8404455;
     name = "Diego Lelis";
   };
+  diogox = {
+    name = "Diogo Xavier";
+    email = "13244408+diogox@users.noreply.github.com";
+    github = "diogox";
+    githubId = 13244408;
+  };
   dipinhora = {
     email = "dipinhora+github@gmail.com";
     github = "dipinhora";

--- a/pkgs/development/tools/frugal/default.nix
+++ b/pkgs/development/tools/frugal/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "frugal";
+  version = "3.14.2";
+
+  src = fetchFromGitHub {
+    owner = "Workiva";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Tcx0jYGKoyBj2vuTJI34TsyCBzXPyccZFqXA8jJNMQI=";
+  };
+
+  subPackages = [ "." ];
+
+  vendorSha256 = "sha256-hyupBMRKuw77SJNIk3mEUixV0LV5mEmZx8M70qGmYJY=";
+
+  meta = with lib; {
+    description = "Thrift improved";
+    homepage = "https://github.com/Workiva/frugal";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ diogox ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -251,6 +251,8 @@ in
 
   eclipse-mat = callPackage ../development/tools/eclipse-mat { };
 
+  frugal = callPackage ../development/tools/frugal { };
+
   glade = callPackage ../development/tools/glade { };
 
   hobbes = callPackage ../development/tools/hobbes { };


### PR DESCRIPTION
###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).