### PR TITLE
river: unstable 2021-04-08 -> unstable 2021-04-27

### DIFF
--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "river";
-  version = "unstable-2021-04-08";
+  version = "unstable-2021-04-27";
 
   src = fetchFromGitHub {
     owner = "ifreund";
-    repo = "river";
-    rev = "9e3e92050e04320949c6cd995273c30319ebd515";
-    sha256 = "1v8dpbadsb3c7bc84sai09dbqv5s5s5d77vs12kdkd45x0ppmk3j";
+    repo = pname;
+    rev = "0c8e718d95a6a621b9cba0caa9158915e567b076";
+    sha256 = "1jjh0dzxi7hy4mg8vag6ipfwb9qxm5lfc07njp1mx6m81nq76ybk";
     fetchSubmodules = true;
   };
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
   installPhase = ''
     zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install
-   '';
+  '';
 
   nativeBuildInputs = [ zig wayland scdoc pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update with bigger changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
