### PR TITLE
[20.09] plasma5Packages.discover: patch CVE-2021-28117

### DIFF
--- a/pkgs/desktops/plasma-5/discover.nix
+++ b/pkgs/desktops/plasma-5/discover.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation,
+  mkDerivation, fetchpatch,
   extra-cmake-modules, gettext, kdoctools, python,
   appstream-qt, discount, flatpak, fwupd, ostree, packagekit-qt, pcre, utillinux,
   qtquickcontrols2,
@@ -9,6 +9,13 @@
 
 mkDerivation {
   name = "discover";
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-28117.patch";
+      url = "https://invent.kde.org/plasma/discover/-/commit/94478827aab63d2e2321f0ca9ec5553718798e60.patch";
+      sha256 = "1r7lb5vm75xk2np2fjlcddf8pwcm76iabk8bxznn6p0nif11xjal";
+    })
+  ];
   nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
   buildInputs = [
     # discount is needed for libmarkdown
@@ -16,8 +23,5 @@ mkDerivation {
     qtquickcontrols2
     karchive kconfig kcrash kdbusaddons kdeclarative kio kirigami2 kitemmodels knewstuff kwindowsystem kxmlgui
     plasma-framework
-  ];
-  meta.knownVulnerabilities = [
-    "https://kde.org/info/security/advisory-20210310-1.txt"
   ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/120656#issuecomment-827083382

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
