### PR TITLE
prs: 0.2.9 -> 0.2.10

### DIFF
--- a/pkgs/tools/security/prs/default.nix
+++ b/pkgs/tools/security/prs/default.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "prs";
-  version = "0.2.9";
+  version = "0.2.10";
 
   src = fetchFromGitLab {
     owner = "timvisee";
     repo = "prs";
     rev = "v${version}";
-    sha256 = "sha256-9qaRhTfdppU72w8jDwD1e8ABuGG+9GyrRIUVsry4Vos=";
+    sha256 = "sha256-czGyBdy4emw7bUV6Nn+k+fJm+JqR6o0TEEUuIbEsml4=";
   };
 
-  cargoSha256 = "sha256-j+kyllMcYj7/Ig5ho548L1wW+TtuQOc/zkxT6SNNN6w=";
+  cargoSha256 = "sha256-jnBYuk7uvnbvT2OQ35DJk6WIUSqJiZCvsmpSIxw9X1U=";
 
   postPatch = ''
     # The GPGME backend is recommended


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://gitlab.com/timvisee/prs/-/blob/v0.2.10/CHANGELOG.md#0210-2021-04-29

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
