### PR TITLE
prometheus-knot-exporter: add patch to fix stats

### DIFF
--- a/pkgs/servers/monitoring/prometheus/knot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/knot-exporter.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, lib, python3, nixosTests }:
+{ stdenv, fetchFromGitHub, lib, python3, nixosTests, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "knot-exporter";
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     rev = "21dd46b401e0c1aea0b173e19462cdf89e1f444e";
     sha256 = "sha256-4au4lpaq3jcqC2JXdCcf8h+YN8Nmm4eE0kZwA+1rWlc=";
   };
+
+  patches = [
+    # Fixes a crash with all metrics enabled. See
+    # https://github.com/ghedo/knot_exporter/pull/6 for further context.
+    (fetchpatch {
+      url = "https://github.com/ghedo/knot_exporter/commit/2317476e080369450ae51a707ccd30d4b89d680f.patch";
+      sha256 = "sha256-yEPu8EE1V/draNx9DeMrPj+bMfJRxauweo33dITl4AA=";
+    })
+  ];
 
   dontBuild = true;
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a patch I filed against upstream[1] a while ago. As it isn't
merged yet and fixes configurations with all stats enabled in knot
(otherwise it'd crash when sending a request to `localhost:9433`), I
decided that it makes sense to add it to the package directly.

I extended the test to make sure that it only passes with this patch.

[1] https://github.com/ghedo/knot_exporter/pull/6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
