### PR TITLE
coqPackages.VST: 2.6 → 2.7.1

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -27,6 +27,33 @@ let param = {
   };
   "3.8" = {
     sha256 = "1gzlyxvw64ca12qql3wnq3bidcx9ygsklv9grjma3ib4hvg7vnr7";
+    patches = [
+     # Support for Coq 8.12.2
+     (fetchpatch {
+        url = "https://github.com/AbsInt/CompCert/commit/06956421b4307054af221c118c5f59593c0e67b9.patch";
+        sha256 = "1f90q6j3xfvnf3z830bkd4d8526issvmdlrjlc95bfsqs78i1yrl";
+      })
+     # Support for Coq 8.13.0
+     (fetchpatch {
+        url = "https://github.com/AbsInt/CompCert/commit/0895388e7ebf9c9f3176d225107e21968919fb97.patch";
+        sha256 = "0qhkzgb2xl5kxys81pldp3mr39gd30lvr2l2wmplij319vp3xavd";
+      })
+     # Support for Coq 8.13.1
+     (fetchpatch {
+        url = "https://github.com/AbsInt/CompCert/commit/6bf310dd678285dc193798e89fc2c441d8430892.patch";
+        sha256 = "026ahhvpj5pksy90f8pnxgmhgwfqk4kwyvcf8x3dsanvz98d4pj5";
+      })
+     # Drop support for Coq < 8.9
+     (fetchpatch {
+        url = "https://github.com/AbsInt/CompCert/commit/7563a5df926a4c6fb1489a7a4c847641c8a35095.patch";
+        sha256 = "05vkslzy399r3dm6dmjs722rrajnyfa30xsyy3djl52isvn4gyfb";
+      })
+     # Support for Coq 8.13.2
+     (fetchpatch {
+        url = "https://github.com/AbsInt/CompCert/commit/48bc183167c4ce01a5c9ea86e49d60530adf7290.patch";
+        sha256 = "0j62lppfk26d1brdp3qwll2wi4gvpx1k70qivpvby5f7dpkrkax1";
+      })
+    ];
     useExternalFlocq = true;
   };
 }."${version}"; in

--- a/pkgs/development/coq-modules/VST/default.nix
+++ b/pkgs/development/coq-modules/VST/default.nix
@@ -7,7 +7,11 @@ with lib; mkCoqDerivation {
   owner = "PrincetonUniversity";
   repo = "VST";
   inherit version;
-  defaultVersion = if coq.coq-version == "8.11" then "2.6" else null;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.12" "8.13"; out = "2.7.1"; }
+    { case = "8.11"; out = "2.6"; }
+  ] null;
+  release."2.7.1".sha256 = "1674j7bkvihiv19vizm99dp6gj3lryb00zx6a87jz214f3ydcvnj";
   release."2.6".sha256 = "00bf9hl4pvmsqa08lzjs1mrxyfgfxq4k6778pnldmc8ichm90jgk";
   releaseRev = v: "v${v}";
   propagatedBuildInputs = [ compcert ];

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -70,9 +70,11 @@ let
       tlc = callPackage ../development/coq-modules/tlc {};
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
-      VST = callPackage ../development/coq-modules/VST {
-        compcert = compcert.override { version = "3.7"; };
-      };
+      VST = callPackage ../development/coq-modules/VST (with lib.versions;
+        lib.switch coq.coq-version [
+          { case = "8.11"; out = { compcert = compcert.override { coqPackages = self; version = "3.7"; }; }; }
+          { case = range "8.12" "8.13"; out = { compcert = compcert.override { coqPackages = self; }; }; }
+        ] {});
       filterPackages = doesFilter: if doesFilter then filterCoqPackages self else self;
     };
 


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.13 and CompCert 3.8.

Cyril, do you have suggestions on how to improve the selection of the matching version of CompCert? The logic of `defaultVersion` is replicated at the call-site…

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
