### PR TITLE
pangolin: 2017-08-02 -> 0.6

### DIFF
--- a/pkgs/development/libraries/pangolin/default.nix
+++ b/pkgs/development/libraries/pangolin/default.nix
@@ -1,18 +1,18 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config, doxygen, libGL, glew
-, xorg , ffmpeg_3, python3 , libjpeg, libpng, libtiff, eigen
+, xorg, ffmpeg, libjpeg, libpng, libtiff, eigen
 , Carbon ? null, Cocoa ? null
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "pangolin";
 
-  version = "2017-08-02";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "stevenlovegrove";
     repo = "Pangolin";
-    rev = "f05a8cdc4f0e32cc1664a430f1f85e60e233c407";
-    sha256 = "0pfbaarlsw7f7cmsppm7m13nz0k530wwwyczy2l9k448p3v7x9j0";
+    rev = "v${version}";
+    sha256 = "0abjajxj7lc2yajshimar4w8kf8115prsjnhy83s6jc7cbz63wj8";
   };
 
   nativeBuildInputs = [ cmake pkg-config doxygen ];
@@ -21,8 +21,7 @@ stdenv.mkDerivation {
     libGL
     glew
     xorg.libX11
-    ffmpeg_3
-    python3
+    ffmpeg
     libjpeg
     libpng
     libtiff


### PR DESCRIPTION
Drop ffmpeg_3 dependency in favor of ffmpeg: https://github.com/NixOS/nixpkgs/issues/120705


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).