### PR TITLE
coqPackages.CoLoR: 1.7.0 → 1.8.1

### DIFF
--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -5,11 +5,13 @@ with lib; mkCoqDerivation {
   owner = "fblanqui";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
+    {case = range "8.12" "8.13"; out = "1.8.1"; }
     {case = range "8.10" "8.11"; out = "1.7.0"; }
     {case = range "8.8"  "8.9";  out = "1.6.0"; }
     {case = range "8.6"  "8.7";  out = "1.4.0"; }
   ] null;
 
+  release."1.8.1".sha256 = "0knhca9fffmyldn4q16h9265i7ih0h4jhcarq4rkn0wnn7x8w8yw";
   release."1.7.0".rev    = "08b5481ed6ea1a5d2c4c068b62156f5be6d82b40";
   release."1.7.0".sha256 = "1w7fmcpf0691gcwq00lm788k4ijlwz3667zj40j5jjc8j8hj7cq3";
   release."1.6.0".rev    = "328aa06270584b578edc0d2925e773cced4f14c8";


### PR DESCRIPTION
###### Motivation for this change

Support for recent versions of Coq.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
