### PR TITLE
eternal-terminal: 6.0.13 -> 6.1.7

### DIFF
--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -3,27 +3,38 @@
 , cmake
 , gflags
 , libsodium
+, openssl
 , protobuf
+, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "eternal-terminal";
-  version = "6.0.13";
+  version = "6.1.7";
 
   src = fetchFromGitHub {
     owner = "MisterTea";
     repo = "EternalTerminal";
     rev = "et-v${version}";
-    sha256 = "0sb1hypg2276y8c2a5vivrkcxp70swddvhnd9h273if3kv6j879r";
+    sha256 = "0jpm1ilr1qfz55y4mqp75v4q433qla5jhi1b8nsmx48srs7f0j2q";
   };
 
+  cmakeFlags= [
+    "-DDISABLE_VCPKG=TRUE"
+    "-DDISABLE_SENTRY=TRUE"
+    "-DDISABLE_CRASH_LOG=TRUE"
+  ];
+
+  CXXFLAGS = lib.optional stdenv.cc.isClang "-std=c++17";
+  LDFLAGS = lib.optional stdenv.cc.isClang "-lc++fs";
+
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ gflags libsodium protobuf ];
+  buildInputs = [ gflags openssl zlib libsodium protobuf ];
 
   meta = with lib; {
     description = "Remote shell that automatically reconnects without interrupting the session";
     license = licenses.asl20;
-    homepage = "https://mistertea.github.io/EternalTerminal/";
+    homepage = "https://eternalterminal.dev/";
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ dezgeg pingiun ];
   };


### PR DESCRIPTION
###### Motivation for this change

Time for an update!
I honestly don't know what "-DDISABLE_VCPKG=TRUE -DDISABLE_SENTRY=TRUE -DDISABLE_CRASH_LOG=TRUE" do, I just know that it keeps the dependencies in check and allows it to compile. I saw them over in the fedora rawhide build changelogs: https://src.fedoraproject.org/rpms/et/commits/rawhide

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
