### PR TITLE
Various systemd fixes and cleanups

### DIFF
--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -228,9 +228,7 @@ in rec {
         mkdir -p $out/getty.target.wants/
         ln -s ../autovt@tty1.service $out/getty.target.wants/
 
-        ln -s ../remote-fs.target \
-        ../nss-lookup.target ../nss-user-lookup.target \
-        $out/multi-user.target.wants/
+        ln -s ../remote-fs.target $out/multi-user.target.wants/
       ''}
     ''; # */
 

--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -228,8 +228,8 @@ in rec {
         mkdir -p $out/getty.target.wants/
         ln -s ../autovt@tty1.service $out/getty.target.wants/
 
-        ln -s ../local-fs.target ../remote-fs.target \
-        ../nss-lookup.target ../nss-user-lookup.target ../swap.target \
+        ln -s ../remote-fs.target \
+        ../nss-lookup.target ../nss-user-lookup.target \
         $out/multi-user.target.wants/
       ''}
     ''; # */

--- a/pkgs/os-specific/linux/systemd/0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,27 +1,32 @@
-From ba19f629c1806ca2d2ab58154e45bce4ae4a3f0c Mon Sep 17 00:00:00 2001
+From 186499cf384ab24397a858e6f4826ab02d4a24ac Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
 Subject: [PATCH 16/19] kmod-static-nodes.service: Update ConditionFileNotEmpty
 
-On NixOS, kernel modules of the currently booted systems are located at
-/run/booted-system/kernel-modules/lib/modules/%v/, not /lib/modules/%v/.
+kmod loads modules from not only /lib/modules but also from
+/run/booted-system/kernel-modules/lib/modules and
+/run/current-system/kernel-modules/lib/module
+
+Co-authored-by: Arian van Putten <arian.vanputten@gmail.com>
 ---
- units/kmod-static-nodes.service.in | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ units/kmod-static-nodes.service.in | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/units/kmod-static-nodes.service.in b/units/kmod-static-nodes.service.in
-index f4170d6a99..9a6a591bea 100644
+index f4170d6a99..5e8dc318b1 100644
 --- a/units/kmod-static-nodes.service.in
 +++ b/units/kmod-static-nodes.service.in
-@@ -12,7 +12,7 @@ Description=Create list of static device nodes for the current kernel
+@@ -12,7 +12,9 @@ Description=Create list of static device nodes for the current kernel
  DefaultDependencies=no
  Before=sysinit.target systemd-tmpfiles-setup-dev.service
  ConditionCapability=CAP_SYS_MODULE
 -ConditionFileNotEmpty=/lib/modules/%v/modules.devname
-+ConditionFileNotEmpty=/run/booted-system/kernel-modules/lib/modules/%v/modules.devname
++ConditionFileNotEmpty=|/lib/modules/%v/modules.devname
++ConditionFileNotEmpty=|/run/booted-system/kernel-modules/lib/modules/%v/modules.devname
++ConditionFileNotEmpty=|/run/current-system/kernel-modules/lib/modules/%v/modules.devname
  
  [Service]
  Type=oneshot
 -- 
-2.30.1
+2.29.3
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -489,12 +489,6 @@ stdenv.mkDerivation {
   '';
 
   postInstall = ''
-    # sysinit.target: Don't depend on
-    # systemd-tmpfiles-setup.service. This interferes with NixOps's
-    # send-keys feature (since sshd.service depends indirectly on
-    # sysinit.target).
-    mv $out/lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup-dev.service $out/lib/systemd/system/multi-user.target.wants/
-
     mkdir -p $out/example/systemd
     mv $out/lib/{modules-load.d,binfmt.d,sysctl.d,tmpfiles.d} $out/example
     mv $out/lib/systemd/{system,user} $out/example/systemd


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I am working on a systemd based initrd and I needed the fixes for `kmod-static-nodes.service` and `systemd-tmpfiles-setup-dev.service` which in conjunction makes sure that any static devices nodes are set up in very early boot so that udev functions properly. Without it I had trouble mounting for example btrfs as it requires the presence of `/dev/btrfs-control` before udev even runs for the btrfs rules to work properly.

I also took the liberty to cleanup some other units that were left from the  `autoLuks` deprecation in `20.03`



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
