### PR TITLE
cereal: add patch for CVE-2020-11105

### DIFF
--- a/pkgs/development/libraries/cereal/default.nix
+++ b/pkgs/development/libraries/cereal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 stdenv.mkDerivation rec {
   pname = "cereal";
   version = "1.3.0";
@@ -12,7 +12,20 @@ stdenv.mkDerivation rec {
     sha256 = "0hc8wh9dwpc1w1zf5lfss4vg5hmgpblqxbrpp1rggicpx9ar831p";
   };
 
-  cmakeFlagsArray = [ "-DJUST_INSTALL_CEREAL=yes" ];
+  patches = [
+    # https://nvd.nist.gov/vuln/detail/CVE-2020-11105
+    # serialized std::shared_ptr variables cannot always be expected to
+    # serialize back into their original values. This can have any number of
+    # consequences, depending on the context within which this manifests.
+    (fetchpatch {
+      name = "CVE-2020-11105.patch";
+      url =
+        "https://github.com/USCiLab/cereal/commit/3e8b9cab82dc4a596dc3bcfe7437946395ad782b.patch";
+      sha256 = "CIkbJ7bAN0MXBhTXQdoQKXUmY60/wQvsdn99FaWt31w=";
+    })
+  ];
+
+  cmakeFlags = [ "-DJUST_INSTALL_CEREAL=yes" ];
 
   meta = with lib; {
     description = "A header-only C++11 serialization library";

--- a/pkgs/development/libraries/cereal/default.nix
+++ b/pkgs/development/libraries/cereal/default.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
     # consequences, depending on the context within which this manifests.
     (fetchpatch {
       name = "CVE-2020-11105.patch";
-      url =
-        "https://github.com/USCiLab/cereal/commit/3e8b9cab82dc4a596dc3bcfe7437946395ad782b.patch";
+      url = "https://github.com/USCiLab/cereal/commit/f27c12d491955c94583512603bf32c4568f20929.patch";
       sha256 = "CIkbJ7bAN0MXBhTXQdoQKXUmY60/wQvsdn99FaWt31w=";
     })
   ];


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2020-11105

A patch to 1.3.0 exists upstream (1.3.1 not released yet):
https://github.com/USCiLab/cereal/pull/667/commits/3e8b9cab82dc4a596dc3bcfe7437946395ad782b

This is the first time I am PRing this kind of commit so please let me know if
I am missing something.

Cereal 1.3.0 seems to exist on 20.09 and 20.03 as well, should this be backported to both of them?
I only ran `nixpkgs-review` on master for this PR.
On the off chance that some reverse dependencies fail to build on 20.09 or 20.03 is the backport for that specific release aborted?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
