### PR TITLE
bucklespring: unstable-2021-01-21 -> 1.5.0

### DIFF
--- a/pkgs/applications/audio/bucklespring/default.nix
+++ b/pkgs/applications/audio/bucklespring/default.nix
@@ -19,12 +19,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bucklespring";
-  version = "unstable-2021-01-21";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "zevv";
     repo = pname;
-    rev = "d63100c4561dd7c57efe6440c12fa8d9e9604145";
+    rev = version;
     sha256 = "114dib4npb7r1z2zd1fwsx71xbf9r6psxqd7n7590cwz1w3r51mz";
   };
 


### PR DESCRIPTION
###### Motivation for this change
FML!

###### Things done
- [x] yell at computer
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


@lukegb looks like there was some terrible timing xD
