### PR TITLE
python3Packages.PyGithub: 1.54.1 -> 1.55

### DIFF
--- a/pkgs/development/python-modules/pyGithub/default.nix
+++ b/pkgs/development/python-modules/pyGithub/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "PyGithub";
-  version = "1.54.1";
+  version = "1.55";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "PyGithub";
     repo = "PyGithub";
     rev = "v${version}";
-    sha256 = "1nl74bp5ikdnrc8xq0qr25ryl1mvarf0xi43k8w5jzlrllhq0nkq";
+    sha256 = "sha256-PuGCBFSbM91NtSzuyf0EQUr3LiuHDq90OwkSf53rSyA=";
   };
 
   checkInputs = [ httpretty parameterized pytestCheckHook ];

--- a/pkgs/development/python-modules/pyGithub/default.nix
+++ b/pkgs/development/python-modules/pyGithub/default.nix
@@ -3,17 +3,16 @@
 , cryptography
 , deprecated
 , fetchFromGitHub
-, httpretty
-, isPy3k
-, parameterized
+, pynacl
 , pyjwt
-, pytestCheckHook
-, requests }:
+, pythonOlder
+, requests
+}:
 
 buildPythonPackage rec {
   pname = "PyGithub";
   version = "1.55";
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "PyGithub";
@@ -22,17 +21,23 @@ buildPythonPackage rec {
     sha256 = "sha256-PuGCBFSbM91NtSzuyf0EQUr3LiuHDq90OwkSf53rSyA=";
   };
 
-  checkInputs = [ httpretty parameterized pytestCheckHook ];
-  propagatedBuildInputs = [ cryptography deprecated pyjwt requests ];
+  propagatedBuildInputs = [
+    cryptography
+    deprecated
+    pynacl
+    pyjwt
+    requests
+  ];
 
   # Test suite makes REST calls against github.com
   doCheck = false;
+  pythonImportsCheck = [ "github" ];
 
   meta = with lib; {
+    description = "Python library to access the GitHub API v3";
     homepage = "https://github.com/PyGithub/PyGithub";
-    description = "A Python (2 and 3) library to access the GitHub API v3";
     platforms = platforms.all;
-    license = licenses.gpl3;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ jhhuh ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.55

Change log: https://github.com/PyGithub/PyGithub/releases/tag/v1.55

For #120804 to get `criticality-score` to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
