### PR TITLE
libdeltachat: init at 1.54.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, mkDerivation
+, fetchFromSourcehut
+, cmake
+, extra-cmake-modules
+, pkg-config
+, kirigami2
+, libdeltachat
+, qtmultimedia
+}:
+
+mkDerivation rec {
+  pname = "kdeltachat";
+  version = "unstable-2021-05-03";
+
+  src = fetchFromSourcehut {
+    owner = "~link2xt";
+    repo = "kdeltachat";
+    rev = "dd7455764074c0864234a6a25ab6f87e8d5c3121";
+    sha256 = "1vsy2jcisvf9mndxlwif3ghv1n2gz5ycr1qh72kgski38qan621v";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+  ];
+
+  buildInputs = [
+    kirigami2
+    libdeltachat
+    qtmultimedia
+  ];
+
+  meta = with lib; {
+    description = "Delta Chat client using Kirigami framework";
+    homepage = "https://git.sr.ht/~link2xt/kdeltachat";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, openssl
+, perl
+, pkg-config
+, rustPlatform
+, sqlite
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libdeltachat";
+  version = "1.54.0";
+
+  src = fetchFromGitHub {
+    owner = "deltachat";
+    repo = "deltachat-core-rust";
+    rev = version;
+    sha256 = "02hvsfv1yar8bdpkfrfiiicq9qqnfhp46v6qqph9ar6khz3f1kim";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "1p5yrhczp9nfijbvkmkmx1rabk5k3c1ni4k1vc0mw4jgl26lslcm";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    perl
+    pkg-config
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+  ]);
+
+  buildInputs = [
+    openssl
+    sqlite
+  ];
+
+  checkInputs = with rustPlatform; [
+    cargoCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Delta Chat Rust Core library";
+    homepage = "https://github.com/deltachat/deltachat-core-rust/";
+    changelog = "https://github.com/deltachat/deltachat-core-rust/blob/${version}/CHANGELOG.md";
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/deltachat/default.nix
+++ b/pkgs/development/python-modules/deltachat/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchpatch
+, setuptools-scm
+, libdeltachat
+, cffi
+, IMAPClient
+, pluggy
+, requests
+, setuptools
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "deltachat";
+  inherit (libdeltachat) version src;
+  sourceRoot = "${src.name}/python";
+
+  disabled = isPy27;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  buildInputs = [
+    libdeltachat
+  ];
+
+  propagatedBuildInputs = [
+    cffi
+    IMAPClient
+    pluggy
+    requests
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "deltachat"
+    "deltachat.account"
+    "deltachat.contact"
+    "deltachat.chat"
+    "deltachat.message"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for the Delta Chat Core library";
+    homepage = "https://github.com/deltachat/deltachat-core-rust/tree/master/python";
+    changelog = "https://github.com/deltachat/deltachat-core-rust/blob/${version}/python/CHANGELOG";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24080,6 +24080,8 @@ in
 
   kbibtex = libsForQt5.callPackage ../applications/office/kbibtex { };
 
+  kdeltachat = libsForQt5.callPackage ../applications/networking/instant-messengers/kdeltachat { };
+
   kdevelop-pg-qt = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix { };
 
   kdevelop-unwrapped = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15458,6 +15458,8 @@ in
 
   libdeflate = callPackage ../development/libraries/libdeflate { };
 
+  libdeltachat = callPackage ../development/libraries/libdeltachat { };
+
   libdevil = callPackage ../development/libraries/libdevil {
     inherit (darwin.apple_sdk.frameworks) OpenGL;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1743,6 +1743,8 @@ in {
 
   delegator-py = callPackage ../development/python-modules/delegator-py { };
 
+  deltachat = callPackage ../development/python-modules/deltachat { };
+
   deluge-client = callPackage ../development/python-modules/deluge-client { };
 
   demjson = callPackage ../development/python-modules/demjson { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

~I could not try KDeltaChat because the interface was unusable for me. Might be that I need to run KDE to test it.~