### PR TITLE
fetchPythonRequirements: init (fixed output pypi fetcher)

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -40,7 +40,7 @@ with pkgs;
               isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder
               python bootstrapped-pip buildPythonPackage buildPythonApplication
               fetchPypi
-              fetchPythonRequirements
+              fetchPythonRequirements_1
               hasPythonModule requiredPythonModules makePythonPath disabledIf
               toPythonModule toPythonApplication
               buildSetupcfg

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -40,6 +40,7 @@ with pkgs;
               isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder
               python bootstrapped-pip buildPythonPackage buildPythonApplication
               fetchPypi
+              fetchPythonRequirements
               hasPythonModule requiredPythonModules makePythonPath disabledIf
               toPythonModule toPythonApplication
               buildSetupcfg

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -106,7 +106,9 @@ let
 
         nativeBuildInputs = with python3.pkgs; [ pythonWithMitmproxy pythonPip curl cacert ];
 
-        phases = [ "buildPhase" ];
+        dontUnpack = true;
+        dontInstall = true;
+        dontFixup = true;
 
         buildPhase = ''
           # the script.py will read this date

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -1,0 +1,127 @@
+# fetchPythonRequirements downlaods python packages specified by a list of
+# pip-style python requirements
+# It also requires a maximum date 'maxDate' being specified.
+# The result will be as if `pip download` would have been executed
+# at the point in time specified by maxDate.
+# This is ensured by putting pip behind a local proxy filtering the
+# api responses from pypi.org to only contain files for which the
+# release date is lower than the specified maxDate.
+
+{
+  # this specifies the python version for which the packages should be downloaded
+  python,
+}:
+
+{
+  lib
+, cacert
+, curl
+, stdenv
+, buildPackages
+, python3
+, ...
+}:
+let
+
+  # we use mitmproxy to filter the pypi responses
+  pythonWithMitmproxy = python3.withPackages (ps: [ ps.mitmproxy ps.python-dateutil ]);
+
+  fetchPythonRequirements = {
+    maxDate,        # maximum release date for packages
+    outputHash,     # hash for the fixed output derivation
+    requirements,   # list of strings of specs
+
+    pipFlags ? [],
+  }:
+    let
+      pythonAttrName = lib.stringAsChars (x: if x == "." then "" else x) python.libPrefix;
+
+      # We need to execute pip from the python version for which we want to download packages.
+      # Pip accepts '--python-version', but this works only for wheel packages.
+      pythonPip = buildPackages."${pythonAttrName}".withPackages (ps: [
+        ps.pip
+        ps.setuptools
+        ps.pkgconfig
+      ]);
+
+      # Normalize package names:
+      #   "Example_Package[extra]" -> "example-package"
+      normalizedNames = map (req:
+        lib.toLower (lib.replaceStrings [ "_" ] [ "-" ] (lib.elemAt (lib.splitString "[" req) 0))
+      ) requirements;
+
+      # fixed output derivation containing packages,
+      # each being symlinked from it's normalized name
+      # Example:
+      #   "$out/werkzeug" will point to "$out/Werkzeug-0.14.1-py2.py3-none-any.whl"
+      self = stdenv.mkDerivation {
+
+        name = "multiple-pypi-packages";
+
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        inherit outputHash;
+
+        nativeBuildInputs = with python3.pkgs; [ pythonWithMitmproxy pythonPip curl cacert ];
+
+        phases = [ "buildPhase" ];
+
+        buildPhase = ''
+          # the script.py will read this date
+          export MAX_DATE=${maxDate}
+          pretty=$(python -c 'import os; import dateutil.parser; print(dateutil.parser.parse(os.getenv("MAX_DATE")))')
+          echo "selected maximum release date for python packages: $pretty"
+
+          # find free port for proxy
+          proxyPort=$(python -c '\
+          import socket
+          s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          s.bind(("", 0))
+          print(s.getsockname()[1])
+          s.close()')
+
+          # start proxy to filter pypi responses
+          # mitmproxy wants HOME set
+          # mitmdump == mitmproxy without GUI
+          HOME=$(pwd) mitmdump \
+            --listen-port "$proxyPort" \
+            --ignore-hosts '.*files.pythonhosted.org.*'\
+            --script ${./filter-pypi-responses.py} &
+
+          # wait for proxy to come up
+          while sleep 0.5; do
+            timeout 5 curl --proxy http://localhost:$proxyPort http://pypi.org 2>/dev/null && break
+          done
+
+          mkdir $out
+
+          # make pip query pypi through the filtering proxy
+          ${pythonPip}/bin/pip download \
+            --no-cache \
+            --dest $out \
+            --proxy http://localhost:$proxyPort \
+            --trusted-host pypi.org \
+            --trusted-host files.pythonhosted.org \
+            ${lib.concatStringsSep " " pipFlags} \
+            "${lib.concatStringsSep "\" \"" requirements}"
+
+          # create symlinks to allow files being referenced via their normalized package names
+          cd $out
+          for f in $(ls $out); do
+            if [[ "$f" == *.whl ]]; then
+              pname=$(echo "$f" | cut -d "-" -f 1 | sed 's/_/-/' | sed 's/\(.*\)/\L\1/')
+            else
+              pname=''${f%-*}
+            fi
+            echo "linking $pname to $f"
+            ln -s "$f" "$pname"
+          done
+
+        '';
+      };
+    in self;
+in
+
+fetchPythonRequirements
+
+

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -140,7 +140,7 @@ let
 
           # wait for proxy to come up
           while sleep 0.5; do
