### PR TITLE
fluidsynth: 2.0.6 -> 2.2.0

### DIFF
--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -1,48 +1,52 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, cmake
-, alsaLib, glib, libjack2, libsndfile, libpulseaudio
-, AudioUnit, CoreAudio, CoreMIDI, CoreServices
-, version ? "2"
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, cmake
+, alsaLib
+, glib
+, libjack2
+, libsndfile
+, libpulseaudio
+, AudioUnit
+, CoreAudio
+, CoreMIDI
+, CoreServices
 }:
 
 let
-  versionMap = {
-    "1" = {
-      fluidsynthVersion = "1.1.11";
-      sha256 = "0n75jq3xgq46hfmjkaaxz3gic77shs4fzajq40c8gk043i84xbdh";
+  generic = version: sha256:
+    stdenv.mkDerivation rec {
+      pname = "fluidsynth";
+      inherit version;
+
+      src = fetchFromGitHub {
+        owner = "FluidSynth";
+        repo = "fluidsynth";
+        rev = "v${version}";
+        inherit sha256;
+      };
+
+      nativeBuildInputs = [ pkg-config cmake ];
+
+      buildInputs = [ glib libsndfile libpulseaudio libjack2 ]
+        ++ lib.optionals stdenv.isLinux [ alsaLib ]
+        ++ lib.optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreMIDI CoreServices ];
+
+      cmakeFlags = [ "-Denable-framework=off" ];
+
+      meta = with lib; {
+        description = "Real-time software synthesizer based on the SoundFont 2 specifications";
+        homepage = "https://www.fluidsynth.org";
+        license = licenses.lgpl21Plus;
+        maintainers = with maintainers; [ goibhniu lovek323 ];
+        platforms = platforms.unix;
+      };
     };
-    "2" = {
-      fluidsynthVersion = "2.0.6";
-      sha256 = "0nas9pp9r8rnziznxm65x2yzf1ryg98zr3946g0br3s38sjf8l3a";
-    };
-  };
+
 in
-
-with versionMap.${version};
-
-stdenv.mkDerivation  {
-  name = "fluidsynth-${fluidsynthVersion}";
-  version = fluidsynthVersion;
-
-  src = fetchFromGitHub {
-    owner = "FluidSynth";
-    repo = "fluidsynth";
-    rev = "v${fluidsynthVersion}";
-    inherit sha256;
-  };
-
-  nativeBuildInputs = [ pkg-config cmake ];
-
-  buildInputs = [ glib libsndfile libpulseaudio libjack2 ]
-    ++ lib.optionals stdenv.isLinux [ alsaLib ]
-    ++ lib.optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreMIDI CoreServices ];
-
-  cmakeFlags = [ "-Denable-framework=off" ];
-
-  meta = with lib; {
-    description = "Real-time software synthesizer based on the SoundFont 2 specifications";
-    homepage    = "https://www.fluidsynth.org";
-    license     = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ goibhniu lovek323 ];
-    platforms   = platforms.unix;
-  };
+rec {
+  fluidsynth_1 = generic "1.1.11" "sha256-sK1OUBwEzIcYIFiq74iG+hwW3/hdqSmrg4bg1weW5Vg=";
+  fluidsynth_2 = generic "2.2.0" "sha256-FT+GhiX5fcTLd8Pk9haaaEoP3aoXNf+V82lDwSdWyZw=";
+  fluidsynth = fluidsynth_2;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22876,10 +22876,12 @@ in
 
   flwrap = callPackage ../applications/radio/flwrap { };
 
-  fluidsynth = callPackage ../applications/audio/fluidsynth {
+  inherit (callPackages ../applications/audio/fluidsynth {
      inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio CoreMIDI CoreServices;
-  };
-  fluidsynth_1 = fluidsynth.override { version = "1"; };
+   })
+   fluidsynth_1
+   fluidsynth_2
+   fluidsynth;
 
   fmit = libsForQt5.callPackage ../applications/audio/fmit { };
 


### PR DESCRIPTION
###### Motivation for this change

Upstream update. Refactor the way we build to remove any self-awareness of *what* to build.

`nix-review` is currently running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
