### PR TITLE
haskell-updates: Example hackage-packages update

### DIFF
--- a/maintainers/scripts/haskell/regenerate-hackage-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-hackage-packages.sh
@@ -18,3 +18,8 @@ extractionDerivation='with import ./. {}; runCommand "unpacked-cabal-hashes" { }
 unpacked_hackage="$(nix-build -E "$extractionDerivation" --no-out-link)"
 
 hackage2nix --hackage "$unpacked_hackage" --preferred-versions <(for n in "$unpacked_hackage"/*/preferred-versions; do cat "$n"; echo; done) --nixpkgs "$PWD" --config pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+
+if [[ "${1:-}" == "--do-commit" ]]; then
+   git add pkgs/development/haskell-modules/hackage-packages.nix
+   git commit -m "hackage-packages.nix: Regenerate based on current config"
+fi

--- a/maintainers/scripts/haskell/update-hackage.sh
+++ b/maintainers/scripts/haskell/update-hackage.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 
 pin_file=pkgs/data/misc/hackage/pin.json
 current_commit="$(jq -r .commit $pin_file)"
-head_commit="$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/commercialhaskell/all-cabal-hashes/branches/hackage | jq -r .commit.sha)"
+git_info="$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/commercialhaskell/all-cabal-hashes/branches/hackage)"
+head_commit="$(echo "$git_info" | jq -r .commit.sha)"
+commit_msg="$(echo "$git_info" | jq -r .commit.commit.message)"
 
 if [ "$current_commit" != "$head_commit" ]; then
    url="https://github.com/commercialhaskell/all-cabal-hashes/archive/$head_commit.tar.gz"
@@ -16,6 +18,12 @@ if [ "$current_commit" != "$head_commit" ]; then
      --arg commit "$head_commit" \
      --arg hash "$hash" \
      --arg url "$url" \
-     '{commit: $commit, url: $url, sha256: $hash}' \
+     --arg commit_msg "$commit_msg" \
+     '{commit: $commit, url: $url, sha256: $hash, msg: $commit_msg}' \
      > $pin_file
+fi
+
+if [[ "${1:-}" == "--do-commit" ]]; then
+   git add pkgs/data/misc/hackage/pin.json
+   git commit -m "all-cabal-hashes: Changing pin to '$commit_msg'"
 fi

--- a/maintainers/scripts/haskell/update-stackage.sh
+++ b/maintainers/scripts/haskell/update-stackage.sh
@@ -49,3 +49,8 @@ sed -e '/  # Stackage Nightly/,/^$/c \TODO\
 sed -e "/TODO/r $tmpfile" \
     -e "s/TODO/  # Stackage Nightly $version/" \
     -i pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+
+if [[ "${1:-}" == "--do-commit" ]]; then
+   git add pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+   git commit -m "configuration-hackage2nix.yaml: Changing Stackage pin to Nightly $version"
+fi

--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,5 +1,6 @@
 {
-  "commit": "f04ff9179e228b67aee1241fe8c6508f91e92fb5",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/f04ff9179e228b67aee1241fe8c6508f91e92fb5.tar.gz",
-  "sha256": "11k786zcj21hgjxd2fvfshllxdl1z252x01wvfs16wp66n720wly"
+  "commit": "95e79fb1492c7f34c2454dcb783ac8b46c0f5c8c",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/95e79fb1492c7f34c2454dcb783ac8b46c0f5c8c.tar.gz",
+  "sha256": "1wp7m8j6z2j6h8z14cnzg223jmkcgpsafraxiirbih3h4wqq2nhr",
+  "msg": "Update from Hackage at 2021-05-03T20:39:01Z"
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -101,7 +101,7 @@ default-package-overrides:
   - gi-secret < 0.0.13
   - gi-vte < 2.91.28
 
-  # Stackage Nightly 2021-04-28
+  # Stackage Nightly 2021-05-03
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -335,7 +335,7 @@ default-package-overrides:
   - benchpress ==0.2.2.16
   - between ==0.11.0.0
   - bibtex ==0.1.0.6
-  - bifunctors ==5.5.10
+  - bifunctors ==5.5.11
   - bimap ==0.4.0
   - bimaps ==0.1.0.2
   - bimap-server ==0.1.0.1
@@ -391,7 +391,7 @@ default-package-overrides:
   - boundingboxes ==0.2.3
   - bower-json ==1.0.0.1
   - boxes ==0.1.5
-  - brick ==0.61
+  - brick ==0.62
   - broadcast-chan ==0.2.1.1
   - bsb-http-chunked ==0.0.0.4
   - bson ==0.4.0.1
@@ -508,6 +508,7 @@ default-package-overrides:
   - cmdargs ==0.10.21
   - codec-beam ==0.2.0
   - code-page ==0.2.1
+  - collect-errors ==0.1.0.0
   - co-log-concurrent ==0.5.0.0
   - co-log-core ==0.2.1.1
   - Color ==0.3.1
@@ -702,7 +703,7 @@ default-package-overrides:
   - Diff ==0.4.0
   - digest ==0.0.1.2
   - digits ==0.3.1
-  - dimensional ==1.3
+  - dimensional ==1.4
   - di-monad ==1.3.1
   - directory-tree ==0.12.1
   - direct-sqlite ==2.3.26
@@ -827,7 +828,7 @@ default-package-overrides:
   - expiring-cache-map ==0.0.6.1
   - explicit-exception ==0.1.10
   - exp-pairs ==0.2.1.0
-  - express ==0.1.6
+  - express ==0.1.8
   - extended-reals ==0.2.4.0
   - extensible-effects ==5.0.0.1
   - extensible-exceptions ==0.1.1.4
@@ -842,7 +843,7 @@ default-package-overrides:
   - fakepull ==0.3.0.2
   - faktory ==1.0.2.1
   - fast-digits ==0.3.0.0
-  - fast-logger ==3.0.3
+  - fast-logger ==3.0.5
   - fast-math ==1.0.2
   - fb ==2.1.1
   - fclabels ==2.0.5
@@ -1076,7 +1077,7 @@ default-package-overrides:
   - happy ==1.20.0
   - happy-meta ==0.2.0.11
   - HasBigDecimal ==0.1.1
-  - hasbolt ==0.1.4.4
+  - hasbolt ==0.1.4.5
   - hashable ==1.3.0.0
   - hashable-time ==0.2.1
   - hashids ==1.0.2.4
@@ -1335,7 +1336,7 @@ default-package-overrides:
   - inliterate ==0.1.0
   - input-parsers ==0.2.2
   - insert-ordered-containers ==0.2.4
-  - inspection-testing ==0.4.4.0
+  - inspection-testing ==0.4.5.0
   - instance-control ==0.1.2.0
   - int-cast ==0.2.0.0
   - integer-logarithms ==1.0.3.1
@@ -1428,7 +1429,7 @@ default-package-overrides:
   - language-avro ==0.1.3.1
   - language-bash ==0.9.2
   - language-c ==0.8.3
-  - language-c-quote ==0.12.2.1
+  - language-c-quote ==0.13
   - language-docker ==9.3.0
   - language-java ==0.2.9
   - language-javascript ==0.7.1.0
@@ -1520,9 +1521,10 @@ default-package-overrides:
   - lzma ==0.0.0.3
   - lzma-conduit ==1.2.1
   - machines ==0.7.2
+  - machines-binary ==7.0.0.0
   - magic ==1.1
   - magico ==0.0.2.1
-  - mainland-pretty ==0.7.0.1
+  - mainland-pretty ==0.7.1
   - main-tester ==0.2.0.1
   - makefile ==1.1.0.0
   - managed ==1.0.8
@@ -1962,7 +1964,7 @@ default-package-overrides:
   - pureMD5 ==2.1.3
   - purescript-bridge ==0.14.0.0
   - pushbullet-types ==0.4.1.0
-  - pusher-http-haskell ==2.1.0.0
+  - pusher-http-haskell ==2.1.0.1
   - pvar ==1.0.0.0
   - PyF ==0.9.0.3
   - qchas ==1.1.0.1
@@ -2011,7 +2013,7 @@ default-package-overrides:
   - rate-limit ==1.4.2
   - ratel-wai ==1.1.5
   - rattle ==0.2
-  - rattletrap ==11.1.0
+  - rattletrap ==11.1.1
   - Rattus ==0.5
   - rawfilepath ==0.2.4
   - rawstring-qm ==0.2.3.0
@@ -2031,7 +2033,7 @@ default-package-overrides:
   - recursion-schemes ==5.2.2.1
   - reducers ==3.12.3
   - refact ==0.3.0.2
-  - ref-fd ==0.4.0.2
+  - ref-fd ==0.5
   - refined ==0.6.2
   - reflection ==2.1.6
   - reform ==0.2.7.4
@@ -2039,7 +2041,7 @@ default-package-overrides:
   - reform-hamlet ==0.0.5.3
   - reform-happstack ==0.2.5.4
   - RefSerialize ==0.4.0
-  - ref-tf ==0.4.0.2
+  - ref-tf ==0.5
   - regex ==1.1.0.0
   - regex-applicative ==0.3.4
   - regex-applicative-text ==0.1.0.1
@@ -2115,8 +2117,9 @@ default-package-overrides:
   - sample-frame ==0.0.3
   - sample-frame-np ==0.0.4.1
   - sampling ==0.3.5
-  - sandwich ==0.1.0.3
-  - sandwich-slack ==0.1.0.3
+  - sandwich ==0.1.0.5
+  - sandwich-quickcheck ==0.1.0.5
+  - sandwich-slack ==0.1.0.4
   - sandwich-webdriver ==0.1.0.4
   - say ==0.1.0.1
   - sbp ==2.6.3
@@ -2284,7 +2287,7 @@ default-package-overrides:
   - sql-words ==0.1.6.4
   - squeal-postgresql ==0.7.0.1
   - squeather ==0.6.0.0
-  - srcloc ==0.5.1.2
+  - srcloc ==0.6
   - stache ==2.2.1
   - stackcollapse-ghc ==0.0.1.3
   - stack-templatizer ==0.1.0.2
@@ -2341,7 +2344,7 @@ default-package-overrides:
   - stripe-http-client ==2.6.2
   - stripe-tests ==2.6.2
   - strive ==5.0.14
-  - structs ==0.1.5
+  - structs ==0.1.6
   - structured ==0.1.0.1
   - structured-cli ==2.7.0.1
   - subcategories ==0.1.1.0
@@ -2692,7 +2695,7 @@ default-package-overrides:
   - Win32 ==2.6.1.0
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
-  - witch ==0.2.0.2
+  - witch ==0.2.1.1
   - witherable ==0.4.1
   - within ==0.2.0.1
   - with-location ==0.1.0


### PR DESCRIPTION
This is a rather unorthodox PR as normally I would just push this to haskell-updates, but I thought it would be nice to briefly discuss this.

I have done:

1. Add `--do-commit` option to the relevant haskell update scripts.
2. Run: `maintainers/scripts/haskell/update-hackage.sh --do-commit && maintainers/scripts/haskell/update-stackage.sh --do-commit && maintainers/scripts/haskell/regenerate-hackage-packages.sh --do-commit`

@NixOS/haskell any suggestions for improvement?