### PR TITLE
createrepo_c: 0.11.1 -> 0.17.1

### DIFF
--- a/pkgs/tools/package-management/createrepo_c/default.nix
+++ b/pkgs/tools/package-management/createrepo_c/default.nix
@@ -1,18 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, bzip2, expat, glib, curl, libxml2, python3, rpm, openssl, sqlite, file, xz, pcre, bash-completion }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, bzip2, expat, glib, curl, libxml2, python3, rpm
+, openssl, sqlite, file, xz, pcre, bash-completion, zstd, zchunk, libmodulemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "createrepo_c";
-  version = "0.11.1";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner  = "rpm-software-management";
     repo   = "createrepo_c";
     rev    = version;
-    sha256 = "0cmysc7gdd2czagl4drfh9gin6aa2847vgi30a3p0cfqvczf9cm6";
+    sha256 = "G2xioH9XWntHFmUfTN2s2mdtIqgTTLKr5jZflwpaC8Q=";
   };
 
   patches = [
+    # Use the output directory to install the bash completions.
     ./fix-bash-completion-path.patch
+    # Use the output directory to install the python modules.
     ./fix-python-install-path.patch
   ];
 
@@ -23,15 +27,15 @@ stdenv.mkDerivation rec {
       --replace "@PYTHON_INSTALL_DIR@" "$out/${python3.sitePackages}"
   '';
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config rpm ];
 
-  buildInputs = [ bzip2 expat glib curl libxml2 python3 rpm openssl sqlite file xz pcre bash-completion ];
+  buildInputs = [ bzip2 expat glib curl libxml2 python3 openssl sqlite file xz pcre bash-completion zstd zchunk libmodulemd ];
 
   meta = with lib; {
     description = "C implementation of createrepo";
-    homepage    = "http://rpm-software-management.github.io/createrepo_c/";
-    license     = licenses.gpl2;
-    platforms   = platforms.linux;
+    homepage    = "https://rpm-software-management.github.io/createrepo_c/";
+    license     = licenses.gpl2Plus;
+    platforms   = platforms.unix;
     maintainers = with maintainers; [ copumpkin ];
   };
 }

--- a/pkgs/tools/package-management/createrepo_c/fix-bash-completion-path.patch
+++ b/pkgs/tools/package-management/createrepo_c/fix-bash-completion-path.patch
@@ -1,11 +1,11 @@
---- createrepo_c-0.10.0-src.orig/CMakeLists.txt	2017-03-19 11:01:02.703173617 +0100
-+++ createrepo_c-0.10.0-src/CMakeLists.txt	2017-03-19 11:02:38.617448248 +0100
-@@ -100,7 +100,7 @@
- 
- pkg_check_modules(BASHCOMP bash-completion)
- if (BASHCOMP_FOUND)
--    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=completionsdir bash-completion OUTPUT_VARIABLE BASHCOMP_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-+    SET(BASHCOMP_DIR "@BASHCOMP_DIR@")
-     message("Bash completion directory: ${BASHCOMP_DIR}")
-     INSTALL(FILES createrepo_c.bash DESTINATION ${BASHCOMP_DIR} RENAME createrepo_c)
-     INSTALL(CODE "
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,7 +117,7 @@ OPTION(ENABLE_BASHCOMP "Install Bash autocompletions?" ON)
+ IF (ENABLE_BASHCOMP)
+     pkg_check_modules(BASHCOMP bash-completion)
+     IF (BASHCOMP_FOUND)
+-        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=completionsdir bash-completion OUTPUT_VARIABLE BASHCOMP_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
++        SET(BASHCOMP_DIR "@BASHCOMP_DIR@")
+         message("Bash completion directory: ${BASHCOMP_DIR}")
+         INSTALL(FILES createrepo_c.bash DESTINATION ${BASHCOMP_DIR} RENAME createrepo_c)
+         INSTALL(CODE "

--- a/pkgs/tools/package-management/createrepo_c/fix-python-install-path.patch
+++ b/pkgs/tools/package-management/createrepo_c/fix-python-install-path.patch
@@ -1,11 +1,11 @@
---- createrepo_c-0.10.0-src.orig/src/python/CMakeLists.txt	2017-03-19 10:50:33.796342953 +0100
-+++ createrepo_c-0.10.0-src/src/python/CMakeLists.txt	2017-03-19 10:53:51.207580073 +0100
-@@ -19,7 +19,7 @@
-     FIND_PACKAGE(PythonInterp 3.0 REQUIRED)
- endif()
- 
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -14,7 +14,7 @@ if (NOT SKBUILD)
+     FIND_PACKAGE(PythonLibs 3 REQUIRED)
+ endif (NOT SKBUILD)
+
 -EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 +SET(PYTHON_INSTALL_DIR "@PYTHON_INSTALL_DIR@")
  INCLUDE_DIRECTORIES (${PYTHON_INCLUDE_PATH})
- 
+
  MESSAGE(STATUS "Python install dir is ${PYTHON_INSTALL_DIR}")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
createrepo_c doesn't build on darwin, this fixes that by updating the version to `0.17.1`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
