### PR TITLE
nixos/pcscd: ensure polkit rules are loaded (fix #121121)

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -50,6 +50,7 @@ in
 
     environment.etc."reader.conf".source = cfgFile;
 
+    environment.systemPackages = [ pkgs.pcsclite ];
     systemd.packages = [ (getBin pkgs.pcsclite) ];
 
     systemd.sockets.pcscd.wantedBy = [ "sockets.target" ];


### PR DESCRIPTION
This makes sure that the polkit policies for pcsclite are correcly loaded.

###### Motivation for this change

Fixed #121121. the pcscd config option didn't correctly load pcsclite (I guess) polkit policies, making it unusable. This seems to fix it.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux) (on the unstable branch though, not master)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
