### PR TITLE
nixos/tests/rspamd: fix OOM flakyness

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -773,7 +773,7 @@ in
         };
 
       services.postfix.config = (mapAttrs (_: v: mkDefault v) {
-        compatibility_level  = "9999";
+        compatibility_level  = pkgs.postfix.version;
         mail_owner           = cfg.user;
         default_privs        = "nobody";
 

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -25,6 +25,7 @@ let
     machine = {
       services.rspamd.enable = true;
       networking.enableIPv6 = enableIPv6;
+      virtualisation.memorySize = 1024;
     };
     testScript = ''
       start_all()
@@ -68,6 +69,7 @@ in
           group = "rspamd";
         }];
       };
+      virtualisation.memorySize = 1024;
     };
 
     testScript = ''
@@ -116,6 +118,7 @@ in
           '';
         };
       };
+      virtualisation.memorySize = 1024;
     };
 
     testScript = ''
@@ -221,6 +224,7 @@ in
           rspamd_logger.infox(rspamd_config, 'Work dammit!!!')
         '';
       };
+      virtualisation.memorySize = 1024;
     };
     testScript = ''
       ${initMachine}
@@ -287,6 +291,7 @@ in
         postfix.enable = true;
         workers.rspamd_proxy.type = "rspamd_proxy";
       };
+      virtualisation.memorySize = 1024;
     };
     testScript = ''
       ${initMachine}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The rspamd tests are a bit flaky due to OOMing and because postfixIntegration is upset that compatibility version is bad. Fix this by increasing the RAM and changing the way we set postfix's compatibility version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
