### PR TITLE
shticker-book-unwritten: fix broken cargoSha256; add libXcursor

### DIFF
--- a/pkgs/games/shticker-book-unwritten/default.nix
+++ b/pkgs/games/shticker-book-unwritten/default.nix
@@ -8,6 +8,7 @@ in buildFHSUserEnv {
   targetPkgs = pkgs: with pkgs; [
       alsaLib
       xorg.libX11
+      xorg.libXcursor
       xorg.libXext
       libglvnd
       shticker-book-unwritten-unwrapped

--- a/pkgs/games/shticker-book-unwritten/unwrapped.nix
+++ b/pkgs/games/shticker-book-unwritten/unwrapped.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoPatches = [ ./cargo-lock.patch ];
-  cargoSha256 = "1lnhdr8mri1ns9lxj6aks4vs2v4fvg7mcriwzwj78inpi1l0xqk5";
+  cargoSha256 = "1d4mnfzkdbqnjmqk7fl4bsy27lr7wnq997nz0hflaybnx2d3nisn";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cargoSha256 started mismatching for some reason. Also I didn't realize I was missing a runtime dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
