### PR TITLE
nixos: add option to load wireless regulatory database as firmware

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -35,6 +35,14 @@ in {
       '';
     };
 
+    hardware.wirelessRegulatoryDatabase = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Load the wireless regulatory database at boot.
+      '';
+    };
+
   };
 
 
@@ -58,6 +66,7 @@ in {
         ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "4.13") [
         rtl8723bs-firmware
       ];
+      hardware.wirelessRegulatoryDatabase = true;
     })
     (mkIf cfg.enableAllFirmware {
       assertions = [{
@@ -74,6 +83,9 @@ in {
         b43Firmware_6_30_163_46
         b43FirmwareCutter
       ] ++ optional (pkgs.stdenv.hostPlatform.isi686 || pkgs.stdenv.hostPlatform.isx86_64) facetimehd-firmware;
+    })
+    (mkIf cfg.wirelessRegulatoryDatabase {
+      hardware.firmware = [ pkgs.wireless-regdb ];
     })
   ];
 }

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -6,7 +6,6 @@ let
   cfg = config.networking.networkmanager;
 
   basePackages = with pkgs; [
-    crda
     modemmanager
     networkmanager
     networkmanager-fortisslvpn
@@ -366,6 +365,8 @@ in {
         '';
       }
     ];
+
+    hardware.wirelessRegulatoryDatabase = true;
 
     environment.etc = with pkgs; {
       "NetworkManager/NetworkManager.conf".source = configFile;

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -228,7 +228,8 @@ in {
     environment.systemPackages = [ package ];
 
     services.dbus.packages = [ package ];
-    services.udev.packages = [ pkgs.crda ];
+
+    hardware.wirelessRegulatoryDatabase = true;
 
     # FIXME: start a separate wpa_supplicant instance per interface.
     systemd.services.wpa_supplicant = let


### PR DESCRIPTION
use it when networkmanager or wpa_supplicant is enabled.

fixes #57053
fixes "Direct firmware load for regulatory.db failed with error -2" in dmesg

Note that all kernels on unstable are newer that 4.15, which is required
for this to work.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Tested on 20.09 by booting and checking for the error message.
