### PR TITLE
Add support for Plasma Mobile

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -205,6 +205,14 @@ in
       default = {};
       type = kdeConfigurationType;
     };
+
+    mobile.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable support for running the Plasma Mobile shell.
+      '';
+    };
   };
 
   imports = [
@@ -364,6 +372,9 @@ in
         # Phonon audio backend
         ++ lib.optional (cfg.phononBackend == "gstreamer") libsForQt5.phonon-backend-gstreamer
         ++ lib.optional (cfg.phononBackend == "vlc") libsForQt5.phonon-backend-vlc
+
+        # Plasma mobile
+        ++ lib.optional cfg.mobile.enable plasma-phone-components
 
         # Optional hardware support features
         ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt pkgs.openobex pkgs.obexftp ]

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -213,6 +213,15 @@ in
         Enable support for running the Plasma Mobile shell.
       '';
     };
+
+    mobile.installRecommendedSoftware = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Installs software recommended for use with Plasma Mobile, but which
+        is not strictly required for Plasma Mobile to run.
+      '';
+    };
   };
 
   imports = [
@@ -491,11 +500,17 @@ in
         with libsForQt5;
         with plasma5; with kdeApplications; with kdeFrameworks;
         [
+          # Basic packages without which Plasma Mobile fails to work properly.
           plasma-phone-components
           plasma-nano
           pkgs.maliit-framework
           pkgs.maliit-keyboard
-        ];
+        ]
+        ++ lib.optionals (cfg.mobile.installRecommendedSoftware) [
+          # Additional software made for Plasma Mobile.
+          pkgs.angelfish
+        ]
+      ;
 
       # The following services are needed or the UI is broken.
       hardware.bluetooth.enable = true;
@@ -524,6 +539,8 @@ in
           };
         };
       };
+
+      services.xserver.displayManager.sessionPackages = [ pkgs.libsForQt5.plasma5.plasma-phone-components ];
     })
   ];
 }

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -493,6 +493,8 @@ in
         [
           plasma-phone-components
           plasma-nano
+          pkgs.maliit-framework
+          pkgs.maliit-keyboard
         ];
 
       # The following services are needed or the UI is broken.

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -506,10 +506,25 @@ in
           pkgs.maliit-framework
           pkgs.maliit-keyboard
         ]
-        ++ lib.optionals (cfg.mobile.installRecommendedSoftware) [
+        ++ lib.optionals (cfg.mobile.installRecommendedSoftware) (with libsForQt5.plasmaMobileGear;[
           # Additional software made for Plasma Mobile.
-          pkgs.angelfish
-        ]
+          alligator
+          angelfish
+          audiotube
+          calindori
+          kalk
+          kasts
+          kclock
+          keysmith
+          koko
+          krecorder
+          ktrip
+          kweather
+          plasma-dialer
+          plasma-phonebook
+          plasma-settings
+          spacebar
+        ])
       ;
 
       # The following services are needed or the UI is broken.

