### PR TITLE
Remove thin provisioning tools dependency from lvm2

### DIFF
--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , util-linux
 , libuuid
-, thin-provisioning-tools, libaio
+, libaio
 , enableCmdlib ? false
 , enableDmeventd ? false
 , udev ? null
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ udev libuuid thin-provisioning-tools libaio ];
+  buildInputs = [ udev libuuid libaio ];
 
   configureFlags = [
     "--disable-readline"


### PR DESCRIPTION
thin-provisioning-tools has a _huge_ closure size (hundreds of
megabytes) and the only reference in the output of the lvm2 package is a
_comment_ in the etc/lvm.conf

The lvm2 package thus does not seem to depend on thin-provisoning-tools
in any way.

Reverts 9326a89910434f96b3af4dd7758614e0143735e2

thin provisoning is broken with or without this change:
https://github.com/NixOS/nixpkgs/issues/15516

People were already doing this revert locally it seems:
https://github.com/NixOS/nixpkgs/issues/14394

A proper fix is here:
https://github.com/NixOS/nixpkgs/pull/46541

References:

$ nix why-depends nixpkgs#lvm2 nixpkgs#thin-provisioning-tools
/nix/store/n7zwwxi0ihjks7qk9bq5lbkniligfcqc-lvm2-2.03.11
└───etc/lvm.conf: …_check_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-prov>
    → /nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0

$ ag thin-provisioning-tools --search-binary
etc/lvm.conf
1093:	# (See package device-mapper-persistent-data or thin-provisioning-tools)
1095:	# thin_check_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0/bin/thin_check"
1100:	# (See package device-mapper-persistent-data or thin-provisioning-tools)
1102:	# thin_dump_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0/bin/thin_dump"
1108:	# (See package device-mapper-persistent-data or thin-provisioning-tools)
1110:	# thin_repair_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0/bin/thin_repair"
1155:	# (See package device-mapper-persistent-data or thin-provisioning-tools)
1157:	# cache_check_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0/bin/cache_check"
1162:	# (See package device-mapper-persistent-data or thin-provisioning-tools)
1164:	# cache_dump_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0/bin/cache_dump"
1170:	# (See package device-mapper-persistent-data or thin-provisioning-tools)
1172:	# cache_repair_executable = "/nix/store/w5an38q6byfr1sihks66srbqdii9hnsd-thin-provisioning-tools-0.9.0/bin/cache_repair"

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
