### PR TITLE
ssm-agent: use the fixed lsb-release instead of workarounds

### DIFF
--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -3,18 +3,6 @@
 with lib;
 let
   cfg = config.services.ssm-agent;
-
-  # The SSM agent doesn't pay attention to our /etc/os-release yet, and the lsb-release tool
-  # in nixpkgs doesn't seem to work properly on NixOS, so let's just fake the two fields SSM
-  # looks for. See https://github.com/aws/amazon-ssm-agent/issues/38 for upstream fix.
-  fake-lsb-release = pkgs.writeScriptBin "lsb_release" ''
-    #!${pkgs.runtimeShell}
-
-    case "$1" in
-      -i) echo "nixos";;
-      -r) echo "${config.system.nixos.version}";;
-    esac
-  '';
 in {
   options.services.ssm-agent = {
     enable = mkEnableOption "AWS SSM agent";
@@ -33,7 +21,7 @@ in {
       after    = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      path = [ fake-lsb-release pkgs.coreutils ];
+      path = [ pkgs.coreutils pkgs.lsb-release ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/amazon-ssm-agent";
         KillMode = "process";

--- a/pkgs/applications/networking/cluster/ssm-agent/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-agent/default.nix
@@ -1,29 +1,15 @@
 { lib
-, writeShellScriptBin
 , buildGoPackage
 , makeWrapper
 , fetchFromGitHub
 , coreutils
+, lsb-release
 , nettools
 , dmidecode
 , util-linux
 , bashInteractive
 }:
 
-let
-  # Tests use lsb_release, so we mock it (the SSM agent used to not
-  # read from our /etc/os-release file, but now it does) because in
-  # reality, it won't (shouldn't) be used when active on a system with
-  # /etc/os-release. If it is, we fake the only two fields it cares about.
-  fake-lsb-release = writeShellScriptBin "lsb_release" ''
-    . /etc/os-release || true
-
-    case "$1" in
-      -i) echo "''${NAME:-unknown}";;
-      -r) echo "''${VERSION:-unknown}";;
-    esac
-  '';
-in
 buildGoPackage rec {
   pname = "amazon-ssm-agent";
   version = "3.0.755.0";
@@ -55,7 +41,7 @@ buildGoPackage rec {
     substituteInPlace agent/platform/platform_unix.go \
         --replace "/usr/bin/uname" "${coreutils}/bin/uname" \
         --replace '"/bin", "hostname"' '"${nettools}/bin/hostname"' \
-        --replace '"lsb_release"' '"${fake-lsb-release}/bin/lsb_release"'
+        --replace '"lsb_release"' '"${lsb-release}/bin/lsb_release"'
 
     substituteInPlace agent/managedInstances/fingerprint/hardwareInfo_unix.go \
         --replace /usr/sbin/dmidecode ${dmidecode}/bin/dmidecode


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Partial fix for https://github.com/NixOS/nixpkgs/issues/66636

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
