### PR TITLE
mujs: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mujs";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchurl {
     url = "https://mujs.com/downloads/mujs-${version}.tar.xz";
-    sha256 = "sha256-meYfyWGfHVULVjVyA7NJ2Ih9CjbffblWc1yijU/3e7A=";
+    sha256 = "sha256-cZ6IK7fZhkDvoWM4Hpto7xzjXIekIuKqQZDJ5AIlh10=";
   };
 
   buildInputs = [ readline ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://git.ghostscript.com/?p=mujs.git;a=log;h=1.1.2
The fix for the use-after-free included in this release might have a
security impact.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>24 packages built:</summary>
  <ul>
    <li>anki</li>
    <li>ankisyncd</li>
    <li>celluloid (gnome-mpv)</li>
    <li>curseradio</li>
    <li>haruna</li>
    <li>hydrus</li>
    <li>jellyfin-media-player</li>
    <li>jellyfin-mpv-shim</li>
    <li>jftui</li>
    <li>minitube</li>
    <li>mnemosyne</li>
    <li>mpc-qt</li>
    <li>mpv (mpv-with-scripts)</li>
    <li>mpv-unwrapped</li>
    <li>mpvScripts.mpris</li>
    <li>mujs</li>
    <li>plex-media-player</li>
    <li>plex-mpv-shim</li>
    <li>python38Packages.mpv</li>
    <li>python39Packages.mpv</li>
    <li>qimgv</li>
    <li>somafm-cli</li>
    <li>sublime-music</li>
    <li>ytfzf</li>
  </ul>
</details>