### PR TITLE
pipewire: 0.3.25 -> 0.3.26

### DIFF
--- a/nixos/modules/services/desktops/pipewire/README.md
+++ b/nixos/modules/services/desktops/pipewire/README.md
@@ -1,6 +1,6 @@
 # Updating
 
 1. Update the version & hash in pkgs/development/libraries/pipewire/default.nix
-2. run `nix build -f /path/to/nixpkgs/checkout pipewire`
+2. run `nix build -f /path/to/nixpkgs/checkout pipewire pipewire.mediaSession`
 3. copy all JSON files from result/nix-support/etc/pipewire and result-mediaSession/nix-support/etc/pipewire/media-session.d to this directory, like this: `cp result/nix-support/etc/pipewire/* result-mediaSession/nix-support/etc/pipewire/media-session.d/* .`
 4. add new files to the module config and passthru tests

--- a/nixos/modules/services/desktops/pipewire/README.md
+++ b/nixos/modules/services/desktops/pipewire/README.md
@@ -1,6 +1,6 @@
 # Updating
 
 1. Update the version & hash in pkgs/development/libraries/pipewire/default.nix
-2. run `nix build -f /path/to/nixpkgs/checkout pipewire pipewire.mediaSession`
-3. copy all JSON files from result/etc/pipewire and result-mediaSession/etc/pipewire/media-session.d to this directory
+2. run `nix build -f /path/to/nixpkgs/checkout pipewire`
+3. copy all JSON files from result/nix-support/etc/pipewire and result-mediaSession/nix-support/etc/pipewire/media-session.d to this directory, like this: `cp result/nix-support/etc/pipewire/* result-mediaSession/nix-support/etc/pipewire/media-session.d/* .`
 4. add new files to the module config and passthru tests

