### PR TITLE
ulauncher: 5.9.0 -> 5.10.0 and patch

### DIFF
--- a/pkgs/applications/misc/ulauncher/add-nix-install-note.diff
+++ b/pkgs/applications/misc/ulauncher/add-nix-install-note.diff
@@ -1,0 +1,17 @@
+diff --git a/ulauncher/config.py b/ulauncher/config.py
+index 0ae693b..fafc6b6 100644
+--- a/ulauncher/config.py
++++ b/ulauncher/config.py
+@@ -67,7 +67,11 @@ def get_data_path():
+     try:
+         return paths[0]
+     except:
+-        raise ProjectPathNotFoundError()
++        raise Exception("ProjectPathNotFoundError.\n\n\x1b[1m**Note added by Nixpkgs maintainer**\x1b[m\n" + \
++            "Ulauncher must be installed via nix-env, nix profile, or systemPackages.\n" + \
++            "Otherwise, Ulauncher tries to save /nix/store paths to settings.json,\n" + \
++            "which would break if those paths are later garbage-collected after\nupdating " + \
++            "Ulauncher.\n\nSee: https://github.com/NixOS/nixpkgs/pull/85350#issuecomment-614421246")
+ 
+ 
+ def is_wayland():

--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -20,13 +20,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ulauncher";
-  version = "5.9.0";
+  version = "5.10.0";
 
   disabled = python3Packages.isPy27;
 
   src = fetchurl {
     url = "https://github.com/Ulauncher/Ulauncher/releases/download/${version}/ulauncher_${version}.tar.gz";
-    sha256 = "sha256-jRCrkJcjUHDd3wF+Hkxg0QaW7YgIh7zM/KZ4TAH84/U=";
+    sha256 = "sha256-9CEfqOU7AT+Tyvhx+eiqUo6g3vnFZ6P3shOTZcTBNCo=";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -62,6 +62,12 @@ python3Packages.buildPythonApplication rec {
     websocket_client
   ];
 
+  # Fixes error
+  #     Couldn’t recognize the image file format for file...
+  # at startup, see https://github.com/NixOS/nixpkgs/issues/56943
+  # and https://github.com/NixOS/nixpkgs/issues/89691#issuecomment-714398705.
+  strictDeps = false;
+
   checkInputs = with python3Packages; [
     mock
     pytest
@@ -72,6 +78,7 @@ python3Packages.buildPythonApplication rec {
   patches = [
     ./fix-path.patch
     ./0001-Adjust-get_data_path-for-NixOS.patch
+    ./add-nix-install-note.diff
     ./fix-extensions.patch
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- updates Ulauncher (https://github.com/NixOS/nixpkgs/pull/112540)
- adds patch to explain error when ulauncher is not installed globally (https://github.com/NixOS/nixpkgs/issues/119350)

I've bundled these two changes because the latter affects code review.

Is adding clearly-labeled notes to software allowed? If not, what would be a better alternative?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
