### PR TITLE
r128gain: add unfree derivation to download test files

### DIFF
--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -1,4 +1,5 @@
 { lib
+, callPackage
 , fetchFromGitHub
 , genericUpdater
 , substituteAll
@@ -6,6 +7,7 @@
 , ffmpeg
 , python3Packages
 , sox
+, doCheck ? false
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -29,9 +31,11 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [ crcmod ffmpeg-python mutagen tqdm ];
   checkInputs = with python3Packages; [ requests sox ];
 
-  # Testing downloads media files for testing, which requires the
-  # sandbox to be disabled.
-  doCheck = false;
+  # The tests require unredistributable media files, so they're not run
+  # by default.  Maintainers can override `doCheck` to toggle testing on
+  # locally (provided building non-free packages is enabled).
+  inherit doCheck;
+  TEST_DL_CACHE_DIR = if doCheck then callPackage ./test-files.nix { } else null;
 
   passthru = {
     updateScript = genericUpdater {

--- a/pkgs/applications/audio/r128gain/test-files.nix
+++ b/pkgs/applications/audio/r128gain/test-files.nix
@@ -1,0 +1,78 @@
+{ stdenvNoCC, lib, fetchurl, symlinkJoin }:
+let
+  inherit (builtins) baseNameOf;
+  inherit (lib) concatMapStrings imap0;
+
+  files = [
+    {
+      url = "https://upload.wikimedia.org/wikipedia/en/0/09/Opeth_-_Deliverance.ogg";
+      hash = "sha256-8YejxLVznB7HMxpljOnnLeHtWgtHvt90EWKf15ns318=";
+    }
+    {
+      name = "ehren-paper_lights-64.opus";
+      url = "https://www.dropbox.com/s/xlp1goezxovlgl4/ehren-paper_lights-64.opus?dl=1";
+      hash = "sha256-JdLGp1rNEL8KKjzW+JrflDw3h8R488wI2F4gtSvzz6I=";
+    }
+    {
+      url = "http://www.largesound.com/ashborytour/sound/brobob.mp3";
+      hash = "sha256-4mTxxnBCssGasC7bM0GK0kBiTdtawoD8bN2v7L+bQAM=";
+    }
+    {
+      name = "Death%20Star.mp3";
+      url = "https://www.dropbox.com/s/bdm7wyqaj3ij8ci/Death%20Star.mp3?dl=1";
+      hash = "sha256-GyJenUtB7dZ9HJyMJdSK8I8qjJBy/UQnA9ZP30TXyVA=";
+    }
+    {
+      url = "https://auphonic.com/media/audio-examples/01.auphonic-demo-unprocessed.m4a";
+      hash = "sha256-AoPg9VdjAesutoDAQsiY5vuXwbOe4Izfw1k8E3ExeZ8=";
+    }
+    {
+      url = "http://helpguide.sony.net/high-res/sample1/v1/data/Sample_HisokanaMizugame_88_2kHz24bit.flac.zip";
+      hash = "sha256-w/UseJCRn3+/65557naWPoUQaVTtibXqQT/YP18KqeM=";
+    }
+    {
+      url = "https://github.com/desbma/r128gain/files/3006101/snippet_with_high_true_peak.zip";
+      hash = "sha256-g7z1wr9vFu6FkzRHUz2VzW0/Oivb2nBudhtXZK/t/iM=";
+    }
+    {
+      name = "04-There%27s%20No%20Other%20Way.mp3";
+      url = "https://www.dropbox.com/s/hnkmioxwu56dgs0/04-There%27s%20No%20Other%20Way.mp3?dl=1";
+      hash = "sha256-uIHTk405nwjN1wggZD4XDLoFY22LyJnjc9sE5wecxQw=";
+    }
+  ];
+
+  srcs = imap0
+    (i: args: fetchurl (args // {
+      # Massaging the URLs into a name Nix accepts takes some effort
+      # that wouldn't help people looking at their /nix/store, so we
+      # just generate a deterministic (and descriptive) name.
+      name = "r128gain-test-file-${toString i}";
+      passthru.realName = args.name or (baseNameOf args.url);
+    }))
+    files;
+in
+stdenvNoCC.mkDerivation {
+  pname = "r128gain-test-cache";
+  version = "1.0.3";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    ${concatMapStrings (src: ''
+    install -m644 ${src} $out/${src.realName}
+    '') srcs}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Test files for r128gain";
+    homepage = "https://github.com/desbma/r128gain";
+    license = licenses.unfree;
+    maintainers = [ maintainers.AluisioASG ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
r128gain downloads unredistributable media files during testing.  After multiple attempts to ease the testing workflow, I've settled on providing an unfree derivation that gets built when the user explicitly enables the check phase (i.e. `nix-build -E '(import ./. {}).r128gain.override { doCheck = true; }'`).

I'm not sure that this is the best way to do it, so I'm looking for feedback.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
