### PR TITLE
github/workflows/editorconfig: add check for nixpkgs-fmt

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         echo 'PR_DIFF<<EOF' >> $GITHUB_ENV
         gh api \
-          repos/NixOS/nixpkgs/pulls/${{github.event.number}}/files --paginate \
+          repos/${{github.repository}}/pulls/${{github.event.number}}/files --paginate \
           | jq '.[] | select(.status != "removed") | .filename' \
           >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -53,7 +53,7 @@ jobs:
         echo "$PR_DIFF" | jq '.' -r | grep '.nix' | xargs -rd '\n' -- nixpkgs-fmt --check
     - if: steps.nixpkgs-fmt.outcome == 'failure'
       run: |
-        echo "::error :: Hey! It looks like your changes don't agree with nixpkgs-fmt."
+        echo "::error :: Hey! It looks like your changes don't follow nixpkgs-fmt. Run nixpkgs-fmt on all .nix files to fix this check."
     - if: steps.nixpkgs-fmt.outcome == 'failure' || steps.editorconfig.outcome == 'failure'
       run: |
         exit 1

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -1,4 +1,4 @@
-name: "Checking EditorConfig"
+name: "Checking EditorConfig and nixpkgs-fmt"
 
 permissions: read-all
 
@@ -33,14 +33,27 @@ jobs:
       with:
         # nixpkgs commit is pinned so that it doesn't break
         nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/f93ecc4f6bc60414d8b73dbdf615ceb6a2c604df.tar.gz
-    - name: install editorconfig-checker
-      run: nix-env -iA editorconfig-checker -f '<nixpkgs>'
+    - name: install editorconfig-checker and nixpkgs-fmt
+      run: nix-env -iA editorconfig-checker -A nixpkgs-fmt -f '<nixpkgs>'
       if: env.PR_DIFF
     - name: Checking EditorConfig
+      id: editorconfig
+      continue-on-error: true
       if: env.PR_DIFF
       run: |
         echo "$PR_DIFF" | xargs editorconfig-checker -disable-indent-size
-    - if: ${{ failure() }}
+    - if: steps.editorconfig.outcome == 'failure'
       run: |
         echo "::error :: Hey! It looks like your changes don't follow our editorconfig settings. Read https://editorconfig.org/#download to configure your editor so you never see this error again."
-
+    - name: Checking nixpkgs-fmt
+      id: nixpkgs-fmt
+      continue-on-error: true
+      if: env.PR_DIFF
+      run: |
+        echo "$PR_DIFF" | jq '.' -r | grep '.nix' | xargs -rd '\n' -- nixpkgs-fmt --check
+    - if: steps.nixpkgs-fmt.outcome == 'failure'
+      run: |
+        echo "::error :: Hey! It looks like your changes don't agree with nixpkgs-fmt."
+    - if: steps.nixpkgs-fmt.outcome == 'failure' || steps.editorconfig.outcome == 'failure'
+      run: |
+        exit 1


### PR DESCRIPTION
**DO NOT MERGE**

This should be held off until nixpkgs has been globally formatted with nixpkgs-fmt (#121490)

Adds a check for nixpkgs-fmt, which seems destined to become the new game in town when it comes to formatting nixpkgs.

Example PRs on my own fork:

* Failing editorconfig: https://github.com/Synthetica9/nixpkgs/pull/6
* Failing nixpkgs-fmt: https://github.com/Synthetica9/nixpkgs/pull/7
* Passing both: https://github.com/Synthetica9/nixpkgs/pull/8

cc @domenkozar 

Related: #120832 #121490 #121379 