### PR TITLE
palemoon: 29.1.1 -> 29.2.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,29 +1,59 @@
-{ stdenv, lib, fetchFromGitHub, writeScript, desktop-file-utils
-, pkg-config, autoconf213, alsaLib, bzip2, cairo
-, dbus, dbus-glib, ffmpeg, file, fontconfig, freetype
-, gnome2, gnum4, gtk2, hunspell, libevent, libjpeg
-, libnotify, libstartup_notification, wrapGAppsHook
-, libGLU, libGL, perl, python2, libpulseaudio
-, unzip, xorg, wget, which, yasm, zip, zlib
-
-, withGTK3 ? true, gtk3
+# Compiler in stdenv MUST be a supported one for official branding
+# See https://developer.palemoon.org/build/linux/
+# TODO assert if stdenv.cc is supported?
+{ stdenv
+, lib
+, fetchFromGitHub
+, writeScript
+, alsaLib
+, autoconf213
+, cairo
+, desktop-file-utils
+, dbus
+, dbus-glib
+, ffmpeg
+, fontconfig
+, freetype
+, gnome2
+, gnum4
+, gtk2
+, libevent
+, libGL
+, libGLU
+, libnotify
+, libpulseaudio
+, libstartup_notification
+, perl
+, pkg-config
+, python2
+, unzip
+, which
+, wrapGAppsHook
+, xorg
+, yasm
+, zip
+, zlib
+, withGTK3 ? true
+, gtk3
 }:
 
 let
-
-  libPath = lib.makeLibraryPath [ ffmpeg libpulseaudio ];
+  libPath = lib.makeLibraryPath [
+    ffmpeg
+    libpulseaudio
+  ];
   gtkVersion = if withGTK3 then "3" else "2";
-
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.1.1";
+  version = "29.2.0";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "1ppdmj816zwccb0l0mgpq14ckdwg785wmqz41wran0nl63fg6i1x";
+    sha256 = "0pa9j41bbfarwi60a6hxi5vpn52mwgr4p05l98acv4fcs1ccb427";
     fetchSubmodules = true;
   };
 
@@ -43,24 +73,55 @@ in stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    desktop-file-utils file gnum4 perl pkg-config python2 wget which wrapGAppsHook unzip
+    autoconf213
+    desktop-file-utils
+    gnum4
+    perl
+    pkg-config
+    python2
+    unzip
+    which
+    wrapGAppsHook
+    yasm
+    zip
   ];
 
   buildInputs = [
-    alsaLib bzip2 cairo dbus dbus-glib ffmpeg fontconfig freetype
-    gnome2.GConf gtk2 hunspell libevent libjpeg libnotify
-    libstartup_notification libGLU libGL
-    libpulseaudio yasm zip zlib
+    alsaLib
+    cairo
+    dbus
+    dbus-glib
+    ffmpeg
+    fontconfig
+    freetype
+    gnome2.GConf
+    gtk2
+    libevent
+    libGL
+    libGLU
+    libnotify
+    libpulseaudio
+    libstartup_notification
+    zlib
   ]
   ++ (with xorg; [
-    libX11 libXext libXft libXi libXrender libXScrnSaver
-    libXt pixman xorgproto
+    libX11
+    libXext
+    libXft
+    libXi
+    libXrender
+    libXScrnSaver
+    libXt
+    pixman
+    xorgproto
   ])
   ++ lib.optional withGTK3 gtk3;
 
   enableParallelBuilding = true;
 
   configurePhase = ''
+    runHook preConfigure
+
     export MOZCONFIG=$PWD/mozconfig
     export MOZ_NOSPAM=1
 
@@ -96,9 +157,6 @@ in stdenv.mkDerivation rec {
     ac_add_options --enable-official-branding
     export MOZILLA_OFFICIAL=1
 
-    # For versions after 28.12.0
-    ac_add_options --enable-phoenix-extensions
-
     ac_add_options --x-libraries=${lib.makeLibraryPath [ xorg.libX11 ]}
 
     export MOZ_PKG_SPECIAL=gtk$_GTK_VERSION
@@ -112,24 +170,42 @@ in stdenv.mkDerivation rec {
     mk_add_options MOZ_MAKE_FLAGS="-j${if enableParallelBuilding then "$NIX_BUILD_CORES" else "1"}"
     mk_add_options AUTOCONF=${autoconf213}/bin/autoconf
     '
+
+    runHook postConfigure
   '';
 
-  buildPhase = "./mach build";
+  buildPhase = ''
+    runHook preBuild
+
+    ./mach build
+
+    runHook postBuild
+  '';
 
   installPhase = ''
+    runHook preInstall
+
     ./mach install
 
     # Fix missing icon due to wrong WMClass
+    # TODO report upstream
     substituteInPlace ./palemoon/branding/official/palemoon.desktop \
       --replace 'StartupWMClass="pale moon"' 'StartupWMClass=Pale moon'
     desktop-file-install --dir=$out/share/applications \
       ./palemoon/branding/official/palemoon.desktop
 
+    # Install official branding icons
     for iconname in default{16,22,24,32,48,256} mozicon128; do
       n=''${iconname//[^0-9]/}
       size=$n"x"$n
       install -Dm644 ./palemoon/branding/official/$iconname.png $out/share/icons/hicolor/$size/apps/palemoon.png
     done
+
+    # Remove unneeded SDK data from installation
+    # TODO: move to a separate output?
+    rm -rf $out/{include,share/idl,lib/palemoon-devel-${version}}
+
+    runHook postInstall
   '';
 
   dontWrapGApps = true;
@@ -154,9 +230,9 @@ in stdenv.mkDerivation rec {
       experience, while offering full customization and a growing collection of
       extensions and themes to make the browser truly your own.
     '';
-    homepage    = "https://www.palemoon.org/";
-    license     = licenses.mpl20;
+    homepage = "https://www.palemoon.org/";
+    license = licenses.mpl20;
     maintainers = with maintainers; [ AndersonTorres OPNA2608 ];
-    platforms   = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25232,10 +25232,7 @@ in
 
   osmscout-server = libsForQt5.callPackage ../applications/misc/osmscout-server { };
 
-  palemoon = callPackage ../applications/networking/browsers/palemoon {
-    # https://developer.palemoon.org/build/linux/
-    stdenv = gcc8Stdenv;
-  };
+  palemoon = callPackage ../applications/networking/browsers/palemoon { };
 
   webbrowser = callPackage ../applications/networking/browsers/webbrowser {};
 


### PR DESCRIPTION
###### Motivation for this change
New version release today, includes security-relevant fixes. (Needs backport)

> - Security issues addressed: CVE-2021-29946 DiD and CVE-2021-23994 DiD .
> - Unified XUL Platform Mozilla Security Patch Summary: 2 DiD, 14 not applicable

Removed some unused dependencies (`[ bzip2 hunspell file libjpeg wget ]`. I'm sure there's more still - maybe `which`, although it'll print alot of `which: command not found` messages during configuration), `nixpkgs-fmt`ed it & did some more cleaning up of the expression.

I removed SDK-related paths and the stdenv override from top-packages, so this partly addresses #117369. The compiler version restrictions from https://developer.palemoon.org/build/linux/ still apply but forcing the compiler like this gave me problems with GL driver loading so I'll just try to keep an eye on the stdenv's GCC version instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
