### PR TITLE
quickbms: init at 0.11.0

### DIFF
--- a/pkgs/tools/archivers/quickbms/default.nix
+++ b/pkgs/tools/archivers/quickbms/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchzip, bzip2, lzo, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  version = "0.11.0";
+  pname = "quickbms";
+
+  src = fetchzip {
+    url = "https://aluigi.altervista.org/papers/quickbms-src-${version}.zip";
+    hash = "sha256-uQKTE36pLO8uhrX794utqaDGUeyqRz6zLCQFA7DYkNc=";
+  };
+
+  buildInputs = [ bzip2 lzo openssl zlib ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Universal script based file extractor and reimporter";
+    homepage = "https://aluigi.altervista.org/quickbms.htm";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ samuelgrf ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7826,6 +7826,8 @@ in
 
   qnial = callPackage ../development/interpreters/qnial { };
 
+  quickbms = pkgsi686Linux.callPackage ../tools/archivers/quickbms { };
+
   ocz-ssd-guru = callPackage ../tools/misc/ocz-ssd-guru { };
 
   q-text-as-data = callPackage ../tools/misc/q-text-as-data { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
QuickBMS is a useful tool for extracting tons of different archive formats (there are 2661 scripts officially available here: http://aluigi.altervista.org/quickbms_scripts.php).
This can be used to extract some Windows installers, making it possible to package the files in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
