### PR TITLE
mailspring: fix build

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailspring/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailspring/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     libsecret
     nss
     xorg.libxkbfile
+    xorg.libXdamage
     xorg.libXScrnSaver
     xorg.libXtst
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Mailspring won't build with the error:
```
error: builder for '/nix/store/pi7rczafwscbqfkgmfhhr9s1nblrvg5r-mailspring-1.9.1.drv' failed with exit code 1;
   last 10 log lines:
   ... 
   > autoPatchelfHook could not satisfy dependency libXdamage.so.1 wanted by /nix/store/gl39a8v69mf2spczcsvph446vnix9n45-mailspring-1.9.1/share/mailspring/mailspring
   > Add the missing dependencies to the build inputs or set autoPatchelfIgnoreMissingDeps=true
   For full logs, run 'nix log /nix/store/pi7rczafwscbqfkgmfhhr9s1nblrvg5r-mailspring-1.9.1.drv'.
```
This patch fixes the build by adding the `libXdamage` dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
