### PR TITLE
segger-jlink: init at 7.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8732,6 +8732,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  reardencode = {
+    email = "freedom@reardencode.com";
+    github = "reardencode";
+    githubId = 730881;
+    name = "Brandon Black";
+  };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -1,0 +1,136 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, qt4
+, udev
+, system
+, config
+, acceptLicense ? config.segger-jlink.acceptLicense or false
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      name = "x86_64";
+      sha256 = "19gh6hlpq4dm3ji9wdf9n435zimybvgkzshdww25j9bdm0dl0595";
+    };
+    i686-linux = {
+      name = "i386";
+      sha256 = "1f0iik519panf3649nxszzh61vss927k7zgr4yx1lj991ba6rjdq";
+    };
+    aarch64-linux = {
+      name = "arm64";
+      sha256 = "0gyka0w7xiphp22vkszkx8bvm46k3pnsxmpg0mzi580gpwh3ay1q";
+    };
+    armv7l-linux = {
+      name = "arm";
+      sha256 = "0ws8l85fl4slvx6d4q779f24ppdwm901kbdbksjl66zn25wz8g33";
+    };
+  };
+
+  platform = supported.${system} or (throw "unsupported platform ${system}");
+
+  version = "720";
+
+  url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
+
+  throwLicense = throw ''
+    Use of the "SEGGER JLink Software and Documentation pack" requires the
+    acceptance of the following licenses:
+
+      - SEGGER Downloads Terms of Use [1]
+      - SEGGER Software Licensing [2]
+
+    You can express acceptance by setting acceptLicense to true in your
+    configuration. Note that this is not a free license so it requires allowing
+    unfree licenses as well.
+
+    configuration.nix:
+      nixpkgs.config.allowUnfree = true;
+      nixpkgs.config.segger-jlink.acceptLicense = true;
+
+    config.nix:
+      allowUnfree = true;
+      segger-jlink.acceptLicense = true;
+
+    [1]: ${url}
+    [2]: https://www.segger.com/purchase/licensing/
+  '';
+
+in stdenv.mkDerivation {
+  pname = "segger-jlink";
+  inherit version;
+
+  src = assert !acceptLicense -> throwLicense; fetchurl {
+    inherit url;
+    inherit (platform) sha256;
+    curlOpts = "--data accept_license_agreement=accepted";
+  };
+
+  # Currently blocked by patchelf bug
+  # https://github.com/NixOS/patchelf/pull/275
+  #runtimeDependencies = [ udev ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ qt4 udev ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    # Install all files to JLink first
+    mkdir -p $out/JLink
+    cp -r * $out/JLink
+
+    # Symlink all binaries into bin
+    mkdir -p $out/bin
+    for prog in $out/JLink/J*; do
+      if test -L $prog; then
+        mv $prog $out/bin
+      else
+        ln -s $prog $out/bin
+      fi
+    done
+
+    # Remove included Qt4
+    rm $out/JLink/libQt*
+
+    ${lib.optionalString (system == "x86_64-linux") ''
+      # Remove 32-bit libs on 64-bit x86 systems
+      rm -r $out/JLink/{x86,lib*_x86.so*}
+    ''}
+
+    ${lib.optionalString (system == "aarch64-linux") ''
+      # Remove 32-bit libs on 64-bit ARM systems
+      rm -r $out/JLink/{arm,lib*_arm.so*}
+    ''}
+
+    # Symlink all libraries into lib
+    mkdir -p $out/lib
+    ln -s $out/JLink/*.so* $out/lib
+
+    # Move docs and examples
+    mkdir -p $out/share
+    mv $out/JLink/Doc $out/share/docs
+    mv $out/JLink/Samples $out/share/examples
+
+    # Move udev rule
+    mkdir -p $out/lib/udev/rules.d
+    mv $out/JLink/99-jlink.rules $out/lib/udev/rules.d/
+  '';
+
+  preFixup = ''
+    # Workaround to setting runtime dependecy
+    patchelf --add-needed libudev.so.1 $out/JLink/libjlinkarm.so
+  '';
+
+  meta = with lib; {
+    description = "J-Link Software and Documentation pack";
+    homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+    license = licenses.unfree;
+    platforms = attrNames supported;
+    maintainers = with maintainers; [ FlorianFranzen reardencode ];
+  };
+}

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -36,7 +36,7 @@ let
 
   url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
 
-  throwLicense = throw ''
+  assert !acceptLicense -> throw ''
     Use of the "SEGGER JLink Software and Documentation pack" requires the
     acceptance of the following licenses:
 
@@ -63,7 +63,7 @@ in stdenv.mkDerivation {
   pname = "segger-jlink";
   inherit version;
 
-  src = assert !acceptLicense -> throwLicense; fetchurl {
+  src = fetchurl {
     inherit url;
     inherit (platform) sha256;
     curlOpts = "--data accept_license_agreement=accepted";

--- a/pkgs/development/tools/misc/segger-jlink/default.nix
+++ b/pkgs/development/tools/misc/segger-jlink/default.nix
@@ -14,25 +14,25 @@ let
   supported = {
     x86_64-linux = {
       name = "x86_64";
-      sha256 = "19gh6hlpq4dm3ji9wdf9n435zimybvgkzshdww25j9bdm0dl0595";
+      sha256 = "0cmd9ny6mslj9260scply573gbmn6k5r9wyxmcbjb14k4b3sldic";
     };
     i686-linux = {
       name = "i386";
-      sha256 = "1f0iik519panf3649nxszzh61vss927k7zgr4yx1lj991ba6rjdq";
+      sha256 = "1jjh5a8y17ma369s9k0xlyr8i10v2r1kxmv0i9v4cix5dnjyq0pp";
     };
     aarch64-linux = {
       name = "arm64";
-      sha256 = "0gyka0w7xiphp22vkszkx8bvm46k3pnsxmpg0mzi580gpwh3ay1q";
+      sha256 = "0p3gjv36a82xyps20drm7h0vm0jmz5gd930ynwr3iy46md41hgyv";
     };
     armv7l-linux = {
       name = "arm";
-      sha256 = "0ws8l85fl4slvx6d4q779f24ppdwm901kbdbksjl66zn25wz8g33";
+      sha256 = "0z9q3mqhfwb341mk5p1d3vp6mfwffcdk68968jy1qr2ga2s34wpb";
     };
   };
 
   platform = supported.${system} or (throw "unsupported platform ${system}");
 
-  version = "720";
+  version = "750";
 
   url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14102,6 +14102,8 @@ in
 
   scss-lint = callPackage ../development/tools/scss-lint { };
 
+  segger-jlink = callPackage ../development/tools/misc/segger-jlink { };
+
   segger-ozone = callPackage ../development/tools/misc/segger-ozone { };
 
   shadowenv = callPackage ../tools/misc/shadowenv {


### PR DESCRIPTION
###### Motivation for this change

The SEGGER JLink Software package was missing from nixpkgs.

I was able to test the 64- and 32-bit version on my local machine. I tried to test both ARM version with binfmt, with mixed results. I was able to build the `aarch64` version, but it seems `autoPatchelf` does not detect any of the dynamic libraries (even though just running `patchelf --print-needed <bin>` displays them correctly. The `armv7l`requires to build 400+ dependencies not in the binary cache, which is slow under binfmt, so I did not have a chance to check that yet.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).