### PR TITLE
solana: init at 1.5.19

### DIFF
--- a/pkgs/applications/blockchains/solana/0001-Make-test_hash_stored_account-pass-in-release-mode.patch
+++ b/pkgs/applications/blockchains/solana/0001-Make-test_hash_stored_account-pass-in-release-mode.patch
@@ -1,0 +1,34 @@
+From a278f9287f5decdc1e75b16bb39049a2673de5e6 Mon Sep 17 00:00:00 2001
+From: Ruud van Asseldonk <ruud@chorus.one>
+Date: Mon, 26 Apr 2021 13:02:27 +0200
+Subject: [PATCH] Make test_hash_stored_account pass in release mode
+
+The hash differs between debug and release mode, which makes the test
+fail when running under "cargo test --release". Use cfg! to include a
+different expected hash in release mode.
+---
+ runtime/src/accounts_db.rs | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git runtime/src/accounts_db.rs runtime/src/accounts_db.rs
+index b351f3353..5d5759bbf 100644
+--- a/runtime/src/accounts_db.rs
++++ b/runtime/src/accounts_db.rs
+@@ -7538,8 +7538,12 @@ pub mod tests {
+             hash: &hash,
+         };
+         let account = stored_account.clone_account();
+-        let expected_account_hash =
+-            Hash::from_str("4StuvYHFd7xuShVXB94uHHvpqGMCaacdZnYB74QQkPA1").unwrap();
++
++        let expected_account_hash = if cfg!(debug_assertions) {
++            Hash::from_str("4StuvYHFd7xuShVXB94uHHvpqGMCaacdZnYB74QQkPA1").unwrap()
++        } else {
++            Hash::from_str("33ruy7m3Xto7irYfsBSN74aAzQwCQxsfoZxXuZy2Rra3").unwrap()
++        };
+ 
+         assert_eq!(
+             AccountsDb::hash_stored_account(slot, &stored_account),
+-- 
+2.31.1
+

--- a/pkgs/applications/blockchains/solana/default.nix
+++ b/pkgs/applications/blockchains/solana/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, stdenv
+, clang
+, fetchFromGitHub
+, llvm
+, llvmPackages
+, openssl
+, pkg-config
+, rustPlatform
+, udev
+, zlib
+, rocksdb
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "solana";
+  # Please stick to mainnet releases here.
+  version = "1.5.19";
+
+  src = fetchFromGitHub {
+    owner = "solana-labs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04d2rz7hbb57w8zz0bcgkwggx2pz45pgad6imz9qsnqidwv4zc1v";
+  };
+
+  cargoSha256 = "0j6j9ivzb430pk154nnn9bm6gw9rh4frk4gvq6iv0nmlnvgqfg42";
+
+  nativeBuildInputs = [
+    pkg-config
+    llvmPackages.clang
+  ];
+
+  buildInputs = [
+    llvm
+    llvmPackages.libclang
+    openssl
+    udev
+    zlib
+    rocksdb
+  ];
+
+  preBuild = ''
+    export LLVM_CONFIG_PATH="${llvm}/bin/llvm-config";
+    export LIBCLANG_PATH="${llvmPackages.libclang}/lib";
+
+    # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+    # try to build RocksDB from source.
+    export ROCKSDB_INCLUDE_DIR="${rocksdb}/include";
+    export ROCKSDB_LIB_DIR="${rocksdb}/lib";
+  '';
+
+  patches = [
+    # https://github.com/solana-labs/solana/issues/16823
+    ./0001-Make-test_hash_stored_account-pass-in-release-mode.patch
+  ];
+
+  # The metrics::counter tests depend on the RUST_LOG environment variable, and
+  # need it to be unset or at least INFO. buildRustPackage sets it to "" if we
+  # don't specify it, which makes these tests fail.
+  # This can be removed after https://github.com/solana-labs/solana/pull/16710
+  # is merged and released.
+  logLevel = "INFO";
+
+  # Some tests are flaky or broken, disable them.
+  postPatch = ''
+    function disable() {
+      sed --regexp-extended --in-place "s/(pub )?fn $1\(\)/#[ignore] fn $1()/g" $2
+    }
+
+    # https://github.com/solana-labs/solana/issues/16680
+    disable test_push_votes_with_tower core/src/cluster_info.rs
+
+    # https://github.com/solana-labs/solana/issues/16684
+    disable test_banking_stage_entryfication core/src/banking_stage.rs
+
+    # https://github.com/solana-labs/solana/issues/16904
+    disable test_new_from_file_crafted_executable runtime/src/append_vec.rs
+
+    # https://github.com/solana-labs/solana/issues/16963
+    disable test_recv_mmsg_batch_size streamer/tests/recvmmsg.rs
+
+    # https://github.com/solana-labs/solana/issues/16970
+    disable test_rpc_subscriptions core/tests/rpc.rs
+    disable test_rpc_slot_updates core/tests/rpc.rs
+
+    # These tests do pass, but they take a long time (~half an hour) to run,
+    # so skip them.
+    rm local-cluster/tests/local_cluster.rs
+  '';
+
+  meta = with lib; {
+    description = "Web-scale blockchain for fast, secure, scalable, decentralized apps and marketplaces";
+    homepage = "https://solana.com/";
+    changelog = "https://github.com/solana-labs/solana/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ruuda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8468,6 +8468,8 @@ in
 
   sonar-scanner-cli = callPackage ../tools/security/sonar-scanner-cli { };
 
+  solana = callPackage ../applications/blockchains/solana { };
+
   solr = callPackage ../servers/search/solr { };
 
   solvespace = callPackage ../applications/graphics/solvespace { };


### PR DESCRIPTION
This adds [Solana](https://solana.com/), a performance-oriented blockchain. The source is the Solana monorepo, which includes the development tools and tools needed to interact with the network.

Version 1.5.19 is not the latest release at the time of writing, but it is the latest one intended for use with the mainnet.

###### Motivation for this change

* Having the Solana devtools available in Nixpkgs makes it easy to manage development environments with Nix.
* Solana users who also use Nix don’t need to download a binary / manually build from source any more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
