### PR TITLE
julia_15: run test suite and mark as broken

### DIFF
--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -38,16 +38,6 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs . contrib
-    for i in backtrace cmdlineargs; do
-      mv test/$i.jl{,.off}
-      touch test/$i.jl
-    done
-    rm stdlib/Sockets/test/runtests.jl && touch stdlib/Sockets/test/runtests.jl
-    rm stdlib/Distributed/test/runtests.jl && touch stdlib/Distributed/test/runtests.jl
-    # LibGit2 fails with a weird error, so we skip it as well now
-    rm stdlib/LibGit2/test/runtests.jl && touch stdlib/LibGit2/test/runtests.jl
-    sed -e 's/Invalid Content-Type:/invalid Content-Type:/g' -i ./stdlib/LibGit2/test/libgit2.jl
-    sed -e 's/Failed to resolve /failed to resolve /g' -i ./stdlib/LibGit2/test/libgit2.jl
   '';
 
   dontUseCmakeConfigure = true;
@@ -112,11 +102,6 @@ stdenv.mkDerivation rec {
     openspecfun pcre2 lapack
   ];
 
-  # Julia's tests require read/write access to $HOME
-  preCheck = ''
-    export HOME="$NIX_BUILD_TOP"
-  '';
-
   preBuild = ''
     sed -e '/^install:/s@[^ ]*/doc/[^ ]*@@' -i Makefile
     sed -e '/[$](DESTDIR)[$](docdir)/d' -i Makefile
@@ -124,6 +109,13 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  # Julia's tests require read/write access to $HOME
+  preCheck = ''
+    export HOME="$NIX_BUILD_TOP"
+  '';
+  doCheck = true;
+  checkTarget = "test";
 
   postInstall = ''
     # Symlink shared libraries from LD_LIBRARY_PATH into lib/julia,
@@ -148,6 +140,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ raskin rob garrison ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
-    broken = stdenv.isi686;
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -140,6 +140,8 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ raskin rob garrison ];
     platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+    # Unfortunately, this derivation does not pass Julia's test suite. See
+    # https://github.com/NixOS/nixpkgs/pull/121114.
     broken = true;
   };
 }


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/121101.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/121101

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
