### PR TITLE
babeld: 1.9.2 -> 1.10

### DIFF
--- a/nixos/modules/services/networking/babeld.nix
+++ b/nixos/modules/services/networking/babeld.nix
@@ -32,6 +32,8 @@ in
 
 {
 
+  meta.maintainers = with maintainers; [ hexa ];
+
   ###### interface
 
   options = {

--- a/pkgs/tools/networking/babeld/default.nix
+++ b/pkgs/tools/networking/babeld/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.irif.fr/~jch/software/babel/";
     description = "Loop-avoiding distance-vector routing protocol";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz hexa ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/babeld/default.nix
+++ b/pkgs/tools/networking/babeld/default.nix
@@ -1,21 +1,13 @@
-{ lib, stdenv, fetchurl, fetchpatch, nixosTests }:
+{ lib, stdenv, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "babeld";
-  version = "1.9.2";
+  version = "1.10";
 
   src = fetchurl {
-    url = "http://www.pps.univ-paris-diderot.fr/~jch/software/files/${pname}-${version}.tar.gz";
-    sha256 = "01vzhrspnm4sy9ggaz9n3bfl5hy3qlynr218j3mdcddzm3h00kqm";
+    url = "https://www.irif.fr/~jch/software/files/${pname}-${version}.tar.gz";
+    sha256 = "1sld5bbig2pkcr4zrdpvfzifc6a3lc8i8kdzk5ryjh166844mxd5";
   };
-
-  patches = [
-    (fetchpatch {
-      # Skip kernel_setup_interface when `skip-kernel-setup` is enabled.
-      url = "https://github.com/jech/babeld/commit/f9698a5616842467ad08a5f9ed3d6fcfa2dd2898.patch";
-      sha256 = "00kj2jxsfq0pjk5wrkslyvkww57makxlwa4fd82g7g9hrgahpqwr";
-    })
-  ];
 
   preBuild = ''
     makeFlags="PREFIX=$out ETCDIR=$out/etc"
@@ -23,11 +15,11 @@ stdenv.mkDerivation rec {
 
   passthru.tests.babeld = nixosTests.babeld;
 
-  meta = {
-    homepage = "http://www.pps.univ-paris-diderot.fr/~jch/software/babel/";
+  meta = with lib; {
+    homepage = "http://www.irif.fr/~jch/software/babel/";
     description = "Loop-avoiding distance-vector routing protocol";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fpletz ];
-    platforms = with lib.platforms; linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ fpletz ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://alioth-lists.debian.net/pipermail/babel-users/2021-April/003818.html

@fpletz Are you still using this package?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
