### PR TITLE
nodejs: Fix build with icu 69

### DIFF
--- a/pkgs/development/web/nodejs/v12.nix
+++ b/pkgs/development/web/nodejs/v12.nix
@@ -1,8 +1,8 @@
-{ callPackage, openssl, icu, python2, lib, stdenv, enableNpm ? true }:
+{ callPackage, icu68, python2, lib, stdenv, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
-    inherit openssl icu;
+    icu = icu68;
     python = python2;
   };
 in

--- a/pkgs/development/web/nodejs/v14.nix
+++ b/pkgs/development/web/nodejs/v14.nix
@@ -1,8 +1,8 @@
-{ callPackage, openssl, python3, lib, stdenv, enableNpm ? true }:
+{ callPackage, icu68, python3, lib, stdenv, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
-    inherit openssl;
+    icu = icu68;
     python = python3;
   };
 in

--- a/pkgs/development/web/nodejs/v15.nix
+++ b/pkgs/development/web/nodejs/v15.nix
@@ -1,8 +1,8 @@
-{ callPackage, openssl, python3, enableNpm ? true }:
+{ callPackage, icu68, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
-    inherit openssl;
+    icu = icu68;
     python = python3;
   };
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Node 12/14/15 no longer build since the icu69 upgrade (https://github.com/NixOS/nixpkgs/pull/120020)


```
../deps/v8/src/objects/js-list-format.cc:172:55: error: 'createInstance' is a private member of 'icu_69::ListFormatter'
  icu::ListFormatter* formatter = icu::ListFormatter::createInstance(
                                  ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/nix/store/j1ihv6hl1fg9b73iz0way875cq5p5vwz-icu4c-69.1-dev/include/unicode/listformatter.h:267:27: note: declared private here
    static ListFormatter* createInstance(const Locale& locale, const char* style, UErrorCode& errorCode);
                          ^
1 error generated.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I've submitted this PR against staging since so far, the icu69 upgrade is only present there - not sure if that's the correct thing to do?

cc @goibhniu @gilligan @cko @marsam