### PR TITLE
python3Packages.sanic: 21.3.2 -> 21.3.4; fix tests

### DIFF
--- a/pkgs/development/python-modules/pytest-sanic/default.nix
+++ b/pkgs/development/python-modules/pytest-sanic/default.nix
@@ -46,5 +46,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/yunstanford/pytest-sanic/";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
+    # pytest-sanic is incompatible with Sanic 21.3, see
+    # https://github.com/sanic-org/sanic/issues/2095 and
+    # https://github.com/yunstanford/pytest-sanic/issues/50.
+    broken = lib.versionAtLeast sanic.version "21.3.0";
   };
 }

--- a/pkgs/development/python-modules/sanic-routing/default.nix
+++ b/pkgs/development/python-modules/sanic-routing/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pytest-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "sanic-routing";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "sanic-org";
+    repo = "sanic-routing";
+    rev = "v${version}";
+    hash = "sha256-ZMl8PB9E401pUfUJ4tW7nBx1TgPQQtx9erVni3zP+lo=";
+  };
+
+  checkInputs = [ pytestCheckHook pytest-asyncio ];
+  pythonImportsCheck = [ "sanic_routing" ];
+
+  meta = with lib; {
+    description = "Core routing component for the Sanic web framework";
+    homepage = "https://github.com/sanic-org/sanic-routing";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AluisioASG ];
+  };
+}

--- a/pkgs/development/python-modules/sanic-testing/default.nix
+++ b/pkgs/development/python-modules/sanic-testing/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, httpcore
+, httpx
+, pytest-asyncio
+, sanic
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "sanic-testing";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "sanic-org";
+    repo = "sanic-testing";
+    rev = "v${version}";
+    hash = "sha256-hBAq+/BKs0a01M89Nb8HaClqxB+W5PTfjVzef/m9SWs=";
+  };
+
+  propagatedBuildInputs = [ httpx sanic websockets httpcore ];
+
+  # `sanic` is explicitly set to null when building `sanic` itself
+  # to prevent infinite recursion.  In that case we skip running
+  # the package at all.
+  doCheck = sanic != null;
+  dontUsePythonImportsCheck = sanic == null;
+
+  checkInputs = [ pytestCheckHook pytest-asyncio ];
+  pythonImportsCheck = [ "sanic_testing" ];
+
+  meta = with lib; {
+    description = "Core testing clients for the Sanic web framework";
+    homepage = "https://github.com/sanic-org/sanic-testing";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AluisioASG ];
+  };
+}

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -1,42 +1,44 @@
 { lib, buildPythonPackage, fetchPypi, doCheck ? true
-, aiofiles, httptools, httpx, multidict, ujson, uvloop, websockets
-, pytestCheckHook, beautifulsoup4, gunicorn, httpcore, uvicorn
-, pytest-asyncio, pytest-benchmark, pytest-dependency, pytest-sanic, pytest-sugar, pytestcov
+, aiofiles, httptools, multidict, sanic-routing, ujson, uvloop, websockets
+, pytestCheckHook, beautifulsoup4, gunicorn, uvicorn, sanic-testing
+, pytest-benchmark, pytest-sanic, pytest-sugar, pytestcov
 }:
 
 buildPythonPackage rec {
   pname = "sanic";
-  version = "21.3.2";
+  version = "21.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "84a04c5f12bf321bed3942597787f1854d15c18f157aebd7ced8c851ccc49e08";
+    sha256 = "1cbd12b9138b3ca69656286b0be91fff02b826e8cb72dd76a2ca8c5eb1288d8e";
   };
 
   postPatch = ''
+    # Loosen dependency requirements.
     substituteInPlace setup.py \