-            timeout 5 curl --proxy http://localhost:$proxyPort http://pypi.org 2>/dev/null && break
+            timeout 5 curl --fail --proxy http://localhost:$proxyPort http://pypi.org 2>/dev/null && break
           done
 
           mkdir $out

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -39,12 +39,13 @@ let
     # for reference see: https://pip.pypa.io/en/stable/cli/pip_download/
     pipFlags ? [],
 
-    # For non-binary downloads, the targetSystem must be a constant.
-    # Do not pass `stdenv.targetPlatform.system` or `builtins.currentSystem`.
-    # This prevents the fetcher from being executed on the wrong platform.
-    targetSystem ?
-      if onlyBinary then stdenv.targetPlatform.system
-      else throw "'targetSystem' must be specified if 'onlyBinary' = false",
+    # Throw an error by default to warn the user about the correct usage
+    targetSystem ? throw ''
+      'targetSystem' must be specified for fetchPythonRequirements.
+      Pass only a constant string like for example "x86_64-linux".
+      Do not pass `stdenv.targetPlatform.system` or `builtins.currentSystem`.
+      This prevents the fetcher from being executed on the wrong platform.
+    '',
   }:
 
     # specifying `--platform` for pip download is only allowed in combination with `--only-binary :all:`
@@ -98,7 +99,7 @@ let
       #   "$out/werkzeug" will point to "$out/Werkzeug-0.14.1-py2.py3-none-any.whl"
       self = stdenv.mkDerivation {
 
-        name = "multiple-pypi-packages";
+        name = "python-sources-${targetSystem}";
 
         outputHashMode = "recursive";
         outputHashAlgo = "sha256";

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -63,6 +63,7 @@ let
           "manylinux1_x86_64"
           "manylinux2010_x86_64"
           "manylinux2014_x86_64"
+          "linux_x86_64"
         ];
         "x86_64-darwin" =
           lib.forEach (lib.range 0 15) (minor: "macosx_10_${builtins.toString minor}_x86_64");
@@ -70,6 +71,7 @@ let
           "manylinux1_aarch64"
           "manylinux2010_aarch64"
           "manylinux2014_aarch64"
+          "linux_aarch64"
         ];
       };
       platforms = if sysToPlatforms ? "${targetSystem}" then sysToPlatforms."${targetSystem}" else throw ''
