### PR TITLE
rtorrent-jesec: init at 0.9.8-r11

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent-jesec/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, cmake, gtest, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "libtorrent-jesec";
+  version = "0.13.8-r1";
+
+  src = fetchFromGitHub {
+    owner = "jesec";
+    repo = "libtorrent";
+    rev = "v${version}";
+    sha256 = "sha256-Eh5pMkSe9uO0dPRWDg2BbbRxxuvX9FM2/OReq/61ojc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl zlib ];
+
+  # https://github.com/jesec/libtorrent/issues/1
+  doCheck = false;
+  checkInputs = [ gtest ];
+
+  meta = with lib; {
+    description = "A BitTorrent library written in C++ for *nix, with focus on high performance and good code (jesec's fork)";
+    homepage = "https://github.com/jesec/libtorrent";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ winterqt ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, libtorrent-jesec
+, curl
+, ncurses
+, xmlrpc_c
+, nlohmann_json
+, xmlRpcSupport ? true
+, jsonRpcSupport ? true
+}:
+let
+  inherit (lib) optional;
+in
+stdenv.mkDerivation rec {
+  pname = "rtorrent-jesec";
+  version = "0.9.8-r10";
+
+  src = fetchFromGitHub {
+    owner = "jesec";
+    repo = "rtorrent";
+    rev = "v${version}";
+    sha256 = "sha256-Ge5W1rLaneUA7LxnBuMO/jQlqLOUKFf3gaAAlRr/qeM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libtorrent-jesec curl ncurses ]
+    ++ optional xmlRpcSupport xmlrpc_c
+    ++ optional jsonRpcSupport nlohmann_json;
+
+  cmakeFlags = [ "-DUSE_RUNTIME_CA_DETECTION=NO" ]
+    ++ optional (!xmlRpcSupport) "-DUSE_XMLRPC=NO"
+    ++ optional (!jsonRpcSupport) "-DUSE_JSONRPC=NO";
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+
+  prePatch = ''
+    substituteInPlace src/main.cc \
+      --replace "/etc/rtorrent/rtorrent.rc" "${placeholder "out"}/etc/rtorrent/rtorrent.rc"
+  '';
+
+  postFixup = ''
+    mkdir -p $out/etc/rtorrent
+    cp $src/doc/rtorrent.rc $out/etc/rtorrent/rtorrent.rc
+  '';
+
+  meta = with lib; {
+    description = "An ncurses client for libtorrent, ideal for use with screen, tmux, or dtach (jesec's fork)";
+    homepage = "https://github.com/jesec/rtorrent";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ winterqt ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5955,6 +5955,8 @@ in
 
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };
 
+  libtorrent-jesec = callPackage ../tools/networking/p2p/libtorrent-jesec { };
+
   libmpack = callPackage ../development/libraries/libmpack { };
 
   libiberty = callPackage ../development/libraries/libiberty { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7585,6 +7585,8 @@ in
 
   rtorrent = callPackage ../tools/networking/p2p/rtorrent { };
 
+  rtorrent-jesec = callPackage ../tools/networking/p2p/rtorrent-jesec { };
+
   rubber = callPackage ../tools/typesetting/rubber { };
 
   rubocop = callPackage ../development/tools/rubocop { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[jesec's fork of `rtorrent`](https://github.com/jesec/rtorrent) is a "distribution" of the rTorrent torrent client, which adds multiple quality-of-life improvements:

> This distribution focuses on additional user-facing features, optimizations and better integrations with modern users of RPC interfaces. One of the long-term goal of this project is to switch from antique XML-RPC to modern protocols with bidirectional capabilities such as gRPC, JSON-RPC over WebSocket or GraphQL, which allows real-time events, less serialization/transfer overheads, better security, etc.

This is the client that is recommended to be used by [Flood](https://github.com/jesec/flood), jesec's web UI for torrent clients. (which we already carry as `flood`.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
