### PR TITLE
pythonPackages.IMAPClient: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/imapclient/default.nix
+++ b/pkgs/development/python-modules/imapclient/default.nix
@@ -1,35 +1,30 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, mock
 , six
+, pytestCheckHook
+, mock
 }:
 
 buildPythonPackage rec {
   pname = "IMAPClient";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "mjs";
     repo = "imapclient";
     rev = version;
-    sha256 = "1zc8qj8ify2zygbz255b6fcg7jhprswf008ccwjmbrnj08kh9l4x";
+    sha256 = "sha256-q/8LFKHgrY3pQV7Coz+5pZAw696uABMTEkYoli6C2KA=";
   };
-
-  # fix test failing in python 36
-  postPatch = ''
-    substituteInPlace tests/test_imapclient.py \
-      --replace "if sys.version_info >= (3, 7):" "if sys.version_info >= (3, 6, 4):"
-  '';
 
   propagatedBuildInputs = [ six ];
 
-  checkInputs = [ mock ];
+  checkInputs = [ pytestCheckHook mock ];
 
   meta = with lib; {
     homepage = "https://imapclient.readthedocs.io";
     description = "Easy-to-use, Pythonic and complete IMAP client library";
     license = licenses.bsd3;
-    maintainers = [ maintainers.almac ];
+    maintainers = with maintainers; [ almac dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Upstream doesn't use pytest, but I think there's no harm in doing so.