### PR TITLE
maintainers/teams: add gcc

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -78,6 +78,13 @@ with lib.maintainers; {
     scope = "Maintain Freedesktop.org packages for graphical desktop.";
   };
 
+  gcc = {
+    members = [
+      synthetica
+    ];
+    scope = "Maitain GCC (GNU Compiler Collection) compilers";
+  };
+
   golang = {
     members = [
       c00w

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -81,6 +81,7 @@ with lib.maintainers; {
   gcc = {
     members = [
       synthetica
+      vcunat
     ];
     scope = "Maitain GCC (GNU Compiler Collection) compilers";
   };

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -83,7 +83,7 @@ with lib.maintainers; {
       synthetica
       vcunat
     ];
-    scope = "Maitain GCC (GNU Compiler Collection) compilers";
+    scope = "Maintain GCC (GNU Compiler Collection) compilers";
   };
 
   golang = {

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -82,6 +82,7 @@ with lib.maintainers; {
     members = [
       synthetica
       vcunat
+      ericson2314
     ];
     scope = "Maintain GCC (GNU Compiler Collection) compilers";
   };

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -280,7 +280,7 @@ stdenv.mkDerivation ({
       compiler used in the GNU system including the GNU/Linux variant.
     '';
 
-    maintainers = with lib.maintainers; [ synthetica ];
+    maintainers = lib.teams.gcc.members;
 
     platforms =
       lib.platforms.linux ++

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -285,7 +285,7 @@ stdenv.mkDerivation ({
       compiler used in the GNU system including the GNU/Linux variant.
     '';
 
-    maintainers = with lib.maintainers; [ synthetica ];
+    maintainers = lib.teams.gcc.members;
 
     platforms =
       lib.platforms.linux ++

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -294,7 +294,7 @@ stdenv.mkDerivation ({
       compiler used in the GNU system including the GNU/Linux variant.
     '';
 
-    maintainers = with lib.maintainers; [ ];
+    maintainers = lib.teams.gcc.members;
 
     platforms =
       lib.platforms.linux ++

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -276,7 +276,7 @@ stdenv.mkDerivation ({
       compiler used in the GNU system including the GNU/Linux variant.
     '';
 
-    maintainers = with lib.maintainers; [ synthetica ];
+    maintainers = lib.teams.gcc.members;
 
     platforms =
       lib.platforms.linux ++

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -295,7 +295,7 @@ stdenv.mkDerivation ({
       compiler used in the GNU system including the GNU/Linux variant.
     '';
 
-    maintainers = with lib.maintainers; [ synthetica ];
+    maintainers = lib.teams.gcc.members;
 
     platforms =
       lib.platforms.linux ++


### PR DESCRIPTION
## Issue description

For many GCC packages, I am listed as the sole maintainer. This is only because I've updated GCC in the past and added myself as a maintainer. I propose we change this to people who do actually regularly work on GCC (I'd be fine being in this team, but definitely not as the sole maintainer)

People who frequently work on GCC according to `git log --since "2 years" --format="for
mat:%aN" ./pkgs/development/compilers/gcc | sort | uniq -c | sort -n`:

- [x] @Ericson2314 
- [x] @vcunat 
- [ ] @matthewbauer 
- [x] @FRidh 
