### PR TITLE
python3Packages.karton-config-extractor: 1.0.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/karton-config-extractor/default.nix
+++ b/pkgs/development/python-modules/karton-config-extractor/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "karton-config-extractor";
-  version = "1.0.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1v0zqa81yjz6hm17x9hp0iwkllymqzn84dd6r2yrhillbwnjg9bb";
+    sha256 = "14592b9vq2iza5agxr29z1mh536if7a9p9hvyjnibsrv22mzwz7l";
   };
 
   propagatedBuildInputs = [
@@ -23,7 +23,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "karton.core==4.0.5" "karton-core"
+      --replace "karton-core==4.2.0" "karton-core"
+    substituteInPlace requirements.txt \
+      --replace "malduck==4.1.0" "malduck"
   '';
 
   # Project has no tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump to the newest version and fix a typo in substitution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
