### PR TITLE
python-language-server: 2020-06-19 -> 2020-10-08

### DIFF
--- a/pkgs/development/dotnet-modules/python-language-server/create_deps.sh
+++ b/pkgs/development/dotnet-modules/python-language-server/create_deps.sh
@@ -4,6 +4,8 @@
 # Run this script to generate deps.nix
 # ./create_deps.sh /path/to/microsoft/python/language/server/source/checkout
 
+set -euo pipefail
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [ -d "$1" ]; then
@@ -14,13 +16,13 @@ else
 fi
 
 # Generate lockfiles in source checkout
-cd $CHECKOUT_PATH/src
+cd "$CHECKOUT_PATH/src"
 dotnet nuget locals all --clear
 dotnet restore -v normal --no-cache PLS.sln --use-lock-file -r linux-x64
 
 # Use the lockfiles to make a file with two columns: name and version number
 # for all possible package dependencies
-cd $SCRIPTDIR
+cd "$SCRIPTDIR"
 echo "" > all_versions.txt
 for lockfile in $(find "$CHECKOUT_PATH" -name packages.lock.json); do
     echo "Processing lockfile $lockfile"

--- a/pkgs/development/dotnet-modules/python-language-server/default.nix
+++ b/pkgs/development/dotnet-modules/python-language-server/default.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation {
   ];
 
   buildPhase = ''
+    runHook preBuild
+
     mkdir home
     export HOME=$(mktemp -d)
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -75,14 +77,20 @@ stdenv.mkDerivation {
     pushd src/LanguageServer/Impl
     dotnet publish --no-restore -c Release -r linux-x64
     popd
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out
     cp -r output/bin/Release/linux-x64/publish $out/lib
 
     mkdir $out/bin
     makeWrapper $out/lib/Microsoft.Python.LanguageServer $out/bin/python-language-server
+
+    runHook postInstall
   '';
 
   postFixup = ''

--- a/pkgs/development/dotnet-modules/python-language-server/default.nix
+++ b/pkgs/development/dotnet-modules/python-language-server/default.nix
@@ -11,7 +11,7 @@
 
 let deps = import ./deps.nix { inherit fetchurl; };
 
-    version = "2020-06-19";
+    version = "2020-10-08";
 
     # Build the nuget source needed for the later build all by itself
     # since it's a time-consuming step that only depends on ./deps.nix.
@@ -49,8 +49,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "python-language-server";
-    rev = "838ba78e00173d639bd90f54d8610ec16b4ba3a2";
-    sha256 = "0nj8l1apcb67gqwy5i49v0f01fs4lvdfmmp4w2hvrpss9if62c1m";
+    rev = "76a29da373a4bb1e81b052f25802f3ca872d0a67";
+    sha256 = "16jb90lacdrhi4dpp084bqzx351mv23f4mhl4lz5h6rkfzj5jxgg";
   };
 
   buildInputs = [dotnet-sdk_3 openssl icu];

