### PR TITLE
liquidctl: 1.5.1 -> 1.6.1; fix build and polish package a bit

### DIFF
--- a/pkgs/development/python-modules/i2c-tools/default.nix
+++ b/pkgs/development/python-modules/i2c-tools/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, buildPythonPackage
+, i2c-tools
+}:
+
+buildPythonPackage rec {
+  inherit (i2c-tools) pname version src;
+
+  buildInputs = [ i2c-tools ];
+
+  preConfigure = "cd py-smbus";
+
+  meta = with lib; {
+    inherit (i2c-tools.meta) homepage platforms;
+
+    description = "wrapper for i2c-tools' smbus stuff";
+    # from py-smbus/smbusmodule.c
+    license = [ licenses.gpl2Only ];
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -2,40 +2,61 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, installShellFiles
 , docopt
 , hidapi
 , pyusb
 , smbus-cffi
+, i2c-tools
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "liquidctl";
-  version = "1.5.1";
+  version = "1.6.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "1l6cvm8vs2gkmg4qwg5m5vqjql1gah2vd9vs7pcj2v5hf0cm5v9x";
+    sha256 = "sha256-FYpr1mYzPc0rOE75fUNjxe/57EWl+zcbIbkqFseDhzI=";
   };
+
+  nativeBuildInputs = [ installShellFiles ];
 
   propagatedBuildInputs = [
     docopt
     hidapi
     pyusb
     smbus-cffi
+    i2c-tools
   ];
 
-  # does not contain tests
-  doCheck = false;
+  outputs = [ "out" "man" ];
+
+  postInstall = ''
+    installManPage liquidctl.8
+    installShellCompletion extra/completions/liquidctl.bash
+
+    mkdir -p $out/lib/udev/rules.d
+    cp extra/linux/71-liquidctl.rules $out/lib/udev/rules.d/.
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+
+  postBuild = ''
+    # needed for pythonImportsCheck
+    export XDG_RUNTIME_DIR=$TMPDIR
+  '';
+
   pythonImportsCheck = [ "liquidctl" ];
 
   meta = with lib; {
     description = "Cross-platform CLI and Python drivers for AIO liquid coolers and other devices";
     homepage    = "https://github.com/liquidctl/liquidctl";
     changelog   = "https://github.com/liquidctl/liquidctl/blob/master/CHANGELOG.md";
-    license     = licenses.gpl3;
-    maintainers = with maintainers; [ arturcygan ];
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ arturcygan evils ];
   };
 }

--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -1,12 +1,18 @@
-{ lib, stdenv, fetchurl, perl, read-edid }:
+{ lib
+, stdenv
+, fetchgit
+, perl
+, read-edid
+}:
 
 stdenv.mkDerivation rec {
   pname = "i2c-tools";
   version = "4.2";
 
-  src = fetchurl {
-    url = "https://www.kernel.org/pub/software/utils/i2c-tools/${pname}-${version}.tar.xz";
-    sha256 = "1mmc1n8awl3winyrp1rcxg94vjsx9dc1y7gj7y88blc2f2ydmwip";
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git";
+    rev = "v${version}";
+    sha256 = "0vqrbp10klr7ylarr6cy1q7nafiqaky4iq5my5dqy101h93vg4pg";
   };
 
   buildInputs = [ perl ];
@@ -18,6 +24,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
+  outputs = [ "out" "man" ];
+
   postInstall = ''
     rm -rf $out/include # Installs include/linux/i2c-dev.h that conflics with kernel headers
   '';
@@ -25,7 +33,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Set of I2C tools for Linux";
     homepage = "https://i2c.wiki.kernel.org/index.php/I2C_Tools";
-    license = licenses.gpl2;
+    # library is LGPL 2.1 or later; "most tools" GPL 2 or later
+    license = with licenses; [ lgpl21Plus gpl2Plus ];
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3168,6 +3168,10 @@ in {
 
   hyppo = callPackage ../development/python-modules/hyppo { };
 
+  i2c-tools = callPackage ../development/python-modules/i2c-tools {
+    inherit (pkgs) i2c-tools;
+  };
+
   i3ipc = callPackage ../development/python-modules/i3ipc { };
 
   i3-py = callPackage ../development/python-modules/i3-py { };


### PR DESCRIPTION
###### Motivation for this change
i want liquidctl to work because i use it

###### Things done
init python.pkgs.i2c-tools with pkgs.i2c-tools' source
switch pkgs.i2c-tools to use git and separate the man page (i wanted to try their latest commit, and git source is preferred?)

bump liquidctl to 1.6.1, which was released today :) (at the same time 1.5.2 was released, (is 1.6.x a new API?))
add the new python.pkgs.i2c-tools package as an input as it has been required since 1.5.0 (this broke our package)
installed man page in separate output
installed upstream available bash completion and udev rules file
add commented out stuff for running upstream's test to make it clear they're there, though i couldn't get them to work (tries to find or create /var/run/liquidctl?)

add myself as a maintainer

(i'd like all of the python stuff in $out/lib in a $dev output as i only need the bin, udev and maybe bash completion in $out)
(this is mostly because i don't consider this a python module (and hadn't put mine in pkgs/development/python-modules/)

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - Result of `nixpkgs-review pr 121402` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>libsForQt512.powerdevil</li>
    <li>libsForQt514.powerdevil</li>
  </ul>
</details>
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>clight</li>
    <li>clightd</li>
    <li>ddcui</li>
    <li>ddcutil</li>
    <li>enlightenment.enlightenment</li>
    <li>i2c-tools</li>
    <li>powerdevil (libsForQt5.powerdevil)</li>
    <li>liquidctl (python38Packages.liquidctl)</li>
    <li>python38Packages.i2c-tools</li>
    <li>python39Packages.i2c-tools</li>
    <li>python39Packages.liquidctl</li>
  </ul>
</details>

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/5ixnilmy9sj8c7lfqa28nvfxdzfdy2nw-i2c-tools-4.2	   90563152` (before my changes)
  - `/nix/store/gagnmly43ljpvj47ap69xkppkh5pipcq-i2c-tools-4.2	   90545336`
  - `/nix/store/zwadh8zszr6h4rpd5z7dcccq67z2ac5z-i2c-tools-4.2-man	      17912`
  - `/nix/store/6b4q61k89mhv7na9fs66hd60dg5mrpr3-python3.8-i2c-tools-4.2	  155791960`
  - `/nix/store/rryxg2yzx5gqa6jnrszv5n10slfpz02q-python3.8-liquidctl-1.4.2	  219122272` (before build failure)
  - `/nix/store/picf5lr5kisg9pij3ppca81084n9qpj5-python3.8-liquidctl-1.6.1	  275119432`
  - `/nix/store/5s2gpa79cqh6ar6vgcqzmh3my04xmmz6-python3.8-liquidctl-1.6.1-man	       5024`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


ping @arcz (maintainer)