### PR TITLE
busybox: Add a fix for CVE-2021-28831

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./busybox-in-store.patch
     (fetchpatch {
+      name = "CVE-2021-28831.patch";
       url = "https://git.busybox.net/busybox/patch/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd";
       sha256 = "0y79flfbk45krwn963nnbqc21a88bsz4k4asqwvcnfk2lkciadxm";
     }) # TODO: Removing when bumping the version

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, fetchurl, fetchFromGitLab
+{ stdenv, lib, buildPackages, fetchurl, fetchFromGitLab, fetchpatch
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableMinimal ? false
 # Allow forcing musl without switching stdenv itself, e.g. for our bootstrapping:
@@ -49,6 +49,9 @@ in
 
 stdenv.mkDerivation rec {
   pname = "busybox";
+  # TODO: When bumping to next version, remove the patch
+  # for CVE-2021-28831 (assuming the patch was included in
+  # the next upstream release)
   version = "1.32.1";
 
   # Note to whoever is updating busybox: please verify that:
@@ -64,6 +67,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./busybox-in-store.patch
+    (fetchpatch {
+      url = "https://git.busybox.net/busybox/patch/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd";
+      sha256 = "0y79flfbk45krwn963nnbqc21a88bsz4k4asqwvcnfk2lkciadxm";
+    }) # TODO: Removing when bumping the version
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 
   postPatch = "patchShebangs .";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It's a security fix, see #120362 and #120363


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
