### PR TITLE
ripgrep[-all]: add meta.mainProgram

### DIFF
--- a/pkgs/tools/text/ripgrep-all/default.nix
+++ b/pkgs/tools/text/ripgrep-all/default.nix
@@ -58,5 +58,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/phiresky/ripgrep-all";
     license = with licenses; [ agpl3Plus ];
     maintainers = with maintainers; [ zaninime ma27 ];
+    mainProgram = "rga";
   };
 }

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -51,5 +51,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/BurntSushi/ripgrep";
     license = with licenses; [ unlicense /* or */ mit ];
     maintainers = with maintainers; [ tailhook globin ma27 zowoq ];
+    mainProgram = "rg";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
```
> nix run nixpkgs#ripgrep
error: unable to execute '/nix/store/i094a0w94rw7ygwiccpp19fdgm6ixbx2-ripgrep-12.1.1/bin/ripgrep': No such file or directory
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
