### PR TITLE
chroma: 0.8.2 -> 0.9.1

### DIFF
--- a/pkgs/tools/text/chroma/default.nix
+++ b/pkgs/tools/text/chroma/default.nix
@@ -2,15 +2,14 @@
 
 buildGoModule rec {
   pname = "chroma";
-  version = "0.8.2";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner  = "alecthomas";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0vzxd0jvjaakwjvkkkjppakjb00z44k7gb5ng1i4924agh24n5ka";
+    sha256 = "0zzk4wcjgxa9lsx8kwpmxvcw67f2fr7ai37jxmdahnws0ai2c2f7";
     leaveDotGit = true;
-    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ git ];
@@ -27,7 +26,7 @@ buildGoModule rec {
       --replace 'date    = "?"' "date = \"$date\""
   '';
 
-  vendorSha256 = "16cnc4scgkx8jan81ymha2q1kidm6hzsnip5mmgbxpqcc2h7hv9m";
+  vendorSha256 = "0y8mp08zccn9qxrsj9j7vambz8dwzsxbbgrlppzam53rg8rpxhrg";
 
   subPackages = [ "cmd/chroma" ];
 


### PR DESCRIPTION
https://github.com/alecthomas/chroma/releases/tag/v0.9.0
https://github.com/alecthomas/chroma/releases/tag/v0.9.1

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
