### PR TITLE
[20.09] gst_all_1.gst-plugins-good: Fix matroska security issues

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 , meson
 , ninja
 , pkgconfig
@@ -55,7 +56,21 @@ stdenv.mkDerivation rec {
     sha256 = "0pzq565ijl5z3mphvix34878m7hck6a58rdpj7sp7rixwwzkm8nk";
   };
 
-  patches = [ ./fix_pkgconfig_includedir.patch ];
+  patches = [
+    ./fix_pkgconfig_includedir.patch
+    (fetchpatch {
+      # https://gstreamer.freedesktop.org/security/sa-2021-0002.html
+      name = "CVE-2021-3497.patch";
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/commit/9181191511f9c0be6a89c98b311f49d66bd46dc3.patch";
+      sha256 = "10dvfxrw7l3gflk9fzn5x18vkj4080dfkjnzldc12r5mnl37qdz8";
+    })
+    (fetchpatch {
+      # https://gstreamer.freedesktop.org/security/sa-2021-0003.html
+      name = "CVE-2021-3498.patch";
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/commit/02174790726dd20a5c73ce2002189bf240ad4fe0.patch";
+      sha256 = "1sygia6z0yv5grzii6z9bviwi6rm6br3xjr0cnffsji6z943d7vc";
+    })
+  ];
 
   nativeBuildInputs = [
     pkgconfig


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Apply patches for these two issues:

- heap corruption when parsing certain malformed Matroska files.
- access already-freed memory in error code paths when demuxing certain malformed Matroska files.

Fixes: CVE-2021-3497, CVE-2021-3498

Not sure if this warrants staging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
