### PR TITLE
python2 and python3: build unoptimized bytecode again

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -27,9 +27,9 @@
 , sha256
 , passthruFun
 , static ? false
-, stripBytecode ? reproducibleBuild
+, stripBytecode ? true
 , rebuildBytecode ? true
-, reproducibleBuild ? true
+, reproducibleBuild ? false
 , enableOptimizations ? false
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:
@@ -48,6 +48,8 @@ assert lib.assertMsg (reproducibleBuild -> stripBytecode)
 assert lib.assertMsg (reproducibleBuild -> (!enableOptimizations))
   "Deterministic builds are not achieved when optimizations are enabled.";
 
+assert lib.assertMsg (reproducibleBuild -> (!rebuildBytecode))
+  "Deterministic builds are not achieved when (default unoptimized) bytecode is created.";
 
 with lib;
 
@@ -296,8 +298,10 @@ in with passthru; stdenv.mkDerivation ({
         # First we delete all old bytecode.
         find $out -name "*.pyc" -delete
         '' + optionalString rebuildBytecode ''
-        # Then, we build for the two optimization levels.
-        # We do not build unoptimized bytecode, because its not entirely deterministic yet.
+        # We build 3 levels of optimized bytecode. Note the default level, without optimizations,
+        # is not reproducible yet. https://bugs.python.org/issue29708
+        # Not creating bytecode will result in a large performance loss however, so we do build it.
+        find $out -name "*.py" | ${pythonForBuildInterpreter} -m compileall -q -f -x "lib2to3" -i -
         find $out -name "*.py" | ${pythonForBuildInterpreter} -O  -m compileall -q -f -x "lib2to3" -i -
         find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
       '' + optionalString stdenv.hostPlatform.isCygwin ''

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -35,7 +35,7 @@
 , stripTests ? false
 , stripTkinter ? false
 , rebuildBytecode ? true
-, stripBytecode ? reproducibleBuild
+, stripBytecode ? true
 , includeSiteCustomize ? true
 , static ? stdenv.hostPlatform.isStatic
 , enableOptimizations ? false
@@ -46,7 +46,7 @@
 # enabling LTO on 32bit arch causes downstream packages to fail when linking
 # enabling LTO on *-darwin causes python3 to fail when linking.
 , enableLTO ? stdenv.is64bit && stdenv.isLinux
-, reproducibleBuild ? true
+, reproducibleBuild ? false
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:
 
@@ -72,6 +72,9 @@ assert lib.assertMsg (reproducibleBuild -> stripBytecode)
 
 assert lib.assertMsg (reproducibleBuild -> (!enableOptimizations))
   "Deterministic builds are not achieved when optimizations are enabled.";
+
+assert lib.assertMsg (reproducibleBuild -> (!rebuildBytecode))
+  "Deterministic builds are not achieved when (default unoptimized) bytecode is created.";
 
 with lib;
 
@@ -422,11 +425,14 @@ in with passthru; stdenv.mkDerivation {
     # First we delete all old bytecode.
     find $out -type d -name __pycache__ -print0 | xargs -0 -I {} rm -rf "{}"
     '' + optionalString rebuildBytecode ''
-    # Then, we build for the two optimization levels.
-    # We do not build unoptimized bytecode, because its not entirely deterministic yet.
     # Python 3.7 implements PEP 552, introducing support for deterministic bytecode.
-    # compileall uses this checked-hash method by default when `SOURCE_DATE_EPOCH` is set.
+    # compileall uses the therein introduced checked-hash method by default when
+    # `SOURCE_DATE_EPOCH` is set.
     # We exclude lib2to3 because that's Python 2 code which fails
+    # We build 3 levels of optimized bytecode. Note the default level, without optimizations,
+    # is not reproducible yet. https://bugs.python.org/issue29708
+    # Not creating bytecode will result in a large performance loss however, so we do build it.
+    find $out -name "*.py" | ${pythonForBuildInterpreter} -m compileall -q -f -x "lib2to3" -i -
     find $out -name "*.py" | ${pythonForBuildInterpreter} -O  -m compileall -q -f -x "lib2to3" -i -
     find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
   '';


### PR DESCRIPTION
In 9d03ff52229f36ff4b4e9d0ee2db4a46b90512bb I made the CPython builds reproducible. This required not generating default unoptimized bytecode. I was under the impression the optimized bytecode would be used then, but you need to opt-in on that. Not having the default bytecode resulted in a significant performance hit. Therefore, bytecode is generated again in this commit, and thereby the builds are no longer reproducible.

https://bugs.python.org/issue29708
https://bugs.python.org/issue37596
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
