### PR TITLE
gnupg23: add variant for beta 2.3.3

### DIFF
--- a/pkgs/development/libraries/libcryptui/default.nix
+++ b/pkgs/development/libraries/libcryptui/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, intltool, glib, gnome, gtk3, gnupg22, gpgme, dbus-glib, libgnome-keyring }:
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, intltool, glib, gnome, gtk3, gnupg, gpgme, dbus-glib, libgnome-keyring }:
 
 stdenv.mkDerivation rec {
   pname = "libcryptui";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkg-config intltool autoreconfHook ];
-  buildInputs = [ glib gtk3 gnupg22 gpgme dbus-glib libgnome-keyring ];
+  buildInputs = [ glib gtk3 gnupg gpgme dbus-glib libgnome-keyring ];
   propagatedBuildInputs = [ dbus-glib ];
 
   enableParallelBuilding = true;

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -1,5 +1,5 @@
 { fetchurl, fetchpatch, lib, stdenv, pkg-config, libgcrypt, libassuan, libksba
-, libgpgerror, libiconv, npth, gettext, texinfo, buildPackages
+, libgpg-error, libiconv, npth, gettext, texinfo, buildPackages
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   pinentryBinaryPath = pinentry.binaryPath or "bin/pinentry";
   configureFlags = [
-    "--with-libgpg-error-prefix=${libgpgerror.dev}"
+    "--with-libgpg-error-prefix=${libgpg-error.dev}"
     "--with-libgcrypt-prefix=${libgcrypt.dev}"
     "--with-libassuan-prefix=${libassuan.dev}"
     "--with-ksba-prefix=${libksba.dev}"

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -1,12 +1,12 @@
 { fetchurl, fetchpatch, lib, stdenv, pkg-config, libgcrypt, libassuan, libksba
-, libgpg-error, libiconv, npth, gettext, texinfo, buildPackages
+, libgpgerror, libiconv, npth, gettext, texinfo, buildPackages
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, guiSupport ? true, enableMinimal ? false
-, adns ? null , bzip2 ? null , gnutls ? null , libusb1 ? null , openldap ? null
-, pcsclite ? null , pinentry ? null , readline ? null , sqlite ? null , zlib ?
-null
+, guiSupport ? stdenv.isDarwin, enableMinimal ? false
+, adns ? null, bzip2 ? null , gnutls ? null , libusb1 ? null , openldap ? null
+, tpm2-tss ? null
+, pcsclite ? null , pinentry ? null , readline ? null , sqlite ? null , zlib ? null
 }:
 
 with lib;
@@ -15,24 +15,22 @@ assert guiSupport -> pinentry != null && enableMinimal == false;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
-
-  version = "2.2.27";
+  version = "2.3.3";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
-    sha256 = "1693s2rp9sjwvdslj94n03wnb6rxysjy0dli0q1698af044h1ril";
+    sha256 = "0dz9x0r5021bhk1kjh29m1q13xbslwb8yn9qzcp7b9m1lrnvi2ap";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config texinfo ];
   buildInputs = [
     libgcrypt libassuan libksba libiconv npth gettext
-    readline libusb1 gnutls adns openldap zlib bzip2 sqlite
+    readline libusb1 gnutls adns openldap zlib bzip2 sqlite tpm2-tss
   ];
 
   patches = [
     ./fix-libusb-include-path.patch
-    ./0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool.patch
     ./tests-add-test-cases-for-import-without-uid.patch
     ./allow-import-of-previously-known-keys-even-without-UI.patch
     ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
@@ -42,23 +40,24 @@ stdenv.mkDerivation rec {
     # Fix broken SOURCE_DATE_EPOCH usage - remove on the next upstream update
     sed -i 's/$SOURCE_DATE_EPOCH/''${SOURCE_DATE_EPOCH}/' doc/Makefile.am
     sed -i 's/$SOURCE_DATE_EPOCH/''${SOURCE_DATE_EPOCH}/' doc/Makefile.in
-  '' + lib.optionalString ( stdenv.isLinux && pcsclite != null) ''
+  '' + lib.optionalString (stdenv.isLinux && pcsclite != null) ''
     sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   '';
 
   pinentryBinaryPath = pinentry.binaryPath or "bin/pinentry";
   configureFlags = [
-    "--with-libgpg-error-prefix=${libgpg-error.dev}"
+    "--with-libgpg-error-prefix=${libgpgerror.dev}"
     "--with-libgcrypt-prefix=${libgcrypt.dev}"
     "--with-libassuan-prefix=${libassuan.dev}"
     "--with-ksba-prefix=${libksba.dev}"
     "--with-npth-prefix=${npth}"
-  ] ++ optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}";
+  ] ++ optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}"
+  ++ optional (tpm2-tss != null) "--with-tss=intel";
 
   postInstall = if enableMinimal
   then ''
     rm -r $out/{libexec,sbin,share}
