### PR TITLE
pythonPackages.sip_5: add `platform_tag` attribute

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , mkDerivation
 , fetchurl
 , poppler_utils
@@ -42,18 +41,11 @@ mkDerivation rec {
   ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 
   escaped_pyqt5_dir = builtins.replaceStrings ["/"] ["\\/"] (toString python3Packages.pyqt5);
-  platform_tag =
-    if stdenv.hostPlatform.isDarwin then
-      "WS_MACX"
-    else if stdenv.hostPlatform.isWindows then
-      "WS_WIN"
-    else
-      "WS_X11";
 
   prePatch = ''
     sed -i "s/\[tool.sip.project\]/[tool.sip.project]\nsip-include-dirs = [\"${escaped_pyqt5_dir}\/share\/sip\/PyQt5\"]/g" \
       setup/build.py
-    sed -i "s/\[tool.sip.bindings.pictureflow\]/[tool.sip.bindings.pictureflow]\ntags = [\"${platform_tag}\"]/g" \
+    sed -i "s/\[tool.sip.bindings.pictureflow\]/[tool.sip.bindings.pictureflow]\ntags = [\"${python3Packages.sip_5.platform_tag}\"]/g" \
       setup/build.py
 
     # Remove unneeded files and libs

--- a/pkgs/development/python-modules/sip/5.x.nix
+++ b/pkgs/development/python-modules/sip/5.x.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, packaging, toml }:
+{ lib, stdenv, fetchPypi, buildPythonPackage, packaging, toml }:
 
 buildPythonPackage rec {
   pname = "sip";
@@ -16,6 +16,20 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "sipbuild" ];
+
+  # FIXME: Why isn't this detected automatically?
+  # Needs to be specified in pyproject.toml, e.g.:
+  # [tool.sip.bindings.MODULE]
+  # tags = [PLATFORM_TAG]
+  platform_tag =
+    if stdenv.targetPlatform.isLinux then
+      "WS_X11"
+    else if stdenv.targetPlatform.isDarwin then
+      "WS_MACX"
+    else if stdenv.targetPlatform.isWindows then
+      "WS_WIN"
+    else
+      throw "unsupported platform";
 
   meta = with lib; {
     description = "Creates C++ bindings for Python modules";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It's value is platform dependend and needs to be specified in `pyproject.toml` for modules that use sip_5. Instead of defining it for each module, we can add it to sip_5, so it can be reused.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
