### PR TITLE
rink: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/applications/science/misc/rink/default.nix
+++ b/pkgs/applications/science/misc/rink/default.nix
@@ -1,17 +1,17 @@
 { lib, fetchFromGitHub, rustPlatform, openssl, pkg-config, ncurses }:
 
 rustPlatform.buildRustPackage rec {
-  version = "0.6.0";
+  version = "0.6.1";
   pname = "rink";
 
   src = fetchFromGitHub {
     owner = "tiffany352";
     repo = "rink-rs";
     rev = "v${version}";
-    sha256 = "sha256-3uhKevuUVh7AObn2GDW2T+5wttX20SbVP+sFaFj3Jmk=";
+    sha256 = "1h93xlavcjvx588q8wkpbzph88yjjhhvzcfxr5nicdca0jnha5ch";
   };
 
-  cargoSha256 = "sha256-luJzIGdcitH+PNgr86AYX6wKEkQlsRhwwylo+hzeovE=";
+  cargoSha256 = "0x4rvfnw3gl2aj6i006nkk3y1f8skyv8g0ss3z2v6qj9nhs7pyir";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ncurses ];


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/tiffany352/rink-rs/issues/92 (causing all currency units to disappear)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
