### PR TITLE
python2-packages.nix: fix typo

### DIFF
--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -638,7 +638,7 @@ with self; with super; {
 
   yt = callPackage ../development/python-modules/yt { };
 
-  zeek = disablede super.zeek;
+  zeek = disabled super.zeek;
 
   zbase32 = callPackage ../development/python-modules/zbase32 { };
 


### PR DESCRIPTION
I think this is typo, and should be corrected

#120781