### PR TITLE
goverlay: init at 0.5.1

### DIFF
--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -1,0 +1,108 @@
+{ lib
+, writeScriptBin
+, bash
+, stdenv
+, fetchFromGitHub
+, fpc
+, lazarus-qt
+, qt5
+, libX11
+, libqt5pas
+, coreutils
+, git
+, gnugrep
+, libnotify
+, mesa-demos
+, polkit
+, procps
+, systemd
+, vulkan-tools
+, which
+}:
+
+let
+  # Finds data files using the XDG Base Directory Specification
+  # See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+  find-xdg-data-files = writeScriptBin "find-xdg-data-files" ''
+    #!${bash}/bin/sh
+    IFS=:
+    for xdg_data_dir in ''${XDG_DATA_HOME:-$HOME/.local/share}:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do
+      if [ -f "$xdg_data_dir/$1" ]; then
+        echo "$xdg_data_dir/$1"
+      fi
+    done
+  '';
+in stdenv.mkDerivation rec {
+  pname = "goverlay";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "benjamimgois";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Zl1pq2MeGJsPdNlwUEpov5MHlsr9pSMkWHVprt8ImKs=";
+  };
+
+  outputs = [ "out" "man" ];
+
+  patches = [
+    # Find MangoHud & vkBasalt Vulkan layers using the XDG Base Directory Specification
+    ./find-xdg-data-files.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace 'prefix = /usr/local' "prefix = $out"
+
+    substituteInPlace overlayunit.pas \
+      --replace '/usr/share/icons/hicolor/128x128/apps/goverlay.png' "$out/share/icons/hicolor/128x128/apps/goverlay.png"
+  '';
+
+  nativeBuildInputs = [
+    fpc
+    lazarus-qt
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libX11
+    libqt5pas
+  ];
+
+  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+
+  buildPhase = ''
+    runHook preBuild
+    HOME=$(mktemp -d) lazbuild --lazarusdir=${lazarus-qt}/share/lazarus -B goverlay.lpi
+    runHook postBuild
+  '';
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [
+      bash
+      coreutils
+      find-xdg-data-files
+      git
+      gnugrep
+      libnotify
+      mesa-demos
+      polkit
+      procps
+      systemd
+      vulkan-tools
+      which
+    ]}"
+
+    # Force xcb since libqt5pas doesn't support Wayland
+    # See https://github.com/benjamimgois/goverlay/issues/107
+    "--set QT_QPA_PLATFORM xcb"
+  ];
+
+  meta = with lib; {
+    description = "An opensource project that aims to create a Graphical UI to help manage Linux overlays";
+    homepage = "https://github.com/benjamimgois/goverlay";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kira-bruneau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
+++ b/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
@@ -1,0 +1,40 @@
+diff --git a/overlayunit.pas b/overlayunit.pas
+index 59f6a81..a096543 100644
+--- a/overlayunit.pas
++++ b/overlayunit.pas
+@@ -4871,7 +4871,7 @@ begin
+    //Determine Mangohud dependency status
+ 
+           //locate MangoHud and store result in tmp folder
+-          RunCommand('bash -c ''find /usr/share/vulkan/implicit_layer.d/MangoHud.json >> /tmp/goverlay/dependency_mangohud''', s);
++          RunCommand('bash -c ''find-xdg-data-files vulkan/implicit_layer.d/MangoHud.json >> /tmp/goverlay/dependency_mangohud''', s);
+ 
+           // Assign Text file dependency_mangohud to variable mangohudVAR
+           AssignFile(mangohudVAR, '/tmp/goverlay/dependency_mangohud');
+@@ -4880,7 +4880,7 @@ begin
+           CloseFile(mangohudVAR);
+ 
+           // Read String and store value on mangohuddependencyVALUE based on result
+-          if mangohudSTR = '/usr/share/vulkan/implicit_layer.d/MangoHud.json' then
++          if mangohudSTR <> '' then
+           mangohuddependencyVALUE := 1
+           else
+           mangohuddependencyVALUE := 0;
+@@ -4889,7 +4889,7 @@ begin
+    //Determine vkBasalt dependency staus
+ 
+            //locate vkBasalt and store result in tmp folder
+-           RunCommand('bash -c ''find /usr/share/vulkan/implicit_layer.d/vkBasalt.json >> /tmp/goverlay/dependency_vkbasalt''', s);
++           RunCommand('bash -c ''find-xdg-data-files vulkan/implicit_layer.d/vkBasalt.json >> /tmp/goverlay/dependency_vkbasalt''', s);
+ 
+            // Assign Text file dependency_mangohud to variable mangohudVAR
+            AssignFile(vkbasaltVAR, '/tmp/goverlay/dependency_vkbasalt');
+@@ -4898,7 +4898,7 @@ begin
+            CloseFile(vkbasaltVAR);
+ 
+            // Read String and store value on vkbasaltdependencyVALUE based on result
+-           if vkbasaltSTR = '/usr/share/vulkan/implicit_layer.d/vkBasalt.json' then
++           if vkbasaltSTR <> '' then
+            vkbasaltdependencyVALUE := 1
+            else
+            vkbasaltdependencyVALUE := 0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5237,6 +5237,8 @@ in
 
   govc = callPackage ../tools/virtualization/govc { };
 
+  goverlay = callPackage ../tools/graphics/goverlay { };
+
   gpart = callPackage ../tools/filesystems/gpart { };
 
   gparted = callPackage ../tools/misc/gparted { };


### PR DESCRIPTION
###### Motivation for this change
Closes #84685

**NOTE:** MangoHud, vkBasalt, and ReplaySorcery aren't patched in as runtime dependencies since MangoHud is just a configuration tool, and will still work without them installed. Also, ReplaySorcery isn't available in nixpkgs yet (see https://github.com/NixOS/nixpkgs/pull/123045).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@ZerataX