### PR TITLE
Add roswell.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3991,6 +3991,16 @@
     githubId = 19825977;
     name = "Hiren Shah";
   };
+  hiro98 = {
+    email = "hiro@protagon.space";
+    github = "vale981";
+    githubId = 4025991;
+    name = "Valentin Boettcher";
+    keys = [{
+      longkeyid = "rsa2048/0xC22D4DE4D7B32D19";
+      fingerprint = "45A9 9917 578C D629 9F5F  B5B4 C22D 4DE4 D7B3 2D19";
+    }];
+  };
   hjones2199 = {
     email = "hjones2199@gmail.com";
     github = "hjones2199";

--- a/pkgs/development/tools/roswell/default.nix
+++ b/pkgs/development/tools/roswell/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, curl, autoconf, automake, makeWrapper, sbcl }:
+
+stdenv.mkDerivation rec {
+  pname = "roswell";
+  version = "21.01.14.108";
+
+  src = fetchFromGitHub {
+    owner = "roswell";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hj9q3ig7naky3pb3jkl9yjc9xkg0k7js3glxicv0aqffx9hkp3p";
+  };
+
+  preConfigure = ''
+    sh bootstrap
+  '';
+
+  configureFlags = [ "--prefix=${placeholder "out"}" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ros \
+      --add-flags 'lisp=sbcl-bin/system sbcl-bin.version=system' \
+      --prefix PATH : ${lib.makeBinPath [ sbcl ]} --argv0 ros
+  '';
+
+  nativeBuildInputs = [ autoconf automake makeWrapper ];
+
+  buildInputs = [ sbcl curl ];
+
+  meta = with lib; {
+    description = "Roswell is a Lisp implementation installer/manager, launcher, and much more";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hiro98 ];
+    platforms = platforms.linux;
+    homepage = "https://github.com/roswell/roswell";
+    mainProgram = "ros";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11496,6 +11496,8 @@ in
   sbcl_2_1_2 = callPackage ../development/compilers/sbcl/2.1.2.nix {};
   sbcl = sbcl_2_1_2;
 
+  roswell = callPackage ../development/tools/roswell/default.nix { };
+
   scala_2_10 = callPackage ../development/compilers/scala/2.x.nix { majorVersion = "2.10"; jre = jdk8; };
   scala_2_11 = callPackage ../development/compilers/scala/2.x.nix { majorVersion = "2.11"; jre = jdk8; };
   scala_2_12 = callPackage ../development/compilers/scala/2.x.nix { majorVersion = "2.12"; jre = jdk8; };


### PR DESCRIPTION
###### Motivation for this change
Although roswell isn't much use as a lisp implementation manager on nix, it nevertheless can be useful.

I have wrapped it, so that the correct lisp implementation is chosen.

It would be great if some people test it and report if it works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
