### PR TITLE
[20.09] Backport of displaylink 5.4.0

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -10,17 +10,17 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "displaylink";
-  version = "5.3.1.34";
+  version = "5.4.0-55.153";
 
   src = requireFile rec {
     name = "displaylink.zip";
-    sha256 = "1c1kbjgpb71f73qnyl44rvwi6l4ivddq789rwvvh0ahw2jm324hy";
+    sha256 = "1m2l3bnlfwfp94w7khr05npsbysg9mcyi7hi85n78xkd0xdcxml8";
     message = ''
       In order to install the DisplayLink drivers, you must first
       comply with DisplayLink's EULA and download the binaries and
       sources from here:
 
-      https://www.displaylink.com/downloads/file?id=1576
+      https://www.synaptics.com/node/3751
 
       Once you have downloaded the file, please use the following
       commands and re-run the installation:

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "v1.7.2";
+  version = "unstable-20210401";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = pname;
-    rev = version;
-    sha256 = "074j0xh037n8mc4isihfz9lap57wvxaxib32pvy6jhjl3wyik632";
+    rev = "b0b3d131b26df62664ca33775679eea7b70c47b1";
+    sha256 = "09apbvdc78bbqzja9z3b1wrwmqkv3k7cn3lll5gsskxjnqbhxk9y";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = with licenses; [ lgpl21 gpl2 ];
     homepage = "https://www.displaylink.com/";
-    broken = with kernel; kernelOlder "5" || stdenv.isAarch64;
+    broken = versionOlder kernel.version "4.19" || stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Backport of https://github.com/NixOS/nixpkgs/pull/119664 as requested https://github.com/NixOS/nixpkgs/issues/119762 .

Not tested, but should work.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
