### PR TITLE
b4: loosen versions for request and dnspython

### DIFF
--- a/pkgs/development/tools/b4/default.nix
+++ b/pkgs/development/tools/b4/default.nix
@@ -11,7 +11,8 @@ python3Packages.buildPythonApplication rec {
 
   preConfigure = ''
     substituteInPlace setup.py \
-      --replace 'requests~=2.24' 'requests~=2.25'
+      --replace 'requests~=2.24.0' 'requests~=2.25' \
+      --replace 'dnspython~=2.0.0' 'dnspython~=2.1'
   '';
 
   # tests make dns requests and fails


### PR DESCRIPTION
Until the next stable release, we need to loosen the version
requirements ourselves by hand for dnspython, since NixOS has updated to
version 2.1. While at it, adjust requests from `~=2.24.0` to `~=2.25` which
effectively enables all `2.*` versions for requests.

Fixes the following build error:
```
  adding 'b4-0.6.2.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/b4-0.6.2/dist /build/b4-0.6.2
  Processing ./b4-0.6.2-py3-none-any.whl
  Requirement already satisfied: dkimpy~=1.0.5 in /nix/store/3war2scyn6pnrhhcfdx48vd5023x2rkp-python3.8-dkimpy-1.0.5/lib/python3.8/site-packages (from b4==0.6.2) (1.0.5)
  ERROR: Could not find a version that satisfies the requirement dnspython~=2.0.0 (from b4)
  ERROR: No matching distribution found for dnspython~=2.0.0
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
