### PR TITLE
nixos/nginx: update hardening settings

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -819,28 +819,38 @@ in
         # Logs directory and mode
         LogsDirectory = "nginx";
         LogsDirectoryMode = "0750";
+        # Proc filesystem
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+        # New file permissions
+        UMask = "0027"; # 0640 / 0750
         # Capabilities
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" "CAP_SYS_RESOURCE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" "CAP_SYS_RESOURCE" ];
         # Security
         NoNewPrivileges = true;
-        # Sandboxing
+        # Sandboxing (sorted by occurrence in https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
         ProtectSystem = "strict";
         ProtectHome = mkDefault true;
         PrivateTmp = true;
         PrivateDevices = true;
         ProtectHostname = true;
+        ProtectClock = true;
         ProtectKernelTunables = true;
         ProtectKernelModules = true;
+        ProtectKernelLogs = true;
         ProtectControlGroups = true;
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
         LockPersonality = true;
         MemoryDenyWriteExecute = !(builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules);
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
+        RemoveIPC = true;
         PrivateMounts = true;
         # System Call Filtering
         SystemCallArchitectures = "native";
+        SystemCallFilter = "~@chown @cpu-emulation @debug @keyring @ipc @module @mount @obsolete @privileged @raw-io @reboot @setuid @swap";
       };
     };
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Set an explicit umask that allows u+rwx and g+r.
- Adds `ProtectControlGroups` and `ProtectKernelLogs`, there should be
  no need to access eitehr.
- `ProtectProc` hides processes from other users within the /proc
  filesystem and `ProcSubSet` hides all files/directories unrelated to
  the process management of the units process.
- Sets `RemoveIPC`, as there is no SysV or POSIX IPC within nginx that I
  know of.
- Restricts the creation of arbitrary namespaces
- Adds a SystemCallFilter with a reasonable preset for @systemd-service
  and an exclusion of @privileged

