### PR TITLE
formats.ini: Introduce `listToValue` argument

### DIFF
--- a/nixos/doc/manual/development/settings-options.xml
+++ b/nixos/doc/manual/development/settings-options.xml
@@ -50,7 +50,7 @@
        </varlistentry>
        <varlistentry>
          <term>
-           <varname>pkgs.formats.ini</varname> { <replaceable>listsAsDuplicateKeys</replaceable> ? false, ... }
+           <varname>pkgs.formats.ini</varname> { <replaceable>listsAsDuplicateKeys</replaceable> ? false, <replaceable>listToValue</replaceable> ? null, ... }
          </term>
          <listitem>
            <para>
@@ -63,6 +63,16 @@
                  <listitem>
                    <para>
                      A boolean for controlling whether list values can be used to represent duplicate INI keys
+                   </para>
+                 </listitem>
+               </varlistentry>
+               <varlistentry>
+                 <term>
+                   <varname>listToValue</varname>
+                 </term>
+                 <listitem>
+                   <para>
+                     A function for turning a list of values into a single value.
                    </para>
                  </listitem>
                </varlistentry>

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -56,7 +56,16 @@ rec {
       };
     };
 
-  ini = { listsAsDuplicateKeys ? false, ... }@args: {
+  ini = {
+    # Represents lists as duplicate keys
+    listsAsDuplicateKeys ? false,
+    # Alternative to listsAsDuplicateKeys, converts list to non-list
+    # listToValue :: [IniAtom] -> IniAtom
+    listToValue ? null,
+    ...
+    }@args:
+    assert !listsAsDuplicateKeys || listToValue == null;
+    {
 
     type = with lib.types; let
 
@@ -72,14 +81,27 @@ rec {
       iniAtom =
         if listsAsDuplicateKeys then
           coercedTo singleIniAtom lib.singleton (listOf singleIniAtom) // {
-            description = singleIniAtom.description + " or a list of them for duplicate keys";
+            description = singleIniAtom.description + " or a list of them";
+          }
+        else if listToValue != null then
+          coercedTo singleIniAtom lib.singleton (nonEmptyListOf singleIniAtom) // {
+            description = singleIniAtom.description + " or a non-empty list of them";
           }
         else
           singleIniAtom;
 
     in attrsOf (attrsOf iniAtom);
 
-    generate = name: value: pkgs.writeText name (lib.generators.toINI args value);
+    generate = name: value:
+      let
+        transformedValue =
+          if listToValue != null
+          then
+            lib.mapAttrs (section: lib.mapAttrs (key: val:
+              if lib.isList val then listToValue val else val
+            )) value
+          else value;
+      in pkgs.writeText name (lib.generators.toINI (removeAttrs args ["listToValue"]) transformedValue);
 
   };
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -81,7 +81,7 @@ rec {
       iniAtom =
         if listsAsDuplicateKeys then
           coercedTo singleIniAtom lib.singleton (listOf singleIniAtom) // {
-            description = singleIniAtom.description + " or a list of them";
+            description = singleIniAtom.description + " or a list of them for duplicate keys";
           }
         else if listToValue != null then
           coercedTo singleIniAtom lib.singleton (nonEmptyListOf singleIniAtom) // {

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -124,6 +124,22 @@ in runBuildTests {
     '';
   };
 
+  testIniListToValue = {
+    drv = evalFormat formats.ini { listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault {}); } {
+      foo = {
+        bar = [ null true "test" 1.2 10 ];
+        baz = false;
+        qux = "qux";
+      };
+    };
+    expected = ''
+      [foo]
+      bar=null, true, test, 1.200000, 10
+      baz=false
+      qux=qux
+    '';
+  };
+
   testTomlAtoms = {
     drv = evalFormat formats.toml {} {
       false = false;


### PR DESCRIPTION
###### Motivation for this change

Allows coercing lists to values. E.g.

```nix
let
  pkgs = import ./. {};
  format = pkgs.formats.ini {
    listToValue = pkgs.lib.concatMapStringsSep ", " (pkgs.lib.generators.mkValueStringDefault {});
  };
in format.generate "config.ini" {
  foo.bar = [ 10 true ];
}
```

to create
```ini
[foo]
bar=10, true
```

For https://github.com/NixOS/nixpkgs/pull/120440#discussion_r619571093

Ping @aanderse @dotlambda @andir 

###### Things done

- [x] Tested manually
- [x] Added new test, running all format tests successfully with `nix-build pkgs/pkgs-lib/tests`
- [x] Updated docs