### PR TITLE
[20.09] steam: fix readonly boostrap.tar.xz

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -48,6 +48,14 @@ let
     export STEAM_LD_LIBRARY_PATH="$STEAM_LD_LIBRARY_PATH''${STEAM_LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
   '';
 
+  # bootstrap.tar.xz has 444 permissions, which means that simple deletes fail
+  # and steam will not be able to start
+  fixBootstrap = ''
+    if [ -r $HOME/.local/share/Steam/bootstrap.tar.xz ]; then
+      chmod +w $HOME/.local/share/Steam/bootstrap.tar.xz
+    fi
+  '';
+
   setupSh = writeScript "setup.sh" ''
     #!${runtimeShell}
   '';
@@ -258,6 +266,7 @@ in buildFHSUserEnv rec {
       fi
     fi
     ${lib.optionalString (!nativeOnly) exportLDPath}
+    ${fixBootstrap}
     exec steam "$@"
   '';
 
@@ -280,6 +289,7 @@ in buildFHSUserEnv rec {
       fi
       shift
       ${lib.optionalString (!nativeOnly) exportLDPath}
+      ${fixBootstrap}
       exec -- "$run" "$@"
     '';
   };


### PR DESCRIPTION
steam writes it with 444 permissions, which makes simple deletions fails, and steam will crash

(cherry picked from commit 373cb5d41db3a60249dfa2c7481fb46642e11a92)

###### Motivation for this change
fix #121025

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
