### PR TITLE
nixos/nsd: atomically create state directories with appropriate mode

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -136,9 +136,9 @@ let
   copyKeys = concatStrings (mapAttrsToList (keyName: keyOptions: ''
     secret=$(cat "${keyOptions.keyFile}")
     dest="${stateDir}/private/${keyName}"
-    echo "  secret: \"$secret\"" > "$dest"
-    chown ${username}:${username} "$dest"
-    chmod 0400 "$dest"
+    tempsec="$(mktemp)"
+    echo "  secret: \"$secret\"" > "$tempsec"
+    install -m 0400 -o ${username} -g ${username} "$tempsec" -D "$dest"
   '') cfg.keys);
 
 
@@ -438,9 +438,7 @@ let
   dnssecTools = pkgs.bind.override { enablePython = true; };
 
   signZones = optionalString dnssec ''
-    mkdir -p ${stateDir}/dnssec
-    chown ${username}:${username} ${stateDir}/dnssec
-    chmod 0600 ${stateDir}/dnssec
+    install -dm 0600 -u ${username} -g ${username} ${stateDir}/dnssec
 
     ${concatStrings (mapAttrsToList signZone dnssecZones)}
   '';
@@ -930,9 +928,9 @@ in
         rm -Rf "${stateDir}/private/"
         rm -Rf "${stateDir}/tmp/"
 
-        mkdir -m 0700 -p "${stateDir}/private"
-        mkdir -m 0700 -p "${stateDir}/tmp"
-        mkdir -m 0700 -p "${stateDir}/var"
+        install -dm 0700 -o ${username} -g ${username} ${stateDir}/private
+        install -dm 0700 -o ${username} -g ${username} ${stateDir}/tmp
+        install -dm 0700 -o ${username} -g ${username} ${stateDir}/var
 
         cat > "${stateDir}/don't touch anything in here" << EOF
         Everything in this directory except NSD's state in var and dnssec
@@ -940,14 +938,12 @@ in
         the nsd.service pre-start script.
         EOF
 
-        chown ${username}:${username} -R "${stateDir}/private"
-        chown ${username}:${username} -R "${stateDir}/tmp"
-        chown ${username}:${username} -R "${stateDir}/var"
-
         rm -rf "${stateDir}/zones"
         cp -rL "${nsdEnv}/zones" "${stateDir}/zones"
 
         ${copyKeys}
+
+        chown ${username}:${username} -R "${stateDir}/var"
       '';
     };
 


### PR DESCRIPTION
Related to https://github.com/NixOS/nixpkgs/issues/121293

I'm not 100% sure this is an actual vulnerability, the statedir being
700, I'm not really sure how we could exploit this to extract secrets.

Better be safe than sorry though. Replacing the file creation followed
by chmod/chown with atomic install statements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@GrahamcOfBorg test nsd
