### PR TITLE
rtl88xxau-aircrack: fc0194 -> c0ce81

### DIFF
--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "rtl88xxau-aircrack-${kernel.version}-${version}";
-  rev = "fc0194c1d90453bf4943089ca237159ef19a7374";
+  rev = "c0ce81745eb3471a639f0efd4d556975153c666e";
   version = "${builtins.substring 0 6 rev}";
 
   src = fetchFromGitHub {
     owner = "aircrack-ng";
     repo = "rtl8812au";
     inherit rev;
-    sha256 = "0hf7mrvxaskc6qcjar5w81y9xc7s2rlsxp34achyqly2hjg7fgmy";
+    sha256 = "131cwwg3czq0i1xray20j71n836g93ac064nvf8wi13c2wr36ppc";
   };
 
   buildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The version of this driver doesn't work with changes to the Linux kernel, somewhere around 5.8. This pull request updates to the latest version.


###### Things done

Tested with review, and works on my machine with my adapter, building from my tree.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
