### PR TITLE
nixos/tests: Replace QEMU_OPTS usages with virtualisation.qemu.options

### DIFF
--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -18,6 +18,10 @@ import ./make-test-python.nix ({ pkgs, ...} :
     };
 
     virtualisation.memorySize = 1024;
+    # Need to switch to a different VGA card / GPU driver because Cage segfaults with the default one (std):
+    # machine # [   14.355893] .cage-wrapped[736]: segfault at 20 ip 00007f035fa0d8c7 sp 00007ffce9e4a2f0 error 4 in libwlroots.so.8[7f035fa07000+5a000]
+    # machine # [   14.358108] Code: 4f a8 ff ff eb aa 0f 1f 44 00 00 c3 0f 1f 80 00 00 00 00 41 54 49 89 f4 55 31 ed 53 48 89 fb 48 8d 7f 18 48 8d 83 b8 00 00 00 <80> 7f 08 00 75 0d 48 83 3f 00 0f 85 91 00 00 00 48 89 fd 48 83 c7
+    virtualisation.qemu.options = [ "-vga virtio" ];
   };
 
   enableOCR = true;
@@ -25,11 +29,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
   testScript = { nodes, ... }: let
     user = nodes.machine.config.users.users.alice;
   in ''
-    # Need to switch to a different VGA card / GPU driver because Cage segfaults with the default one (std):
-    # machine # [   14.355893] .cage-wrapped[736]: segfault at 20 ip 00007f035fa0d8c7 sp 00007ffce9e4a2f0 error 4 in libwlroots.so.8[7f035fa07000+5a000]
-    # machine # [   14.358108] Code: 4f a8 ff ff eb aa 0f 1f 44 00 00 c3 0f 1f 80 00 00 00 00 41 54 49 89 f4 55 31 ed 53 48 89 fb 48 8d 7f 18 48 8d 83 b8 00 00 00 <80> 7f 08 00 75 0d 48 83 3f 00 0f 85 91 00 00 00 48 89 fd 48 83 c7
-    os.environ["QEMU_OPTS"] = "-vga virtio"
-
     with subtest("Wait for cage to boot up"):
         start_all()
         machine.wait_for_file("/run/user/${toString user.uid}/wayland-0.lock")

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -69,6 +69,9 @@ in {
       imports = [ ../modules/profiles/installation-device.nix
                   ../modules/profiles/base.nix ];
       virtualisation.memorySize = 1300;
+      # To add the secondary disk:
+      virtualisation.qemu.options = [ "-drive index=2,file=${debianImage}/disk-image.qcow2,read-only,if=virtio" ];
+
       # The test cannot access the network, so any packages
       # nixos-rebuild needs must be included in the VM.
       system.extraDependencies = with pkgs;
@@ -95,11 +98,6 @@ in {
   });
 
   testScript = ''
-    # hack to add the secondary disk
-    os.environ[
-        "QEMU_OPTS"
-    ] = "-drive index=2,file=${debianImage}/disk-image.qcow2,read-only,if=virtio"
-
     machine.start()
     machine.succeed("udevadm settle")
     machine.wait_for_unit("multi-user.target")


### PR DESCRIPTION
See [0]: "QEMU_OPTS is something that should be set by people running VM
tests interactively, to do port forwardings etc.
We really should not poke with it from the test script - that's what
virtualisation.qemu.options is for."

[0]: https://github.com/NixOS/nixpkgs/pull/119615#discussion_r624145020

Co-authored-by: Florian Klink <flokli@flokli.de>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
