### PR TITLE
kernel/generic: add kernelTests automatically

### DIFF
--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -9,7 +9,7 @@ let
   testsForLinuxPackages = linuxPackages: (import ./make-test-python.nix ({ pkgs, ... }: {
     name = "kernel-${linuxPackages.kernel.version}";
     meta = with pkgs.lib.maintainers; {
-      maintainers = [ nequissimus ];
+      maintainers = [ nequissimus atemu ];
     };
 
     machine = { ... }:

--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -6,7 +6,7 @@
 with pkgs.lib;
 
 let
-  makeKernelTest = linuxPackages: (import ./make-test-python.nix ({ pkgs, ... }: {
+  testsForLinuxPackages = linuxPackages: (import ./make-test-python.nix ({ pkgs, ... }: {
     name = "kernel-${linuxPackages.kernel.version}";
     meta = with pkgs.lib.maintainers; {
       maintainers = [ nequissimus ];
@@ -41,4 +41,8 @@ let
       linuxPackages_testing;
   };
 
-in mapAttrs (_: kernel: makeKernelTest kernel) kernels
+in mapAttrs (_: lP: testsForLinuxPackages lP) kernels // {
+  inherit testsForLinuxPackages;
+
+  testsForKernel = kernel: testsForLinuxPackages (pkgs.linuxPackagesFor kernel);
+}

--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -6,8 +6,8 @@
 with pkgs.lib;
 
 let
-  makeKernelTest = version: linuxPackages: (import ./make-test-python.nix ({ pkgs, ... }: {
-    name = "kernel-${version}";
+  makeKernelTest = linuxPackages: (import ./make-test-python.nix ({ pkgs, ... }: {
+    name = "kernel-${linuxPackages.kernel.version}";
     meta = with pkgs.lib.maintainers; {
       maintainers = [ nequissimus ];
     };
@@ -23,20 +23,22 @@ let
         assert "${linuxPackages.kernel.modDirVersion}" in machine.succeed("uname -a")
       '';
   }) args);
-in
-with pkgs; {
-  linux_4_4 = makeKernelTest "4.4" linuxPackages_4_4;
-  linux_4_9 = makeKernelTest "4.9" linuxPackages_4_9;
-  linux_4_14 = makeKernelTest "4.14" linuxPackages_4_14;
-  linux_4_19 = makeKernelTest "4.19" linuxPackages_4_19;
-  linux_5_4 = makeKernelTest "5.4" linuxPackages_5_4;
-  linux_5_10 = makeKernelTest "5.10" linuxPackages_5_10;
-  linux_5_13 = makeKernelTest "5.13" linuxPackages_5_13;
+  kernels = {
+    inherit (pkgs)
+      linuxPackages_4_4
+      linuxPackages_4_9
+      linuxPackages_4_14
+      linuxPackages_4_19
+      linuxPackages_5_4
+      linuxPackages_5_10
+      linuxPackages_5_13
 
-  linux_hardened_4_14 = makeKernelTest "4.14" linuxPackages_4_14_hardened;
-  linux_hardened_4_19 = makeKernelTest "4.19" linuxPackages_4_19_hardened;
-  linux_hardened_5_4 = makeKernelTest "5.4" linuxPackages_5_4_hardened;
-  linux_hardened_5_10 = makeKernelTest "5.10" linuxPackages_5_10_hardened;
+      linuxPackages_4_14_hardened
+      linuxPackages_4_19_hardened
+      linuxPackages_5_4_hardened
+      linuxPackages_5_10_hardened
 
-  linux_testing = makeKernelTest "testing" linuxPackages_testing;
-}
+      linuxPackages_testing;
+  };
+
+in mapAttrs (_: kernel: makeKernelTest kernel) kernels

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -58,6 +58,7 @@
 , preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false
 , kernelArch ? stdenv.hostPlatform.linuxArch
 , kernelTests ? []
+, nixosTests
 , ...
 }:
 
@@ -192,7 +193,16 @@ let
     kernelOlder = lib.versionOlder version;
     kernelAtLeast = lib.versionAtLeast version;
     passthru = kernel.passthru // (removeAttrs passthru [ "passthru" ]);
-    tests = kernelTests;
+    tests = let
+      overridableKernel = finalKernel // {
+        override = args:
+          lib.warn (
+            "override is stubbed for NixOS kernel tests, not applying changes these arguments: "
+            + toString (lib.attrNames (if lib.isAttrs args then args else args {}))
+          ) overridableKernel;
+      };
+    in [ (nixosTests.kernel-generic.testsForKernel overridableKernel) ] ++ kernelTests;
   };
 
-in lib.extendDerivation true passthru kernel
+  finalKernel = lib.extendDerivation true passthru kernel;
+in finalKernel

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -15,6 +15,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "0wdk93qv91pa6bd3ff1gv7manhkzh190c5blcpl14cbh9m2ms8vz";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_14 ];
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19.nix
@@ -15,6 +15,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "09ya7n0il8fipp8ksb8cyl894ihny2r75g70vbhclbv20q2pv0pj";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_19 ];
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -9,6 +9,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "12grr2vc2mcvy7k8w1apqs9mhfg0lvz6mrpksym234m4n5yy48ng";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_4 ];
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -9,6 +9,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
     sha256 = "0am9qg9j18j4fc5zi6bk1g0mi8dp31pl62wlihxhhkc5yspzrna3";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_9 ];
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.10.nix
@@ -15,6 +15,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
     sha256 = "0b8lwfjlyd6j0csk71v07bxb5lrrzp545g1wv6kdk0kzq6maxfq0";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_5_10 ];
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.13.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.13.nix
@@ -15,6 +15,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
     sha256 = "0za59652wrh4mlhd9w3dx4y1nnk8nrj9hb56pssgdckdvp7rp4l0";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_5_13 ];
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4.nix
@@ -15,6 +15,4 @@ buildLinux (args // rec {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
     sha256 = "0zx3hj8fc0qpdmkn56cna5438wjxmj42a69msbkxlg4mnz6d0w84";
   };
-
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_5_4 ];
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -14,8 +14,6 @@ buildLinux (args // rec {
     sha256 = "sha256-PunFd6tOsmrsPItp2QX4TEVxHnvvi1BMSwWio/DTlMU=";
   };
 
-  kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_testing ];
-
   # Should the testing kernels ever be built on Hydra?
   extraMeta.hydraPlatforms = [];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tests for different kernels had to be added manually and many didn't have that done. Now, they're simply generated automatically. 

I didn't build all tests again but the couple I did run were the same drv as before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
