### PR TITLE
vscode-extensions.hashicorp.terraform: 2.10.0 -> 2.10.1

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,13 +3,13 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.10.0";
+    version = "2.10.1";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/${mktplcRef.name}-${mktplcRef.version}.vsix";
-    sha256 = "1xhypy4vvrzxj3qwkzpfx8b48hddf72mxmh0hgz7iry6bch6sh5f";
+    sha256 = "1galibrk4fx4qwa6q17mmwlikx78nmhgv1h98haiyak666cinzcq";
   };
 
   patches = [ ./fix-terraform-ls.patch ];

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,8 +1,8 @@
 diff --git a/out/extension.js b/out/extension.js
-index e44cef2..fba0899 100644
+index e815393..aeade0e 100644
 --- a/out/extension.js
 +++ b/out/extension.js
-@@ -141,24 +141,6 @@ function updateLanguageServer() {
+@@ -141,25 +141,6 @@ function updateLanguageServer() {
      return __awaiter(this, void 0, void 0, function* () {
          const delay = 1000 * 60 * 24;
          setTimeout(updateLanguageServer, delay); // check for new updates every 24hrs
@@ -16,6 +16,7 @@ index e44cef2..fba0899 100644
 -                    yield installer.install();
 -                }
 -                catch (err) {
+-                    console.log(err); // for test failure reporting
 -                    reporter.sendTelemetryException(err);
 -                    throw err;
 -                }
@@ -27,7 +28,7 @@ index e44cef2..fba0899 100644
          return startClients(); // on repeat runs with no install, this will be a no-op
      });
  }
-@@ -256,7 +238,7 @@ function pathToBinary() {
+@@ -257,7 +238,7 @@ function pathToBinary() {
                  reporter.sendTelemetryEvent('usePathToBinary');
              }
              else {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
