### PR TITLE
python3Packages.pgspecial: add configobj to checkInputs

### DIFF
--- a/pkgs/development/python-modules/pgspecial/default.nix
+++ b/pkgs/development/python-modules/pgspecial/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, psycopg2, click, sqlparse }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, psycopg2
+, click
+, sqlparse
+, configobj }:
 
 buildPythonPackage rec {
   pname = "pgspecial";
@@ -9,13 +16,12 @@ buildPythonPackage rec {
     sha256 = "b68feb0005f57861573d3fbb82c5c777950decfbb2d1624af57aec825db02c02";
   };
 
-  checkInputs = [ pytest ];
+  checkInputs = [
+    pytestCheckHook
+    configobj
+  ];
   propagatedBuildInputs = [ click sqlparse psycopg2 ];
 
-  checkPhase = ''
-    find tests -name \*.pyc -delete
-    py.test tests
-  '';
 
   meta = with lib; {
     description = "Meta-commands handler for Postgres Database";


### PR DESCRIPTION
###### Motivation for this change
Tests currently fail: <https://hydra.nixos.org/build/141969386>, `configobj>=5.0.6` in [requirements-dev.txt](https://github.com/dbcli/pgspecial/blob/2e84eeaa7be4575e27e47eef11effbd7faf51941/requirements-dev.txt#L10)

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
