### PR TITLE
libconfig: fix static windows build

### DIFF
--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+, # this also disables building tests.
+  # on static windows cross-compile they fail to build
+  doCheck ? with stdenv.hostPlatform; !(isWindows && isStatic)
+}:
 
 stdenv.mkDerivation rec {
   pname = "libconfig";
@@ -9,15 +15,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VFFm1srAN3RDgdHpzFpUBQlOe/rRakEWmbz/QLuzHuc=";
   };
 
-  doCheck = true;
+  inherit doCheck;
 
-  configureFlags = lib.optional (stdenv.targetPlatform.isWindows || stdenv.hostPlatform.isStatic) "--disable-examples";
+  configureFlags = lib.optional (stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic) "--disable-examples"
+    ++ lib.optional (!doCheck) "--disable-tests";
+
+  cmakeFlags = lib.optionals (!doCheck) [ "-DBUILD_TESTS:BOOL=OFF" ];
 
   meta = with lib; {
     homepage = "http://www.hyperrealm.com/libconfig";
     description = "A simple library for processing structured configuration files";
     license = licenses.lgpl3;
     maintainers = [ maintainers.goibhniu ];
-    platforms = with platforms; linux ++ darwin ++ windows;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
when building statically for windows, libconfig tests fail to build. This disables them in that situation.

I feel like this is a lot of tweaking for an edge case, and it seems ugly and hard to follow sprinkled throughout the derivation. Is there a canonical way to change a bunch of stuff based on one conditional all in once place? I can imagine using something like

```
(stdenv.mkDerivation rec {
  ...
}).overrideAttrs (old: 
lib.optionalAttrs (stdenv.hostPlatform.isWindows && stdenv.hostPlatform.isStatic) {
  doCheck = false;
  ...
}
```

But I've never seen such a thing in a derivation before, so I don't know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
