### PR TITLE
nixos/self-deploy: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -876,6 +876,7 @@
   ./services/system/kerberos/default.nix
   ./services/system/nscd.nix
   ./services/system/saslauthd.nix
+  ./services/system/self-deploy.nix
   ./services/system/uptimed.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.services.self-deploy;
 
-  workingDirectory = "/var/lib/self-deploy";
+  workingDirectory = "/var/lib/nixos-self-deploy";
   repositoryDirectory = "${workingDirectory}/repo";
   outPath = "${workingDirectory}/system";
 
@@ -16,11 +16,12 @@ let
         then " --argstr ${lib.escapeShellArg key} ${lib.escapeShellArg value}"
         else " --arg ${lib.escapeShellArg key} ${lib.escapeShellArg (toString value)}";
     in
-      lib.concatStrings (lib.mapAttrsToList toArg args);
+    lib.concatStrings (lib.mapAttrsToList toArg args);
 
   isPathType = x: lib.strings.isCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
 
-in {
+in
+{
   options.services.self-deploy = {
     enable = lib.mkEnableOption "self-deploy";
 
@@ -30,8 +31,8 @@ in {
       default = "/default.nix";
 
       description = ''
-      Path to nix file in repository. Leading '/' refers to root of
-      git repository.
+        Path to nix file in repository. Leading '/' refers to root of
+        git repository.
       '';
     };
 
@@ -39,18 +40,18 @@ in {
       type = lib.types.str;
 
       description = ''
-      Attribute of `nixFile` that builds the current system.
+        Attribute of `nixFile` that builds the current system.
       '';
     };
 
     nixArgs = lib.mkOption {
       type = lib.types.attrs;
 
-      default = {};
+      default = { };
 
       description = ''
-      Arguments to `nix-build` passed as `--argstr` or `--arg` depending on
-      the type.
+        Arguments to `nix-build` passed as `--argstr` or `--arg` depending on
+        the type.
       '';
     };
 
@@ -60,7 +61,7 @@ in {
       default = "switch";
 
       description = ''
-      The `switch-to-configuration` subcommand used.
+        The `switch-to-configuration` subcommand used.
       '';
     };
 
@@ -68,15 +69,15 @@ in {
       type = with lib.types; oneOf [ path str ];
 
       description = ''
-      The repository to fetch from. Must be properly formatted for git.
+        The repository to fetch from. Must be properly formatted for git.
 
-      If this value is set to a path (must begin with `/`) then it's
-      assumed that the repository is local and the resulting service
-      won't wait for the network to be up.
+        If this value is set to a path (must begin with `/`) then it's
+        assumed that the repository is local and the resulting service
+        won't wait for the network to be up.
 
-      If the repository will be fetched over SSH, you must add an
-      entry to `programs.ssh.knownHosts` for the SSH host for the fetch
-      to be successful.
+        If the repository will be fetched over SSH, you must add an
+        entry to `programs.ssh.knownHosts` for the SSH host for the fetch
+        to be successful.
       '';
     };
 
@@ -86,8 +87,8 @@ in {
       default = null;
 
       description = ''
-      Path to SSH private key used to fetch private repositories over
-      SSH.
+        Path to SSH private key used to fetch private repositories over
+        SSH.
       '';
     };
 
@@ -97,11 +98,11 @@ in {
       default = "master";
 
       description = ''
-      Branch to track
+        Branch to track
 
-      Technically speaking any ref can be specified here, as this is
-      passed directly to a `git fetch`, but for the use-case of
-      continuous deployment you're likely to want to specify a branch.
+        Technically speaking any ref can be specified here, as this is
+        passed directly to a `git fetch`, but for the use-case of
+        continuous deployment you're likely to want to specify a branch.
       '';
     };
 
@@ -111,12 +112,12 @@ in {
       default = "hourly";
 
       description = ''
-      The schedule on which to run the `self-deploy` service. Format
-      specified by `systemd.time 7`.
+        The schedule on which to run the `self-deploy` service. Format
+        specified by `systemd.time 7`.
 
-      This value can also be a list of `systemd.time 7` formatted
-      strings, in which case the service will be started on multiple
-      schedules.
+        This value can also be a list of `systemd.time 7` formatted
+        strings, in which case the service will be started on multiple
+        schedules.
       '';
     };
   };
@@ -133,34 +134,36 @@ in {
       restartIfChanged = false;
 
       path = with pkgs; [
-        git nix systemd
+        git
+        nix
+        systemd
       ];
 
       script = ''
-      if [ ! -e ${repositoryDirectory} ]; then
-        mkdir --parents ${repositoryDirectory}
-        git init ${repositoryDirectory}
-      fi
+        if [ ! -e ${repositoryDirectory} ]; then
+          mkdir --parents ${repositoryDirectory}
+          git init ${repositoryDirectory}
+        fi
 
-      ${gitWithRepo} fetch ${lib.escapeShellArg cfg.repository} ${lib.escapeShellArg cfg.branch}
+        ${gitWithRepo} fetch ${lib.escapeShellArg cfg.repository} ${lib.escapeShellArg cfg.branch}
 
-      ${gitWithRepo} checkout FETCH_HEAD
+        ${gitWithRepo} checkout FETCH_HEAD
 
-      nix-build${renderNixArgs cfg.nixArgs} ${lib.cli.toGNUCommandLineShell {} {
-        attr = cfg.nixAttribute;
-        out-link = outPath;
-      }} ${lib.escapeShellArg "${repositoryDirectory}${cfg.nixFile}"}
+        nix-build${renderNixArgs cfg.nixArgs} ${lib.cli.toGNUCommandLineShell { } {
+          attr = cfg.nixAttribute;
+          out-link = outPath;
+        }} ${lib.escapeShellArg "${repositoryDirectory}${cfg.nixFile}"}
 
-      ${lib.optionalString (cfg.switchCommand != "test")
-        "nix-env --profile /nix/var/nix/profiles/system --set ${outPath}"}
+        ${lib.optionalString (cfg.switchCommand != "test")
+          "nix-env --profile /nix/var/nix/profiles/system --set ${outPath}"}
 
-      ${outPath}/bin/switch-to-configuration ${cfg.switchCommand}
+        ${outPath}/bin/switch-to-configuration ${cfg.switchCommand}
 
-      rm ${outPath}
+        rm ${outPath}
 
-      ${gitWithRepo} gc --prune=all
+        ${gitWithRepo} gc --prune=all
 
-      ${lib.optionalString (cfg.switchCommand == "boot") "systemctl reboot"}
+        ${lib.optionalString (cfg.switchCommand == "boot") "systemctl reboot"}
       '';
     };
   };

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -1,0 +1,174 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.self-deploy;
+
+  workingDirectory = "/var/lib/self-deploy";
+  repositoryDirectory = "${workingDirectory}/repo";
+  outPath = "${workingDirectory}/system";
+
+  gitWithRepo = "git -C ${repositoryDirectory}";
+
+  renderNixArgs = args:
+    let
+      toArg = key: value:
+        if builtins.isString value
+        then " --argstr ${lib.escapeShellArg key} ${lib.escapeShellArg value}"
+        else " --arg ${lib.escapeShellArg key} ${lib.escapeShellArg (toString value)}";
+    in
+      lib.concatStrings (lib.mapAttrsToList toArg args);
+
+  isPathType = x: lib.strings.isCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
+
+in {
+  options.services.self-deploy = {
+    enable = lib.mkEnableOption "self-deploy";
+
+    nixFile = lib.mkOption {
+      type = lib.types.path;
+
+      default = "/default.nix";
+
+      description = ''
+      Path to nix file in repository. Leading '/' refers to root of
+      git repository.
+      '';
+    };
+
+    nixAttribute = lib.mkOption {
+      type = lib.types.str;
+
+      description = ''
+      Attribute of `nixFile` that builds the current system.
+      '';
+    };
+
+    nixArgs = lib.mkOption {
+      type = lib.types.attrs;
+
+      default = {};
+
+      description = ''
+      Arguments to `nix-build` passed as `--argstr` or `--arg` depending on
+      the type.
+      '';
+    };
+
+    switchCommand = lib.mkOption {
+      type = lib.types.enum [ "boot" "switch" "dry-activate" "test" ];
+
+      default = "switch";
+
+      description = ''
+      The `switch-to-configuration` subcommand used.
+      '';
+    };
+
+    repository = lib.mkOption {
+      type = with lib.types; oneOf [ path str ];
+
+      description = ''
+      The repository to fetch from. Must be properly formatted for git.
+
+      If this value is set to a path (must begin with `/`) then it's
+      assumed that the repository is local and the resulting service
+      won't wait for the network to be up.
+
+      If the repository will be fetched over SSH, you must add an
+      entry to `programs.ssh.knownHosts` for the SSH host for the fetch
+      to be successful.
+      '';
+    };
+
+    sshKeyFile = lib.mkOption {
+      type = with lib.types; nullOr path;
+
+      default = null;
+
+      description = ''
+      Path to SSH private key used to fetch private repositories over
+      SSH.
+      '';
+    };
+
+    branch = lib.mkOption {
+      type = lib.types.str;
+
+      default = "master";
+
+      description = ''
+      Branch to track
+
+      You can also specify a revision or tag, too, if you want to pin this
+      machine to a specific commit.
+      '';
+    };
+
+    startAt = lib.mkOption {
+      type = with lib.types; either str (listOf str);
+
+      default = "hourly";
+
+      description = ''
+      The schedule on which to run the `self-deploy` service. Format
+      specified by `systemd.time 7`.
+
+      This value can also be a list of `systemd.time 7` formatted
+      strings, in which case the service will be started on multiple
+      schedules.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.self-deploy = {
+      wantedBy = [ "multi-user.target" ];
+
+      requires = lib.mkIf (!(isPathType cfg.repository)) [ "network-online.target" ];
+
+      environment.GIT_SSH_COMMAND = lib.mkIf (!(isNull cfg.sshKeyFile))
+        "${pkgs.openssh}/bin/ssh -i ${lib.escapeShellArg cfg.sshKeyFile}";
+
+      serviceConfig.X-RestartIfChanged = false;
+
+      path = with pkgs; [
+        git nix systemd
+      ];
+
+      script = ''
+      if [ ! -e ${workingDirectory} ]; then
+        mkdir --parents ${workingDirectory}
+      fi
+
+      if [ ! -e ${repositoryDirectory} ]; then
+        git clone ${lib.cli.toGNUCommandLineShell {} {
+          local = (isPathType cfg.repository);
+        }} ${lib.escapeShellArg cfg.repository} ${repositoryDirectory}
+      fi
+
+      # Ensure that if cfg.repository is changed, origin is updated
+      ${gitWithRepo} remote set-url origin ${lib.escapeShellArg cfg.repository}
+
+      ${gitWithRepo} fetch origin ${lib.escapeShellArg cfg.branch}
+
+      ${gitWithRepo} checkout FETCH_HEAD
+
+      nix-build${renderNixArgs cfg.nixArgs} ${lib.cli.toGNUCommandLineShell {} {
+        attr = cfg.nixAttribute;
+        out-link = outPath;
+      }} ${lib.escapeShellArg "${repositoryDirectory}${cfg.nixFile}"}
+
+      ${lib.optionalString (cfg.switchCommand != "test")
+        "nix-env --profile /nix/var/nix/profiles/system --set ${outPath}"}
+
+      ${outPath}/bin/switch-to-configuration ${cfg.switchCommand}
+
+      ${lib.optionalString (cfg.switchCommand == "boot") "systemctl reboot"}
+
+      rm ${outPath}
+
+      ${gitWithRepo} gc --prune=all
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Add `self-deploy` service to facilitate continuous deployment of a NixOS system derivation from a git repository to the local system. This is based on an internal NixOS module of the same name we've been using at Awake Security that we've generalized for open source use.

###### Motivation for this change

At Awake Security we've found our internal version of this service useful in ensuring infrastructure is always up to date and felt it could be useful for others.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
