### PR TITLE
firefox-bin: rpath pipewire

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -33,6 +33,7 @@
 , nspr
 , nss
 , pango
+, pipewire
 , pciutils
 , libheimdal
 , libpulseaudio
@@ -126,6 +127,7 @@ stdenv.mkDerivation {
       nspr
       nss
       pango
+      pipewire
       pciutils
       libheimdal
       libpulseaudio


### PR DESCRIPTION
###### Motivation for this change
Fixes screensharing on Wayland via pipewire/xdp infrastructure.

###### Things done

I built a similar change by applying an equivalent overlay to my system. Tested screensharing on https://mozilla.github.io/webrtc-landing/gum_test.html within sway.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

r? @lovesegfault 