--- a/nixos/modules/services/desktops/pipewire/bluez-monitor.conf.json
+++ b/nixos/modules/services/desktops/pipewire/bluez-monitor.conf.json
@@ -9,7 +9,7 @@
       ],
       "actions": {
         "update-props": {
-          "bluez5.reconnect-profiles": [
+          "bluez5.auto-connect": [
             "hfp_hf",
             "hsp_hs",
             "a2dp_sink"

--- a/nixos/modules/services/desktops/pipewire/media-session.conf.json
+++ b/nixos/modules/services/desktops/pipewire/media-session.conf.json
@@ -59,6 +59,7 @@
     "with-pulseaudio": [
       "with-audio",
       "bluez5",
+      "logind",
       "restore-stream",
       "streams-follow-default"
     ]

--- a/nixos/modules/services/desktops/pipewire/pipewire-pulse.conf.json
+++ b/nixos/modules/services/desktops/pipewire/pipewire-pulse.conf.json
@@ -30,7 +30,10 @@
       "args": {
         "server.address": [
           "unix:native"
-        ]
+        ],
+        "vm.overrides": {
+          "pulse.min.quantum": "1024/48000"
+        }
       }
     }
   ],

--- a/nixos/modules/services/desktops/pipewire/pipewire.conf.json
+++ b/nixos/modules/services/desktops/pipewire/pipewire.conf.json
@@ -2,7 +2,10 @@
   "context.properties": {
     "link.max-buffers": 16,
     "core.daemon": true,
-    "core.name": "pipewire-0"
+    "core.name": "pipewire-0",
+    "vm.overrides": {
+      "default.clock.min-quantum": 1024
+    }
   },
   "context.spa-libs": {
     "audio.convert.*": "audioconvert/libspa-audioconvert",

--- a/nixos/tests/installed-tests/pipewire.nix
+++ b/nixos/tests/installed-tests/pipewire.nix
@@ -2,4 +2,14 @@
 
 makeInstalledTest {
   tested = pkgs.pipewire;
+  testConfig = {
+    hardware.pulseaudio.enable = false;
+    services.pipewire = {
+      enable = true;
+      pulse.enable = true;
+      jack.enable = true;
+      alsa.enable = true;
+      alsa.support32Bit = true;
+    };
+  };
 }

--- a/pkgs/development/libraries/pipewire/0040-alsa-profiles-use-libdir.patch
+++ b/pkgs/development/libraries/pipewire/0040-alsa-profiles-use-libdir.patch
@@ -2,12 +2,11 @@ diff --git a/meson.build b/meson.build
 index ffee41b4..f3e4ec74 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -53,7 +53,7 @@ endif
- 
+@@ -55,5 +55,5 @@ endif
+
  spa_plugindir = join_paths(pipewire_libdir, spa_name)
- 
--alsadatadir = join_paths(pipewire_datadir, 'alsa-card-profile', 'mixer')
-+alsadatadir = join_paths(pipewire_libdir, '..', 'share', 'alsa-card-profile', 'mixer')
- 
+
+-alsadatadir = pipewire_datadir / 'alsa-card-profile' / 'mixer'
++alsadatadir = pipewire_libdir / '..' / 'share' / 'alsa-card-profile' / 'mixer'
+
  pipewire_headers_dir = join_paths(pipewire_name, 'pipewire')
- 

--- a/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
@@ -22,7 +22,7 @@ index 0a5e5042..4a70b0b0 100644
  systemd_config = configuration_data()
  systemd_config.set('PW_BINARY', pipewire_bindir / 'pipewire')
 -systemd_config.set('PW_PULSE_BINARY', pipewire_bindir / 'pipewire-pulse')
-+systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin' / 'pipewire-pulse')
++systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin/pipewire-pulse')
  systemd_config.set('PW_MEDIA_SESSION_BINARY', pipewire_bindir / 'pipewire-media-session')
  
  configure_file(input : 'pipewire.service.in',

--- a/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
@@ -1,3 +1,4 @@
+
 diff --git a/meson_options.txt b/meson_options.txt
 index ce364d93..a6c8af72 100644
 --- a/meson_options.txt
@@ -19,9 +20,9 @@ index 0a5e5042..4a70b0b0 100644
 @@ -9,7 +9,7 @@ install_data(
  
  systemd_config = configuration_data()
- systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))
--systemd_config.set('PW_PULSE_BINARY', join_paths(pipewire_bindir, 'pipewire-pulse'))
-+systemd_config.set('PW_PULSE_BINARY', join_paths(get_option('pipewire_pulse_prefix'), 'bin/pipewire-pulse'))
- systemd_config.set('PW_MEDIA_SESSION_BINARY', join_paths(pipewire_bindir, 'pipewire-media-session'))
+ systemd_config.set('PW_BINARY', pipewire_bindir / 'pipewire')
+-systemd_config.set('PW_PULSE_BINARY', pipewire_bindir / 'pipewire-pulse')
++systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin' / 'pipewire-pulse')
+ systemd_config.set('PW_MEDIA_SESSION_BINARY', pipewire_bindir / 'pipewire-media-session')
  
  configure_file(input : 'pipewire.service.in',

--- a/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
+++ b/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
@@ -18,10 +18,10 @@ index 5c4d1af0..7296220f 100644
 +++ b/src/daemon/systemd/user/meson.build
 @@ -10,7 +10,7 @@ install_data(
  systemd_config = configuration_data()
- systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))
- systemd_config.set('PW_PULSE_BINARY', join_paths(get_option('pipewire_pulse_prefix'), 'bin/pipewire-pulse'))
--systemd_config.set('PW_MEDIA_SESSION_BINARY', join_paths(pipewire_bindir, 'pipewire-media-session'))
-+systemd_config.set('PW_MEDIA_SESSION_BINARY', join_paths(get_option('media-session-prefix'), 'bin/pipewire-media-session'))
+ systemd_config.set('PW_BINARY', pipewire_bindir / 'pipewire')
+ systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin' / 'pipewire-pulse')
+-systemd_config.set('PW_MEDIA_SESSION_BINARY', pipewire_bindir / 'pipewire-media-session')
++systemd_config.set('PW_MEDIA_SESSION_BINARY', get_option('media-session-prefix') / 'bin' / 'pipewire-media-session')
 
  configure_file(input : 'pipewire.service.in',
                 output : 'pipewire.service',

--- a/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
+++ b/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
@@ -19,9 +19,9 @@ index 5c4d1af0..7296220f 100644
 @@ -10,7 +10,7 @@ install_data(
  systemd_config = configuration_data()
  systemd_config.set('PW_BINARY', pipewire_bindir / 'pipewire')
- systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin' / 'pipewire-pulse')
+ systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin/pipewire-pulse')
 -systemd_config.set('PW_MEDIA_SESSION_BINARY', pipewire_bindir / 'pipewire-media-session')
-+systemd_config.set('PW_MEDIA_SESSION_BINARY', get_option('media-session-prefix') / 'bin' / 'pipewire-media-session')
++systemd_config.set('PW_MEDIA_SESSION_BINARY', get_option('media-session-prefix') / 'bin/pipewire-media-session')
 
  configure_file(input : 'pipewire.service.in',
                 output : 'pipewire.service',

--- a/pkgs/development/libraries/pipewire/0070-installed-tests-path.patch
+++ b/pkgs/development/libraries/pipewire/0070-installed-tests-path.patch
@@ -2,14 +2,14 @@ diff --git a/meson.build b/meson.build
 index 97d4d939..b17358e5 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -353,8 +353,8 @@ libinotify_dep = (build_machine.system() == 'freebsd'
+@@ -353,7 +353,7 @@ libinotify_dep = (build_machine.system() == 'freebsd'
 
  alsa_dep = dependency('alsa', version : '>=1.1.7', required: get_option('pipewire-alsa'))
 
--installed_tests_metadir = join_paths(pipewire_datadir, 'installed-tests', pipewire_name)
--installed_tests_execdir = join_paths(pipewire_libexecdir, 'installed-tests', pipewire_name)
-+installed_tests_metadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', pipewire_name)
-+installed_tests_execdir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', pipewire_name)
+-installed_tests_metadir = pipewire_datadir / 'installed-tests' / pipewire_name
+-installed_tests_execdir = pipewire_libexecdir / 'installed-tests' / pipewire_name
++installed_tests_metadir = get_option('installed_test_prefix') / 'share' / 'installed-tests' / pipewire_name
++installed_tests_execdir = get_option('installed_test_prefix') / 'libexec' / 'installed-tests' / pipewire_name
  installed_tests_enabled = not get_option('installed_tests').disabled()
  installed_tests_template = files('template.test.in')
 

--- a/pkgs/development/libraries/pipewire/0080-pipewire-config-dir.patch
+++ b/pkgs/development/libraries/pipewire/0080-pipewire-config-dir.patch
@@ -6,12 +6,12 @@ index 0073eb13..0ffc6863 100644
  pipewire_localedir = join_paths(prefix, get_option('localedir'))
  pipewire_sysconfdir = join_paths(prefix, get_option('sysconfdir'))
  
--pipewire_configdir = join_paths(pipewire_sysconfdir, 'pipewire')
+-pipewire_configdir = pipewire_sysconfdir / 'pipewire'
 +pipewire_configdir = get_option('pipewire_config_dir')
 +if pipewire_configdir == ''
-+  pipewire_configdir = join_paths(pipewire_sysconfdir, 'pipewire')
++  pipewire_configdir = pipewire_sysconfdir / 'pipewire'
 +endif
- modules_install_dir = join_paths(pipewire_libdir, pipewire_name)
+ modules_install_dir = pipewire_libdir / pipewire_name
  
  if host_machine.system() == 'linux'
 diff --git a/meson_options.txt b/meson_options.txt

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -42,6 +42,8 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
+
+    # Don't forget to also update the NixOS module; see <nixpkgs/nixos/modules/services/desktops/pipewire/README.md>
     version = "0.3.26";
 
     outputs = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -42,7 +42,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.25";
+    version = "0.3.26";
 
     outputs = [
       "out"
@@ -60,7 +60,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      hash = "sha256:EbXWcf6QLtbvm6/eXBI+PF2sTw2opYfmc+H/SMDEH1U=";
+      hash = "sha256-s9+70XXMN4K3yDVwIu+L15gL6rFlpRNVQpeekZQOEec=";
     };
 
     patches = [

--- a/pkgs/development/libraries/pipewire/test-paths.nix
+++ b/pkgs/development/libraries/pipewire/test-paths.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, pipewire, paths-out, paths-lib }:
+{ lib, runCommand, pipewire, paths-out, paths-lib, paths-out-media-session }:
 
 let
   check-path = output: path: ''


### PR DESCRIPTION
###### Motivation for this change

A new update is out for pipewire, fixing many bugs and adding bluetooth Absolute Volume.

Changelog: <https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.26>

This release should be API and ABI compatible with all other 0.3.x releases.

CC @jtojnar @jansol @gebner @ryantm @nglen

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
