### PR TITLE
Allow swap size and partition UUIDs to be specified in make-disk-image

### DIFF
--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -17,7 +17,7 @@ let
       ../modules/testing/test-instrumentation.nix
       ../modules/profiles/qemu-guest.nix
       {
-        fileSystems."/".device = "/dev/disk/by-label/nixos";
+        fileSystems."/".device = "/dev/disk/by-label/test-nixos";
         boot.loader.grub.device = "/dev/vda";
         boot.loader.timeout = 0;
       }
@@ -27,6 +27,11 @@ let
     inherit pkgs config;
     lib = pkgs.lib;
     format = "qcow2";
+    partitionTableType = "hybrid";
+    swapSize = 512;
+    bootLabel = "test-boot";
+    swapLabel = "test-swap";
+    label = "test-nixos";
     contents = [{
       source = pkgs.writeText "testFile" "contents";
       target = "/testFile";
@@ -47,5 +52,23 @@ in makeEc2Test {
     assert "1234" in fileDetails
     assert "5678" in fileDetails
     assert "rwxr-xr-x" in fileDetails
+
+    # Make sure the disk labels are correct
+    assert (
+        machine.succeed("readlink -f /dev/disk/by-label/TEST-BOOT").strip() == "/dev/vda1"
+    )
+    assert (
+        machine.succeed("readlink -f /dev/disk/by-partlabel/test-swap").strip()
+        == "/dev/vda3"
+    )
+    assert (
+        machine.succeed("readlink -f /dev/disk/by-label/test-nixos").strip() == "/dev/vda4"
+    )
+
+    # Turn the swap on
+    machine.succeed("swapoff -a")
+    machine.succeed("swapon /dev/disk/by-partlabel/test-swap")
+    swapSize = machine.succeed("grep SwapTotal /proc/meminfo")
+    assert "524284" in swapSize  # +4k header = 524288
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

Specifying swap space in image builds is potentially useful, especially if we support ZFS in make-disk-image.nix someday, since ZVOLs cause system deadlocks if they are used as swap devices:

https://github.com/zfsonlinux/pkg-zfs/wiki/HOWTO-use-a-zvol-as-a-swap-device

Along the way, add hardcoded UUIDs for the MBR and boot/swap/root partitions to match nixos/modules/installer/sd-card/sd-image.nix. This probably isn't perfect, but makes the behavior a little closer, which is good for reproducibility.

Add tests in image-contents.nix.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
