### PR TITLE
oathToolkit: 2.6.6 -> 2.6.7

### DIFF
--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -7,14 +7,16 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "oath-toolkit";
-  version = "2.6.6";
+  version = "2.6.7";
 
   src = fetchurl {
     url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "0v4lrgip08b8xlivsfn3mwql3nv8hmcpzrn6pi3xp88vqwav6s7x";
+    sha256 = "1aa620k05lsw3l3slkp2mzma40q3p9wginspn9zk8digiz7dzv9n";
   };
 
   buildInputs = [ securityDependency ];
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Components for building one-time password authentication systems";

--- a/pkgs/tools/security/oath-toolkit/update.sh
+++ b/pkgs/tools/security/oath-toolkit/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl git gnugrep nix
+
+set -euo pipefail
+
+nixfile='default.nix'
+release_url='https://download.savannah.nongnu.org/releases/oath-toolkit/'
+attr='oathToolkit'
+command='oathtool --version'
+
+color() {
+    printf '%s: \033[%sm%s\033[39m\n' "$0" "$1" "$2" >&2 || true
+}
+
+color 32 "downloading $release_url..."
+if ! release_page=$(curl -Lf "$release_url"); then
+    color 31 "cannot download release page"
+    exit 1
+fi
+
+tarball_name=$(printf '%s\n' "$release_page" \
+    | grep -Po '(?<=href=").*?\.tar\.gz(?=")' \
+    | sort -n | tail -n1)
+tarball_version="${tarball_name%.tar.*}"
+tarball_version="${tarball_version##*-}"
+tarball_url="mirror://savannah${release_url#https://*/releases}$tarball_name"
+
+color 32 "nix-prefetch-url $tarball_url..."
+if ! tarball_sha256=$(nix-prefetch-url --type sha256 "$tarball_url"); then
+    color 31 "cannot prefetch $tarball_url"
+    exit 1
+fi
+
+old_version=$(grep -Pom1 '(?<=version = ").*?(?=";)' "$nixfile")
+
+version=$(printf 'version = "%s";\n' "$tarball_version")
+sha256=$(printf 'sha256 = "%s";\n' "$tarball_sha256")
+sed -e "s,version = .*,$version," -e "s,sha256 = .*,$sha256," -i "$nixfile"
+
+if git diff --exit-code "$nixfile" > /dev/stderr; then
+    printf '\n' >&2 || true
+    color 32 "$tarball_version is up to date"
+else
+    color 32 "running '$command' with nix-shell..."
+    nix-shell -p "callPackage ./$nixfile {}" --run "$command"
+    msg="$attr: $old_version -> $tarball_version"
+    printf '\n' >&2 || true
+    color 31 "$msg"
+    git commit -m "$msg" "$nixfile"
+fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Added update script.

###### Motivation for this change

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
