### PR TITLE
python3Packages.pynndescent: 0.5.1 -> 0.5.2; python3Packages.umap-learn: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -1,12 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, scikitlearn
-, numpy
-, matplotlib
-, scipy
+, deprecated
 , hopcroftkarp
-, pytest
+, joblib
+, matplotlib
+, numpy
+, scikitlearn
+, scipy
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,26 +21,24 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    scikitlearn
-    numpy
-    matplotlib
-    scipy
+    deprecated
     hopcroftkarp
+    joblib
+    matplotlib
+    numpy
+    scikitlearn
+    scipy
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
   ];
 
-  checkPhase = ''
+  preCheck = ''
     # specifically needed for darwin
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.matplotlib
     echo "backend: ps" > $HOME/.matplotlib/matplotlibrc
-
-    # ignore tests due to python 2.7 fail
-    pytest --ignore test/test_plots.py \
-           --ignore test/test_visuals.py
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pynndescent/default.nix
+++ b/pkgs/development/python-modules/pynndescent/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , nose
 , scikitlearn
 , scipy
@@ -12,24 +11,12 @@
 
 buildPythonPackage rec {
   pname = "pynndescent";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "74a05a54d13573a38878781d44812ac6df97d8762a56f9bb5dd87a99911820fe";
+    sha256 = "0w87c2v0li2rdbx6qfc2lb6y6bxpdy3jwfgzfs1kcr4d1chj5zfr";
   };
-
-  patches = [
-    # fixes tests, included in 0.5.2
-    (fetchpatch {
-      url = "https://github.com/lmcinnes/pynndescent/commit/ef5d8c3c3bfe976063b6621e3e0734c0c22d813b.patch";
-      sha256 = "sha256-49n3kevs3wpzd4FfZVKmNpF2o1V8pJs4KOx8zCAhR3s=";
-    })
-  ];
-
-  checkInputs = [
-    nose
-  ];
 
   propagatedBuildInputs = [
     scikitlearn
@@ -37,6 +24,10 @@ buildPythonPackage rec {
     numba
     llvmlite
     joblib
+  ];
+
+  checkInputs = [
+    nose
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/umap-learn/default.nix
+++ b/pkgs/development/python-modules/umap-learn/default.nix
@@ -13,20 +13,14 @@
 
 buildPythonPackage rec {
   pname = "umap-learn";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "lmcinnes";
     repo = "umap";
     rev = version;
-    sha256 = "sha256-2Z5RDi4bz8hh8zMwkcCQY9NrGaVd1DJEBOmrCl2oSvM=";
+    sha256 = "0favphngcz5jvyqs06x07hk552lvl9qx3vka8r4x0xmv88gsg349";
   };
-
-  checkInputs = [
-    nose
-    tensorflow
-    pytestCheckHook
-  ];
 
   propagatedBuildInputs = [
     numpy
@@ -34,6 +28,12 @@ buildPythonPackage rec {
     scipy
     numba
     pynndescent
+  ];
+
+  checkInputs = [
+    nose
+    tensorflow
+    pytestCheckHook
   ];
 
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes the tests after a recent numba update.

https://github.com/lmcinnes/pynndescent/releases/tag/0.5.2

Unblocks tts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
