### PR TITLE
clevis: fix TPM2 encrypt/decrypt

### DIFF
--- a/pkgs/tools/security/clevis/default.nix
+++ b/pkgs/tools/security/clevis/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, asciidoc
-, jansson, jose, cryptsetup, curl, libpwquality, luksmeta
+, makeWrapper, jansson, jose, cryptsetup, curl, libpwquality, luksmeta
+, coreutils, tpm2-tools
 }:
 
 stdenv.mkDerivation rec {
@@ -13,8 +14,21 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-m1UhyjD5ydSgCTBu6sECLlxFx0rnQxFnBA7frbdUqU8=";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config asciidoc ];
-  buildInputs = [ jansson jose cryptsetup curl libpwquality luksmeta ];
+  postPatch = ''
+    for f in $(find src/ -type f); do
+      grep -q "/bin/cat" "$f" && substituteInPlace "$f" \
+        --replace '/bin/cat' '${coreutils}/bin/cat' || true
+    done
+  '';
+
+  postInstall = ''
+    # We wrap the main clevis binary entrypoint but not the sub-binaries.
+    wrapProgram $out/bin/clevis \
+      --prefix PATH ':' "${tpm2-tools}/bin:${jose}/bin:${placeholder "out"}/bin"
+  '';
+
+  nativeBuildInputs = [ meson ninja pkg-config asciidoc makeWrapper ];
+  buildInputs = [ jansson jose cryptsetup curl libpwquality luksmeta tpm2-tools ];
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Allow using the TPM2 encrypt/decrypt commands from clevis.

This also fixes using the "clevis" entrypoint binary without making sure
that all the other tooling is in the PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
