### PR TITLE
Make the bootsrap respect the contentAddressedByDefault setting

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -44,7 +44,7 @@ in rec {
     stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
   '';
 
-  bootstrapTools = derivation {
+  bootstrapTools = derivation ({
     inherit system;
 
     name    = "bootstrap-tools";
@@ -54,7 +54,11 @@ in rec {
     inherit (bootstrapFiles) mkdir bzip2 cpio tarball;
 
     __impureHostDeps = commonImpureHostDeps;
-  };
+  } // lib.optionalAttrs (config.contentAddressedByDefault or false) {
+    __contentAddressed = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  });
 
   stageFun = step: last: {shell             ? "${bootstrapTools}/bin/bash",
                           overrides         ? (self: super: {}),

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -170,7 +170,7 @@ in
   ({}: {
     __raw = true;
 
-    bootstrapTools = derivation {
+    bootstrapTools = derivation ({
       inherit system;
       inherit make bash coreutils findutils
         diffutils grep patch gawk cpio sed
@@ -182,7 +182,11 @@ in
       buildInputs = [ make ];
       mkdir = "/bin/mkdir";
       ln = "/bin/ln";
-    };
+    } // lib.optionalAttrs (config.contentAddressedByDefault or false) {
+      __contentAddressed = true;
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+    });
   })
 
   ({ bootstrapTools, ... }: rec {

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -84,6 +84,11 @@ let
       allowedRequisites = allowedRequisites
         ++ defaultNativeBuildInputs ++ defaultBuildInputs;
     }
+    // lib.optionalAttrs (config.contentAddressedByDefault or false) {
+      __contentAddressed = true;
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+    }
     // {
       inherit name;
 

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
@@ -1,6 +1,6 @@
-{ system, bootstrapFiles }:
+{ system, bootstrapFiles, extraAttrs }:
 
-derivation {
+derivation ({
   name = "bootstrap-tools";
 
   builder = bootstrapFiles.busybox;
@@ -15,4 +15,4 @@ derivation {
   langC = true;
   langCC = true;
   isGNU = true;
-}
+} // extraAttrs)

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -1,6 +1,6 @@
-{ system, bootstrapFiles }:
+{ system, bootstrapFiles, extraAttrs }:
 
-derivation {
+derivation ({
   name = "bootstrap-tools";
 
   builder = bootstrapFiles.busybox;
@@ -15,4 +15,4 @@ derivation {
   langC = true;
   langCC = true;
   isGNU = true;
-}
+} // extraAttrs)

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -61,7 +61,16 @@ let
 
 
   # Download and unpack the bootstrap tools (coreutils, GCC, Glibc, ...).
-  bootstrapTools = import (if localSystem.libc == "musl" then ./bootstrap-tools-musl else ./bootstrap-tools) { inherit system bootstrapFiles; };
+  bootstrapTools = import (if localSystem.libc == "musl" then ./bootstrap-tools-musl else ./bootstrap-tools) {
+    inherit system bootstrapFiles;
+    extraAttrs = lib.optionalAttrs
+      (config.contentAddressedByDefault or false)
+      {
+        __contentAddressed = true;
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+      };
+  };
 
   getLibc = stage: stage.${localSystem.libc};
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -224,15 +224,24 @@ in with pkgs; rec {
     bootstrapTools = runCommand "bootstrap-tools.tar.xz" {} "cp ${build}/on-server/bootstrap-tools.tar.xz $out";
   };
 
-  bootstrapTools = if (stdenv.hostPlatform.libc == "glibc") then
+  bootstrapTools =
+    let extraAttrs = lib.optionalAttrs
+      (config.contentAddressedByDefault or false)
+      {
+        __contentAddressed = true;
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+      };
+    in
+    if (stdenv.hostPlatform.libc == "glibc") then
     import ./bootstrap-tools {
       inherit (stdenv.buildPlatform) system; # Used to determine where to build
-      inherit bootstrapFiles;
+      inherit bootstrapFiles extraAttrs;
     }
     else if (stdenv.hostPlatform.libc == "musl") then
     import ./bootstrap-tools-musl {
       inherit (stdenv.buildPlatform) system; # Used to determine where to build
-      inherit bootstrapFiles;
+      inherit bootstrapFiles extraAttrs;
     }
     else throw "unsupported libc";
 


### PR DESCRIPTION
###### Motivation for this change

Patch every `derivation` call in the bootsrap process to add it a
conditional `__contentAddressed` parameter.

That way, passing `contentAddressedByDefault` means that the entire
build closure of a system can be content addressed.

As an example,

```console
$ nix-build --experimental-features ca-derivations '<nixpkgs>' -A hello --arg config '{ contentAddressedByDefault = true; }'
```

Will build a `hello` package whose entire closure (both build closure and runtime dependencies) only consists of content-addressed paths (be they plain store paths, fixed-output derivations or floating-ca derivations).

Like #120316 this shouldn't cause any rebuild by default.

/cc @edolstra @ericson2314

