### PR TITLE
nixos/botamusique: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -238,6 +238,7 @@
   ./services/amqp/activemq/default.nix
   ./services/amqp/rabbitmq.nix
   ./services/audio/alsa.nix
+  ./services/audio/botamusique.nix
   ./services/audio/jack.nix
   ./services/audio/icecast.nix
   ./services/audio/jmusicbot.nix

--- a/nixos/modules/services/audio/botamusique.nix
+++ b/nixos/modules/services/audio/botamusique.nix
@@ -1,0 +1,114 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.botamusique;
+
+  format = pkgs.formats.ini {};
+  configFile = format.generate "botamusique.ini" cfg.settings;
+in
+{
+  meta.maintainers = with lib.maintainers; [ hexa ];
+
+  options.services.botamusique = {
+    enable = mkEnableOption "botamusique, a bot to play audio streams on mumble";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.botamusique;
+      description = "The botamusique package to use.";
+    };
+
+    settings = mkOption {
+      type = with types; submodule {
+        freeformType = format.type;
+        options = {
+          server.host = mkOption {
+            type = types.str;
+            default = "localhost";
+            example = "mumble.example.com";
+            description = "Hostname of the mumble server to connect to.";
+          };
+
+          server.port = mkOption {
+            type = types.port;
+            default = 64738;
+            description = "Port of the mumble server to connect to.";
+          };
+
+          bot.username = mkOption {
+            type = types.str;
+            default = "botamusique";
+            description = "Name the bot should appear with.";
+          };
+
+          bot.comment = mkOption {
+            type = types.str;
+            default = "Hi, I'm here to play radio, local music or youtube/soundcloud music. Have fun!";
+            description = "Comment displayed for the bot.";
+          };
+        };
+      };
+      default = {};
+      description = ''
+        Your <filename>configuration.ini</filename> as a Nix attribute set. Look up
+        possible options in the <link xlink:href="https://github.com/azlux/botamusique/blob/master/configuration.example.ini">configuration.example.ini</link>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.botamusique = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      unitConfig.Documentation = "https://github.com/azlux/botamusique/wiki";
+
+      environment.HOME = "/var/lib/botamusique";
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/botamusique --config ${configFile}";
+        Restart = "always"; # the bot exits when the server connection is lost
+
+        # Hardening
+        CapabilityBoundingSet = [ "" ];
+        DynamicUser = true;
+        IPAddressDeny = [
+          "link-local"
+          "multicast"
+        ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        ProcSubset = "pid";
+        PrivateDevices = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        StateDirectory = "botamusique";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+        WorkingDirectory = "/var/lib/botamusique";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -47,6 +47,7 @@ in
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};
+  botamusique = handleTest ./botamusique.nix {};
   buildbot = handleTest ./buildbot.nix {};
   buildkite-agents = handleTest ./buildkite-agents.nix {};
   caddy = handleTest ./caddy.nix {};

--- a/nixos/tests/botamusique.nix
+++ b/nixos/tests/botamusique.nix
@@ -1,0 +1,47 @@
+import ./make-test-python.nix ({ pkgs, lib, ...} :
+
+{
+  name = "botamusique";
+  meta.maintainers = with lib.maintainers; [ hexa ];
+
+  nodes = {
+    machine = { config, ... }: {
+      services.murmur = {
+        enable = true;
+        registerName = "NixOS tests";
+      };
+
+      services.botamusique = {
+        enable = true;
+        settings = {
+          server = {
+            channel = "NixOS tests";
+          };
+          bot = {
+            version = false;
+            auto_check_update = false;
+          };
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("murmur.service")
+    machine.wait_for_unit("botamusique.service")
+
+    machine.sleep(10)
+
+    machine.wait_until_succeeds(
+        "journalctl -u murmur.service -e | grep -q '<1:botamusique(-1)> Authenticated'"
+    )
+
+    with subtest("Check systemd hardening"):
+        output = machine.execute("systemctl show botamusique.service")[1]
+        machine.log(output)
+        output = machine.execute("systemd-analyze security botamusique.service")[1]
+        machine.log(output)
+  '';
+})

--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -11,23 +11,15 @@
 
 buildPythonPackage rec {
   pname = "pymumble";
-  version = "1.6";
+  version = "1.6.1";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "azlux";
     repo = "pymumble";
     rev = version;
-    sha256 = "04nc66d554a98mbmdgzgsg6ncaz0jsn4zdr3mr14w6wnhrxpjkrs";
+    sha256 = "1qbsd2zvwd9ksclgiyrl1z79ms0zximm4527mnmhvq36lykgki7s";
   };
-  patches = [
-    # Compatibility with pycryptodome (which is what our pycrypto really is)
-    # See https://github.com/azlux/pymumble/pull/99
-    (fetchpatch {
-      url = "https://github.com/azlux/pymumble/pull/99/commits/b85548a0e1deaac820954b1c0b308af214311a14.patch";
-      sha256 = "0w9dpc87rny6vmhi634pih1p97b67jm26qajscpa9wp6nphdlxlj";
-    })
-  ];
 
   postPatch = ''
     # Changes all `library==x.y.z` statements to just `library`
@@ -35,11 +27,20 @@ buildPythonPackage rec {
     sed -i 's/\(.*\)==.*/\1/' requirements.txt
   '';
 
-  propagatedBuildInputs = [ opuslib protobuf ];
+  propagatedBuildInputs = [
+    opuslib
+    protobuf
+  ];
 
-  checkInputs = [ pytestCheckHook pycrypto ];
+  checkInputs = [
+    pycrypto
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "pymumble_py3" ];
+  pythonImportsCheck = [
+    "pymumble_py3"
+    "pymumble_py3.constants"
+  ];
 
   meta = with lib; {
     description = "Python 3 version of pymumble, Mumble library used for multiple uses like making mumble bot.";

--- a/pkgs/tools/audio/botamusique/default.nix
+++ b/pkgs/tools/audio/botamusique/default.nix
@@ -5,6 +5,7 @@
 , python3Packages
 , ffmpeg
 , makeWrapper
+, nixosTests
 
 # For the update script
 , coreutils
@@ -139,6 +140,10 @@ stdenv.mkDerivation rec {
       --composition /dev/null \
       --output ${toString ./node-packages.nix}
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) botamusique;
+  };
 
   meta = with lib; {
     description = "Bot to play youtube / soundcloud / radio / local music on Mumble";

--- a/pkgs/tools/audio/botamusique/node-packages.nix
+++ b/pkgs/tools/audio/botamusique/node-packages.nix
@@ -1624,13 +1624,13 @@ let
         sha512 = "dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
       };
     };
-    "colorette-1.2.1" = {
+    "colorette-1.2.2" = {
       name = "colorette";
       packageName = "colorette";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz";
-        sha512 = "puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==";
+        url = "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz";
+        sha512 = "MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==";
       };
     };
     "command-line-usage-6.1.1" = {
@@ -2497,13 +2497,13 @@ let
         sha512 = "F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==";
       };
     };
-    "hosted-git-info-2.8.8" = {
+    "hosted-git-info-2.8.9" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.8.8";
+      version = "2.8.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz";
-        sha512 = "f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz";
+        sha512 = "mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==";
       };
     };
     "html-minifier-terser-5.1.1" = {
@@ -2992,13 +2992,13 @@ let
         sha512 = "t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==";
       };
     };
-    "lodash-4.17.20" = {
+    "lodash-4.17.21" = {
       name = "lodash";
       packageName = "lodash";
-      version = "4.17.20";
+      version = "4.17.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz";
-        sha512 = "PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==";
+        url = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz";
+        sha512 = "v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==";
       };
     };
     "lower-case-2.0.1" = {
@@ -3109,13 +3109,13 @@ let
         sha512 = "sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==";
       };
     };
-    "nanoid-3.1.18" = {
+    "nanoid-3.1.23" = {
       name = "nanoid";
       packageName = "nanoid";
-      version = "3.1.18";
+      version = "3.1.23";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz";
-        sha512 = "rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA==";
+        url = "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz";
+        sha512 = "FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==";
       };
     };
     "natural-compare-1.4.0" = {
@@ -3523,13 +3523,13 @@ let
         sha512 = "Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==";
       };
     };
-    "postcss-8.1.10" = {
+    "postcss-8.2.15" = {
       name = "postcss";
       packageName = "postcss";
-      version = "8.1.10";
+      version = "8.2.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-8.1.10.tgz";
-        sha512 = "iBXEV5VTTYaRRdxiFYzTtuv2lGMQBExqkZKSzkJe+Fl6rvQrA/49UVGKqB+LG54hpW/TtDBMGds8j33GFNW7pg==";
+        url = "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz";
+        sha512 = "2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==";
       };
     };
     "postcss-loader-4.1.0" = {
@@ -4414,15 +4414,6 @@ let
         sha512 = "DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==";
       };
     };
