### PR TITLE
python3Packages.meshtastic: init at 1.2.30

### DIFF
--- a/pkgs/development/python-modules/dotmap/default.nix
+++ b/pkgs/development/python-modules/dotmap/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "dotmap";
+  version = "1.3.23";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hy88kzzb7zhxfr7iyvl6rhmvz02538pbna7zypaard4a88bbbka";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "dotmap/test.py" ];
+
+  pythonImportsCheck = [ "dotmap" ];
+
+  meta = with lib; {
+    description = "Python for dot-access dictionaries";
+    homepage = "https://github.com/drgrib/dotmap";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/meshtastic/default.nix
+++ b/pkgs/development/python-modules/meshtastic/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, dotmap
+, fetchPypi
+, pexpect
+, protobuf
+, pygatt
+, pypubsub
+, pyqrcode
+, pyserial
+, pythonOlder
+, tabulate
+, timeago
+}:
+
+buildPythonPackage rec {
+  pname = "meshtastic";
+  version = "1.2.30";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kjflc2jwnsgxyr2zx1gyykhak9fsgy6hxaxlggsz5sw9b8rdrby";
+  };
+
+  propagatedBuildInputs = [
+    dotmap
+    pexpect
+    protobuf
+    pygatt
+    pypubsub
+    pyqrcode
+    pyserial
+    tabulate
+    timeago
+  ];
+
+  postPatch = ''
+    # https://github.com/meshtastic/Meshtastic-python/pull/87
+    substituteInPlace setup.py \
+      --replace 'with open("README.md", "r") as fh:' "" \
+      --replace "long_description = fh.read()" "" \
+      --replace "long_description=long_description," 'long_description="",'
+  '';
+
+  # Project only provides PyPI releases which don't contain the tests
+  # https://github.com/meshtastic/Meshtastic-python/issues/86
+  doCheck = false;
+  pythonImportsCheck = [ "meshtastic" ];
+
+  meta = with lib; {
+    description = "Python API for talking to Meshtastic devices";
+    homepage = "https://meshtastic.github.io/Meshtastic-python/";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pygatt/default.nix
+++ b/pkgs/development/python-modules/pygatt/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, nose
+, pexpect
+, pyserial
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pygatt";
+  version = "4.0.5";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "peplin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zdfxidiw0l8n498sy0l33n90lz49n25x889cx6jamjr7frlcihd";
+  };
+
+  propagatedBuildInputs = [
+    pexpect
+    pyserial
+  ];
+
+  checkInputs = [
+    mock
+    nose
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Not support for Python < 3.4
+    substituteInPlace setup.py --replace "'enum-compat'" ""
+  '';
+
+  pythonImportsCheck = [ "pygatt" ];
+
+  meta = with lib; {
+    description = "Python wrapper the BGAPI for accessing Bluetooth LE Devices";
+    homepage = "https://github.com/peplin/pygatt";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/timeago/default.nix
+++ b/pkgs/development/python-modules/timeago/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "timeago";
+  version = "1.0.15";
+
+  src = fetchFromGitHub {
+    owner = "hustcc";
+    repo = pname;
+    rev = version;
+    sha256 = "03vm7c02l4g2d1x33w382i1psk8i3an7xchk69yinha33fjj1cag";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "test/testcase.py" ];
+
+  pythonImportsCheck = [ "timeago" ];
+
+  meta = with lib; {
+    description = "Python module to format past datetime output";
+    homepage = "https://github.com/hustcc/timeago";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8014,6 +8014,8 @@ in {
 
   tilestache = callPackage ../development/python-modules/tilestache { };
 
+  timeago = callPackage ../development/python-modules/timeago { };
+
   timelib = callPackage ../development/python-modules/timelib { };
 
   timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2030,6 +2030,8 @@ in {
     inherit (pkgs) graphviz;
   };
 
+  dotmap = callPackage ../development/python-modules/dotmap { };
+
   dparse = callPackage ../development/python-modules/dparse { };
 
   dpath = callPackage ../development/python-modules/dpath { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5539,6 +5539,8 @@ in {
 
   pygame_sdl2 = callPackage ../development/python-modules/pygame_sdl2 { };
 
+  pygatt = callPackage ../development/python-modules/pygatt { };
+
   pygbm = callPackage ../development/python-modules/pygbm { };
 
   pygccxml = callPackage ../development/python-modules/pygccxml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4111,6 +4111,8 @@ in {
 
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };
 
+  meshtastic = callPackage ../development/python-modules/meshtastic { };
+
   meson = toPythonModule ((pkgs.meson.override { python3 = python; }).overrideAttrs
     (oldAttrs: { # We do not want the setup hook in Python packages because the build is performed differently.
       setupHook = null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A Python client for using Meshtastic devices. This small library (and example application) provides an easy API for sending and receiving messages over mesh radios. It also provides access to any of the operations/data available in the device user interface or the Android application. Events are delivered using a publish-subscribe model, and you can subscribe to only the message types you are interested in.

https://meshtastic.github.io/Meshtastic-python/

Requires `tabulate-0.8.9` which is only available in `staging`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
