### PR TITLE
innernet: test and fixup

### DIFF
--- a/pkgs/tools/networking/innernet/default.nix
+++ b/pkgs/tools/networking/innernet/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, llvmPackages, linuxHeaders, sqlite, Security }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, llvmPackages, sqlite, installShellFiles, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "innernet";
@@ -10,11 +10,37 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "sha256-Z4F5RYPVgFiiDBg6lxILjAh/a/rL7IJBqHIJ/tQyLnE=";
   };
+  cargoSha256 = "sha256-WSkN5aXMgfqZJAV1b3elF7kwf2f5OpcntKSf8620YcY=";
+
+  nativeBuildInputs = with llvmPackages; [
+    llvm
+    clang
+    installShellFiles
+  ];
+  buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
-  nativeBuildInputs = with llvmPackages; [ llvm clang ];
-  buildInputs = [ sqlite ] ++ lib.optionals stdenv.isDarwin [ Security ];
-  cargoSha256 = "sha256-WSkN5aXMgfqZJAV1b3elF7kwf2f5OpcntKSf8620YcY=";
+  postInstall = ''
+    installManPage doc/innernet-server.8.gz
+    installManPage doc/innernet.8.gz
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if [[ "$("$out/bin/${pname}"-server --version)" == "${pname}-server ${version}" ]]; then
+      echo '${pname}-server smoke check passed'
+    else
+      echo '${pname}-server smoke check failed'
+      return 1
+    fi
+    if [[ "$("$out/bin/${pname}" --version)" == "${pname} ${version}" ]]; then
+      echo '${pname} smoke check passed'
+    else
+      echo '${pname} smoke check failed'
+      return 1
+    fi
+  '';
 
   meta = with lib; {
     description = "A private network system that uses WireGuard under the hood";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- add simple packaging test
- add manpages
- remove unused linuxHeaders input (nixpkgs-review suggestion from #120686)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
