### PR TITLE
python3Packages.ha-ffmpeg: does not depend on ffmpeg_3

### DIFF
--- a/pkgs/development/python-modules/ha-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/ha-ffmpeg/default.nix
@@ -17,6 +17,12 @@ buildPythonPackage rec {
   # only manual tests
   doCheck = false;
 
+  pythonImportsCheck = [
+    "haffmpeg.camera"
+    "haffmpeg.sensor"
+    "haffmpeg.tools"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/pvizeli/ha-ffmpeg";
     description = "Library for home-assistant to handle ffmpeg";

--- a/pkgs/development/python-modules/ha-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/ha-ffmpeg/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k
-, ffmpeg_3, async-timeout }:
+, async-timeout }:
 
 buildPythonPackage rec {
   pname = "ha-ffmpeg";
@@ -12,8 +12,6 @@ buildPythonPackage rec {
     sha256 = "8d92f2f5790da038d828ac862673e0bb43e8e972e4c70b1714dd9a0fb776c8d1";
   };
 
-  buildInputs = [ ffmpeg_3 ];
-
   propagatedBuildInputs = [ async-timeout ];
 
   # only manual tests
@@ -23,6 +21,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pvizeli/ha-ffmpeg";
     description = "Library for home-assistant to handle ffmpeg";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = teams.home-assistant.members;
   };
 }


### PR DESCRIPTION
The path to the binary is specified in the configuration:
https://www.home-assistant.io/integrations/ffmpeg#ffmpeg_bin

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/120705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