@@ -105,7 +107,7 @@ let
         outputHashAlgo = "sha256";
         inherit outputHash;
 
-        nativeBuildInputs = with python3.pkgs; [ pythonWithMitmproxy pythonPip curl cacert ];
+        nativeBuildInputs = [ pythonWithMitmproxy pythonPip curl cacert ];
 
         dontUnpack = true;
         dontInstall = true;
@@ -141,7 +143,7 @@ let
 
           # wait for proxy to come up
           while sleep 0.5; do
-            timeout 5 curl -fLsS --proxy http://localhost:$proxyPort http://pypi.org && break
+            timeout 5 curl -fs --proxy http://localhost:$proxyPort http://pypi.org && break
           done
 
           mkdir $out

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -163,7 +163,7 @@ let
           cd $out
           for f in $(ls $out); do
             if [[ "$f" == *.whl ]]; then
-              pname=$(echo "$f" | cut -d "-" -f 1 | sed 's/_/-/' | sed 's/\(.*\)/\L\1/')
+              pname=$(echo "$f" | cut -d "-" -f 1 | sed -e 's/_/-/' -e 's/\(.*\)/\L\1/')
             else
               pname=''${f%-*}
             fi
@@ -177,5 +177,4 @@ let
 in
 
 fetchPythonRequirements
-
 

--- a/pkgs/development/interpreters/python/fetch-python-requirements.nix
+++ b/pkgs/development/interpreters/python/fetch-python-requirements.nix
@@ -141,7 +141,7 @@ let
 
           # wait for proxy to come up
           while sleep 0.5; do
-            timeout 5 curl --fail --proxy http://localhost:$proxyPort http://pypi.org 2>/dev/null && break
+            timeout 5 curl -fLsS --proxy http://localhost:$proxyPort http://pypi.org && break
           done
 
           mkdir $out
@@ -177,4 +177,3 @@ let
 in
 
 fetchPythonRequirements
-

--- a/pkgs/development/interpreters/python/filter-pypi-responses.py
+++ b/pkgs/development/interpreters/python/filter-pypi-responses.py
@@ -1,0 +1,62 @@
+"""
+This script is part of fetchPythonRequirements
+It is meant to be used with mitmproxy via `--script`
+It will filter api repsonses from the pypi.org api (used by pip),
+to only contain files with release date < MAX_DATE
+
+For retrieving the release dates for files, it uses the pypi.org json api
+It has to do one extra api request for each queried package name
+"""
+import json
+import os
+import re
+from urllib import request
+import dateutil.parser
+
+from mitmproxy import http
+
+
+def get_files_to_hide(pname, max_ts):
+    """
+    Query the pypi json api to get timestamps for all release files of the given pname.
+    return all file names which are newer than the given timestamp
+    """
+    url = f"https://pypi.org/pypi/{pname}/json"
+    with request.urlopen(url) as f:
+        resp = json.load(f)
+    files = []
+    for ver, releases in resp['releases'].items():
+        for release in releases:
+            ts = dateutil.parser.parse(release['upload_time']).timestamp()
+            if ts > max_ts:
+                files.append(release['filename'])
+    return files
+
+
+# accept unix timestamp or human readable format
+try:
+    max_ts = int(os.getenv("MAX_DATE"))
+except ValueError:
+    max_date = dateutil.parser.parse(os.getenv("MAX_DATE"))
+    max_ts = max_date.timestamp()
+
+
+def response(flow: http.HTTPFlow) -> None:
+    if not "/simple/" in flow.request.url:
+        return
+    pname = flow.request.url.strip('/').split('/')[-1]
+    badFiles = get_files_to_hide(pname, max_ts)
+    html = flow.response.text
+    for fname in badFiles:
+        if fname not in html:
+            continue
+        pattern = rf'<a href="https://files.pythonhosted.org/packages/../../[\d\w]+/{fname}#sha256=[\d\w]+".*>{fname}</a>'
+        html_new = re.sub(pattern, "", html)
+        if html == html_new:
+            raise Exception(
+                f"Removing file {fname} from pypi response failed.\n"
+                f"Check the regex in {__file__}"
+                f"html document: \n{html}")
+        html = html_new
+    flow.response.text = html
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -58,10 +58,12 @@ let
 
   fetchPypi = callPackage ../development/interpreters/python/fetchpypi.nix {};
 