-      --replace '"multidict==5.0.0"' '"multidict"' \
-      --replace '"httpx==0.15.4"' '"httpx"' \
-      --replace '"httpcore==0.3.0"' '"httpcore"' \
-      --replace '"pytest==5.2.1"' '"pytest"'
+      --replace '"pytest==5.2.1"' '"pytest"' \
+      --replace '"gunicorn==20.0.4"' '"gunicorn"' \
+      --replace '"pytest-sanic",' ""
+    # Patch a request headers test to allow brotli encoding
+    # (we build httpx with brotli support, upstream doesn't).
+    substituteInPlace tests/test_headers.py \
+      --replace "deflate\r\n" "deflate, br\r\n"
   '';
 
   propagatedBuildInputs = [
-    aiofiles httptools httpx multidict ujson uvloop websockets
+    sanic-routing httptools uvloop ujson aiofiles websockets multidict
   ];
 
   checkInputs = [
-    pytestCheckHook beautifulsoup4 gunicorn httpcore uvicorn
-    pytest-asyncio pytest-benchmark pytest-dependency pytest-sanic pytest-sugar pytestcov
+    sanic-testing gunicorn pytestcov beautifulsoup4 pytest-sanic pytest-sugar
+    pytest-benchmark pytestCheckHook uvicorn
   ];
 
   inherit doCheck;
 
   disabledTests = [
     "test_gunicorn" # No "examples" directory in pypi distribution.
-    "test_logo" # Fails to filter out "DEBUG asyncio:selector_events.py:59 Using selector: EpollSelector"
     "test_zero_downtime" # No "examples.delayed_response.app" module in pypi distribution.
-    "test_reloader_live" # OSError: [Errno 98] error while attempting to bind on address ('127.0.0.1', 42104)
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -45,8 +47,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A microframework based on uvloop, httptools, and learnings of flask";
-    homepage = "https://github.com/channelcat/sanic/";
+    homepage = "https://github.com/sanic-org/sanic/";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc AluisioASG ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7201,6 +7201,9 @@ in {
       doCheck = false;
       meta.broken = false;
     });
+    # Don't pass any `sanic` to avoid dependency loops.  `sanic-testing`
+    # has special logic to disable tests when this is the case.
+    sanic-testing = self.sanic-testing.override { sanic = null; };
   };
 
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7207,6 +7207,8 @@ in {
 
   sanic-routing = callPackage ../development/python-modules/sanic-routing { };
 
+  sanic-testing = callPackage ../development/python-modules/sanic-testing { };
+
   sapi-python-client = callPackage ../development/python-modules/sapi-python-client { };
 
   sarge = callPackage ../development/python-modules/sarge { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7205,7 +7205,7 @@ in {
 
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };
 
-  sanic = callPackage ../development/python-modules/sanic { };
+  sanic-routing = callPackage ../development/python-modules/sanic-routing { };
 
   sapi-python-client = callPackage ../development/python-modules/sapi-python-client { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7195,6 +7195,14 @@ in {
 
   samsungtvws = callPackage ../development/python-modules/samsungtvws { };
 
+  sanic = callPackage ../development/python-modules/sanic {
+    # pytest-sanic is doing ok for the sole purpose of testing Sanic.
+    pytest-sanic = self.pytest-sanic.overridePythonAttrs (oldAttrs: {
+      doCheck = false;
+      meta.broken = false;
+    });
+  };
+
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };
 
   sanic = callPackage ../development/python-modules/sanic { };


### PR DESCRIPTION
Sanic 21.3.0 split up parts of itself into new packages that are consumed as dependencies, while those packages themselves need Sanic for testing, so we need a few `doCheck = false` here and there to break loops.

pytest-sanic is in the odd situation that it doesn't work with Sanic 21.3 (https://github.com/yunstanford/pytest-sanic/issues/50) yet it is needed to run Sanic's tests. Right now I'm just disabling checks for this combination of versions, but it might be better to mark `pytest-sanic` as broken and override that in `sanic` instead.

cc @costrouc

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

@dotlambda discovered that `python3Packages.sanic` was broken in https://github.com/NixOS/nixpkgs/pull/120447#issuecomment-827382960.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
