### PR TITLE
last-resort: init at 13.001

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10299,6 +10299,12 @@
     githubId = 2212422;
     name = "uwap";
   };
+  V = {
+    name = "V";
+    email = "v@anomalous.eu";
+    github = "deviant";
+    githubId = 68829907;
+  };
   va1entin = {
     email = "github@valentinsblog.com";
     github = "va1entin";

--- a/pkgs/data/fonts/last-resort/default.nix
+++ b/pkgs/data/fonts/last-resort/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl }:
+
+let
+  version = "13.001";
+in fetchurl {
+  name = "last-resort-${version}";
+
+  url = "https://github.com/unicode-org/last-resort-font/releases/download/${version}/LastResortHE-Regular.ttf";
+  downloadToTemp = true;
+
+  postFetch = ''
+    install -D -m 0644 $downloadedFile $out/share/fonts/truetype/LastResortHE-Regular.ttf
+  '';
+
+  recursiveHash = true;
+  sha256 = "08mi65j46fv6a3y3pqnglqdjxjnbzg25v25f7c1zyk3c285m14hq";
+
+  meta = with lib; {
+    description = "Fallback font of last resort";
+    homepage = "https://github.com/unicode-org/last-resort-font";
+    license = licenses.ofl;
+    maintainers = with maintainers; [ V ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5959,6 +5959,8 @@ in
 
   lalezar-fonts = callPackage ../data/fonts/lalezar-fonts { };
 
+  last-resort = callPackage ../data/fonts/last-resort {};
+
   ldc = callPackage ../development/compilers/ldc { };
 
   ldgallery = callPackage ../tools/graphics/ldgallery { };


### PR DESCRIPTION
Last Resort is a fallback font that covers every Unicode codepoint.

An example glyph:

![image](https://user-images.githubusercontent.com/68829907/116078484-f6bfc400-a696-11eb-8170-0208a8d72294.png)

How this looks in practice:

(Sinhala/Malayalam are covered by system fonts, Telugu/Kannada/Grantham are rendered using Last Resort.)

![image](https://user-images.githubusercontent.com/68829907/116077393-bad82f00-a695-11eb-9743-28a4a42a54fc.png)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
