### PR TITLE
amdvlk: 2021.Q1.6 -> 2021.Q2.2

### DIFF
--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -21,13 +21,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "amdvlk";
-  version = "2021.Q1.6";
+  version = "2021.Q2.2";
 
   src = fetchRepoProject {
     name = "${pname}-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${version}";
-    sha256 = "FSQ/bYlvdw0Ih3Yl329o8Gizw0YcZTLtiI222Ju4M8w=";
+    sha256 = "4k9ZkBxJGuNUO44F9D+u54eUREl5/8zxjxhaShhzGv0=";
   };
 
   buildInputs = [
@@ -70,12 +70,8 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     install -Dm755 -t $out/lib icd/amdvlk${suffix}.so
-    install -Dm644 -t $out/share/vulkan/icd.d ../drivers/AMDVLK/json/Redhat/amd_icd${suffix}.json
-
-    substituteInPlace $out/share/vulkan/icd.d/amd_icd${suffix}.json --replace \
-      "/usr/lib64" "$out/lib"
-    substituteInPlace $out/share/vulkan/icd.d/amd_icd${suffix}.json --replace \
-      "/usr/lib" "$out/lib"
+    install -Dm644 -t $out/share/vulkan/icd.d icd/amd_icd${suffix}.json
+    install -Dm644 -t $out/share/vulkan/implicit_layer.d icd/amd_icd${suffix}.json
 
     patchelf --set-rpath "$rpath" $out/lib/amdvlk${suffix}.so
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
2021.Q2.2 was published: https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2021.Q2.2
Starting with 2021.Q2.1, the ‘AMD switchable graphics layer’ is enabled. That means adding the `amdvlk` package to `hardware.opengl.extraPackages` will now hide radv from applications, so amdvlk should be used by default.
This behavior can be changed by setting `AMD_VULKAN_ICD=RADV` (this will hide amdvlk) or `VK_ICD_FILENAMES=/run/opengl-driver/share/vulkan/icd.d/radeon_icd.x86_64.json` (this will only show radv and not load others like lavapipe).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested vkcube and Dota 2
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