-    "vfile-location-3.2.0" = {
-      name = "vfile-location";
-      packageName = "vfile-location";
-      version = "3.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz";
-        sha512 = "aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==";
-      };
-    };
     "watchpack-2.0.1" = {
       name = "watchpack";
       packageName = "watchpack";
@@ -4536,7 +4527,7 @@ let
     name = "botamusique";
     packageName = "botamusique";
     version = "0.0.0";
-    src = ../../../../../../../../run/user/1000/tmp.ioJA7NbZmp;
+    src = ../../../../../../../../../tmp/tmp.hWY9btrx5g;
     dependencies = [
       sources."@babel/code-frame-7.10.4"
       sources."@babel/compat-data-7.12.7"
@@ -4735,7 +4726,7 @@ let
       })
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."colorette-1.2.1"
+      sources."colorette-1.2.2"
       sources."command-line-usage-6.1.1"
       sources."commander-4.1.1"
       sources."comment-parser-0.7.6"
@@ -4886,7 +4877,7 @@ let
       sources."has-flag-3.0.0"
       sources."has-symbols-1.0.1"
       sources."he-1.2.0"
-      sources."hosted-git-info-2.8.8"
+      sources."hosted-git-info-2.8.9"
       sources."html-minifier-terser-5.1.1"
       sources."html-webpack-plugin-4.5.0"
       (sources."htmlparser2-3.10.1" // {
@@ -4964,7 +4955,7 @@ let
         ];
       })
       sources."locate-path-2.0.0"
