### PR TITLE
[WIP] rhash: fix static build

### DIFF
--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, which }:
+{ lib, stdenv, fetchFromGitHub, which
+, isStatic ? stdenv.hostPlatform.isStatic
+, fetchpatch
+}:
 
 stdenv.mkDerivation rec {
   version = "1.4.1";
@@ -11,16 +14,49 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-kmi1FtJYPBUdMfJlzEsQkTwcYB99isP3yzH1EYlk54g=";
   };
 
-  nativeBuildInputs = [ which ];
+  patches = [
+    ( fetchpatch {
+      url = "https://github.com/rhash/RHash/pull/160/commits/ff3cfb65e4d8ed64a40d61213c36f328c1e44aef.patch";
+      sha256 = "1ppir5is2nr4bvsx7d19qcd15qdscg43fr3chqzbv19z85n2yzh8";
+    })
+  ];
+
+  nativeBuildInputs = [
+    which
+  ] ++ lib.optionals isStatic [
+    # needed for ar
+    stdenv.cc.bintools.bintools
+  ];
+
+  preConfigure = ''
+    patchShebangs configure
+  '';
 
   # configure script is not autotools-based, doesn't support these options
   configurePlatforms = [ ];
+  configureFlags = lib.optionals isStatic [
+    "--enable-static"
+    "--enable-lib-static"
+    "--disable-lib-shared"
+  ];
+
+  makeFlags = lib.optionals isStatic [
+    "lib-static"
+  ];
 
   doCheck = true;
 
   checkTarget = "test-full";
 
-  installTargets = [ "install" "install-lib-shared" "install-lib-so-link" "install-lib-headers" ];
+  installTargets = [
+    "install"
+    "install-lib-headers"
+  ] ++ lib.optionals (!isStatic) [
+    "install-lib-so-link"
+    "install-lib-shared"
+  ] ++ lib.optionals isStatic [
+    "install-lib-static"
+  ];
 
   meta = with lib; {
     homepage = "http://rhash.sourceforge.net/";

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -140,4 +140,9 @@ in {
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
   };
+
+  rhash = super.rhash.overrideAttrs (o: {
+    configureFlags = removeUnknownConfigureFlags o.configureFlags;
+  });
+
 }


### PR DESCRIPTION
###### Motivation for this change
Trying to get `pkgsStatic.cmake` to work. Probably not totally necessary for actual builds, since `nativeBuildInputs = [ cmake ];` seems to pull in the non-static version. But thought it would just be a good exercise to see if I could get it to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
