### PR TITLE
python3.pkgs.frozendict: 1.2 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -1,19 +1,23 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k }:
 
 buildPythonPackage rec {
   pname = "frozendict";
-  version = "1.2";
+  version = "2.0.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0ibf1wipidz57giy53dh7mh68f2hz38x8f4wdq88mvxj5pr7jhbp";
+  src = fetchFromGitHub {
+    owner = "Marco-Sulla";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "0qvh36pdcsv0w963fwb1f6zlzwngjxyy6zd3n5925cgxaqxn54gj";
   };
+
+  disabled = !isPy3k;
 
   # frozendict does not come with tests
   doCheck = false;
 
   meta = with lib; {
-    homepage = "https://github.com/slezica/python-frozendict";
+    homepage = "https://github.com/Marco-Sulla/python-frozendict";
     description = "An immutable dictionary";
     license = licenses.mit;
   };


### PR DESCRIPTION
###### Motivation for this change
Fix build of `python310.pkgs.canonicaljson`.

The downside is that this breaks frozendict on python2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
