### PR TITLE
python3Packages.qiskit: 0.25.0 -> 0.26.2

### DIFF
--- a/pkgs/development/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/development/python-modules/qiskit-aqua/default.nix
@@ -10,7 +10,6 @@
 , networkx
 , numpy
 , psutil
-, python
 , qiskit-ignis
 , qiskit-terra
 , quandl
@@ -34,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.9.0";
+  version = "0.9.1";
 
   disabled = pythonOlder "3.6";
 
@@ -43,7 +42,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    hash = "sha256-knue9uJih72UQHsvfXZ9AA94mol4ERa9Lo/GMcp+2hA=";
+    hash = "sha256-fptyqPrkUgl3UjtlEmDYORdX/SsONxWozQGEs/EahmU=";
   };
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.
@@ -97,8 +96,6 @@ buildPythonPackage rec {
       >> qiskit/optimization/__init__.py
   '';
 
-  postInstall = "rm -rf $out/${python.sitePackages}/docs";  # Remove docs dir b/c it can cause conflicts.
-
   checkInputs = [
     pytestCheckHook
     ddt
@@ -123,9 +120,6 @@ buildPythonPackage rec {
     "--ignore=test/chemistry/test_bopes_sampler.py"
   ];
   disabledTests = [
-    # Disabled due to missing pyscf
-    "test_validate" # test/chemistry/test_inputparser.py
-
     # Online tests
     "test_exchangedata"
     "test_yahoo"
@@ -163,6 +157,8 @@ buildPythonPackage rec {
     "test_eoh"
     "test_qasm_5"
     "test_uccsd_hf"
+  ] ++ lib.optionals (!withPyscf) [
+    "test_validate" # test/chemistry/test_inputparser.py
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/development/python-modules/qiskit-ibmq-provider/default.nix
@@ -39,7 +39,7 @@ let
 in
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.12.2";
+  version = "0.13.1";
 
   disabled = pythonOlder "3.6";
 
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "0yil363mqssq0453nrwxgkjivzk3a4jgbnaf21bp7lwfcl2jdhqm";
+    hash = "sha256-DlHlXncttzGo4uVoh2aQ7urW6krN3ej2sJ/EwuxeF2I=";
   };
 
   propagatedBuildInputs = [
@@ -83,7 +83,9 @@ buildPythonPackage rec {
 
   # Skip tests that rely on internet access (mostly to IBM Quantum Experience cloud).
   # Options defined in qiskit.terra.test.testing_options.py::get_test_options
-  QISKIT_TESTS = "skip_online";
+  preCheck = ''
+    export QISKIT_TESTS=skip_online
+  '';
 
   meta = with lib; {
     description = "Qiskit provider for accessing the quantum devices and simulators at IBMQ";

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
@@ -56,7 +57,7 @@ in
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.17.0";
+  version = "0.17.4";
 
   disabled = pythonOlder "3.6";
 
@@ -64,7 +65,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    hash = "sha256-LbNbaHAWAVG5YLc9juuwcOlrREBW6OjEl7VPtACfl3I=";
+    hash = "sha256-JyNuke+XPqjLVZbvPud9Y7k0+EmvETVKcOYcDldBiVo=";
   };
 
   nativeBuildInputs = [ cython ];
@@ -106,11 +107,17 @@ buildPythonPackage rec {
     "test/python/classical_function_compiler/"
   ];
   disabledTests = [
+    # Not working on matplotlib >= 3.4.0, checks images match.
+    "test_plot_circuit_layout"
+
     # Flaky tests
     "test_cx_equivalence"
     "test_pulse_limits"
+    "test_1q_random"
   ] ++ lib.optionals (!withClassicalFunctionCompiler) [
     "TestPhaseOracle"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    "test_circuit_init" # failed on aarch64, https://gist.github.com/r-rmcgibbo/c2e173d43ced4f6954811004f6b5b842
   ]
   # Disabling slow tests for build constraints
   ++ [
@@ -155,8 +162,8 @@ buildPythonPackage rec {
     pushd $PACKAGEDIR
   '';
   postCheck = ''
-    rm -rf test
-    rm -rf examples
+    rm -r test
+    rm -r examples
     popd
   '';
 

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.25.0";
+  version = "0.26.2";
 
   disabled = pythonOlder "3.6";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "qiskit";
     repo = "qiskit";
     rev = version;
-    hash = "sha256-pJM6d3AyFs9AexvQXG+8QQ4zwpFisJC16iBFR9gNSk0=";
+    hash = "sha256-QYWKKS7e/uCt5puWV4jA9Emp7M4Cyv2RUCxilbChWhw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/retworkx/default.nix
+++ b/pkgs/development/python-modules/retworkx/default.nix
@@ -1,18 +1,23 @@
 { lib
+, stdenv
 , buildPythonPackage
 , pythonOlder
 , rustPlatform
 , fetchFromGitHub
-
+, libiconv
   # Check inputs
 , pytestCheckHook
+, fixtures
+, graphviz
+, matplotlib
 , networkx
 , numpy
+, pydot
 }:
 
 buildPythonPackage rec {
   pname = "retworkx";
-  version = "0.8.0";
+  version = "0.9.0";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -20,22 +25,29 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "retworkx";
     rev = version;
-    sha256 = "0plpri6a3d6f1000kmcah9066vq2i37d14bdf8sm96493fhpqhrd";
+    hash = "sha256-1W7DexS+ECAPsxyZAF36xcEguFkjUMX9lDBylNVPqyk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-+k779gmge8wDdoZrWn9ND47kUqt7pqe75Zuj2Byfefo=";
+    hash = "sha256-y5l7jqrlk3ONHefZPS31IvcaO9ttXWLM7fIUmNVwbco=";
   };
 
   nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
 
-  # Needed b/c need to check AFTER python wheel is installed (using Rust Build, not buildPythonPackage)
-  doCheck = false;
-  doInstallCheck = true;
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
-  installCheckInputs = [ pytestCheckHook networkx numpy ];
+  pythonImportsCheck = [ "retworkx" ];
+  checkInputs = [
+    pytestCheckHook
+    fixtures
+    graphviz
+    matplotlib
+    networkx
+    numpy
+    pydot
+  ];
 
   preCheck = ''
     export TESTDIR=$(mktemp -d)

--- a/pkgs/development/python-modules/yfinance/default.nix
+++ b/pkgs/development/python-modules/yfinance/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "yfinance";
-  version = "0.1.56";
+  version = "0.1.59";
 
   # GitHub source releases aren't tagged
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a6d4c7b939fdd48d983556501f5b387e20aaef86afc8e6ba6f91a49a7e22d2dd";
+    sha256 = "fe4dc46807eceadc6604bf51ece7297b752dc5402a38a87385094fbfc7565fa0";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update super-package & all subpackages to the latest version. <strike>https://github.com/Qiskit/qiskit/releases/tag/0.25.3</strike> https://github.com/Qiskit/qiskit/releases/tag/0.26.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
