### PR TITLE
nixos/systemd: Add overrides to unit derivations

### DIFF
--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -36,6 +36,9 @@ in rec {
 
   digits = map toString (range 0 9);
 
+  # Apply a list of overrideAttrs functions to a drv
+  applyOverrides = drv: overrides: lib.foldl' (drv': override: drv'.overrideAttrs override) drv overrides;
+
   isByteFormat = s:
     let
       l = reverseList (stringToCharacters s);

--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -92,6 +92,15 @@ in rec {
       description = "The generated unit.";
     };
 
+    unitFileOverrides = mkOption {
+      description = "Overrides to apply to the derivation of the unit file";
+      type = types.listOf (types.functionTo types.attrs);
+      default = [];
+      internal = true;
+      example = [ (oA: {
+        patches = (oA.patches or []) ++ [ "$somepatch" ];
+      }) ];
+    };
   };
 
   commonUnitOptions = sharedOptions // {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -434,7 +434,7 @@ in
         { name, config, ... }:
         { options = concreteUnitOptions;
           config = {
-            unit = mkDefault (makeUnit name config);
+            unit = mkDefault (applyOverrides (makeUnit name config) config.unitFileOverrides);
           };
         }));
     };
@@ -787,7 +787,7 @@ in
         { name, config, ... }:
         { options = concreteUnitOptions;
           config = {
-            unit = mkDefault (makeUnit name config);
+            unit = mkDefault (applyOverrides (makeUnit name config) config.unitFileOverrides);
           };
         }));
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This one might be a bit of a corner case but it really makes your life
easier when you need something like this. Basically, it allows adding
overrides to the derivation of unit files.

We have two use cases, both are related to out-of tree work. The first
is an out-of-tree AppArmor module that attaches profiles to the literal
unit files and loads them on activation. The second one is an override
to gitlab-runner which is needed since we run it in a really
non-standard way. It essentially removes the `!` from the ExecStartPre
line. This would not have been as easy without this module we already
had laying around. Maybe it will be of use for other people and use
cases as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - `systemd.nix`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ajs124 since you contributed to some of this