### PR TITLE
xfce: does not explicitly require a gvfs package

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -984,6 +984,24 @@ environment.systemPackages = [
      PostgreSQL 9.5 is scheduled EOL during the 21.05 life cycle and has been removed.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <link xlink:href="https://www.xfce.org/">Xfce4</link> relies on
+     GIO/GVfs for userspace virtual filesystem access in applications
+     like <link xlink:href="https://docs.xfce.org/xfce/thunar/">thunar</link> and
+     <link xlink:href="https://docs.xfce.org/apps/gigolo/">gigolo</link>.
+     For that to work, the gvfs nixos service is enabled by default,
+     and it can be configured with the specific package that provides
+     GVfs. Until now Xfce4 was setting it to use a lighter version of
+     GVfs (without support for samba). To avoid conflicts with other
+     desktop environments this setting has been dropped. Users that
+     still want it should add the following to their system
+     configuration:
+     <programlisting>
+<xref linkend="opt-services.gvfs.package" /> = pkgs.gvfs.override { samba = null; };
+     </programlisting>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -151,7 +151,6 @@ in
     services.upower.enable = config.powerManagement.enable;
     services.gnome3.glib-networking.enable = true;
     services.gvfs.enable = true;
-    services.gvfs.package = pkgs.xfce.gvfs;
     services.tumbler.enable = true;
     services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
     services.xserver.libinput.enable = mkDefault true; # used in xfce4-settings-manager

--- a/pkgs/desktops/xfce/applications/gigolo/default.nix
+++ b/pkgs/desktops/xfce/applications/gigolo/default.nix
@@ -10,11 +10,6 @@ mkXfceDerivation {
 
   buildInputs = [ gtk3 glib ];
 
-  postPatch = ''
-    # exo-csource has been dropped from exo
-    substituteInPlace src/Makefile.am --replace exo-csource xdt-csource
-  '';
-
   meta = {
     description = "A frontend to easily manage connections to remote filesystems";
     license = with lib.licenses; [ gpl2Only ];

--- a/pkgs/desktops/xfce/applications/gigolo/default.nix
+++ b/pkgs/desktops/xfce/applications/gigolo/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkXfceDerivation, gtk3, gvfs, glib }:
+{ lib, mkXfceDerivation, gtk3, glib }:
 
 mkXfceDerivation {
   category = "apps";
@@ -8,7 +8,7 @@ mkXfceDerivation {
 
   sha256 = "8UDb4H3zxRKx2y+MRsozQoR3es0fs5ooR/5wBIE11bY=";
 
-  buildInputs = [ gtk3 glib gvfs ];
+  buildInputs = [ gtk3 glib ];
 
   postPatch = ''
     # exo-csource has been dropped from exo

--- a/pkgs/desktops/xfce/core/thunar/default.nix
+++ b/pkgs/desktops/xfce/core/thunar/default.nix
@@ -12,7 +12,6 @@
 , libxslt
 , xfconf
 , gobject-introspection
-, gvfs
 , makeWrapper
 , symlinkJoin
 , thunarPlugins ? []
@@ -35,7 +34,6 @@ let unwrapped = mkXfceDerivation {
     exo
     gdk-pixbuf
     gtk3
-    gvfs
     libX11
     libgudev
     libnotify

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -15,9 +15,6 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   automakeAddFlags = pkgs.makeSetupHook { } ./automakeAddFlags.sh;
 
-  # Samba is a rather heavy dependency
-  gvfs = pkgs.gvfs.override { samba = null; };
-
   #### CORE
 
   exo = callPackage ./core/exo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- In order to use GIO/GVFS it is enough to enable the `gvfs` service.

- The module option `services.gvfs.package` can be used to choose a  variation of the `gvfs` package, if desired.

Related to https://github.com/NixOS/nixpkgs/issues/69208.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