-  fetchPythonRequirements =
-    callPackage (import ../development/interpreters/python/fetch-python-requirements.nix {
+  fetchPythonRequirements_1 =
+    callPackage ../development/interpreters/python/fetch-python-requirements.nix {
       inherit python;
-    }) {};
+      logicVersion = "1";
+      pythonMitmproxy = pkgs.python3;
+    };
 
   # Check whether a derivation provides a Python module.
   hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;
@@ -112,7 +114,7 @@ in {
   inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
   inherit python bootstrapped-pip buildPythonPackage buildPythonApplication;
   inherit fetchPypi;
-  inherit fetchPythonRequirements;
+  inherit fetchPythonRequirements_1;
   inherit hasPythonModule requiredPythonModules makePythonPath disabled disabledIf;
   inherit toPythonModule toPythonApplication;
   inherit buildSetupcfg;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -58,6 +58,11 @@ let
 
   fetchPypi = callPackage ../development/interpreters/python/fetchpypi.nix {};
 
+  fetchPythonRequirements =
+    callPackage (import ../development/interpreters/python/fetch-python-requirements.nix {
+      inherit python;
+    }) {};
+
   # Check whether a derivation provides a Python module.
   hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;
 
@@ -107,6 +112,7 @@ in {
   inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
   inherit python bootstrapped-pip buildPythonPackage buildPythonApplication;
   inherit fetchPypi;
+  inherit fetchPythonRequirements;
   inherit hasPythonModule requiredPythonModules makePythonPath disabled disabledIf;
   inherit toPythonModule toPythonApplication;
   inherit buildSetupcfg;


### PR DESCRIPTION
fetchPythonRequirements is a multi package fetcher for python/pypi similar to the one used by buildGoModule or fetchCrate for rust.

It downlaods python packages specified by a list of pip-style python requirements.
It requires a maximum date 'maxDate' being specified.

The result will be as if `pip download` would have been executed at the point in time specified by maxDate.

This is ensured by putting pip behind a local proxy filtering the api responses from pypi.org to only contain files for which the release date is lower than the specified maxDate.

In other words, the proxy provides a snapshot-like view on pypi.org

The fetcher is reproducible without the need of specifying package versions or hashes. Any pip compatible requirement specifiers are allowed.

Here an example on how this fetcher can be used to build jupyterlab.
This environment, containing more than 40 python packages, can be described in less than 30 lines of nix code:

```nix
let
  pkgs = import <nixpkgs> {};
  python = pkgs.python38;
  downloaded = python.pkgs.fetchPythonRequirements {
    requirements = [
      "jupyterlab"
    ];
    maxDate = "2020-03";
    outputHash = "08h3a606kfijmm73h90dybi9pkldc4421ffxzvp47vw05ijrr2rj";
  };
  multiplePackages = python.pkgs.buildPythonPackage {
    name = "bunch-of-python-pkgs";
    format = "";
    src = downloaded;
    buildInputs = pkgs.pythonManylinuxPackages.manylinux1;
    nativeBuildInputs = [ pkgs.autoPatchelfHook python.pkgs.wheelUnpackHook ];
    unpackPhase = "mkdir dist && cp $src/* dist/";
    installPhase = ''
      mkdir -p "$out/${python.sitePackages}"
      export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
      ${python}/bin/python -m pip install ./dist/*.{whl,tar.gz,zip} --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags --ignore-installed
    '';
  };
in

python.withPackages (ps: [ multiplePackages ])

```