### PR TITLE
python3Packages.aiopg: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, psycopg2
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aiopg";
+  version = "1.2.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "aio-libs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0c6s2p1fjbdk1ygpl6a1s1rbnsk8gw9kj99pf98nxhb9j3iahas4";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+    psycopg2
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "psycopg2-binary" "psycopg2"
+  '';
+
+  # Tests requires a PostgreSQL Docker instance
+  doCheck = false;
+
+  pythonImportsCheck = [ "aiopg" ];
+
+  meta = with lib; {
+    description = "Python library for accessing a PostgreSQL database";
+    homepage = "https://aiopg.readthedocs.io/";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -311,6 +311,8 @@ in {
 
   aionotion = callPackage ../development/python-modules/aionotion { };
 
+  aiopg = callPackage ../development/python-modules/aiopg { };
+
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
   aiopulse = callPackage ../development/python-modules/aiopulse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for accessing a PostgreSQL database

https://aiopg.readthedocs.io/

Will be needed for fixing python3Packages.databases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
