### PR TITLE
pkgsLLVM: cross compiled package set using llvm compilers

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -158,6 +158,20 @@ let
                               nixpkgsFun { inherit crossSystem; })
                               lib.systems.examples;
 
+    pkgsLLVM = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsLLVM = super';
+        })
+      ] ++ overlays;
+      # Bootstrap a cross stdenv using the LLVM toolchain.
+      # This is currently not possible when compiling natively,
+      # so we don't need to check hostPlatform != buildPlatform.
+      crossSystem = stdenv.hostPlatform // {
+        useLLVM = true;
+      };
+    };
+
     # All packages built with the Musl libc. This will override the
     # default GNU libc on Linux systems. Non-Linux systems are not
     # supported.


### PR DESCRIPTION
Provide a version of nixpkgs which is built using the LLVM toolchain.
This is achieved by reusing the useLLVM attribute usable in the cross
toolchain bootstrapping which is a) perfectly acceptable and b) the only
way to bootstrap a LLVM stdenv across platforms without unreasonable
amounts of work.

This is mostly working now since we fixed some issues with
llvmPackages_7.lldClang in #119717 and compile glibc with gcc at all
times as of #119786 (since clang can't compile our glibc at the moment).
There are seemingly some issues left to be ironed out, for example the
C++ library of ncurses fails to build with a linking issue. I have
attempted to alleviate that problem with #120790, but to no avail so
far.

Nonetheless, having a working pkgsLLVM.hello is a good start.

A currently present issue is that there is no way to change the libc
since there is some issue with lldClang actually picking up on the set
libc. This will need investigation and fixing.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
