### PR TITLE
nixos/tests/cage: Increase the xterm font size to fix the test

### DIFF
--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -13,17 +13,9 @@ import ./make-test-python.nix ({ pkgs, ...} :
     services.cage = {
       enable = true;
       user = "alice";
-      program = "${pkgs.xterm}/bin/xterm -cm -pc"; # disable color and bold to make OCR easier
+      # Disable color and bold and use a larger font to make OCR easier:
+      program = "${pkgs.xterm}/bin/xterm -cm -pc -fa Monospace -fs 24";
     };
-
-    # this needs a fairly recent kernel, otherwise:
-    #   [backend/drm/util.c:215] Unable to add DRM framebuffer: No such file or directory
-    #   [backend/drm/legacy.c:15] Virtual-1: Failed to set CRTC: No such file or directory
-    #   [backend/drm/util.c:215] Unable to add DRM framebuffer: No such file or directory
-    #   [backend/drm/legacy.c:15] Virtual-1: Failed to set CRTC: No such file or directory
-    #   [backend/drm/drm.c:618] Failed to initialize renderer on connector 'Virtual-1': initial page-flip failed
-    #   [backend/drm/drm.c:701] Failed to initialize renderer for plane
-    boot.kernelPackages = pkgs.linuxPackages_latest;
 
     virtualisation.memorySize = 1024;
   };


### PR DESCRIPTION
The result still looks far from ideal but at least it gets recognized
now. "-fa Monospace" is required to switch to a font from the FreeType
library so that "-fs 24" works.

Note: Using linuxPackages_latest is not required anymore.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The test was broken for more than two months: https://hydra.nixos.org/build/142244537

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
