### PR TITLE
opera: add libdrm and mesa dependencies

### DIFF
--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -26,9 +26,11 @@
 , libXrandr
 , libXrender
 , libXtst
+, libdrm
 , libnotify
 , libpulseaudio
 , libuuid
+, mesa
 , nspr
 , nss
 , pango
@@ -88,9 +90,11 @@ in stdenv.mkDerivation rec {
     libXrandr
     libXrender
     libXtst
+    libdrm
     libnotify
     libuuid
     libxcb
+    mesa
     nspr
     nss
     pango


### PR DESCRIPTION
###### Motivation for this change
Fixes #120873 (Opera failing to build)

I'm not quite sure _why_ the Opera build started failing, but adding the missing shared libraries fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
