### PR TITLE
bind: 9.16.13 -> 9.16.15

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -10,11 +10,11 @@ assert enablePython -> python3 != null;
 
 stdenv.mkDerivation rec {
   pname = "bind";
-  version = "9.16.13";
+  version = "9.16.15";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-pUzHk/pbabNfYQ8glXYPgjjf9c/VJBn37hycIn2kzAg=";
+    sha256 = "0fbqisrh84f8wszm94cqp7v8q9r7pql3qyzbay7vz9vqv0rg9dlq";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://kb.isc.org/docs/cve-2021-25214

https://kb.isc.org/docs/cve-2021-25215

https://kb.isc.org/docs/cve-2021-25216

Fixes: CVE-2021-25214, CVE-2021-25215, CVE-2021-25216

In 20.09 we have 9.14, which is sadly not a supported release, so we have to fish the commit log for the relevant patches.  They are not mentioned in the KB, but there are patches for 9.11.x and 9.16.x mentioned on oss-security.

https://www.openwall.com/lists/oss-security/2021/04/29/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
