### PR TITLE
 python3Packages.openapi-spec-validator: add missing dependency on openapi-schema-validator

### DIFF
--- a/pkgs/development/python-modules/openapi-schema-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-schema-validator/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, isodate
+, jsonschema
+, pytest-flake8
+, pytestcov
+, rfc3339-validator
+, six
+, strict-rfc3339
+}:
+
+buildPythonPackage rec {
+  pname = "openapi-schema-validator";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a4b2712020284cee880b4c55faa513fbc2f8f07f365deda6098f8ab943c9f0df";
+  };
+
+  propagatedBuildInputs = [ isodate jsonschema six strict-rfc3339 rfc3339-validator ];
+
+  checkInputs = [ pytestCheckHook pytestcov pytest-flake8 ];
+  pythonImportsCheck = [ "openapi_schema_validator" ];
+
+  meta = with lib; {
+    description = "Validates OpenAPI schema against the OpenAPI Schema Specification v3.0";
+    homepage = "https://github.com/p1c2u/openapi-schema-validator";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ AluisioASG ];
+  };
+}

--- a/pkgs/development/python-modules/openapi-spec-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-spec-validator/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, isPy27, fetchPypi
-, jsonschema, pyyaml, six, pathlib
+, jsonschema, openapi-schema-validator, pyyaml, six, pathlib
 , mock, pytest, pytestcov, pytest-flake8, tox, setuptools }:
 
 buildPythonPackage rec {
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "53ba3d884e98ff2062d5ada025aa590541dcd665b8f81067dc82dd61c0923759";
   };
 
-  propagatedBuildInputs = [ jsonschema pyyaml six setuptools ]
+  propagatedBuildInputs = [ jsonschema openapi-schema-validator pyyaml six setuptools ]
     ++ (lib.optionals (isPy27) [ pathlib ]);
 
   checkInputs = [ mock pytest pytestcov pytest-flake8 tox ];

--- a/pkgs/development/python-modules/rfc3339-validator/default.nix
+++ b/pkgs/development/python-modules/rfc3339-validator/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, hypothesis
+, six
+, strict-rfc3339
+}:
+
+buildPythonPackage rec {
+  pname = "rfc3339-validator";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    pname = "rfc3339_validator";
+    inherit version;
+    sha256 = "7a578aa0740e9ee2b48356fe1f347139190c4c72e27f303b3617054efd15df32";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytestCheckHook hypothesis strict-rfc3339 ];
+  pythonImportsCheck = [ "rfc3339_validator" ];
+
+  meta = with lib; {
+    description = "RFC 3339 validator for Python";
+    homepage = "https://github.com/naimetti/rfc3339-validator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AluisioASG ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4594,6 +4594,8 @@ in {
 
   openant = callPackage ../development/python-modules/openant { };
 
+  openapi-schema-validator = callPackage ../development/python-modules/openapi-schema-validator { };
+
   openapi-spec-validator = callPackage ../development/python-modules/openapi-spec-validator { };
 
   openbabel-bindings = callPackage ../development/python-modules/openbabel-bindings {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7020,6 +7020,8 @@ in {
 
   retworkx = callPackage ../development/python-modules/retworkx { };
 
+  rfc3339-validator = callPackage ../development/python-modules/rfc3339-validator { };
+
   rfc3986 = callPackage ../development/python-modules/rfc3986 { };
 
   rfc3987 = callPackage ../development/python-modules/rfc3987 { };


### PR DESCRIPTION
Add a new dependency introduced in 0.2.10 (or 0.3.0 since we updated straight to that).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Trying to unbreak #120447.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
