### PR TITLE
php: 7.3.23, 8.0.5, 7.4.18

### DIFF
--- a/pkgs/development/interpreters/php/7.3.nix
+++ b/pkgs/development/interpreters/php/7.3.nix
@@ -4,8 +4,8 @@ let
   generic = (import ./generic.nix) _args;
 
   base = callPackage generic (_args // {
-    version = "7.3.27";
-    sha256 = "00z0vadxazm2flks9g8qmchj2pwkli880kg313jgbb1mx3shc84x";
+    version = "7.3.28";
+    sha256 = "0r4r8famg3a8x6ch24y1370nsphkxg4k9zq5x8v88f4l8mj6wqwg";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -4,8 +4,8 @@ let
   generic = (import ./generic.nix) _args;
 
   base = callPackage generic (_args // {
-    version = "7.4.16";
-    sha256 = "0gnfb4vaj71fiap0q9lk6vs1xs7l6sha60isw6aaw3zxgh00ywc5";
+    version = "7.4.18";
+    sha256 = "0bw4q7svijsqi5vinaspzzqyli2pvmpz6yf83ndqixf6x4r5ji9f";
   });
 
 in base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -4,8 +4,8 @@ let
   generic = (import ./generic.nix) _args;
 
   base = callPackage generic (_args // {
-    version = "8.0.3";
-    sha256 = "04mh5sznbgwv67x9p0qz4i377zwdb5cc6r1mb3925y1lkqfn5y4m";
+    version = "8.0.5";
+    sha256 = "1q08xx9pbn7plsnfh6j16jj294vm968ng1n5kaqw7apgxd7r6p8r";
   });
 
 in base.withExtensions ({ all, ... }: with all; ([


### PR DESCRIPTION
###### Motivation for this change
This is the first batch of releases after they stopped using their own git and are officially on github, I think. Maybe we should go with #89329 now? ~The 7.4 release also doesn't have any release notes up yet and hasn't seem to hit https://www.php.net/distributions/ yet~.

https://www.php.net/ChangeLog-7.php#7.3.28
https://www.php.net/ChangeLog-7.php#7.4.18
https://www.php.net/ChangeLog-8.php#8.0.5

cc @NixOS/php 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s): `php`, `nextcloud`, `wordpress`, `mediawiki`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
