### PR TITLE
[20.09] strace: 5.8 -> 5.12

### DIFF
--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -6,11 +6,11 @@ assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
   pname = "strace";
-  version = "5.11";
+  version = "5.12";
 
   src = fetchurl {
     url = "https://strace.io/files/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-/+NAsQwUWg+Fc0Jx6czlZFfSPyGn6lkxqzL4z055OHk=";
+    sha256 = "sha256-KRce350lL4nJiKTDQN/exmL0WMuMY9hUMdZLq1kR58Q=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "strace";
-  version = "5.8";
+  version = "5.9";
 
   src = fetchurl {
     url = "https://strace.io/files/${version}/${pname}-${version}.tar.xz";
-    sha256 = "1abs3svkg9985f4jrxx34sj1dcpsf95vv1a0g01c777zgygncjnz";
+    sha256 = "1nb6bm6ll6cxd6a2fc67c0qn39gbh6rkqrpv83lw6ijm8sw3wirr";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -17,10 +17,6 @@ stdenv.mkDerivation rec {
   postPatch = "patchShebangs --host strace-graph";
 
   configureFlags = stdenv.lib.optional (!stdenv.hostPlatform.isx86) "--enable-mpers=check";
-
-  # fails 1 out of 523 tests with
-  # "strace-k.test: failed test: ../../strace -e getpid -k ../stack-fcall output mismatch"
-  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = "https://strace.io/";

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   postPatch = "patchShebangs --host strace-graph";
 
-  configureFlags = stdenv.lib.optional (!stdenv.hostPlatform.isx86) "--enable-mpers=check";
+  configureFlags = [ "--enable-mpers=check" ];
 
   meta = with stdenv.lib; {
     homepage = "https://strace.io/";

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "strace";
-  version = "5.10";
+  version = "5.11";
 
   src = fetchurl {
     url = "https://strace.io/files/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-/jmC6kzZrrO0ujX2J58LV3o3F10ygr4kuaVTe1a48Bw=";
+    sha256 = "sha256-/+NAsQwUWg+Fc0Jx6czlZFfSPyGn6lkxqzL4z055OHk=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "strace";
-  version = "5.9";
+  version = "5.10";
 
   src = fetchurl {
     url = "https://strace.io/files/${version}/${pname}-${version}.tar.xz";
-    sha256 = "1nb6bm6ll6cxd6a2fc67c0qn39gbh6rkqrpv83lw6ijm8sw3wirr";
+    sha256 = "sha256-/jmC6kzZrrO0ujX2J58LV3o3F10ygr4kuaVTe1a48Bw=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "A system call tracer for Linux";
     license =  with licenses; [ lgpl21Plus gpl2Plus ]; # gpl2Plus is for the test suite
     platforms = platforms.linux;
-    maintainers = with maintainers; [ globin ];
+    maintainers = with maintainers; [ globin ma27 ];
   };
 }

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl, perl, libunwind, buildPackages }:
 
+# libunwind does not have the supportsHost attribute on darwin, thus
+# when this package is evaluated it causes an evaluation error
+assert stdenv.isLinux;
+
 stdenv.mkDerivation rec {
   pname = "strace";
   version = "5.11";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backports strace updates up to #120769 

> Added a 9.needs: port to stable label because new kernel minors get backported to stable and each strace release (including this one) adds support for e.g. newly added syscalls, so a new strace may be useful there as well.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
(cherry picked from commit 3f01bf51e78efc59d445bf792d29b2dd535c2acf)