### PR TITLE
python3Packages.denonavr: 0.9.10 -> 0.10.6

### DIFF
--- a/pkgs/development/python-modules/asyncstdlib/default.nix
+++ b/pkgs/development/python-modules/asyncstdlib/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, typing-extensions
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "asyncstdlib";
+  version = "3.9.1";
+  disabled = pythonOlder "3.7";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "maxfischer2781";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13ranr7zi61w52vfrxwkf32bbhk88j0r5c5z2x2h5vw268001lk2";
+  };
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "asyncstdlib" ];
+
+  meta = with lib; {
+    description = "Python library that extends the Python asyncio standard library";
+    homepage = "https://asyncstdlib.readthedocs.io/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -1,33 +1,51 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27, requests, netifaces
-, pytestCheckHook, testtools, requests-mock }:
+{ lib
+, asyncstdlib
+, attrs
+, buildPythonPackage
+, defusedxml
+, fetchFromGitHub
+, httpx
+, netifaces
+, pytest-asyncio
+, pytestCheckHook
+, pytest-httpx
+, pytest-timeout
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "denonavr";
-  version = "0.9.10";
-  disabled = isPy27;
+  version = "0.10.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "scarface-4711";
-    repo = "denonavr";
+    repo = pname;
     rev = version;
-    sha256 = "sha256-3ap8F3ayBTpaR98md+gT0+hkIWlFBNxStTGWT5AL//A=";
+    sha256 = "sha256-jcbjExcyZSE+qVPuYiMmuneugDMBoYz4apY/lz4JnMI=";
   };
 
   propagatedBuildInputs = [
-    requests
+    asyncstdlib
+    attrs
+    defusedxml
+    httpx
     netifaces
   ];
 
   checkInputs = [
+    pytest-asyncio
     pytestCheckHook
-    testtools
-    requests-mock
+    pytest-httpx
+    pytest-timeout
   ];
 
+  pythonImportsCheck = [ "denonavr" ];
+
   meta = with lib; {
+    description = "Automation Library for Denon AVR receivers";
     homepage = "https://github.com/scarface-4711/denonavr";
-    description = "Automation Library for Denon AVR receivers.";
-    license = licenses.mit;
+    license = with licenses; [ mit ];
     maintainers = with maintainers; [ colemickens ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -243,6 +243,7 @@ in with py.pkgs; buildPythonApplication rec {
     "deconz"
     "default_config"
     "demo"
+    "denonavr"
     "derivative"
     "device_automation"
     "device_sun_light_trigger"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -557,6 +557,8 @@ in {
 
   asyncssh = callPackage ../development/python-modules/asyncssh { };
 
+  asyncstdlib = callPackage ../development/python-modules/asyncstdlib { };
+
   async_stagger = callPackage ../development/python-modules/async_stagger { };
 
   asynctest = callPackage ../development/python-modules/asynctest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.10.5

Change log: https://github.com/scarface-4711/denonavr/releases/tag/0.10.6

- Related Home Assistant change: https://github.com/home-assistant/core/pull/49984
- Target Home Assistant release: 2021.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
