### PR TITLE
mix2nix: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11465,6 +11465,16 @@
     github = "pulsation";
     githubId = 1838397;
   };
+  ydlr = {
+    name = "ydlr";
+    email = "ydlr@ydlr.io";
+    github = "ydlr";
+    githubId = 58453832;
+    keys = [{
+      longkeyid = "rsa4096/0x43AB44130A29AD9D";
+      fingerprint = "FD0A C425 9EF5 4084 F99F 9B47 2ACC 9749 7C68 FAD4";
+    }];
+  };
   zane = {
     name = "Zane van Iperen";
     email = "zane@zanevaniperen.com";

--- a/pkgs/development/tools/mix2nix/default.nix
+++ b/pkgs/development/tools/mix2nix/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, elixir, erlang }:
+
+stdenv.mkDerivation {
+  pname = "mix2nix";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ydlr";
+    repo = "mix2nix";
+    rev = "b153a252f0689d3f6919e16c2df2fb3b6bcc9d2a";
+    sha256 = "15wyz7gdjywsqvsf1ad9gklvqsqi7lwgmyks3bjlc2sk6kpdxdmi";
+  };
+
+  buildInputs = [ elixir erlang ];
+
+  buildPhase = "mix escript.build";
+  installPhase = "install -Dt $out/bin mix2nix";
+
+  meta = with lib; {
+    description = "Generate nix expressions from mix.lock file.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ydlr beam ];
+  };
+}

--- a/pkgs/development/tools/mix2nix/default.nix
+++ b/pkgs/development/tools/mix2nix/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Generate nix expressions from mix.lock file.";
     license = licenses.mit;
-    maintainers = with maintainers; [ ydlr beam ];
+    maintainers = with maintainers; [ ydlr ] ++ teams.beams.members;
   };
 }

--- a/pkgs/development/tools/mix2nix/default.nix
+++ b/pkgs/development/tools/mix2nix/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, fetchFromGitHub, elixir, erlang }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "mix2nix";
   version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "ydlr";
     repo = "mix2nix";
-    rev = "66c277bdffb93da9a63e3f1ea42432a73e572b51";
+    rev = version;
     sha256 = "11qn80im5zfbx25ibxqrgi90mglf8pnsmrqsami633mcf2gvj2hy";
   };
 

--- a/pkgs/development/tools/mix2nix/default.nix
+++ b/pkgs/development/tools/mix2nix/default.nix
@@ -2,16 +2,17 @@
 
 stdenv.mkDerivation {
   pname = "mix2nix";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "ydlr";
     repo = "mix2nix";
-    rev = "b153a252f0689d3f6919e16c2df2fb3b6bcc9d2a";
-    sha256 = "15wyz7gdjywsqvsf1ad9gklvqsqi7lwgmyks3bjlc2sk6kpdxdmi";
+    rev = "66c277bdffb93da9a63e3f1ea42432a73e572b51";
+    sha256 = "11qn80im5zfbx25ibxqrgi90mglf8pnsmrqsami633mcf2gvj2hy";
   };
 
-  buildInputs = [ elixir erlang ];
+  nativeBuildInputs = [ elixir ];
+  buildInputs = [ erlang ];
 
   buildPhase = "mix escript.build";
   installPhase = "install -Dt $out/bin mix2nix";

--- a/pkgs/development/tools/mix2nix/default.nix
+++ b/pkgs/development/tools/mix2nix/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Generate nix expressions from mix.lock file.";
     license = licenses.mit;
-    maintainers = with maintainers; [ ydlr ] ++ teams.beams.members;
+    maintainers = with maintainers; [ ydlr ] ++ teams.beam.members;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -269,6 +269,8 @@ in
     inherit (darwin.apple_sdk.frameworks) AppKit IOKit;
   };
 
+  mix2nix = callPackage ../development/tools/mix2nix/default.nix { };
+
   proto-contrib = callPackage ../development/tools/proto-contrib {};
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};


### PR DESCRIPTION
###### Motivation for this change
Mix2nix is a tool for generating nix expressions from a mix.lock file. It makes developing elixir applications with nix a little easier.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
