### PR TITLE
ocaml_4_00_1, ocaml_4_03: mark as insecure

### DIFF
--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -62,6 +62,11 @@ stdenv.mkDerivation rec {
       '';
 
     platforms = with platforms; linux;
+
+    knownVulnerabilities = [
+      "CVE-2015-8869"
+      "CVE-2017-9779"
+    ];
   };
 
 }

--- a/pkgs/development/compilers/ocaml/4.03.nix
+++ b/pkgs/development/compilers/ocaml/4.03.nix
@@ -3,4 +3,10 @@ import ./generic.nix {
   minor_version = "03";
   patch_version = "0";
   sha256 = "09p3iwwi55r6rbrpyp8f0wmkb0ppcgw67yxw6yfky60524wayp39";
+  meta = {
+    knownVulnerabilities = [
+      "CVE-2015-8869"
+      "CVE-2017-9779"
+    ];
+  };
 }

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -1,4 +1,4 @@
-{ minor_version, major_version, patch_version
+{ minor_version, major_version, patch_version, meta ? {}
 , ...}@args:
 let
   versionNoPatch = "${toString major_version}.${toString minor_version}";
@@ -110,7 +110,7 @@ stdenv.mkDerivation (args // {
 
     platforms = with platforms; linux ++ darwin;
     broken = stdenv.isAarch64 && !lib.versionAtLeast version "4.06";
-  };
+  } // meta;
 
 })
 


### PR DESCRIPTION
Although virtually all OCaml versions before 4.05 are affected by at
least one CVE, we only mark 4.00.1 and 4.03.0 as insecure for now
because we don't actually depend on them for anything in nixpkgs.

The other versions warrant future clean up.

Marking as insecure is a first step towards removing the two
corresponding ocamlPackages sets completely.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
