### PR TITLE
undistract-me: init at unstable-2020-08-09

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -114,6 +114,8 @@
   ./programs/autojump.nix
   ./programs/bandwhich.nix
   ./programs/bash/bash.nix
+  ./programs/bash/bash-completion.nix
+  ./programs/bash/ls-colors.nix
   ./programs/bash-my-aws.nix
   ./programs/bcc.nix
   ./programs/browserpass.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -116,6 +116,7 @@
   ./programs/bash/bash.nix
   ./programs/bash/bash-completion.nix
   ./programs/bash/ls-colors.nix
+  ./programs/bash/undistract-me.nix
   ./programs/bash-my-aws.nix
   ./programs/bcc.nix
   ./programs/browserpass.nix

--- a/nixos/modules/programs/bash/bash-completion.nix
+++ b/nixos/modules/programs/bash/bash-completion.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  enable = config.programs.bash.enableCompletion;
+in
+{
+  options = {
+    programs.bash.enableCompletion = mkEnableOption "Bash completion for all interactive bash shells" // {
+      default = true;
+    };
+  };
+
+  config = mkIf enable {
+    programs.bash.promptPluginInit = ''
+      # Check whether we're running a version of Bash that has support for
+      # programmable completion. If we do, enable all modules installed in
+      # the system and user profile in obsolete /etc/bash_completion.d/
+      # directories. Bash loads completions in all
+      # $XDG_DATA_DIRS/bash-completion/completions/
+      # on demand, so they do not need to be sourced here.
+      if shopt -q progcomp &>/dev/null; then
+        . "${pkgs.bash-completion}/etc/profile.d/bash_completion.sh"
+        nullglobStatus=$(shopt -p nullglob)
+        shopt -s nullglob
+        for p in $NIX_PROFILES; do
+          for m in "$p/etc/bash_completion.d/"*; do
+            . $m
+          done
+        done
+        eval "$nullglobStatus"
+        unset nullglobStatus p m
+      fi
+    '';
+  };
+}

--- a/nixos/modules/programs/bash/ls-colors.nix
+++ b/nixos/modules/programs/bash/ls-colors.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  enable = config.programs.bash.enableLsColors;
+in
+{
+  options = {
+    programs.bash.enableLsColors = mkEnableOption "extra colors in directory listings" // {
+      default = true;
+    };
+  };
+
+  config = mkIf enable {
+    programs.bash.promptPluginInit = ''
+      eval "$(${pkgs.coreutils}/bin/dircolors -b)"
+    '';
+  };
+}

--- a/nixos/modules/programs/bash/undistract-me.nix
+++ b/nixos/modules/programs/bash/undistract-me.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.bash.undistractMe;
+in
+{
+  options = {
+    programs.bash.undistractMe = {
+      enable = mkEnableOption "notifications when long-running terminal commands complete";
+
+      playSound = mkEnableOption "notification sounds when long-running terminal commands complete";
+
+      timeout = mkOption {
+        default = 10;
+        description = ''
+          Number of seconds it would take for a command to be considered long-running.
+        '';
+        type = types.int;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.bash.promptPluginInit = ''
+      export LONG_RUNNING_COMMAND_TIMEOUT=${toString cfg.timeout}
+      export UDM_PLAY_SOUND=${if cfg.playSound then "1" else "0"}
+      . "${pkgs.undistract-me}/etc/profile.d/undistract-me.sh"
+    '';
+  };
+
+  meta = {
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/shells/bash/undistract-me/default.nix
+++ b/pkgs/shells/bash/undistract-me/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, fetchpatch
+, coreutils
+, gnused
+, libnotify
+, pulseaudio
+, sound-theme-freedesktop
+, xprop
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "undistract-me";
+  version = "unstable-2020-08-09";
+
+  src = fetchFromGitHub {
+    owner = "jml";
+    repo = pname;
+    rev = "2f8ac25c6ad8efcf160d2b480825b1cbb6772aab";
+    hash = "sha256-Qw7Cu9q0ZgK/RTvyDdHM5N3eBaKjtYqYH0J+hKMUZX8=";
+  };
+
+  patches = [
+    # Don't block the terminal when notification sound is played
+    #
+    # See https://github.com/jml/undistract-me/pull/69
+    (fetchpatch {
+      url = "https://github.com/jml/undistract-me/commit/2356ebbe8bf2bcb4b95af1ae2bcdc786ce7cc6e8.patch";
+      sha256 = "sha256-Ij3OXTOnIQsYhKVmqjChhN1q4ASZ7waOkfQTTp5XfPo=";
+    })
+
+    # Fix showing notifications when using Wayland apps with XWayland
+    # running, or connection to X server fails.
+    #
+    # NOTE: Without a real X server, notifications will not be
+    # suppressed when the window running the command is focused.
+    #
+    # See https://github.com/jml/undistract-me/pull/71
+    (fetchpatch {
+      url = "https://github.com/jml/undistract-me/commit/3f4ceaf5a4eba8e3cb02236c48247f87e3d1124f.patch";
+      sha256 = "sha256-9AK9Jp3TXJ75Y+jwZXlwQ6j54FW1rOBddoktrm0VX68=";
+    })
+  ];
+
+  # Patch in dependencies. Can't use makeWrapper because the bash
+  # functions will be sourced and invoked in a different environment
+  # for each command invocation.
+  postPatch = ''
+    for script in *.bash *.sh; do
+      substituteInPlace "$script" \
+        --replace /usr/share/undistract-me "$out/share/undistract-me" \
+        --replace basename ${coreutils}/bin/basename \
+        --replace 'cut ' '${coreutils}/bin/cut ' \
+        --replace date ${coreutils}/bin/date \
+        --replace dirname ${coreutils}/bin/dirname \
+        --replace sed ${gnused}/bin/sed \
+        --replace notify-send ${libnotify}/bin/notify-send \
+        --replace paplay ${pulseaudio}/bin/paplay \
+        --replace /usr/share/sounds/freedesktop ${sound-theme-freedesktop}/share/sounds/freedesktop \
+        --replace xprop ${xprop}/bin/xprop
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/share/undistract-me" "$out/etc/profile.d" "$out/share/licenses/undistract-me"
+    cp long-running.bash "$out/share/undistract-me"
+    cp preexec.bash "$out/share/undistract-me"
+    cp undistract-me.sh "$out/etc/profile.d"
+    cp LICENSE "$out/share/licenses/undistract-me"
+  '';
+
+  meta = with lib; {
+    description = "Notifies you when long-running terminal commands complete";
+    homepage = "https://github.com/jml/undistract-me";
+    license = licenses.mit;
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9890,6 +9890,8 @@ in
 
   nix-bash-completions = callPackage ../shells/bash/nix-bash-completions { };
 
+  undistract-me = callPackage ../shells/bash/undistract-me { };
+
   dash = callPackage ../shells/dash { };
 
   dasht = callPackage ../tools/misc/dasht { };


### PR DESCRIPTION
###### Motivation for this change
Closes #119879

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, enabled with:
  ```
  programs.bash.undistract-me.enable = true;
  ```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).