### PR TITLE
phpPackages.composer: 2.0.12 -> 2.0.13, 1.10.15 -> 1.10.22

### DIFF
--- a/pkgs/development/php-packages/composer/1.x.nix
+++ b/pkgs/development/php-packages/composer/1.x.nix
@@ -1,14 +1,14 @@
 { mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
 let
   pname = "composer";
-  version = "1.10.15";
+  version = "1.10.22";
 in
 mkDerivation {
   inherit pname version;
 
   src = fetchurl {
     url = "https://getcomposer.org/download/${version}/composer.phar";
-    sha256 = "1shsxsrc2kq74s1jbq3njn9wzidcz7ak66n9vyz8z8d0hqpg37d6";
+    sha256 = "00073smi1jja00d4bqfs6p4fqs38mki2ziy7b1kwsmiv5lcsw9v1";
   };
 
   dontUnpack = true;
@@ -16,11 +16,13 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/composer/composer.phar
     makeWrapper ${php}/bin/php $out/bin/composer \
       --add-flags "$out/libexec/composer/composer.phar" \
       --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -1,14 +1,14 @@
 { mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
 let
   pname = "composer";
-  version = "2.0.12";
+  version = "2.0.13";
 in
 mkDerivation {
   inherit pname version;
 
   src = fetchurl {
     url = "https://getcomposer.org/download/${version}/composer.phar";
-    sha256 = "sha256-guqMFTfPrOt+VvYATHzN+Z3a/OcjfAc3TZIOY1cwpjE=";
+    sha256 = "sha256-EW/fB8ySavZGY1pqvJLYiv97AqXcNlOPgcUKfSc2bb8=";
   };
 
   dontUnpack = true;
@@ -16,11 +16,13 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/composer/composer.phar
     makeWrapper ${php}/bin/php $out/bin/composer \
       --add-flags "$out/libexec/composer/composer.phar" \
       --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
 
A security issue has been identified: https://blog.packagist.com/composer-command-injection-vulnerability/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>bookstack</li>
    <li>php73Packages.composer</li>
    <li>php73Packages.composer1</li>
    <li>php73Packages.php-parallel-lint</li>
    <li>php74Packages.composer</li>
    <li>php74Packages.composer1</li>
    <li>php74Packages.php-parallel-lint</li>
    <li>php80Packages.composer</li>
    <li>php80Packages.composer1</li>
    <li>php80Packages.php-parallel-lint</li>
  </ul>
</details>
