### PR TITLE
bombono: update ffmpeg, fix iso generation

### DIFF
--- a/pkgs/applications/video/bombono/default.nix
+++ b/pkgs/applications/video/bombono/default.nix
@@ -7,7 +7,8 @@
 , dvdauthor
 , dvdplusrwtools
 , enca
-, ffmpeg_3
+, cdrkit
+, ffmpeg
 , gettext
 , gtk2
 , gtkmm2
@@ -59,7 +60,7 @@ stdenv.mkDerivation rec {
     dvdauthor
     dvdplusrwtools
     enca
-    ffmpeg_3
+    ffmpeg
     gtk2
     gtkmm2
     libdvdread
@@ -70,6 +71,13 @@ stdenv.mkDerivation rec {
   prefixKey = "PREFIX=";
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    # fix iso authoring
+    install -Dt  $out/share/bombono/resources/scons_authoring tools/scripts/SConsTwin.py
+
+    wrapProgram $out/bin/bombono-dvd --prefix PATH : ${lib.makeBinPath [ ffmpeg dvdauthor cdrkit ]}
+  '';
 
   meta = with lib; {
     description = "a DVD authoring program for personal computers";


### PR DESCRIPTION


###### Motivation for this change

#120705 

###### Things done

**version:** `nixpkgs-check v0.1.0` on NixOS 20.09.3732.91b77fe6942, sandbox = "true"
**packages declared changed:** {"bombono"}
**manual tests declared performed:**
 * ✔ built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions

**complies with contributing.md:** ✔ yes
**package bombono:** ✔ continued building
**closure size for bombono:** 💚 increased by 62.8 MB, from 556.6 MB to 619.4 MB
**tests of bombono:** 😢 there are no tests
**binaries of bombono:**
  * *added binaries:*
    * 😢 .bombono-dvd-wrapped_ was not run

  * *updated binaries:*
    * ✔ bombono-dvd continued running successfully
    * 😢 mpeg2demux was not run

