### PR TITLE
pythonModules.Nuitka: 0.6.8.4 -> 0.6.14.5

### DIFF
--- a/pkgs/development/python-modules/nuitka/default.nix
+++ b/pkgs/development/python-modules/nuitka/default.nix
@@ -1,28 +1,29 @@
 { lib, stdenv
 , buildPythonPackage
-, fetchurl
+, fetchFromGitHub
 , vmprof
 , pyqt4
 , isPyPy
 , pkgs
+, scons
+, chrpath
 }:
 
-let
-  # scons is needed but using it requires Python 2.7
-  # Therefore we create a separate env for it.
-  scons = pkgs.python27.withPackages(ps: [ pkgs.scons ]);
-in buildPythonPackage rec {
-  version = "0.6.8.4";
+buildPythonPackage rec {
+  version = "0.6.14.5";
   pname = "Nuitka";
 
   # Latest version is not yet on PyPi
-  src = fetchurl {
-    url = "https://github.com/kayhayen/Nuitka/archive/${version}.tar.gz";
-    sha256 = "0awhwksnmqmbciimqmd11wygp7bnq57khcg4n9r4ld53s147rmqm";
+  src = fetchFromGitHub {
+    owner = "kayhayen";
+    repo = "Nuitka";
+    rev = version;
+    sha256 = "08kcp22zdgp25kk4bp56z196mn6bdi3z4x0q2y9vyz0ywfzp9zap";
   };
 
   checkInputs = [ vmprof pyqt4 ];
   nativeBuildInputs = [ scons ];
+  propagatedBuildInputs = [ chrpath ];
 
   postPatch = ''
     patchShebangs tests/run-tests


### PR DESCRIPTION
+ add runtime dep on chrpath
+ use system SConS instead of old Python2 version

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Newer version has support for `--onefile` option, performance improvements, see https://github.com/Nuitka/Nuitka/blob/0.6.14.5/Changelog.rst
Drop dependency on Python2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
