### PR TITLE
libgnurx: output libgnurx.a when static

### DIFF
--- a/pkgs/os-specific/windows/libgnurx/default.nix
+++ b/pkgs/os-specific/windows/libgnurx/default.nix
@@ -10,6 +10,11 @@ in stdenv.mkDerivation rec {
     sha256 = "0xjxcxgws3bblybw5zsp9a4naz2v5bs1k3mk8dw00ggc0vwbfivi";
   };
 
+  # file looks for libgnurx.a when compiling statically
+  postInstall = lib.optionalString stdenv.hostPlatform.isStatic ''
+    ln -s $out/lib/libgnurx{.dll.a,.a}
+  '';
+
   meta = {
     platforms = lib.platforms.windows;
   };


### PR DESCRIPTION
###### Motivation for this change
When building statically, `file` looks for `libgnurx.a`, but we only output `libgnurx.dll.a` and `libregex.a`. I arbitrarily chose to link `libgnurx.dll.a` to `libgnurx.a` and it seems to have worked. I didn't try it with `libregex.a`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
