### PR TITLE
wrap: init at 0.3.1

### DIFF
--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -4,7 +4,7 @@
 , unwrapped
 # If it's a minimal build, we don't want to wrap it with lndir and
 # wrapProgram..
-, wrap ? true
+, doWrap ? true
 # For the wrapper
 , makeWrapper
 # For lndir
@@ -138,7 +138,7 @@ let
     ;
     pkgs = packages;
   };
-  self = if wrap then
+  self = if doWrap then
     stdenv.mkDerivation {
       inherit name passthru;
       buildInputs = [

--- a/pkgs/tools/text/wrap/default.nix
+++ b/pkgs/tools/text/wrap/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch, makeWrapper, courier-prime }:
+
+buildGoModule rec {
+  pname = "wrap";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Wraparound";
+    repo = "wrap";
+    rev = "v${version}";
+    sha256 = "0scf7v83p40r9k7k5v41rwiy9yyanfv3jm6jxs9bspxpywgjrk77";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  vendorSha256 = "03q5a5lm8zj1523gxkbc0y6a3mjj1z2h7nrr2qcz8nlghvp4cfaz";
+
+  patches = [
+    (fetchpatch {
+      name = "courier-prime-variants.patch";
+      url = "https://github.com/Wraparound/wrap/commit/b72c280b6eddba9ec7b3507c1f143eb28a85c9c1.patch";
+      sha256 = "1d9v0agfd7mgd17k4a8l6vr2kyswyfsyq3933dz56pgs5d3jric5";
+    })
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/wrap --prefix XDG_DATA_DIRS : ${courier-prime}/share/
+  '';
+
+  meta = with lib; {
+    description = "A Fountain export tool with some extras";
+    homepage = "https://github.com/Wraparound/wrap";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.austinbutler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23022,7 +23022,7 @@ in
   # A build without gui components and other utilites not needed for end user
   # libraries
   gnuradioMinimal = gnuradio.override {
-    wrap = false;
+    doWrap = false;
     unwrapped = gnuradio.unwrapped.override {
       volk = volk.override {
         # So it will not reference python
@@ -23052,7 +23052,7 @@ in
   # A build without gui components and other utilites not needed if gnuradio is
   # used as a c++ library.
   gnuradio3_8Minimal = gnuradio3_8.override {
-    wrap = false;
+    doWrap = false;
     unwrapped = gnuradio3_8.unwrapped.override {
       volk = volk.override {
         enableModTool = false;
@@ -23081,7 +23081,7 @@ in
   # A build without gui components and other utilites not needed if gnuradio is
   # used as a c++ library.
   gnuradio3_7Minimal = gnuradio3_7.override {
-    wrap = false;
+    doWrap = false;
     unwrapped = gnuradio3_7.unwrapped.override {
       volk = volk.override {
         enableModTool = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9639,6 +9639,8 @@ in
 
   wpgtk = callPackage ../tools/X11/wpgtk { };
 
+  wrap = callPackage ../tools/text/wrap { };
+
   wring = nodePackages.wring;
 
   wrk = callPackage ../tools/networking/wrk { };


### PR DESCRIPTION
###### Motivation for this change

Add package. It's somewhat difficult to get tools like this to use the right font with Nix.

Initializing at unstable because I submitted a PR that helps the program find the font and that was merged, but there hasn't been a release yet. I'll update to a version when there is.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).