### PR TITLE
tdesktop: 2.7.1 -> 2.7.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, pkgs, fetchurl, callPackage
+{ mkDerivation, lib, fetchurl, writeTextFile, callPackage
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
 , qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
@@ -20,7 +20,7 @@ with lib;
 
 let
   tg_owt = callPackage ./tg_owt.nix {};
-  webviewPatch = pkgs.writeTextFile {
+  webviewPatch = writeTextFile {
     name = "fix-webview-includes.patch";
     text = ''
       diff --git a/webview/platform/linux/webview_linux_webkit_gtk.h b/webview/platform/linux/webview_linux_webkit_gtk.h

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,8 +1,8 @@
-{ mkDerivation, lib, fetchurl, fetchpatch, callPackage
+{ mkDerivation, lib, pkgs, fetchurl, callPackage
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
 , qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
-, tl-expected, hunspell, glibmm
+, tl-expected, hunspell, glibmm, webkitgtk
 # Transitive dependencies:
 , pcre, xorg, util-linux, libselinux, libsepol, epoxy
 , at-spi2-core, libXtst, libthai, libdatrie
@@ -20,19 +20,31 @@ with lib;
 
 let
   tg_owt = callPackage ./tg_owt.nix {};
-  tgcalls-gcc10-fix = fetchpatch { # "Fix build on GCC 10, second attempt."
-    url = "https://github.com/TelegramMessenger/tgcalls/commit/eded7cc540123eaf26361958b9a61c65cb2f7cfc.patch";
-    sha256 = "19n1hvn44pp01zc90g93vq2bcr2gdnscaj5il9f82klgh4llvjli";
+  webviewPatch = pkgs.writeTextFile {
+    name = "fix-webview-includes.patch";
+    text = ''
+      diff --git a/webview/platform/linux/webview_linux_webkit_gtk.h b/webview/platform/linux/webview_linux_webkit_gtk.h
+      index a7f0f97..c2b21c7 100644
+      --- a/webview/platform/linux/webview_linux_webkit_gtk.h
+      +++ b/webview/platform/linux/webview_linux_webkit_gtk.h
+      @@ -14,6 +14,7 @@ extern "C" {
+       #include <gtk/gtk.h>
+       #include <webkit2/webkit2.h>
+       #include <X11/Xlib.h>
+      +#include <gdk/gdkx.h>
+       #define signals public
+       } // extern "C"
+    '';
   };
 
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.7.1";
+  version = "2.7.3";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "01fxzcfz3xankmdar55ja55pb9hkvlf1plgpgjpsda9xwqgbxgs1";
+    sha256 = "1mrzdv432hm5c2hh6l7v5zqviqa8xymd3c4jvrdwgpxsj1l9ph68";
   };
 
   postPatch = ''
@@ -40,7 +52,7 @@ in mkDerivation rec {
       --replace '"libenchant-2.so.2"' '"${enchant2}/lib/libenchant-2.so.2"'
     substituteInPlace Telegram/CMakeLists.txt \
       --replace '"''${TDESKTOP_LAUNCHER_BASENAME}.appdata.xml"' '"''${TDESKTOP_LAUNCHER_BASENAME}.metainfo.xml"'
-    patch -d Telegram/ThirdParty/tgcalls/ -p1 < "${tgcalls-gcc10-fix}"
+    patch -d Telegram/lib_webview -p1 < "${webviewPatch}"
   '';
 
   # We want to run wrapProgram manually (with additional parameters)
@@ -52,7 +64,7 @@ in mkDerivation rec {
   buildInputs = [
     qtbase qtimageformats gtk3 libsForQt5.kwayland libsForQt5.libdbusmenu enchant2 lz4 xxHash
     dee ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
-    tl-expected hunspell glibmm
+    tl-expected hunspell glibmm webkitgtk
     tg_owt
     # Transitive dependencies:
     pcre xorg.libpthreadstubs xorg.libXdmcp util-linux libselinux libsepol epoxy

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, writeTextFile, callPackage
+{ mkDerivation, lib, fetchurl, fetchpatch, callPackage
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
 , qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
@@ -20,21 +20,9 @@ with lib;
 
 let
   tg_owt = callPackage ./tg_owt.nix {};
-  webviewPatch = writeTextFile {
-    name = "fix-webview-includes.patch";
-    text = ''
-      diff --git a/webview/platform/linux/webview_linux_webkit_gtk.h b/webview/platform/linux/webview_linux_webkit_gtk.h
-      index a7f0f97..c2b21c7 100644
-      --- a/webview/platform/linux/webview_linux_webkit_gtk.h
-      +++ b/webview/platform/linux/webview_linux_webkit_gtk.h
-      @@ -14,6 +14,7 @@ extern "C" {
-       #include <gtk/gtk.h>
-       #include <webkit2/webkit2.h>
-       #include <X11/Xlib.h>
-      +#include <gdk/gdkx.h>
-       #define signals public
-       } // extern "C"
-    '';
+  webviewPatch = fetchpatch {
+    url = "https://raw.githubusercontent.com/archlinux/svntogit-community/013eff77a13b6c2629a04e07a4d09dbe60c8ca48/trunk/fix-webview-includes.patch";
+    sha256 = "0112zaysf3f02dd4bgqc5hwg66h1bfj8r4yjzb06sfi0pl9vl96l";
   };
 
 in mkDerivation rec {

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -27,12 +27,12 @@ let
 
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.7.3";
+  version = "2.7.4";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "1mrzdv432hm5c2hh6l7v5zqviqa8xymd3c4jvrdwgpxsj1l9ph68";
+    sha256 = "1cigqvxa8lp79y7sp2w2izmmikxaxzrq9bh5ns3cy16z985nyllp";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Bump version. Add webkitgtk dependency (inline patch taken from Arch package).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
