### PR TITLE
libsForQt5.quazip: 0.9.1 -> 1.1

### DIFF
--- a/pkgs/applications/gis/qmapshack/default.nix
+++ b/pkgs/applications/gis/qmapshack/default.nix
@@ -18,13 +18,13 @@ mkDerivation rec {
 
   cmakeFlags = [
     "-DROUTINO_XML_PATH=${routino}/share/routino"
-    "-DQUAZIP_INCLUDE_DIR=${quazip}/include/quazip5"
-    "-DLIBQUAZIP_LIBRARY=${quazip}/lib/libquazip.so"
   ];
 
   patches = [
     "${src}/FindPROJ4.patch"
-    "${src}/FindQuaZip5.patch"
+
+    # Support QuaZip 1.x.
+    ./pr350-support-quazip-1x.patch
   ];
 
   qtWrapperArgs = [

--- a/pkgs/applications/gis/qmapshack/pr350-support-quazip-1x.patch
+++ b/pkgs/applications/gis/qmapshack/pr350-support-quazip-1x.patch
@@ -1,0 +1,141 @@
+From 8fb751c656a14020ba37fb91b7f7cba3c49d8504 Mon Sep 17 00:00:00 2001
+From: kiozen <oliver.eichler@gmx.de>
+Date: Sat, 20 Mar 2021 12:14:29 +0100
+Subject: [PATCH] [QMS-349] Upgrade to Quazip Qt5 V1.x
+
+Simply adjusted the cmake scripts
+---
+ CMakeLists.txt               |  2 +-
+ src/qmapshack/CMakeLists.txt | 27 +++++++++++++--------------
+ 3 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8d2cf127..7420d9b2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -152,7 +152,7 @@ find_package(GDAL                   REQUIRED)
+ find_package(PROJ                   REQUIRED)
+ find_package(JPEG                   REQUIRED)
+ find_package(ROUTINO                REQUIRED)
+-find_package(QuaZip5                REQUIRED)
++find_package(QuaZip-Qt5             REQUIRED)
+ find_package(ALGLIB                         ) # optional as we can use our local version
+ 
+ 
+diff --git a/src/qmapshack/CMakeLists.txt b/src/qmapshack/CMakeLists.txt
+index 08eeb183..9b3836d6 100644
+--- a/src/qmapshack/CMakeLists.txt
++++ b/src/qmapshack/CMakeLists.txt
+@@ -22,8 +22,8 @@ add_definitions(-DROUTINO_XML_PATH=${ROUTINO_XML_PATH})
+ # All source files needed to compile
+ ###############################################################################################
+ 
+-set( SRCS    
+-    CAbout.cpp    
++set( SRCS
++    CAbout.cpp
+     CMainWindow.cpp
+     CSingleInstanceProxy.cpp
+     canvas/CCanvas.cpp
+@@ -160,7 +160,7 @@ set( SRCS
+     gis/trk/CInvalidTrk.cpp
+     gis/trk/CKnownExtension.cpp
+     gis/trk/CListTrkPts.cpp
+-    gis/trk/CPropertyTrk.cpp    
++    gis/trk/CPropertyTrk.cpp
+     gis/trk/CScrOptTrk.cpp
+     gis/trk/CSelectActivityColor.cpp
+     gis/trk/CTableTrk.cpp
+@@ -272,7 +272,7 @@ set( SRCS
+     mouse/line/CLineOpMovePoint.cpp
+     mouse/line/CLineOpSelectRange.cpp
+     mouse/line/CScrOptEditLine.cpp
+-    mouse/line/CScrOptRangeLine.cpp    
++    mouse/line/CScrOptRangeLine.cpp
+     mouse/line/ILineOp.cpp
+     mouse/line/IMouseEditLine.cpp
+     plot/CPlot.cpp
+@@ -401,7 +401,7 @@ set( HDRS
+     gis/CGisListDB.h
+     gis/CGisListWks.h
+     gis/CGisWorkspace.h
+-    gis/CSelDevices.h    
++    gis/CSelDevices.h
+     gis/IGisItem.h
+     gis/IGisLine.h
+     gis/Poi.h
+@@ -512,7 +512,7 @@ set( HDRS
+     gis/trk/CInvalidTrk.h
+     gis/trk/CKnownExtension.h
+     gis/trk/CListTrkPts.h
+-    gis/trk/CPropertyTrk.h    
++    gis/trk/CPropertyTrk.h
+     gis/trk/CScrOptTrk.h
+     gis/trk/CSelectActivityColor.h
+     gis/trk/CTableTrk.h
+@@ -579,7 +579,7 @@ set( HDRS
+     map/CMapList.h
+     map/CMapMAP.h
+     map/CMapPathSetup.h
+-    map/CMapPropSetup.h    
++    map/CMapPropSetup.h
+     map/CMapRMAP.h
+     map/CMapTMS.h
+     map/CMapVRT.h
+@@ -655,7 +655,7 @@ set( HDRS
+     realtime/CRtSelectSource.h
+     realtime/CRtWorkspace.h
+     realtime/IRtInfo.h
+-    realtime/IRtRecord.h    
++    realtime/IRtRecord.h
+     realtime/IRtSource.h
+     realtime/gpstether/CRtGpsTether.h
+     realtime/gpstether/CRtGpsTetherInfo.h
+@@ -764,7 +764,7 @@ set( UIS
+     gis/search/IGeoSearchWebConfigDialog.ui
+     gis/search/ISearchExplanationDialog.ui
+     gis/summary/IGisSummary.ui
+-    gis/summary/IGisSummarySetup.ui    
++    gis/summary/IGisSummarySetup.ui
+     gis/trk/ICombineTrk.ui
+     gis/trk/ICutTrk.ui
+     gis/trk/IDetailsTrk.ui
+@@ -818,7 +818,7 @@ set( UIS
+     mouse/range/IActionSelect.ui
+     mouse/range/IRangeToolSetup.ui
+     mouse/range/IScrOptRangeTool.ui
+-    mouse/range/IScrOptRangeTrk.ui    
++    mouse/range/IScrOptRangeTrk.ui
+     mouse/IScrOptRuler.ui
+     mouse/IScrOptSelect.ui
+     mouse/line/IScrOptEditLine.ui
+@@ -899,7 +899,6 @@ include_directories(
+     ${PROJ_INCLUDE_DIRS}
+     ${ROUTINO_INCLUDE_DIRS}
+     ${ALGLIB_INCLUDE_DIRS}
+-    ${QUAZIP_INCLUDE_DIRS}
+ )
+ 
+ if(APPLE)
+@@ -934,10 +933,10 @@ endif(Qt5DBus_FOUND)
+ 
+ target_link_libraries(${APPLICATION_NAME}
+     Qt5::Widgets
+-    Qt5::Xml    
++    Qt5::Xml
+     Qt5::Sql
+     Qt5::PrintSupport
+-    Qt5::UiTools    
++    Qt5::UiTools
+     Qt5::Network
+     Qt5::WebEngineWidgets
+     Qt5::Qml
+@@ -947,7 +946,7 @@ target_link_libraries(${APPLICATION_NAME}
+     ${PROJ_LIBRARIES}
+     ${ROUTINO_LIBRARIES}
+     ${ALGLIB_LIBRARIES}
+-    ${QUAZIP_LIBRARIES}
++    QuaZip::QuaZip
+ )
+ 
+ if(APPLE)

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -27,6 +27,15 @@ mkDerivation rec {
     sha256 = "1bq7bv4p7w67172y893lvpk90d6fgdpnylynbj2kn8m2hs6khya4";
   };
 
+  patches = [
+    # Add support for Quazip 1.x.
+    (fetchpatch {
+      url = "https://github.com/nomacs/nomacs/pull/576.patch";
+      sha256 = "11ryjvd9jbb0cqagai4a6980jfq8lrcbyw2d7z9yld1f42w9kbxm";
+      stripLen = 1;
+    })
+  ];
+
   setSourceRoot = ''
     sourceRoot=$(echo */ImageLounge)
   '';

--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -34,7 +34,8 @@ in mkDerivation rec {
 
   postPatch = ''
     substituteInPlace OpenBoard.pro \
-      --replace '/usr/include/quazip' '${quazip}/include/quazip5' \
+      --replace '/usr/include/quazip' '${quazip}/include/QuaZip-Qt5-${quazip.version}/quazip' \
+      --replace '-lquazip5' '-lquazip1-qt5' \
       --replace '/usr/include/poppler' '${poppler.dev}/include/poppler'
   '';
 

--- a/pkgs/applications/misc/ideamaker/default.nix
+++ b/pkgs/applications/misc/ideamaker/default.nix
@@ -9,7 +9,7 @@
 , libcork
 , makeDesktopItem
 , qt5
-, quazip_qt4
+, quazip
 , zlib
 }:
 stdenv.mkDerivation rec {
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     libcork
     qt5.qtbase
     qt5.qtserialport
-    quazip_qt4
+    quazip
     zlib
   ];
 
@@ -73,5 +73,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ lovesegfault ];
+    broken = true;  # Segfaults on startup.
   };
 }

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     ''
       mv ts3client_linux_${arch} ts3client
       echo "patching ts3client..."
-      patchelf --replace-needed libquazip.so ${quazip}/lib/libquazip5.so ts3client
+      patchelf --replace-needed libquazip.so ${quazip}/lib/libquazip1-qt5.so ts3client
       patchelf \
         --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath ${lib.makeLibraryPath deps}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir} \

--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "quazip";
-  version = "0.9.1";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "stachenov";
     repo = pname;
     rev = "v${version}";
-    sha256 = "11icgwv2xyxhd1hm1add51xv54zwkcqkg85d1xqlgiigvbm196iq";
+    sha256 = "06srglrj6jvy5ngmidlgx03i0d5w91yhi7sf846wql00v8rvhc5h";
   };
 
   buildInputs = [ zlib qtbase ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8229,15 +8229,9 @@ in
 
   screen-message = callPackage ../tools/X11/screen-message { };
 
-  screencloud = callPackage ../applications/graphics/screencloud {
-    quazip = quazip_qt4;
-  };
+  screencloud = libsForQt5.callPackage ../applications/graphics/screencloud { };
 
   screenkey = callPackage ../applications/video/screenkey { };
-
-  quazip_qt4 = libsForQt5.quazip.override {
-    qtbase = qt4;
-  };
 
   scfbuild = python3.pkgs.callPackage ../tools/misc/scfbuild { };
 
@@ -23918,7 +23912,7 @@ in
 
   id3v2 = callPackage ../applications/audio/id3v2 { };
 
-  ideamaker = callPackage ../applications/misc/ideamaker { };
+  ideamaker = libsForQt5.callPackage ../applications/misc/ideamaker { };
 
   ifenslave = callPackage ../os-specific/linux/ifenslave { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update quazip!

Technically the upstream maintainer says that 1.x and 0.x should be packaged separately, but with only a few* fixes, all currently working* packages can be made to build with Quazip 1.x.

Obsoletes https://github.com/NixOS/nixpkgs/pull/103254.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
