### PR TITLE
miniaudicle: init at 1.3.5.2

### DIFF
--- a/pkgs/applications/audio/miniaudicle/default.nix
+++ b/pkgs/applications/audio/miniaudicle/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchurl
+, bison
+, flex
+, which
+, alsaLib
+, libsndfile
+, qt4
+, qscintilla
+, libpulseaudio
+, libjack2
+, audioBackend ? "pulse" # "pulse", "alsa", or "jack"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "miniaudicle";
+  version = "1.3.5.2";
+
+  src = fetchurl {
+    url = "https://audicle.cs.princeton.edu/mini/release/files/miniAudicle-${version}.tgz";
+    hash = "sha256-dakDz69uHbKZFj8z67CubmRXEQ5X6GuYqlCXXvLzqSI=";
+  };
+
+  sourceRoot = "miniAudicle-${version}/src";
+
+  postPatch = ''
+    substituteInPlace miniAudicle.pro \
+      --replace "/usr/local" $out
+  '';
+
+  nativeBuildInputs = [
+    bison
+    flex
+    which
+  ];
+
+  buildInputs = [
+    alsaLib
+    libsndfile
+    qt4
+    qscintilla
+  ] ++ lib.optional (audioBackend == "pulse") libpulseaudio
+    ++ lib.optional (audioBackend == "jack")  libjack2;
+
+  buildFlags = [ "linux-${audioBackend}" ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "A light-weight integrated development environment for the ChucK digital audio programming language";
+    homepage = "https://audicle.cs.princeton.edu/mini/";
+    downloadPage = "https://audicle.cs.princeton.edu/mini/linux/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+    broken = stdenv.isDarwin; # not attempted
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24600,6 +24600,8 @@ in
 
   mikmod = callPackage ../applications/audio/mikmod { };
 
+  miniaudicle = callPackage ../applications/audio/miniaudicle { };
+
   minicom = callPackage ../tools/misc/minicom { };
 
   minimodem = callPackage ../applications/radio/minimodem { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
