### PR TITLE
rofi-power-menu: init at 3.0.2

### DIFF
--- a/pkgs/applications/misc/rofi-power-menu/default.nix
+++ b/pkgs/applications/misc/rofi-power-menu/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Shows a Power/Lock menu with Rofi";
     homepage = "https://github.com/jluttine/rofi-power-menu";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ikervagyok ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/rofi-power-menu/default.nix
+++ b/pkgs/applications/misc/rofi-power-menu/default.nix
@@ -1,22 +1,25 @@
 { lib, stdenv, fetchFromGitHub, rofi }:
 
 stdenv.mkDerivation rec {
+  pname = "rofi-power-menu";
   version = "3.0.2";
-  name = "rofi-power-menu-${version}";
+
   src = fetchFromGitHub {
     owner = "jluttine";
     repo = "rofi-power-menu";
     rev = version;
     sha256 = "sha256-Bkc87BXSnAR517wCkyOAfoACYx/5xprDGJQhLWGUNns=";
   };
+
   installPhase = ''
     mkdir -p $out/bin
     cp rofi-power-menu $out/bin/rofi-power-menu
     cp dmenu-power-menu $out/bin/dmenu-power-menu
   '';
+
   meta = with lib; {
     description = "Shows a Power/Lock menu with Rofi";
-    homepage = "https://github.com/${src.owner}/${src.repo}";
+    homepage = "https://github.com/jluttine/rofi-power-menu";
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/rofi-power-menu/default.nix
+++ b/pkgs/applications/misc/rofi-power-menu/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, rofi }:
+
+stdenv.mkDerivation rec {
+  version = "3.0.2";
+  name = "rofi-power-menu-${version}";
+  src = fetchFromGitHub {
+    owner = "jluttine";
+    repo = "rofi-power-menu";
+    rev = version;
+    sha256 = "sha256-Bkc87BXSnAR517wCkyOAfoACYx/5xprDGJQhLWGUNns=";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    cp rofi-power-menu $out/bin/rofi-power-menu
+    cp dmenu-power-menu $out/bin/dmenu-power-menu
+  '';
+  meta = with lib; {
+    description = "Shows a Power/Lock menu with Rofi";
+    homepage = "https://github.com/${src.owner}/${src.repo}";
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24728,6 +24728,8 @@ in
 
   rofi-file-browser = callPackage ../applications/misc/rofi-file-browser { };
 
+  rofi-power-menu = callPackage ../applications/misc/rofi-power-menu { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   # a somewhat more maintained fork of ympd


### PR DESCRIPTION
###### Motivation for this change
New package

###### Things done
using this for month with xmonad+rofi, no problems encountered

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
