### PR TITLE
home-assistant 2021.5 dependency bumps

### DIFF
--- a/pkgs/development/python-modules/authcaptureproxy/default.nix
+++ b/pkgs/development/python-modules/authcaptureproxy/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, aiohttp
+, beautifulsoup4
+, httpx
+, importlib-metadata
+, multidict
+, typer
+, yarl
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "authcaptureproxy";
+  version = "1.0.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "alandtse";
+    repo = "auth_capture_proxy";
+    rev = "v${version}";
+    sha256 = "1fbrmh6qa3dm3q3zdxaa0fls94wardbcvnjgwxk686wpjgs1xrs4";
+  };
+
+  postPatch = ''
+    # https://github.com/alandtse/auth_capture_proxy/issues/14
+    substituteInPlace pyproject.toml --replace \
+      "poetry.masonry.api" \
+      "poetry.core.masonry.api"
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    beautifulsoup4
+    httpx
+    importlib-metadata
+    multidict
+    typer
+    yarl
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "A proxy to capture authentication information from a webpage";
+    homepage = "https://github.com/alandtse/auth_capture_proxy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ graham33 hexa ];
+  };
+}

--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "bellows";
-  version = "0.23.1";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "bellows";
     rev = version;
-    sha256 = "sha256-c9rKRmGMlYrzVQmUuM9P3c/Jm4QVM2aBRSZ0OkyrPTY=";
+    sha256 = "00sa4x1qzv861z9d83lk4lp1g2pqiv9hpawj92w4qn1wnqxbz6rw";
   };
 
   prePatch = ''

--- a/pkgs/development/python-modules/pysmappee/default.nix
+++ b/pkgs/development/python-modules/pysmappee/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "pysmappee";
-  version = "0.2.24";
+  version = "0.2.25";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "smappee";
     repo = pname;
     rev = version;
-    sha256 = "sha256-M1qzwGf8q4WgkEL0nK1yjn3JSBbP7mr75IV45Oa+ypM=";
+    sha256 = "0ld3pb86dq61fcvr6zigdz1vjjcwf7izzkajyg82nmb508a570d7";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pysonos/default.nix
+++ b/pkgs/development/python-modules/pysonos/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pysonos";
-  version = "0.0.43";
+  version = "0.0.44";
 
   disabled = !isPy3k;
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "amelchio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-OobKlAymXXvQH6m77Uqn2eoTlWgs8EBxYIDFJ5wwMKA=";
+    sha256 = "108818mkb037zs4ikilrskfppcbmqslsm6zaxmy8pphjh7c299mz";
   };
 
   propagatedBuildInputs = [ ifaddr requests xmltodict ];

--- a/pkgs/development/python-modules/simplisafe-python/default.nix
+++ b/pkgs/development/python-modules/simplisafe-python/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "simplisafe-python";
-  version = "9.6.9";
+  version = "9.6.10";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "1q5w5pvrgj94bzd5wig79l4hipkfrcdah54rvwyi7b8q46gw77sg";
+    sha256 = "0cc5kxxishxhkg1nqmgbh36yxs8yjfynmimzjnaqkqfrs9iq46mr";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/teslajsonpy/default.nix
+++ b/pkgs/development/python-modules/teslajsonpy/default.nix
@@ -1,10 +1,12 @@
 { lib
 , aiohttp
+, authcaptureproxy
 , backoff
 , beautifulsoup4
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
+, poetry-core
 , pytest-asyncio
 , pytestCheckHook
 , wrapt
@@ -12,24 +14,22 @@
 
 buildPythonPackage rec {
   pname = "teslajsonpy";
-  version = "0.11.5";
+  version = "0.18.3";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "zabuldon";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-s0IZ1UNldYddaR3zJoYS6ey8Kjxd1fr4fOwf0gNNbow=";
+    sha256 = "1hdc5gm6dg1vw6qfs3z6mg2m94scrvjphj0lin6pi8n3zqj1h26k";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "dont-use-dummpy-module-bs4.patch";
-      url = "https://github.com/zabuldon/teslajsonpy/pull/138/commits/f5a788e47d8338c8ebb06d954f802ba1ec614db3.patch";
-      sha256 = "0rws7fhxmca8d5w0bkygx8scvzah3yvb3yfhn05qmp73mn3pmcb3";
-    })
+  nativeBuildInputs = [
+    poetry-core
   ];
 
   propagatedBuildInputs = [
+    authcaptureproxy
     aiohttp
     backoff
     beautifulsoup4

--- a/pkgs/development/python-modules/yeelight/default.nix
+++ b/pkgs/development/python-modules/yeelight/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "yeelight";
-  version = "0.6.1";
+  version = "0.6.2";
   disabled = pythonOlder "3.4";
 
   src = fetchFromGitLab {
     owner = "stavros";
     repo = "python-yeelight";
     rev = "v${version}";
-    sha256 = "sha256-LB7A8E22hyqhVBElrOwtC3IPNkyQkU7ZJ1ScqaXQ6zs=";
+    sha256 = "0v0i0s8d5z6b63f2sy42wf85drdzrzswlm1hknzr7v6lfr52pwwm";
   };
 
   propagatedBuildInputs = [
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python library for controlling YeeLight RGB bulbs";
     homepage = "https://gitlab.com/stavros/python-yeelight/";
-    license = licenses.asl20;
+    license = licenses.bsd2;
     maintainers = with maintainers; [ nyanloutre ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -389,6 +389,7 @@ in with py.pkgs; buildPythonApplication rec {
     "tasmota"
     "tcp"
     "template"
+    "tesla"
     "threshold"
     "time_date"
     "timer"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -605,6 +605,8 @@ in {
 
   auth0-python = callPackage ../development/python-modules/auth0-python { };
 
+  authcaptureproxy = callPackage ../development/python-modules/authcaptureproxy { };
+
   authheaders = callPackage ../development/python-modules/authheaders { };
 
   authlib = callPackage ../development/python-modules/authlib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.5.0b5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
