### PR TITLE
python3Packages.pytest-helpers-namespace: add missing dependency

### DIFF
--- a/pkgs/development/python-modules/pypiserver/default.nix
+++ b/pkgs/development/python-modules/pypiserver/default.nix
@@ -1,0 +1,40 @@
+{ buildPythonPackage, fetchFromGitHub, lib, passlib, pytestCheckHook, setuptools
+, setuptools-git, twine, webtest }:
+
+buildPythonPackage rec {
+  pname = "pypiserver";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1z5rsmqgin98m6ihy1ww42fxxr6jb4hzldn8vlc9ssv7sawdz8vz";
+  };
+
+  nativeBuildInputs = [ setuptools-git ];
+
+  propagatedBuildInputs = [ setuptools ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [ passlib pytestCheckHook twine webtest ];
+
+  # These tests try to use the network
+  disabledTests = [
+    "test_pipInstall_openOk"
+    "test_pipInstall_authedOk"
+    "test_hash_algos"
+  ];
+
+  pythonImportsCheck = [ "pypiserver" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pypiserver/pypiserver";
+    description = "Minimal PyPI server for use with pip/easy_install";
+    license = with licenses; [ mit zlib ];
+    maintainers = [ maintainers.austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-helpers-namespace/default.nix
+++ b/pkgs/development/python-modules/pytest-helpers-namespace/default.nix
@@ -1,30 +1,28 @@
 { buildPythonPackage
-, fetchFromGitHub
-, pytest
+, fetchPypi
+, pytestCheckHook
+, isPy27
 , lib
+, setuptools
+, setuptools-declarative-requirements
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "pytest-helpers-namespace";
   version = "2021.3.24";
+  disabled = isPy27;
 
-  src = fetchFromGitHub {
-    owner = "saltstack";
-    repo = pname;
-    rev = version;
-    sha256 = "0ikwiwp9ycgg7px78nxdkqvg7j97krb6vzqlb8fq8fvbwrj4q4v2";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pyj2d45zagmzlajzqdnkw5yz8k49pkihbydsqkzm413qnkzb38q";
   };
 
-  buildInputs = [ pytest ];
+  nativeBuildInputs = [ setuptools setuptools-declarative-requirements setuptools-scm ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    pytest
-  '';
-
-  # The tests fail with newest pytest. They passed with pytest_3, which no longer exists
-  doCheck = false;
+  pythonImportsCheck = [ "pytest_helpers_namespace" ];
 
   meta = with lib; {
     homepage = "https://github.com/saltstack/pytest-helpers-namespace";

--- a/pkgs/development/python-modules/setuptools-declarative-requirements/default.nix
+++ b/pkgs/development/python-modules/setuptools-declarative-requirements/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage, fetchPypi, lib, pypiserver, pytestCheckHook
+, setuptools-scm, virtualenv }:
+
+buildPythonPackage rec {
+  pname = "setuptools-declarative-requirements";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1l8zmcnp9h8sp8hsw7b81djaa1a9yig0y7i4phh5pihqz1gdn7yi";
+  };
+
+  buildInputs = [ setuptools-scm ];
+
+  checkInputs = [ pypiserver pytestCheckHook virtualenv ];
+
+  # Tests use network
+  doCheck = false;
+
+  pythonImportsCheck = [ "declarative_requirements" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/s0undt3ch/setuptools-declarative-requirements";
+    description = "Declarative setuptools Config Requirements Files Support";
+    license = licenses.asl20;
+    maintainers = [ maintainers.austinbutler ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7346,6 +7346,8 @@ in {
 
   setproctitle = callPackage ../development/python-modules/setproctitle { };
 
+  setuptools-declarative-requirements = callPackage ../development/python-modules/setuptools-declarative-requirements { };
+
   setuptools-git = callPackage ../development/python-modules/setuptools-git { };
 
   setuptools-lint = callPackage ../development/python-modules/setuptools-lint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5896,6 +5896,8 @@ in {
 
   pypinyin = callPackage ../development/python-modules/pypinyin { };
 
+  pypiserver = callPackage ../development/python-modules/pypiserver { };
+
   pyplaato  = callPackage ../development/python-modules/pyplaato { };
 
   pyplatec = callPackage ../development/python-modules/pyplatec { };


### PR DESCRIPTION
###### Motivation for this change

Found `ocrmypdf` was broken, I think by https://github.com/NixOS/nixpkgs/pull/117452 where `pytest-helpers-namespace` was upgraded but was missing a dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).