### PR TITLE
rq: fix compilation by disabling '-Werror'

### DIFF
--- a/pkgs/development/tools/rq/default.nix
+++ b/pkgs/development/tools/rq/default.nix
@@ -11,6 +11,13 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0km9d751jr6c5qy4af6ks7nv3xfn13iqi03wq59a1c73rnf0zinp";
   };
 
+  postPatch = ''
+    # Remove #[deny(warnings)] which is equivalent to -Werror in C.
+    # Prevents build failures when upgrading rustc, which may give more warnings.
+    substituteInPlace src/lib.rs \
+      --replace "#![deny(warnings)]" ""
+  '';
+
   cargoSha256 = "0c5vwy3c5ji602dj64z6jqvcpi2xff03zvjbnwihb3ydqwnb3v67";
 
   buildInputs = [ llvmPackages.clang-unwrapped v8 ]


### PR DESCRIPTION
###### Motivation for this change

Apparently the used syntax is not valid anymore in rust edition 2021.
Apply a patch from a PR on the project to fix the build.

Not using this package personally, I'm just fixing some low-hanging build failures from hydra :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @NixOS/nixos-release-managers

ZHF: #122042