### PR TITLE
clementine: fetchpatch to fix execution on wayland; some cleanup

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -34,6 +34,15 @@
 , config
 , makeWrapper
 , gst_plugins
+
+, util-linux
+, libunwind
+, libselinux
+, elfutils
+, libsepol
+, orc
+
+, alsaLib
 }:
 
 let
@@ -66,6 +75,13 @@ let
     cmake
     pkg-config
     makeWrapper
+
+    util-linux
+    libunwind
+    libselinux
+    elfutils
+    libsepol
+    orc
   ];
 
   buildInputs = [
@@ -90,6 +106,8 @@ let
     qttools
     sqlite
     taglib
+
+    alsaLib
   ]
   ++ lib.optionals (withIpod) [ libgpod libplist usbmuxd ]
   ++ lib.optionals (withMTP) [ libmtp ]

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -1,8 +1,40 @@
-{ lib, mkDerivation, fetchFromGitHub, fetchpatch, boost, cmake, chromaprint, gettext, gst_all_1, liblastfm
-, qtbase, qtx11extras, qttools
-, taglib, fftw, glew, qjson, sqlite, libgpod, libplist, usbmuxd, libmtp
-, libpulseaudio, gvfs, libcdio, libechonest, libspotify, pcre, projectm, protobuf
-, qca2, pkg-config, sparsehash, config, makeWrapper, gst_plugins }:
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchpatch
+, boost
+, cmake
+, chromaprint
+, gettext
+, gst_all_1
+, liblastfm
+, qtbase
+, qtx11extras
+, qttools
+, taglib
+, fftw
+, glew
+, qjson
+, sqlite
+, libgpod
+, libplist
+, usbmuxd
+, libmtp
+, libpulseaudio
+, gvfs
+, libcdio
+, libechonest
+, libspotify
+, pcre
+, projectm
+, protobuf
+, qca2
+, pkg-config
+, sparsehash
+, config
+, makeWrapper
+, gst_plugins
+}:
 
 let
   withIpod = config.clementine.ipod or false;
@@ -30,7 +62,11 @@ let
     })
   ];
 
-  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
 
   buildInputs = [
     boost
@@ -55,10 +91,10 @@ let
     sqlite
     taglib
   ]
-  ++ lib.optionals (withIpod) [libgpod libplist usbmuxd]
-  ++ lib.optionals (withMTP) [libmtp]
-  ++ lib.optionals (withCD) [libcdio]
-  ++ lib.optionals (withCloud) [sparsehash];
+  ++ lib.optionals (withIpod) [ libgpod libplist usbmuxd ]
+  ++ lib.optionals (withMTP) [ libmtp ]
+  ++ lib.optionals (withCD) [ libcdio ]
+  ++ lib.optionals (withCloud) [ sparsehash ];
 
   postPatch = ''
     sed -i src/CMakeLists.txt \
@@ -138,4 +174,5 @@ let
     };
   };
 
-in free
+in
+free

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -22,6 +22,12 @@ let
 
   patches = [
     ./clementine-spotify-blob.patch
+    (fetchpatch {
+      # "short-term" fix for execution on wayland (1.4.0rc1-131-g2179027a6)
+      # for https://github.com/clementine-player/Clementine/issues/6587
+      url = "https://github.com/clementine-player/Clementine/commit/2179027a6d97530c857e43be873baacd696ff332.patch";
+      sha256 = "0344bfcyvjim5ph8w4km6zkg96rj5g9ybp9x14qgyw2gkdksimn6";
+    })
   ];
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
wanted to try out `clementine`, it segfaulted at startup

###### Things done
`nix-update clementine --version=unstable --commit`
`nixpkgs-fmt`
add some dependencies the config phase noted as not found ¯\\\_(ツ)\_/¯

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/6py3kv649fdyx2i11qn6vj9pjf4xfq04-clementine-free-1.4.0rc1    915311856`
  - `/nix/store/yawqv0bl36q6scnn0sx23lxd6x2fvhhv-clementine-free-1.4.0rc1    915321680`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
