### PR TITLE
glcontext: init at 2.3.3 and add as moderngl dep

### DIFF
--- a/pkgs/development/python-modules/glcontext/default.nix
+++ b/pkgs/development/python-modules/glcontext/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, libGL
+, libX11
+, pytestCheckHook
+, psutil
+}:
+
+buildPythonPackage rec {
+  pname = "glcontext";
+  version = "2.3.3";
+
+  src = fetchFromGitHub {
+    owner = "moderngl";
+    repo = pname;
+    rev = version;
+    sha256 = "16kwrfjijn9bnb48rk17wapmhxq6g9s59zczh65imyncb9k82wkc";
+  };
+
+  disabled = !isPy3k;
+
+  buildInputs = [ libGL libX11 ];
+
+  postPatch = ''
+    substituteInPlace glcontext/x11.cpp \
+      --replace '"libGL.so"' '"${libGL}/lib/libGL.so"' \
+      --replace '"libX11.so"' '"${libX11}/lib/libX11.so"'
+    substituteInPlace glcontext/egl.cpp \
+      --replace '"libGL.so"' '"${libGL}/lib/libGL.so"' \
+      --replace '"libEGL.so"' '"${libGL}/lib/libEGL.so"'
+  '';
+
+  # Tests fail because they try to open display. See
+  # https://github.com/NixOS/nixpkgs/pull/121439
+  # for details.
+  doCheck = false;
+
+  pythonImportsCheck = [ "glcontext" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/moderngl/glcontext";
+    description = "OpenGL implementation for ModernGL";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ friedelino ];
+  };
+}

--- a/pkgs/development/python-modules/moderngl/default.nix
+++ b/pkgs/development/python-modules/moderngl/default.nix
@@ -4,6 +4,7 @@
 , isPy3k
 , libGL
 , libX11
+, glcontext
 }:
 
 buildPythonPackage rec {
@@ -17,7 +18,7 @@ buildPythonPackage rec {
 
   disabled = !isPy3k;
 
-  buildInputs = [ libGL libX11 ];
+  buildInputs = [ libGL libX11 glcontext ];
 
   # Tests need a display to run.
   doCheck = false;

--- a/pkgs/development/python-modules/moderngl_window/default.nix
+++ b/pkgs/development/python-modules/moderngl_window/default.nix
@@ -7,6 +7,7 @@
 , pyglet
 , pillow
 , pyrr
+, glcontext
 }:
 
 buildPythonPackage rec {
@@ -20,7 +21,7 @@ buildPythonPackage rec {
     sha256 = "1p03j91pk2bwycd13p0qi8kns1sf357180hd2mkaip8mfaf33x3q";
   };
 
-  propagatedBuildInputs = [ numpy moderngl pyglet pillow pyrr ];
+  propagatedBuildInputs = [ numpy moderngl pyglet pillow pyrr glcontext ];
 
   disabled = !isPy3k;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2689,6 +2689,8 @@ in {
 
   glasgow = callPackage ../development/python-modules/glasgow { };
 
+  glcontext = callPackage ../development/python-modules/glcontext { };
+
   glob2 = callPackage ../development/python-modules/glob2 { };
 
   globre = callPackage ../development/python-modules/globre { };


### PR DESCRIPTION
###### Motivation for this change
glcontext is a new dependency for existing and recently updated pythonPackage `moderngl` which is broken without this dep.
Tests fail during `nix-build` because they try to open display.

ZHF: #122042 and @NixOS/nixos-release-managers 

because this fixes failing build of moderngl: https://hydra.nixos.org/build/142072318 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
