### PR TITLE
nsis: enable builds on darwin.

### DIFF
--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "A free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";
     homepage = "https://nsis.sourceforge.io/";
     license = licenses.zlib;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ pombeirp ];
   };
 }

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -31,11 +31,11 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ sconsPackages.scons_3_1_2 ];
-  buildInputs = [ zlib ] ++ lib.optionals (stdenv.isDarwin) [ libiconv ];
+  buildInputs = [ zlib ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   nsisIncludes = symlinkJoin {
     name = "includes";
-    paths = [zlib.dev] ++ lib.optionals (stdenv.isDarwin) [ libiconv ];
+    paths = [ zlib.dev ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
   };
 
   sconsFlags = [

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ sconsPackages.scons_3_1_2 ];
   buildInputs = [ zlib libiconv ];
 
-  preBuild = (if stdenv.isLinux then ''
+  preBuild = lib.optionalString stdenv.isLinux ''
     sconsFlagsArray+=("PATH=$PATH")
-  '' else "") + ''
+  '' + ''
     mkdir -p $out/tmp/include
     cp ${zlib.dev}/include/* $out/tmp/include
     cp ${libiconv}/include/* $out/tmp/include


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
nsis currently doesn't build on darwin, this fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
