### PR TITLE
xdg-desktop-portal-wlr: add grim to PATH

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, makeWrapper
 , meson, ninja, pkg-config, wayland-protocols
-, pipewire, wayland, systemd, libdrm, iniparser, scdoc }:
+, pipewire, wayland, systemd, libdrm, iniparser, scdoc, grim }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-wlr";
@@ -13,12 +13,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-6ArUQfWx5rNdpsd8Q22MqlpxLT8GTSsymAf21zGe1KI=";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config wayland-protocols ];
+  nativeBuildInputs = [ meson ninja pkg-config wayland-protocols makeWrapper ];
   buildInputs = [ pipewire wayland systemd libdrm iniparser scdoc ];
 
   mesonFlags = [
     "-Dsd-bus-provider=libsystemd"
   ];
+
+  postInstall = ''
+    wrapProgram $out/libexec/xdg-desktop-portal-wlr --prefix PATH ":" ${lib.makeBinPath [ grim ]}
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/emersion/xdg-desktop-portal-wlr";


### PR DESCRIPTION
###### Motivation for this change

xdpw execs to `grim` to implement screenshotting. Make sure `grim` is in
the path so that this functionality works out of the box.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
