### PR TITLE
citrix_workspace: fix build / add mesa dependency

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, requireFile, makeWrapper, autoPatchelfHook, wrapGAppsHook, which, more
 , file, atk, alsaLib, cairo, fontconfig, gdk-pixbuf, glib, gnome3, gtk2-x11, gtk3
 , heimdal, krb5, libsoup, libvorbis, speex, openssl, zlib, xorg, pango, gtk2
-, gnome2, nss, nspr, gtk_engines, freetype, dconf, libpng12, libxml2
+, gnome2, mesa, nss, nspr, gtk_engines, freetype, dconf, libpng12, libxml2
 , libjpeg, libredirect, tzdata, cacert, systemd, libcxxabi, libcxx, e2fsprogs, symlinkJoin
 , libpulseaudio, pcsclite
 
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
     libsoup
     libvorbis
     libxml2
+    mesa
     nspr
     nss
     openssl'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A recent change in nixpkgs has made several binary packages break because they are now unable to find libraries from mesa.

```
       > autoPatchelfHook could not satisfy dependency libdrm.so.2 wanted by /nix/store/9zdaircmn2pin0918xr220rwvmvjzgnx-citrix-workspace-21.3.0.38/opt/citrix-icaclient/cef/libcef.so
       > autoPatchelfHook could not satisfy dependency libgbm.so.1 wanted by /nix/store/9zdaircmn2pin0918xr220rwvmvjzgnx-citrix-workspace-21.3.0.38/opt/citrix-icaclient/cef/libcef.so
       > Add the missing dependencies to the build inputs or set autoPatchelfIgnoreMissingDeps=true
       For full logs, run 'nix log /nix/store/9asvd7b0acw7fksap12q6hkgpyahvlsj-citrix-workspace-21.3.0.38.drv'.
```

This PR just fixes the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
