### PR TITLE
pcsclite: Remove the confdir configure option (fix #121088)

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -57,16 +57,6 @@ in
     systemd.services.pcscd = {
       environment.PCSCLITE_HP_DROPDIR = pluginEnv;
       restartTriggers = [ "/etc/reader.conf" ];
-
-      # If the cfgFile is empty and not specified (in which case the default
-      # /etc/reader.conf is assumed), pcscd will happily start going through the
-      # entire confdir (/etc in our case) looking for a config file and try to
-      # parse everything it finds. Doesn't take a lot of imagination to see how
-      # well that works. It really shouldn't do that to begin with, but to work
-      # around it, we force the path to the cfgFile.
-      #
-      # https://github.com/NixOS/nixpkgs/issues/121088
-      serviceConfig.ExecStart = [ "" "${getBin pkgs.pcsclite}/bin/pcscd -f -x -c ${cfgFile}" ];
     };
   };
 }

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -30,7 +30,12 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--enable-confdir=/etc"
+    # Despite what `./configure --help` says, the value below is not
+    # the default, because the default is located under $sysconfdir,
+    # which in turn is under $prefix, effectively putting the confdir
+    # in the Nix store.  We obviously don't want this, since non-NixOS
+    # users may want to put things in that directory.
+    "--enable-confdir=/etc/reader.conf.d"
     # The OS should care on preparing the drivers into this location
     "--enable-usbdropdir=/var/lib/pcsc/drivers"
   ]


### PR DESCRIPTION
# Motivation

This reverts commit 6d23cfd56bbecfd27f230705b709575ba9d66c26 by @peterhoeg, which solved #121088 by hardcoding the configuration file path into the binary call. Instead, it removes the --enable-confdir build option which was the root cause of the issue.  To clarify, this is how ./configure --help describes the parameter:

```
  --enable-confdir=DIR directory containing reader
                       configurations (default /etc/reader.conf.d)
```

But it was set as:

```
  configureFlags = [
     "--enable-confdir=/etc" … ]
```

(Also a very minor formatting change that Emacs insisted to make and I forgot to unstage.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
