### PR TITLE
Teleport 6.1.2 -> 6.1.3 + patch

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -11,14 +11,14 @@ in
 
 buildGoModule rec {
   pname = "teleport";
-  version = "6.1.2";
+  version = "6.1.3";
 
   # This repo has a private submodule "e" which fetchgit cannot handle without failing.
   src = fetchFromGitHub {
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    sha256 = "sha256-4ZaebTTgGrGRQbMfDw1PL/qtDKmHbSY6kPmWyFeIcAU=";
+    sha256 = "sha256-kb7qRPZKXDY0Qy3/72epAGaN2FCOO/XAN8lOoUYkoM0=";
   };
 
   vendorSha256 = null;
@@ -54,8 +54,8 @@ buildGoModule rec {
 
   postInstall = ''
     install -Dm755 -t $client/bin $out/bin/tsh
-    wrapProgram $client/bin/tsh --prefix PATH : ${xdg-utils}/bin
-    wrapProgram $out/bin/tsh --prefix PATH : ${xdg-utils}/bin
+    wrapProgram $client/bin/tsh --prefix PATH : ${lib.makeBinPath [ xdg-utils ]}
+    wrapProgram $out/bin/tsh --prefix PATH : ${lib.makeBinPath [ xdg-utils ]}
   '';
 
   doInstallCheck = true;

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -27,6 +27,9 @@ buildGoModule rec {
 
   nativeBuildInputs = [ zip makeWrapper ];
 
+  # https://github.com/NixOS/nixpkgs/issues/120738
+  patches = [ ./tsh.patch ];
+
   postBuild = ''
     pushd .
     mkdir -p build

--- a/pkgs/servers/teleport/tsh.patch
+++ b/pkgs/servers/teleport/tsh.patch
@@ -1,0 +1,17 @@
+diff --git a/tool/tsh/tsh.go b/tool/tsh/tsh.go
+index 57379c40f..cb4d7b84c 100644
+--- a/tool/tsh/tsh.go
++++ b/tool/tsh/tsh.go
+@@ -514,10 +514,11 @@ func Run(args []string, opts ...cliOption) error {
+ 		}
+ 	}
+ 
+-	cf.executablePath, err = os.Executable()
++	tempBinaryPath, err := os.Executable()
+ 	if err != nil {
+ 		return trace.Wrap(err)
+ 	}
++	cf.executablePath = path.Dir(tempBinaryPath) + "/tsh"
+ 
+ 	if err := client.ValidateAgentKeyOption(cf.AddKeysToAgent); err != nil {
+ 		return trace.Wrap(err)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes #120738 + version bump to `6.1.2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
