### PR TITLE
timg: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/tools/graphics/timg/default.nix
+++ b/pkgs/tools/graphics/timg/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "timg";
-  version = "1.4.0";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "hzeller";
     repo = "timg";
     rev = "v${version}";
-    sha256 = "10qhjfkbazncmj07y0a6cpmi7ki0l10qzpvi2zh8369yycqqxr8y";
+    sha256 = "1zjcaxnik8imkn22g5kz6zly3yxpknrzd093sfxpgqnfw4sq8149";
   };
 
   buildInputs = [ graphicsmagick ffmpeg libexif libjpeg zlib ];


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>

###### Motivation for this change
Tracking upstream version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
