### PR TITLE
ffmpeg-normalize: 1.19.0 -> 1.22.1

### DIFF
--- a/pkgs/applications/video/ffmpeg-normalize/default.nix
+++ b/pkgs/applications/video/ffmpeg-normalize/default.nix
@@ -1,20 +1,20 @@
 { lib
 , buildPythonApplication
 , fetchPypi
-, ffmpeg_3
-, tqdm
+, ffmpeg
+, ffmpeg-progress-yield
 }:
 
 buildPythonApplication rec {
   pname = "ffmpeg-normalize";
-  version = "1.19.0";
+  version = "1.22.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "18dpck9grnr3wgbjvdh4mjlx0zfwcxpy4rnpmc39in0yk3w7li2x";
+    sha256 = "df826053212d540ab1bbe9819587fcbf36162f8c2535ae85b88b252e47d6d632";
   };
 
-  propagatedBuildInputs = [ ffmpeg_3 tqdm ];
+  propagatedBuildInputs = [ ffmpeg ffmpeg-progress-yield ];
 
   checkPhase = ''
     $out/bin/ffmpeg-normalize --help > /dev/null

--- a/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, colorama
+, tqdm
+, pytestCheckHook
+, ffmpeg
+}:
+
+buildPythonPackage rec {
+  pname = "ffmpeg-progress-yield";
+  version = "0.0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e944093e2c1b213da8fa4f0c276c1bad44e0b8ba8be7e4fd001f5132d16baef5";
+  };
+
+  propagatedBuildInputs = [ colorama tqdm ];
+
+  checkInputs = [ pytestCheckHook ffmpeg ];
+
+  pytestFlagsArray = [ "test/test.py" ];
+
+  pythonImportsCheck = [ "ffmpeg_progress_yield" ];
+
+  meta = with lib; {
+    description = "Run an ffmpeg command with progress";
+    homepage = "https://github.com/slhck/ffmpeg-progress-yield";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2323,6 +2323,8 @@ in {
 
   ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
 
+  ffmpeg-progress-yield = callPackage ../development/python-modules/ffmpeg-progress-yield { };
+
   fido2 = callPackage ../development/python-modules/fido2 { };
 
   filebrowser_safe = callPackage ../development/python-modules/filebrowser_safe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


- version update ffmpeg-normalize: 1.19.0 -> 1.22.1
- move from ffmpeg_3 to ffmpeg (part of https://github.com/NixOS/nixpkgs/issues/120705)
- introduce ffmpeg-progress-yield dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
