### PR TITLE
opusfile: fix windows compilation

### DIFF
--- a/pkgs/applications/audio/opusfile/default.nix
+++ b/pkgs/applications/audio/opusfile/default.nix
@@ -1,23 +1,27 @@
 { lib, stdenv, fetchurl, pkg-config, openssl, libogg, libopus }:
 
 stdenv.mkDerivation rec {
-  name = "opusfile-0.12";
+  pname = "opusfile";
+  version = "0.12";
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/opus/${name}.tar.gz";
+    url = "http://downloads.xiph.org/releases/opus/opusfile-${version}.tar.gz";
     sha256 = "02smwc5ah8nb3a67mnkjzqmrzk43j356hgj2a97s9midq40qd38i";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl libogg ];
   propagatedBuildInputs = [ libopus ];
-  patches = [ ./include-multistream.patch ];
+  patches = [ ./include-multistream.patch ]
+    # fixes problem with openssl 1.1 dependency
+    # see https://github.com/xiph/opusfile/issues/13
+    ++ lib.optionals stdenv.hostPlatform.isWindows [ ./disable-cert-store.patch ];
   configureFlags = [ "--disable-examples" ];
 
   meta = with lib; {
     description = "High-level API for decoding and seeking in .opus files";
     homepage = "https://www.opus-codec.org/";
     license = licenses.bsd3;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ taeer ];
   };
 }

--- a/pkgs/applications/audio/opusfile/disable-cert-store.patch
+++ b/pkgs/applications/audio/opusfile/disable-cert-store.patch
@@ -1,0 +1,35 @@
+diff --git a/src/http.c b/src/http.c
+index bd08562..3a3592c 100644
+--- a/src/http.c
++++ b/src/http.c
+@@ -327,10 +327,12 @@ static int op_poll_win32(struct pollfd *_fds,nfds_t _nfds,int _timeout){
+ typedef ptrdiff_t ssize_t;
+ #  endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ /*Load certificates from the built-in certificate store.*/
+ int SSL_CTX_set_default_verify_paths_win32(SSL_CTX *_ssl_ctx);
+ #  define SSL_CTX_set_default_verify_paths \
+  SSL_CTX_set_default_verify_paths_win32
++#endif
+ 
+ # else
+ /*Normal Berkeley sockets.*/
+diff --git a/src/wincerts.c b/src/wincerts.c
+index 409a4e0..c355952 100644
+--- a/src/wincerts.c
++++ b/src/wincerts.c
+@@ -33,6 +33,8 @@
+ # include <openssl/err.h>
+ # include <openssl/x509.h>
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++
+ static int op_capi_new(X509_LOOKUP *_lu){
+   HCERTSTORE h_store;
+   h_store=CertOpenStore(CERT_STORE_PROV_SYSTEM_A,0,0,
+@@ -171,3 +173,4 @@ int SSL_CTX_set_default_verify_paths_win32(SSL_CTX *_ssl_ctx){
+ }
+ 
+ #endif
++#endif

--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
     description = "Open, royalty-free, highly versatile audio codec";
     license = lib.licenses.bsd3;
     homepage = "https://www.opus-codec.org/";
-    platforms = platforms.unix;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Windows openssl got updated recently #108170. Compiling opusfile on windows breaks with openssl 1.1 (see https://github.com/xiph/opusfile/issues/13). I pulled a patch from that issue and it compiles now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
