### PR TITLE
tela-icon-theme: more changes to change the hash

### DIFF
--- a/pkgs/data/icons/tela-icon-theme/default.nix
+++ b/pkgs/data/icons/tela-icon-theme/default.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, gtk3, hicolor-icon-theme, jdupes, lib, stdenv }:
+{ fetchFromGitHub, gtk3, hicolor-icon-theme, jdupes, lib, stdenvNoCC }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "tela-icon-theme";
   version = "2021-01-21";
 

--- a/pkgs/data/icons/tela-icon-theme/default.nix
+++ b/pkgs/data/icons/tela-icon-theme/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
+  # These fixup steps are slow and unnecessary.
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/icons/tela-icon-theme/default.nix
+++ b/pkgs/data/icons/tela-icon-theme/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A flat colorful Design icon theme";
     homepage = "https://github.com/vinceliuice/tela-icon-theme";
-    license = licenses.gpl3Plus;
+    license = licenses.gpl3Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [ figsoda ];
   };


### PR DESCRIPTION
###### Motivation for this change

Thanks to some detective work by @grahamc we've managed to figure out what's wrong, and _this time_ we're pretty sure we've fixed it properly.

Anyway, this is a random collection of changes designed to get the hash to change again so we can rebuild this package in a manner that's acceptable to the NixOS channel scripts.

Sorry for the noise @figsoda!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
