### PR TITLE
python3Packages.jq: fix build by updating patch

### DIFF
--- a/pkgs/development/python-modules/jq/jq-py-setup.patch
+++ b/pkgs/development/python-modules/jq/jq-py-setup.patch
@@ -1,17 +1,14 @@
-From 968ddf2bd773e800e46737fced743bd00af9aa0d Mon Sep 17 00:00:00 2001
-From: William Kral <william.kral@gmail.com>
-Date: Tue, 8 Sep 2020 22:04:24 -0700
-Subject: [PATCH] Vastly simplify setup.py for distro compatibility
+commit 31d040e9d28fe8e425e7f46ee6c64ae12aa3fd15
+Author: Rick van Schijndel <rol3517@gmail.com>
+Date:   Sun May 2 23:19:59 2021 +0200
 
----
- setup.py | 101 ++-----------------------------------------------------
- 1 file changed, 2 insertions(+), 99 deletions(-)
+    [PATCH] Vastly simplify setup.py for distro compatibility
 
 diff --git a/setup.py b/setup.py
-index cb63f60..87380ed 100644
+index 3e7b3b3..5f6fa69 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -1,114 +1,19 @@
+@@ -1,113 +1,19 @@
  #!/usr/bin/env python
  
  import os
@@ -79,8 +76,7 @@ index cb63f60..87380ed 100644
 -            tarball_path=jq_lib_tarball_path,
 -            lib_dir=jq_lib_dir,
 -            commands=[
--                ["autoreconf", "-i"],
--                ["./configure", "CFLAGS=-fPIC", "--disable-maintainer-mode", "--with-oniguruma=" + oniguruma_lib_install_dir],
+-                ["./configure", "CFLAGS=-fPIC -pthread", "--disable-maintainer-mode", "--with-oniguruma=" + oniguruma_lib_install_dir],
 -                ["make"],
 -            ])
 -
@@ -93,7 +89,7 @@ index cb63f60..87380ed 100644
 -
 -        macosx_deployment_target = sysconfig.get_config_var("MACOSX_DEPLOYMENT_TARGET")
 -        if macosx_deployment_target:
--            os.environ['MACOSX_DEPLOYMENT_TARGET'] = macosx_deployment_target
+-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = str(macosx_deployment_target)
 -
 -        def run_command(args):
 -            print("Executing: %s" % ' '.join(args))
@@ -127,21 +123,11 @@ index cb63f60..87380ed 100644
  )
  
  setup(
-@@ -120,8 +25,7 @@ setup(
-     url='http://github.com/mwilliamson/jq.py',
+@@ -120,7 +26,6 @@ setup(
      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
      license='BSD 2-Clause',
--    ext_modules = [jq_extension],
+     ext_modules = [jq_extension],
 -    cmdclass={"build_ext": jq_build_ext},
-+    ext_modules=[jq_extension],
      classifiers=[
          'Development Status :: 5 - Production/Stable',
          'Intended Audience :: Developers',
-@@ -137,4 +41,3 @@ setup(
-         'Programming Language :: Python :: 3.8',
-     ],
- )
--
--- 
-2.28.0
-


### PR DESCRIPTION
This is probably not really sustainable, but will fix the issue for now.
It would be good to ask upstream to make this optional / configurable,
I guess.

###### Motivation for this change

Less hydra failures. I'm not using this package personally.

I've tried running some sample commands from the readme, that worked: https://github.com/mwilliamson/jq.py

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
