### PR TITLE
roon-server: 100800753 -> 100800790

### DIFF
--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -11,15 +11,15 @@
 , zlib
 }: stdenv.mkDerivation rec {
   name = "roon-server";
-  version = "100800753";
+  version = "100800790";
 
   # N.B. The URL is unstable. I've asked for them to provide a stable URL but
   # they have ignored me. If this package fails to build for you, you may need
   # to update the version and sha256.
   # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
   src = fetchurl {
-    url = "https://web.archive.org/web/20210209195555/https://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
-    sha256 = "sha256-uas1vqIDWlYr7jgsrlBeJSPjMxwzVnrkCD9jJljkFZs=";
+    url = "https://web.archive.org/web/20210428204513/https://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
+    sha256 = "1jhj52fmkdgr9qfang1i9qrl1z56h56x07k31n3kllknkv02lc8p";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update `roon-server` to current build 790

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
