### PR TITLE
pythonPackages.pgpy: 0.5.2 -> 0.5.4

### DIFF
--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -1,30 +1,30 @@
-{ lib, isPy3k, fetchFromGitHub, buildPythonPackage
+{ lib, pythonOlder, fetchFromGitHub, buildPythonPackage
 , six, enum34, pyasn1, cryptography, singledispatch ? null
-, fetchPypi, pytestCheckHook }:
+, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "pgpy";
-  version = "0.5.2";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "SecurityInnovation";
     repo = "PGPy";
-    rev = version;
-    sha256 = "1v2b1dyq1sl48d2gw7vn4hv6sasd9ihpzzcq8yvxj9dgfak2y663";
+    rev = "v${version}";
+    sha256 = "03pch39y3hi4ici6y6lvz0j0zram8dw2wvnmq1zyjy3vyvm1ms4a";
   };
 
   propagatedBuildInputs = [
     six
     pyasn1
     cryptography
+  ] ++ lib.optionals (pythonOlder "3.4") [
     singledispatch
-  ] ++ lib.optional (!isPy3k) enum34;
+    enum34
+  ];
 
   checkInputs = [
     pytestCheckHook
   ];
-
-  disabledTests = [ "test_sign_string" "test_verify_string" ];
 
   meta = with lib; {
     homepage = "https://github.com/SecurityInnovation/PGPy";
@@ -35,6 +35,6 @@ buildPythonPackage rec {
       4880.
     '';
     license = licenses.bsd3;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/SecurityInnovation/PGPy/releases/tag/v0.5.3
https://github.com/SecurityInnovation/PGPy/releases/tag/v0.5.4


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
