### PR TITLE
openldap: Enable argon2 hash support by default

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, db, groff, libtool
+{ lib, stdenv, fetchurl, openssl, db, groff, libtool, libsodium
 , withCyrusSasl ? true
 , cyrus_sasl
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ groff ];
 
-  buildInputs = [ openssl cyrus_sasl db libtool ];
+  buildInputs = [ openssl cyrus_sasl db libsodium libtool ];
 
   # Disable install stripping as it breaks cross-compiling.
   # We strip binaries anyway in fixupPhase.
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
   postBuild = ''
     make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/sha2
     make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/pbkdf2
+    make $makeFlags CC=$CC -C contrib/slapd-modules/passwd/argon2
   '';
 
   doCheck = false; # needs a running LDAP server
@@ -54,6 +55,9 @@ stdenv.mkDerivation rec {
     "sysconfdir=$(out)/etc"
     "localstatedir=$(out)/var"
     "moduledir=$(out)/lib/modules"
+    # The argon2 module hardcodes /usr/bin/install as the path for the
+    # `install` binary, which is overridden here.
+    "INSTALL=install"
   ];
 
   # 1. Libraries left in the build location confuse `patchelf --shrink-rpath`
@@ -76,6 +80,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     make $installFlags install -C contrib/slapd-modules/passwd/sha2
     make $installFlags install -C contrib/slapd-modules/passwd/pbkdf2
+    make $installFlags install-lib -C contrib/slapd-modules/passwd/argon2
     chmod +x "$out"/lib/*.{so,dylib}
   '';
 


### PR DESCRIPTION
argon2 is the recommended password hashing function, and the module is included with OpenLDAP contrib. This change enables argon2 hashes by default in our OpenLDAP package.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
