### PR TITLE
_1password-gui: 8.0.30 -> 8.0.33-53.BETA

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "8.0.30";
+  version = "8.0.33-53.BETA";
 
   src = fetchurl {
-    url = "https://downloads.1password.com/linux/tar/1password-${version}.tar.gz";
-    hash = "sha256-R4Tbu2TAig0iF/IN8hnO3Bzqqj6Ru1YyyGhzraM7/9Y=";
+    url = "https://downloads.1password.com/linux/tar/beta/x86_64/1password-${version}.x64.tar.gz";
+    hash = "sha256-YUYER+UiM1QEDgGl0P9bIT65YVacUnuGtQVkV91teEU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -33,12 +33,12 @@ stdenv.mkDerivation rec {
     install -Dm0755 -t $out/share/${pname} {1Password-BrowserSupport,1Password-KeyringHelper}
 
     # Desktop file.
-    install -Dt $out/share/applications usr/share/applications/${pname}.desktop
+    install -Dt $out/share/applications resources/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=/opt/1Password/${pname}' 'Exec=${pname}'
 
     # Icons.
-    cp -a usr/share/icons $out/share
+    cp -a resources/icons $out/share
 
     # Wrap the application with Electron.
     makeWrapper "${electron_11}/bin/electron" "$out/bin/${pname}" \

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
-, appimageTools
 , makeWrapper
 , electron_11
 , openssl
@@ -11,18 +11,12 @@ stdenv.mkDerivation rec {
   version = "8.0.30";
 
   src = fetchurl {
-    url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    hash = "sha256-j+fp/f8nta+OOuOFU4mmUrGYlVmAqdaXO4rLJ0in+m8=";
+    url = "https://downloads.1password.com/linux/tar/1password-${version}.tar.gz";
+    hash = "sha256-R4Tbu2TAig0iF/IN8hnO3Bzqqj6Ru1YyyGhzraM7/9Y=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  appimageContents = appimageTools.extractType2 {
-    name = "${pname}-${version}";
-    inherit src;
-  };
-
-  dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;
 
@@ -35,19 +29,32 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/share/1password
 
     # Applications files.
-    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
+    cp -a {locales,resources} $out/share/${pname}
+    install -Dm0755 -t $out/share/${pname} {1Password-BrowserSupport,1Password-KeyringHelper}
 
     # Desktop file.
-    install -Dt $out/share/applications ${appimageContents}/${pname}.desktop
+    install -Dt $out/share/applications usr/share/applications/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+      --replace 'Exec=/opt/1Password/${pname}' 'Exec=${pname}'
 
     # Icons.
-    cp -a ${appimageContents}/usr/share/icons $out/share
+    cp -a usr/share/icons $out/share
 
     # Wrap the application with Electron.
     makeWrapper "${electron_11}/bin/electron" "$out/bin/${pname}" \
       --add-flags "$out/share/${pname}/resources/app.asar" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}"
+
+    # Set the interpreter for the helper binaries and wrap them with
+    # the runtime libraries.
+    interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
+    patchelf --set-interpreter $interp \
+      $out/share/$pname/{1Password-BrowserSupport,1Password-KeyringHelper}
+
+    wrapProgram $out/share/${pname}/1Password-BrowserSupport \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}"
+
+    wrapProgram $out/share/${pname}/1Password-KeyringHelper \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}"
   '';
 

--- a/pkgs/applications/misc/1password-gui/update.sh
+++ b/pkgs/applications/misc/1password-gui/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnused common-updater-scripts
 
-version="$(curl -sL https://onepassword.s3.amazonaws.com/linux/debian/dists/edge/main/binary-amd64/Packages | sed -r -n 's/^Version: (.*)-[0-9]+/\1/p' | head -n1)"
+version="$(curl -sL https://onepassword.s3.amazonaws.com/linux/debian/dists/edge/main/binary-amd64/Packages | sed -r -n 's/^Version: (.*)/\1/p' | head -n1)"
 update-source-version _1password-gui "$version"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update 1Password.
- Use the upstream tarball rather than AppImage.
- Include the browser support and keyring helper programs.
- Fix the update script.

Many of the improvements and cleanups were provided by Savanni D'Gerinel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
