### PR TITLE
vscode: add meta.mainProgram

### DIFF
--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -45,6 +45,7 @@ in
         Open source source code editor developed by Microsoft for Windows,
         Linux and macOS
       '';
+      mainProgram = "code";
       longDescription = ''
         Open source source code editor developed by Microsoft for Windows,
         Linux and macOS. It includes support for debugging, embedded Git


### PR DESCRIPTION
###### Motivation for this change

Currently users cannot execute these commands:

```bash
NIXPKGS_ALLOW_UNFREE=1 nix run github:nixos/nixpkgs#vscode --impure
NIXPKGS_ALLOW_UNFREE=1 nix run github:nixos/nixpkgs#vscode-with-extensions --impure
```

This is because the main program of `vscode` (and `vscode-with-extensions`) is `code`.

This patch sets the `meta.mainProgram` according to the `nix run` docs: https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-run.html#description

It is possible on this change to run:

```bash
NIXPKGS_ALLOW_UNFREE=1 nix run .#vscode --impure
NIXPKGS_ALLOW_UNFREE=1 nix run .#vscode-with-extensions --impure
```

Related to #120692 #120662 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
