### PR TITLE
jp2a: 1.0.7 -> 1.1.0

### DIFF
--- a/pkgs/applications/misc/jp2a/default.nix
+++ b/pkgs/applications/misc/jp2a/default.nix
@@ -1,25 +1,43 @@
-{ lib, stdenv, fetchFromGitHub, libjpeg, autoreconfHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, libjpeg
+, libpng
+, ncurses
+, autoreconfHook
+, autoconf-archive
+, pkg-config
+, bash-completion
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.0.7";
+  version = "1.1.0";
   pname = "jp2a";
 
   src = fetchFromGitHub {
-    owner = "cslarsen";
+    owner = "Talinx";
     repo = "jp2a";
     rev = "v${version}";
-    sha256 = "12a1z9ba2j16y67f41y8ax5sgv1wdjd71pg7circdxkj263n78ql";
+    sha256 = "1dz2mrhl45f0vwyfx7qc3665xma78q024c10lfsgn6farrr0c2lb";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ libjpeg ];
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    pkg-config
+    bash-completion
+  ];
+  buildInputs = [ libjpeg libpng ncurses ];
+
+  installFlags = [ "bashcompdir=\${out}/share/bash-completion/completions" ];
 
   meta = with lib; {
     homepage = "https://csl.name/jp2a/";
     description = "A small utility that converts JPG images to ASCII";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.FlorianFranzen ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updates package to latest release from fork (Debian does the same) as well as includes ncurse for libterm functionality (e,g. `--term-fit` flag).

__CHANGES SINCE 1.1.0__
- support for PNG images
- support for HTML (Living Standard) additionally to XHTML
- (optional) support for other character encodings than ASCII

__CHANGES SINCE 1.0.9__
- support for true color and 256 color palette output for terminals
- support for bash completion

__CHANGES SINCE 1.0.8__
- Fix images with very small height

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
