### PR TITLE
river: refactor

### DIFF
--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv ,fetchFromGitHub
-, zig, wayland, pkg-config, scdoc
-, xwayland, wayland-protocols, wlroots
-, libxkbcommon, pixman, udev, libevdev, libX11, libGL
+, wayland-protocols, wlroots, pixman, libxkbcommon, udev, libevdev, libX11, libGL
+, zig, wayland, xwayland, pkg-config, scdoc
 }:
 
 stdenv.mkDerivation rec {
@@ -16,27 +15,36 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ xwayland wayland-protocols wlroots pixman
-    libxkbcommon pixman udev libevdev libX11 libGL
+  buildInputs = [
+    wayland-protocols
+    wlroots
+    pixman
+    libxkbcommon
+    udev
+    libevdev
+    libX11
+    libGL
   ];
 
   preBuild = ''
     export HOME=$TMPDIR
   '';
   installPhase = ''
+    runHook preInstall
     zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install
+    runHook postInstall
   '';
 
-  nativeBuildInputs = [ zig wayland scdoc pkg-config ];
+  nativeBuildInputs = [ zig wayland xwayland scdoc pkg-config ];
 
   installFlags = [ "DESTDIR=$(out)" ];
 
   meta = with lib; {
+    homepage = "https://github.com/ifreund/river";
     description = "A dynamic tiling wayland compositor";
     longDescription = ''
       river is a dynamic tiling wayland compositor that takes inspiration from dwm and bspwm.
     '';
-    homepage = "https://github.com/ifreund/river";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ branwright1 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes for previous probably untested commit.
**Note**: Added xwayland into nativeBuldInputs since it's runtime dependency and packages in header are sorted by phases (easier dependency management)

Why?
- Run hooks in prebuild gives me segfault locally (tested on NixOS and kiss linux with nix)
- No needed super long description about design goals copied straight from project's readmie
- Derivation was built twice because of `zig build` in preBuild phase
- Looks like previous commiter doesn't know anything about zig and it's build system

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
