### PR TITLE
exaile: init at 4.1.1

### DIFF
--- a/pkgs/applications/audio/exaile/default.nix
+++ b/pkgs/applications/audio/exaile/default.nix
@@ -1,0 +1,107 @@
+{ stdenv, lib, fetchFromGitHub
+, gobject-introspection, makeWrapper, wrapGAppsHook
+, gtk3, gst_all_1, python3
+, gettext, gnome, help2man, keybinder3, libnotify, librsvg, streamripper, udisks, webkitgtk
+, iconTheme ? gnome.adwaita-icon-theme
+, deviceDetectionSupport ? true
+, documentationSupport ? true
+, notificationSupport ? true
+, scalableIconSupport ? true
+, translationSupport ? true
+, bpmCounterSupport ? false
+, ipythonSupport ? false
+, lastfmSupport ? false
+, lyricsManiaSupport ? false
+, lyricsWikiSupport ? false
+, multimediaKeySupport ? false
+, musicBrainzSupport ? false
+, podcastSupport ? false
+, streamripperSupport ? false
+, wikipediaSupport ? false
+, fetchpatch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "exaile";
+  version = "4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "exaile";
+    repo = pname;
+    rev = version;
+    sha256 = "0s29lm0i4slgaw5l5s9a2zx0b83xac43rnil5cvyi210dxm5s048";
+  };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/exaile/exaile/pull/751.patch";
+      sha256 = "sha256-jCJh85Z3HQcyS4ntQP5HwYJgM7WNHcWzjf0BdNJitsM=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    makeWrapper
+    wrapGAppsHook
+  ] ++ lib.optionals documentationSupport [
+    help2man
+    python3.pkgs.sphinx
+    python3.pkgs.sphinx_rtd_theme
+  ] ++ lib.optional translationSupport gettext;
+
+  buildInputs = [
+    iconTheme
+    gtk3
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+  ]) ++ (with python3.pkgs; [
+    bsddb3
+    dbus-python
+    mutagen
+    pygobject3
+    pycairo
+    gst-python
+  ]) ++ lib.optional deviceDetectionSupport udisks
+  ++ lib.optional notificationSupport libnotify
+  ++ lib.optional scalableIconSupport librsvg
+  ++ lib.optional bpmCounterSupport gst_all_1.gst-plugins-bad
+  ++ lib.optional ipythonSupport python3.pkgs.ipython
+  ++ lib.optional lastfmSupport python3.pkgs.pylast
+  ++ lib.optional (lyricsManiaSupport || lyricsWikiSupport) python3.pkgs.lxml
+  ++ lib.optional lyricsWikiSupport python3.pkgs.beautifulsoup4
+  ++ lib.optional multimediaKeySupport keybinder3
+  ++ lib.optional musicBrainzSupport python3.pkgs.musicbrainzngs
+  ++ lib.optional podcastSupport python3.pkgs.feedparser
+  ++ lib.optional wikipediaSupport webkitgtk;
+
+  checkInputs = with python3.pkgs; [
+    mox3
+    pytest
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  doCheck = true;
+  preCheck = ''
+    substituteInPlace Makefile --replace "PYTHONPATH=$(shell pwd)" "PYTHONPATH=$PYTHONPATH:$(shell pwd)"
+    export PYTEST="py.test"
+    export XDG_CACHE_HOME=$(mktemp -d)
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/exaile \
+      --set PYTHONPATH $PYTHONPATH \
+      ${lib.optionalString streamripperSupport "--prefix PATH : ${lib.makeBinPath [ streamripper ]}"}
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.exaile.org/";
+    description = "A music player with a simple interface and powerful music management capabilities";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ ryneeverett ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24257,6 +24257,8 @@ with pkgs;
 
   evilpixie = libsForQt5.callPackage ../applications/graphics/evilpixie { };
 
+  exaile = callPackage ../applications/audio/exaile { };
+
   exercism = callPackage ../applications/misc/exercism { };
 
   expenses = callPackage ../applications/misc/expenses { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Disclaimers:

- I haven't tested the binary built on master because I run the stable channel on my workstation and it fails with the error `ImportError: /nix/store/0c7c96gikmzv87i7lv3vq5s1cmfjd6zf-glibc-2.31-74/lib/libc.so.6: version GLIBC_2.32' not found (required by /nix/store/ap4d6cqfhakl2dp6081z2c6bsdcinsha-glib-2.66.8/lib/libglib-2.0.so.0)`. However the binary works fine when I backport this branch to 20.09 so I believe this is just a case of glibc incompatibility.
- I tested that enabling the optional dependencies allows the plugins to load but I did not test the functionality of all of them. Also there are a plugin or two with dependencies that aren't in nixpkgs yet so those still wont work.
- I do find it a bit weird that a package like this would have so many optional inputs but that is my deferral to upstream's decision to implement all these features as plugins with [optional dependencies](https://exaile.readthedocs.io/en/stable/user/deps.html#optional-dependencies). Let me know if there's a better way to handle this or if you disagree with my choices of default settings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
