### PR TITLE
CODEOWNERS: Haskell files. Add maralorn, declutter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,12 +79,9 @@
 /pkgs/development/tools/poetry2nix @adisbladis
 
 # Haskell
-/pkgs/development/compilers/ghc                       @cdepillabout @sternenseemann
-/pkgs/development/haskell-modules		      @cdepillabout @sternenseemann
-/pkgs/development/haskell-modules/default.nix	      @cdepillabout @sternenseemann
-/pkgs/development/haskell-modules/generic-builder.nix @cdepillabout @sternenseemann
-/pkgs/development/haskell-modules/hoogle.nix	      @cdepillabout @sternenseemann
-/pkgs/test/haskell	@cdepillabout @sternenseemann
+/pkgs/development/compilers/ghc    @cdepillabout @sternenseemann @maralorn
+/pkgs/development/haskell-modules  @cdepillabout @sternenseemann @maralorn
+/pkgs/test/haskell                 @cdepillabout @sternenseemann @maralorn
 
 # Perl
 /pkgs/development/interpreters/perl @volth @stigtsp


### PR DESCRIPTION
I would like to be notified, too.

Also I think some of those lines were redundant and unnecessary.

We can‘t just put the @.Haskell team in there because we don‘t want to bother peti.
