### PR TITLE
python3Packages.black: 20.8b1 → 21.4b0

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -7,6 +7,7 @@
 , click
 , dataclasses
 , mypy-extensions
+, parameterized
 , pathspec
 , regex
 , toml
@@ -15,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "20.8b1";
+  version = "21.4b0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1spv6sldp3mcxr740dh3ywp25lly9s8qlvs946fin44rl1x5a0hw";
+    sha256 = "sha256-kV2RbEhkbb6AQNUmXP9xEUIaYKPf5/fgcnMXalfCSjQ=";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
@@ -30,7 +31,7 @@ buildPythonPackage rec {
   # Black starts a local server and needs to bind a local address.
   __darwinAllowLocalNetworking = true;
 
-  checkInputs =  [ pytestCheckHook ];
+  checkInputs =  [ parameterized pytestCheckHook ];
 
   preCheck = ''
     export PATH="$PATH:$out/bin"
@@ -40,6 +41,8 @@ buildPythonPackage rec {
     # Don't know why these tests fails
     "test_cache_multiple_files"
     "test_failed_formatting_does_not_get_cached"
+    "test_output_locking_when_writeback_diff"
+    "test_output_locking_when_writeback_color_diff"
     # requires network access
     "test_gen_check_output"
     "test_process_queue"


### PR DESCRIPTION
###### Motivation for this change

Update to newly released version.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).