### PR TITLE
python3Packages.astropy: unbreak multiple modules

### DIFF
--- a/pkgs/development/python-modules/astropy-healpix/default.nix
+++ b/pkgs/development/python-modules/astropy-healpix/default.nix
@@ -3,25 +3,42 @@
 , fetchPypi
 , numpy
 , astropy
-, astropy-helpers
+, astropy-extension-helpers
+, setuptools-scm
+, pytestCheckHook
+, pytest-doctestplus
+, hypothesis
 }:
 
 buildPythonPackage rec {
   pname = "astropy-healpix";
   version = "0.6";
 
-  doCheck = false; # tests require pytest-astropy
-
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = lib.replaceStrings ["-"] ["_"] pname;
     sha256 = "409a6621c383641456c074f0f0350a24a4a58e910eaeef14e9bbce3e00ad6690";
   };
 
-  propagatedBuildInputs = [ numpy astropy astropy-helpers ];
+  nativeBuildInputs = [
+    astropy-extension-helpers
+    setuptools-scm
+  ];
 
-  # Disable automatic update of the astropy-helper module
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  propagatedBuildInputs = [
+    numpy
+    astropy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-doctestplus
+    hypothesis
+  ];
+
+  # tests must be run in the build directory
+  preCheck = ''
+    cd build/lib*
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/glymur/default.nix
+++ b/pkgs/development/python-modules/glymur/default.nix
@@ -2,10 +2,10 @@
 , buildPythonPackage
 , fetchFromGitHub
 , numpy
-, python
 , scikitimage
 , openjpeg
 , procps
+, pytestCheckHook
 , contextlib2
 , mock
 , importlib-resources
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "glymur";
-  version = "0.8.18";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "quintusdias";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zbghzw1q4fljb019lsrhka9xrnn4425qnxrjbmbv7dssgkkywd7";
+    sha256 = "1xlpax56qg5qqh0s19xidgvv2483sc684zj7rh6zw1m1z9m37drr";
   };
 
   propagatedBuildInputs = [
@@ -30,16 +30,21 @@ buildPythonPackage rec {
   checkInputs = [
     scikitimage
     procps
+    pytestCheckHook
   ];
 
   postConfigure = ''
     substituteInPlace glymur/config.py \
-    --replace "path = read_config_file(libname)" "path = '${openjpeg}/lib' + libname + ${if stdenv.isDarwin then "'.dylib'" else "'.so'"}"
+    --replace "path = read_config_file(libname)" "path = '${openjpeg}/lib/lib' + libname + ${if stdenv.isDarwin then "'.dylib'" else "'.so'"}"
   '';
 
-  checkPhase = ''
-    ${python.interpreter} -m unittest discover
-  '';
+  disabledTestPaths = [
+    # this test involves glymur's different ways of finding the openjpeg path on
+    # fsh systems by reading an .rc file and such, and is obviated by the patch
+    # in postConfigure
+    "tests/test_config.py"
+  ];
+
 
   meta = with lib; {
     description = "Tools for accessing JPEG2000 files";

--- a/pkgs/development/python-modules/pytest-doctestplus/default.nix
+++ b/pkgs/development/python-modules/pytest-doctestplus/default.nix
@@ -4,7 +4,9 @@
 , isPy27
 , six
 , pytest
+, pytestCheckHook
 , numpy
+, setuptools_scm
 }:
 
 buildPythonPackage rec {
@@ -17,7 +19,12 @@ buildPythonPackage rec {
     sha256 = "6fe747418461d7b202824a3486ba8f4fa17a9bd0b1eddc743ba1d6d87f03391a";
   };
 
-  buildInputs = [ pytest ];
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+  buildInputs = [
+    pytest
+  ];
 
   propagatedBuildInputs = [
     six
@@ -25,13 +32,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
   ];
-
-  # check_distribution incorrectly pulls pytest version
-  checkPhase = ''
-    pytest -k 'not check_distribution'
-  '';
 
   meta = with lib; {
     description = "Pytest plugin with advanced doctest features";

--- a/pkgs/development/python-modules/radio_beam/default.nix
+++ b/pkgs/development/python-modules/radio_beam/default.nix
@@ -2,9 +2,8 @@
 , fetchPypi
 , buildPythonPackage
 , astropy
-, pytest
-, pytest-astropy
-, astropy-helpers
+, pytestCheckHook
+, pytest-doctestplus
 , scipy
 }:
 
@@ -13,25 +12,18 @@ buildPythonPackage rec {
   version = "0.3.3";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit version;
+    pname = "radio-beam";
     sha256 = "e34902d91713ccab9f450b9d3e82317e292cf46a30bd42f9ad3c9a0519fcddcd";
   };
 
   propagatedBuildInputs = [ astropy ];
 
-  nativeBuildInputs = [ astropy-helpers ];
-
-  # Disable automatic update of the astropy-helper module
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
-  '';
-
-  checkInputs = [ pytest pytest-astropy scipy ];
+  checkInputs = [ pytestCheckHook pytest-doctestplus scipy ];
 
   # Tests must be run in the build directory
-  checkPhase = ''
+  preCheck = ''
     cd build/lib
-    pytest
   '';
 
   meta = {

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -1,11 +1,12 @@
 { lib
 , fetchPypi
+, fetchpatch
 , buildPythonPackage
 , aplpy
 , joblib
 , astropy
 , radio_beam
-, pytest
+, pytestCheckHook
 , pytest-astropy
 , astropy-helpers
 }:
@@ -20,13 +21,18 @@ buildPythonPackage rec {
     sha256 = "17zisr26syfb8kn89xj17lrdycm0hsmy5yp5zrn236wgd8rjriki";
   };
 
+  patches = [
+    # Fix compatibility with radio_beam >= 0.3.3. Will be included
+    # in the next release of spectral cube > 0.5.0
+    (fetchpatch {
+      url = "https://github.com/radio-astro-tools/spectral-cube/commit/bbe4295ebef7dfa6fe4474275a29acd6cb0cb544.patch";
+    sha256 = "1qddfm3364kc34yf6wd9nd6rxh4qc2v5pqilvz9adwb4a50z28bf";
+    })
+  ];
+
   nativeBuildInputs = [ astropy-helpers ];
   propagatedBuildInputs = [ astropy radio_beam joblib ];
-  checkInputs = [ aplpy pytest pytest-astropy ];
-
-  checkPhase = ''
-    pytest spectral_cube
-  '';
+  checkInputs = [ pytestCheckHook aplpy pytest-astropy ];
 
   meta = {
     description = "Library for reading and analyzing astrophysical spectral data cubes";

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -11,6 +11,7 @@
 , beautifulsoup4
 , drms
 , glymur
+, h5netcdf
 , hypothesis
 , matplotlib
 , numpy
@@ -50,6 +51,7 @@ buildPythonPackage rec {
     pandas
     astropy
     astropy-helpers
+    h5netcdf
     parfive
     sqlalchemy
     scikitimage


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I noticed that a few astropy packages were broken since a recent mass update: https://rmcgibbo.github.io/mydra/post/nixpkgs-fdce3b59/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
