### PR TITLE
man-pages-posix: use version format as repology

### DIFF
--- a/pkgs/data/documentation/man-pages-posix/default.nix
+++ b/pkgs/data/documentation/man-pages-posix/default.nix
@@ -1,11 +1,16 @@
 {lib, stdenv, fetchurl}:
 
+let
+  year = "2017";
+  minor = "a";
+in
+
 stdenv.mkDerivation rec {
   pname = "man-pages-posix";
-  version = "2017-a";
+  version = "${year}${minor}";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/docs/man-pages/man-pages-posix/${pname}-${version}.tar.xz";
+    url = "mirror://kernel/linux/docs/man-pages/man-pages-posix/${pname}-${year}-${minor}.tar.xz";
     sha256 = "ce67bb25b5048b20dad772e405a83f4bc70faf051afa289361c81f9660318bc3";
   };
 


### PR DESCRIPTION
repology considers 2017a, not 2017-a as current since all other
distributions seem to use that versioning scheme.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
