### PR TITLE
backblaze-b2: 2.1.0 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -1,16 +1,47 @@
-{ lib, buildPythonPackage, fetchPypi, setuptools-scm, isPy27, pytestCheckHook
-, requests, arrow, logfury, tqdm }:
+{ lib
+, arrow
+, buildPythonPackage
+, fetchPypi
+, importlib-metadata
+, isPy27
+, logfury
+, pytestCheckHook
+, pytest-lazy-fixture
+, pytest-mock
+, pythonOlder
+, requests
+, setuptools-scm
+, tqdm
+}:
 
 buildPythonPackage rec {
   pname = "b2sdk";
   version = "1.7.0";
-
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-8X5XLh9SxZI1P7/2ZjOy8ipcEzTcriJfGI7KlMXncv4=";
   };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    arrow
+    logfury
+    requests
+    tqdm
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-lazy-fixture
+    pytest-mock
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \
@@ -19,16 +50,16 @@ buildPythonPackage rec {
       --replace 'arrow>=0.8.0,<1.0.0' 'arrow'
   '';
 
+  disabledTests = [
+    # Test requires an API key
+    "test_raw_api"
+    "test_files_headers"
+  ];
+
   pythonImportsCheck = [ "b2sdk" ];
 
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ requests arrow logfury tqdm ];
-
-  # requires unpackaged dependencies like liccheck
-  doCheck = false;
-
   meta = with lib; {
-    description = "Client library and utilities for access to B2 Cloud Storage (backblaze).";
+    description = "Client library and utilities for access to B2 Cloud Storage (backblaze)";
     homepage = "https://github.com/Backblaze/b2-sdk-python";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "b2sdk";
-  version = "1.6.0";
+  version = "1.7.0";
 
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-6fjreuMUC056ljddfAidfBbJkvEDndB/dIkx1bF7efs=";
+    sha256 = "sha256-8X5XLh9SxZI1P7/2ZjOy8ipcEzTcriJfGI7KlMXncv4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/rst2ansi/default.nix
+++ b/pkgs/development/python-modules/rst2ansi/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, docutils, }:
+
+buildPythonPackage rec {
+  pname = "rst2ansi";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Gxf7mmKNQPV5M60aOqlSNGREvgaUaVCOc+lQYNoz/m8=";
+  };
+
+  propagatedBuildInputs = [ docutils ];
+
+  meta = with lib; {
+    description = "A rst converter to ansi-decorated console output";
+    homepage = "https://github.com/Snaipe/python-rst-to-ansi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vojta001 ];
+  };
+}

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -1,21 +1,41 @@
 { fetchFromGitHub, lib, python3Packages }:
 
+let
+  python3Packages2 = python3Packages.override {
+    overrides = self: super: {
+      arrow = self.callPackage ../../python-modules/arrow/2.nix { };
+    };
+  };
+in
+let
+  python3Packages = python3Packages2; # two separate let … in to avoid infinite recursion
+in
 python3Packages.buildPythonApplication rec {
   pname = "backblaze-b2";
-  version = "2.1.0";
+  version = "2.4.0";
 
-  src = fetchFromGitHub {
-    owner = "Backblaze";
-    repo = "B2_Command_Line_Tool";
-    rev = "v${version}";
-    sha256 = "1kkpvxqgh5pw4kr8lh5gy9d7960hv9zvajbjiqhj6xgykwbpbgmq";
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "b2";
+    sha256 = "sha256-nNQDdSjUolj3PjWRn1fPBAEtPlgeent2PxzHqwH1Z6s=";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'setuptools_scm<6.0' 'setuptools_scm'
+  '';
 
   propagatedBuildInputs = with python3Packages; [
     b2sdk
     class-registry
     phx-class-registry
     setuptools
+    docutils
+    rst2ansi
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools-scm
   ];
 
   checkInputs = with python3Packages; [ pytestCheckHook ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7144,6 +7144,8 @@ in {
 
   rsa = callPackage ../development/python-modules/rsa { };
 
+  rst2ansi = callPackage ../development/python-modules/rst2ansi { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
 
   Rtree = callPackage ../development/python-modules/Rtree {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

#### Help wanted
Let me explain, what I did. I updated backblaze-b2. It turned out it needed the older setuptools_acm (fortunately we keep it for old Python). I injected it will callpackage. Then it cried it cannot determine the package version, because we used neither pip, nor raw git. So I changed the src to fetchPypi. Now it makes is to the installPhase, but fails with:

```
@nix { "action": "setPhase", "phase": "installPhase" }
installing
Executing pipInstallPhase
/build/b2-2.4.0/dist /build/b2-2.4.0
Processing ./b2-2.4.0-py3-none-any.whl
ERROR: Could not find a version that satisfies the requirement b2sdk<2.0.0,>=1.7.0 (from b2)
ERROR: No matching distribution found for b2sdk<2.0.0,>=1.7.0
```

I don't know why it happens, `b2sdk` is clearly passed in on line 14. I'll have a look at it later, but if anybody had already encountered this before, it might be simple for them.

Maintainers: @hrdinka @kevincox 

###### Motivation for this change
Fix the package as its dependencies have already already been updated (closes #121221).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
