### PR TITLE
 pkgs/top-level: init expression for haskell-updates jobset 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,7 @@
 /pkgs/development/compilers/ghc               @cdepillabout @sternenseemann @maralorn
 /pkgs/development/haskell-modules             @cdepillabout @sternenseemann @maralorn
 /pkgs/test/haskell                            @cdepillabout @sternenseemann @maralorn
+/pkgs/top-level/release-haskell.nix           @cdepillabout @sternenseemann @maralorn
 /pkgs/top-level/haskell-packages.nix          @cdepillabout @sternenseemann @maralorn
 
 # Perl

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,6 +56,7 @@
   - pkgs/development/tools/haskell/**/*
   - pkgs/test/haskell/**/*
   - pkgs/top-level/haskell-packages.nix
+  - pkgs/top-level/release-haskell.nix
 
 "6.topic: kernel":
   - pkgs/build-support/kernel/**/*

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -1,0 +1,201 @@
+/*
+  To debug this expression you can use `hydra-eval-jobs` from
+  `pkgs.hydra-unstable` which prints the jobset description
+  to `stdout`:
+
+  $ hydra-eval-jobs -I . pkgs/top-level/release-haskell.nix
+*/
+{ supportedSystems ? [ "x86_64-linux" ] }:
+
+let
+
+  releaseLib = import ./release-lib.nix {
+    inherit supportedSystems;
+  };
+
+  inherit (releaseLib)
+    pkgs
+    packagePlatforms
+    mapTestOn
+    aggregate
+    ;
+
+  inherit (pkgs) lib;
+
+  # helper function which traverses a (nested) set
+  # of derivations produced by mapTestOn and flattens
+  # it to a list of derivations suitable to be passed
+  # to `releaseTools.aggregate` as constituents.
+  accumulateDerivations = jobList:
+    lib.concatMap (
+      attrs:
+        if lib.isDerivation attrs
+        then [ attrs ]
+        else if lib.isAttrs attrs
+        then accumulateDerivations (lib.attrValues attrs)
+        else []
+    ) jobList;
+
+  # names of all subsets of `pkgs.haskell.packages`
+  compilerNames = lib.mapAttrs (name: _: name) pkgs.haskell.packages;
+
+  # list of all compilers to test specific packages on
+  all = with compilerNames; [
+    ghc884
+    ghc8104
+    ghc901
+  ];
+
+  # packagePlatforms applied to `haskell.packages.*`
+  compilerPlatforms = lib.mapAttrs
+    (_: v: packagePlatforms v)
+    pkgs.haskell.packages;
+
+  # This function lets you specify specific packages
+  # which are to be tested on a list of specific GHC
+  # versions and returns a job set for all specified
+  # combinations. See `jobs` below for an example.
+  versionedCompilerJobs = config: mapTestOn {
+    haskell.packages =
+      (lib.mapAttrs (
+        ghc: jobs:
+        lib.filterAttrs (
+          jobName: platforms:
+          lib.elem ghc (config."${jobName}" or [])
+        ) jobs
+      ) compilerPlatforms);
+  };
+
+  # hydra jobs for `pkgs` of which we import a subset of
+  pkgsPlatforms = packagePlatforms pkgs // {
+    gitAndTools = packagePlatforms pkgs.gitAndTools;
+  };
+
+  jobs = mapTestOn {
+    haskellPackages = packagePlatforms pkgs.haskellPackages;
+    haskell.compiler = packagePlatforms pkgs.haskell.compiler;
+
+    tests.haskell = packagePlatforms pkgs.tests.haskell;
+
+    # top-level haskell packages
+    inherit (pkgsPlatforms)
+      bench
+      cabal-install
+      cabal2nix
+      cachix
+      darcs
+      dhall
+      dhall-bash
+      dhall-docs
+      dhall-lsp-server
+      dhall-json
+      dhall-nix
+      dhall-text
+      elm2nix
+      fffuu
+      futhark
+      glirc
+      hadolint
+      haskell-ci
+      haskell-language-server
+      hasura-graphql-engine
+      hinit
+      hledger
+      hledger-iadd
+      hledger-interest
+      hledger-ui
+      hledger-web
+      hlint
+      hpack
+      icepeak
+      koka
+      krank
+      madlang
+      matterhorn
+      neuron-notes
+      niv
+      nix-delegate
+      nix-deploy
+      nix-diff
+      nix-linter
+      nix-output-monitor
+      nix-tree
+      nixfmt
+      pandoc
+      place-cursor-at
+      shake
+      shellcheck
+      spacecookie
+      splot
+      stack
+      stack2nix
+      stutter
+      stylish-haskell
+      taskell
+      tweet-hs
+      update-nix-fetchgit
+      uuagc
+      wstunnel
+      ;
+
+    gitAndTools.git-annex = pkgsPlatforms.gitAndTools.git-annex;
+  } // versionedCompilerJobs {
+    # Packages which should be checked on more than the
+    # default GHC version. This list can be used to test
+    # the state of the package set with newer compilers
+    # and to confirm that critical packages for the
+    # package sets (like Cabal, jailbreak-cabal) are
+    # working as expected.
+    cabal-install = all;
+    Cabal_3_4_0_0 = with compilerNames; [ ghc884 ghc8104 ];
+    funcmp = all;
+    haskell-language-server = all;
+    hoogle = all;
+    hsdns = all;
+    jailbreak-cabal = all;
+    language-nix = all;
+    nix-paths = all;
+    titlecase = all;
+  } // {
+    mergeable = pkgs.releaseTools.aggregate {
+      name = "haskell-updates-mergeable";
+      meta = {
+        description = ''
+          Critical haskell packages that should work at all times,
+          serves as minimum requirement for an update merge
+        '';
+        maintainers = lib.teams.haskell.members;
+      };
+      constituents = accumulateDerivations [
+        # haskell specific tests
+        jobs.tests.haskell
+        # important top-level packages
+        jobs.cabal-install
+        jobs.cabal2nix
+        jobs.cachix
+        jobs.darcs
+        jobs.haskell-language-server
+        jobs.hledger
+        jobs.hledger-ui
+        jobs.hpack
+        jobs.niv
+        jobs.pandoc
+        jobs.stack
+        jobs.stylish-haskell
+        # important haskell (library) packages
+        jobs.haskellPackages.cabal-plan
+        jobs.haskellPackages.distribution-nixpkgs
+        jobs.haskellPackages.hackage-db
+        jobs.haskellPackages.policeman
+        jobs.haskellPackages.xmonad
+        jobs.haskellPackages.xmonad-contrib
+        # haskell packages maintained by @peti
+        # imported from the old hydra jobset
+        jobs.haskellPackages.hopenssl
+        jobs.haskellPackages.hsemail
+        jobs.haskellPackages.hsyslog
+      ];
+    };
+  };
+
+in jobs


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



release-haskell.nix is intended to be a replacement for
https://github.com/peti/ci/blob/master/haskell-nixpkgs.nix
which is currently the main expression for the haskell-updates jobset
on hydra (in the nixpkgs project).

It has the same jobs as the old haskell-nixpkgs.nix file:

* haskellPackages.*
* haskell.compiler.*
* Some extra haskell packages for certain compilers

The following jobs are new:

* tests.haskell.*
* A manually maintained list of top-level haskell packages (most of them
  using justStaticExecutables)
* An aggregate job which is intended to aid merging the haskell-updates
  branch: It holds an arbitrary list of haskell-related packages and
  tests we intend have working at all times. This is still somewhat
  incomplete and should be extendend in the future.

Additionally a lot of refactoring has been done and some unnecessary
code has been eliminated. Due to the increased set of jobs and my
ideas of convenience however, the code size has grown overall.
I've tried document the individual parts and would be happy about
feedback in general.

One future improvement could be making adding top-level haskell packages
more convenient and adding them all to the aggregate job automatically.

Evaluation is currently at 20s on my laptop, I suspect the main offender is
`versionedCompilerJobs`, but haven't done any testing

---

Contains some commits of #121386.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
