### PR TITLE
add maintainer scripts for haskell package generation

### DIFF
--- a/maintainers/scripts/haskell/regenerate-hackage-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-hackage-packages.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils haskellPackages.cabal2nix-latest -I nixpkgs=.
+
+# This script is used to regenerate nixpkgs' Haskell package set, using a tool
+# called hackage2nix. hackage2nix looks at
+# pkgs/development/haskell-modules/configuration-hackage2nix.yaml and generates
+# a Nix expression for package version specified there, using the Cabal files
+# from the Hackage database (available under all-cabal-hashes) and its
+# companion tool cabal2nix.
+#
+# Related scripts are update-hackage.sh, for updating the snapshot of the
+# Hackage database used by hackage2nix, and update-cabal2nix-latest.sh,
+# for updating the version of hackage2nix used to perform this task.
+
+set -euo pipefail
+
+extractionDerivation='with import ./. {}; runCommand "unpacked-cabal-hashes" { } "tar xf ${all-cabal-hashes} --strip-components=1 --one-top-level=$out"'
+unpacked_hackage="$(nix-build -E "$extractionDerivation" --no-out-link)"
+
+hackage2nix --hackage "$unpacked_hackage" --preferred-versions <(for n in "$unpacked_hackage"/*/preferred-versions; do cat "$n"; echo; done) --nixpkgs "$PWD" --config pkgs/development/haskell-modules/configuration-hackage2nix.yaml

--- a/maintainers/scripts/haskell/update-cabal2nix-latest.sh
+++ b/maintainers/scripts/haskell/update-cabal2nix-latest.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils curl jq gnused haskellPackages.cabal2nix-latest -I nixpkgs=.
+
+# Updates cabal2nix-latest to the latest master of the nixos/cabal2nix repository.
+# See regenerate-hackage-packages.sh for details on the purpose of this script.
+
+set -euo pipefail
+
+# fetch current master HEAD from Github
+head_info="$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/NixOS/cabal2nix/branches/master)"
+# extract commit hash
+commit="$(jq -r .commit.sha <<< "$head_info")"
+# extract commit timestamp and convert to date
+date="$(date "--date=$(jq -r .commit.commit.committer.date <<< "$head_info")" +%F)"
+# generate nix expression from cabal file, replacing the version with the commit date
+echo '# This file defines cabal2nix-latest, used by maintainers/scripts/haskell/regenerate-hackage-packages.sh.' > pkgs/development/haskell-modules/cabal2nix-latest.nix
+cabal2nix "https://github.com/NixOS/cabal2nix/archive/$commit.tar.gz" | sed -e 's/version = ".*"/version = "'"$date"'"/' >> pkgs/development/haskell-modules/cabal2nix-latest.nix

--- a/maintainers/scripts/haskell/update-hackage.sh
+++ b/maintainers/scripts/haskell/update-hackage.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix curl jq nix-prefetch-github -I nixpkgs=.
+
+# See regenerate-hackage-packages.sh for details on the purpose of this script.
+
+set -euo pipefail
+
+pin_file=pkgs/data/misc/hackage/pin.json
+current_commit="$(jq -r .commit $pin_file)"
+head_commit="$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/commercialhaskell/all-cabal-hashes/branches/hackage | jq -r .commit.sha)"
+
+if [ "$current_commit" != "$head_commit" ]; then
+   url="https://github.com/commercialhaskell/all-cabal-hashes/archive/$head_commit.tar.gz"
+   hash="$(nix-prefetch-url "$url")"
+   jq -n \
+     --arg commit "$head_commit" \
+     --arg hash "$hash" \
+     --arg url "$url" \
+     '{commit: $commit, url: $url, sha256: $hash}' \
+     > $pin_file
+fi

--- a/maintainers/scripts/haskell/update-stackage.sh
+++ b/maintainers/scripts/haskell/update-stackage.sh
@@ -1,0 +1,51 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+tmpfile=$(mktemp "update-stackage.XXXXXXX")
+# shellcheck disable=SC2064
+trap "rm ${tmpfile} ${tmpfile}.new" 0
+
+curl -L -s "https://stackage.org/nightly/cabal.config" >"$tmpfile"
+version=$(sed -rn "s/^--.*http:..(www.)?stackage.org.snapshot.nightly-//p" "$tmpfile")
+
+# Create a simple yaml version of the file.
+sed -r \
+    -e '/^--/d' \
+    -e 's|^constraints:||' \
+    -e 's|^ +|  - |' \
+    -e 's|,$||' \
+    -e '/installed$/d' \
+    -e '/^$/d' \
+    < "${tmpfile}" | sort --ignore-case >"${tmpfile}.new"
+
+# Drop restrictions on some tools where we always want the latest version.
+sed -r \
+    -e '/ cabal-install /d' \
+    -e '/ cabal2nix /d' \
+    -e '/ cabal2spec /d' \
+    -e '/ distribution-nixpkgs /d' \
+    -e '/ git-annex /d' \
+    -e '/ hindent /d' \
+    -e '/ hledger/d' \
+    -e '/ hlint /d' \
+    -e '/ hoogle /d' \
+    -e '/ hopenssl /d' \
+    -e '/ jailbreak-cabal /d' \
+    -e '/ json-autotype/d' \
+    -e '/ language-nix /d' \
+    -e '/ shake /d' \
+    -e '/ ShellCheck /d' \
+    -e '/ stack /d' \
+    -e '/ weeder /d' \
+    < "${tmpfile}.new" > "${tmpfile}"
+
+# Drop the previous configuration ...
+# shellcheck disable=SC1004
+sed -e '/  # Stackage Nightly/,/^$/c \TODO\
+'   -i pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+
+# ... and replace it with the new one.
+sed -e "/TODO/r $tmpfile" \
+    -e "s/TODO/  # Stackage Nightly $version/" \
+    -i pkgs/development/haskell-modules/configuration-hackage2nix.yaml

--- a/pkgs/data/misc/hackage/default.nix
+++ b/pkgs/data/misc/hackage/default.nix
@@ -1,6 +1,10 @@
+# Hackage database snapshot, used by maintainers/scripts/regenerate-hackage-packages.sh
+# and callHackage
 { fetchurl }:
-
+let
+  pin = builtins.fromJSON (builtins.readFile ./pin.json);
+in
 fetchurl {
-  url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/d202e2aff06500ede787ed63544476f6d41e9eb7.tar.gz";
-  sha256 = "00hmclrhr3a2h9vshsl909g0zgymlamx491lkhwr5kgb3qx9sfh2";
+  inherit (pin) url sha256;
+  passthru.updateScript = ../../../../maintainers/scripts/haskell/update-hackage.sh;
 }

--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,0 +1,5 @@
+{
+  "commit": "f04ff9179e228b67aee1241fe8c6508f91e92fb5",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/f04ff9179e228b67aee1241fe8c6508f91e92fb5.tar.gz",
+  "sha256": "11k786zcj21hgjxd2fvfshllxdl1z252x01wvfs16wp66n720wly"
+}

--- a/pkgs/development/haskell-modules/cabal2nix-latest.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-latest.nix
@@ -1,0 +1,40 @@
+# This file defines cabal2nix-latest, used by maintainers/scripts/haskell/regenerate-hackage-packages.sh.
+{ mkDerivation, aeson, ansi-wl-pprint, base, bytestring, Cabal
+, containers, deepseq, directory, distribution-nixpkgs, fetchzip
+, filepath, hackage-db, hopenssl, hpack, language-nix, lens, lib
+, monad-par, monad-par-extras, mtl, optparse-applicative, pretty
+, process, split, tasty, tasty-golden, text, time, transformers
+, yaml
+}:
+mkDerivation {
+  pname = "cabal2nix";
+  version = "2021-05-01";
+  src = fetchzip {
+    url = "https://github.com/NixOS/cabal2nix/archive/849a3507c849e3e2331efbc5ebe391b70a215ddc.tar.gz";
+    sha256 = "0g91d2bd72l3kkykc47a2raymvgw6427n7cg9ayzvrpldkd0silc";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-wl-pprint base bytestring Cabal containers deepseq
+    directory distribution-nixpkgs filepath hackage-db hopenssl hpack
+    language-nix lens optparse-applicative pretty process split text
+    time transformers yaml
+  ];
+  executableHaskellDepends = [
+    aeson base bytestring Cabal containers directory
+    distribution-nixpkgs filepath hopenssl language-nix lens monad-par
+    monad-par-extras mtl optparse-applicative pretty
+  ];
+  testHaskellDepends = [
+    base Cabal containers directory filepath language-nix lens pretty
+    process tasty tasty-golden
+  ];
+  preCheck = ''
+    export PATH="$PWD/dist/build/cabal2nix:$PATH"
+    export HOME="$TMPDIR/home"
+  '';
+  homepage = "https://github.com/nixos/cabal2nix#readme";
+  description = "Convert Cabal files into Nix build instructions";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1797,4 +1797,8 @@ self: super: {
   # https://github.com/obsidiansystems/database-id/issues/1
   database-id-class = doJailbreak super.database-id-class;
 
+  cabal2nix-latest = overrideCabal super.cabal2nix-latest {
+    passthru.updateScript = ../../../maintainers/scripts/haskell/update-cabal2nix-latest.sh;
+  };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -11,6 +11,10 @@ self: super: {
 
   ldgallery-compiler = self.callPackage ../../tools/graphics/ldgallery/compiler { };
 
+  # Used by maintainers/scripts/regenerate-hackage-packages.sh, and generated
+  # from the latest master instead of the current version on Hackage.
+  cabal2nix-latest = self.callPackage ./cabal2nix-latest.nix { };
+
   # https://github.com/channable/vaultenv/issues/1
   vaultenv = self.callPackage ../tools/haskell/vaultenv { };
 


### PR DESCRIPTION
This is a slightly reworked version of #86699. Thx again @hyperfekt.

Introduces a script that can be used to update the Nix expressions for
the Haskell package set. In service of that, also
- introduces cabal2nix-latest, which pins the hackage2nix version used
- changes all-cabal-hashes to use fetchFromGitHub
- adds update-hackage.sh & update-cabal2nix-latest.sh maintainer scripts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
