### PR TITLE
neovim, neovimUtils, neovim-qt: drop python2 support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -330,7 +330,7 @@
    </listitem>
    <listitem>
     <para>
-      <literal>vim</literal> switched to Python 3, dropping all Python 2 support.
+      <literal>vim</literal> and <literal>neovim</literal> switched to Python 3, dropping all Python 2 support.
     </para>
    </listitem>
    <listitem>

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -6,7 +6,7 @@
 
 # now defaults to false because some tests can be flaky (clipboard etc)
 , doCheck ? false
-, nodejs ? null, fish ? null, python ? null
+, nodejs ? null, fish ? null, python3 ? null
 }:
 
 with lib;
@@ -19,7 +19,7 @@ let
       ]
     ));
 
-  pyEnv = python.withPackages(ps: [ ps.pynvim ps.msgpack ]);
+  pyEnv = python3.withPackages(ps: with ps; [ pynvim msgpack ]);
 
   # FIXME: this is verry messy and strange.
   # see https://github.com/NixOS/nixpkgs/pull/80528

--- a/pkgs/applications/editors/neovim/neovim-qt.nix
+++ b/pkgs/applications/editors/neovim/neovim-qt.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
-, msgpack, neovim, pythonPackages, qtbase }:
+, msgpack, neovim, python3Packages, qtbase }:
 
 mkDerivation rec {
   pname = "neovim-qt-unwrapped";
@@ -20,7 +20,7 @@ mkDerivation rec {
   buildInputs = [
     neovim.unwrapped # only used to generate help tags at build time
     qtbase
-  ] ++ (with pythonPackages; [
+  ] ++ (with python3Packages; [
     jinja2 python msgpack
   ]);
 

--- a/pkgs/applications/editors/neovim/neovim-remote.nix
+++ b/pkgs/applications/editors/neovim/neovim-remote.nix
@@ -1,11 +1,14 @@
-{ lib, fetchFromGitHub, pythonPackages }:
+{ lib
+, fetchFromGitHub
+, python3
+, neovim
+}:
 
 with lib;
 
-pythonPackages.buildPythonApplication rec {
+with python3.pkgs; buildPythonApplication rec {
   pname = "neovim-remote";
   version = "2.4.0";
-  disabled = !pythonPackages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "mhinz";
@@ -14,10 +17,22 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0jlw0qksak4bdzddpsj74pm2f2bgpj3cwrlspdjjy0j9qzg0mpl9";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = [
     pynvim
     psutil
     setuptools
+  ];
+
+  checkInputs = [
+    neovim
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # these tests get stuck and never return
+    "test_escape_filenames_properly"
+    "test_escape_single_quotes_in_filenames"
+    "test_escape_double_quotes_in_filenames"
   ];
 
   meta = {

--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -1,5 +1,4 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
-, msgpack, neovim, pythonPackages, qtbase, neovim-qt-unwrapped }:
+{ stdenv, makeWrapper, neovim, neovim-qt-unwrapped }:
 
 let
   unwrapped = neovim-qt-unwrapped;

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -4,7 +4,6 @@
 , neovim-unwrapped
 , bundlerEnv
 , ruby
-, pythonPackages
 , python3Packages
 , writeText
 , wrapNeovimUnstable
@@ -48,12 +47,6 @@ let
       requiredPlugins = vimUtils.requiredPlugins configure;
       getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
 
-      pluginPython2Packages = getDeps "pythonDependencies" requiredPlugins;
-      python2Env = pythonPackages.python.withPackages (ps:
-        [ ps.pynvim ]
-        ++ (extraPython2Packages ps)
-        ++ (lib.concatMap (f: f ps) pluginPython2Packages));
-
       pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
       python3Env = python3Packages.python.withPackages (ps:
         [ ps.pynvim ]
@@ -69,7 +62,6 @@ let
       # While the latter tells nvim that this provider is not available
       hostprog_check_table = {
         node = withNodeJs;
-        python = withPython2;
         python3 = withPython3;
         ruby = withRuby;
       };
@@ -99,11 +91,12 @@ let
       manifestRc = vimUtils.vimrcContent (configure // { customRC = ""; });
       neovimRcContent = vimUtils.vimrcContent configure;
     in
+    assert withPython2 -> throw "Python2 support has been removed from neovim, please remove withPython2 and extraPython2Packages.";
+
     args // {
       wrapperArgs = makeWrapperArgs;
       inherit neovimRcContent;
       inherit manifestRc;
-      inherit python2Env;
       inherit python3Env;
       inherit withNodeJs;
     } // lib.optionalAttrs withRuby {
@@ -120,7 +113,7 @@ let
   # to keep backwards compatibility
   legacyWrapper = neovim: {
     extraMakeWrapperArgs ? ""
-    , withPython ? true
+    , withPython ? false
     /* the function you would have passed to python.withPackages */
     , extraPythonPackages ? (_: [])
     /* the function you would have passed to python.withPackages */
@@ -138,14 +131,14 @@ let
       else funOrList);
 
       res = makeNeovimConfig {
-        withPython2 = withPython;
-        extraPythonPackages = compatFun extraPythonPackages;
         inherit withPython3;
         extraPython3Packages = compatFun extraPython3Packages;
         inherit withNodeJs withRuby viAlias vimAlias;
         inherit configure;
       };
     in
+    assert withPython -> throw "Python2 support has been removed from neovim, please remove withPython and extraPythonPackages.";
+
     wrapNeovimUnstable neovim (res // {
       wrapperArgs = lib.escapeShellArgs (
         res.wrapperArgs ++ lib.optionals (configure != {}) [

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -3,7 +3,6 @@
 , bundlerEnv, ruby
 , nodejs
 , nodePackages
-, pythonPackages
 , python3Packages
 }:
 with lib;
@@ -15,7 +14,7 @@ let
       # should contain all args but the binary
       wrapperArgs ? ""
     , manifestRc ? null
-    , withPython2 ? true, python2Env ? null
+    , withPython2 ? false
     , withPython3 ? true,  python3Env ? null
     , withNodeJs ? false
     , rubyEnv ? null
@@ -35,6 +34,8 @@ let
     [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim" ] ++
       [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ];
   in
+  assert withPython2 -> throw "Python2 support has been removed from the neovim wrapper, please remove withPython2 and python2Env.";
+
   symlinkJoin {
       name = "neovim-${lib.getVersion neovim}";
       # Remove the symlinks created by symlinkJoin which we need to perform
@@ -43,9 +44,6 @@ let
         rm $out/share/applications/nvim.desktop
         substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
           --replace 'Name=Neovim' 'Name=WrappedNeovim'
-      ''
-      + optionalString withPython2 ''
-        makeWrapper ${python2Env}/bin/python $out/bin/nvim-python --unset PYTHONPATH
       ''
       + optionalString withPython3 ''
         makeWrapper ${python3Env}/bin/python3 $out/bin/nvim-python3 --unset PYTHONPATH

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26625,7 +26625,7 @@ in
 
   gnvim = callPackage ../applications/editors/neovim/gnvim/wrapper.nix { };
 
-  neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { pythonPackages = python3Packages; };
+  neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { };
 
   vis = callPackage ../applications/editors/vis {
     inherit (lua52Packages) lpeg;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In 2a00e53bd pynvim support for python2 was disabled, this broke the
neovim build. I really think it is time to let go of python2 support in
neovim.

Fixes the build for me, I have no regrets.

I'm aware we might need a release notes entry for that. I'm open to suggestions, I've never relied on python2 in neovim.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  ```
  /nix/store/synllhwl09qs1jzg9v452npvbgq6y0pf-neovim-0.4.4	  425376328
  /nix/store/zapccq0qrj4k5b94j49ifnqy6i5mzxkx-neovim-0.4.4	  383572776
  ```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