-      sources."lodash-4.17.20"
+      sources."lodash-4.17.21"
       sources."lower-case-2.0.1"
       sources."make-dir-2.1.0"
       sources."merge-stream-2.0.0"
@@ -4981,7 +4972,7 @@ let
       sources."minimist-1.2.5"
       sources."mkdirp-0.5.5"
       sources."ms-2.1.2"
-      sources."nanoid-3.1.18"
+      sources."nanoid-3.1.23"
       sources."natural-compare-1.4.0"
       sources."neo-async-2.6.2"
       sources."no-case-3.0.3"
@@ -5024,7 +5015,7 @@ let
       sources."pify-4.0.1"
       sources."pkg-dir-2.0.0"
       sources."popper.js-1.16.1"
-      (sources."postcss-8.1.10" // {
+      (sources."postcss-8.2.15" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -5179,7 +5170,6 @@ let
       sources."utila-0.4.0"
       sources."v8-compile-cache-2.2.0"
       sources."validate-npm-package-license-3.0.4"
-      sources."vfile-location-3.2.0"
       sources."watchpack-2.0.1"
       (sources."webpack-5.6.0" // {
         dependencies = [

--- a/pkgs/tools/audio/botamusique/src.json
+++ b/pkgs/tools/audio/botamusique/src.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/azlux/botamusique",
-  "rev": "df38c7dbd6d59c6790cf2364d1f344b7f6f72107",
-  "date": "2021-03-13T15:44:40+08:00",
-  "path": "/nix/store/30ds4gp7aldj9rqix1xf7j2ps5blrx8w-botamusique",
-  "sha256": "06xw1pif145zcm9z8l9kzl8ayl7vy5ywr0m3a5yswybcp2fzj087",
+  "rev": "33a9e75ba9d0a382f7a76d23a0ceb626924a8b49",
+  "date": "2021-05-19T22:37:39+08:00",
+  "path": "/nix/store/dqc2vjd43cixm49w8g66wvi9zmdfwsdd-botamusique",
+  "sha256": "18lbgslx9vdwd5nrbkqfjvzaikp2swvv375v9gql7cg8p46w7i11",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Proper setup of botamusique, a mumble music bot.

I did look into certificate creation, the upstreams example looks like this: 

> openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout botamusique.pem -out botamusique.pem -subj "/CN=botamusique"

Something users could do themselves, or we could handle it in ExecStartPre, not sure.

I did not look into what giving the bot tokens would do, I guess allow them to register?

Both could be exposed at the top-level, certificate is actually a path, tokens are literal strings. Nothing really security-critical ig.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