And finally applies some light sorting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```✗ PrivateNetwork=                    Service has access to the host's …      0.5
✓ User=/DynamicUser=                 Service runs under a static non-r…
✓ CapabilityBoundingSet=~CAP_SET(UI… Service cannot change UID/GID ide…
✓ CapabilityBoundingSet=~CAP_SYS_AD… Service has no administrator priv…
✓ CapabilityBoundingSet=~CAP_SYS_PT… Service has no ptrace() debugging…
✗ RestrictAddressFamilies=~AF_(INET… Service may allocate Internet soc…      0.3
✓ RestrictNamespaces=~CLONE_NEWUSER  Service cannot create user namesp…
✓ RestrictAddressFamilies=~…         Service cannot allocate exotic so…
✓ CapabilityBoundingSet=~CAP_(CHOWN… Service cannot change file owners…
✓ CapabilityBoundingSet=~CAP_(DAC_*… Service cannot override UNIX file…
✓ CapabilityBoundingSet=~CAP_NET_AD… Service has no network configurat…
✓ CapabilityBoundingSet=~CAP_SYS_MO… Service cannot load kernel modules
✓ CapabilityBoundingSet=~CAP_SYS_RA… Service has no raw I/O access
✓ CapabilityBoundingSet=~CAP_SYS_TI… Service processes cannot change t…
✓ DeviceAllow=                       Service has a minimal device ACL
✗ IPAddressDeny=                     Service does not define an IP add…      0.2
✓ KeyringMode=                       Service doesn't share key materia…
✓ NoNewPrivileges=                   Service processes cannot acquire …
✓ NotifyAccess=                      Service child processes cannot al…
✓ PrivateDevices=                    Service has no access to hardware…
✓ PrivateMounts=                     Service cannot install system mou…
✓ PrivateTmp=                        Service has no access to other so…
✗ PrivateUsers=                      Service has access to other users       0.2
✗ ProtectClock=                      Service may write to the hardware…      0.2
✓ ProtectControlGroups=              Service cannot modify the control…
✓ ProtectHome=                       Service has no access to home dir…
✓ ProtectKernelLogs=                 Service cannot read from or write…
✓ ProtectKernelModules=              Service cannot load or read kerne…
✓ ProtectKernelTunables=             Service cannot alter kernel tunab…
✓ ProtectProc=                       Service has restricted access to …
✓ ProtectSystem=                     Service has strict read-only acce…
✓ RestrictAddressFamilies=~AF_PACKET Service cannot allocate packet so…
✓ RestrictSUIDSGID=                  SUID/SGID file creation by servic…
✓ SystemCallArchitectures=           Service may execute system calls …
✓ SystemCallFilter=~@clock           System call allow list defined fo…
✓ SystemCallFilter=~@debug           System call allow list defined fo…
✓ SystemCallFilter=~@module          System call allow list defined fo…
✓ SystemCallFilter=~@mount           System call allow list defined fo…
✓ SystemCallFilter=~@raw-io          System call allow list defined fo…
✓ SystemCallFilter=~@reboot          System call allow list defined fo…
✓ SystemCallFilter=~@swap            System call allow list defined fo…
✓ SystemCallFilter=~@privileged      System call allow list defined fo…
✗ SystemCallFilter=~@resources       System call allow list defined fo…      0.2
✗ AmbientCapabilities=               Service process receives ambient …      0.1
✓ CapabilityBoundingSet=~CAP_AUDIT_* Service has no audit subsystem ac…
✓ CapabilityBoundingSet=~CAP_KILL    Service cannot send UNIX signals …
✓ CapabilityBoundingSet=~CAP_MKNOD   Service cannot create device nodes
✗ CapabilityBoundingSet=~CAP_NET_(B… Service has elevated networking p…      0.1
✓ CapabilityBoundingSet=~CAP_SYSLOG  Service has no access to kernel l…
✗ CapabilityBoundingSet=~CAP_SYS_(N… Service has privileges to change …      0.1
✓ RestrictNamespaces=~CLONE_NEWCGRO… Service cannot create cgroup name…
✓ RestrictNamespaces=~CLONE_NEWIPC   Service cannot create IPC namespa…
✓ RestrictNamespaces=~CLONE_NEWNET   Service cannot create network nam…
✓ RestrictNamespaces=~CLONE_NEWNS    Service cannot create file system…
✓ RestrictNamespaces=~CLONE_NEWPID   Service cannot create process nam…
✓ RestrictRealtime=                  Service realtime scheduling acces…
✓ SystemCallFilter=~@cpu-emulation   System call allow list defined fo…
✓ SystemCallFilter=~@obsolete        System call allow list defined fo…
✓ RestrictAddressFamilies=~AF_NETLI… Service cannot allocate netlink s…
✗ RootDirectory=/RootImage=          Service runs within the host's ro…      0.1
✓ SupplementaryGroups=               Service has no supplementary grou…
✓ CapabilityBoundingSet=~CAP_MAC_*   Service cannot adjust SMACK MAC
✓ CapabilityBoundingSet=~CAP_SYS_BO… Service cannot issue reboot()
✓ Delegate=                          Service does not maintain its own…
✓ LockPersonality=                   Service cannot change ABI persona…
✓ MemoryDenyWriteExecute=            Service cannot create writable ex…
✓ RemoveIPC=                         Service user cannot leave SysV IP…
✓ RestrictNamespaces=~CLONE_NEWUTS   Service cannot create hostname na…
✗ UMask=                             Files created by service are grou…      0.1
✓ CapabilityBoundingSet=~CAP_LINUX_… Service cannot mark files immutab…
✓ CapabilityBoundingSet=~CAP_IPC_LO… Service cannot lock memory into R…
✓ CapabilityBoundingSet=~CAP_SYS_CH… Service cannot issue chroot()
✓ ProtectHostname=                   Service cannot change system host…
✓ CapabilityBoundingSet=~CAP_BLOCK_… Service cannot establish wake loc…
✓ CapabilityBoundingSet=~CAP_LEASE   Service cannot create file leases
✓ CapabilityBoundingSet=~CAP_SYS_PA… Service cannot use acct()
✓ CapabilityBoundingSet=~CAP_SYS_TT… Service cannot issue vhangup()
✓ CapabilityBoundingSet=~CAP_WAKE_A… Service cannot program timers tha…
✗ RestrictAddressFamilies=~AF_UNIX   Service may allocate local sockets      0.1
✓ ProcSubset=                        Service has no access to non-proc…

→ Overall exposure level for nginx.service: 1.7 OK :-)
```
