### PR TITLE
nixos/nftables: Allow use with iptables

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -15,19 +15,14 @@ in
           Whether to enable nftables.  nftables is a Linux-based packet
           filtering framework intended to replace frameworks like iptables.
 
-          This conflicts with the standard networking firewall, so make sure to
-          disable it before using nftables.
+          If you use both the standard networking firewall and nftables,
+          you may have conflicting rules. Please see [1] for more information
+          on how iptables and nftables interact with each other.
+          
+          Be aware that some applications (in particular, Docker and libvirt)
+          will load iptables themselves if it not already loaded.
 
-          Note that if you have Docker enabled you will not be able to use
-          nftables without intervention. Docker uses iptables internally to
-          setup NAT for containers. This module disables the ip_tables kernel
-          module, however Docker automatically loads the module. Please see [1]
-          for more information.
-
-          There are other programs that use iptables internally too, such as
-          libvirt.
-
-          [1]: https://github.com/NixOS/nixpkgs/issues/24318#issuecomment-289216273
+          [1]: https://wiki.nftables.org/wiki-nftables/index.php/Troubleshooting#Question_4._How_do_nftables_and_iptables_interact_when_used_on_the_same_system.3F
         '';
     };
     networking.nftables.ruleset = mkOption {
@@ -97,11 +92,6 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    assertions = [{
-      assertion = config.networking.firewall.enable == false;
-      message = "You can not use nftables and iptables at the same time. networking.firewall.enable must be set to false.";
-    }];
-    boot.blacklistedKernelModules = [ "ip_tables" ];
     environment.systemPackages = [ pkgs.nftables ];
     systemd.services.nftables = {
       description = "nftables firewall";
@@ -115,20 +105,11 @@ in
           flush ruleset
           include "${cfg.rulesetFile}"
         '';
-        checkScript = pkgs.writeScript "nftables-check" ''
-          #! ${pkgs.runtimeShell} -e
-          if $(${pkgs.kmod}/bin/lsmod | grep -q ip_tables); then
-            echo "Unload ip_tables before using nftables!" 1>&2
-            exit 1
-          else
-            ${rulesScript}
-          fi
-        '';
       in {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = checkScript;
-        ExecReload = checkScript;
+        ExecStart = rulesScript;
+        ExecReload = rulesScript;
         ExecStop = "${pkgs.nftables}/bin/nft flush ruleset";
       };
     };

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -14,15 +14,21 @@ in
         ''
           Whether to enable nftables.  nftables is a Linux-based packet
           filtering framework intended to replace frameworks like iptables.
+          
+          This conflicts with the standard networking firewall, so make sure to
+          disable it before using nftables.
 
-          If you use both the standard networking firewall and nftables,
-          you may have conflicting rules. Please see [1] for more information
-          on how iptables and nftables interact with each other.
-
-          Be aware that some applications (in particular, Docker and libvirt)
-          will load iptables themselves if it not already loaded.
-
-          [1]: https://wiki.nftables.org/wiki-nftables/index.php/Troubleshooting#Question_4._How_do_nftables_and_iptables_interact_when_used_on_the_same_system.3F
+          Note that if you have Docker enabled you will not be able to use
+          nftables without intervention. Docker uses iptables internally to
+          setup NAT for containers. This module disables the ip_tables kernel
+          module, however Docker automatically loads the module. Please see [1]
+          for more information.
+          
+          There are other programs that use iptables internally too, such as
+          libvirt. For information on how the two firewalls interact, see [2].
+          
+          [1]: https://github.com/NixOS/nixpkgs/issues/24318#issuecomment-289216273
+          [2]: https://wiki.nftables.org/wiki-nftables/index.php/Troubleshooting#Question_4._How_do_nftables_and_iptables_interact_when_used_on_the_same_system.3F
         '';
     };
     networking.nftables.ruleset = mkOption {
@@ -92,6 +98,11 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
+    assertions = [{
+      assertion = config.networking.firewall.enable == false;
+      message = "You can not use nftables and iptables at the same time. networking.firewall.enable must be set to false.";
+    }];
+    boot.blacklistedKernelModules = [ "ip_tables" ];
     environment.systemPackages = [ pkgs.nftables ];
     systemd.services.nftables = {
       description = "nftables firewall";

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -14,7 +14,7 @@ in
         ''
           Whether to enable nftables.  nftables is a Linux-based packet
           filtering framework intended to replace frameworks like iptables.
-          
+
           This conflicts with the standard networking firewall, so make sure to
           disable it before using nftables.
 
@@ -23,10 +23,10 @@ in
           setup NAT for containers. This module disables the ip_tables kernel
           module, however Docker automatically loads the module. Please see [1]
           for more information.
-          
+
           There are other programs that use iptables internally too, such as
           libvirt. For information on how the two firewalls interact, see [2].
-          
+
           [1]: https://github.com/NixOS/nixpkgs/issues/24318#issuecomment-289216273
           [2]: https://wiki.nftables.org/wiki-nftables/index.php/Troubleshooting#Question_4._How_do_nftables_and_iptables_interact_when_used_on_the_same_system.3F
         '';

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -18,7 +18,7 @@ in
           If you use both the standard networking firewall and nftables,
           you may have conflicting rules. Please see [1] for more information
           on how iptables and nftables interact with each other.
-          
+
           Be aware that some applications (in particular, Docker and libvirt)
           will load iptables themselves if it not already loaded.
 


### PR DESCRIPTION
This pull request removes the checkScript portion of the nftables module (which currently prevents nftables from being used together with iptables) and updates the relevant documentation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Since iptables and nftables do not actually conflict with each other, there's no real reason to artificially prevent people from combining them. What happens if you combine the two is [well-defined](https://wiki.nftables.org/wiki-nftables/index.php/Troubleshooting#Question_4._How_do_nftables_and_iptables_interact_when_used_on_the_same_system.3F).

The current "prevent nftables from being used with iptables" policy causes issues like #88643.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
