### PR TITLE
fishplugins: forgit fix dependency linking

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -15,7 +15,7 @@ lib.makeScope newScope (self: with self; {
 
   foreign-env = callPackage ./foreign-env { };
 
-  forgit-fish = callPackage ./forgit.nix { };
+  forgit = callPackage ./forgit.nix { };
 
   fzf-fish = callPackage ./fzf-fish.nix { };
 

--- a/pkgs/shells/fish/plugins/forgit.nix
+++ b/pkgs/shells/fish/plugins/forgit.nix
@@ -4,7 +4,11 @@ buildFishPlugin rec {
   pname = "forgit";
   version = "unstable-2021-04-09";
 
-  buildInputs = [ git fzf ];
+  preFixup = ''
+    substituteInPlace $out/share/fish/vendor_conf.d/forgit.plugin.fish \
+      --replace "fzf " "${fzf}/bin/fzf " \
+      --replace "git " "${git}/bin/git "
+  '';
 
   src = fetchFromGitHub {
     owner = "wfxr";


### PR DESCRIPTION
###### Motivation for this change

dependency linking is currently broken. The plugin depends on fzf and git

I've tested building and I've briefly checked that the resulting file doesn't seem broken, but I'm not sure if that is the right way to proceed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
