### PR TITLE
bitwig-studio: Move away from from ffmpeg_3

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, freetype, gdk-pixbuf
 , wrapGAppsHook, gtk2, gtk3, harfbuzz, jdk, lib, xorg
-, libbsd, libjack2, libpng, ffmpeg_3
+, libbsd, libjack2, libpng, ffmpeg
 , libxkbcommon
 , makeWrapper, pixman, autoPatchelfHook
 , xdg-utils, zenity, zlib }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   binPath = lib.makeBinPath [
-    xdg-utils zenity ffmpeg_3
+    xdg-utils zenity ffmpeg
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, alsaLib, cairo, dpkg, freetype
 , gdk-pixbuf, glib, gtk3, lib, xorg
-, libglvnd, libjack2, ffmpeg_3
+, libglvnd, libjack2, ffmpeg
 , libxkbcommon, xdg-utils, zlib, pulseaudio
 , wrapGAppsHook, makeWrapper }:
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   binPath = lib.makeBinPath [
-    xdg-utils ffmpeg_3
+    xdg-utils ffmpeg
   ];
 
   ldLibraryPath = lib.strings.makeLibraryPath buildInputs;


### PR DESCRIPTION
###### Motivation for this change

ffmpeg_3 -> ffmpeg #120705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
