### PR TITLE
kopia: 0.7.3 -> 0.8.4

### DIFF
--- a/pkgs/tools/backup/kopia/default.nix
+++ b/pkgs/tools/backup/kopia/default.nix
@@ -1,17 +1,17 @@
-{ lib, buildGoModule, fetchFromGitHub, coreutils }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "kopia";
-  version = "0.7.3";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1dnk764y71c9k9nghn9q06f2zz9igsvm4z826azil2d58h5d06j6";
+    sha256 = "sha256-Or6RL6yT/X3rVIySqt5lWbXbI25f8HNLBpY3cOhMC0g=";
   };
 
-  vendorSha256 = "1mnhq6kn0pn67l55a9k6irmjlprr295218nms3klsk2720syzdwq";
+  vendorSha256 = "sha256-1FK5IIvm2iyzGqj8IPL3/qvxFj0dC37aycQQ5MO0mBI=";
 
   doCheck = false;
 
@@ -21,12 +21,6 @@ buildGoModule rec {
     -ldflags=
        -X github.com/kopia/kopia/repo.BuildVersion=${version}
        -X github.com/kopia/kopia/repo.BuildInfo=${src.rev}
-  '';
-
-  postConfigure = ''
-    # speakeasy hardcodes /bin/stty https://github.com/bgentry/speakeasy/issues/22
-    substituteInPlace vendor/github.com/bgentry/speakeasy/speakeasy_unix.go \
-      --replace "/bin/stty" "${coreutils}/bin/stty"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/nix/store/pgafij1isn2w2558d7pfa73n5awr4m82-kopia-0.7.3	 59.8M

/nix/store/9bszqbbbxlkv875f7gblmycy9iig1vyh-kopia-0.8.4	 60.1M

Generated using `nix-update`, and removed `postConfigure` step since the source file couldn't be found in the vendor directory during the build and kept failing.

I attempted to `go mod vendor` for kopia and for the package that lists `speakeasy` as its direct dependency, but couldn't find it.

I was able to successfully connect to a repository created with an older version and take a backup.
