### PR TITLE
python3Packages.ffmpeg-python: replace ffmpeg_3 with ffmpeg

### DIFF
--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -2,9 +2,9 @@
 , buildPythonPackage
 , fetchFromGitHub
 , substituteAll
-, ffmpeg_3
+, pytestCheckHook
+, ffmpeg
 , future
-, pytest
 , pytestrunner
 , pytest-mock
 }:
@@ -21,23 +21,20 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (
-      substituteAll {
-        src = ./ffmpeg-location.patch;
-        ffmpeg = ffmpeg_3;
-      }
-    )
+    (substituteAll {
+      src = ./ffmpeg-location.patch;
+      inherit ffmpeg;
+    })
   ];
 
   buildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ future ];
-  checkInputs = [ pytest pytest-mock ];
+  checkInputs = [ pytestCheckHook pytest-mock ];
 
   meta = with lib; {
     description = "Python bindings for FFmpeg - with complex filtering support";
     homepage = "https://github.com/kkroening/ffmpeg-python";
     license = licenses.asl20;
     maintainers = [ maintainers.AluisioASG ];
-    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/120705 for the rationale.
ffmpeg-python doesn't seem to be strongly bound to any ffmpeg version so we can just migrate away.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
