### PR TITLE
knightos-mkrom : 1.0.3 -> 1.0.4, knightos-scas: 0.5.3 -> 0.5.5

### DIFF
--- a/pkgs/development/tools/knightos/mkrom/default.nix
+++ b/pkgs/development/tools/knightos/mkrom/default.nix
@@ -1,25 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libxslt, asciidoc }:
+{ lib, stdenv, fetchFromGitHub, libxslt, asciidoc }:
 
 stdenv.mkDerivation rec {
   pname = "mkrom";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "KnightOS";
     repo = "mkrom";
     rev = version;
-    sha256 = "0xgvanya40mdwy35j94j61hsp80dm5b440iphmr5ng3kjgchvpx2";
+    sha256 = "sha256-YFrh0tOGiM90uvU9ZWopW1+9buHDQtetuOtPDSYYaXw=";
   };
 
   strictDeps = true;
-  nativeBuildInputs = [ asciidoc cmake libxslt.bin ];
+  nativeBuildInputs = [ asciidoc libxslt.bin ];
 
-  hardeningDisable = [ "format" ];
+  installFlags = [ "DESTDIR=$(out)" ];
+  installTargets = [ "install" "install_man" ];
 
   meta = with lib; {
     homepage    = "https://knightos.org/";
     description = "Packages KnightOS distribution files into a ROM";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/development/tools/knightos/scas/default.nix
+++ b/pkgs/development/tools/knightos/scas/default.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "scas";
-
-  version = "0.5.3";
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "KnightOS";
     repo = "scas";
     rev = version;
-    sha256 = "0z6r07cl92kq860ddas5p88l990ih9cfqlzy5y4mk5hrmjzya60j";
+    sha256 = "sha256-JGQE+orVDKKJsTt8sIjPX+3yhpZkujISroQ6g19+MzU=";
   };
 
   cmakeFlags = [ "-DSCAS_LIBRARY=1" ];


### PR DESCRIPTION
###### Motivation for this change
Bump KnightOS packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
