### PR TITLE
python2Packages.importlib-resources: use version 3.3.1 for python2

### DIFF
--- a/pkgs/development/python-modules/importlib-resources/2.nix
+++ b/pkgs/development/python-modules/importlib-resources/2.nix
@@ -3,28 +3,27 @@
 , fetchPypi
 , setuptools-scm
 , importlib-metadata
-, typing ? null
-, singledispatch ? null
-, pythonOlder
+, typing
+, singledispatch
 , python
 }:
 
 buildPythonPackage rec {
   pname = "importlib-resources";
-  version = "5.1.2";
+  version = "3.3.1";
 
   src = fetchPypi {
     pname = "importlib_resources";
     inherit version;
-    sha256 = "642586fc4740bd1cad7690f836b3321309402b20b332529f25617ff18e8e1370";
+    sha256 = "0ed250dbd291947d1a298e89f39afcc477d5a6624770503034b72588601bcc05";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
   propagatedBuildInputs = [
     importlib-metadata
-  ] ++ lib.optional (pythonOlder "3.4") singledispatch
-    ++ lib.optional (pythonOlder "3.5") typing
-  ;
+    singledispatch
+    typing
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -178,6 +178,8 @@ with self; with super; {
 
   importlib-metadata = callPackage ../development/python-modules/importlib-metadata/2.nix { };
 
+  importlib-resources = callPackage ../development/python-modules/importlib-resources/2.nix { };
+
   ipaddr = callPackage ../development/python-modules/ipaddr { };
 
   ipykernel = callPackage ../development/python-modules/ipykernel/4.nix { };


### PR DESCRIPTION
###### Motivation for this change

Fixes #121011 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
