### PR TITLE
mesa: Don't fail to build when d3d isn't built

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -185,14 +185,14 @@ self = stdenv.mkDerivation {
   postFixup = optionalString stdenv.isLinux ''
     # set the default search path for DRI drivers; used e.g. by X server
     substituteInPlace "$dev/lib/pkgconfig/dri.pc" --replace "$drivers" "${libglvnd.driverLink}"
-    substituteInPlace "$dev/lib/pkgconfig/d3d.pc" --replace "$drivers" "${libglvnd.driverLink}"
+    [ -f "$dev/lib/pkgconfig/d3d.pc" ] && substituteInPlace "$dev/lib/pkgconfig/d3d.pc" --replace "$drivers" "${libglvnd.driverLink}"
 
     # remove pkgconfig files for GL/EGL; they are provided by libGL.
     rm -f $dev/lib/pkgconfig/{gl,egl}.pc
 
     # Move development files for libraries in $drivers to $driversdev
     mkdir -p $driversdev/include
-    mv $dev/include/xa_* $dev/include/d3d* $driversdev/include
+    mv $dev/include/xa_* $dev/include/d3d* -t $driversdev/include || true
     mkdir -p $driversdev/lib/pkgconfig
     for pc in lib/pkgconfig/{xatracker,d3d}.pc; do
       if [ -f "$dev/$pc" ]; then


### PR DESCRIPTION
###### Motivation for this change

`d3d.pc` isn't necessarily there depending on how you build mesa. The `postFixup` script depends on it
being there since https://github.com/NixOS/nixpkgs/commit/acbfd3f7c09e4df7300261d85edf586c8a5028af.

###### Things done

I changed the script to check for existence of the files, or not err when something fails.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
