### PR TITLE
darwin bootstrap-tools bump LLVM to 11

### DIFF
--- a/pkgs/stdenv/darwin/fixed-xnu-python3.patch
+++ b/pkgs/stdenv/darwin/fixed-xnu-python3.patch
@@ -1,0 +1,41 @@
+diff --git a/bsd/kern/makekdebugevents.py b/bsd/kern/makekdebugevents.py
+index 73b2db4..d354ba0 100755
+--- a/bsd/kern/makekdebugevents.py
++++ b/bsd/kern/makekdebugevents.py
+@@ -5,7 +5,7 @@
+ # named kd_events[] or these mappings.
+ # Required to generate a header file used by DEVELOPMENT and DEBUG kernels.
+ #
+- 
++
+ import sys
+ import re
+ 
+@@ -21,18 +21,18 @@ code_table = []
+ # scan file to generate internal table
+ with open(trace_code_file, 'rt') as codes:
+     for line in codes:
+-	m = id_name_pattern.match(line)
+-	if m:
++        m = id_name_pattern.match(line)
++        if m:
+             code_table += [(int(m.group(1),base=16), m.group(2))]
+ 
+ # emit typedef:
+-print "typedef struct {"
+-print "        uint32_t   id;"
+-print "        const char *name;"
+-print "} kd_event_t;"
++print("typedef struct {")
++print("        uint32_t   id;")
++print("        const char *name;")
++print("} kd_event_t;")
+ # emit structure declaration and sorted initialization:
+-print "kd_event_t kd_events[] = {"
++print("kd_event_t kd_events[] = {")
+ for mapping in sorted(code_table, key=lambda x: x[0]):
+-        print "        {0x%x, \"%s\"}," % mapping
+-print "};"
++        print("        {0x%x, \"%s\"}," % mapping)
++print("};")
+ 

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -14,8 +14,7 @@ let cross = if crossSystem != null
 in with import pkgspath ({ inherit system; } // cross // custom-bootstrap);
 
 let
-  llvmPackageSet = if stdenv.hostPlatform.isAarch64 then "llvmPackages_11" else "llvmPackages_7";
-  llvmPackages = pkgs."${llvmPackageSet}";
+  llvmPackages = llvmPackages_11;
   storePrefixLen = builtins.stringLength builtins.storeDir;
 in rec {
   coreutils_ = coreutils.override (args: {

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -26,6 +26,12 @@ in rec {
   # Avoid messing with libkrb5 and libnghttp2.
   curl_ = curlMinimal.override (args: { gssSupport = false; http2Support = false; });
 
+  # Avoid stdenv rebuild.
+  Libsystem_ = darwin.Libsystem.override (args:
+    { xnu = darwin.xnu.overrideAttrs (oldAttrs:
+      { patches = [ ./fixed-xnu-python3.patch ]; });
+    });
+
   build = stdenv.mkDerivation {
     name = "stdenv-bootstrap-tools";
 
@@ -37,12 +43,12 @@ in rec {
 
       ${lib.optionalString stdenv.targetPlatform.isx86_64 ''
         # Copy libSystem's .o files for various low-level boot stuff.
-        cp -d ${darwin.Libsystem}/lib/*.o $out/lib
+        cp -d ${Libsystem_}/lib/*.o $out/lib
 
         # Resolv is actually a link to another package, so let's copy it properly
-        cp -L ${darwin.Libsystem}/lib/libresolv.9.dylib $out/lib
+        cp -L ${Libsystem_}/lib/libresolv.9.dylib $out/lib
 
-        cp -rL ${darwin.Libsystem}/include $out
+        cp -rL ${Libsystem_}/include $out
         chmod -R u+w $out/include
         cp -rL ${darwin.ICU}/include*             $out/include
         cp -rL ${libiconv}/include/*       $out/include

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -33,9 +33,47 @@ in rec {
   curl_ = curlMinimal.override (args: { gssSupport = false; http2Support = false; });
 
   # Avoid stdenv rebuild.
-  Libsystem_ = darwin.Libsystem.override (args:
+  Libsystem_ = (darwin.Libsystem.override (args:
     { xnu = darwin.xnu.overrideAttrs (oldAttrs:
       { patches = [ ./fixed-xnu-python3.patch ]; });
+    })).overrideAttrs (oldAttrs:
+    { installPhase = oldAttrs.installPhase + ''
+        cat <<EOF > $out/include/TargetConditionals.h
+        #ifndef __TARGETCONDITIONALS__
+        #define __TARGETCONDITIONALS__
+        #define TARGET_OS_MAC               1
+        #define TARGET_OS_WIN32             0
+        #define TARGET_OS_UNIX              0
+        #define TARGET_OS_OSX               1
+        #define TARGET_OS_IPHONE            0
+        #define TARGET_OS_IOS               0
+        #define TARGET_OS_WATCH             0
+        #define TARGET_OS_BRIDGE            0
+        #define TARGET_OS_TV                0
+        #define TARGET_OS_SIMULATOR         0
+        #define TARGET_OS_EMBEDDED          0
+        #define TARGET_OS_EMBEDDED_OTHER    0 /* Used in configd */
+        #define TARGET_IPHONE_SIMULATOR     TARGET_OS_SIMULATOR /* deprecated */
+        #define TARGET_OS_NANO              TARGET_OS_WATCH /* deprecated */
+
+        #define TARGET_CPU_PPC          0
+        #define TARGET_CPU_PPC64        0
+        #define TARGET_CPU_68K          0
+        #define TARGET_CPU_X86          0
+        #define TARGET_CPU_X86_64       1
+        #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
+        #define TARGET_CPU_MIPS         0
+        #define TARGET_CPU_SPARC        0
+        #define TARGET_CPU_ALPHA        0
+        #define TARGET_RT_MAC_CFM       0
+        #define TARGET_RT_MAC_MACHO     1
+        #define TARGET_RT_LITTLE_ENDIAN 1
+        #define TARGET_RT_BIG_ENDIAN    0
+        #define TARGET_RT_64_BIT        1
+        #endif  /* __TARGETCONDITIONALS__ */
+        EOF
+      '';
     });
 
   build = stdenv.mkDerivation {

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -99,6 +99,7 @@ in rec {
       cp -d ${llvmPackages.clang-unwrapped}/bin/clang* $out/bin
       cp -rd ${llvmPackages.clang-unwrapped.lib}/lib/* $out/lib
 
+      cp -d ${llvmPackages.libclang}/lib/libclang-cpp.dylib $out/lib
       cp -d ${llvmPackages.libcxx}/lib/libc++*.dylib $out/lib
       cp -d ${llvmPackages.libcxxabi}/lib/libc++abi*.dylib $out/lib
       cp -d ${llvmPackages.compiler-rt}/lib/darwin/libclang_rt* $out/lib/darwin

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -99,7 +99,7 @@ in rec {
       cp -d ${llvmPackages.clang-unwrapped}/bin/clang* $out/bin
       cp -rd ${llvmPackages.clang-unwrapped.lib}/lib/* $out/lib
 
-      cp -d ${llvmPackages.libclang}/lib/libclang-cpp.dylib $out/lib
+      cp -d ${llvmPackages.libclang}/lib/libclang-cpp*.dylib $out/lib
       cp -d ${llvmPackages.libcxx}/lib/libc++*.dylib $out/lib
       cp -d ${llvmPackages.libcxxabi}/lib/libc++abi*.dylib $out/lib
       cp -d ${llvmPackages.compiler-rt}/lib/darwin/libclang_rt* $out/lib/darwin

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -137,7 +137,6 @@ in rec {
       cp -d ${llvmPackages.clang-unwrapped}/bin/clang* $out/bin
       cp -rd ${llvmPackages.clang-unwrapped.lib}/lib/* $out/lib
 
-      cp -d ${llvmPackages.libclang}/lib/libclang-cpp*.dylib $out/lib
       cp -d ${llvmPackages.libcxx}/lib/libc++*.dylib $out/lib
       cp -d ${llvmPackages.libcxxabi}/lib/libc++abi*.dylib $out/lib
       cp -d ${llvmPackages.compiler-rt}/lib/darwin/libclang_rt* $out/lib/darwin


### PR DESCRIPTION
###### Motivation for this change

To bump the Apple SDK we need an updated bootstrap-tools for the Darwin stdenv.

###### Current status

I have added two tags on my branch. `bs1` points to the latest commit that can be built with the current bootstrap-tools, for everything after this you have to pass in this bootstrap-tools, and we need another bootstrap-tools to get `darwin.Csu` a dependency of stdenv to build, this would be tagged `bs2`. `current` points to the commit I'm currently working on, something's depending on a libunwind path it shouldn't be when trying to make-bootstrap-tools. The commits dealing with `darwin.xnu` and `darwin-stubs` are specific to the Apple SDK bump. I have a [messy build log](https://git.io/JmxTi) of this, which may help (or hinder) understanding the changes.

One big change in this branch is the bump from LLVM 7 to 11. This is because of [this build failure](https://git.io/J3T9N). I didn't really see a way forward and another part of `darwin.CF` was problematic because of LLVM 7 anyway so @LnL7 figured I might as well try bumping stdenv (and bootstrap-tools) LLVM, this was based on previous work trying to bump it to 9 #85151. If the priority is to bump only the Apple SDK (and we find an alternative solution to that build failure) it might be less time consuming to delay the LLVM bump and continue on my `apple_sdk-bump` branch.

cc @domenkozar 

