### PR TITLE
firebird: 2.5.7 -> 2.5.9, init 3.0.7, init 4.0.0-rc1

### DIFF
--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, libtool }:
+{ lib, stdenv, fetchurl, fetchpatch, libtool, libtommath }:
 
 stdenv.mkDerivation rec {
   pname = "libtomcrypt";
@@ -17,14 +17,16 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ libtool ];
+  nativeBuildInputs = [ libtool libtommath ];
 
   postPatch = ''
     substituteInPlace makefile.shared --replace "LT:=glibtool" "LT:=libtool"
   '';
 
   preBuild = ''
-    makeFlagsArray=(PREFIX=$out \
+    makeFlagsArray+=(PREFIX=$out \
+      CFLAGS="-DUSE_LTM -DLTM_DESC -DLTC_PTHREAD" \
+      EXTRALIBS=\"-ltommath\" \
       INSTALL_GROUP=$(id -g) \
       INSTALL_USER=$(id -u))
   '';

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -1,91 +1,84 @@
-{lib, stdenv, fetchurl, libedit, automake, autoconf, libtool
-,
-  # icu = null: use icu which comes with firebird
+{ lib, stdenv, fetchFromGitHub, libedit, autoreconfHook, zlib, unzip, libtommath, libtomcrypt, icu, superServer ? false }:
 
-  # icu = pkgs.icu => you may have trouble sharing database files with windows
-  # users if "Collation unicode" columns are being used
-  # windows icu version is *30.dll, however neither the icu 3.0 nor the 3.6
-  # sources look close to what ships with this package.
-  # Thus I think its best to trust firebird devs and use their version
-
-  # icu version missmatch may cause such error when selecting from a table:
-  # "Collation unicode for character set utf8 is not installed"
-
-  # icu 3.0 can still be built easily by nix (by dropping the #elif case and
-  # make | make)
-  icu ? null
-
-, superServer ? false
-, port ? 3050
-, serviceName ? "gds_db"
-}:
-
-/*
-   there are 3 ways to use firebird:
-   a) superserver
-    - one process, one thread for each connection
-   b) classic
-    - is built by default
-    - one process for each connection
-    - on linux direct io operations (?)
-   c) embedded.
-
-   manual says that you usually don't notice the difference between a and b.
-
-   I'm only interested in the embedder shared libary for now.
-   So everything isn't tested yet
-
-*/
-
-stdenv.mkDerivation rec {
-  version = "2.5.7.27050-0";
+let base = {
   pname = "firebird";
 
-  # enableParallelBuilding = false; build fails
+  meta = with lib; {
+    description = "SQL relational database management system";
+    homepage = "https://firebirdsql.org/";
+    changelog = "https://github.com/FirebirdSQL/firebird/blob/master/CHANGELOG.md";
+    license = [ "IDPL" "Interbase-1.0" ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ marcweber ];
+  };
 
-  # http://tracker.firebirdsql.org/browse/CORE-3246
-  preConfigure = ''
-    makeFlags="$makeFlags CPU=$NIX_BUILD_CORES"
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ libedit icu ];
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath [ icu ];
+
+  configureFlags = [
+    "--with-system-editline"
+  ] ++ (lib.optional superServer "--enable-superserver");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r gen/Release/firebird/* $out
+    runHook postInstall
   '';
 
-  configureFlags =
-    [ "--with-serivec-port=${builtins.toString port}"
-      "--with-service-name=${serviceName}"
-      "--with-system-editline"
-      "--with-fblog=/var/log/firebird"
-      "--with-fbconf=/etc/firebird"
-      "--with-fbsecure-db=/var/db/firebird/system"
-    ]
-    ++ (lib.optional  (icu != null) "--with-system-icu")
-    ++ (lib.optional superServer "--enable-superserver");
+}; in {
 
-  src = fetchurl {
-    url = "mirror://sourceforge/firebird/Firebird-${version}.tar.bz2";
-    sha256 = "06hp6bq5irqvm3h03s79qjgcc3jsjpq150y9aq7anklx9v4nhfqa";
-  };
+  firebird_2_5 = stdenv.mkDerivation (base // rec {
+    version = "2.5.9";
 
-  hardeningDisable = [ "format" ];
+    src = fetchFromGitHub {
+      owner = "FirebirdSQL";
+      repo = "firebird";
+      rev = "R${builtins.replaceStrings [ "." ] [ "_" ] version}";
+      sha256 = "sha256-YyvlMeBux80OpVhsCv+6IVxKXFRsgdr+1siupMR13JM=";
+    };
 
-  # configurePhase = ''
-  #   sed -i 's@cp /usr/share/automake-.*@@' autogen.sh
-  #   sh autogen.sh $configureFlags --prefix=$out
-  # '';
-  buildInputs = [libedit icu automake autoconf libtool];
+    configureFlags = base.configureFlags ++ [ "--with-system-icu" ];
 
-  # TODO: Probably this hase to be tidied up..
-  # make install requires beeing. disabling the root checks
-  # dosen't work. Copying the files manually which can be found
-  # in ubuntu -dev -classic, -example packages:
-  # maybe some of those files can be removed again
-  installPhase = "cp -r gen/firebird $out";
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r gen/firebird/* $out
+      runHook postInstall
+    '';
 
-  meta = {
-    description = "SQL relational database management system";
-    homepage = "https://www.firebirdnews.org";
-    license = ["IDPL" "Interbase-1.0"];
-    maintainers = [lib.maintainers.marcweber];
-    platforms = lib.platforms.linux;
-    broken = true;
-  };
+    meta = base.meta // { platforms = [ "x86_64-linux" ]; };
+  });
+
+  firebird_3 = stdenv.mkDerivation (base // rec {
+    version = "3.0.7";
+
+    src = fetchFromGitHub {
+      owner = "FirebirdSQL";
+      repo = "firebird";
+      rev = "R${builtins.replaceStrings [ "." ] [ "_" ] version}";
+      sha256 = "sha256-8nGan10qjW8dFF89BL/tUWtwMGhahBiODbOqRrHSrbs=";
+    };
+
+    buildInputs = base.buildInputs ++ [ zlib libtommath ];
+
+    meta = base.meta // { platforms = [ "x86_64-linux" ]; };
+  });
+
+  firebird_4 = stdenv.mkDerivation (base // rec {
+    version = "4.0.0-rc1";
+
+    src = fetchFromGitHub {
+      owner = "FirebirdSQL";
+      repo = "firebird";
+      rev = "T4_0_0_RC1";
+      sha256 = "sha256-FLaRePosF5dtJ+fmrfvzkE6wawC9Z9YLhT/ZWkwWXb4=";
+    };
+
+    buildInputs = base.buildInputs ++ [ zlib unzip libtommath libtomcrypt ];
+  });
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18775,8 +18775,8 @@ in
 
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 
-  firebird = callPackage ../servers/firebird { icu = null; /*stdenv = gcc5Stdenv;*/ };
-  firebirdSuper = firebird.override { icu = icu58; superServer = true; /*stdenv = gcc5Stdenv;*/ };
+  inherit (callPackages ../servers/firebird { }) firebird_4 firebird_3 firebird_2_5;
+  firebird = firebird_3;
 
   freeradius = callPackage ../servers/freeradius { };
 


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/88048

---

This PR is ready to be merged!

---

Thanks to [Firebird maintainers](https://github.com/FirebirdSQL/firebird/issues/6784) and to @jnetod for his critical contribution on debugging the tricky ICU issue.

* All 3 current versions of Firebird (2.5.9, 3.0.7, 4.0.0-rc1) builds for x86_64 successfully now.
* I have not tested Firebird. I'm not providing tests [yet?]. My goal here was to solve the critical points to fix this package for x86_64 at least. (But feel free to suggest test implementations for it.)
  * aarch64-linux: Firebird 4 works. Firebird 2.5 / 3 is broken. Won't fix for now so I've limited platform to x86_64 only.
* Release of Firebird 4.0 is expected to happen soon (but don't know when), rc1 for now is fine. I'll upgrade the package when released.
* Is relevant to have all 3 Firebird versions because there are breaking changes between them, most existing software for Firebird is legacy and tied to a specific version.
* This package could benefit from polishing and tests. Contributions are welcomed. Useful reference: [firebird-superserver AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=firebird-superserver)
* I have removed Super server version to avoid duplication of packages for hydra. Someone wanting Super server can use: `firebird.override { superServer = true; };`

---

Unsolved issues that are pending solution:
* Firebird 3 for aarch64
* Firebird 2.5 embedded ICU (3.0)

This should not stop this PR from being merged. A new PR can be made if the solution is found.

---

This PR is ready to be merged!