### PR TITLE
mercurial: 5.6 -> 5.8, oxidize

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -67,14 +67,14 @@ in python3Packages.buildPythonApplication rec {
     install -v -m644 -D contrib/zsh_completion $out/share/zsh/site-functions/_hg
   '';
 
-  meta = {
+  meta = with lib; {
     inherit version;
     description = "A fast, lightweight SCM system for very large distributed projects";
     homepage = "https://www.mercurial-scm.org";
     downloadPage = "https://www.mercurial-scm.org/release/";
-    license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.eelco ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ eelco lukegb ];
     updateWalker = true;
-    platforms = lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python3Packages, makeWrapper, unzip
+{ lib, stdenv, fetchurl, python3Packages, makeWrapper
 , guiSupport ? false, tk ? null
 , ApplicationServices
 }:
@@ -19,7 +19,7 @@ in python3Packages.buildPythonApplication rec {
 
   passthru = { inherit python; }; # pass it so that the same version can be used in hg2git
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ docutils ]
     ++ lib.optionals stdenv.isDarwin [ ApplicationServices ];
 

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch, python3Packages, makeWrapper, gettext
+, re2Support ? true
 , rustSupport ? stdenv.hostPlatform.isLinux, rustPlatform
 , guiSupport ? false, tk ? null
 , ApplicationServices
@@ -41,7 +42,7 @@ in python3Packages.buildPythonApplication rec {
   } else null;
   cargoRoot = if rustSupport then "rust" else null;
 
-  propagatedBuildInputs = [ fb-re2 ];
+  propagatedBuildInputs = lib.optional re2Support fb-re2;
   nativeBuildInputs = [ makeWrapper gettext ]
     ++ lib.optionals rustSupport (with rustPlatform; [
          cargoSetupHook

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python3Packages, makeWrapper, gettext
+{ lib, stdenv, fetchurl, fetchpatch, python3Packages, makeWrapper, gettext
 , rustSupport ? stdenv.hostPlatform.isLinux, rustPlatform
 , guiSupport ? false, tk ? null
 , ApplicationServices
@@ -15,6 +15,19 @@ in python3Packages.buildPythonApplication rec {
     url = "https://mercurial-scm.org/release/mercurial-${version}.tar.gz";
     sha256 = "17rhlmmkqz5ll3k68jfzpcifg3nndbcbc2nx7kw8xn3qcj7nlpgw";
   };
+
+  patches = [
+    # https://phab.mercurial-scm.org/D10638, needed for below patch to apply
+    (fetchpatch {
+      url = "https://phab.mercurial-scm.org/file/data/oymk4awh2dd7q6cwjbzu/PHID-FILE-bfcr7qrp5spg42wspxpd/D10638.diff";
+      sha256 = "0mfi324is02l7cnd3j0gbmg5rpyyqn3afg3f73flnfwmz5njqa5f";
+    })
+    # https://phab.mercurial-scm.org/D10639, fixes https://bz.mercurial-scm.org/show_bug.cgi?id=6514
+    (fetchpatch {
+      url = "https://phab.mercurial-scm.org/file/data/re4uqdhtknjiacx2ogwu/PHID-FILE-4m26id65dno5gzix2ngh/D10639.diff";
+      sha256 = "0h5ilrd2x1789fr6sf4k1mcvxdh0xdyr94yawdacw87v3x12c8cb";
+    })
+  ];
 
   format = "other";
 

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  inherit (python3Packages) docutils python;
+  inherit (python3Packages) docutils python fb-re2;
 
 in python3Packages.buildPythonApplication rec {
   pname = "mercurial";
@@ -28,6 +28,7 @@ in python3Packages.buildPythonApplication rec {
   } else null;
   cargoRoot = if rustSupport then "rust" else null;
 
+  propagatedBuildInputs = [ fb-re2 ];
   nativeBuildInputs = [ makeWrapper gettext ]
     ++ lib.optionals rustSupport (with rustPlatform; [
          cargoSetupHook

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -8,11 +8,11 @@ let
 
 in python3Packages.buildPythonApplication rec {
   pname = "mercurial";
-  version = "5.6";
+  version = "5.8";
 
   src = fetchurl {
     url = "https://mercurial-scm.org/release/mercurial-${version}.tar.gz";
-    sha256 = "1hk2y30zzdnlv8f71kabvh0xi9c7qhp28ksh20vpd0r712sv79yz";
+    sha256 = "17rhlmmkqz5ll3k68jfzpcifg3nndbcbc2nx7kw8xn3qcj7nlpgw";
   };
 
   format = "other";

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python3Packages, makeWrapper
+{ lib, stdenv, fetchurl, python3Packages, makeWrapper, gettext
 , rustSupport ? stdenv.hostPlatform.isLinux, rustPlatform
 , guiSupport ? false, tk ? null
 , ApplicationServices
@@ -28,7 +28,7 @@ in python3Packages.buildPythonApplication rec {
   } else null;
   cargoRoot = if rustSupport then "rust" else null;
 
-  nativeBuildInputs = [ makeWrapper ]
+  nativeBuildInputs = [ makeWrapper gettext ]
     ++ lib.optionals rustSupport (with rustPlatform; [
          cargoSetupHook
          rust.cargo

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -9,12 +9,16 @@ let
     sha256 = "031bafj88wggpvw0lgvl0djhlbhs9nls9vzwvni8yn0m0bgzc9gr";
   };
 
-  tortoiseMercurial = mercurial.overridePythonAttrs (old: rec {
+  tortoiseMercurial = (mercurial.override {
+    rustSupport = false;
+    re2Support = lib.versionAtLeast tortoisehgSrc.meta.version "5.8";
+  }).overridePythonAttrs (old: rec {
     inherit (tortoisehgSrc.meta) version;
     src = fetchurl {
       url = "https://mercurial-scm.org/release/mercurial-${version}.tar.gz";
       sha256 = "1hk2y30zzdnlv8f71kabvh0xi9c7qhp28ksh20vpd0r712sv79yz";
     };
+    patches = [];
   });
 
 in python3Packages.buildPythonApplication {


### PR DESCRIPTION
###### Motivation for this change

* Mercurial 5.8 is out. And so was 5.7.
* Add Rust support (for Linux, only, since there are dire warnings about it on other platforms). This speeds up some operations.
* Adds re2 for speedier regex evaluation.
* Compile the translations that are provided.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
      - Before: `/nix/store/q4xydpsb37149dl7xxvwp456c58x6hwb-mercurial-5.6         113840224`
      - After: `/nix/store/q3z0h1mwsyxi3kd77j65f8b9mawppga7-mercurial-5.8         131381528`
      - --> ~20MB increase
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
