### PR TITLE
autoconf: 2:70 -> 2.71

### DIFF
--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -6,11 +6,11 @@
 # files.
 
 stdenv.mkDerivation rec {
-  name = "autoconf-2.70";
+  name = "autoconf-2.71";
 
   src = fetchurl {
     url = "mirror://gnu/autoconf/${name}.tar.xz";
-    sha256 = "1ipckz0wr2mvhj9n3ys54fmf2aksin6bhqvzl304bn6rc1w257ps";
+    sha256 = "sha256-8UyDz+vMlCfyw86nJYvZDfly2S6yZ1LaTdrYHIeg+qQ=";
   };
 
   nativeBuildInputs = [ m4 perl ];


### PR DESCRIPTION
###### Motivation for this change
I was running into [this bug](https://lists.gnu.org/archive/html/bug-autoconf/2020-12/msg00036.html) and updating autoconf fixes that

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