--- a/pkgs/development/dotnet-modules/python-language-server/deps.nix
+++ b/pkgs/development/dotnet-modules/python-language-server/deps.nix
@@ -47,36 +47,6 @@ in [
   })
 
   (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Ref";
-    version = "3.0.1";
-    sha256 = "0k2ry757qhm99xwm0wh4zalxn9nmxhfswd184z1fjr42szr511fb";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.0.2";
-    sha256 = "0d4r744n3bk4v7ddfjpy5ils150h0693bil3c7v27n84037hqndj";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.0.3";
-    sha256 = "1jcqy8i9fzb1pmkazi80yqr09zi5nk30n57i46ggr5ky45jngfq9";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "19wfh9yg4n2khbl7pvf6ngx95m5p8lw4l9y935pv7nh4xgwk02p9";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "3.1.3";
-    sha256 = "0kvnzb9xjii48kg30ac63qdf0fn1y8j3nblbrfaqv2aiy6kp0iwn";
-  })
-
-  (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
     version = "3.1.8";
     sha256 = "140zr3nwkmf6xc52gq4iz6ycyh95fxy0jpgn637pkd9z423z8135";
@@ -104,60 +74,6 @@ in [
     name = "Microsoft.Extensions.FileSystemGlobbing";
     version = "3.1.8";
     sha256 = "1v2lr0vbssqayzgxvdwb54jmvz7mvlih4l9h7i71gm3c62nlbq8y";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Host.linux-x64";
-    version = "3.0.2";
-    sha256 = "0y14y2x3wbi44i23ndmf4323cii8wrqw9s289gcab3s393l71sf5";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Host.linux-x64";
-    version = "3.0.3";
-    sha256 = "19igfvwsjzwkh90gqzabl6pdkyygslj2iwpsxg680phffzr411w4";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Host.linux-x64";
-    version = "3.1.3";
-    sha256 = "013ibnhsimgqj5l2dqma035xvsvrb47bn65z6xbxgg88383hpgvw";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Ref";
-    version = "3.0.0";
-    sha256 = "1qi382157ln7yngazvr3nskpjkab4x8sqx11l13xyg56vyyjyyiw";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Ref";
-    version = "3.1.0";
-    sha256 = "08svsiilx9spvjamcnjswv0dlpdrgryhr3asdz7cvnl914gjzq4y";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.0.2";
-    sha256 = "1h6d0nl495k0bh4my43l578l7m8qwah7ll42aax7jrib2py354f1";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.0.3";
-    sha256 = "1ykgfnphbkyck0gqbbh5n96w59z2bq47g896ygal1j4nblj3s44v";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.1.2";
-    sha256 = "0a332ia5pabnz7mdfc99a5hlc7drnwzlc7cj9b5c3an6dq636p66";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.NetCore.App.Runtime.linux-x64";
-    version = "3.1.3";
-    sha256 = "1ynhzsr8a0hfby2wjhzkdiimj18izgfzp7m2yp3pby2iwb4v3xy9";
   })
 
   (fetchNuGet {

--- a/pkgs/development/dotnet-modules/python-language-server/deps.nix
+++ b/pkgs/development/dotnet-modules/python-language-server/deps.nix
@@ -54,8 +54,26 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
+    version = "3.0.2";
+    sha256 = "0d4r744n3bk4v7ddfjpy5ils150h0693bil3c7v27n84037hqndj";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
     version = "3.0.3";
     sha256 = "1jcqy8i9fzb1pmkazi80yqr09zi5nk30n57i46ggr5ky45jngfq9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
+    version = "3.1.2";
+    sha256 = "19wfh9yg4n2khbl7pvf6ngx95m5p8lw4l9y935pv7nh4xgwk02p9";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Runtime.linux-x64";
+    version = "3.1.3";
+    sha256 = "0kvnzb9xjii48kg30ac63qdf0fn1y8j3nblbrfaqv2aiy6kp0iwn";
   })
 
   (fetchNuGet {
@@ -72,8 +90,8 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.CodeCoverage";
-    version = "16.5.0";
-    sha256 = "0610wzn4qyywf9lb4538vwqhprxc4g0g7gjbmnjzvx97jr5nd5mf";
+    version = "16.7.1";
+    sha256 = "1farw63445cdyciplfs6l9j1gayxw16rkzmrwsiswfyjhqz70xd4";
   })
 
   (fetchNuGet {
@@ -84,8 +102,14 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.Extensions.FileSystemGlobbing";
-    version = "3.1.2";
-    sha256 = "1zwvzp0607irs7irfbq8vnclg5nj2jpyggw9agm4a32la5ngg27m";
+    version = "3.1.8";
+    sha256 = "1v2lr0vbssqayzgxvdwb54jmvz7mvlih4l9h7i71gm3c62nlbq8y";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NetCore.App.Host.linux-x64";
+    version = "3.0.2";
+    sha256 = "0y14y2x3wbi44i23ndmf4323cii8wrqw9s289gcab3s393l71sf5";
   })
 
   (fetchNuGet {
@@ -96,8 +120,8 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.NetCore.App.Host.linux-x64";
-    version = "3.1.8";
-    sha256 = "0iawz5mqaf1c4r5cf0ks4wqhgpbqi185l80q4909axh516xsjnvs";
+    version = "3.1.3";
+    sha256 = "013ibnhsimgqj5l2dqma035xvsvrb47bn65z6xbxgg88383hpgvw";
   })
 
   (fetchNuGet {
@@ -114,8 +138,26 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.NetCore.App.Runtime.linux-x64";
+    version = "3.0.2";
+    sha256 = "1h6d0nl495k0bh4my43l578l7m8qwah7ll42aax7jrib2py354f1";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NetCore.App.Runtime.linux-x64";
     version = "3.0.3";
     sha256 = "1ykgfnphbkyck0gqbbh5n96w59z2bq47g896ygal1j4nblj3s44v";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NetCore.App.Runtime.linux-x64";
+    version = "3.1.2";
+    sha256 = "0a332ia5pabnz7mdfc99a5hlc7drnwzlc7cj9b5c3an6dq636p66";
+  })
+
+  (fetchNuGet {
+    name = "Microsoft.NetCore.App.Runtime.linux-x64";
+    version = "3.1.3";
+    sha256 = "1ynhzsr8a0hfby2wjhzkdiimj18izgfzp7m2yp3pby2iwb4v3xy9";
   })
 
   (fetchNuGet {
@@ -138,8 +180,8 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.NETCore.Platforms";
-    version = "2.0.0";
-    sha256 = "1fk2fk2639i7nzy58m9dvpdnzql4vb8yl8vr19r2fp8lmj9w2jr0";
+    version = "3.0.0";
+    sha256 = "1bk8r4r3ihmi6322jmcag14jmw11mjqys202azqjzglcx59pxh51";
   })
 
   (fetchNuGet {
@@ -156,44 +198,38 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.NET.Test.Sdk";
-    version = "16.5.0";
-    sha256 = "19f5bvzci5mmfz81jwc4dax4qdf7w4k67n263383mn8mawf22bfq";
+    version = "16.7.1";
+    sha256 = "0yqxipj74ax2n76w9ccydppx78ym8m5fda88qnvj4670qjvl0kf8";
   })
 
   (fetchNuGet {
     name = "Microsoft.TestPlatform.ObjectModel";
-    version = "16.5.0";
-    sha256 = "02h7j1fr0fwcggn0wgddh59k8b2wmly3snckwhswzqvks5rvfnnw";
+    version = "16.7.1";
+    sha256 = "0s9dyh99gzdpk1i5v468i2r9m6i3jrr41r394pwdwiajsz99kay0";
   })
 
   (fetchNuGet {
     name = "Microsoft.TestPlatform.TestHost";
-    version = "16.5.0";
-    sha256 = "08cvss66lqa92h55dxkbrzn796jckhlyj53zz22x3qyr6xi21v5v";
+    version = "16.7.1";
+    sha256 = "1xik06rxn9ps83in0zn9vcl2ibv3acmdqvrx07qq89lxj1sgqlhs";
   })
 
   (fetchNuGet {
     name = "Microsoft.VisualStudio.Threading";
-    version = "16.4.33";
-    sha256 = "09djx2xz22w48csd0bkpwi1rgpjpaj3mml16wfy8jlsnc66swmnh";
+    version = "16.5.132";
+    sha256 = "05lngndl6hg4v3vk9l1n1g2lbfjb7jnr5dnkjld9wx3vamdfcfxw";
   })
 
   (fetchNuGet {
     name = "Microsoft.VisualStudio.Threading";
-    version = "16.4.45";
-    sha256 = "16p61kxsnwanp3nac0gkarl7a94c02qyqjzdkijl5va9k3fa97m6";
+    version = "16.6.13";
+    sha256 = "0qbvcwy7njz5zpqgfqdf41gf9xqcz64z4rkfjf6bi4zynpkv6n1l";
   })
 
   (fetchNuGet {
     name = "Microsoft.VisualStudio.Threading.Analyzers";
-    version = "16.4.45";
-    sha256 = "12m0f037pz3ynm69810p4c96nrlnqihx6w4qyrs0kqsxiajf16jc";
-  })
-
-  (fetchNuGet {
-    name = "Microsoft.VisualStudio.Validation";
-    version = "15.3.15";
-    sha256 = "1v3r2rlichlvxjrmj1grii1blnl9lp9npg2p6q3q4j6lamskxa9r";
+    version = "16.6.13";
+    sha256 = "09nqkjnarwj0chb6xrzscq98mpgi86n2a3mfdd3y695kviq99s18";
   })
 
   (fetchNuGet {
@@ -210,8 +246,8 @@ in [
 
   (fetchNuGet {
     name = "Microsoft.Win32.Registry";
-    version = "4.5.0";
-    sha256 = "1zapbz161ji8h82xiajgriq6zgzmb1f3ar517p2h63plhsq5gh2q";
+    version = "4.6.0";
+    sha256 = "0i4y782yrqqyx85pg597m20gm0v126w0j9ddk5z7xb3crx4z9f2s";
   })
 
   (fetchNuGet {
@@ -222,20 +258,20 @@ in [
 
   (fetchNuGet {
     name = "MSTest.TestAdapter";
-    version = "2.1.0";
-    sha256 = "1g1v8yjnk4nr1c36k3cz116889bnpiw1i1jkmqnpb19wms7sq7cz";
+    version = "2.1.2";
+    sha256 = "1390nyc0sf5c4j75cq58bzqjcw77sp2lmpllmm5sp8ysi0fjyfs5";
   })
 
   (fetchNuGet {
     name = "MSTest.TestFramework";
-    version = "2.1.0";
-    sha256 = "0mac4h7ylw953chclhz0lrn19yks3bab9dn9x9fpjqi7309gid0p";
+    version = "2.1.2";
+    sha256 = "1617q2accpa8fwy9n1snmjxyx2fz3phks62mdi45cl65kdin0x4z";
   })
 
   (fetchNuGet {
     name = "Nerdbank.Streams";
-    version = "2.4.60";
-    sha256 = "01554nbs6dj4fjd59b95kaw84j27kfb5y5ixjbl23nh62kpgrd3r";
+    version = "2.5.76";
+    sha256 = "017h8m1zrm247alhlz4vqsz580b8b88s50cyxb939hmc2nn0qlfv";
   })
 
   (fetchNuGet {
@@ -276,8 +312,8 @@ in [
 
   (fetchNuGet {
     name = "NSubstitute";
-    version = "4.2.1";
-    sha256 = "0wgfjh032qds994fmgxvsg88nhgjrx7p9rnv6z678jm62qi14asy";
+    version = "4.2.2";
+    sha256 = "1zi1z5i61c2nq8p3jwbkca28yaannrvv6g6q5mmz1775apmfyh79";
   })
 
   (fetchNuGet {
@@ -600,8 +636,8 @@ in [
 
   (fetchNuGet {
     name = "StreamJsonRpc";
-    version = "2.3.103";
-    sha256 = "0z8ahxkbbrzsn56ylzlciriiid4bslf6y1rk49wzahwpvzlik1iw";
+    version = "2.5.46";
+    sha256 = "0rsgxfxcfgbx1w2jhllx1cwnbj9vra6034gv4kgzahh0v5vn8shf";
   })
 
   (fetchNuGet {
@@ -804,14 +840,8 @@ in [
 
   (fetchNuGet {
     name = "System.IO.Pipelines";
-    version = "4.5.3";
-    sha256 = "1z44vn1qp866lkx78cfqdd4vs7xn1hcfn7in6239sq2kgf5qiafb";
-  })
-
-  (fetchNuGet {
-    name = "System.IO.Pipelines";
-    version = "4.6.0";
-    sha256 = "0r9ygjbxpyi6jgb67qnpbp42b7yvvhgmcjxnb50k3lb416claavh";
+    version = "4.7.0";
+    sha256 = "1cx6bl2bhzp30ahy2csnwbphmlwwp840j56wgab105xc32la0mg4";
   })
 
   (fetchNuGet {
@@ -1080,8 +1110,8 @@ in [
 
   (fetchNuGet {
     name = "System.Security.AccessControl";
-    version = "4.5.0";
-    sha256 = "1wvwanz33fzzbnd2jalar0p0z3x0ba53vzx1kazlskp7pwyhlnq0";
+    version = "4.6.0";
+    sha256 = "1wl1dyghi0qhpap1vgfhg2ybdyyhy9vc2a7dpm1xb30vfgmlkjmf";
   })
 
   (fetchNuGet {
@@ -1146,8 +1176,8 @@ in [
 
   (fetchNuGet {
     name = "System.Security.Principal.Windows";
-    version = "4.5.0";
-    sha256 = "0rmj89wsl5yzwh0kqjgx45vzf694v9p92r4x4q6yxldk1cv1hi86";
+    version = "4.6.0";
+    sha256 = "1jmfzfz1n8hp63s5lja5xxpzkinbp6g59l3km9h8avjiisdrg5wm";
   })
 
   (fetchNuGet {

--- a/pkgs/development/dotnet-modules/python-language-server/manual_deps.txt
+++ b/pkgs/development/dotnet-modules/python-language-server/manual_deps.txt
@@ -1,3 +1,4 @@
+Microsoft.AspNetCore.App.Runtime.linux-x64 3.1.8
 Microsoft.AspNetCore.App.Runtime.linux-x64 3.1.3
 Microsoft.AspNetCore.App.Ref 3.0.1
 Microsoft.AspNetCore.App.Runtime.linux-x64 3.1.2
@@ -5,6 +6,7 @@ Microsoft.AspNetCore.App.Runtime.linux-x64 3.0.3
 Microsoft.AspNetCore.App.Runtime.linux-x64 3.0.2
 Microsoft.NetCore.App.Ref 3.1.0
 Microsoft.NetCore.App.Ref 3.0.0
+Microsoft.NetCore.App.Runtime.linux-x64 3.1.8
 Microsoft.NetCore.App.Runtime.linux-x64 3.1.3
 Microsoft.NetCore.App.Runtime.linux-x64 3.1.2
 Microsoft.NetCore.App.Runtime.linux-x64 3.0.2

--- a/pkgs/development/dotnet-modules/python-language-server/manual_deps.txt
+++ b/pkgs/development/dotnet-modules/python-language-server/manual_deps.txt
@@ -1,16 +1,2 @@
 Microsoft.AspNetCore.App.Runtime.linux-x64 3.1.8
-Microsoft.AspNetCore.App.Runtime.linux-x64 3.1.3
-Microsoft.AspNetCore.App.Ref 3.0.1
-Microsoft.AspNetCore.App.Runtime.linux-x64 3.1.2
-Microsoft.AspNetCore.App.Runtime.linux-x64 3.0.3
-Microsoft.AspNetCore.App.Runtime.linux-x64 3.0.2
-Microsoft.NetCore.App.Ref 3.1.0
-Microsoft.NetCore.App.Ref 3.0.0
 Microsoft.NetCore.App.Runtime.linux-x64 3.1.8
-Microsoft.NetCore.App.Runtime.linux-x64 3.1.3
-Microsoft.NetCore.App.Runtime.linux-x64 3.1.2
-Microsoft.NetCore.App.Runtime.linux-x64 3.0.2
-Microsoft.NetCore.App.Runtime.linux-x64 3.0.3
-Microsoft.NetCore.App.Host.linux-x64 3.1.3
-Microsoft.NetCore.App.Host.linux-x64 3.0.2
-Microsoft.NetCore.App.Host.linux-x64 3.0.3


### PR DESCRIPTION
###### Motivation for this change

This updates to a version of `python-language-server` that supports Python 3.9 (which is also the current `master` of `github:microsoft/python-language-server` at the time of writing).

@thomasjm Pinging you since you are the maintainer; I ran `create-deps.sh` and then added all package versions that were missing during `nix-build` to `manual_deps.txt` until the build succeeded. Was that right?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).



Before:
```
/nix/store/s3vmrmpmliwy0sxfpzr7cp0ygkk6xxzc-python-language-server-2020-06-19	  165113576
```
After:
```
/nix/store/2k67mrg6kc690h1m898ga3dryslrcgl3-python-language-server-2020-10-08	  165204600
```