### PR TITLE
openblas: Allow setting DYNAMIC_ARCH

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -15,6 +15,8 @@
 # Select a specific optimization target (other than the default)
 # See https://github.com/xianyi/OpenBLAS/blob/develop/TargetList.txt
 , target ? null
+# Select whether DYNAMIC_ARCH is enabled or not.
+, dynamicArch ? null
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
@@ -25,27 +27,28 @@ let blas64_ = blas64; in
 
 let
   setTarget = x: if target == null then x else target;
+  setDynamicArch = x: if dynamicArch == null then x else dynamicArch;
 
   # To add support for a new platform, add an element to this set.
   configs = {
     armv6l-linux = {
       BINARY = 32;
       TARGET = setTarget "ARMV6";
-      DYNAMIC_ARCH = false;
+      DYNAMIC_ARCH = setDynamicArch false;
       USE_OPENMP = true;
     };
 
     armv7l-linux = {
       BINARY = 32;
       TARGET = setTarget "ARMV7";
-      DYNAMIC_ARCH = false;
+      DYNAMIC_ARCH = setDynamicArch false;
       USE_OPENMP = true;
     };
 
     aarch64-darwin = {
       BINARY = 64;
       TARGET = setTarget "VORTEX";
-      DYNAMIC_ARCH = true;
+      DYNAMIC_ARCH = setDynamicArch true;
       USE_OPENMP = false;
       MACOSX_DEPLOYMENT_TARGET = "11.0";
     };
@@ -53,21 +56,21 @@ let
     aarch64-linux = {
       BINARY = 64;
       TARGET = setTarget "ARMV8";
-      DYNAMIC_ARCH = true;
+      DYNAMIC_ARCH = setDynamicArch true;
       USE_OPENMP = true;
     };
 
     i686-linux = {
       BINARY = 32;
       TARGET = setTarget "P2";
-      DYNAMIC_ARCH = true;
+      DYNAMIC_ARCH = setDynamicArch true;
       USE_OPENMP = true;
     };
 
     x86_64-darwin = {
       BINARY = 64;
       TARGET = setTarget "ATHLON";
-      DYNAMIC_ARCH = true;
+      DYNAMIC_ARCH = setDynamicArch true;
       USE_OPENMP = false;
       MACOSX_DEPLOYMENT_TARGET = "10.7";
     };
@@ -75,14 +78,14 @@ let
     x86_64-linux = {
       BINARY = 64;
       TARGET = setTarget "ATHLON";
-      DYNAMIC_ARCH = true;
+      DYNAMIC_ARCH = setDynamicArch true;
       USE_OPENMP = !stdenv.hostPlatform.isMusl;
     };
 
     powerpc64le-linux = {
       BINARY = 64;
       TARGET = setTarget "POWER5";
-      DYNAMIC_ARCH = true;
+      DYNAMIC_ARCH = setDynamicArch true;
       USE_OPENMP = !stdenv.hostPlatform.isMusl;
     };
   };


### PR DESCRIPTION
###### Motivation for this change

It is useful in certain scenarios to force a specific architecture to be used for OpenBLAS even if a newer one is available. Just setting the `target` does not appear to be enough: setting `target` to `HASWELL` still resulted in detection and usage of `SkylakeX` during my testing.

To force Haswell in this case, we have to disable dynamic detection too apparently. This patch allows that.

There should be no difference in default behaviour.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
