### PR TITLE
burpsuite: 2020.12.1 -> 2021.4.2

### DIFF
--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -2,12 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "burpsuite";
-  version = "2020.12.1";
+  version = "2021.4.2";
 
   src = fetchurl {
     name = "burpsuite.jar";
-    url = "https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar";
-    sha256 = "AcoPyVXUf2YGfX2/GbtGZeQ4P7zSsYFb9L57trXive0=";
+    urls = [
+      "https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar"
+      "https://web.archive.org/web/https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar"
+    ];
+    sha256 = "034c9d0a7e0b5e7b1b286949c6b31b475ff2a15e75f1230ccc07e236fc61d2aa";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes the build, solves CVE-2021-29416 and pull the latest version.
https://portswigger.net/burp/releases/professional-community-2021-4-2

Also see #113340

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
