### PR TITLE
python3Packages.karton-autoit-ripper: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/autoit-ripper/default.nix
+++ b/pkgs/development/python-modules/autoit-ripper/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, lief
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "autoit-ripper";
+  version = "1.0.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mbsrfa72n7y1vkm9jhwhn1z3k45jxrlgx58ia1l2bp6chnnn2zy";
+  };
+
+  propagatedBuildInputs = [
+    lief
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "lief==0.10.1" "lief>=0.10.1"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "autoit_ripper" ];
+
+  meta = with lib; {
+    description = "Python module to extract AutoIt scripts embedded in PE binaries";
+    homepage = "https://github.com/nazywam/AutoIt-Ripper";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/karton-autoit-ripper/default.nix
+++ b/pkgs/development/python-modules/karton-autoit-ripper/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, autoit-ripper
+, buildPythonPackage
+, fetchFromGitHub
+, karton-core
+, malduck
+, regex
+}:
+
+buildPythonPackage rec {
+  pname = "karton-autoit-ripper";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "CERT-Polska";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vdsxkbjcr0inpcfjh45gl72ipzklkhgs06fdpkyy9y0cfx3zq7z";
+  };
+
+  propagatedBuildInputs = [
+    autoit-ripper
+    karton-core
+    malduck
+    regex
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "autoit-ripper==1.0.0" "autoit-ripper" \
+      --replace "karton.core==4.0.4" "karton-core" \
+      --replace "malduck==3.1.0" "malduck>=3.1.0" \
+      --replace "regex==2020.2.20" "regex>=2020.2.20"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "karton.autoit_ripper" ];
+
+  meta = with lib; {
+    description = "AutoIt script ripper for Karton framework";
+    homepage = "https://github.com/CERT-Polska/karton-autoit-ripper";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3555,6 +3555,8 @@ in {
 
   karton-asciimagic = callPackage ../development/python-modules/karton-asciimagic { };
 
+  karton-autoit-ripper = callPackage ../development/python-modules/karton-autoit-ripper { };
+
   karton-classifier = callPackage ../development/python-modules/karton-classifier { };
 
   karton-config-extractor = callPackage ../development/python-modules/karton-config-extractor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -617,6 +617,8 @@ in {
 
   autograd = callPackage ../development/python-modules/autograd { };
 
+  autoit-ripper = callPackage ../development/python-modules/autoit-ripper { };
+
   autologging = callPackage ../development/python-modules/autologging { };
 
   automat = callPackage ../development/python-modules/automat { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
AutoIt script ripper for Karton framework

https://github.com/CERT-Polska/karton-autoit-ripper

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
