### PR TITLE
llvmPackages_7: misc improvements for lldClang

### DIFF
--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -188,13 +188,12 @@ let
         libunwind = libraries.libunwind;
       }));
 
-    openmp = callPackage ./openmp.nix {};
-
     libunwind = callPackage ./libunwind ({} //
       (lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
         stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
       }));
 
+    openmp = callPackage ./openmp.nix {};
   });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -189,13 +189,12 @@ let
         libunwind = libraries.libunwind;
       }));
 
-    openmp = callPackage ./openmp.nix {};
-
     libunwind = callPackage ./libunwind ({} //
       (lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
         stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
       }));
 
+    openmp = callPackage ./openmp.nix {};
   });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -236,7 +236,6 @@ let
     });
 
     openmp = callPackage ./openmp { inherit llvm_meta; };
-
   });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -229,12 +229,13 @@ let
         libunwind = libraries.libunwind;
       }));
 
-    openmp = callPackage ./openmp { inherit llvm_meta; };
+    libunwind = callPackage ./libunwind ({
+      inherit (buildLlvmTools) llvm;
+    } // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
+      stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
+    });
 
-    libunwind = callPackage ./libunwind ({ inherit llvm_meta; } //
-      (lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
-        stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
-      }));
+    openmp = callPackage ./openmp { inherit llvm_meta; };
 
   });
 

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -106,6 +106,8 @@ let
       extraPackages = [
         targetLlvmLibraries.libcxxabi
         targetLlvmLibraries.compiler-rt
+      ] ++ lib.optionals (!stdenv.targetPlatform.isWasm) [
+        targetLlvmLibraries.libunwind
       ];
       extraBuildCommands = ''
         echo "-rtlib=compiler-rt -Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/7/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/7/libunwind/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, version, fetch, fetchpatch, cmake, llvm, libcxx
+{ lib, stdenv, version, fetch, fetchpatch, cmake, llvm
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
@@ -7,6 +7,11 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetch "libunwind" "035dsxs10nyiqd00q07yycvmkjl01yz4jdlrjvmch8klxg4pyjhp";
+
+  postUnpack = ''
+    unpackFile ${llvm.src}
+    cmakeFlagsArray=($cmakeFlagsArray -DLLVM_PATH=$PWD/$(ls -d llvm-*))
+  '';
 
   patches = [
     ./gnu-install-dirs.patch
@@ -24,12 +29,11 @@ stdenv.mkDerivation {
     })
   ];
 
-  nativeBuildInputs = [ cmake llvm.dev ];
+  nativeBuildInputs = [ cmake ];
 
   cmakeFlags = lib.optionals (!enableShared) [
     "-DLIBUNWIND_ENABLE_SHARED=OFF"
   ] ++ lib.optionals (stdenv.hostPlatform.useLLVM or false) [
-    "-DLIBUNWIND_HAS_NOSTDINCXX_FLAG=ON"
     "-DLLVM_ENABLE_LIBCXX=ON"
   ];
 }

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -191,13 +191,12 @@ let
         libunwind = libraries.libunwind;
       }));
 
-    openmp = callPackage ./openmp.nix {};
-
     libunwind = callPackage ./libunwind ({} //
       (lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
         stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
       }));
 
+    openmp = callPackage ./openmp.nix {};
   });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -191,13 +191,12 @@ let
         libunwind = libraries.libunwind;
       }));
 
-    openmp = callPackage ./openmp.nix {};
-
     libunwind = callPackage ./libunwind ({} //
       (lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
         stdenv = overrideCC stdenv buildLlvmTools.lldClangNoLibcxx;
       }));
 
+    openmp = callPackage ./openmp.nix {};
   });
 
 in { inherit tools libraries; } // libraries // tools


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This stems from my attempts to make `ncurses` (more specifically its C++ library) work with `useLLVM == true`. While this hasn't worked out yet, the libunwind derivation is at least a bit better now.

Curiously, it works with LLVM 8 and I'm not sure what difference between the versions exactly causes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
