### PR TITLE
cxxtest: build using python3

### DIFF
--- a/pkgs/development/libraries/cxxtest/default.nix
+++ b/pkgs/development/libraries/cxxtest/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub }:
+{ lib, buildPythonApplication, fetchFromGitHub, ply }:
 
 buildPythonApplication rec {
   pname = "cxxtest";
@@ -13,13 +13,22 @@ buildPythonApplication rec {
 
   sourceRoot = "source/python";
 
+  propagatedBuildInputs = [
+    ply
+  ];
+
   postCheck = ''
-    python scripts/cxxtestgen --error-printer -o build/GoodSuite.cpp ../test/GoodSuite.h
-    $CXX -I.. -o build/GoodSuite build/GoodSuite.cpp
-    build/GoodSuite
+    python scripts/cxxtestgen --error-printer -o python3/build/GoodSuite.cpp ../test/GoodSuite.h
+    $CXX -I.. -o python3/build/GoodSuite python3/build/GoodSuite.cpp
+    python3/build/GoodSuite
+  '';
+
+  preInstall = ''
+    pushd python3
   '';
 
   postInstall = ''
+    popd
     mkdir -p "$out/include"
     cp -r ../cxxtest "$out/include"
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13485,7 +13485,7 @@ in
 
   cxxopts = callPackage ../development/libraries/cxxopts { };
 
-  cxxtest = python2Packages.callPackage ../development/libraries/cxxtest { };
+  cxxtest = python3Packages.callPackage ../development/libraries/cxxtest { };
 
   cypress = callPackage ../development/web/cypress { };
 


### PR DESCRIPTION
It is 2021 we should start moving everything to python3 :-)

I randomly saw this package on hydra and thought it might be a good candidate to port.

The project follows a very unique approach to supporting python3. The
python3 code is in a subdirectory of the python directory and the
setup.py changes into that directory during execution when python3 is
detected. This required changing a few directories in our build script
to match that layout.

Also the python package `ply` is now a dependency as they are using it
for parsing C++ code.

When reviewing this do not be confused by the first test result line
that says that zero tests have been ran. Tests are being executed in the
postCheck phase (after compiling the test binary).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
