### PR TITLE
djangorestframework-jwt: fix build error

### DIFF
--- a/pkgs/development/python-modules/djangorestframework-jwt/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-jwt/default.nix
@@ -6,6 +6,18 @@
 , buildPythonPackage
 }:
 
+let
+
+  pyjwt' = pyjwt.overridePythonAttrs (oldAttrs: rec {
+    version = "1.7.1";
+    src = oldAttrs.src.override {
+      inherit version;
+      sha256 = "jVmpdvt3Pz5qOchWNjV8Tw4kJwc5TK2t2YFPXLqiDpY=";
+    };
+  });
+
+in
+
 buildPythonPackage rec {
   pname = "djangorestframework-jwt";
   version = "1.11.0";
@@ -15,7 +27,7 @@ buildPythonPackage rec {
     sha256 = "19rng6v1sw14mbjp5cplnrgxjnhlj8faalfw02iihi9s5w1k7zjy";
   };
 
-  propagatedBuildInputs = [ pyjwt django djangorestframework ];
+  propagatedBuildInputs = [ pyjwt' django djangorestframework ];
 
   # ./runtests.py fails because the project must be tested against a django
   # installation, there are missing database tables for User, that don't exist.


### PR DESCRIPTION
This package depends on an older version of 'pyjwt' than is packaged in
nixpkgs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently, building djangorestframework-jwt errors out:
```
ERROR: Could not find a version that satisfies the requirement PyJWT<2.0.0,>=1.5.2 (from djangorestframework-jwt)
ERROR: No matching distribution found for PyJWT<2.0.0,>=1.5.2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
