### PR TITLE
dbeaver: 21.0.3 -> 21.0.4

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , copyDesktopItems
 , fetchFromGitHub
-, fetchpatch
 , makeDesktopItem
 , makeWrapper
 , fontconfig
@@ -19,18 +18,18 @@
 
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "21.0.3"; # When updating also update fetchedMavenDeps.sha256
+  version = "21.0.4"; # When updating also update fetchedMavenDeps.sha256
 
   src = fetchFromGitHub {
     owner = "dbeaver";
     repo = "dbeaver";
     rev = version;
-    sha256 = "sha256-ItM8t+gqE0ccuuimfEMUddykl+xt2eZIBd3MbpreRwA=";
+    sha256 = "sha256-jV7Pe4MsLQnIrkDnlI2SrPzSjiDHM59GbMy4G7oeQK8=";
   };
 
   fetchedMavenDeps = stdenv.mkDerivation {
     name = "dbeaver-${version}-maven-deps";
-    inherit src patches;
+    inherit src;
 
     buildInputs = [
       maven
@@ -51,17 +50,8 @@ stdenv.mkDerivation rec {
     dontFixup = true;
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-rsK/B39ogNu5nC41OfyAsLiwBz4gWyH+8Fj7E6+rOng=";
+    outputHash = "sha256-RspJTWVM0ZpAz4yDeKsG7wSHZ//bi3SSV5c0gbsqZKY=";
   };
-
-  patches = [
-    # Fix eclipse-color-theme URL (https://github.com/dbeaver/dbeaver/pull/12133)
-    # After April 15, 2021 eclipse-color-theme.github.com no longer redirects to eclipse-color-theme.github.io
-    (fetchpatch {
-      url = "https://github.com/dbeaver/dbeaver/commit/65d65e2c2c711cc87fddcec425a6915aa80f4ced.patch";
-      sha256 = "sha256-pxOcRYkV/5o+tHcRhHDZ1TmZSHMnKBmkNTVAlIf9nUE=";
-    })
-  ];
 
   nativeBuildInputs = [
     copyDesktopItems


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/dbeaver/dbeaver/releases/tag/21.0.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/dj5h2lzg3347yll268cdkq31pwa0wz2k-dbeaver-ce-21.0.3	 1344237928
/nix/store/sa95wr6vr58mcwqlqr3zbnwrwgn06ssk-dbeaver-ce-21.0.4	 1343977752
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
