### PR TITLE
movine: init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6979,6 +6979,12 @@
     githubId = 628342;
     name = "Tim Steinbach";
   };
+  netcrns = {
+    email = "jason.wing@gmx.de";
+    github = "netcrns";
+    githubId = 34162313;
+    name = "Jason Wing";
+  };
   netixx = {
     email = "dev.espinetfrancois@gmail.com";
     github = "netixx";

--- a/pkgs/development/tools/database/movine/default.nix
+++ b/pkgs/development/tools/database/movine/default.nix
@@ -1,0 +1,54 @@
+{ rustPlatform
+, fetchFromGitHub
+, lib
+, stdenv
+, pkg-config
+, postgresql
+, sqlite
+, openssl
+, Security
+, libiconv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "movine";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "byronwasti";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rms8np8zd23xzrd5avhp2q1ndhdc8f49lfwpff9h0slw4rnzfnj";
+  };
+
+  cargoSha256 = "sha256-4ghfenwmauR4Ft9n7dvBflwIMXPdFq1vh6FpIegHnZk=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ postgresql sqlite ] ++ (
+    if !stdenv.isDarwin then [ openssl ] else [ Security libiconv ]
+  );
+
+  meta = with lib; {
+    description = "A migration manager written in Rust, that attempts to be smart yet minimal";
+    homepage = "https://github.com/byronwasti/movine";
+    license = licenses.mit;
+    longDescription = ''
+      Movine is a simple database migration manager that aims to be compatible
+      with real-world migration work. Many migration managers get confused
+      with complicated development strategies for migrations. Oftentimes
+      migration managers do not warn you if the SQL saved in git differs from
+      what was actually run on the database. Movine solves this issue by
+      keeping track of the unique hashes for the <literal>up.sql</literal> and
+      <literal>down.sql</literal> for each migration, and provides tools for
+      fixing issues. This allows users to easily keep track of whether their
+      local migration history matches the one on the database.
+
+      This project is currently in early stages.
+
+      Movine does not aim to be an ORM.
+      Consider <link xling:href="https://diesel.rs/">diesel</link> instead if
+      you want an ORM.
+    '';
+    maintainers = with maintainers; [ netcrns ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16499,6 +16499,10 @@ in
 
   mono-addins = callPackage ../development/libraries/mono-addins { };
 
+  movine = callPackage ../development/tools/database/movine {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   movit = callPackage ../development/libraries/movit { };
 
   mosquitto = callPackage ../servers/mqtt/mosquitto { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We want [`movine`](https://github.com/byronwasti/movine) packaged upstream.

###### Things done
Packaged [`movine`](https://github.com/byronwasti/movine) to be merged upstream.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
