### PR TITLE
soldat-unstable: unstable-2021-02-09 -> unstable-2021-04-27

### DIFF
--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, fpc, zip, makeWrapper
+{ lib, stdenv, fetchFromGitHub, fpc, zip, makeWrapper
 , SDL2, freetype, physfs, openal, gamenetworkingsockets
 , xorg, autoPatchelfHook
 }:
@@ -39,29 +39,20 @@ in
 
 stdenv.mkDerivation rec {
   pname = "soldat";
-  version = "unstable-2021-02-09";
+  version = "unstable-2021-04-27";
 
   src = fetchFromGitHub {
     name = "soldat";
     owner = "Soldat";
     repo = "soldat";
-    rev = "c304c3912ca7a88461970a859049d217a44c6375";
-    sha256 = "09sl2zybfcmnl2n3qghp0gylmr71y01534l6nq0y9llbdy0bf306";
+    rev = "4d17667c316ff08934e97448b7f290a8dc434e81";
+    sha256 = "1pf557psmhfaagblfwdn36cw80j7bgs0lgjq8hmjbv58dysw3jdb";
   };
 
   nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook ];
 
   buildInputs = [ SDL2 freetype physfs openal gamenetworkingsockets ];
   runtimeDependencies = [ xorg.libX11 ];
-
-  patches = [
-    # fix an argument parsing issue which prevents
-    # us from passing nix store paths to soldat
-    (fetchpatch {
-      url = "https://github.com/sternenseemann/soldat/commit/9f7687430f5fe142c563b877d2206f5c9bbd5ca0.patch";
-      sha256 = "0wsrazb36i7v4idg06jlzfhqwf56q9szzz7jp5cg4wsvcky3wajf";
-    })
-  ];
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