--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -1,0 +1,68 @@
+{ mkDerivation
+, lib
+, fetchFromGitHub
+
+, at-spi2-atk
+, at-spi2-core
+, libepoxy
+, gtk3
+, libdatrie
+, libselinux
+, libsepol
+, libthai
+, pcre
+, util-linux
+, wayland
+, xorg
+
+, cmake
+, doxygen
+, pkg-config
+, wayland-protocols
+}:
+
+mkDerivation rec {
+  pname = "maliit-framework";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "maliit";
+    repo = "framework";
+    rev = version;
+    sha256 = "138jyvw130kmrldksbk4l38gvvahh3x51zi4vyplad0z5nxmbazb";
+  };
+
+  buildInputs = [
+    at-spi2-atk
+    at-spi2-core
+    libepoxy
+    gtk3
+    libdatrie
+    libselinux
+    libsepol
+    libthai
+    pcre
+    util-linux
+    wayland
+    xorg.libXdmcp
+    xorg.libXtst
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    pkg-config
+    wayland-protocols
+  ];
+
+  preConfigure = ''
+    cmakeFlags+="-DQT5_PLUGINS_INSTALL_DIR=$out/$qtPluginPrefix"
+  '';
+
+  meta = with lib; {
+    description = "Core libraries of Maliit and server";
+    homepage = "http://maliit.github.io/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/misc/maliit-keyboard/default.nix
+++ b/pkgs/applications/misc/maliit-keyboard/default.nix
@@ -1,0 +1,82 @@
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, fetchpatch
+
+, anthy
+, hunspell
+, libchewing
+, libpinyin
+, maliit-framework
+, pcre
+, presage
+, qtfeedback
+, qtmultimedia
+, qtquickcontrols2
+, qtgraphicaleffects
+
+, cmake
+, pkg-config
+, wrapGAppsHook
+}:
+
+mkDerivation rec {
+  pname = "maliit-keyboard";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "maliit";
+    repo = "keyboard";
+    rev = version;
+    sha256 = "10dh0abxq90024dqq3fs8mjxww3igb4l09d19i2fq9f3flvh11hc";
+  };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/maliit/keyboard/pull/34
+      url = "https://github.com/maliit/keyboard/commit/9848a73b737ad46b5790ebf713a559d340c91b82.patch";
+      sha256 = "0qrsga0npahjrgbl6mycvl6d6vjm0d17i5jadcn7y6khbhq2y6rg";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace data/schemas/org.maliit.keyboard.maliit.gschema.xml \
+      --replace /usr/share "$out/share"
+  '';
+
+  buildInputs = [
+    anthy
+    hunspell
+    libchewing
+    libpinyin
+    maliit-framework
+    pcre
+    presage
+    qtfeedback
+    qtmultimedia
+    qtquickcontrols2
+    qtgraphicaleffects
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  postInstall = ''
+    glib-compile-schemas "$out"/share/glib-2.0/schemas
+  '';
+
+  meta = with lib; {
+    description = "Virtual keyboard";
+    homepage = "http://maliit.github.io/";
+    license = with licenses; [ lgpl3Only bsd3 cc-by-30 ];
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -75,6 +75,7 @@ let
       kweather = callPackage ./kweather.nix {};
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
+      plasma-settings = callPackage ./plasma-settings.nix {};
       spacebar = callPackage ./spacebar.nix {};
     };
 

--- a/pkgs/applications/plasma-mobile/plasma-settings.nix
+++ b/pkgs/applications/plasma-mobile/plasma-settings.nix
@@ -1,0 +1,42 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+
+, cmake
+, extra-cmake-modules
+
+, kauth
+, kconfig
+, kcoreaddons
+, kdbusaddons
+, ki18n
+, kitemmodels
+, plasma-framework
+}:
+
+mkDerivation rec {
+  pname = "plasma-settings";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kauth
+    kconfig
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kitemmodels
+    plasma-framework
+  ];
+
+  meta = with lib; {
+    description = "Settings application for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/plasma-settings";
+    # https://invent.kde.org/plasma-mobile/plasma-settings/-/commit/a59007f383308503e59498b3036e1483bca26e35
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -134,6 +134,7 @@ let
       milou = callPackage ./milou.nix {};
       oxygen = callPackage ./oxygen.nix {};
       plasma-browser-integration = callPackage ./plasma-browser-integration.nix {};
+      plasma-phone-components = callPackage ./plasma-phone-components {};
       plasma-desktop = callPackage ./plasma-desktop {};
       plasma-disks = callPackage ./plasma-disks.nix {};
       plasma-integration = callPackage ./plasma-integration {};

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -138,6 +138,7 @@ let
       plasma-desktop = callPackage ./plasma-desktop {};
       plasma-disks = callPackage ./plasma-disks.nix {};
       plasma-integration = callPackage ./plasma-integration {};
+      plasma-nano = callPackage ./plasma-nano {};
       plasma-nm = callPackage ./plasma-nm {};
       plasma-pa = callPackage ./plasma-pa.nix { inherit gconf; };
       plasma-sdk = callPackage ./plasma-sdk.nix {};

--- a/pkgs/desktops/plasma-5/plasma-nano/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-nano/default.nix
@@ -1,0 +1,13 @@
+{
+  mkDerivation,
+  extra-cmake-modules,
+  plasma-framework
+}:
+
+mkDerivation {
+  name = "plasma-nano";
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [
+    plasma-framework
+  ];
+}

--- a/pkgs/desktops/plasma-5/plasma-phone-components/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-phone-components/default.nix
@@ -1,0 +1,43 @@
+{
+  mkDerivation, lib,
+
+  extra-cmake-modules, kdoctools,
+
+  coreutils, dbus, gnugrep, gnused, libdbusmenu, pam, wayland, appstream,
+
+  kdeclarative, kdelibs4support, kpeople, kconfig, krunner, kinit, kwayland, kwin,
+  plasma-framework, telepathy, libphonenumber, protobuf, libqofono, modemmanager-qt,
+  plasma-workspace,
+  maliit-framework, maliit-keyboard,
+
+  qtwayland, qttools
+}:
+
+let inherit (lib) getBin getLib; in
+
+mkDerivation {
+  name = "plasma-phone-components";
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    appstream libdbusmenu pam wayland
+    kdeclarative kdelibs4support kpeople kconfig krunner kinit kwayland kwin
+    plasma-framework telepathy libphonenumber protobuf libqofono modemmanager-qt
+    maliit-framework maliit-keyboard
+  ];
+
+  postPatch = ''
+    substituteInPlace bin/kwinwrapper.in \
+      --replace @KDE_INSTALL_FULL_LIBEXECDIR@ "${plasma-workspace}/libexec"
+
+    substituteInPlace bin/plasma-mobile.desktop.cmake \
+      --replace @CMAKE_INSTALL_FULL_LIBEXECDIR@ "${plasma-workspace}/libexec"
+  '';
+
+  # Ensures dependencies like libqofono (at the very least) are present for the shell.
+  preFixup = ''
+    wrapQtApp "$out/bin/kwinwrapper"
+  '';
+
+  passthru.providedSessions = [ "plasma-mobile" ];
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1214,6 +1214,7 @@ mapAliases ({
     qqc2-breeze-style
     sddm-kcm systemsettings
     xdg-desktop-portal-kde
+    plasma-phone-components
   ;
   inherit (plasma5Packages.thirdParty)
     plasma-applet-caffeine-plus

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1215,6 +1215,7 @@ mapAliases ({
     sddm-kcm systemsettings
     xdg-desktop-portal-kde
     plasma-phone-components
+    plasma-nano
   ;
   inherit (plasma5Packages.thirdParty)
     plasma-applet-caffeine-plus

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3286,6 +3286,8 @@ with pkgs;
 
   maigret = callPackage ../tools/security/maigret { };
 
+  maliit-framework = libsForQt5.callPackage ../applications/misc/maliit-framework { };
+
   mapcidr = callPackage ../tools/misc/mapcidr { };
 
   mapproxy = callPackage ../applications/misc/mapproxy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3288,6 +3288,8 @@ with pkgs;
 
   maliit-framework = libsForQt5.callPackage ../applications/misc/maliit-framework { };
 
+  maliit-keyboard = libsForQt5.callPackage ../applications/misc/maliit-keyboard { };
+
   mapcidr = callPackage ../tools/misc/mapcidr { };
 
   mapproxy = callPackage ../applications/misc/mapproxy { };


### PR DESCRIPTION
**:heavy_check_mark: This is pretty much ready for a final review.**

Note that the first chunk of commits is in:

- Be mindful about reviews that should go in #130151.

This includes work form #58370. Thank you @Slabity.


### What this is

This includes the "basic" set of released applications from the Plasma Mobile project. In addition to the shell configuration, and the NixOS configuration to use Plasma Mobile.


### Known issues

Probably not specific to Plasma Mobile

 - ~~Notifications are "full-screen", probably is the same issue as #118650~~ As expected, fixed with the same solution that fixes #118650.
 - ~~Night colors not working #117036~~ Fixed

Probably specific to Plasma Mobile

 - Long clicking the wi-fi icon goes to the main settings menu (I assume it should go to some sort of network configuration utility) (unclear)
 - ~~Forced numeric passwords!!!!!~~ This is an upstream issue.

### Things done

 - Testing with https://github.com/NixOS/mobile-nixos/pull/351, which works with the UEFI VM, *and* on hardware on a Pine64 Pinephone.
 - [A standard NixOS VM](https://gist.github.com/67692b13614a50f0f485e2316bfc7092)
 - A pinephone


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @NixOS/qt-kde 