### PR TITLE
fastd: fix build on aarch64

### DIFF
--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -1,5 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, bison, meson, ninja, pkg-config
-, libuecc, libsodium, libcap, json_c, openssl }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, bison
+, meson
+, ninja
+, pkg-config
+, libuecc
+, libsodium
+, libcap
+, json_c
+, openssl
+}:
 
 stdenv.mkDerivation rec {
   pname = "fastd";
@@ -12,8 +23,27 @@ stdenv.mkDerivation rec {
     sha256 = "1p4k50dk8byrghbr0fwmgwps8df6rlkgcd603r14i71m5g27z5gw";
   };
 
-  nativeBuildInputs = [ pkg-config bison meson ninja ];
-  buildInputs = [ libuecc libsodium libcap json_c openssl ];
+  nativeBuildInputs = [
+    bison
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    json_c
+    libcap
+    libsodium
+    libuecc
+    openssl
+  ];
+
+  # some options are only available on x86
+  mesonFlags = lib.optionals (!stdenv.isx86_64 && !stdenv.isi686) [
+    "-Dcipher_salsa20_xmm=disabled"
+    "-Dcipher_salsa2012_xmm=disabled"
+    "-Dmac_ghash_pclmulqdq=disabled"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nix-cache.s3.amazonaws.com/log/8n7ap217w110lzh4wa82m0i89b9vzcsz-fastd-21.drv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
