### PR TITLE
neovimUtils: pynvim is disabled with python < 3.4

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -50,8 +50,7 @@ let
 
       pluginPython2Packages = getDeps "pythonDependencies" requiredPlugins;
       python2Env = pythonPackages.python.withPackages (ps:
-        [ ps.pynvim ]
-        ++ (extraPython2Packages ps)
+           (extraPython2Packages ps)
         ++ (lib.concatMap (f: f ps) pluginPython2Packages));
 
       pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;


### PR DESCRIPTION
###### Motivation for this change
Fixes neovim build, neovim was failing since https://github.com/NixOS/nixpkgs/commit/2a00e53bdae84e2aa371384347586c13bf3ed10c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
