### PR TITLE
grub: build PVH variant of Grub2 for Xen

### DIFF
--- a/pkgs/tools/misc/grub/pvhgrub_image/configs/grub-bootstrap.cfg
+++ b/pkgs/tools/misc/grub/pvhgrub_image/configs/grub-bootstrap.cfg
@@ -1,0 +1,1 @@
+normal (memdisk)/grub.cfg

--- a/pkgs/tools/misc/grub/pvhgrub_image/configs/grub.cfg
+++ b/pkgs/tools/misc/grub/pvhgrub_image/configs/grub.cfg
@@ -1,0 +1,10 @@
+# The parentheses around ${root} here to match Grub's config file syntax
+if search -s -f /boot/grub/grub.cfg ; then
+        echo "Reading (${root})/boot/grub/grub.cfg"
+	configfile /boot/grub/grub.cfg
+fi
+
+if search -s -f /grub/grub.cfg ; then
+	echo "Reading (${root})/grub/grub.cfg"
+	configfile /grub/grub.cfg
+fi

--- a/pkgs/tools/misc/grub/pvhgrub_image/default.nix
+++ b/pkgs/tools/misc/grub/pvhgrub_image/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, grub2_xen_pvh }:
+
+with lib;
+let
+  targets = {
+    i686-linux.target = "i386";
+    x86_64-linux.target = "i386"; # Xen PVH is only i386 on x86.
+    aarch64-linux.target = "aarch64";
+  };
+
+in (
+
+stdenv.mkDerivation rec {
+  name = "pvhgrub-image";
+
+  configs = ./configs;
+
+  buildInputs = [ grub2_xen_pvh ];
+
+  buildCommand = ''
+    cp "${configs}"/* .
+    tar -cf memdisk.tar grub.cfg
+    # We include all modules except all_video.mod as otherwise grub will fail printing "no symbol table"
+    # if we include it.
+    grub-mkimage -O "${targets.${stdenv.hostPlatform.system}.target}-xen_pvh" -c grub-bootstrap.cfg \
+      -m memdisk.tar -o "grub-${targets.${stdenv.hostPlatform.system}.target}-xen_pvh.bin" \
+      $(ls "${grub2_xen_pvh}/lib/grub/${targets.${stdenv.hostPlatform.system}.target}-xen_pvh/" |grep 'mod''$'|grep -v '^all_video\.mod''$')
+    mkdir -p "$out/lib/grub-xen_pvh"
+    cp "grub-${targets.${stdenv.hostPlatform.system}.target}-xen_pvh.bin" $out/lib/grub-xen_pvh/
+  '';
+
+  meta = with lib; {
+    description = "PVH Grub image for use for booting PVH Xen guests";
+
+    longDescription =
+      '' This package provides a PVH Grub image for booting HVM-based Para-Virtualized (PVH)
+         Xen guests
+      '';
+
+    platforms = platforms.gnu ++ platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5281,6 +5281,12 @@ in
 
   grub2_pvgrub_image = callPackage ../tools/misc/grub/pvgrub_image { };
 
+  grub2_xen_pvh = grub2_full.override {
+    xenPvhSupport = true;
+  };
+
+  grub2_pvhgrub_image = callPackage ../tools/misc/grub/pvhgrub_image { };
+
   grub4dos = callPackage ../tools/misc/grub4dos {
     stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
###### Motivation for this change

Needed to boot PVH guests, which a more modern Xen is capable to do (see related PR #121513 that bumps Xen to 4.15).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Manual tests:
- [x] Booted a PVH guest under x86_64 Xen 4.15
- [ ] Anything under arm64
- [ ] Anything under i386