### PR TITLE
libtorch: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -18,7 +18,7 @@ let
   # this derivation. However, we should ensure on version bumps
   # that the CUDA toolkit for `passthru.tests` is still
   # up-to-date.
-  version = "1.8.0";
+  version = "1.8.1";
   device = if cudaSupport then "cuda" else "cpu";
   srcs = import ./binary-hashes.nix version;
   unavailable = throw "libtorch is not available for this platform";

--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -1,14 +1,14 @@
 version: {
   x86_64-darwin-cpu = {
     url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-${version}.zip";
-    hash = "sha256-V1lbztMB09wyWjdiJrwVwJ00DT8Kihy/TC2cKmdBLIE=";
+    hash = "sha256-FYgnd5zlycjCYnP5bZcjpMdGYXrRERwhFFBYo/SJgzs=";
   };
   x86_64-linux-cpu = {
     url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcpu.zip";
-    hash = "sha256-xBaNyI7eiQnSArHMITonrQQLZnZCZK/SWKOTWnxzdpc=";
+    hash = "sha256-xneCcVrY25Whgbs/kPbwdS1Lc0e6RxsDRpA5lHTZigc=";
   };
   x86_64-linux-cuda = {
     url = "https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcu111.zip";
-    hash = "sha256-uQ7ptOuzowJ0JSPIvJHyNotBfpsqAnxpMDLq7Vl6L00=";
+    hash = "sha256-VW+TW00nD49GBztCyxHE4dTyy81aN/kfYE3hKQOIm50=";
   };
 }

--- a/pkgs/development/libraries/science/math/libtorch/test/default.nix
+++ b/pkgs/development/libraries/science/math/libtorch/test/default.nix
@@ -42,8 +42,9 @@ in stdenv.mkDerivation {
     touch $out
   '';
 
-  checkPhase = ''
+  checkPhase = lib.optionalString cudaSupport ''
     LD_LIBRARY_PATH=${cudaStub}''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH \
-      ./test
+  '' + ''
+    ./test
   '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

libtorch-bin: 1.8.0 -> 1.8.1
    
Changelog:
https://github.com/pytorch/pytorch/releases/tag/v1.8.1

libtorch-bin: fix false CUDA dependency in passthru test

The passthru test used the CUDA toolkit for the CUDA stub
unconditionally, also requiring the cudatoolkit derivation when
cudaSupport = false.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
