### PR TITLE
python3Packages.anyio: 2.2.0 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -6,8 +6,8 @@
 , idna
 , sniffio
 , typing-extensions
-, curio
 , hypothesis
+, pytest-mock
 , pytestCheckHook
 , trio
 , trustme
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "anyio";
-  version = "2.2.0";
+  version = "3.1.0";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = pname;
     rev = version;
-    sha256 = "0ram1niv2lg9qj53zssph104a4kxl8f94ilfn6mibn034m3ikcc8";
+    sha256 = "17zc8wxkp22xn84dqw2wbmfx8h9j3bv4why8zdn9swkv0c0r426d";
   };
 
   propagatedBuildInputs = [
@@ -35,8 +35,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    curio
     hypothesis
+    pytest-mock
     pytestCheckHook
     trio
     trustme


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/agronholm/anyio/blob/3.0.0/docs/versionhistory.rst

Anyio uses semver 2.0, so this is a breaking change, any boy does it break jupyter_server. @elohmeier 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
