### PR TITLE
libcint: 4.1.1 -> 4.3.0

### DIFF
--- a/pkgs/development/libraries/libcint/default.nix
+++ b/pkgs/development/libraries/libcint/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libcint";
-  version = "4.1.1";
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "sunqm";
     repo = "libcint";
     rev = "v${version}";
-    sha256 = "sha256-HBZ/VMuTLAYpqcIPzQ4JbsMSXsI/sKc14ZFpbVhQF/g=";
+    hash = "sha256-vJ4OyU9HYQvF1SWmniNGAuHQ7K/TfiK8C4celK5hjiA=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
<!-- To help with the large amounts of pull requests, we would appreciate your 
reviews of other pull requests, especially simple package updates. Just leave a 
comment describing what you have tested in the relevant package/service. Reviewing 
helps to reduce the average time-to-merge for everyone. Thanks a lot if you do! List 
of open PRs: https://github.com/NixOS/nixpkgs/pulls Reviewing guidelines: 
https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions -->

###### Motivation for this change

Update to latest version. https://github.com/sunqm/libcint/releases/tag/v4.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
