### PR TITLE
signal-desktop: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -25,7 +25,7 @@ let
       else "");
 in stdenv.mkDerivation rec {
   pname = "signal-desktop";
-  version = "5.0.0"; # Please backport all updates to the stable channel.
+  version = "5.1.0"; # Please backport all updates to the stable channel.
   # All releases have a limited lifetime and "expire" 90 days after the release.
   # When releases "expire" the application becomes unusable until an update is
   # applied. The expiration date for the current release can be extracted with:
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "17hxg61m9kk1kph6ifqy6507kzx5hi6yafr2mj8n0a6c39vc8f9g";
+    sha256 = "1cirnnxy63jfkl98472k25bn1yp5apa7b5s74r42sxhlwzwkplw1";
   };
 
   nativeBuildInputs = [
@@ -79,6 +79,7 @@ in stdenv.mkDerivation rec {
     pango
     systemd
     xorg.libxcb
+    xorg.libxshmfence
   ];
 
   runtimeDependencies = [


### PR DESCRIPTION
This is the most important Signal-Desktop release in a while as we
finally have Wayland support via Electron 12 \o/ #YAY :D

https://github.com/signalapp/Signal-Desktop/issues/3411

https://github.com/signalapp/Signal-Desktop/commit/5bcf50ede96fed18dccc207e89bbae7ceb2d2dff#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R231
https://github.com/signalapp/Signal-Desktop/commit/c6d5d852a9f9668268803bb5a20d94b4a505dd87#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R232
https://en.wikipedia.org/wiki/Electron_(software_framework)#Versions

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~**Warning: This should use `'~/.config/Signal Beta/` but testing this might still cause data-loss!**~~

`signal-desktop-beta --enable-features=UseOzonePlatform --ozone-platform=wayland` works without XWayland but is also affected by #103049 (which makes sense but is really unfortunate for the Wayland support...). I.e. the 1st launch should be fine but when closing the window and re-launching it no window appears unless `--disable-gpu` is used, the compositor is restarted, or  `'~/.config/Signal Beta/` is removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
