### PR TITLE
Fix grab-site and python3Packages.lmdb

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "lmdb";
-  version = "0.9.28";
+  version = "0.9.29";
 
   src = fetchgit {
     url = "https://git.openldap.org/openldap/openldap.git";
     rev = "LMDB_${version}";
-    sha256 = "012a8bs49cswsnzw7k4piis5b6dn4by85w7a7mai9i04xcjyy9as";
+    sha256 = "0airps4cd0d91nbgy7hgvifa801snxwxzwxyr6pdv61plsi7h8l3";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";

--- a/pkgs/development/python-modules/lmdb/default.nix
+++ b/pkgs/development/python-modules/lmdb/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "lmdb";
-  version = "1.1.1";
+  version = "1.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "165cd1669b29b16c2d5cc8902b90fede15a7ee475c54d466f1444877a3f511ac";
+    sha256 = "5f76a90ebd08922acca11948779b5055f7a262687178e9e94f4e804b9f8465bc";
   };
 
   buildInputs = [ lmdb ];

--- a/pkgs/development/python-modules/lmdb/default.nix
+++ b/pkgs/development/python-modules/lmdb/default.nix
@@ -4,7 +4,6 @@
 , pytestCheckHook
 , cffi
 , lmdb
-, ludios_wpull
 }:
 
 buildPythonPackage rec {
@@ -17,8 +16,6 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ lmdb ];
-
-  propogatedBuildInputs = [ ludios_wpull ];
 
   checkInputs = [ cffi pytestCheckHook ];
 


### PR DESCRIPTION
###### Motivation for this change

This fixes:
- python3Packages.lmdb
  - upgraded lmdb to fix a failing test with lmdb 0.9.28: https://github.com/jnwatson/py-lmdb/issues/278
  - removed the strange dependency on ludios_wpull, which was breaking the python38Packages.lmdb build
- grab-site, which depends on python37Packages.lmdb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainers @copumpkin @jb55 @vcunat 

I confirmed that grab-site now builds and runs on NixOS master.