-    for f in `find $out/bin -type f -not -name gpg`
+    for f in $(find $out/bin -type f -not -name gpg)
     do
       rm $f
     done
@@ -73,12 +72,17 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/gpg $out/bin/gpg2
 
     # Make libexec tools available in PATH
-    ln -s -t $out/bin $out/libexec/*
+    for f in $out/libexec/; do
+      if [[ "$(basename $f)" == "gpg-wks-client" ]]; then continue; fi
+      ln -s $f $out/bin/$(basename $f)
+    done
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://gnupg.org";
-    description = "Modern (2.1) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
+    description = "Modern release of the GNU Privacy Guard, a GPL OpenPGP implementation";
     license = licenses.gpl3Plus;
     longDescription = ''
       The GNU Privacy Guard is the GNU project's complete and free
@@ -91,7 +95,7 @@ stdenv.mkDerivation rec {
       frontend applications and libraries are available.  Version 2 of GnuPG
       also provides support for S/MIME.
     '';
-    maintainers = with maintainers; [ fpletz vrthra ];
+    maintainers = with maintainers; [ peti fpletz vrthra ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/gnupg/allow-import-of-previously-known-keys-even-without-UI.patch
+++ b/pkgs/tools/security/gnupg/allow-import-of-previously-known-keys-even-without-UI.patch
@@ -17,10 +17,10 @@ Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
  1 file changed, 11 insertions(+), 33 deletions(-)
 
 diff --git a/g10/import.c b/g10/import.c
-index 95d419a..4fdf248 100644
+index 5d3162c..f9acf95 100644
 --- a/g10/import.c
 +++ b/g10/import.c
-@@ -1792,7 +1792,6 @@ import_one_real (ctrl_t ctrl,
+@@ -1788,7 +1788,6 @@ import_one_real (ctrl_t ctrl,
    size_t an;
    char pkstrbuf[PUBKEY_STRING_SIZE];
    int merge_keys_done = 0;
@@ -28,12 +28,12 @@ index 95d419a..4fdf248 100644
    KEYDB_HANDLE hd = NULL;
  
    if (r_valid)
-@@ -1829,14 +1828,6 @@ import_one_real (ctrl_t ctrl,
+@@ -1825,14 +1824,6 @@ import_one_real (ctrl_t ctrl,
        log_printf ("\n");
      }
  
 -
--  if (!uidnode )
+-  if (!uidnode)
 -    {
 -      if (!silent)
 -        log_error( _("key %s: no user ID\n"), keystr_from_pk(pk));
@@ -43,16 +43,17 @@ index 95d419a..4fdf248 100644
    if (screener && screener (keyblock, screener_arg))
      {
        log_error (_("key %s: %s\n"), keystr_from_pk (pk),
-@@ -1911,17 +1902,10 @@ import_one_real (ctrl_t ctrl,
+@@ -1907,18 +1898,10 @@ import_one_real (ctrl_t ctrl,
  	  }
      }
  
--  if (!delete_inv_parts (ctrl, keyblock, keyid, options ) )
+-  /* Delete invalid parts and bail out if there are no user ids left.  */
+-  if (!delete_inv_parts (ctrl, keyblock, keyid, options))
 -    {
 -      if (!silent)
 -        {
--          log_error( _("key %s: no valid user IDs\n"), keystr_from_pk(pk));
--          if (!opt.quiet )
+-          log_error ( _("key %s: no valid user IDs\n"), keystr_from_pk(pk));
+-          if (!opt.quiet)
 -            log_info(_("this may be caused by a missing self-signature\n"));
 -        }
 -      stats->no_user_id++;
@@ -65,7 +66,7 @@ index 95d419a..4fdf248 100644
  
    /* Get rid of deleted nodes.  */
    commit_kbnode (&keyblock);
-@@ -1931,24 +1915,11 @@ import_one_real (ctrl_t ctrl,
+@@ -1927,24 +1911,11 @@ import_one_real (ctrl_t ctrl,
      {
        apply_keep_uid_filter (ctrl, keyblock, import_filter.keep_uid);
        commit_kbnode (&keyblock);
@@ -90,7 +91,7 @@ index 95d419a..4fdf248 100644
      }
  
    /* The keyblock is valid and ready for real import.  */
-@@ -2006,6 +1977,13 @@ import_one_real (ctrl_t ctrl,
+@@ -2002,6 +1973,13 @@ import_one_real (ctrl_t ctrl,
        err = 0;
        stats->skipped_new_keys++;
      }

--- a/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
+++ b/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
@@ -1,6 +1,17 @@
+From 29974d94c9e01bb7d999af925293a3ae66454d9d Mon Sep 17 00:00:00 2001
+From: Cole Mickens <cole.mickens@gmail.com>
+Date: Sun, 25 Apr 2021 03:21:02 +0000
+Subject: [PATCH] fix-libusb-include-path
+
+---
+ configure | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 9bea53c..d50c908 100755
 --- a/configure
 +++ b/configure
-@@ -8987,8 +8987,7 @@
+@@ -9281,8 +9281,7 @@ fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking libusb include dir" >&5
  $as_echo_n "checking libusb include dir... " >&6; }
     usb_incdir_found="no"
@@ -10,3 +21,6 @@
       _libusb_save_cppflags=$CPPFLAGS
       if test -n "${_incdir}"; then
         CPPFLAGS="-I${_incdir} ${CPPFLAGS}"
+-- 
+2.31.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5775,11 +5775,11 @@ with pkgs;
   gnupg1orig = callPackage ../tools/security/gnupg/1.nix { };
   gnupg1compat = callPackage ../tools/security/gnupg/1compat.nix { };
   gnupg1 = gnupg1compat;    # use config.packageOverrides if you prefer original gnupg1
-  gnupg22 = callPackage ../tools/security/gnupg/22.nix {
+  gnupg23 = callPackage ../tools/security/gnupg/23.nix {
     guiSupport = stdenv.isDarwin;
     pinentry = if stdenv.isDarwin then pinentry_mac else pinentry-gtk2;
   };
-  gnupg = gnupg22;
+  gnupg = gnupg23;
 
   gnupg-pkcs11-scd = callPackage ../tools/security/gnupg-pkcs11-scd { };
 
@@ -22527,7 +22527,7 @@ with pkgs;
     # break some cyclic dependencies
     util-linux = util-linuxMinimal;
     # provide a super minimal gnupg used for systemd-machined
-    gnupg = callPackage ../tools/security/gnupg/22.nix {
+    gnupg = callPackage ../tools/security/gnupg/23.nix {
       enableMinimal = true;
       guiSupport = false;
       pcsclite = null;


### PR DESCRIPTION
###### Motivation for this change

gnupg-2.3 changes how gnupg handles smartcards, and some fallback behavior. I'm suspicious it's might affect NixOS GPG users, so I'm sending this in so that we can make it easy for folks to **optionally** try out gpg-2.3.

Note that this change will not affect any current NixOS users. It does not change the gpg that (virtually all) system components are built with.

It is expected that users using this, are using Home-Manager and the options I've recently added for managing the package used for both gpg-agent and gpg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
g