### PR TITLE
just: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "just";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "casey";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-orHUovyFFOPRvbfLKQhkfZzM0Gs2Cpe1uJg/6+P8HKY=";
+    sha256 = "sha256-5W/5HgXjDmr2JGYGy5FPmCNIuAagmzEHnskDUg+FzjY=";
   };
 
-  cargoSha256 = "sha256-YDIGZRbszhgWM7iAc2i89jyndZvZZsg63ADQfqFxfXw=";
+  cargoSha256 = "sha256-4lLWtj/MLaSZU7nC4gVn7TyhaLtO1FUSinQejocpiuY=";
 
   nativeBuildInputs = [ installShellFiles ];
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
@@ -32,15 +32,21 @@ rustPlatform.buildRustPackage rec {
     export USER=just-user
     export USERNAME=just-user
 
+    # Prevent string.rs from being changed
+    cp tests/string.rs $TMPDIR/string.rs
+
     sed -i src/justfile.rs \
         -i tests/*.rs \
         -e "s@/bin/echo@${coreutils}/bin/echo@g" \
         -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
         -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g" \
         -e "s@#!/usr/bin/env bash@#!${bash}/bin/sh@g"
+
+    # Return unchanged string.rs
+    cp $TMPDIR/string.rs tests/string.rs
   '';
 
-  # Skip "edit" when running "cargo test", since this test case needs "cat".
+  # Skip "edit" when running "cargo test", since this test case needs "cat" and "vim".
   # Skip "choose" when running "cargo test", since this test case needs "fzf".
   checkFlags = [ "--skip=choose" "--skip=edit" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bumped just to `0.9.1`

Added some stuff to avoid editing tests/string.rs so that the test continues to pass
Added more notes to explain why edit is ignored even though cat has been sed-ed in

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
