### PR TITLE
qmmp: switch from ffmpeg_3 to ffmpeg

### DIFF
--- a/pkgs/applications/audio/qmmp/default.nix
+++ b/pkgs/applications/audio/qmmp/default.nix
@@ -57,6 +57,6 @@ mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
-    repositories.svn = "http://qmmp.googlecode.com/svn/";
+    repositories.svn = "https://svn.code.sf.net/p/qmmp-dev/code";
   };
 }

--- a/pkgs/applications/audio/qmmp/default.nix
+++ b/pkgs/applications/audio/qmmp/default.nix
@@ -53,7 +53,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Qt-based audio player that looks like Winamp";
-    homepage = "http://qmmp.ylsoftware.com/";
+    homepage = "https://qmmp.ylsoftware.com/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/applications/audio/qmmp/default.nix
+++ b/pkgs/applications/audio/qmmp/default.nix
@@ -54,7 +54,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "Qt-based audio player that looks like Winamp";
     homepage = "http://qmmp.ylsoftware.com/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
     repositories.svn = "http://qmmp.googlecode.com/svn/";

--- a/pkgs/applications/audio/qmmp/default.nix
+++ b/pkgs/applications/audio/qmmp/default.nix
@@ -4,7 +4,7 @@
 , curl, libmms
 # input plugins
 , libmad, taglib, libvorbis, libogg, flac, libmpcdec, libmodplug, libsndfile
-, libcdio, cdparanoia, libcddb, faad2, ffmpeg_3, wildmidi
+, libcdio, cdparanoia, libcddb, faad2, ffmpeg, wildmidi
 # output plugins
 , alsaLib, libpulseaudio
 # effect plugins
@@ -44,7 +44,7 @@ mkDerivation rec {
       curl libmms
       # input plugins
       libmad taglib libvorbis libogg flac libmpcdec libmodplug libsndfile
-      libcdio cdparanoia libcddb faad2 ffmpeg_3 wildmidi
+      libcdio cdparanoia libcddb faad2 ffmpeg wildmidi
       # output plugins
       alsaLib libpulseaudio
       # effect plugins


### PR DESCRIPTION
###### Motivation for this change
Ref. issue #120705.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
