### PR TITLE
xcolor: init at unstable-2021-02-02

### DIFF
--- a/pkgs/tools/graphics/xcolor/default.nix
+++ b/pkgs/tools/graphics/xcolor/default.nix
@@ -1,0 +1,26 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, libX11, libXcursor, libxcb, python3 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "xcolor";
+  version = "unstable-2021-02-02";
+
+  src = fetchFromGitHub {
+    owner = "Soft";
+    repo = pname;
+    rev = "0e99e67cd37000bf563aa1e89faae796ec25f163";
+    sha256 = "sha256-rHqK05dN5lrvDNbRCWGghI7KJwWzNCuRDEThEeMzmio=";
+  };
+
+  cargoSha256 = "sha256-lHOT/P1Sh1b53EkPIQM3l9Tozdqh60qlUDdjthj32jM=";
+
+  nativeBuildInputs = [ pkg-config python3 ];
+
+  buildInputs = [ libX11 libXcursor libxcb ];
+
+  meta = with lib; {
+    description = "Lightweight color picker for X11";
+    homepage = "https://github.com/Soft/xcolor";
+    maintainers = with lib.maintainers; [ fortuneteller2k ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31252,5 +31252,7 @@ in
 
   lc3tools = callPackage ../development/tools/lc3tools {};
 
+  xcolor = callPackage ../tools/graphics/xcolor { };
+
   zktree = callPackage ../applications/misc/zktree {};
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
