### PR TITLE
[20.09] cifs-utils: fix CVE-2021-20208

### DIFF
--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -20,12 +20,17 @@ stdenv.mkDerivation rec {
       url = "https://attachments.samba.org/attachment.cgi?id=16148";
       sha256 = "1xw3d11wb1l8a89jhdp6hhy987nq0gafxfhx5jdhcc5nazahc7s4";
     })
+    (fetchpatch {
+      name = "CVE-2021-20208.patch";
+      url = "https://attachments.samba.org/attachment.cgi?id=16477";
+      sha256 = "1nic669fa65r845pxfb6lmfs78g7aqbaz86r0axm332inb60hj10";
+    })
   ];
 
   makeFlags = [ "root_sbindir=$(out)/sbin" ];
 
   meta = with stdenv.lib; {
-    homepage = "http://www.samba.org/linux-cifs/cifs-utils/";
+    homepage = "https://wiki.samba.org/index.php/LinuxCIFS_utils";
     description = "Tools for managing Linux CIFS client filesystems";
     platforms = platforms.linux;
     license = licenses.lgpl3;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://lists.samba.org/archive/samba-technical/2021-April/136467.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
