### PR TITLE
workstyle: 0.2.1 -> unstable-2021-05-09

### DIFF
--- a/pkgs/applications/window-managers/i3/workstyle.nix
+++ b/pkgs/applications/window-managers/i3/workstyle.nix
@@ -5,16 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "workstyle";
-  version = "0.2.1";
+  version = "unstable-2021-05-09";
 
   src = fetchFromGitHub {
     owner = "pierrechevalier83";
     repo = pname;
-    rev = "43b0b5bc0a66d40289ff26b8317f50510df0c5f9";
-    sha256 = "0f4hwf236823qmqy31fczjb1hf3fvvac3x79jz2l7li55r6fd8hn";
+    rev = "f2023750d802259ab3ee7d7d1762631ec157a0b1";
+    sha256 = "04xds691sw4pi2nq8xvdhn0312wwia60gkd8b1bjqy11zrqbivbx";
   };
 
-  cargoSha256 = "1hy68wvsxncsy4yx4biigfvwyq18c7yp1g543c6nca15cdzs1c54";
+  cargoSha256 = "0xwv8spr96z4aimjlr15bhwl6i3zqp7jr45d9zr3sbi9d8dbdja2";
 
   doCheck = false; # No tests
 


### PR DESCRIPTION
###### Motivation for this change

A recent compiler updater causes workstyle to crash on start. This fixes this issue.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
