### PR TITLE
cloudsmith-cli: init at 0.26.0

### DIFF
--- a/pkgs/development/python-modules/click-configfile/default.nix
+++ b/pkgs/development/python-modules/click-configfile/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, click
+, six
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "click-configfile";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "lb7sE77pUOmPQ8gdzavvT2RAkVWepmKY+drfWTUdkNE=";
+  };
+
+  propagatedBuildInputs = [
+    click
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_configfile__with_unbound_section"
+    "test_matches_section__with_bad_arg"
+  ];
+
+  meta = with lib; {
+    description = "Add support for commands that use configuration files to Click";
+    homepage = "https://github.com/click-contrib/click-configfile";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/python-modules/click-spinner/default.nix
+++ b/pkgs/development/python-modules/click-spinner/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, click
+, six
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "click-spinner";
+  version = "0.1.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "h+rPnXKYlzol12Fe9X1Hgq6/kTpTK7pLKKN+Nm6XXa8=";
+  };
+
+  checkInputs = [
+    click
+    six
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Add support for showwing that command line app is active to Click";
+    homepage = "https://github.com/click-contrib/click-spinner";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/python-modules/cloudsmith-api/default.nix
+++ b/pkgs/development/python-modules/cloudsmith-api/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, certifi
+, six
+, dateutil
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "cloudsmith-api";
+  version = "0.54.15";
+
+  format = "wheel";
+
+  src = fetchPypi {
+    pname = "cloudsmith_api";
+    inherit format version;
+    sha256 = "X72xReosUnUlj69Gq+i+izhaKZuakM9mUrRHZI5L9h0=";
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    six
+    dateutil
+    urllib3
+  ];
+
+  # Wheels have no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "cloudsmith_api"
+  ];
+
+  meta = with lib; {
+    description = "Cloudsmith API Client";
+    homepage = "https://github.com/cloudsmith-io/cloudsmith-api";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/development/tools/cloudsmith-cli/default.nix
+++ b/pkgs/development/tools/cloudsmith-cli/default.nix
@@ -1,0 +1,43 @@
+{ python3
+, lib
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "cloudsmith-cli";
+  version = "0.26.0";
+
+  format = "wheel";
+
+  src = python3.pkgs.fetchPypi {
+    pname = "cloudsmith_cli";
+    inherit format version;
+    sha256 = "c2W5+z+X4oRZxlNhB6for4mN4NeBX9MtEtmXhU5sz4A=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    click-configfile
+    click-didyoumean
+    click-spinner
+    cloudsmith-api
+    colorama
+    future
+    requests
+    requests_toolbelt
+    semver
+    simplejson
+    six
+    setuptools # needs pkg_resources
+  ];
+
+  # Wheels have no tests
+  doCheck = false;
+
+  meta = {
+    homepage = "https://help.cloudsmith.io/docs/cli/";
+    description = "Cloudsmith Command Line Interface";
+    maintainers = with lib.maintainers; [ jtojnar ];
+    license = lib.licenses.asl20;
+    platforms = with lib.platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1256,6 +1256,8 @@ in
 
   cloud-sql-proxy = callPackage ../tools/misc/cloud-sql-proxy { };
 
+  cloudsmith-cli = callPackage ../development/tools/cloudsmith-cli { };
+
   codeql = callPackage ../development/tools/analysis/codeql { };
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1361,6 +1361,8 @@ in {
 
   click-completion = callPackage ../development/python-modules/click-completion { };
 
+  click-configfile = callPackage ../development/python-modules/click-configfile { };
+
   click-datetime = callPackage ../development/python-modules/click-datetime { };
 
   click-default-group = callPackage ../development/python-modules/click-default-group { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1407,6 +1407,8 @@ in {
 
   cloudscraper = callPackage ../development/python-modules/cloudscraper { };
 
+  cloudsmith-api = callPackage ../development/python-modules/cloudsmith-api { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cma = callPackage ../development/python-modules/cma { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1373,6 +1373,8 @@ in {
 
   click-plugins = callPackage ../development/python-modules/click-plugins { };
 
+  click-spinner = callPackage ../development/python-modules/click-spinner { };
+
   click-repl = callPackage ../development/python-modules/click-repl { };
 
   click-threading = callPackage ../development/python-modules/click-threading { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
