### PR TITLE
dotty: 0.26.0-RC1 -> 3.0.0-RC3

### DIFF
--- a/pkgs/development/compilers/scala/dotty-bare.nix
+++ b/pkgs/development/compilers/scala/dotty-bare.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchurl, makeWrapper, jre, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "0.26.0-RC1";
+  version = "3.0.0-RC3";
   pname = "dotty-bare";
 
   src = fetchurl {
-    url = "https://github.com/lampepfl/dotty/releases/download/${version}/dotty-${version}.tar.gz";
-    sha256 = "16njy9f0lk7q5x5w1k4yqy644005w4cxhq20r8i2qslhxjndz66f";
+    url = "https://github.com/lampepfl/dotty/releases/download/${version}/scala3-${version}.tar.gz";
+    sha256 = "1xp9nql2l62fra8p29fgk3srdbvza9g5inxr8p0sihsrp0bgxa0m";
   };
 
   propagatedBuildInputs = [ jre ncurses.dev ] ;

--- a/pkgs/development/compilers/scala/dotty.nix
+++ b/pkgs/development/compilers/scala/dotty.nix
@@ -13,9 +13,10 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s ${dotty-bare}/bin/dotc $out/bin/dotc
-    ln -s ${dotty-bare}/bin/dotd $out/bin/dotd
-    ln -s ${dotty-bare}/bin/dotr $out/bin/dotr
+    ln -s ${dotty-bare}/bin/scalac $out/bin/scalac
+    ln -s ${dotty-bare}/bin/scaladoc $out/bin/scaladoc
+    ln -s ${dotty-bare}/bin/scala $out/bin/scala
+    ln -s ${dotty-bare}/bin/common $out/bin/common
   '';
 
   inherit (dotty-bare) meta;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update dotty compiler to the latest version. Compiler has been tested on NixOS with some trivial scala code which compiled and executed correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
