### PR TITLE
nixos/doc/manual: correct gpu acceleration opencl configs

### DIFF
--- a/nixos/doc/manual/configuration/gpu-accel.xml
+++ b/nixos/doc/manual/configuration/gpu-accel.xml
@@ -73,7 +73,7 @@ Platform Vendor      Advanced Micro Devices, Inc.</screen>
        support:
 
        <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = [
-         rocm-opencl-icd
+         pkgs.rocm-opencl-icd
        ];</programlisting>
       </para>
     </section>
@@ -101,7 +101,7 @@ Platform Vendor      Advanced Micro Devices, Inc.</screen>
        configuration can be used:
 
       <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = [
-        intel-compute-runtime
+        pkgs.intel-compute-runtime
       ];</programlisting>
 
       </para>


### PR DESCRIPTION
###### Motivation for this change
The current configurations given for AMD and Intel OpenCL GPU acceleration in the NixOS manual fail to build as `rocm-opencl-icd` and `intel-compute-runtime` are not defined as packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
