### PR TITLE
cardboard: init at 0.0.0-unstable=2021-01-21

### DIFF
--- a/pkgs/applications/window-managers/cardboard/default.nix
+++ b/pkgs/applications/window-managers/cardboard/default.nix
@@ -1,0 +1,115 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchurl
+, fetchgit
+, ffmpeg
+, libGL
+, libX11
+, libcap
+, libdrm
+, libinput
+, libpng
+, libxcb
+, libxkbcommon
+, mesa
+, meson
+, ninja
+, pixman
+, pkg-config
+, unzip
+, wayland
+, wayland-protocols
+, xcbutilerrors
+, xcbutilimage
+, xcbutilwm
+}:
+
+let
+  # cereal.wrap
+  cereal-wrap = fetchurl {
+    name = "cereal-1.3.0.tar.gz";
+    url = "https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz";
+    hash = "sha256-Mp6j4xMLAmwDpKzFDhaOfa/05uZhvGp9/sDXe1cIUdU=";
+  };
+  cereal-wrapdb = fetchurl {
+    name = "cereal-1.3.0-1-wrap.zip";
+    url = "https://wrapdb.mesonbuild.com/v1/projects/cereal/1.3.0/1/get_zip";
+    hash = "sha256-QYck5UT7fPLqtLDb1iOSX4Hnnns48Jj23Ae/LCfLSKY=";
+  };
+
+  # expected.wrap
+  expected-wrap = fetchgit {
+    name = "expected";
+    url = "https://gitlab.com/cardboardwm/expected";
+    rev = "0ee13cb2b058809aa9708c45ca18d494e72a759e";
+    sha256 = "sha256-gYr4/pjuLlr3k6Jcrg2/SzJLtbgyA+ZN2oMHkHXANDo=";
+  };
+
+  # wlroots.wrap
+  wlroots-wrap = fetchgit {
+    name = "wlroots";
+    url = "https://github.com/swaywm/wlroots";
+    rev = "0.12.0";
+    sha256 = "sha256-1rE3D+kQprjcjobc95/mQkUa5y1noY0MdoYJ/SpFQwY=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "cardboard";
+  version = "0.0.0-unstable=2021-01-21";
+
+  src = fetchFromGitLab {
+    owner = "cardboardwm";
+    repo = pname;
+    rev = "f2ef2ff076ddbbd23994553b8eff131f9bd0207f";
+    hash = "sha256-43aqAWk4QoIP0BpRyPRDWFtVh/1UbrBoEeTDEF2gZX4=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    unzip
+  ];
+  buildInputs = [
+    ffmpeg
+    libGL
+    libX11
+    libcap
+    libdrm
+    libinput
+    libpng
+    libxcb
+    libxkbcommon
+    mesa
+    pixman
+    wayland
+    wayland-protocols
+    xcbutilerrors
+    xcbutilimage
+    xcbutilwm
+  ];
+
+  postPatch = ''
+    (cd subprojects
+     tar xvf ${cereal-wrap}
+     unzip ${cereal-wrapdb}
+     cp -r ${expected-wrap} ${expected-wrap.name}
+     cp -r ${wlroots-wrap} ${wlroots-wrap.name}
+    )
+  '';
+
+  # "Inherited" from Nixpkgs expression for wlroots
+  mesonFlags = [
+    "-Dwlroots:logind-provider=systemd"
+    "-Dwlroots:libseat=disabled"
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/cardboardwm/cardboard";
+    description = "A scrollable, tiling Wayland compositor inspired on PaperWM";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22365,6 +22365,8 @@ in
 
   caerbannog = callPackage ../applications/misc/caerbannog { };
 
+  cardboard = callPackage ../applications/window-managers/cardboard { };
+
   cage = callPackage ../applications/window-managers/cage { };
 
   calf = callPackage ../applications/audio/calf {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
