### PR TITLE
pipewire: 0.3.25 -> 0.3.26

### DIFF
--- a/nixos/modules/services/desktops/pipewire/README.md
+++ b/nixos/modules/services/desktops/pipewire/README.md
@@ -1,6 +1,0 @@
-# Updating
-
-1. Update the version & hash in pkgs/development/libraries/pipewire/default.nix
-2. run `nix build -f /path/to/nixpkgs/checkout pipewire pipewire.mediaSession`
-3. copy all JSON files from result/etc/pipewire and result-mediaSession/etc/pipewire/media-session.d to this directory
-4. add new files to the module config and passthru tests

--- a/nixos/modules/services/desktops/pipewire/bluez-monitor.conf.json
+++ b/nixos/modules/services/desktops/pipewire/bluez-monitor.conf.json
@@ -9,7 +9,7 @@
       ],
       "actions": {
         "update-props": {
-          "bluez5.reconnect-profiles": [
+          "bluez5.auto-connect": [
             "hfp_hf",
             "hsp_hs",
             "a2dp_sink"

--- a/nixos/modules/services/desktops/pipewire/media-session.conf.json
+++ b/nixos/modules/services/desktops/pipewire/media-session.conf.json
@@ -59,6 +59,7 @@
     "with-pulseaudio": [
       "with-audio",
       "bluez5",
+      "logind",
       "restore-stream",
       "streams-follow-default"
     ]

--- a/nixos/modules/services/desktops/pipewire/pipewire-pulse.conf.json
+++ b/nixos/modules/services/desktops/pipewire/pipewire-pulse.conf.json
@@ -30,7 +30,10 @@
       "args": {
         "server.address": [
           "unix:native"
-        ]
+        ],
+        "vm.overrides": {
+          "pulse.min.quantum": "1024/48000"
+        }
       }
     }
   ],

--- a/nixos/modules/services/desktops/pipewire/pipewire.conf.json
+++ b/nixos/modules/services/desktops/pipewire/pipewire.conf.json
@@ -2,7 +2,10 @@
   "context.properties": {
     "link.max-buffers": 16,
     "core.daemon": true,
-    "core.name": "pipewire-0"
+    "core.name": "pipewire-0",
+    "vm.overrides": {
+      "default.clock.min-quantum": 1024
+    }
   },
   "context.spa-libs": {
     "audio.convert.*": "audioconvert/libspa-audioconvert",

--- a/nixos/tests/installed-tests/pipewire.nix
+++ b/nixos/tests/installed-tests/pipewire.nix
@@ -2,4 +2,14 @@
 
 makeInstalledTest {
   tested = pkgs.pipewire;
+  testConfig = {
+    hardware.pulseaudio.enable = false;
+    services.pipewire = {
+      enable = true;
+      pulse.enable = true;
+      jack.enable = true;
+      alsa.enable = true;
+      alsa.support32Bit = true;
+    };
+  };
 }

--- a/pkgs/development/libraries/pipewire/0040-alsa-profiles-use-libdir.patch
+++ b/pkgs/development/libraries/pipewire/0040-alsa-profiles-use-libdir.patch
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index ffee41b4..f3e4ec74 100644
+index 99a4b2d1..d4a4cda7 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -53,7 +53,7 @@ endif
+@@ -55,7 +55,7 @@ endif
  
- spa_plugindir = join_paths(pipewire_libdir, spa_name)
+ spa_plugindir = pipewire_libdir / spa_name
  
--alsadatadir = join_paths(pipewire_datadir, 'alsa-card-profile', 'mixer')
-+alsadatadir = join_paths(pipewire_libdir, '..', 'share', 'alsa-card-profile', 'mixer')
+-alsadatadir = pipewire_datadir / 'alsa-card-profile' / 'mixer'
++alsadatadir = pipewire_libdir / '..' / 'share' / 'alsa-card-profile' / 'mixer'
  
- pipewire_headers_dir = join_paths(pipewire_name, 'pipewire')
+ pipewire_headers_dir = pipewire_name / 'pipewire'
  

--- a/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
@@ -1,8 +1,8 @@
 diff --git a/meson_options.txt b/meson_options.txt
-index ce364d93..a6c8af72 100644
+index 66791f3a..93b5e2a9 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -152,6 +152,9 @@ option('udev',
+@@ -172,6 +172,9 @@ option('udev',
  option('udevrulesdir',
         type : 'string',
         description : 'Directory for udev rules (defaults to /lib/udev/rules.d)')
@@ -13,15 +13,15 @@ index ce364d93..a6c8af72 100644
         type : 'string',
         description : 'Directory for user systemd units (defaults to /usr/lib/systemd/user)')
 diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
-index 0a5e5042..4a70b0b0 100644
+index aa30a86f..1edebb2d 100644
 --- a/src/daemon/systemd/user/meson.build
 +++ b/src/daemon/systemd/user/meson.build
 @@ -9,7 +9,7 @@ install_data(
  
  systemd_config = configuration_data()
- systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))
--systemd_config.set('PW_PULSE_BINARY', join_paths(pipewire_bindir, 'pipewire-pulse'))
-+systemd_config.set('PW_PULSE_BINARY', join_paths(get_option('pipewire_pulse_prefix'), 'bin/pipewire-pulse'))
- systemd_config.set('PW_MEDIA_SESSION_BINARY', join_paths(pipewire_bindir, 'pipewire-media-session'))
+ systemd_config.set('PW_BINARY', pipewire_bindir / 'pipewire')
+-systemd_config.set('PW_PULSE_BINARY', pipewire_bindir / 'pipewire-pulse')
++systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin/pipewire-pulse')
+ systemd_config.set('PW_MEDIA_SESSION_BINARY', pipewire_bindir / 'pipewire-media-session')
  
  configure_file(input : 'pipewire.service.in',

--- a/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
+++ b/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
@@ -1,8 +1,8 @@
 diff --git a/meson_options.txt b/meson_options.txt
-index e2a1e028..310029f2 100644
+index 93b5e2a9..1b915ac3 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -10,6 +10,9 @@ option('media-session',
+@@ -13,6 +13,9 @@ option('media-session',
         description: 'Build and install pipewire-media-session',
         type: 'feature',
         value: 'auto')
@@ -13,15 +13,15 @@ index e2a1e028..310029f2 100644
         description: 'Build manpages',
         type: 'feature',
 diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
-index 5c4d1af0..7296220f 100644
+index 1edebb2d..251270eb 100644
 --- a/src/daemon/systemd/user/meson.build
 +++ b/src/daemon/systemd/user/meson.build
 @@ -10,7 +10,7 @@ install_data(
  systemd_config = configuration_data()
- systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))
- systemd_config.set('PW_PULSE_BINARY', join_paths(get_option('pipewire_pulse_prefix'), 'bin/pipewire-pulse'))
--systemd_config.set('PW_MEDIA_SESSION_BINARY', join_paths(pipewire_bindir, 'pipewire-media-session'))
-+systemd_config.set('PW_MEDIA_SESSION_BINARY', join_paths(get_option('media-session-prefix'), 'bin/pipewire-media-session'))
-
+ systemd_config.set('PW_BINARY', pipewire_bindir / 'pipewire')
+ systemd_config.set('PW_PULSE_BINARY', get_option('pipewire_pulse_prefix') / 'bin/pipewire-pulse')
+-systemd_config.set('PW_MEDIA_SESSION_BINARY', pipewire_bindir / 'pipewire-media-session')
++systemd_config.set('PW_MEDIA_SESSION_BINARY', get_option('media-session-prefix') / 'bin/pipewire-media-session')
+ 
  configure_file(input : 'pipewire.service.in',
                 output : 'pipewire.service',

--- a/pkgs/development/libraries/pipewire/0070-installed-tests-path.patch
+++ b/pkgs/development/libraries/pipewire/0070-installed-tests-path.patch
@@ -1,23 +1,23 @@
 diff --git a/meson.build b/meson.build
-index 97d4d939..b17358e5 100644
+index d4a4cda7..a27569bd 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -353,8 +353,8 @@ libinotify_dep = (build_machine.system() == 'freebsd'
-
+ 
  alsa_dep = dependency('alsa', version : '>=1.1.7', required: get_option('pipewire-alsa'))
-
--installed_tests_metadir = join_paths(pipewire_datadir, 'installed-tests', pipewire_name)
--installed_tests_execdir = join_paths(pipewire_libexecdir, 'installed-tests', pipewire_name)
-+installed_tests_metadir = join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', pipewire_name)
-+installed_tests_execdir = join_paths(get_option('installed_test_prefix'), 'libexec', 'installed-tests', pipewire_name)
+ 
+-installed_tests_metadir = pipewire_datadir / 'installed-tests' / pipewire_name
+-installed_tests_execdir = pipewire_libexecdir / 'installed-tests' / pipewire_name
++installed_tests_metadir = get_option('installed_test_prefix') / 'share' / 'installed-tests' / pipewire_name
++installed_tests_execdir = get_option('installed_test_prefix') / 'libexec' / 'installed-tests' / pipewire_name
  installed_tests_enabled = not get_option('installed_tests').disabled()
  installed_tests_template = files('template.test.in')
-
+ 
 diff --git a/meson_options.txt b/meson_options.txt
-index fba0d647..8c6106cd 100644
+index 1b915ac3..85beb86a 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -26,6 +26,9 @@ option('installed_tests',
+@@ -29,6 +29,9 @@ option('installed_tests',
         description: 'Install manual and automated test executables',
         type: 'feature',
         value: 'disabled')

--- a/pkgs/development/libraries/pipewire/0080-pipewire-config-dir.patch
+++ b/pkgs/development/libraries/pipewire/0080-pipewire-config-dir.patch
@@ -1,30 +1,30 @@
 diff --git a/meson.build b/meson.build
-index 0073eb13..0ffc6863 100644
+index a27569bd..fcf18344 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -34,7 +34,10 @@ pipewire_libexecdir = join_paths(prefix, get_option('libexecdir'))
- pipewire_localedir = join_paths(prefix, get_option('localedir'))
- pipewire_sysconfdir = join_paths(prefix, get_option('sysconfdir'))
+@@ -36,7 +36,10 @@ pipewire_libexecdir = prefix / get_option('libexecdir')
+ pipewire_localedir = prefix / get_option('localedir')
+ pipewire_sysconfdir = prefix / get_option('sysconfdir')
  
--pipewire_configdir = join_paths(pipewire_sysconfdir, 'pipewire')
+-pipewire_configdir = pipewire_sysconfdir / 'pipewire'
 +pipewire_configdir = get_option('pipewire_config_dir')
 +if pipewire_configdir == ''
-+  pipewire_configdir = join_paths(pipewire_sysconfdir, 'pipewire')
++  pipewire_configdir = pipewire_sysconfdir / 'pipewire'
 +endif
- modules_install_dir = join_paths(pipewire_libdir, pipewire_name)
+ modules_install_dir = pipewire_libdir / pipewire_name
  
  if host_machine.system() == 'linux'
 diff --git a/meson_options.txt b/meson_options.txt
-index 4b9e46b8..8c301459 100644
+index 85beb86a..372e8faa 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -56,6 +56,9 @@ option('pipewire-pulseaudio',
- option('libpulse-path',
-        description: 'Where to install the libpulse.so library',
+@@ -67,6 +67,9 @@ option('jack-devel',
+ option('libjack-path',
+        description: 'Where to install the libjack.so library',
         type: 'string')
 +option('pipewire_config_dir',
 +       type : 'string',
 +       description : 'Directory for pipewire configuration (defaults to /etc/pipewire)')
  option('spa-plugins',
         description: 'Enable spa plugins integration',
-        type: 'boolean',
+        type: 'feature',

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -42,7 +42,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.25";
+    version = "0.3.26";
 
     outputs = [
       "out"
@@ -60,7 +60,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      hash = "sha256:EbXWcf6QLtbvm6/eXBI+PF2sTw2opYfmc+H/SMDEH1U=";
+      hash = "sha256:1rqi1sa937lp89ai79b5n7m0p66pigpj4w1mr2vq4dycfp8vppxk";
     };
 
     patches = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -60,7 +60,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      hash = "sha256:1rqi1sa937lp89ai79b5n7m0p66pigpj4w1mr2vq4dycfp8vppxk";
+      sha256 = "sha256-s9+70XXMN4K3yDVwIu+L15gL6rFlpRNVQpeekZQOEec=";
     };
 
     patches = [
@@ -146,29 +146,31 @@ let
       moveToOutput "bin/pipewire-pulse" "$pulse"
     '';
 
-    passthru.tests = {
-      installedTests = nixosTests.installed-tests.pipewire;
+    passthru = {
+      updateScript = ./update.sh;
+      tests = {
+        installedTests = nixosTests.installed-tests.pipewire;
 
-      # This ensures that all the paths used by the NixOS module are found.
-      test-paths = callPackage ./test-paths.nix {
-        paths-out = [
-          "share/alsa/alsa.conf.d/50-pipewire.conf"
-          "nix-support/etc/pipewire/client.conf.json"
-          "nix-support/etc/pipewire/client-rt.conf.json"
-          "nix-support/etc/pipewire/jack.conf.json"
-          "nix-support/etc/pipewire/pipewire.conf.json"
-          "nix-support/etc/pipewire/pipewire-pulse.conf.json"
-        ];
-        paths-out-media-session = [
-          "nix-support/etc/pipewire/media-session.d/alsa-monitor.conf.json"
-          "nix-support/etc/pipewire/media-session.d/bluez-monitor.conf.json"
-          "nix-support/etc/pipewire/media-session.d/media-session.conf.json"
-          "nix-support/etc/pipewire/media-session.d/v4l2-monitor.conf.json"
-        ];
-        paths-lib = [
-          "lib/alsa-lib/libasound_module_pcm_pipewire.so"
-          "share/alsa-card-profile/mixer"
-        ];
+        # This ensures that all the paths used by the NixOS module are found.
+        test-paths = callPackage ./test-paths.nix {
+          paths-out = [
+            "share/alsa/alsa.conf.d/50-pipewire.conf"
+            "nix-support/etc/pipewire/client.conf.json"
+            "nix-support/etc/pipewire/jack.conf.json"
+            "nix-support/etc/pipewire/pipewire.conf.json"
+            "nix-support/etc/pipewire/pipewire-pulse.conf.json"
+          ];
+          paths-out-media-session = [
+            "nix-support/etc/pipewire/media-session.d/alsa-monitor.conf.json"
+            "nix-support/etc/pipewire/media-session.d/bluez-monitor.conf.json"
+            "nix-support/etc/pipewire/media-session.d/media-session.conf.json"
+            "nix-support/etc/pipewire/media-session.d/v4l2-monitor.conf.json"
+          ];
+          paths-lib = [
+            "lib/alsa-lib/libasound_module_pcm_pipewire.so"
+            "share/alsa-card-profile/mixer"
+          ];
+        };
       };
     };
 

--- a/pkgs/development/libraries/pipewire/test-paths.nix
+++ b/pkgs/development/libraries/pipewire/test-paths.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, pipewire, paths-out, paths-lib }:
+{ lib, runCommand, pipewire, paths-out, paths-lib, paths-out-media-session }:
 
 let
   check-path = output: path: ''

--- a/pkgs/development/libraries/pipewire/update.sh
+++ b/pkgs/development/libraries/pipewire/update.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p nix-update -i bash
+# shellcheck shell=bash
+
+set -o errexit -o pipefail -o nounset -o errtrace
+shopt -s inherit_errexit
+shopt -s nullglob
+IFS=$'\n'
+
+NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
+
+cd "$NIXPKGS_ROOT"
+nix-update pipewire
+outputs=$(nix-build . -A pipewire -A pipewire.mediaSession)
+for p in $outputs; do
+    conf_files=$(find "$p/nix-support/etc/pipewire/" -name '*.conf.json')
+    for c in $conf_files; do
+        file_name=$(basename "$c")
+        if [[ ! -e "nixos/modules/services/desktops/pipewire/$file_name" ]]; then
+            echo "New file $file_name found! Add it to the module config and passthru tests!"
+        fi
+        install -m 0644 "$c" "nixos/modules/services/desktops/pipewire/"
+    done
+done


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Update `pipewire` to the latest version. See the [changelog](https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/f0fc4f7fc644c29762fa34e57e60d4b5cbcefb47/NEWS) for details.
- Fix the tests
- Add an update script

###### Things done
- Tested manually
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
