### PR TITLE
mautrix-signal: fix escape in postInstall

### DIFF
--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonPackage rec {
     # Make a little wrapper for running mautrix-signal with its dependencies
     echo "$mautrixSignalScript" > $out/bin/mautrix-signal
     echo "#!/bin/sh
-      exec python -m mautrix_signal \"$@\"
+      exec python -m mautrix_signal \"\$@\"
     " > $out/bin/mautrix-signal
     chmod +x $out/bin/mautrix-signal
     wrapProgram $out/bin/mautrix-signal \


### PR DESCRIPTION
###### Motivation for this change

mautrix-signal wrapper is incorrect because of the missing $ escape in the postInstall patch phase.
Without the fix:
```
#!/bin/sh
  exec python -m mautrix_signal "0 postInstall"
```
With the fix:
```
#!/bin/sh
exec python -m mautrix_signal "$@"

```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
