### PR TITLE
tcpreplay: 4.3.3 -> 4.3.4

### DIFF
--- a/pkgs/tools/networking/tcpreplay/default.nix
+++ b/pkgs/tools/networking/tcpreplay/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "tcpreplay";
-  version = "4.3.3";
+  version = "4.3.4";
 
   src = fetchurl {
     url = "https://github.com/appneta/tcpreplay/releases/download/v${version}/tcpreplay-${version}.tar.gz";
-    sha256 = "1plgjm3dr9rr5q71s7paqk2wgrvkihbk2yrf9g3zaks3m750497d";
+    sha256 = "sha256-7gZTEIBsIuL9NvAU4euzMbmKfsTblY6Rw9nL2gZA2Sw=";
   };
 
   buildInputs = [ libpcap ]
@@ -27,13 +27,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A suite of utilities for editing and replaying network traffic";
-    homepage = "http://tcpreplay.appneta.com/";
-    license = with licenses; [ bsd3 gpl3 ];
+    homepage = "https://tcpreplay.appneta.com/";
+    license = with licenses; [ bsdOriginalUC gpl3Only ];
     maintainers = with maintainers; [ eleanor ];
     platforms = platforms.unix;
-    knownVulnerabilities = [
-      "CVE-2020-24265" # https://github.com/appneta/tcpreplay/issues/616
-      "CVE-2020-24266" # https://github.com/appneta/tcpreplay/issues/617
-    ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/appneta/tcpreplay/releases/tag/v4.3.4


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I did not test whether it actually works.