### PR TITLE
py3c: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/py3c/default.nix
+++ b/pkgs/development/libraries/py3c/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "04i2z7hrig78clc59q3i1z2hh24g7z1bfvxznlzxv00d4s57nhpi";
   };
 
+  postPatch = lib.optionalString stdenv.cc.isClang ''
+    substituteInPlace test/setup.py \
+      --replace "'-Werror', " ""
+  '';
+
   makeFlags = [
     "prefix=${placeholder "out"}"
   ];
@@ -26,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/encukou/py3c";
     description = "Python 2/3 compatibility layer for C extensions";
     license = licenses.mit;
-    maintainers = with maintainers; [ ajs124 ];
+    maintainers = with maintainers; [ ajs124 dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/120731#issuecomment-830696360
related to https://github.com/NixOS/nixpkgs/issues/39687

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

On Linux, `nix-build -E "with import ./. { }; py3c.override { stdenv = clangStdenv; }"` fails with
```
make test-python2
make[1]: Entering directory '/build/source'
cd test; rm -rvf build ; python2 setup.py build
running build
running build_ext
building 'test_py3c' extension
creating build
creating build/temp.linux-x86_64-2.7
clang -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../include -I/nix/store/r8xqa85n5m0xg7p6rymwh0ldzf0h5wqv-python-2.7.18/include/python2.7 -c test_py3c.c -o build/temp.linux-x86_64-2.7/test_py3c.o -Werror -Wall
creating build/lib.linux-x86_64-2.7
gcc -pthread -shared -lgcc_s build/temp.linux-x86_64-2.7/test_py3c.o -L/nix/store/r8xqa85n5m0xg7p6rymwh0ldzf0h5wqv-python-2.7.18/lib -lpython2.7 -o build/lib.linux-x86_64-2.7/test_py3c.so
unable to execute 'gcc': No such file or directory
```
@FRidh I guess Python is not expected to work with clang on Linux? 

Can someone test this on macOS?
cc @d1egoaz 