### PR TITLE
backblaze-b2: 2.1.0 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -1,16 +1,47 @@
-{ lib, buildPythonPackage, fetchPypi, setuptools-scm, isPy27, pytestCheckHook
-, requests, arrow, logfury, tqdm }:
+{ lib
+, arrow
+, buildPythonPackage
+, fetchPypi
+, importlib-metadata
+, isPy27
+, logfury
+, pytestCheckHook
+, pytest-lazy-fixture
+, pytest-mock
+, pythonOlder
+, requests
+, setuptools-scm
+, tqdm
+}:
 
 buildPythonPackage rec {
   pname = "b2sdk";
   version = "1.7.0";
-
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1zkjwz2r9jlf31gj5bnw6h9mqapjn8rndxmz7wsr5iaj3wp5fzpi";
   };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    arrow
+    logfury
+    requests
+    tqdm
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-lazy-fixture
+    pytest-mock
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \
@@ -19,16 +50,16 @@ buildPythonPackage rec {
       --replace 'arrow>=0.8.0,<1.0.0' 'arrow'
   '';
 
+  disabledTests = [
+    # Test requires an API key
+    "test_raw_api"
+    "test_files_headers"
+  ];
+
   pythonImportsCheck = [ "b2sdk" ];
 
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ requests arrow logfury tqdm ];
-
-  # requires unpackaged dependencies like liccheck
-  doCheck = false;
-
   meta = with lib; {
-    description = "Client library and utilities for access to B2 Cloud Storage (backblaze).";
+    description = "Client library and utilities for access to B2 Cloud Storage (backblaze)";
     homepage = "https://github.com/Backblaze/b2-sdk-python";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "b2sdk";
-  version = "1.6.0";
+  version = "1.7.0";
 
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-6fjreuMUC056ljddfAidfBbJkvEDndB/dIkx1bF7efs=";
+    sha256 = "1zkjwz2r9jlf31gj5bnw6h9mqapjn8rndxmz7wsr5iaj3wp5fzpi";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/rst2ansi/default.nix
+++ b/pkgs/development/python-modules/rst2ansi/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, docutils
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "rst2ansi";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "Snaipe";
+    repo = "python-rst2ansi";
+    rev = "v${version}";
+    sha256 = "0h4s0g9kj6wgp8g2vsqajy3vish463za7q91k6674cdkfh9hsq46";
+  };
+
+  propagatedBuildInputs = [
+    docutils
+  ];
+
+  # Project only has templates to tests but no tests
+  doCheck = false;
+  pythonImportsCheck = [ "rst2ansi" ];
+
+  meta = with lib; {
+    description = "Python module for rendering RST";
+    homepage = "https://github.com/Snaipe/python-rst2ansi/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7136,6 +7136,8 @@ in {
 
   rsa = callPackage ../development/python-modules/rsa { };
 
+  rst2ansi = callPackage ../development/python-modules/rst2ansi { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
 
   Rtree = callPackage ../development/python-modules/Rtree {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
backblaze-b2:  https://github.com/Backblaze/B2_Command_Line_Tool/releases/tag/v2.4.0
python3Packages.b2sdk: https://github.com/Backblaze/b2-sdk-python/releases/tag/v1.7.0



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
