### PR TITLE
Rpiplay

### DIFF
--- a/pkgs/servers/rpiplay/default.nix
+++ b/pkgs/servers/rpiplay/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, pkg-config, fetchFromGitHub, fetchpatch, cmake, wrapGAppsHook, avahi, avahi-compat, openssl, gst_all_1, libplist }:
+
+stdenv.mkDerivation rec {
+  pname = "rpiplay";
+  version = "unstable-2021-02-27";
+
+  src = fetchFromGitHub {
+    owner = "FD-";
+    repo = "RPiPlay";
+    rev = "4a65c7b84ff09acd7d6d494bb9037bbf106153a8";
+    sha256 = "06znqlj5b09z3mc965dyvmx2kh64fd7s571q34fh8r9ng98k351s";
+  };
+
+  patches = [
+    # allow rpiplay to be used with firewall enabled.
+    # sets static ports 7000 7100 (tcp) and 6000 6001 7011 (udp)
+    (fetchpatch {
+      name = "use-static-ports.patch";
+      url = "https://github.com/FD-/RPiPlay/commit/2ffc287ba822e1d2b2ed0fc0e41a2bb3d9dab105.patch";
+      sha256 = "08dy829gyhyzw2n54zn5m3176cmd24k5hij24vpww5bhbwkbabww";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    openssl
+    libplist
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    avahi
+    avahi-compat
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/FD-/RPiPlay";
+    description = "An open-source implementation of an AirPlay mirroring server.";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mschneider ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/rpiplay/default.nix
+++ b/pkgs/servers/rpiplay/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rpiplay";
-  version = "unstable-2021-02-27";
+  version = "unstable-2021-06-14";
 
   src = fetchFromGitHub {
     owner = "FD-";
     repo = "RPiPlay";
-    rev = "4a65c7b84ff09acd7d6d494bb9037bbf106153a8";
-    sha256 = "06znqlj5b09z3mc965dyvmx2kh64fd7s571q34fh8r9ng98k351s";
+    rev = "35dd995fceed29183cbfad0d4110ae48e0635786";
+    sha256 = "sha256-qe7ZTT45NYvzgnhRmz15uGT/FnGi9uppbKVbmch5B9A=";
   };
 
   patches = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20471,6 +20471,8 @@ with pkgs;
 
   roon-bridge = callPackage ../servers/roon-bridge { };
 
+  rpiplay = callPackage ../servers/rpiplay { };
+
   roon-server = callPackage ../servers/roon-server { };
 
   s6 = skawarePackages.s6;


### PR DESCRIPTION
###### Motivation for this change

Added new package RPiPlay.
It is an open-source implementation of an AirPlay mirroring server

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
