### PR TITLE
nixos/wireguard: Add `dynamicEndpointRefreshSeconds` option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -350,6 +350,15 @@
    </listitem>
    <listitem>
     <para>
+     The WireGuard module gained a new option
+     <option>networking.wireguard.interfaces.&lt;name&gt;.peers.*.dynamicEndpointRefreshSeconds</option>
+     that implements refreshing the IP of DNS-based endpoints periodically
+     (which WireGuard itself
+     <link xlink:href="https://lists.zx2c4.com/pipermail/wireguard/2017-November/002028.html">cannot do</link>).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      MariaDB has been updated to 10.5.
      Before you upgrade, it would be best to take a backup of your database and read
      <link xlink:href="https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#incompatible-changes-between-104-and-105">


### PR DESCRIPTION
###### Motivation for this change

Implements refreshing the IP of DNS-based endpoints periodically, which WireGuard itself [cannot do](https://lists.zx2c4.com/pipermail/wireguard/2017-November/002028.html). It only does it once at the beginning when the `wg` utility is invoked.

See also [ArchWiki: Endpoint with changing IP](https://wiki.archlinux.org/index.php/WireGuard#Endpoint_with_changing_IP)

Those also mention a script called `reresolve-dns` that is included in WireGuard's examples folder (but not packaged in nixpkgs); however, that does some pretty ugly shell-based config file parsing, and it is much cleaner to just periodically execute the `wg set wg0 peer` command we already construct in the module for initial setup.

Also included:

* A refactoring that implement correct shell argument quoting for all CLI invocations

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
