### PR TITLE
flip-link: init at 0.1.3

### DIFF
--- a/pkgs/development/tools/flip-link/default.nix
+++ b/pkgs/development/tools/flip-link/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "flip-link";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "knurling-rs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0x6l5aps0aryf3iqiyk969zrq77bm95jvm6f0f5vqqqizxjd3yfl";
+  };
+
+  cargoSha256 = "13rgpbwaz2b928rg15lbaszzjymph54pwingxpszp5paihx4iayr";
+
+  meta = with lib; {
+    description = "Adds zero-cost stack overflow protection to your embedded programs";
+    homepage = "https://github.com/knurling-rs/flip-link";
+    license = with licenses; [ asl20 mit ];
+    maintainers = [ maintainers.FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4569,6 +4569,8 @@ in
 
   flawfinder = callPackage ../development/tools/flawfinder { };
 
+  flip-link = callPackage ../development/tools/flip-link { };
+
   flips = callPackage ../tools/compression/flips { };
 
   fmbt = callPackage ../development/tools/fmbt {


### PR DESCRIPTION
###### Motivation for this change

flip-link was missing from nixpkgs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
