### PR TITLE
libnixxml: fix build, enable tests, fix cross-compile

### DIFF
--- a/pkgs/development/libraries/libnixxml/default.nix
+++ b/pkgs/development/libraries/libnixxml/default.nix
@@ -11,17 +11,40 @@ stdenv.mkDerivation {
     sha256 = "sha256-HKQnCkO1TDs1e0MDil0Roq4YRembqRHQvb7lK3GAftQ=";
   };
 
-  preConfigure = ''
-    ./bootstrap
+  postPatch = ''
+    # Remove broken test
+    substituteInPlace tests/draw/Makefile.am \
+      --replace "draw-wrong.sh" ""
+    rm tests/draw/draw-wrong.sh
+  '';
+
+  preAutoreconf = ''
+    # Copied from bootstrap script
+    ln -s README.md README
+    mkdir -p config
   '';
 
   configureFlags = [ "--with-gd" "--with-glib" ];
   CFLAGS = "-Wall";
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libxml2 gd.dev glib getopt libxslt nix ];
+  strictDeps = true;
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    getopt
+    libxslt
+  ];
+  buildInputs = [
+    libxml2
+    gd.dev
+    glib
+    nix
+  ];
+  checkInputs = [
+    nix
+  ];
 
-  doCheck = false;
+  doCheck = true;
 
   meta = with lib; {
     description = "XML-based Nix-friendly data integration library";

--- a/pkgs/development/libraries/libnixxml/default.nix
+++ b/pkgs/development/libraries/libnixxml/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, lib, stdenv, autoreconfHook, pkg-config, libxml2, gd, glib, getopt, libxslt, nix }:
+{ fetchFromGitHub, lib, stdenv, autoreconfHook, pkg-config, libxml2, gd, glib, getopt, libxslt, nix, bash}:
 
 stdenv.mkDerivation {
   pname = "libnixxml";
@@ -11,11 +11,15 @@ stdenv.mkDerivation {
     sha256 = "sha256-HKQnCkO1TDs1e0MDil0Roq4YRembqRHQvb7lK3GAftQ=";
   };
 
-  postPatch = ''
+  prePatch = ''
     # Remove broken test
     substituteInPlace tests/draw/Makefile.am \
       --replace "draw-wrong.sh" ""
     rm tests/draw/draw-wrong.sh
+
+    # Fix bash path
+    substituteInPlace scripts/nixexpr2xml.in \
+      --replace "/bin/bash" "${bash}/bin/bash"
   '';
 
   preAutoreconf = ''
@@ -35,6 +39,7 @@ stdenv.mkDerivation {
     libxslt
   ];
   buildInputs = [
+    bash
     libxml2
     gd.dev
     glib


### PR DESCRIPTION
###### Motivation for this change

I was looking at hydra failures and this one seemed simple to fix. I'm not using this package myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>dydisnix</li>
    <li>libnixxml</li>
  </ul>
</details>

ping @NixOS/nixos-release-managers 

ZHF: #122042
