### PR TITLE
CODEOWNERS: make sure all Haskell files are present

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,9 +79,12 @@
 /pkgs/development/tools/poetry2nix @adisbladis
 
 # Haskell
-/pkgs/development/compilers/ghc    @cdepillabout @sternenseemann @maralorn
-/pkgs/development/haskell-modules  @cdepillabout @sternenseemann @maralorn
-/pkgs/test/haskell                 @cdepillabout @sternenseemann @maralorn
+/doc/languages-frameworks/haskell.section.md  @cdepillabout @sternenseemann @maralorn
+/maintainers/scripts/haskell                  @cdepillabout @sternenseemann @maralorn
+/pkgs/development/compilers/ghc               @cdepillabout @sternenseemann @maralorn
+/pkgs/development/haskell-modules             @cdepillabout @sternenseemann @maralorn
+/pkgs/test/haskell                            @cdepillabout @sternenseemann @maralorn
+/pkgs/top-level/haskell-packages.nix          @cdepillabout @sternenseemann @maralorn
 
 # Perl
 /pkgs/development/interpreters/perl @volth @stigtsp

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -50,11 +50,12 @@
 
 "6.topic: haskell":
   - doc/languages-frameworks/haskell.section.md
+  - maintainers/scripts/haskell/**/*
   - pkgs/development/compilers/ghc/**/*
   - pkgs/development/haskell-modules/**/*
   - pkgs/development/tools/haskell/**/*
-  - pkgs/top-level/haskell-packages.nix
   - pkgs/test/haskell/**/*
+  - pkgs/top-level/haskell-packages.nix
 
 "6.topic: kernel":
   - pkgs/build-support/kernel/**/*


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This updates the CODEOWNERS and labeler files in order to make sure all Haskell-related files are present.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
