### PR TITLE
haunt: fix Guile load paths

### DIFF
--- a/pkgs/applications/misc/haunt/default.nix
+++ b/pkgs/applications/misc/haunt/default.nix
@@ -29,11 +29,15 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postInstall = ''
-    wrapProgram $out/bin/haunt \
-      --prefix GUILE_LOAD_PATH : "$out/share/guile/site:${guile-commonmark}/share/guile/site:${guile-reader}/share/guile/site" \
-      --prefix GUILE_LOAD_COMPILED_PATH : "$out/share/guile/site:${guile-commonmark}/share/guile/site:${guile-reader}/share/guile/site"
-  '';
+  postInstall =
+    let
+      guileVersion = lib.versions.majorMinor guile.version;
+    in
+    ''
+      wrapProgram $out/bin/haunt \
+        --prefix GUILE_LOAD_PATH : "$out/share/guile/site/${guileVersion}:$GUILE_LOAD_PATH" \
+        --prefix GUILE_LOAD_COMPILED_PATH : "$out/lib/guile/${guileVersion}/site-ccache:$GUILE_LOAD_COMPILED_PATH"
+    '';
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/applications/misc/haunt/default.nix
+++ b/pkgs/applications/misc/haunt/default.nix
@@ -27,10 +27,19 @@ stdenv.mkDerivation rec {
     guile-reader
   ];
 
+  doCheck = true;
+
   postInstall = ''
     wrapProgram $out/bin/haunt \
       --prefix GUILE_LOAD_PATH : "$out/share/guile/site:${guile-commonmark}/share/guile/site:${guile-reader}/share/guile/site" \
       --prefix GUILE_LOAD_COMPILED_PATH : "$out/share/guile/site:${guile-commonmark}/share/guile/site:${guile-reader}/share/guile/site"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/haunt --version
+    runHook postInstallCheck
   '';
 
   meta = with lib; {
@@ -53,7 +62,7 @@ stdenv.mkDerivation rec {
       to do things that aren't provided out-of-the-box.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ AndersonTorres AluisioASG ];
     platforms = guile.meta.platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The current `haunt` package doesn't actually run due to looking in the wrong paths – Guile packages may or may not include the Guile version in their install paths, and Haunt does include it.

Also include checks to catch this in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
