### PR TITLE
jre_minimal: add basic test

### DIFF
--- a/pkgs/development/compilers/openjdk/jre.nix
+++ b/pkgs/development/compilers/openjdk/jre.nix
@@ -1,6 +1,7 @@
 { stdenv
 , jdk
 , lib
+, callPackage
 , modules ? [ "java.base" ]
 }:
 
@@ -29,6 +30,10 @@ let
 
     passthru = {
       home = "${jre}";
+      tests = [
+        (callPackage ./tests/test_jre_minimal.nix {})
+        (callPackage ./tests/test_jre_minimal_with_logging.nix {})
+      ];
     };
   };
 in jre

--- a/pkgs/development/compilers/openjdk/jre_minimal_test1.nix
+++ b/pkgs/development/compilers/openjdk/jre_minimal_test1.nix
@@ -1,0 +1,16 @@
+{ runCommand
+, callPackage
+, jdk
+, jre_minimal
+}:
+
+let
+  hello = callPackage tests/hello.nix {
+    jdk = jdk;
+    jre = jre_minimal;
+  };
+in
+  runCommand "test" {} ''
+    ${hello}/bin/hello | grep "Hello, world!"
+    touch $out
+  ''

--- a/pkgs/development/compilers/openjdk/tests/hello-logging.nix
+++ b/pkgs/development/compilers/openjdk/tests/hello-logging.nix
@@ -1,0 +1,47 @@
+{ jdk
+, jre
+, pkgs
+}:
+
+/* 'Hello world' Java application derivation for use in tests */
+let
+  source = pkgs.writeTextDir "src/Hello.java" ''
+    import java.util.logging.Logger;
+    import java.util.logging.Level;
+
+    class Hello {
+      static Logger logger = Logger.getLogger(Hello.class.getName());
+
+      public static void main(String[] args) {
+        logger.log(Level.INFO, "Hello, world!");
+      }
+    }
+  '';
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "hello";
+    version = "1.0.0";
+
+    src = source;
+
+    buildPhase = ''
+      runHook preBuildPhase
+      ${jdk}/bin/javac src/Hello.java
+      runHook postBuildPhase
+    '';
+    installPhase = ''
+      runHook preInstallPhase
+
+      mkdir -p $out/lib
+      cp src/Hello.class $out/lib
+
+      mkdir -p $out/bin
+      cat >$out/bin/hello <<EOF;
+      #!/usr/bin/env sh
+      ${jre}/bin/java -cp $out/lib Hello
+      EOF
+      chmod a+x $out/bin/hello
+
+      runHook postInstallPhase
+    '';
+  }

--- a/pkgs/development/compilers/openjdk/tests/hello.nix
+++ b/pkgs/development/compilers/openjdk/tests/hello.nix
@@ -1,0 +1,42 @@
+{ jdk
+, jre
+, pkgs
+}:
+
+/* 'Hello world' Java application derivation for use in tests */
+let
+  source = pkgs.writeTextDir "src/Hello.java" ''
+    class Hello {
+      public static void main(String[] args) {
+        System.out.println("Hello, world!");
+      }
+    }
+  '';
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "hello";
+    version = "1.0.0";
+
+    src = source;
+
+    buildPhase = ''
+      runHook preBuildPhase
+      ${jdk}/bin/javac src/Hello.java
+      runHook postBuildPhase
+    '';
+    installPhase = ''
+      runHook preInstallPhase
+
+      mkdir -p $out/lib
+      cp src/Hello.class $out/lib
+
+      mkdir -p $out/bin
+      cat >$out/bin/hello <<EOF;
+      #!/usr/bin/env sh
+      ${jre}/bin/java -cp $out/lib Hello
+      EOF
+      chmod a+x $out/bin/hello
+
+      runHook postInstallPhase
+    '';
+  }

--- a/pkgs/development/compilers/openjdk/tests/test_jre_minimal.nix
+++ b/pkgs/development/compilers/openjdk/tests/test_jre_minimal.nix
@@ -1,0 +1,16 @@
+{ runCommand
+, callPackage
+, jdk
+, jre_minimal
+}:
+
+let
+  hello = callPackage ./hello.nix {
+    jdk = jdk;
+    jre = jre_minimal;
+  };
+in
+  runCommand "test" {} ''
+    ${hello}/bin/hello | grep "Hello, world!"
+    touch $out
+  ''

--- a/pkgs/development/compilers/openjdk/tests/test_jre_minimal_with_logging.nix
+++ b/pkgs/development/compilers/openjdk/tests/test_jre_minimal_with_logging.nix
@@ -1,0 +1,21 @@
+{ runCommand
+, callPackage
+, jdk
+, jre_minimal
+}:
+
+let
+  hello-logging = callPackage ./hello-logging.nix {
+    jdk = jdk;
+    jre = jre_minimal.override {
+      modules = [
+        "java.base"
+        "java.logging"
+      ];
+    };
+  };
+in
+  runCommand "test" {} ''
+    ${hello-logging}/bin/hello &>/dev/stdout | grep "Hello, world!"
+    touch $out
+  ''


### PR DESCRIPTION
###### Motivation for this change

Adds a very basic test for jre_minimal.

This is a rather crude starting point, I'd welcome feedback!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).