### PR TITLE
x264: 20191217-2245 -> unstable-2021-06-13

### DIFF
--- a/pkgs/development/libraries/x264/default.nix
+++ b/pkgs/development/libraries/x264/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, lib, fetchurl, nasm
+{ stdenv, lib, fetchFromGitLab, nasm
 , enableShared ? !stdenv.hostPlatform.isStatic
  }:
 
 stdenv.mkDerivation rec {
   pname = "x264";
-  version = "20191217-2245";
+  version = "unstable-2021-06-13";
 
-  src = fetchurl {
-    url = "https://download.videolan.org/x264/snapshots/x264-snapshot-${version}-stable.tar.bz2";
-    sha256 = "0q214q4rhbhigyx3dfhp6d5v5gzln01cxccl153ps5ih567mqjdj";
+  src = fetchFromGitLab {
+    domain = "code.videolan.org";
+    owner = "videolan";
+    repo = pname;
+    rev = "5db6aa6cab1b146e07b60cc1736a01f21da01154";
+    sha256 = "0swyrkz6nvajivxvrr08py0jrfcsjvpxw78xm1k5gd9xbdrxvknh";
   };
 
   # Upstream ./configure greps for (-mcpu|-march|-mfpu) in CFLAGS, which in nix


### PR DESCRIPTION
###### Motivation for this change
The version we have is >1 year old and the snapshots we were building from got discontinued: https://download.videolan.org/x264/snapshots/x264-snapshot-20191218-README.txt

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
