### PR TITLE
Re-add Transcribe, version 9.00

### DIFF
--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchzip, lib, wrapGAppsHook, alsaLib, atk, cairo, gdk-pixbuf
+, glib, gst_all_1,  gtk3, libSM, libX11, libpng12, pango, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "transcribe";
+  version = "9.00";
+
+  src = if stdenv.hostPlatform.system == "x86_64-linux" then
+    fetchzip {
+      url = "https://www.seventhstring.com/xscribe/downlo/xscsetup-9.00.0.tar.gz";
+      sha256 = "0mgjx0hnps3jmc2d9hkskxbmwcqf7f9jx595j5sc501br1l84sdf";
+    }
+  else throw "Platform not supported";
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = with gst_all_1; [ gst-plugins-base gst-plugins-good
+    gst-plugins-bad gst-plugins-ugly ];
+
+  dontPatchELF = true;
+
+  libPath = with gst_all_1; lib.makeLibraryPath [
+    stdenv.cc.cc glib gtk3 atk pango cairo gdk-pixbuf alsaLib
+    libX11 libSM libpng12 gstreamer gst-plugins-base zlib
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/libexec $out/share/doc
+    cp transcribe $out/libexec
+    cp xschelp.htb readme_gtk.html $out/share/doc
+    cp -r gtkicons $out/share/icons
+    ln -s $out/share/doc/xschelp.htb $out/libexec
+    patchelf \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      $out/libexec/transcribe
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+      --prefix LD_LIBRARY_PATH : "${libPath}"
+    )
+  '';
+
+  postFixup = ''
+    ln -s $out/libexec/transcribe $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Software to help transcribe recorded music";
+    longDescription = ''
+      The Transcribe! application is an assistant for people who want
+      to work out a piece of music from a recording, in order to write
+      it out, or play it themselves, or both. It doesn't do the
+      transcribing for you, but it is essentially a specialised player
+      program which is optimised for the purpose of transcription. It
+      has many transcription-specific features not found on
+      conventional music players.
+    '';
+    homepage = "https://www.seventhstring.com/xscribe/";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -796,7 +796,6 @@ mapAliases ({
   torch-repl = throw "torch-repl has been removed, as the upstream project has been abandoned"; # added 2020-03-28
   torchPackages = throw "torchPackages has been removed, as the upstream project has been abandoned"; # added 2020-03-28
   trang = jing-trang; # added 2018-04-25
-  transcribe = throw "transcribe has been removed after being marked a broken for over a year"; # added 2020-09-16
   transmission_gtk = transmission-gtk; # added 2018-01-06
   transmission_remote_gtk = transmission-remote-gtk; # added 2018-01-06
   transmission-remote-cli = "transmission-remote-cli has been removed, as the upstream project has been abandoned. Please use tremc instead"; # added 2020-10-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26456,6 +26456,8 @@ in
 
   transcode = callPackage ../applications/audio/transcode { };
 
+  transcribe = callPackage ../applications/audio/transcribe { };
+
   transmission = callPackage ../applications/networking/p2p/transmission { };
   libtransmission = transmission.override {
     installLib = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Transcribe was dropped by 5e8db8802bda69a09b58a66c7af0dcb57b77d6f5, I use it so I would like to add it back.

https://www.seventhstring.com/xscribe/overview.html

###### Things done

I asked the author of Transcribe to put the archives at a URL with the version, this should prevent the package from breaking unexpectedly in the future.
I basically reverted the change and fixed the URL and hash.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
