### PR TITLE
spotify: upgrade dependency to ffmpeg4

### DIFF
--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, lib, stdenv, squashfsTools, xorg, alsaLib, makeWrapper, openssl, freetype
 , glib, pango, cairo, atk, gdk-pixbuf, gtk3, cups, nspr, nss, libpng, libnotify
-, libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg_3, curl, zlib, gnome3
+, libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg, curl, zlib, gnome3
 , at-spi2-atk, at-spi2-core, libpulseaudio, libdrm, mesa, libxkbcommon
 }:
 
@@ -29,7 +29,7 @@ let
     curl
     dbus
     expat
-    ffmpeg_3
+    ffmpeg
     fontconfig
     freetype
     gdk-pixbuf
@@ -127,8 +127,8 @@ stdenv.mkDerivation {
       ln -s ${nspr.out}/lib/libnspr4.so $libdir/libnspr4.so
       ln -s ${nspr.out}/lib/libplc4.so $libdir/libplc4.so
 
-      ln -s ${ffmpeg_3.out}/lib/libavcodec.so* $libdir
-      ln -s ${ffmpeg_3.out}/lib/libavformat.so* $libdir
+      ln -s ${ffmpeg.out}/lib/libavcodec.so* $libdir
+      ln -s ${ffmpeg.out}/lib/libavformat.so* $libdir
 
       rpath="$out/share/spotify:$libdir"
 


### PR DESCRIPTION
Upgrade to ffmpeg 4 from 3.

###### Motivation for this change

#120705

###### Things done

Just tested on 20.09 and required additional patch . https://hg.sr.ht/~sheenobu/config/rev/98765d83a39647270a4f6e13d6f806400558f477 : 

```
curlWithGnuTls = curl.override { gnutlsSupport = true; sslSupport = false; };
```

verification of ffmpeg link:

```

config summoner % grep spotify nixpkgs/summoner.nix
    spotifyNoFF3 = (pkgs.callPackage ./pkgs/spotify.nix) {};
   
config summoner % grep ffmpeg nixpkgs/pkgs/spotify.nix
, libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg, curl, zlib, gnome3
    ffmpeg
      ln -s ${ffmpeg.out}/lib/libavcodec.so* $libdir
      ln -s ${ffmpeg.out}/lib/libavformat.so* $libdi
      
      
config summoner % nix-env -iA nixos.spotifyNoFF3
installing 'spotify-unwrapped-1.1.55.498.gf9a83c60'
these derivations will be built:
  /nix/store/gb84qg6y7qfzx3zr8mpsq95r1jy4drx8-pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_46.snap.drv
  /nix/store/gg60kxb8pqn9q1iz397c8cw5m6nb6gs7-spotify-unwrapped-1.1.55.498.gf9a83c60.drv
these paths will be fetched (0.11 MiB download, 0.34 MiB unpacked):
  /nix/store/d9j1hbbz8d2g620dsvga9n0l1qcdniz9-squashfs-4.4
...
config summoner % whereis spotify
spotify: /nix/store/y2kx7h38wqds20raabr46j2lp8c0679s-user-environment/bin/spotify
config summoner % readlink /nix/store/y2kx7h38wqds20raabr46j2lp8c0679s-user-environment/bin/spotify
/nix/store/gjzlkc8kya32pgc47cvxdysjcn5zjkkq-spotify-unwrapped-1.1.55.498.gf9a83c60/bin/spotify
config summoner % ls -l /nix/store/gjzlkc8kya32pgc47cvxdysjcn5zjkkq-spotify-unwrapped-1.1.55.498.gf9a83c60/lib/spotify/
total 40
lrwxrwxrwx 1 root root 74 Dec 31  1969 libavcodec.so -> /nix/store/bsqw5h0wlf1d793hr2bxvls4hw4hx9yr-ffmpeg-4.3.2/lib/libavcodec.so
lrwxrwxrwx 1 root root 77 Dec 31  1969 libavcodec.so.58 -> /nix/store/bsqw5h0wlf1d793hr2bxvls4hw4hx9yr-ffmpeg-4.3.2/lib/libavcodec.so.58
lrwxrwxrwx 1 root root 84 Dec 31  1969 libavcodec.so.58.91.100 -> /nix/store/bsqw5h0wlf1d793hr2bxvls4hw4hx9yr-ffmpeg-4.3.2/lib/libavcodec.so.58.91.100
lrwxrwxrwx 1 root root 75 Dec 31  1969 libavformat.so -> /nix/store/bsqw5h0wlf1d793hr2bxvls4hw4hx9yr-ffmpeg-4.3.2/lib/libavformat.so
lrwxrwxrwx 1 root root 78 Dec 31  1969 libavformat.so.58 -> /nix/store/bsqw5h0wlf1d793hr2bxvls4hw4hx9yr-ffmpeg-4.3.2/lib/libavformat.so.58
lrwxrwxrwx 1 root root 85 Dec 31  1969 libavformat.so.58.45.100 -> /nix/store/bsqw5h0wlf1d793hr2bxvls4hw4hx9yr-ffmpeg-4.3.2/lib/libavformat.so.58.45.100
lrwxrwxrwx 1 root root 75 Dec 31  1969 libcrypto.so.1.0.0 -> /nix/store/abxvl3x7hrlmimw3ck5nx04izhb0phhg-openssl-1.1.1k/lib/libcrypto.so
lrwxrwxrwx 1 root root 69 Dec 31  1969 libnspr4.so -> /nix/store/gs4sybyk9cjbqlm27ggg2jg55irqswwj-nspr-4.28/lib/libnspr4.so
lrwxrwxrwx 1 root root 68 Dec 31  1969 libplc4.so -> /nix/store/gs4sybyk9cjbqlm27ggg2jg55irqswwj-nspr-4.28/lib/libplc4.so
lrwxrwxrwx 1 root root 72 Dec 31  1969 libssl.so.1.0.0 -> /nix/store/abxvl3x7hrlmimw3ck5nx04izhb0phhg-openssl-1.1.1k/lib/libssl.so
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
