### PR TITLE
cc-wrapper: fix regression for the C compiler wrapper

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -132,11 +132,10 @@ if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
 fi
 
 if [[ "$isCpp" = 1 ]]; then
+    if [[ "$cppInclude" = 1 ]]; then
+        NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"
+    fi
     NIX_CFLAGS_LINK_@suffixSalt@+=" $NIX_CXXSTDLIB_LINK_@suffixSalt@"
-fi
-
-if [[ "$cppInclude" = 1 ]]; then
-    NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"
 fi
 
 source @out@/nix-support/add-hardening.sh

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -25,8 +25,8 @@ dontLink=0
 nonFlagArgs=0
 cc1=0
 # shellcheck disable=SC2193
-[[ "@prog@" = *++ ]] && isCpp=1 || isCpp=0
-cppInclude=1
+[[ "@prog@" = *++ ]] && isCxx=1 || isCxx=0
+cxxInclude=1
 cInclude=1
 setDynamicLinker=1
 
@@ -50,15 +50,15 @@ while (( "$n" < "$nParams" )); do
         dontLink=1
     elif [[ "$p" = -x && "$p2" = *-header ]]; then
         dontLink=1
-    elif [[ "$p" = -x && "$p2" = c++* && "$isCpp" = 0 ]]; then
-        isCpp=1
+    elif [[ "$p" = -x && "$p2" = c++* && "$isCxx" = 0 ]]; then
+        isCxx=1
     elif [ "$p" = -nostdlib ]; then
-        isCpp=-1
+        isCxx=-1
     elif [ "$p" = -nostdinc ]; then
         cInclude=0
-        cppInclude=0
+        cxxInclude=0
     elif [ "$p" = -nostdinc++ ]; then
-        cppInclude=0
+        cxxInclude=0
     elif [[ "$p" = -static || "$p" = -static-pie ]]; then
         setDynamicLinker=0
     elif [[ "$p" != -?* ]]; then
@@ -131,8 +131,8 @@ if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
     params=(${rest+"${rest[@]}"})
 fi
 
-if [[ "$isCpp" = 1 ]]; then
-    if [[ "$cppInclude" = 1 ]]; then
+if [[ "$isCxx" = 1 ]]; then
+    if [[ "$cxxInclude" = 1 ]]; then
         NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"
     fi
     NIX_CFLAGS_LINK_@suffixSalt@+=" $NIX_CXXSTDLIB_LINK_@suffixSalt@"

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -27,6 +27,7 @@ cc1=0
 # shellcheck disable=SC2193
 [[ "@prog@" = *++ ]] && isCxx=1 || isCxx=0
 cxxInclude=1
+cxxLibrary=1
 cInclude=1
 setDynamicLinker=1
 
@@ -53,7 +54,7 @@ while (( "$n" < "$nParams" )); do
     elif [[ "$p" = -x && "$p2" = c++* && "$isCxx" = 0 ]]; then
         isCxx=1
     elif [ "$p" = -nostdlib ]; then
-        isCxx=-1
+        cxxLibrary=0
     elif [ "$p" = -nostdinc ]; then
         cInclude=0
         cxxInclude=0
@@ -135,7 +136,9 @@ if [[ "$isCxx" = 1 ]]; then
     if [[ "$cxxInclude" = 1 ]]; then
         NIX_CFLAGS_COMPILE_@suffixSalt@+=" $NIX_CXXSTDLIB_COMPILE_@suffixSalt@"
     fi
-    NIX_CFLAGS_LINK_@suffixSalt@+=" $NIX_CXXSTDLIB_LINK_@suffixSalt@"
+    if [[ "$cxxLibrary" = 1 ]]; then
+        NIX_CFLAGS_LINK_@suffixSalt@+=" $NIX_CXXSTDLIB_LINK_@suffixSalt@"
+    fi
 fi
 
 source @out@/nix-support/add-hardening.sh


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#111970 caused a regression: C compiler is now passed a path to the C++ standard library includes
Fixes: #118195
Fixes: #119866
Fixes the original issue behind #111970 (cc @ttuegel)
cc @abbradar as author of the original nostdlib logic 87607af7a1bf35682f8ad206307ed46e8ead260a

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
