### PR TITLE
coq2html: 20170720 -> 1.2

### DIFF
--- a/pkgs/applications/science/logic/coq2html/default.nix
+++ b/pkgs/applications/science/logic/coq2html/default.nix
@@ -1,20 +1,17 @@
-{ lib, stdenv, fetchgit, ocaml }:
+{ lib, stdenv, fetchFromGitHub, ocaml }:
 
-let
-  version = "20170720";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation  rec {
   pname = "coq2html";
-  inherit version;
+  version = "1.2";
 
-  src = fetchgit {
-    url = "https://github.com/xavierleroy/coq2html";
-    rev = "e2b94093c6b9a877717f181765e30577de22439e";
-    sha256 = "1x466j0pyjggyz0870pdllv9f5vpnfrgkd0w7ajvm9rkwyp3f610";
+  src = fetchFromGitHub {
+    owner = "xavierleroy";
+    repo = "coq2html";
+    rev = "v${version}";
+    sha256 = "sha256-ty/6A3wivjDCrmlZAcZyaIwQQ+vPBJm9MhtW6nZcV3s=";
   };
 
-  buildInputs = [ ocaml ];
+  nativeBuildInputs = [ ocaml ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -32,8 +29,8 @@ stdenv.mkDerivation {
       "Proof" keyword.
     '';
     homepage = "https://github.com/xavierleroy/coq2html";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ jwiegley ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jwiegley siraben ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bump a very outdated version

cc maintainer @jwiegley 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
