### PR TITLE
emacs.pkgs: 2021-05-03

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-generated.nix
@@ -114,10 +114,10 @@
       elpaBuild {
         pname = "aggressive-completion";
         ename = "aggressive-completion";
-        version = "1.5";
+        version = "1.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/aggressive-completion-1.5.tar";
-          sha256 = "1gy0q5yc1a0w31qpyb92f672zcfgxbp5s104ycgk11jxk4y17nw9";
+          url = "https://elpa.gnu.org/packages/aggressive-completion-1.6.tar";
+          sha256 = "0i7kcxd7pbdw57gczbxddr2n4j778x2ccfpkgjhdlpdsyidfh2bq";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -219,16 +219,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    async = callPackage ({ cl-lib ? null, elpaBuild, fetchurl, lib, nadvice }:
+    async = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "async";
         ename = "async";
-        version = "1.9.3";
+        version = "1.9.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/async-1.9.3.tar";
-          sha256 = "1pmfjrlapvhkjqcal8x95w190hm9wsgxb3byc22rc1gf5z0p52c8";
+          url = "https://elpa.gnu.org/packages/async-1.9.5.tar";
+          sha256 = "02f43vqlggy4qkqdggkl9mcg3rvagjysj45xgrx41jjx6cnjnm19";
         };
-        packageRequires = [ cl-lib nadvice ];
+        packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/async.html";
           license = lib.licenses.free;
@@ -238,10 +238,10 @@
       elpaBuild {
         pname = "auctex";
         ename = "auctex";
-        version = "13.0.6";
+        version = "13.0.11";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/auctex-13.0.6.tar";
-          sha256 = "00wp388rh2nnk8fam53kilykg90jylps31qxv9ijy1lsp1hqdjys";
+          url = "https://elpa.gnu.org/packages/auctex-13.0.11.tar";
+          sha256 = "0sy4f1n38q58vyzw5l0f80ci3j99rb25gbwj0frl0pglfmgzl44k";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -482,10 +482,10 @@
       elpaBuild {
         pname = "cl-lib";
         ename = "cl-lib";
-        version = "0.6.1";
+        version = "0.7";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/cl-lib-0.6.1.el";
-          sha256 = "00w7bw6wkig13pngijh7ns45s1jn5kkbbjaqznsdh6jk5x089j9y";
+          url = "https://elpa.gnu.org/packages/cl-lib-0.7.tar";
+          sha256 = "0s1vkkj1yc5zn6bvc84sr726cm4v3jh2ymm7hc3rr00swwbz35lv";
         };
         packageRequires = [];
         meta = {
@@ -651,6 +651,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    corfu = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "corfu";
+        ename = "corfu";
+        version = "0.4";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/corfu-0.4.tar";
+          sha256 = "0yaspx58w02n3liqy5i4lm6lk5f1fm6v5lfrzp7xaqnngq1f4gbj";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/corfu.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     counsel = callPackage ({ elpaBuild, emacs, fetchurl, ivy, lib, swiper }:
       elpaBuild {
         pname = "counsel";
@@ -775,10 +790,10 @@
       elpaBuild {
         pname = "debbugs";
         ename = "debbugs";
-        version = "0.27";
+        version = "0.28";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/debbugs-0.27.tar";
-          sha256 = "1zn9p9vmfv5ihrp8d06b6abs48q225v42cgwa01s39hld6zg6wbv";
+          url = "https://elpa.gnu.org/packages/debbugs-0.28.tar";
+          sha256 = "1qks38hpg3drhxzw66n5yxfq0v6fj9ya7d9dc6x0xwfp6r2x0li0";
         };
         packageRequires = [ emacs soap-client ];
         meta = {
@@ -1209,7 +1224,8 @@
           license = lib.licenses.free;
         };
       }) {};
-    excorporate = callPackage ({ elpaBuild
+    excorporate = callPackage ({ cl-lib ? null
+                               , elpaBuild
                                , emacs
                                , fetchurl
                                , fsm
@@ -1220,12 +1236,19 @@
       elpaBuild {
         pname = "excorporate";
         ename = "excorporate";
-        version = "0.9.5";
+        version = "0.9.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/excorporate-0.9.5.tar";
-          sha256 = "0z5x8lqvxh8zra23nmh36cdnr2yk855i4fc3mlbwaj5sdy9sqpf5";
+          url = "https://elpa.gnu.org/packages/excorporate-0.9.6.tar";
+          sha256 = "0ljav8g1npg0a36x1xxpfs2gvk622fh3si95s3w2vmwa27ynirzj";
         };
-        packageRequires = [ emacs fsm nadvice soap-client url-http-ntlm ];
+        packageRequires = [
+          cl-lib
+          emacs
+          fsm
+          nadvice
+          soap-client
+          url-http-ntlm
+        ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/excorporate.html";
           license = lib.licenses.free;
@@ -2233,10 +2256,10 @@
       elpaBuild {
         pname = "modus-themes";
         ename = "modus-themes";
-        version = "1.2.4";
+        version = "1.3.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-themes-1.2.4.tar";
-          sha256 = "0wz6dgkrq4ryvj0kxnzqxwh4i8b9lw15d5dsazjpqa7gfwffpzp0";
+          url = "https://elpa.gnu.org/packages/modus-themes-1.3.2.tar";
+          sha256 = "085zi3ckf4s1kjskqb04b78rgrhbdhrrp74yksb5w0hl58bd8rsc";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2696,10 +2719,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.4.2";
+        version = "0.4.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.4.2.tar";
-          sha256 = "0ngh54jdh56563crgvf0r4gd6zfvhbkxs9prp12930gav8mdm3sh";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.4.3.tar";
+          sha256 = "0yvwfaj7l4z3zgycvnf1j0r5jx4lryaapljbw2sqvwqpbgyiw0y0";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2741,10 +2764,10 @@
       elpaBuild {
         pname = "posframe";
         ename = "posframe";
-        version = "1.0.0";
+        version = "1.0.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/posframe-1.0.0.tar";
-          sha256 = "1k06dbh9xqn2vix5qkcapl57v0c21b344r8dx6j5qr4jxirsn2x5";
+          url = "https://elpa.gnu.org/packages/posframe-1.0.2.tar";
+          sha256 = "19a1dkjyw9m74aamyqrsvzrdwshngqpmjzdngx6v5nifvcilrlnk";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2756,10 +2779,10 @@
       elpaBuild {
         pname = "project";
         ename = "project";
-        version = "0.5.4";
+        version = "0.6.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/project-0.5.4.tar";
-          sha256 = "0arjvhzzcf8b80w94yvpgfdlhsjwf5jk1r7vcai5a4dg3bi9cxyb";
+          url = "https://elpa.gnu.org/packages/project-0.6.0.tar";
+          sha256 = "0m0r1xgz1ffx6mi2gjz1dkgrn89sh4y5ysi0gj6p1w05bf8p0lc0";
         };
         packageRequires = [ emacs xref ];
         meta = {
@@ -2801,10 +2824,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.6";
+        version = "3.7.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.6.tar";
-          sha256 = "1fmbzh33s9xdvrfjhkqr9ydcqbiv8lr04k5idvbpc9vwjjjan5y0";
+          url = "https://elpa.gnu.org/packages/pyim-3.7.1.tar";
+          sha256 = "0k73f1qdl51qshnvycjassdh70id5gp5qi5wz7k4zyl8pbampiyd";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3081,10 +3104,10 @@
       elpaBuild {
         pname = "rec-mode";
         ename = "rec-mode";
-        version = "1.6";
+        version = "1.8.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/rec-mode-1.6.tar";
-          sha256 = "1dhv3n2x0bpdisi9bj3qa0bhpjzhs57fga72s4fxh44gp92yl18q";
+          url = "https://elpa.gnu.org/packages/rec-mode-1.8.1.tar";
+          sha256 = "0injk27l38d0sl9nzjz2bkd0qgccxyf31i42mwmivv86kv0kyxyb";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3267,10 +3290,10 @@
       elpaBuild {
         pname = "setup";
         ename = "setup";
-        version = "0.1.2";
+        version = "0.2.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/setup-0.1.2.tar";
-          sha256 = "1q29phch4fvmvc255kgvzsnzdqp6kaip7ybpxprd0kkdjs3jrsqv";
+          url = "https://elpa.gnu.org/packages/setup-0.2.0.tar";
+          sha256 = "1xhjkyksilw1vbx12a4yz4bpj0dhl3m02yi8d9nyd19z098cfa9y";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3297,10 +3320,10 @@
       elpaBuild {
         pname = "shell-command-plus";
         ename = "shell-command+";
-        version = "2.0.0";
+        version = "2.1.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.0.0.tar";
-          sha256 = "1l8lwami4rbp94sbb1k4dvv7z0dvf51s0992xragpn9b9jbx5qd6";
+          url = "https://elpa.gnu.org/packages/shell-command+-2.1.0.tar";
+          sha256 = "1jyrnv89989bi03m5h8dj0cllsw3rvyxkiyfrh9v6gpxjwfy8lmq";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3691,10 +3714,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.0.3";
+        version = "2.5.0.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.0.3.tar";
-          sha256 = "0c77d1ihn17lzk9jb7ss346ryprnbii1zmijl6zj0kk4lm8fpfl3";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.0.4.tar";
+          sha256 = "0yk4ckk45gkjp24nfywz49j8pazq33m6pga3lirb5h6zc8an5z24";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3736,10 +3759,10 @@
       elpaBuild {
         pname = "transient";
         ename = "transient";
-        version = "0.3.0";
+        version = "0.3.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/transient-0.3.0.tar";
-          sha256 = "1a457apfl762nn5xf1h3hbvrgs9hybkxh0jwb2y713zkhhck66cp";
+          url = "https://elpa.gnu.org/packages/transient-0.3.2.tar";
+          sha256 = "10zqa245dn6z689z7ap6nx6q9s95whzgybpwl2slpmnawxix2q6i";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3927,10 +3950,10 @@
       elpaBuild {
         pname = "vertico";
         ename = "vertico";
-        version = "0.4";
+        version = "0.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-0.4.tar";
-          sha256 = "1af9ri51i7pn1pcsmbavnwqafrn46vbxrbqjzfi6a7q6n5yv77im";
+          url = "https://elpa.gnu.org/packages/vertico-0.6.tar";
+          sha256 = "19f6ffljraikz83nc2y9q83zjc4cfyzn9rnwm18lwh6sjsydz6kk";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4235,10 +4258,10 @@
       elpaBuild {
         pname = "xref";
         ename = "xref";
-        version = "1.0.4";
+        version = "1.1.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/xref-1.0.4.el";
-          sha256 = "0hkm59qqlsfw3w9ws9xhpmmz30ylifmh05a00ba58zvv1kz04x1g";
+          url = "https://elpa.gnu.org/packages/xref-1.1.0.tar";
+          sha256 = "1s7pwk09bry4nqr4bc78a3mbwyrxagai2gpsd49x47czy2x7m3ax";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/org-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210412";
+        version = "20210503";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210412.tar";
-          sha256 = "17hj4y0c9hjqqa7inzjadz9z64vh621lm4cb0asm13r7d1v186yf";
+          url = "https://orgmode.org/elpa/org-20210503.tar";
+          sha256 = "0j9p834c67qzxbxz8s1n8l5blylrpb3jh9wywphlb6jgbgl0mw09";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210412";
+        version = "20210503";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210412.tar";
-          sha256 = "162nl1a62l9d4nazply93sx4lih11845z87hxmpfd0n7i7s290mh";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210503.tar";
+          sha256 = "0k0wmnx2g919h3s9ynv1cvdlyxvydglslamlwph4xng4kzcr5lrk";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
@@ -34,8 +34,8 @@
     20201121,
     1210
    ],
-   "commit": "996f822a7c6a7ff7caf49ee537e92c0d01be1f9c",
-   "sha256": "0fij6gz4188g7dr3gip1w5bc1947j45gf2xc2xl8gyg6hb9c7ycq"
+   "commit": "eb4d1ec4b667040429aa496838f758823dc55788",
+   "sha256": "0llngx5ccy2v2ppbydg8nmkz4fpv5vz8knj5i7bq2mvf6rsid8jx"
   },
   "stable": {
    "version": [
@@ -198,19 +198,19 @@
   "repo": "ymarco/auto-activating-snippets",
   "unstable": {
    "version": [
-    20210316,
-    2027
+    20210417,
+    1134
    ],
-   "commit": "e2b3edafd7aafa8c47833a70984d7404c607626c",
-   "sha256": "0xg651vfjnq5dywg855wf7ld34gnfspql4b0b0413kydhh15fmxi"
+   "commit": "3076cefea0f6ae9d7757f13c27b5602e007b58ec",
+   "sha256": "1psy6qpqxh6dm2ix7pwqdcq0rbiy6hyd830g76jk4wvj4spm5rpf"
   },
   "stable": {
    "version": [
-    0,
-    2
+    1,
+    0
    ],
-   "commit": "ffafc54e02475b9e7f7bcbe1d8ed3f11bcb4b542",
-   "sha256": "054sfzvm1ihaxy4hnhl424y5py8k7wi73rb0lqvbi4v8iphihzhr"
+   "commit": "3076cefea0f6ae9d7757f13c27b5602e007b58ec",
+   "sha256": "1psy6qpqxh6dm2ix7pwqdcq0rbiy6hyd830g76jk4wvj4spm5rpf"
   }
  },
  {
@@ -310,8 +310,8 @@
     "flymake",
     "maude-mode"
    ],
-   "commit": "c9b7a2af3232aad8a51138194544c9a427cf46ca",
-   "sha256": "0h8assjgwwcgnqhlndsc86z9lc1nzlglhvhzxdnkz2ksk90n85q1"
+   "commit": "3b332ec1e941874f220897e5c0e0a6df762ca28d",
+   "sha256": "0m7v87w2akdpgr360gyjiw0p5sc6ms3y9bccwi9j4jz4gnlix6l5"
   },
   "stable": {
    "version": [
@@ -510,15 +510,15 @@
   "repo": "atilaneves/ac-dcd",
   "unstable": {
    "version": [
-    20210329,
-    1928
+    20210428,
+    1556
    ],
    "deps": [
     "auto-complete",
     "flycheck-dmd-dub"
    ],
-   "commit": "56cdead8c9d2ca64db1f24c59d005ba8b3780bd5",
-   "sha256": "1z38mg76376xac3rnamzhhmx4h4yzn89xycx7kk51vkcjffjzvg6"
+   "commit": "56d9817159acdebdbb3d5499c7e9379d29af0cd4",
+   "sha256": "0p5cjs156ac1x3fsxnb4kc6bd4z09kdkwkyav9ryw5nkrdzv0bd6"
   },
   "stable": {
    "version": [
@@ -1603,11 +1603,11 @@
   "repo": "ianpan870102/acme-emacs-theme",
   "unstable": {
    "version": [
-    20200724,
-    1833
+    20210430,
+    302
    ],
-   "commit": "e416ec678be72eb1aed3de3d88a8a9e3ee7315ca",
-   "sha256": "0y98il3gsnhm586hr1qdmif4r6v1987fzl82wgx75g8kiy5shbrj"
+   "commit": "7c408d111c5e451ecb8fdd5f76cf7d8074aec793",
+   "sha256": "16qxspzlf0bvw36ff4qnrn5p7mc5sf923ba0ar04cr87bfqgyak4"
   },
   "stable": {
    "version": [
@@ -1918,8 +1918,8 @@
     "annotation",
     "eri"
    ],
-   "commit": "3e079614f2b4810ff5920ae69a389da91c855217",
-   "sha256": "1jn0kp33b77lskhi02d0jm0rpcgxhrpxdj82bmr7vi7m199p5jn0"
+   "commit": "26d473648853255a6a46d9dedff66df7f644c42f",
+   "sha256": "18yz278724ydvkdpcwiszfx4lg40bqbwq78268pr5mg0wif0y4q6"
   },
   "stable": {
    "version": [
@@ -2015,11 +2015,11 @@
   "url": "https://bitbucket.org/agriggio/ahg",
   "unstable": {
    "version": [
-    20200304,
-    741
+    20210412,
+    847
    ],
-   "commit": "0ece48646ef7a8c813005934cc13f984b9998707",
-   "sha256": "0ypck79bmv4pa8l555kgij69jbpkv4fz9w91qs30lacjmrj0nha5"
+   "commit": "77bc2a628df006dcd2dc359ac12acdf8091a1356",
+   "sha256": "1wmvz9d40aznqh2y078v8k7n3l66m48vnf873vifi8rwg6158kqh"
   }
  },
  {
@@ -2378,11 +2378,11 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20210411,
-    1650
+    20210425,
+    1035
    ],
-   "commit": "07a4f7315bf5dd609f95e18390a9707b5a29fe9c",
-   "sha256": "0z0bqs2cqwndkjaiv301l1n4i1g7h6v89cl95inilfxxkyxhbzig"
+   "commit": "7a1225826798622d5dbe416b1d5e0a6fba8c19d7",
+   "sha256": "1h85cbr4bnianwk77f6g5k7phcrq5cw8fqxxd6b7x396ffn2pmgm"
   },
   "stable": {
    "version": [
@@ -2405,14 +2405,14 @@
   "repo": "wyuenho/all-the-icons-dired",
   "unstable": {
    "version": [
-    20210411,
-    1226
+    20210422,
+    921
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "07f035d2f6df4f1e840572784a96f5b407a74680",
-   "sha256": "134p5wz5jgbwfri6ihwf4p8xxbdmwwzpkklxn195gl46r2zqnnwx"
+   "commit": "a294f45ec2c338e1255ae2dd98b19f3f143204e6",
+   "sha256": "1m3gqsgybx57qhdlswbn92cnsz9w10sqfzs2lnja63hzwzwxjg92"
   }
  },
  {
@@ -2517,15 +2517,15 @@
   "stable": {
    "version": [
     1,
-    4,
-    1
+    5,
+    0
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "e918b23d55313a7464d8cb5d45eb917249638e32",
-   "sha256": "1wz3dgn8cggdkijzm7qf13g3s9gmz6v895bjck7sdhmr5mbr28a4"
+   "commit": "7f8249ac92321a81d3db11e56888e569988b51d5",
+   "sha256": "1fwih9qidv0wkqrcsngcainw8b5bxcbk15g5a0p5dpl6hqcxj3rz"
   }
  },
  {
@@ -3104,11 +3104,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20210322,
-    1739
+    20210429,
+    1258
    ],
-   "commit": "54ac759facadacbfea5c1e7c2975e2da6434cdda",
-   "sha256": "18pr4bympwl6c2a1bsk4s8ixg4l7ykcxfh1bk42vvbcqnbmvd7dw"
+   "commit": "ff3a0089e0a2d64803a152bdb126fd7d3de5dbc9",
+   "sha256": "0c54yjrf33fx9v0m2gh67gjnwzjb5s7b5s3f4g6aic7s052ywmix"
   },
   "stable": {
    "version": [
@@ -3146,8 +3146,8 @@
     20200914,
     644
    ],
-   "commit": "3e079614f2b4810ff5920ae69a389da91c855217",
-   "sha256": "1jn0kp33b77lskhi02d0jm0rpcgxhrpxdj82bmr7vi7m199p5jn0"
+   "commit": "26d473648853255a6a46d9dedff66df7f644c42f",
+   "sha256": "18yz278724ydvkdpcwiszfx4lg40bqbwq78268pr5mg0wif0y4q6"
   },
   "stable": {
    "version": [
@@ -3468,11 +3468,11 @@
   "repo": "dieter-wilhelm/apdl-mode",
   "unstable": {
    "version": [
-    20201024,
-    1900
+    20210423,
+    1115
    ],
-   "commit": "178af26baac72890fca1904aa9e9c90bc1668a4c",
-   "sha256": "1mkhjp9i4zhbxj72915g6b976dz7jmzyn2ma9x6n85psi3v7ldk1"
+   "commit": "5e9de43494cc307a3b43b0eebf774c03670a4582",
+   "sha256": "00lz9mcxcmlgnnbc05b49arxa2fcckjhsxdcqi66v66zn9h8kr13"
   },
   "stable": {
    "version": [
@@ -4031,11 +4031,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20210117,
-    718
+    20210501,
+    1527
    ],
-   "commit": "d7e7f79ee42311a0187aa2ab4f4e2f8843fa28da",
-   "sha256": "11r6jzqyywgzxmpq2z97j3ni5b1sv6z5lrjmkqip396bxmw9zxm1"
+   "commit": "9a8cd0c3d5c120bfa03187c54dba6e33f6e3ca19",
+   "sha256": "1s2gdilaf38m2dg6nm4kcz5n4n455a9127pl4cbz9lg7mp3l2pg5"
   },
   "stable": {
    "version": [
@@ -4237,8 +4237,8 @@
   "repo": "jyp/attrap",
   "unstable": {
    "version": [
-    20210407,
-    1826
+    20210426,
+    1348
    ],
    "deps": [
     "dash",
@@ -4246,8 +4246,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "4b088698ec81f7cd0f715b30e280b37e3881b91d",
-   "sha256": "1jil04a69fx946vh6f81x3ki84jmmdfz7g3c9v4phddz58clb1sb"
+   "commit": "a5bc695af27349ae6fe4541a581e6fd449d2a026",
+   "sha256": "06j1cpqmplh1xy5aal8fk7r8s42jf3zlk92mh3lll9knx81xix9q"
   },
   "stable": {
    "version": [
@@ -4414,6 +4414,21 @@
   }
  },
  {
+  "ename": "auth-source-kwallet",
+  "commit": "047cc780e55a0f574afaf7fa0d94c31ed86cb57f",
+  "sha256": "1fz63fdfw3cm8k59nxnbsaiylbs0nn5f250fwwfh51bknrqj3vin",
+  "fetcher": "github",
+  "repo": "vaartis/auth-source-kwallet",
+  "unstable": {
+   "version": [
+    20210421,
+    1504
+   ],
+   "commit": "c2abee6ada13d7332725bd700ad76da8aebea530",
+   "sha256": "1w43mlfslvmqabnm76j0bhkdsb4a2iwwidhm83qqrjpj08cq3ldj"
+  }
+ },
+ {
   "ename": "auth-source-pass",
   "commit": "6e63342b442794ead4d8bed803b0924d9cd26dc4",
   "sha256": "10l3kbffy08fh0krwvh4gn75k37criv2ma5hgkadvq1s2p5ps8r6",
@@ -4424,8 +4439,8 @@
     20210210,
     1908
    ],
-   "commit": "468bba286fc20d739ed7724ec884357907ac8bda",
-   "sha256": "1pazl19rd4fvnfi9i2ssaygby5pw2a821aysy8jswsij57lw40dy"
+   "commit": "fa8b964494c1ef42035fad340ff5f29fcdbed21c",
+   "sha256": "0fn30iy1jy0kh09652a0fn7zg93cf3xvs2bz28lml7knj2hbqi2r"
   },
   "stable": {
    "version": [
@@ -5008,11 +5023,11 @@
   "repo": "jcs-elpa/auto-rename-tag",
   "unstable": {
    "version": [
-    20201012,
-    630
+    20210418,
+    1758
    ],
-   "commit": "88c5236280ff8212ff5c74f3e2e654c1a288dbf2",
-   "sha256": "0q584zrqyz8cc8ib5rll44qvf30xsrjnmdz7yipzqjbvciv6kh7g"
+   "commit": "8dbf13b344f6d5eba5c4876b18905d30b3118bb9",
+   "sha256": "1nlwg78d60w6xjpqhrc49nxxvjaxj07wb036rb5jsng9yb6r94m9"
   },
   "stable": {
    "version": [
@@ -5079,26 +5094,26 @@
   "repo": "ncaq/auto-sudoedit",
   "unstable": {
    "version": [
-    20200427,
-    635
+    20210502,
+    1103
    ],
    "deps": [
     "f"
    ],
-   "commit": "0ad8247fdd0f1d747cd1ff73adb6b5efcecc7f3b",
-   "sha256": "10p0hc95j382km8655pqld9wxg10j1f36czzppkdd6a55cxarv9f"
+   "commit": "54a7f295e6b1eecbcc86741aaf5d72e404b43bce",
+   "sha256": "1rhdvrj2rjbvl7vkb0wcp6krqxcaigl7jk9z8yvhx6s4cm2qli6q"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "f"
    ],
-   "commit": "0ad8247fdd0f1d747cd1ff73adb6b5efcecc7f3b",
-   "sha256": "10p0hc95j382km8655pqld9wxg10j1f36czzppkdd6a55cxarv9f"
+   "commit": "738fd22452f00fa05daf200f997cb5db2531a211",
+   "sha256": "1rhdvrj2rjbvl7vkb0wcp6krqxcaigl7jk9z8yvhx6s4cm2qli6q"
   }
  },
  {
@@ -5216,14 +5231,14 @@
   "url": "https://git.sr.ht/~zge/autocrypt",
   "unstable": {
    "version": [
-    20210411,
-    1759
+    20210412,
+    1127
    ],
    "deps": [
     "cl-generic"
    ],
-   "commit": "39c06eb4020c38de8f282340449691210cc23bb8",
-   "sha256": "0gvdjgfnisx1acy5jmzs82yngmnmiimq1ralbvw9a28knlsdbnig"
+   "commit": "5b55f8d37545e9c441788627c17e350d7edf4055",
+   "sha256": "0b06xnjkgwjpxl96mdi674pmvdaiwncifi1a30wxhl1dwr7kr084"
   }
  },
  {
@@ -5273,36 +5288,6 @@
   }
  },
  {
-  "ename": "autopair",
-  "commit": "4150455d424326667390f72f6edd22b274d9fa01",
-  "sha256": "0l2ypsj3dkasm0lj9jmnaqjs3rv97ldfw8cmayv77mzfd6lhjmh3",
-  "fetcher": "github",
-  "repo": "joaotavora/autopair",
-  "unstable": {
-   "version": [
-    20160304,
-    1237
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "2b6d72bccb0ebba6e7e711528872b898b0c65b0a",
-   "sha256": "09p56vi5zgm2djglimwyhv4n4gyydjndzn46vg9qzzlxvvmw66i1"
-  },
-  "stable": {
-   "version": [
-    0,
-    6,
-    1
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "2d1eb81d12f71248ad305e70cceddf08d4fe2b39",
-   "sha256": "0g6kd1r0wizamw26bhp5jkvpsd98rcybkfchc622b9v5b89a07nq"
-  }
- },
- {
   "ename": "autotest",
   "commit": "5fc2c4a590cbeccfb43003972a78f5d76ec4a9e7",
   "sha256": "0f46m5pc40i531dzfnhkcn192dcs1q20y083c1c0wg2zhjcdr5iy",
@@ -5313,8 +5298,8 @@
     20190331,
     2230
    ],
-   "commit": "74e1fcbeca25734235afec9c6a4d0cf73736b62c",
-   "sha256": "0yrcsr4360v222klahbccfq3vb4kp5xdsibydwircv36xhxplzq3"
+   "commit": "2d76365d2aa13543121d5c623df465adb68b76f7",
+   "sha256": "1n247g5dq73rkxf0wys5lsbvma44y5qlh577s3rcx7l0yrylwdry"
   }
  },
  {
@@ -5457,8 +5442,8 @@
     "avy",
     "embark"
    ],
-   "commit": "a005eef82a63950927a68a5ef79b33d25245687b",
-   "sha256": "1dy01y87bqjddsdjqhmp6m144azn72yswsj0prywm5alxypck9lg"
+   "commit": "05aa11bca37db1751c86fe78f784741be5b1a066",
+   "sha256": "1nnrn6dd248l6ngvgjjniqkahlwz45y3n50nw555a67pmi88grh9"
   },
   "stable": {
    "version": [
@@ -6830,14 +6815,14 @@
   "repo": "cpitclaudel/biblio.el",
   "unstable": {
    "version": [
-    20200416,
-    1407
+    20210418,
+    406
    ],
    "deps": [
     "biblio-core"
    ],
-   "commit": "242c3f3ac1198b1e969e2a34d6348354a9d83345",
-   "sha256": "0m1ih8p7s3335wah1wzaiipqphvjd88nyig582ja3ra6xkvazf00"
+   "commit": "517ec18f00f91b61481214b178f7ae0b8fbc499b",
+   "sha256": "0m5vpyj6312rc3xq8lrr1g2hyl26adzwvjxb3jqrm7bvqvs4i5zp"
   },
   "stable": {
    "version": [
@@ -6877,16 +6862,16 @@
   "repo": "cpitclaudel/biblio.el",
   "unstable": {
    "version": [
-    20210311,
-    2310
+    20210418,
+    406
    ],
    "deps": [
     "dash",
     "let-alist",
     "seq"
    ],
-   "commit": "242c3f3ac1198b1e969e2a34d6348354a9d83345",
-   "sha256": "0m1ih8p7s3335wah1wzaiipqphvjd88nyig582ja3ra6xkvazf00"
+   "commit": "517ec18f00f91b61481214b178f7ae0b8fbc499b",
+   "sha256": "0m5vpyj6312rc3xq8lrr1g2hyl26adzwvjxb3jqrm7bvqvs4i5zp"
   },
   "stable": {
    "version": [
@@ -6917,8 +6902,8 @@
     "a",
     "pdf-tools"
    ],
-   "commit": "331252334ea2e62d8e06b2dfa24be5dbd7f9c09f",
-   "sha256": "0gri6k1px53lmi5nq3zpv0m0kc3c8pbnc4h0zard5v449gmf1d5q"
+   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
+   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
   }
  },
  {
@@ -6966,14 +6951,25 @@
   "repo": "bdarcus/bibtex-actions",
   "unstable": {
    "version": [
-    20210411,
-    1846
+    20210503,
+    1214
    ],
    "deps": [
     "bibtex-completion"
    ],
-   "commit": "516cbdb63810bcb571e41436e2c568c328fc8980",
-   "sha256": "0n3byfv1khn2lr9c1r619gc52993hf01nwl5c7ih7nmrr5q3rckk"
+   "commit": "149f9aefd2fc90e32f25a0b290e975da55ab8fe6",
+   "sha256": "16264is954pdh0jvnjw057sdccl297w1v8r9wg39raljl44vzr44"
+  },
+  "stable": {
+   "version": [
+    0,
+    4
+   ],
+   "deps": [
+    "bibtex-completion"
+   ],
+   "commit": "c18b1ad05168597a3cbaee67775d15d2ebb737f4",
+   "sha256": "0x45wq2nw753dz6694li3f0zmjm0rljmrr5rvj2qrhgqldlwn6zn"
   }
  },
  {
@@ -6995,8 +6991,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "9870333cdd4a54b309e2709af647cda6f4070a42",
-   "sha256": "02cpg60hif4rz6va2ynh3wc9dwj0nyig4fa0l6jchmzz8v2zvf86"
+   "commit": "9f6ea920a49457d85096caa0e61f086a42b2908e",
+   "sha256": "0dqf2anmjlgcz7xn4q2pw8cfmhwdhdg4fm8q41vhrp60ymbc6dik"
   },
   "stable": {
    "version": [
@@ -7201,8 +7197,8 @@
    "deps": [
     "seq"
    ],
-   "commit": "9cec78c685dbca51ab9d1014eb535a541083effc",
-   "sha256": "065cqvdjdb5w60b7ga7q51920ib5vpz63zq9s68q0fjwb55q3k8z"
+   "commit": "52f1c11b01a5f7e7a470a73dec4c3335dea4124b",
+   "sha256": "00kjjr28bvimbdhg016n0g6ws1lix87c1bic1xb3nk0bvnbkpwfp"
   },
   "stable": {
    "version": [
@@ -7609,11 +7605,11 @@
   "repo": "joodland/bm",
   "unstable": {
    "version": [
-    20201116,
-    2341
+    20210421,
+    1351
    ],
-   "commit": "dc69eb6e431151d3942cb812b7161e6f23c28c07",
-   "sha256": "0gxj8m8q4md1kaay5ymsyynw5990apnqxa6lw73y8w1py785drmn"
+   "commit": "9a31c61f44e6f1033ca43bd7f3eb33ffdb2ca595",
+   "sha256": "0iizqcbxm8yjv1fz2lhn23vbyzmmc8g6xazk0glv9mrldmmppgn5"
   },
   "stable": {
    "version": [
@@ -7658,8 +7654,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "d88eef69ae66ea1ffa21a65317afe84c9ddb0814",
-   "sha256": "1bci2w8drwgcli9hqg55izaxpwq4fvqdigvlrfc0524s7021ij24"
+   "commit": "2d1ee12f3ba6e75841066bf429d7bf836d4b89d7",
+   "sha256": "1hls8463fl8ndbfry1x4pimx2fz1b9zl3b6wfgcrb3jw3p4ys86x"
   },
   "stable": {
    "version": [
@@ -7840,8 +7836,8 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20210323,
-    1341
+    20210413,
+    1322
    ],
    "deps": [
     "dash",
@@ -7849,8 +7845,8 @@
     "multiple-cursors",
     "pcre2el"
    ],
-   "commit": "17a7a9219a5a9b7156f58f7f30227fc2b79b6020",
-   "sha256": "1jcvz9vy5sz9bysrlg2b9d3732zab8hmg8hg5ghwjx5kgxl2yfzh"
+   "commit": "a4f2d2caaf2d7a0adf36c19ea20a79dcfa129cad",
+   "sha256": "1m3yw1i6c5j3fswbcyrk95qa7azq26bgzc7zcmjncx23idijhfpf"
   },
   "stable": {
    "version": [
@@ -8068,25 +8064,25 @@
   "url": "https://bitbucket.org/MikeWoolley/brf-mode",
   "unstable": {
    "version": [
-    20210325,
-    2154
+    20210501,
+    1723
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "733a44bc491d9d28f9eefc2550616e97b1419cee",
-   "sha256": "0dfd3w3g31fjzqvzn57xw3whr60fy8yj8hnga8b4n9698dihw0bn"
+   "commit": "9d6b6797c465589ca39a1020d7af5775f5ddc801",
+   "sha256": "1jpsrsc4qi2yiwxccdagxz1gj9fgzaxnd5fszgdmwvsgzqwfasvh"
   },
   "stable": {
    "version": [
     1,
-    19
+    20
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "0024b1a276c43fde0d85011b51b5aaf1f201da64",
-   "sha256": "1nnhb0vyx5f3f7h2fsg2p7656kcsk7ahrndxrhs7a77svnr426lb"
+   "commit": "9d6b6797c465589ca39a1020d7af5775f5ddc801",
+   "sha256": "1jpsrsc4qi2yiwxccdagxz1gj9fgzaxnd5fszgdmwvsgzqwfasvh"
   }
  },
  {
@@ -9634,15 +9630,14 @@
   "repo": "kwrooijen/cargo.el",
   "unstable": {
    "version": [
-    20210327,
-    1821
+    20210422,
+    657
    ],
    "deps": [
-    "markdown-mode",
-    "rust-mode"
+    "markdown-mode"
    ],
-   "commit": "4846373bf1ed6268f1a1d9f9c489f8740351d8bb",
-   "sha256": "0y4wxddjp055kisv7yx6zs9bzggw65b08aa1g3y0vlaafrps8bga"
+   "commit": "0174599fd1c1b429042c7ca67c3d45f07441a43d",
+   "sha256": "0qm6cgzsr86s1rcvqpv8x5b3r1v7nq7z8il8ci4vlw9hk0wg65a2"
   },
   "stable": {
    "version": [
@@ -9729,8 +9724,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20210410,
-    2057
+    20210424,
+    125
    ],
    "deps": [
     "ansi",
@@ -9741,27 +9736,26 @@
     "s",
     "shut-up"
    ],
-   "commit": "dce91052dc8fae386a1898fd88d554b5cb527fdc",
-   "sha256": "1j853gbdc50s1csvsi2a0f6i2vakgnd8afb97qkkj5alpwq8883p"
+   "commit": "81edfa78428fd2d9689507fd4d3b13c24cd99323",
+   "sha256": "071biqz1fv3rzjbn9xprpazk65xfl78hzhf2gdvz944pks3rhdfi"
   },
   "stable": {
    "version": [
     0,
     8,
-    6
+    7
    ],
    "deps": [
     "ansi",
     "cl-lib",
-    "dash",
     "epl",
     "f",
     "package-build",
     "s",
     "shut-up"
    ],
-   "commit": "610894d57f467a55fb146ade4d6f8173e4e9579b",
-   "sha256": "1y12m5sjgws4a4bikr8d1ccysy55j7xx3cp1qii4pw62bkf9y2bq"
+   "commit": "9600dd9a341c61ac006c0a44912e13f3810f3c54",
+   "sha256": "0aqc3p7i00rbdgj2cjil71c8wqq9ard637fnpdq1ny6wnb8kblm7"
   }
  },
  {
@@ -9937,11 +9931,11 @@
   "repo": "skk-dev/ddskk",
   "unstable": {
    "version": [
-    20210403,
-    1958
+    20210501,
+    820
    ],
-   "commit": "a266f70eb99ffb657b7821c2e1de49f5184a59ed",
-   "sha256": "0j1gcsi40yrfy9saqjdhxnwsvmqf32l9mnwfvhbbfxm82ddhwxnk"
+   "commit": "7a7e1ecaf7f4f68058f1b8831d0b7b839d228614",
+   "sha256": "0gcgbr28j88a73p5ng4f20qp0fx288na9hi4fnj32grqyrl6f1pq"
   }
  },
  {
@@ -9989,8 +9983,8 @@
     20200904,
     1431
    ],
-   "commit": "a266f70eb99ffb657b7821c2e1de49f5184a59ed",
-   "sha256": "0j1gcsi40yrfy9saqjdhxnwsvmqf32l9mnwfvhbbfxm82ddhwxnk"
+   "commit": "7a7e1ecaf7f4f68058f1b8831d0b7b839d228614",
+   "sha256": "0gcgbr28j88a73p5ng4f20qp0fx288na9hi4fnj32grqyrl6f1pq"
   }
  },
  {
@@ -10124,15 +10118,15 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20210309,
-    1822
+    20210420,
+    1415
    ],
    "deps": [
     "cl-lib",
     "powerline"
    ],
-   "commit": "df972095135de90b47413190f61ec4f5af33f9f1",
-   "sha256": "0is51bc9zd9lr0y59md2ci4ddlfylp5jb9hwyll9r6j8gn3lrzza"
+   "commit": "51f28d03936aef5237f14bc08b2ae26949ecef0f",
+   "sha256": "13cg8ds0dkrw26ln4qi7yfb4gdbcavky6ykyhx49ph0gzinjhd3b"
   },
   "stable": {
    "version": [
@@ -10259,8 +10253,8 @@
     20171115,
     2108
    ],
-   "commit": "02478862ea707ed51223c1d5d2d8cd8d61d2915d",
-   "sha256": "0vf94pkd2slwkrgv93yqh2qb2y72bzya9nq5gmqd0g08nb6kdmjx"
+   "commit": "0c75766aa79f1f744011a1bddd8659e3631177dc",
+   "sha256": "1crww8asa1cxknmbdf46xjm7rlxzss5wqzn5bza5f2wwj5mw9gpj"
   },
   "stable": {
    "version": [
@@ -10994,8 +10988,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20210408,
-    1212
+    20210422,
+    802
    ],
    "deps": [
     "clojure-mode",
@@ -11006,14 +11000,15 @@
     "sesman",
     "spinner"
    ],
-   "commit": "fd2bb0c64eb3590cffa91188644d1e40fbbc634b",
-   "sha256": "0mhscf5cpcqs68c863ns6rbjwr1p71wb7kp80ds5qzar8x2k2qwn"
+   "commit": "68bc5e393929561a00e2d20e83fd01df37214af2",
+   "sha256": "0kyliz2vz240g381qkgkyjxh3i9f016a7x4plf2jcw2y5rmqspxl"
   },
   "stable": {
    "version": [
     1,
+    1,
     0,
-    0
+    1
    ],
    "deps": [
     "clojure-mode",
@@ -11024,8 +11019,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "140b062e62165e536dcdb878a00f492a1d5b3518",
-   "sha256": "143kh9k34yk0g6kdlkma6g432kmb2r9r1lhyq4irsw6d3vaql7dj"
+   "commit": "45f6125301fbbe69333dc450804ce8ecdd611539",
+   "sha256": "1kf4056bga3cr40mm812m21r9mi0r30gn9v3jil3q6yhb5bm1gcl"
   }
  },
  {
@@ -11198,14 +11193,14 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20210323,
-    1704
+    20210423,
+    746
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e67e2d1149ebf3e79cd2162e78802af3ed5f82da",
-   "sha256": "0jrpa8kndq2v69nr9jva970q0n3662x2g0chg89nd2d3gbv693mw"
+   "commit": "2f70aa236878d9c3726c31d6ba922e2d7076951d",
+   "sha256": "1fi0qc8qbcgkjjvi5iysifammqcc6nwcrwjhwi713zykd5cir180"
   },
   "stable": {
    "version": [
@@ -11600,14 +11595,14 @@
   "repo": "redguardtoo/cliphist",
   "unstable": {
    "version": [
-    20210301,
-    748
+    20210426,
+    245
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "1ef50459fa6044c4d571cec0009368948bcf5fc5",
-   "sha256": "0xba2gxwy1y8zl9nvga186873icvwfi0yan3qbw2vdkpzry5ifhk"
+   "commit": "0d02d72fb63453ff5623b26234a63f66090da7ac",
+   "sha256": "033z367nmfh6mc1k8kv2m3xsxjw44hnvgiai2n7fp4h9jdv5j8h8"
   },
   "stable": {
    "version": [
@@ -11705,8 +11700,8 @@
   "repo": "clojure-emacs/clj-refactor.el",
   "unstable": {
    "version": [
-    20210407,
-    724
+    20210413,
+    733
    ],
    "deps": [
     "cider",
@@ -11719,8 +11714,8 @@
     "seq",
     "yasnippet"
    ],
-   "commit": "9f88174878d62e3906be5b04b8ba7788e6ca4570",
-   "sha256": "155lhb3myzxpxnnp257p3rxhgw9xmr3l2h39gj23q5sr0hhsnm5s"
+   "commit": "f50fb242ba0ff8526746ae0ffeb19b9a535c00b2",
+   "sha256": "0ajnc3x7fy9mlgdrfq1p1hvafcisvdnilh9vv0h5s091qkvv3hp9"
   },
   "stable": {
    "version": [
@@ -11967,11 +11962,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20210322,
-    704
+    20210502,
+    824
    ],
-   "commit": "a14671e03c867c9d759ee9e59cdc5cecbf271245",
-   "sha256": "1jnqwcspm7c3v33wywvm605hsf6vp29ym3smy2jaq8j5vwywi8k3"
+   "commit": "8280e4479c89b0f7958d34febafd6932e5a2b3d3",
+   "sha256": "0w84cc0s8mgh7zx2qdi6csvxzq436p0cnmkbg8zfcwwpp4x6ncb8"
   },
   "stable": {
    "version": [
@@ -11997,8 +11992,8 @@
    "deps": [
     "clojure-mode"
    ],
-   "commit": "a14671e03c867c9d759ee9e59cdc5cecbf271245",
-   "sha256": "1jnqwcspm7c3v33wywvm605hsf6vp29ym3smy2jaq8j5vwywi8k3"
+   "commit": "8280e4479c89b0f7958d34febafd6932e5a2b3d3",
+   "sha256": "0w84cc0s8mgh7zx2qdi6csvxzq436p0cnmkbg8zfcwwpp4x6ncb8"
   },
   "stable": {
    "version": [
@@ -12300,19 +12295,17 @@
     20210104,
     1831
    ],
-   "commit": "b1c739ad8bcacae6d66d88514102dcd4423c2dcb",
-   "sha256": "1jwkscld38b6b6f4w3hw1m9dgdvcvbbwwfx2dd5v7548mp3wpxrj"
+   "commit": "4e5893b658b1c360c1b2d9413dbd66b2b02dbacc",
+   "sha256": "0ywi74q3csqvn9pb53gcvz5bg9xc94nnq1nbmzsmhf8yj7lrlkcm"
   },
   "stable": {
    "version": [
     3,
     20,
-    0,
-    -1,
-    5
+    2
    ],
-   "commit": "fab7fe7ef5a5462952297611c1dd668a603e3a36",
-   "sha256": "12v6v1hpw0ykkikj4qid3m4m7sb164rgpx6fxin4hvsm20pjcrd4"
+   "commit": "1ad4501ae97fb6c6deab096ff0ac7e03d554e26d",
+   "sha256": "0zr4zbbd1zng0v3mj8kql0ci2w18p4izjfq7hh6g5adq6l7ckfhm"
   }
  },
  {
@@ -13271,11 +13264,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20210411,
-    2221
+    20210503,
+    1211
    ],
-   "commit": "4037e82cf82b459b6a1d8529f2a3bb3e310fbdf7",
-   "sha256": "0hqm4529cng2zwj5nlm9b5k1yngf0viywmrq7k052g3fpx21b4l2"
+   "commit": "dbb5d8cac2d7b854e883b381c7504e227a7185eb",
+   "sha256": "0f31pjgnagq1jv557i0pifsjgp12zm7j2k2qjgf3j64j470ffr99"
   },
   "stable": {
    "version": [
@@ -13516,8 +13509,8 @@
   "repo": "cpitclaudel/company-coq",
   "unstable": {
    "version": [
-    20210324,
-    1603
+    20210420,
+    215
    ],
    "deps": [
     "cl-lib",
@@ -13526,7 +13519,7 @@
     "dash",
     "yasnippet"
    ],
-   "commit": "7423ee253951a439b2491e1cd2ea8bb876d25cb7",
+   "commit": "6a23da61e4008f54cf1b713f8b8bffd37887e172",
    "sha256": "15rd9ga4ydhl6ljzdg26a3kcaqlhaygp67507wrrf8j3801ivks4"
   },
   "stable": {
@@ -13690,15 +13683,15 @@
   "repo": "dunn/company-emoji",
   "unstable": {
    "version": [
-    20201212,
-    2325
+    20210427,
+    2151
    ],
    "deps": [
     "cl-lib",
     "company"
    ],
-   "commit": "4ba7dc60ba67f736e698a5fa0b754b866f36a646",
-   "sha256": "1rhf2hr345953mkn52i58aiq8j16ps2ckapd5f7jxmhkcpzxxfhk"
+   "commit": "90594eb58b20fb937cfd4e946efcc446ee630e6f",
+   "sha256": "08dx812vg92bkwp0ham40rv3x9648x7y5bmbvphcc71s9knfgxcz"
   },
   "stable": {
    "version": [
@@ -14041,8 +14034,8 @@
     "lean-mode",
     "s"
    ],
-   "commit": "5a2a36356e73c74a42e49fad19a71f4f12929a90",
-   "sha256": "18lswxxwvp85yzg1kc9vxn4dpmxmj40j6g64c8ns83nb7hw9lszg"
+   "commit": "bf32bb97930ed67c5cbe0fe3d4a69dedcf68be44",
+   "sha256": "1bkv5zs38ijawvavbba0fdf2flb6fiwici3qi99ws8wvwhnbkws2"
   }
  },
  {
@@ -14455,15 +14448,15 @@
   "repo": "tumashu/company-posframe",
   "unstable": {
    "version": [
-    20210331,
-    325
+    20210419,
+    607
    ],
    "deps": [
     "company",
     "posframe"
    ],
-   "commit": "a28f38213a2a30ce68fdb0b124cadc68ebbcb24f",
-   "sha256": "1ys40y62c0aqs8nlyhnkahb67slh0i4dpvxvj8mcvcmp68aiih3f"
+   "commit": "c7a820a35ff132aaec53c81e05afc829de39eb68",
+   "sha256": "0fyc7c4r4jfa5y0x9lfcqlx0qazg1d4il5p0bdw4hdcpjd2h26ys"
   },
   "stable": {
    "version": [
@@ -14494,8 +14487,8 @@
     "company",
     "prescient"
    ],
-   "commit": "ed2b762241bbea03e374dc9dcd4fbe207c6b2ea4",
-   "sha256": "03c0dmblixh5mx8365b6608l7z3vcgp6pzdflwqf8nfwj2c5rm0w"
+   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
+   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
   },
   "stable": {
    "version": [
@@ -14621,15 +14614,15 @@
   "repo": "TheBB/company-reftex",
   "unstable": {
    "version": [
-    20201116,
-    1605
+    20210418,
+    1316
    ],
    "deps": [
     "company",
     "s"
    ],
-   "commit": "291c283c8a015fd7cbaa99f836e1a721f1e2c832",
-   "sha256": "0qwmjqcpi10lwsrppifjyr041hmgqb86nxpb970rb1m3n9p5rnk0"
+   "commit": "42eb98c6504e65989635d95ab81b65b9d5798e76",
+   "sha256": "0x5zhhy70cdhbark2vm364bazg2mbwlhy7123qyq02knsjdwwqrl"
   }
  },
  {
@@ -14775,17 +14768,16 @@
   "repo": "nathankot/company-sourcekit",
   "unstable": {
    "version": [
-    20170126,
-    1153
+    20210430,
+    2155
    ],
    "deps": [
     "company",
     "dash",
-    "dash-functional",
     "sourcekit"
    ],
-   "commit": "abf9bc5a0102eb666d3aa6d6bf22f6efcc852781",
-   "sha256": "1g8a4fgy2c5nqk8gysbnzn5jvfw6ynmfhc6j3hkrbswgf9188v5n"
+   "commit": "a1860ad4dd3a542acd2fa0dfac2a388cbdf4af0c",
+   "sha256": "18pv1hcilj7kndr7a29jjskp21khh1sd0wy01h8y8y9mf70kikg6"
   },
   "stable": {
    "version": [
@@ -15162,11 +15154,11 @@
   "repo": "muffinmad/emacs-completions-frame",
   "unstable": {
    "version": [
-    20201123,
-    1213
+    20210430,
+    640
    ],
-   "commit": "95e0845fdac5412a511ca15b12189ed9487a64a7",
-   "sha256": "1mz7dxa4bhay4h2kh1f4g4dwsfswidlhiy11s4a6l3zjqjj8hklb"
+   "commit": "860e5b97730df7ef5c34584ad164bc69c561db84",
+   "sha256": "026qzq1ddk1acqsgbsd2nk2g5gm9ml2sq31rnsdapzaj4rxa192w"
   }
  },
  {
@@ -15467,19 +15459,19 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210411,
-    2120
+    20210503,
+    1638
    ],
-   "commit": "812204b647b1f45cc9d04d7d2f565061940f5e70",
-   "sha256": "11jpmswhx5x69wsrl5mg9wmxm49hqkdn2r9swz9z7hikk7485mx8"
+   "commit": "665a3105d5cbe6c44a270c1009e74d4fcad9d6d4",
+   "sha256": "163kfs042gq9kisra23g27zwval6jyl8yanr7y2s1rx185m2z6yb"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
-   "commit": "3184edd6ccf9cfb300511feb297b9012ce902bbe",
-   "sha256": "09n3q3dyi83s4fk4z7csnjicbxd69ws4zp4371c1lbxcvvq2fdnd"
+   "commit": "7480f020e57036ef14c2fda1d83c830583b2a53b",
+   "sha256": "1kzwybp87srckd1238drdcn9h7jyyqz9pzcwvw3ld8bgyyrwsxkj"
   }
  },
  {
@@ -15490,27 +15482,60 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210410,
-    1355
+    20210429,
+    1158
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "812204b647b1f45cc9d04d7d2f565061940f5e70",
-   "sha256": "11jpmswhx5x69wsrl5mg9wmxm49hqkdn2r9swz9z7hikk7485mx8"
+   "commit": "665a3105d5cbe6c44a270c1009e74d4fcad9d6d4",
+   "sha256": "163kfs042gq9kisra23g27zwval6jyl8yanr7y2s1rx185m2z6yb"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "3184edd6ccf9cfb300511feb297b9012ce902bbe",
-   "sha256": "09n3q3dyi83s4fk4z7csnjicbxd69ws4zp4371c1lbxcvvq2fdnd"
+   "commit": "7480f020e57036ef14c2fda1d83c830583b2a53b",
+   "sha256": "1kzwybp87srckd1238drdcn9h7jyyqz9pzcwvw3ld8bgyyrwsxkj"
+  }
+ },
+ {
+  "ename": "consult-lsp",
+  "commit": "c2d4a871be8f52fcfd24c3823382a983d9dcce46",
+  "sha256": "0qrillb8yg8lzilbf40y8c9jpf8jyhfdry2xp6d9mlfnkrdc1qr0",
+  "fetcher": "github",
+  "repo": "gagbo/consult-lsp",
+  "unstable": {
+   "version": [
+    20210428,
+    1515
+   ],
+   "deps": [
+    "consult",
+    "f",
+    "lsp-mode"
+   ],
+   "commit": "12989949cc21a1173206f688d56a1e798073a4c3",
+   "sha256": "0g3bpi53x6gr9631kzidbv4596bvdbxlr8y84ln40iwx5j8w6s7p"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "deps": [
+    "consult",
+    "f",
+    "lsp-mode"
+   ],
+   "commit": "c4c0426b58946578ac1806a60258d2b275d5b524",
+   "sha256": "11lrnv5ssiwwdvdib05nz070yc3w9lfcqikgnl3bq8gbcrm9zjf4"
   }
  },
  {
@@ -15895,15 +15920,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210404,
-    1716
+    20210423,
+    1127
    ],
    "deps": [
     "ivy",
     "swiper"
    ],
-   "commit": "471d644d6bdd7d5dc6ca4efb405e6a6389dff245",
-   "sha256": "0zw5sypr9kwb65627b8wrgl542gyq0xh7pwhghbkwfpwx7rjvk36"
+   "commit": "4ffee1c37340a432b9d94a2aa3c870c0a8203dcc",
+   "sha256": "02d5a8s263lp2zvy39mxkyr7qy5475i4ic2bpm2qm0ixr4fkfdy8"
   },
   "stable": {
    "version": [
@@ -16207,14 +16232,32 @@
   "stable": {
    "version": [
     1,
-    0,
-    0
+    1
    ],
    "deps": [
+    "ivy",
     "swiper"
    ],
-   "commit": "33d709f5b73a68093ec9414c774844d5f4983aee",
-   "sha256": "120i4j4bw3v1ybcwrfpn0v7jphhk7hhlp738m60fck97p9lwfyy0"
+   "commit": "8cadd2e96470402ede4881b4e955872976443689",
+   "sha256": "1chfrzkqfsw1rlwkb3k7v827fwipg0cish22rr3sxxydxr7kysx5"
+  }
+ },
+ {
+  "ename": "counsel-mairix",
+  "commit": "2ca80edc78250911b84e806f750d5474e7d93e86",
+  "sha256": "1i535x0xw9sj602l70sabg6y5mxzff5wlr0gpfqw9by5g7q79w95",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~ane/counsel-mairix",
+  "unstable": {
+   "version": [
+    20210422,
+    649
+   ],
+   "deps": [
+    "ivy"
+   ],
+   "commit": "39fa2ad10a5f899cb3f3275f9a6ebd166c51216a",
+   "sha256": "1z5qn9k68413jr946dy53l02zk2b1qx6wl5w3gp0jh34i3b6yk2y"
   }
  },
  {
@@ -16544,6 +16587,21 @@
    ],
    "commit": "0beae208d0e7d746a94385428bd61aa5cd7ea828",
    "sha256": "1qf1s0997n6bfx50bd0jln25p7z6y8pfibijnbqcg2011xmv5dqh"
+  }
+ },
+ {
+  "ename": "cowsay",
+  "commit": "1731327f28b2b47285a526b3ddd322d5b4a862e8",
+  "sha256": "0f2iq8jd2w5bcsv4yksyj7l50g9yvi28dhjx29dyxlywbj0nqz98",
+  "fetcher": "github",
+  "repo": "lassik/emacs-cowsay",
+  "unstable": {
+   "version": [
+    20210430,
+    1625
+   ],
+   "commit": "690b4d2c18bbe1a19169b03260b13c663f4f3d96",
+   "sha256": "0yhxmk07jnj0v40dxpywr1yhlj9srid0n6ds13y4zvih5prrmlms"
   }
  },
  {
@@ -17258,11 +17316,11 @@
   "repo": "raxod502/ctrlf",
   "unstable": {
    "version": [
-    20210404,
-    1704
+    20210418,
+    2044
    ],
-   "commit": "45026a8655fb170004959f83b984589224cc156e",
-   "sha256": "0ij830jpkrp29rrpapmr9cglnjsdiycp3j620sd10s069wavbmcr"
+   "commit": "dbe83710d06bc39315f1455f6f21479f3747c0aa",
+   "sha256": "0nl7mh1i9pw039gd0ma6xrv499aw2vs3a1fm1bxz71hh13jmbd4c"
   },
   "stable": {
    "version": [
@@ -17463,11 +17521,11 @@
   "repo": "lassik/emacs-currency-convert",
   "unstable": {
    "version": [
-    20201017,
-    1817
+    20210427,
+    2032
    ],
-   "commit": "0b12614956085444d73c47bc308c02cef0f64f97",
-   "sha256": "0abpkcn2mcg0c4nycannwz9skvl6w7zgvbh1rx30qw0wl0i5svdm"
+   "commit": "12805ea66aa8421de5eedda39d23f709de634460",
+   "sha256": "1p304k3s0iawsrlpndc9vrjxm1vv4nlkv0fb51x8pmcqw5ivy1dg"
   }
  },
  {
@@ -17488,10 +17546,10 @@
    "version": [
     1,
     0,
-    3
+    4
    ],
-   "commit": "2d7c5547e4b0da361b1533d2ff30e3f62f4b682c",
-   "sha256": "1d1mz0j51i09g2fn25iik7wk0cc9i6ps8qviik73fy7ivvxjn0vp"
+   "commit": "d82441c85773bec2bc41eb3c5778659f0be31a61",
+   "sha256": "0qi40qgya3k028sgmqhqslgdfkxq9iv3wpzhz6x87j0xqv32jd55"
   }
  },
  {
@@ -17690,17 +17748,17 @@
     20190111,
     2150
    ],
-   "commit": "8cef4203124241911f63dc171f5536665f324507",
-   "sha256": "0qm605xkr294yrmrkzsqq9bhdqyg9nxiwxwg1br6hzcj01wvgjqf"
+   "commit": "2f493526d09ac8fa3d195bee14a3c9df5e649041",
+   "sha256": "03qrqppfv3hjabq3ycinkq8ngx5cdx0kixwygk2z9n6pc9n3gsfa"
   },
   "stable": {
    "version": [
     0,
     29,
-    22
+    23
    ],
-   "commit": "3e470fcc3a4e9a33b66d5db6ab761c773888a1ea",
-   "sha256": "1fbi0ladg9c37hw3js72i72nza8hfjzm5c8w95c6bmzsl22lszwi"
+   "commit": "17670781083e3ccfedb1af4adcec614d4599eef9",
+   "sha256": "1yri0ay0p3p80h9ypq692470y1b99y4hk468zqlmfzb87yv8vv7j"
   }
  },
  {
@@ -17842,11 +17900,11 @@
   "repo": "rails-to-cosmos/danneskjold-theme",
   "unstable": {
    "version": [
-    20210407,
-    1942
+    20210429,
+    657
    ],
-   "commit": "cd45635155aa6bae941156043217ce11531deca9",
-   "sha256": "1j2fr8gcy5pxzvaf3xh9z2k6bsdbw5z0a2ciys1zy8629sfx6w83"
+   "commit": "e4d1f2c76245fe9d0d07133a841e789d139df28d",
+   "sha256": "1ii3cgf4hlclwaraisxksv98mmhajx517i60p1cgd7vapznn2b6v"
   }
  },
  {
@@ -17898,8 +17956,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20210405,
-    1739
+    20210425,
+    1933
    ],
    "deps": [
     "bui",
@@ -17911,8 +17969,8 @@
     "posframe",
     "s"
    ],
-   "commit": "2cb49bb2ec22a7d6d4fd403bd4e2cc468f512501",
-   "sha256": "0zymjabd6xpsdy3jr72rag8dmd7c1hsr1d973yjmvwj1awh9d0dd"
+   "commit": "e8fe25768c44ba005e0ff51a0d781ba1693e60a0",
+   "sha256": "1xjv8fdm7byrwfzw45zhq33s8nbkh6ad1fj04506x2dyiklpp0n1"
   },
   "stable": {
    "version": [
@@ -18268,14 +18326,14 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20210325,
-    757
+    20210427,
+    705
    ],
    "deps": [
     "page-break-lines"
    ],
-   "commit": "00f1dc84d3fbaf439d23645aa531eee59e28f688",
-   "sha256": "0afn7p79na8351gimmjrj2z4y3slyvsrinm8gx7qphflz2a13m2z"
+   "commit": "9983aa0838ce5a2219ef4b674e6b37de41b5b585",
+   "sha256": "1mi1jn5gknvs7xjgj2v4dcq7z1a7xknksgfqi66bby7cl6cr3hqd"
   },
   "stable": {
    "version": [
@@ -18614,8 +18672,8 @@
     "ccc",
     "cdb"
    ],
-   "commit": "a266f70eb99ffb657b7821c2e1de49f5184a59ed",
-   "sha256": "0j1gcsi40yrfy9saqjdhxnwsvmqf32l9mnwfvhbbfxm82ddhwxnk"
+   "commit": "7a7e1ecaf7f4f68058f1b8831d0b7b839d228614",
+   "sha256": "0gcgbr28j88a73p5ng4f20qp0fx288na9hi4fnj32grqyrl6f1pq"
   }
  },
  {
@@ -18839,11 +18897,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20201227,
-    2319
+    20210418,
+    924
    ],
-   "commit": "e5aad0510139cca42b37614d3599951ac0a28ccc",
-   "sha256": "0kp3ngmdwip7c4c9mvw1l04p13gjjfaigwdiaycbzd5jzlgdh6rq"
+   "commit": "81ef9d54000617ce98c40b4627eca64e076ff11d",
+   "sha256": "14l1m8jaqranj01fr040l2g560gbpbnd4sha4x4rcs2gc99sjqxx"
   }
  },
  {
@@ -19498,8 +19556,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "8f4c2358ac00e32d261f7e77b29af60adfdf0e41",
-   "sha256": "1grd6pzbirdq42qcwxis3q97cxlx6r3m20lqg0lb77vk6k75y619"
+   "commit": "b39c08c8d08d5c58b5b2a76214e0872984e1ae7d",
+   "sha256": "1hw6c7v6n229p8bz829b3nfzdg7afrxdn4rblgk39q1wl04v4cd5"
   },
   "stable": {
    "version": [
@@ -20233,11 +20291,11 @@
   "repo": "thomp/dired-launch",
   "unstable": {
    "version": [
-    20200430,
-    1625
+    20210416,
+    1954
    ],
-   "commit": "95a411f6d4bb5eec4ef8fdbba9f038ddf60da81f",
-   "sha256": "0rz8d9lj2zbipz6cwrlw2a3z9y4rybbmz73h73l1i7fjg9q1kqm4"
+   "commit": "2a946c72473b3d2e4a7c3827298f54c2b9f3edc2",
+   "sha256": "1l63il1a0x7clb44wgir8zig0g7acanq830721ss7c2qwzg69rl2"
   }
  },
  {
@@ -20491,14 +20549,14 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20210301,
-    2158
+    20210411,
+    2315
    ],
    "deps": [
     "dired-subtree"
    ],
-   "commit": "92e7f77ec65c2089d75edb63ca312f55e3033be0",
-   "sha256": "0ad9r63jp257z95jb5537nbw64q6shdg4m5cmlx8asb7fp2wgsf8"
+   "commit": "79d8187da373b573a2d5385ca868553bb73e0005",
+   "sha256": "0b1f6ddhn8z4q790d370zhyqrn4mlqk7i6901sld52m14zigd72j"
   },
   "stable": {
    "version": [
@@ -20604,6 +20662,25 @@
   }
  },
  {
+  "ename": "dired-view-data",
+  "commit": "4a3f94025604a6efc529891d4bc78293f0a11a98",
+  "sha256": "00gc7qa278nfyxhpx9h765m62i1g6z5ambcg0kgksl8k0571xqj3",
+  "fetcher": "github",
+  "repo": "ShuguangSun/dired-view-data",
+  "unstable": {
+   "version": [
+    20210430,
+    156
+   ],
+   "deps": [
+    "ess",
+    "ess-view-data"
+   ],
+   "commit": "3bb4e135486b2166b81fd4f5684bea27fd13081f",
+   "sha256": "08xsnsqjqxkx53j207hhxps3d9m9cq7d441yi7rpiq9qq7qkpy87"
+  }
+ },
+ {
   "ename": "diredc",
   "commit": "abaea37c792e6593665dc536e8803e0f591f7359",
   "sha256": "09wfizmqp2njb2xi532qixs5syccmadpc5bbm55i7xfqrr52d7zy",
@@ -20611,11 +20688,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20210316,
-    1841
+    20210428,
+    247
    ],
-   "commit": "dd945de3e0c66a164f003a96d473376b58fc6dc7",
-   "sha256": "1d4rdrc827nnb9p56la1sd9nzwjbxbnr8fgmcgardlz3qw97j3q1"
+   "deps": [
+    "key-assist"
+   ],
+   "commit": "7651b1dcc98cbc37f5e4d0992a27d1f96279900c",
+   "sha256": "0y59z1651g0jsvrzjq4nx5i7r1rqrhgas6bplwlw60sb6ygqijpy"
   },
   "stable": {
    "version": [
@@ -20680,14 +20760,14 @@
   "repo": "wbolster/emacs-direnv",
   "unstable": {
    "version": [
-    20210117,
-    1213
+    20210419,
+    1851
    ],
    "deps": [
     "dash"
    ],
-   "commit": "381176f301dea8414a5a395c0d6546507838f6ce",
-   "sha256": "0hmj5m3wiqwdmjzxbzkf4sg8gaswdv5rv6jqgqvz3h9sm17fnps7"
+   "commit": "4b94393a9adf677c7c037215e233eef5fbca553d",
+   "sha256": "14whrhi6hgzadrw9z9k2sh2800483xs1h611avz4x68c8d2jfj5k"
   },
   "stable": {
    "version": [
@@ -21661,14 +21741,14 @@
   "repo": "jcs-elpa/docstr",
   "unstable": {
    "version": [
-    20210410,
-    1249
+    20210417,
+    1315
    ],
    "deps": [
     "s"
    ],
-   "commit": "67a219425d1fe9a29ad3beae0677d5ca0047bd53",
-   "sha256": "0irqfn5cxb8gkxvdmikmjz2j9km6k7057r7yw5aypgaxm89a404x"
+   "commit": "c14485468439056bcfc6a0862fe35fa8d787d34a",
+   "sha256": "198vqmhyasilxgz2lwn7y3a0g885ws3pyhvvj80wy7n4ml8mfdr4"
   },
   "stable": {
    "version": [
@@ -21810,21 +21890,21 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20210330,
-    1522
+    20210501,
+    1628
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "669cac3839271f84ccfed06eddaad206224ca831",
-   "sha256": "1p5w5qbz6dgsk1dcy4fspdqwh03h4cxs175ng6zm6590dk0xs5bb"
+   "commit": "12f1ab19b9d1ad8bfea2986b60c527be0425c9f1",
+   "sha256": "01xh5jdy7csa09i0lz76xqh6x21dklhmmavvvwba9mzq387nijp3"
   },
   "stable": {
    "version": [
     3,
-    0,
+    1,
     0
    ],
    "deps": [
@@ -21832,8 +21912,8 @@
     "dash",
     "shrink-path"
    ],
-   "commit": "b44955841a301f4930b054e912fa4c1a700d426d",
-   "sha256": "08m75rl5i812pa87zcsjvb4mm3jjhpwzgx9mf2m7sxj807airz5d"
+   "commit": "92f141f91a87664104ffb17177b01b9fcc706744",
+   "sha256": "0flxjyzccqv8yyk6iaxmcb3m47khy6ck3vffnfdkqs5lckm9c31s"
   }
  },
  {
@@ -21863,14 +21943,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20210322,
-    1750
+    20210503,
+    1730
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4199e74db170200995ee8dfbb55ffae004d6e219",
-   "sha256": "0vfhnywww560rf0b7h2gc9w4x4738xwq12c8qi9y267110zg62mz"
+   "commit": "cdfbf878bae788b8d4a983c19e3ab3b1d39cfdea",
+   "sha256": "1swlfbsrmjjzfybl17jvnyqwcxdabqp33zda1cdsdy6hgrmrm9x3"
   },
   "stable": {
    "version": [
@@ -22114,11 +22194,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20210220,
-    1358
+    20210502,
+    1743
    ],
-   "commit": "b5e50ed1e30ee054fb6a0827e78382b038e83c46",
-   "sha256": "0bdlcvx95r0hwxpvdfac6xjcs59jn4mi29yny7bjz3x463czidcy"
+   "commit": "0a76928fdb49d1cf65b10c706ae0e1bbc779effb",
+   "sha256": "0a1jvcgzrp38xwa3rx7h7c5j5gcdgncfjgsjz8vcfnhckcj5zmzn"
   },
   "stable": {
    "version": [
@@ -22194,6 +22274,21 @@
    ],
    "commit": "d914845725719d8293e2f0dea3c9c7e0a1e0e62a",
    "sha256": "1ynjxfvx8b6rq6d4gm1sl96rmlk5pi8j5s1rd1y0p8x2lwqcfv77"
+  }
+ },
+ {
+  "ename": "dream-theme",
+  "commit": "21d32adebc711ffcff2633c5ec4ba4fe58dcb0b5",
+  "sha256": "1lbfassmf2b6ibi3szp5p1q57nabj133bgwfnlf21svhb85zax05",
+  "fetcher": "github",
+  "repo": "djcb/dream-theme",
+  "unstable": {
+   "version": [
+    20210419,
+    605
+   ],
+   "commit": "0c27f05544b90e41338f79ea923044b358a323c6",
+   "sha256": "1dnfisa6smrnjxm6yvb3w57skz4i8akigvzr8lsh1zr7by821wl0"
   }
  },
  {
@@ -22377,11 +22472,11 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20210307,
-    2140
+    20210423,
+    745
    ],
-   "commit": "37529fc7a98564164c87103e5107a6dca32b0e44",
-   "sha256": "1h2j25b6qayydl841zwbh73fw1177xgskrqm27cqmfx0bcpx7qq3"
+   "commit": "9714f2c5f1c9b7c21e732df8c15a870a88caba84",
+   "sha256": "1aygba84si1g8kx12hscwa6m3c3946r0vbk93p9izib9fkbgngw6"
   },
   "stable": {
    "version": [
@@ -22467,8 +22562,8 @@
     "popup",
     "s"
    ],
-   "commit": "8bc195000e17ce6c72755a8fb55ca0fcd36add76",
-   "sha256": "0dc31yy4r41nwwv57dzbd6zgwddizqh4q4qagpqx645l509s7k7i"
+   "commit": "8f70acbe164553b225476fed55019ecddcf0bbd6",
+   "sha256": "08g417yf4byhhldvcbkmhrlm7iaylkv0cbcg1c701dyfngxn01y2"
   },
   "stable": {
    "version": [
@@ -22512,17 +22607,35 @@
     20210213,
     757
    ],
-   "commit": "65404cf973aa7ffc0e9dd7d05c9dd3709c7db2d4",
-   "sha256": "13v4i59f0m5syjz49g5xh4nnr7k2wck0nf0pc5hgsv6g61gkpwvj"
+   "commit": "07ca7ccf8ecaad2fb153fbd2ccfda3aeb9d3d5e2",
+   "sha256": "0kw3bvzvwn6hfa981qn13b3lmm74dwhrllssbs1wyf1fsx0x77ag"
   },
   "stable": {
    "version": [
     2,
     8,
-    4
+    5
    ],
-   "commit": "b6a3f66fb15378fc7170e94778f4d2c0b142ad92",
-   "sha256": "1p3r197cfb96675n2s7mbggndqspcxxmk9lkncirixm3k7ww36l1"
+   "commit": "e84ba5230f6afacb12f022937138a752f1c301b6",
+   "sha256": "0a1jj6njzsfjgklsirs6a79079wg4jhy6n888vg3dgp44awwq5jn"
+  }
+ },
+ {
+  "ename": "dune-format",
+  "commit": "9158dc00e15f573e09d311f1389413d6168d7e07",
+  "sha256": "19kqy05hnzywc8hspv9vh5b7rcgv23rhzay5pcixsy464glxhnj6",
+  "fetcher": "github",
+  "repo": "purcell/dune-format-el",
+  "unstable": {
+   "version": [
+    20210411,
+    2348
+   ],
+   "deps": [
+    "reformatter"
+   ],
+   "commit": "22af9fcf75eea577a39fc315fd9bcaa709fb4e1c",
+   "sha256": "0r0329x8r55ivnc6n16hi3rw3556xza5sdw2a06vk17pyiaskf1z"
   }
  },
  {
@@ -22572,11 +22685,11 @@
   "stable": {
    "version": [
     1,
-    0,
-    1
+    1,
+    0
    ],
-   "commit": "66d92f592b35fd168f23d7c58d698a1ed2dcaa0a",
-   "sha256": "1pfz1wwrdpdkd29309dryy7ficl1h1rfmgv7fbpy9p33vs9mdi9p"
+   "commit": "61c5718ba64ace4c9e29de18aa2690ecc3f0f258",
+   "sha256": "14nd544ispfj165ys6lv9bpy41p9j8kf4lwy73qigr4c7qlf43by"
   }
  },
  {
@@ -22587,14 +22700,14 @@
   "repo": "harsman/dyalog-mode",
   "unstable": {
    "version": [
-    20200822,
-    1536
+    20210413,
+    810
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f42e49b9dd7ab41f08361185cc25509f19b949a8",
-   "sha256": "1cqaa12pycwiv4cj100n8326f3yg59xgww3lk2l6x7841n7g7szm"
+   "commit": "697a84194766708d2607e8ba48a552e383c6523e",
+   "sha256": "1afcfqf9z1d67va9cdi2fxpr1l1nrgkksxh5g7h8ggqkml2ks8hn"
   }
  },
  {
@@ -22654,11 +22767,11 @@
   "repo": "zellerin/dynamic-graphs",
   "unstable": {
    "version": [
-    20200902,
-    1238
+    20210430,
+    352
    ],
-   "commit": "ba3fdf2cf0e5e1e952a1961a03dfb7f61a4ab0e7",
-   "sha256": "0cyngkba93swhgklh88r5czlvimc0pa9blg02cwz3mjwj5r558bl"
+   "commit": "f7239e381de56af5d6ff8e0d6ab31a78d3e3da58",
+   "sha256": "1v3p0ycm3yh8gvpbr96ml89470piam25qyhrwrkin228k17949br"
   }
  },
  {
@@ -22698,6 +22811,24 @@
    ],
    "commit": "97ae8480c257ba573ca3d06dbf602f9b23c41d38",
    "sha256": "0qs7gqjl6ilwwmd21663345az6766j7h1pv7wvd2kyh24yfs1xkj"
+  }
+ },
+ {
+  "ename": "dyncloze",
+  "commit": "4725983cb1d5d2c5ad1dda162050973516196323",
+  "sha256": "173z9skkmpmjw0h5z1dcdlplihjz9yszn1h20p53w9sicif58i1c",
+  "fetcher": "github",
+  "repo": "ahyatt/emacs-dyncloze",
+  "unstable": {
+   "version": [
+    20210405,
+    212
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "38aac1a38017a707b4c539a7932cc8f6cd8f1a77",
+   "sha256": "05i0a1680a79xvawa93iip10ln6bkrnvzqh3a2lica4hfx0hsi0x"
   }
  },
  {
@@ -23183,26 +23314,26 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20210407,
-    2146
+    20210503,
+    1412
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "bd1c9dcda79f734f6302e7c81ee0f13106a3a9e1",
-   "sha256": "1bd6hqiq178h1z8x0hjyrxg6l0h2inkzmrg6fadfj3ly1hbs5157"
+   "commit": "3142de8d64789c611e553667cac3bb84428d004c",
+   "sha256": "1xgpdw0sxl2c9dn6x6fk0rqpqlqxsjlj0vyag611blj600br7dqr"
   },
   "stable": {
    "version": [
     2,
-    30,
+    32,
     1
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "6a3351c4bee70517facf0eac457a17a1efc21144",
-   "sha256": "0ppp6a8qyllh1kjrh8fa8dvhv98wnq0w742mzh8gahkjbrsjdwcj"
+   "commit": "3142de8d64789c611e553667cac3bb84428d004c",
+   "sha256": "1xgpdw0sxl2c9dn6x6fk0rqpqlqxsjlj0vyag611blj600br7dqr"
   }
  },
  {
@@ -24031,8 +24162,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20210410,
-    1942
+    20210430,
+    832
    ],
    "deps": [
     "eldoc",
@@ -24041,8 +24172,8 @@
     "project",
     "xref"
    ],
-   "commit": "8a5598d06a0539492ec30fc90201a263ea6a03e6",
-   "sha256": "0jlqskw08zlqhckhz64w2c0a14kk100lmnadwf4li5h2b2clmr7l"
+   "commit": "3f1ad3bd1bf6c2ccef61c3ca606ef69962ae6e55",
+   "sha256": "0532fd44lb913qpx6h6hdmk1gsmj3klwh2l41vkwc7vwqsb0rg23"
   },
   "stable": {
    "version": [
@@ -24099,28 +24230,28 @@
   "repo": "non-Jedi/eglot-jl",
   "unstable": {
    "version": [
-    20200726,
-    741
+    20210415,
+    1207
    ],
    "deps": [
     "eglot",
     "julia-mode"
    ],
-   "commit": "84cff9d6ef1643f3eac6c9d620cc1e380a9847d9",
-   "sha256": "1g3k3ym0hx97dk3sv1kz3vq0p1s1zw6r34ynhwm31y954miwyvm4"
+   "commit": "49f170e01c5a107c2cb662c00544d827eaa2c4d8",
+   "sha256": "1bmp517zfsspxlj0k67q15ladiphjha45zgnq3djs631mvr9bfaw"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "eglot",
     "julia-mode"
    ],
-   "commit": "84cff9d6ef1643f3eac6c9d620cc1e380a9847d9",
-   "sha256": "1g3k3ym0hx97dk3sv1kz3vq0p1s1zw6r34ynhwm31y954miwyvm4"
+   "commit": "49f170e01c5a107c2cb662c00544d827eaa2c4d8",
+   "sha256": "1bmp517zfsspxlj0k67q15ladiphjha45zgnq3djs631mvr9bfaw"
   }
  },
  {
@@ -24192,8 +24323,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20210330,
-    1531
+    20210429,
+    1630
    ],
    "deps": [
     "anaphora",
@@ -24204,8 +24335,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "608c3cbfd58a626aab3cea6aa5b31d8a4032cf10",
-   "sha256": "103sg5wzzr7zp0x181nardc8r63cyx1f7s1l5drig5dwzp4dnd60"
+   "commit": "d33e04da06421813cdffed6af18e5379f7399c07",
+   "sha256": "0b365lx7sv95k52w8k6zyz5nbs7v7br04mhn9r5xm126a8gcb285"
   },
   "stable": {
    "version": [
@@ -24371,8 +24502,8 @@
     20200912,
     1653
    ],
-   "commit": "84dd1837f9ac80a329ab0c2de6859777f445f8ff",
-   "sha256": "098x17hg9dc28s7g50mxhv6m6fgch1xp1di7rplkg7w1dfphpc5a"
+   "commit": "d76ac84ae9670de7bf7725b362cafe86688771f9",
+   "sha256": "18x4qj75bh45b0dirp3jpw1zqni8xfqqh1q13q6b5ncy1nhvm4gl"
   },
   "stable": {
    "version": [
@@ -24702,11 +24833,11 @@
   "repo": "Mstrodl/elcord",
   "unstable": {
    "version": [
-    20210323,
-    2234
+    20210416,
+    1333
    ],
-   "commit": "25531186c10b74a10ee24990f9e967296cc70342",
-   "sha256": "14lk3whvj45ilb7mv60dfpxhbw3jsddglz0mq5vhdgy6n8wkcpa9"
+   "commit": "6608e0392b46324fc09a5b5f4457c15ac1394f80",
+   "sha256": "0mr6xx1bwpfn24x6vbrzd482scz6mrdmgdrk03ixwlspaqmancdm"
   }
  },
  {
@@ -24751,20 +24882,19 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20210410,
-    1721
+    20210425,
+    2011
    ],
-   "commit": "635744890ba2d55d9569a66cb72b13870418a513",
-   "sha256": "1hlsnd9ppw18p0kbjgf2g5xwikipjkzzqcvql63pn9ds5zr1gn6q"
+   "commit": "7256b1b953fd8bf09acc840354e3a28e63fd1ba6",
+   "sha256": "0491iq2ia76lm4sn9q4ks74qfn4wwzrj66mz4hck3962h8iabydz"
   },
   "stable": {
    "version": [
     0,
-    8,
-    1
+    9
    ],
-   "commit": "c4f9b7ff4d12c59cc80b4a67f856601ba7cff2cd",
-   "sha256": "19s45hdhcg5l608awfxvmhd61xzp7dd5pvviv89xzzksx74l1188"
+   "commit": "70612cead889bb763f7b353aa2ecf67577da344c",
+   "sha256": "1m067l3wf7dx2qya4mw1ngvl266ln26ngac3vkswxj9l3s69mqjn"
   }
  },
  {
@@ -24894,6 +25024,21 @@
   }
  },
  {
+  "ename": "electric-cursor",
+  "commit": "639747f3e5b2f8753478826a69b27727e1738d04",
+  "sha256": "12rlgyp9r4dgp0mid95rx0p5ygpxjzhvlxkmidlzakyirc1i0jlw",
+  "fetcher": "github",
+  "repo": "duckwork/electric-cursor",
+  "unstable": {
+   "version": [
+    20210501,
+    2107
+   ],
+   "commit": "e20c6f6e85c020e472ef05b12af7a12bbae65dbf",
+   "sha256": "0x1bhpb86bhkyyg28w81jw124l6zcbbqmf8i3fx28sc14q4y1gsd"
+  }
+ },
+ {
   "ename": "electric-operator",
   "commit": "906cdf8647524bb76f644373cf8b65397d9053a5",
   "sha256": "043bkpvvk42lmkll5jnz4q8i0m44y4wdxvkz6hiqhqcp1rv03nw2",
@@ -24932,11 +25077,11 @@
   "repo": "xwl/electric-spacing",
   "unstable": {
    "version": [
-    20210313,
-    1118
+    20210430,
+    1714
    ],
-   "commit": "fb1437a3386f55440abdbe7c107c86e5b028bdc5",
-   "sha256": "00pmp1596p24i7pasmm080aly8ifinp9hbvia2l4jf8mbfg2ndlw"
+   "commit": "800e09af7b0cd5d78d22f857dbce10fb080637df",
+   "sha256": "0ykndvbbx8rvaxppmkngyrzp1x6fghj9xv55i847kpzx1c6gs4fc"
   }
  },
  {
@@ -25121,15 +25266,15 @@
   "repo": "fasheng/elfeed-protocol",
   "unstable": {
    "version": [
-    20210401,
-    100
+    20210430,
+    846
    ],
    "deps": [
     "cl-lib",
     "elfeed"
    ],
-   "commit": "2b2aaf2f3b92e7c27827e0f280598cb52db558e0",
-   "sha256": "1nffhs0mnc0j87wfk6siw3zaj6p1dm1hxz55p54v9895x8c5bakv"
+   "commit": "5e17d4280f5f8019c3f8962a710c9b3e633f41ff",
+   "sha256": "0kv6svwg1h0wcj7z89xs20a9wns7v67af9m9rir3m8f47iyy70gr"
   },
   "stable": {
    "version": [
@@ -25153,26 +25298,26 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20210302,
-    2051
+    20210429,
+    1337
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "f59cbc38c83007e160722347c8cb5438d5fe13a0",
-   "sha256": "07xid0a31ghknbfwj8dxzbqkg4sfayjhlqvp17p2bzlf1mj0zjyd"
+   "commit": "8c694d0feb33dca66d9a8d88f9aaa6e7ded472ea",
+   "sha256": "0lcpj2vp947kbfk6fq7xz7j71mcpjs9086pqh690w4mzv1253gra"
   },
   "stable": {
    "version": [
     0,
     7,
-    7
+    8
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "f59cbc38c83007e160722347c8cb5438d5fe13a0",
-   "sha256": "07xid0a31ghknbfwj8dxzbqkg4sfayjhlqvp17p2bzlf1mj0zjyd"
+   "commit": "8c694d0feb33dca66d9a8d88f9aaa6e7ded472ea",
+   "sha256": "0lcpj2vp947kbfk6fq7xz7j71mcpjs9086pqh690w4mzv1253gra"
   }
  },
  {
@@ -25866,20 +26011,20 @@
   "repo": "redguardtoo/elpa-mirror",
   "unstable": {
    "version": [
-    20210325,
-    1219
+    20210414,
+    208
    ],
-   "commit": "2d50b2861ab0ba6a2a518de44823869fb4b14dfc",
-   "sha256": "0x0sfim9l5xl4fysy61w7migf504ynnmnraiwisdxl9bap7iraw9"
+   "commit": "944c79d654739ae83c8003b2b483e393589eee3f",
+   "sha256": "1i1f8l66arwsl6yh9wfn63lnjnb4ifrqhhvnakrmhqckxrs009lm"
   },
   "stable": {
    "version": [
     2,
     1,
-    4
+    6
    ],
-   "commit": "47f194c77830946c66bc6ffecdecadc5a3191402",
-   "sha256": "00c33b0k5rw66xbzv1ggz1ai1yaqa705vqb25b54sirwr0s37wly"
+   "commit": "abc8d7b7de12e4eb06efa2dbb1cc77a714f14479",
+   "sha256": "0p5jbdbl7bmx94fj7qyqqsy0clvkzjgczbgvhx4ay9wyq83wdaav"
   }
  },
  {
@@ -26242,11 +26387,11 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20210228,
-    2103
+    20210426,
+    1933
    ],
-   "commit": "de9d42c86fc3e71239492f64bf4ed7325b056363",
-   "sha256": "0778izaq1hjcc9i7d0v3p9xb08y6bwj9brcmpyd2yj3lfajbhxdx"
+   "commit": "95fe33007c663bc22ac60b6969551e07ce6cfa10",
+   "sha256": "0b2757m8zgdnb8vr21593ih5bq0cz0asy0i1x6sjr6mpd3sgysf9"
   },
   "stable": {
    "version": [
@@ -26266,14 +26411,14 @@
   "repo": "tecosaur/emacs-everywhere",
   "unstable": {
    "version": [
-    20210303,
-    1507
+    20210422,
+    1053
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "99997af93310128cc95b8ddceacb448daed2403a",
-   "sha256": "03syfvwsbrrmghdav3xkmpjvdfh1q1qr880a6f6wkri9iazg021g"
+   "commit": "64ba2e3f3096f48928f7be06ed690069b96add22",
+   "sha256": "1cjzrckbxcl1ahhnnk78778yxsrhwb725cwjbx6i8y6jxwbddpqj"
   }
  },
  {
@@ -26563,11 +26708,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210411,
-    1954
+    20210430,
+    1740
    ],
-   "commit": "a005eef82a63950927a68a5ef79b33d25245687b",
-   "sha256": "1dy01y87bqjddsdjqhmp6m144azn72yswsj0prywm5alxypck9lg"
+   "commit": "05aa11bca37db1751c86fe78f784741be5b1a066",
+   "sha256": "1nnrn6dd248l6ngvgjjniqkahlwz45y3n50nw555a67pmi88grh9"
   },
   "stable": {
    "version": [
@@ -26593,8 +26738,8 @@
     "consult",
     "embark"
    ],
-   "commit": "a005eef82a63950927a68a5ef79b33d25245687b",
-   "sha256": "1dy01y87bqjddsdjqhmp6m144azn72yswsj0prywm5alxypck9lg"
+   "commit": "05aa11bca37db1751c86fe78f784741be5b1a066",
+   "sha256": "1nnrn6dd248l6ngvgjjniqkahlwz45y3n50nw555a67pmi88grh9"
   },
   "stable": {
    "version": [
@@ -26761,27 +26906,28 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20210407,
-    1604
+    20210503,
+    1629
    ],
    "deps": [
     "cl-lib",
+    "nadvice",
     "seq"
    ],
-   "commit": "f79343bf03f6ece09638ec27eeb831c0abe59667",
-   "sha256": "1ki2hd38fxvd4112bhgfifr3raar3yz345h9hya7dn8aw9hscr14"
+   "commit": "b0173b6b4c5b66a4706cb82c9b50a179bf159a0f",
+   "sha256": "1scppj8wkiml4dgsg4540hdd8mv9ghcp2r17b647az0ccxwp73qm"
   },
   "stable": {
    "version": [
-    6,
-    3
+    7,
+    1
    ],
    "deps": [
     "cl-lib",
     "seq"
    ],
-   "commit": "a2738fe1a9013f641eeba31300e828e88b468b14",
-   "sha256": "0r2krmrhmwqcw3sdmy7z9rw4l222ja4jz8an8av11qjhpacr8v98"
+   "commit": "e1247af518d0d983d889d5ba60bbde38431d0c68",
+   "sha256": "17ny15p26nl29k2jis4kslh85cryljb151p71w5886rf3abr58pb"
   }
  },
  {
@@ -27486,6 +27632,19 @@
    ],
    "commit": "99d3a4b6973d5b09864e0af7425a61f99c19b90a",
    "sha256": "0k6isn6szbwc6jc7kzfq82p8w737z7iyn2yi9aqf6j54a6xa5aka"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "0d5d80dd0c76f0d46a3565d940a2b0ed955dfd0a",
+   "sha256": "0bfab8yh2r08vqgnk81avw9n46fda5jb4fcm0h2y8f1lv6jgnfy0"
   }
  },
  {
@@ -27821,24 +27980,6 @@
   }
  },
  {
-  "ename": "erc-status-sidebar",
-  "commit": "29631de8ec4140a8e35cc500902b58115faa3955",
-  "sha256": "04qh70ih74vbavq7ccwj1ixpd8s3g8rck9bxv6zhm1yv34bslw5d",
-  "fetcher": "github",
-  "repo": "drewbarbs/erc-status-sidebar",
-  "unstable": {
-   "version": [
-    20200907,
-    1307
-   ],
-   "deps": [
-    "seq"
-   ],
-   "commit": "87210a3ccc16a86e6b5992744b68daabed3b2d11",
-   "sha256": "1gb8lzsi3clbass40sllfwf8akzlgb2k93wqlw1lf4gfb9shx08v"
-  }
- },
- {
   "ename": "erc-terminal-notifier",
   "commit": "f2ba978b1ba63fac3b7f1e9776ddc3b054455ac4",
   "sha256": "0vrxkg62qr3ki8n9mdn02sdni5fkj79fpkn0drx0a4kqp0nrrj7c",
@@ -28152,8 +28293,8 @@
     20200914,
     644
    ],
-   "commit": "3e079614f2b4810ff5920ae69a389da91c855217",
-   "sha256": "1jn0kp33b77lskhi02d0jm0rpcgxhrpxdj82bmr7vi7m199p5jn0"
+   "commit": "26d473648853255a6a46d9dedff66df7f644c42f",
+   "sha256": "18yz278724ydvkdpcwiszfx4lg40bqbwq78268pr5mg0wif0y4q6"
   },
   "stable": {
    "version": [
@@ -28177,18 +28318,18 @@
     20210315,
     1640
    ],
-   "commit": "165f8fe9354aaf23c166b5c54f352b3024da9bd3",
-   "sha256": "102dbzpfcysq7pinli2jcdff1mxh2af0s79qmia1wfm8jmzh0zhf"
+   "commit": "ed2aee59bd43ff1cd0ac29a9b4bc2ecd5ba6ebdc",
+   "sha256": "1148di7jk8ayq07ck4zd0wxrw90iigrwzg2j9xmjh8skddh0yihd"
   },
   "stable": {
    "version": [
     24,
     0,
     -1,
-    1
+    3
    ],
-   "commit": "655bd1a27673720bcee187e9fd9f07d739860ad3",
-   "sha256": "00k0x24diq2z24582bjk65c07ky1kf5h1zihs06ndl782i5cqjfa"
+   "commit": "dd36117cca61bfd2554bf7980b170f76bbf92278",
+   "sha256": "0sq6kzs8zsvv9anmrjv85sy2m1yvysjfn9fmyf0m7ffx648lwv4n"
   }
  },
  {
@@ -28199,14 +28340,14 @@
   "repo": "k32/erlstack-mode",
   "unstable": {
    "version": [
-    20190812,
-    1117
+    20210419,
+    1917
    ],
    "deps": [
     "dash"
    ],
-   "commit": "d0a67fb6f91cef02376e71b4b4669b071ebd9737",
-   "sha256": "10b77q2qwwlvj56g9yd6d9lkmk184mjf6x3067vvqs40xiv9bsgl"
+   "commit": "ca264bca24cdaa8b2bac57882716f03f633e42b0",
+   "sha256": "0541q21srscy8x7w4f8vbag1nsjksv9i1wi6sq5xjqnrl0piyv4k"
   },
   "stable": {
    "version": [
@@ -28757,11 +28898,11 @@
   "repo": "akreisher/eshell-syntax-highlighting",
   "unstable": {
    "version": [
-    20210223,
-    936
+    20210429,
+    413
    ],
-   "commit": "eeace52ebb2c730f3665fb235017cd57dc6050a2",
-   "sha256": "1anlan2ldvx0qzj44dhb44flcs3h0d57v79qzn21jpy4d0y0m3kq"
+   "commit": "32d2568ebeb42553a30dda77e03c0e2ec8854199",
+   "sha256": "0my99472i5zdlhcv95jhfv58ph28gaw159p2llp4wv13acryin56"
   },
   "stable": {
    "version": [
@@ -29040,11 +29181,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20210403,
-    520
+    20210414,
+    2354
    ],
-   "commit": "b501beec408b66e2f2a8c4f3117e0c84ee1b0262",
-   "sha256": "03rd1qp9d8br36cynxm73ajac0f2kyyjnffnciix3vf7w5lpsily"
+   "commit": "1782c6730a8fadcf4c162c7aac4329d4e28259b6",
+   "sha256": "0whjmvxxpx55cndngmky04kbfhcxamb7h3nhaclklm5sjlbc16qa"
   },
   "stable": {
    "version": [
@@ -29245,8 +29386,8 @@
     "cl-lib",
     "s"
    ],
-   "commit": "fa1413737b8d5173a4db8c18d8de9ac798365d53",
-   "sha256": "1barvpcxw9v0gy16drcrmq2izmasm0icahnzrpyzdfnvcmvp3al7"
+   "commit": "5169dd7fc8765a7377b0ab93aa63b7f0f934689a",
+   "sha256": "0mn9pffw7kzdzwv3jkhygdkmlqax9fsrbjznbck90ydiv095fmp6"
   },
   "stable": {
    "version": [
@@ -29283,10 +29424,14 @@
    "version": [
     0,
     3,
-    5
+    7
    ],
-   "commit": "68efaa4a7e9841b9bf2b80ea4841ee07d7bd68f9",
-   "sha256": "16jn404vfmsvm12wrf8iczqlgdf2iycbxrvalvzxnm2gr5dfzp7z"
+   "deps": [
+    "cl-lib",
+    "kv"
+   ],
+   "commit": "9f96449f6059cb75491dc812ddeb1b6200ec6740",
+   "sha256": "1xzxmgsg0j72sf1vjh9gjswz3c29js0kqhm7r3jrqrh3a5agdnml"
   }
  },
  {
@@ -29374,8 +29519,8 @@
     "f",
     "xterm-color"
    ],
-   "commit": "05fdbd336a888a0f4068578a6d385d8bf812a4e8",
-   "sha256": "0ln1agcgr607n5akm0ax659g11kfbik7cq8ssnqpr3z7riiv95dm"
+   "commit": "c9cfccef03e730f7ab2b407aada3df15ace1fe32",
+   "sha256": "1ip1mcry2mryr3gzina16c7m2pw71klx1ldbfv8w7rv8fsx2dsma"
   },
   "stable": {
    "version": [
@@ -29630,15 +29775,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20210411,
-    2050
+    20210424,
+    1855
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "d998a8195e404b01e2ea62a455c3dec74d0823c3",
-   "sha256": "0d4839nqdhr858nzb2cqj3wak2g8ynm5l8ak3467p1k9sn4d487a"
+   "commit": "adb551dc36492c74ea6c2a75a85465c6bbbc1cf2",
+   "sha256": "090q0dcy019clrs3nkp68ljcfk1dggzlhl7x8dsvd1bb6a8phn67"
   },
   "stable": {
    "version": [
@@ -29832,15 +29977,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20210401,
-    1012
+    20210424,
+    2326
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "f2be91297029ae002d15e23510f9f686d848d7a8",
-   "sha256": "0ikb3ic84bxj9rzvkjhcvzgiwjpwmhfi6xli5yh03li7qdqsg5j5"
+   "commit": "09b165d4c2ecac66224f674966c920c25d20f3f6",
+   "sha256": "1gj4ds110kx10bgxxflin7ghj3bcyll8pv2h4cqkp9wv79f7plam"
   },
   "stable": {
    "version": [
@@ -29949,15 +30094,15 @@
   "repo": "cute-jumper/evil-embrace.el",
   "unstable": {
    "version": [
-    20160519,
-    1829
+    20210418,
+    2038
    ],
    "deps": [
     "embrace",
     "evil-surround"
    ],
-   "commit": "4379adea032b25e359d01a36301b4a5afdd0d1b7",
-   "sha256": "0rj1ippc6yi560xalhd91r7a00lk3d0jk13w464myznkpnasfw3a"
+   "commit": "464e8ec52ff78edf3c9060143fc375f6ce5f275f",
+   "sha256": "1bga1idxj8mg5xpl7k4ymwaniyba2x13lf8yihyh713s5238fdmd"
   },
   "stable": {
    "version": [
@@ -30411,13 +30556,13 @@
    "version": [
     2,
     3,
-    10
+    11
    ],
    "deps": [
     "evil"
    ],
-   "commit": "b24a7232a2de114cb09774111c2ff8462451894f",
-   "sha256": "14nrc46290q54y7wv25251f2kqc0z8i9byl09xkgjijqldl9vdxa"
+   "commit": "a0c5bd1fe89119b94ffb0a266d2969434e7ec4c1",
+   "sha256": "1990g1b6v0i7jaiv35bdssdn601rjifzg4fy9s3sxk0drqm1xiss"
   }
  },
  {
@@ -30657,14 +30802,14 @@
   "repo": "mamapanda/evil-owl",
   "unstable": {
    "version": [
-    20210408,
-    32
+    20210416,
+    1700
    ],
    "deps": [
     "evil"
    ],
-   "commit": "949ab1331ed9ff65d04930b215e033ef19f3696e",
-   "sha256": "1nkqxpzczlpw7yn8jjr9lqs2izdbw86x7nz0y67x9yy49aj19v6q"
+   "commit": "a41a6d28e26052b25f3d21da37ccf1d8fde1e6aa",
+   "sha256": "15yp158krz3znixgxgcblmsfh0dbxc6bf7fig8757vnmjcwlpqrv"
   },
   "stable": {
    "version": [
@@ -31155,8 +31300,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "d998a8195e404b01e2ea62a455c3dec74d0823c3",
-   "sha256": "0d4839nqdhr858nzb2cqj3wak2g8ynm5l8ak3467p1k9sn4d487a"
+   "commit": "adb551dc36492c74ea6c2a75a85465c6bbbc1cf2",
+   "sha256": "090q0dcy019clrs3nkp68ljcfk1dggzlhl7x8dsvd1bb6a8phn67"
   },
   "stable": {
    "version": [
@@ -31186,8 +31331,8 @@
     "auctex",
     "evil"
    ],
-   "commit": "5f0d6fb11bce66d32c27c765e93557f6ca89cc7d",
-   "sha256": "1856liiy75w3r6s5ss6hnzcrypymfp6fpnw0i6ybrw351fkw4k9w"
+   "commit": "c0b8a9215bba6844487f2a678ea85a0a6e1da825",
+   "sha256": "1vkdq4cf4q3ngdx0f6yx9mgrjm63i8bx7hxa73d9gkbbplkkkjw5"
   },
   "stable": {
    "version": [
@@ -32140,39 +32285,30 @@
   "repo": "tumashu/exwm-x",
   "unstable": {
    "version": [
-    20210411,
-    1120
+    20210419,
+    950
    ],
    "deps": [
     "async",
-    "bind-key",
     "cl-lib",
-    "counsel",
-    "exwm",
-    "ivy",
-    "swiper",
-    "switch-window"
+    "exwm"
    ],
-   "commit": "7bc7a930998117a714cf1f2940dcab12bcac9b73",
-   "sha256": "1zs2sixp77q6dd9pdsk3w4y3nj1iz8j74q7nn5rsdmk0ja8i9sws"
+   "commit": "2ab026f407b011a8e8380c889990e85e69cb3a4e",
+   "sha256": "05jilbhpbbqbgpxhy11yadmal4gsh8bh1fffxkz8b5k8dpajc634"
   },
   "stable": {
    "version": [
-    1,
-    9,
-    0
+    2,
+    0,
+    2
    ],
    "deps": [
-    "bind-key",
+    "async",
     "cl-lib",
-    "counsel",
-    "exwm",
-    "ivy",
-    "swiper",
-    "switch-window"
+    "exwm"
    ],
-   "commit": "88c8b70be678ce0e9fa31e191ffd3f76bbfee61f",
-   "sha256": "03l3dl7s1qys1kkh40rm1sfx7axy1b8sf5f6nyksj9ps6d30p5i4"
+   "commit": "8fd00a0ca586e1c80d08209919f1414b448bc228",
+   "sha256": "0h248mma7kky30jr9bbhmp95wchl2cx5p6kh0gxmzpbc247dn2cc"
   }
  },
  {
@@ -32447,19 +32583,19 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20210331,
-    233
+    20210427,
+    2150
    ],
-   "commit": "ef7efae7a86979e9267f9a600ef1482e0f6a2aa3",
-   "sha256": "0dl9i2l8186ir56v9vx32rw30pj9xgd7zhf24y6sqfjxn80hkdz8"
+   "commit": "7b994f27c798a6cd528af25bccbba28e27e6adcf",
+   "sha256": "0m826s1hll6gjr7y665kix7rnyghdrwi7rga57s158vgg0j345wy"
   },
   "stable": {
    "version": [
     2,
-    17
+    19
    ],
-   "commit": "2db5c559ca7356189083fb698a053bb1fee922a9",
-   "sha256": "1gk2dxmxv0sgkng7zgakz0gq9i0zh3wrwzsi785s338vjyypwm3g"
+   "commit": "7b994f27c798a6cd528af25bccbba28e27e6adcf",
+   "sha256": "0m826s1hll6gjr7y665kix7rnyghdrwi7rga57s158vgg0j345wy"
   }
  },
  {
@@ -32926,11 +33062,7 @@
     1942
    ],
    "commit": "59ab02344f569069b9899a3a5ffdca4a30093df4",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/technomancy/fennel-mode/repository/archive.tar.gz?ref=59ab02344f569069b9899a3a5ffdca4a30093df4': HTTP error 503; retrying in 262 ms\nwarning: unable to download 'https://gitlab.com/technomancy/fennel-mode/repository/archive.tar.gz?ref=59ab02344f569069b9899a3a5ffdca4a30093df4': HTTP error 503; retrying in 704 ms\nwarning: unable to download 'https://gitlab.com/technomancy/fennel-mode/repository/archive.tar.gz?ref=59ab02344f569069b9899a3a5ffdca4a30093df4': HTTP error 503; retrying in 1035 ms\nwarning: unable to download 'https://gitlab.com/technomancy/fennel-mode/repository/archive.tar.gz?ref=59ab02344f569069b9899a3a5ffdca4a30093df4': HTTP error 503; retrying in 2286 ms\nerror: unable to download 'https://gitlab.com/technomancy/fennel-mode/repository/archive.tar.gz?ref=59ab02344f569069b9899a3a5ffdca4a30093df4': HTTP error 503\n"
-   ]
+   "sha256": "1vh6n2sg89g43sidymk22wjzjh71wgbajshhh7y3f6zf8xs94mmz"
   },
   "stable": {
    "version": [
@@ -33072,9 +33204,20 @@
   "ename": "filetree",
   "commit": "b4714ecde7200de934165d8e3b7f94ab5d711fa6",
   "sha256": "0d8ryxq7xa95av36fc25dxrrdxbm69iik22q52fjl9pzivrzlz58",
-  "error": "Not in archive",
   "fetcher": "github",
-  "repo": "knpatel401/filetree"
+  "repo": "knpatel401/filetree",
+  "unstable": {
+   "version": [
+    20210405,
+    524
+   ],
+   "deps": [
+    "dash",
+    "helm"
+   ],
+   "commit": "1328a624847886f8f92dfaf13fb6d73ba3d5d7a6",
+   "sha256": "1zvv3h6c488v8wqnw71inz4s6ag3bnpnsqm1k20n9kwsfqysr1rf"
+  }
  },
  {
   "ename": "fill-column-indicator",
@@ -33233,11 +33376,11 @@
   "repo": "ShuguangSun/find-dupes-dired",
   "unstable": {
    "version": [
-    20210204,
-    49
+    20210426,
+    835
    ],
-   "commit": "3c9783589e43717b682c9e37dd229839735402e8",
-   "sha256": "1wd7n08cf1mnd7czca3mcsfyh4nlkl36arhc3lnh7lzi98nyd0zv"
+   "commit": "af56f75afc240d8121c8944a614a272be811830c",
+   "sha256": "151c9hvsb5bnprn7kf3g23igazkw9l7xvzizikifizfabay9wi2h"
   },
   "stable": {
    "version": [
@@ -33256,20 +33399,20 @@
   "repo": "redguardtoo/find-file-in-project",
   "unstable": {
    "version": [
-    20210323,
-    118
+    20210427,
+    1205
    ],
-   "commit": "595c6ac9d5e5b2dc138b472a40bc85c7f20a56c0",
-   "sha256": "1fqg4jg3x7vrcap46vbncazzjaj6yan57rdmi2n8xbhmw3jcc8z9"
+   "commit": "3bf010d2be073d499de5ffdaa98f48bf8a3dd21e",
+   "sha256": "0zpckqcx4fbjni1f0c6wzi1356ab06j33himfgkhvyl1bn4w5jna"
   },
   "stable": {
    "version": [
     6,
     0,
-    3
+    7
    ],
-   "commit": "6a6328c59a96b09e771cbcc5f4188f20d0757aca",
-   "sha256": "17l5b9nibhfymyndppq0avbdr2rh20527fyr1q5i1c3xkn4d6wvp"
+   "commit": "2f44af320b4e62053c5b6b523f69a8f16eaaa1c9",
+   "sha256": "1qkfijqr839y605ssyalr2v9n6b86hr64mxikc96lx6nzdyjyyl0"
   }
  },
  {
@@ -34346,14 +34489,14 @@
   "repo": "leotaku/flycheck-aspell",
   "unstable": {
    "version": [
-    20210213,
-    1822
+    20210411,
+    2342
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "8cd2e747c3f3c1a0879f66b42db090b2878af508",
-   "sha256": "0m6s8kjk1xpr9pp1s7r39mmm5ry2sa05ync3vjr4kr2m7s5fqchh"
+   "commit": "74fa2837fd667235121a12eba43aa1675a58c0ec",
+   "sha256": "0kgib5igj4ngr589v57k3pwk5v8an33v9mdw5g8kxlsiw7ibr3xk"
   }
  },
  {
@@ -34895,15 +35038,15 @@
   "repo": "atilaneves/flycheck-dmd-dub",
   "unstable": {
    "version": [
-    20210329,
-    1926
+    20210412,
+    1608
    ],
    "deps": [
     "f",
     "flycheck"
    ],
-   "commit": "0799b16872829405e9da4e806ffffa42ad51fa36",
-   "sha256": "07jip6x59h439m714kx0fs6xfqi9p7yfl47js2py0q51hr51k2ij"
+   "commit": "818bfed45ac8597b6ad568c71eb9428138a125c8",
+   "sha256": "19xgj1z1b6m30syq2ps99v1gk76prmvh27nqj83nbqz57nqa0vjb"
   },
   "stable": {
    "version": [
@@ -35012,14 +35155,14 @@
   "repo": "lbolla/emacs-flycheck-elixir",
   "unstable": {
    "version": [
-    20180810,
-    642
+    20210413,
+    612
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "11998d7e3e63a33453e934d25b3673f7c558e579",
-   "sha256": "1hdbg0hvb6hwzjma9mxy0h888c8j2z4g38gwixrdixzbw5727r75"
+   "commit": "b57a77a21d6cf9621b3387831cba34135c4fa35d",
+   "sha256": "10y2z3w2hjycy0hx8zbhma88i2v9fs5xs7pwz3k56jnv95ipjmpy"
   }
  },
  {
@@ -35256,8 +35399,8 @@
     "flycheck",
     "grammarly"
    ],
-   "commit": "192109f43ca5508709a49875ff5f99c25b7f1696",
-   "sha256": "0ymnypijbivncjncs57dsn096wjccl7vwslv2pa8fl9hjl4y34r0"
+   "commit": "8321fc98a0809cad17e37ca924d364423c37b8c0",
+   "sha256": "1pga651wnvw3czqshn731nx0cdaf157v7v1c5n7kh95lc2r3jmn3"
   },
   "stable": {
    "version": [
@@ -35767,8 +35910,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "a285d849e6e227b79bef98f575ecfa43a70661da",
-   "sha256": "1wdv7iv3lmrpxxdas1p3grkpi08c4ipjfg170nfd2fy9nhr8iy38"
+   "commit": "2f5f7502c1e422c1df5b347b8142d67d5cd5caa7",
+   "sha256": "11bhblr96s8a19sb7lnzrwgihqjcwdnajxr6kiplgqd0wsh2h07v"
   },
   "stable": {
    "version": [
@@ -36081,8 +36224,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "039a6c9d0324208d4f4b006693c16248fcf5519b",
-   "sha256": "1sr1n7gv5n22w018z5nxfnknjqmk2lc8h2flv4d2f23aihlss9h3"
+   "commit": "ca00e018ecb9ebea4dde7f17eadb95d755ea88ab",
+   "sha256": "0j2klnv15v2gqnly5vgdrdrkccsza9mwz5c87i6qgnfawmnsh32d"
   },
   "stable": {
    "version": [
@@ -36269,14 +36412,14 @@
   "repo": "msherry/flycheck-pycheckers",
   "unstable": {
    "version": [
-    20200828,
-    1814
+    20210414,
+    2023
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "e8ce874eea4bba13aead8eb8e0262e94fb51f25e",
-   "sha256": "0i98viqm5plifaw3qdf2sxnk70l32qnkr82gl6j561vqhycxjq40"
+   "commit": "771fb9a66223287fcd4998b5f6d32d8c602bd91c",
+   "sha256": "1p4fys8hb89dfqqrzrwqdglxxm50g4x5na2hgzvkq1n0ss617rdj"
   },
   "stable": {
    "version": [
@@ -36843,11 +36986,11 @@
   "repo": "leotaku/flycheck-aspell",
   "unstable": {
    "version": [
-    20210213,
-    1822
+    20210411,
+    2342
    ],
-   "commit": "8cd2e747c3f3c1a0879f66b42db090b2878af508",
-   "sha256": "0m6s8kjk1xpr9pp1s7r39mmm5ry2sa05ync3vjr4kr2m7s5fqchh"
+   "commit": "74fa2837fd667235121a12eba43aa1675a58c0ec",
+   "sha256": "0kgib5igj4ngr589v57k3pwk5v8an33v9mdw5g8kxlsiw7ibr3xk"
   }
  },
  {
@@ -37149,8 +37292,8 @@
    "deps": [
     "grammarly"
    ],
-   "commit": "f09caa56254e6c639993afba29f5a4b8b9f9c73e",
-   "sha256": "0djjxnmy2bkkc6nyl5iq3axnp0marpzpnb8cgh79w1fch300avrf"
+   "commit": "bc7c7e74013816ea06463ff85627bdc08ad60d9a",
+   "sha256": "0yj0mqyg0c87kvxz21y0wmfx97lwvym6qm3sdppgkff5fwppyj91"
   },
   "stable": {
    "version": [
@@ -38455,8 +38598,8 @@
     20191004,
     1850
    ],
-   "commit": "331252334ea2e62d8e06b2dfa24be5dbd7f9c09f",
-   "sha256": "0gri6k1px53lmi5nq3zpv0m0kc3c8pbnc4h0zard5v449gmf1d5q"
+   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
+   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
   }
  },
  {
@@ -38533,8 +38676,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20210406,
-    1356
+    20210426,
+    2126
    ],
    "deps": [
     "closql",
@@ -38546,8 +38689,8 @@
     "markdown-mode",
     "transient"
    ],
-   "commit": "ab3be5a703f319e6de7e76ed292d20deb60cb2d7",
-   "sha256": "1flpxzmxyz94vl0y2mw437nmcsls1fncapa75kqnbbcf641nidhy"
+   "commit": "aa5891178aa67d61ec17069375c07ca989f5741e",
+   "sha256": "07rxs00kk3xmk97i24rf7nbmcfdpa949j351ijcp3pdadinlijzw"
   },
   "stable": {
    "version": [
@@ -38602,15 +38745,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20210315,
-    640
+    20210413,
+    802
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "94239d35944830ce009d01ac3369e0d61f9723c2",
-   "sha256": "1q27yr916vhk0ah1406vs540f8hpp8bca1f118xwhyj1fw3yrbaw"
+   "commit": "eb5906c7070b667432194da3991daf21f24b516a",
+   "sha256": "02i9qijkwzwjcl52ivzhcjamsiygdxn62gdkb9v511036vv4dqff"
   },
   "stable": {
    "version": [
@@ -38747,14 +38890,14 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20210411,
-    1308
+    20210425,
+    335
    ],
    "deps": [
     "seq"
    ],
-   "commit": "3416d8cbf17af8b6f9118ae1963f203bf9b2509d",
-   "sha256": "1a9w6l46fs3dq52vih5dlm3163iy3dghz08d7c5xfg17c1b98yg8"
+   "commit": "7bee756bab352ecd93253343988bb274645cd10b",
+   "sha256": "062kp05x2iy0i5ni1viz2r26dnnvlh7wr7lk7pz1qrjh0qqqzi58"
   },
   "stable": {
    "version": [
@@ -39037,8 +39180,8 @@
     20210201,
     731
    ],
-   "commit": "752fe042ba3153473cd149875388c8dd9b4a8a26",
-   "sha256": "0x4sp6n6dksa8vps465i8sqvdzacr7hrxd4jlxj9gqkcspalrjgy"
+   "commit": "d5dc811fc892d78e042394bb4a1342dea2480b5c",
+   "sha256": "0n1w3rycc5cpqvhw6d1dzkwjdy1xx7bps7d994l4hcpdfx5c25lx"
   },
   "stable": {
    "version": [
@@ -39371,8 +39514,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "43dfeb07bd3932f9d42c2b964413001cf32f0d50",
-   "sha256": "16an39w1ycbw90d6l0d2mcvyndah1j21b2jf7iwnqipwsac9f1qm"
+   "commit": "ee4f57c0d0b5bd3fb8277b3bdced55540743162a",
+   "sha256": "1n89wjlsli7krb4fs8ln55wms5386xky4n2zm7k6457bhbh54fvn"
   },
   "stable": {
    "version": [
@@ -39971,23 +40114,19 @@
   "repo": "emacs-geiser/geiser",
   "unstable": {
    "version": [
-    20210410,
-    2304
+    20210428,
+    1942
    ],
-   "commit": "aa26163aa81b5af3bc5bbf23bec8b5776de3a8bc",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/geiser/repository/archive.tar.gz?ref=aa26163aa81b5af3bc5bbf23bec8b5776de3a8bc': HTTP error 503; retrying in 278 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/geiser/repository/archive.tar.gz?ref=aa26163aa81b5af3bc5bbf23bec8b5776de3a8bc': HTTP error 503; retrying in 535 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/geiser/repository/archive.tar.gz?ref=aa26163aa81b5af3bc5bbf23bec8b5776de3a8bc': HTTP error 503; retrying in 1141 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/geiser/repository/archive.tar.gz?ref=aa26163aa81b5af3bc5bbf23bec8b5776de3a8bc': HTTP error 503; retrying in 2003 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/geiser/repository/archive.tar.gz?ref=aa26163aa81b5af3bc5bbf23bec8b5776de3a8bc': HTTP error 503\n"
-   ]
+   "commit": "70c3d6d5d247836b2d9d988f204ce804ae5db67d",
+   "sha256": "16jqni4s2yxszhkbb83fkgflygbxzx01cmq2qq40p4ihbvwm0gb0"
   },
   "stable": {
    "version": [
     0,
-    12
+    16
    ],
-   "commit": "adc5c4ab5ff33cf94cb3fcd892bb9503b5fa2aa2",
-   "sha256": "0n718xpys7v94zaf9lpmsx97qgn6qxif1acr718wyvpmfr4hiv08"
+   "commit": "803dfeb9414ed7b99c5d567170f32c97cafa1114",
+   "sha256": "16jqni4s2yxszhkbb83fkgflygbxzx01cmq2qq40p4ihbvwm0gb0"
   }
  },
  {
@@ -39998,18 +40137,25 @@
   "repo": "emacs-geiser/chez",
   "unstable": {
    "version": [
-    20210405,
-    1922
+    20210421,
+    120
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "4cb7f2667ea1c53da53f0144910fbbd67bccbf4d",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chez/repository/archive.tar.gz?ref=4cb7f2667ea1c53da53f0144910fbbd67bccbf4d': HTTP error 503; retrying in 257 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chez/repository/archive.tar.gz?ref=4cb7f2667ea1c53da53f0144910fbbd67bccbf4d': HTTP error 503; retrying in 677 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chez/repository/archive.tar.gz?ref=4cb7f2667ea1c53da53f0144910fbbd67bccbf4d': HTTP error 503; retrying in 1142 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chez/repository/archive.tar.gz?ref=4cb7f2667ea1c53da53f0144910fbbd67bccbf4d': HTTP error 503; retrying in 2316 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/chez/repository/archive.tar.gz?ref=4cb7f2667ea1c53da53f0144910fbbd67bccbf4d': HTTP error 503\n"
-   ]
+   "commit": "03da1c17253856d8713bc5a25140cb5002c9c188",
+   "sha256": "0cc1z5z5cpvxa5f3n8kvms0wxlybzcg4l1bh3rwv1l1sb0lk1xzx"
+  },
+  "stable": {
+   "version": [
+    0,
+    16
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "03da1c17253856d8713bc5a25140cb5002c9c188",
+   "sha256": "0cc1z5z5cpvxa5f3n8kvms0wxlybzcg4l1bh3rwv1l1sb0lk1xzx"
   }
  },
  {
@@ -40020,18 +40166,25 @@
   "repo": "emacs-geiser/chibi",
   "unstable": {
    "version": [
-    20210405,
-    1924
+    20210421,
+    123
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "54e7f384618c73d8fb675b5289d443a8ee3e4dc8",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chibi/repository/archive.tar.gz?ref=54e7f384618c73d8fb675b5289d443a8ee3e4dc8': HTTP error 503; retrying in 250 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chibi/repository/archive.tar.gz?ref=54e7f384618c73d8fb675b5289d443a8ee3e4dc8': HTTP error 503; retrying in 530 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chibi/repository/archive.tar.gz?ref=54e7f384618c73d8fb675b5289d443a8ee3e4dc8': HTTP error 503; retrying in 1321 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chibi/repository/archive.tar.gz?ref=54e7f384618c73d8fb675b5289d443a8ee3e4dc8': HTTP error 503; retrying in 2133 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/chibi/repository/archive.tar.gz?ref=54e7f384618c73d8fb675b5289d443a8ee3e4dc8': HTTP error 503\n"
-   ]
+   "commit": "6f59291d8d1dc92ffd3f53f919d8cab4bf50b7d3",
+   "sha256": "0r92iay5cw7jqyd8cy2mm02y0sl89flp4asbz6ca9l818micphfn"
+  },
+  "stable": {
+   "version": [
+    0,
+    16
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "6f59291d8d1dc92ffd3f53f919d8cab4bf50b7d3",
+   "sha256": "0r92iay5cw7jqyd8cy2mm02y0sl89flp4asbz6ca9l818micphfn"
   }
  },
  {
@@ -40042,18 +40195,25 @@
   "repo": "emacs-geiser/chicken",
   "unstable": {
    "version": [
-    20210405,
-    1931
+    20210421,
+    127
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "47be5b43b35d3bf35b0f668b4c08715ea41fb97d",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chicken/repository/archive.tar.gz?ref=47be5b43b35d3bf35b0f668b4c08715ea41fb97d': HTTP error 503; retrying in 302 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chicken/repository/archive.tar.gz?ref=47be5b43b35d3bf35b0f668b4c08715ea41fb97d': HTTP error 503; retrying in 546 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chicken/repository/archive.tar.gz?ref=47be5b43b35d3bf35b0f668b4c08715ea41fb97d': HTTP error 503; retrying in 1206 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/chicken/repository/archive.tar.gz?ref=47be5b43b35d3bf35b0f668b4c08715ea41fb97d': HTTP error 503; retrying in 2316 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/chicken/repository/archive.tar.gz?ref=47be5b43b35d3bf35b0f668b4c08715ea41fb97d': HTTP error 503\n"
-   ]
+   "commit": "ceab39c89607f55cba88e5606ba5eb37c7df5260",
+   "sha256": "0klssx0vhj48868p36nkn22qh2k4188gpvi3c2pjk9lb7d5356xj"
+  },
+  "stable": {
+   "version": [
+    0,
+    16
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "ceab39c89607f55cba88e5606ba5eb37c7df5260",
+   "sha256": "0klssx0vhj48868p36nkn22qh2k4188gpvi3c2pjk9lb7d5356xj"
   }
  },
  {
@@ -40064,18 +40224,25 @@
   "repo": "emacs-geiser/gambit",
   "unstable": {
    "version": [
-    20210405,
-    1925
+    20210421,
+    124
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "0ee4156640988497779345452c3aa0417356e606",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/gambit/repository/archive.tar.gz?ref=0ee4156640988497779345452c3aa0417356e606': HTTP error 503; retrying in 251 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/gambit/repository/archive.tar.gz?ref=0ee4156640988497779345452c3aa0417356e606': HTTP error 503; retrying in 559 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/gambit/repository/archive.tar.gz?ref=0ee4156640988497779345452c3aa0417356e606': HTTP error 503; retrying in 1131 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/gambit/repository/archive.tar.gz?ref=0ee4156640988497779345452c3aa0417356e606': HTTP error 503; retrying in 2010 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/gambit/repository/archive.tar.gz?ref=0ee4156640988497779345452c3aa0417356e606': HTTP error 503\n"
-   ]
+   "commit": "3294c944d1c3b79db44ed14b133129fec454bd60",
+   "sha256": "1vwr0iv7pznr7n6j76i90n306mhq5pxdj8b2f7l5mb32m442w2w9"
+  },
+  "stable": {
+   "version": [
+    0,
+    16
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "3294c944d1c3b79db44ed14b133129fec454bd60",
+   "sha256": "1vwr0iv7pznr7n6j76i90n306mhq5pxdj8b2f7l5mb32m442w2w9"
   }
  },
  {
@@ -40098,14 +40265,10 @@
   "stable": {
    "version": [
     0,
-    0,
-    2
+    14
    ],
-   "deps": [
-    "geiser"
-   ],
-   "commit": "9e7ed54e5629f759660569bc7efc3d75dbabbc5f",
-   "sha256": "0rxncnzx7qgcpvc8nz0sd8r0hwrplazzraahdwhbpq0q6z8ywqgg"
+   "commit": "362f1d1189c090ece8b94f6a51680f74b1ff40f9",
+   "sha256": "1gsvl0r6r385lkv0z4gkxirz9as6k0ghmk402zsyz8gvdpl0f3jw"
   }
  },
  {
@@ -40116,36 +40279,54 @@
   "repo": "emacs-geiser/guile",
   "unstable": {
    "version": [
-    20210405,
-    1917
+    20210421,
+    118
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "93ef7101fdfcc7eac6f465b4b9788c384a323c14",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/guile/repository/archive.tar.gz?ref=93ef7101fdfcc7eac6f465b4b9788c384a323c14': HTTP error 503; retrying in 250 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/guile/repository/archive.tar.gz?ref=93ef7101fdfcc7eac6f465b4b9788c384a323c14': HTTP error 503; retrying in 632 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/guile/repository/archive.tar.gz?ref=93ef7101fdfcc7eac6f465b4b9788c384a323c14': HTTP error 503; retrying in 1153 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/guile/repository/archive.tar.gz?ref=93ef7101fdfcc7eac6f465b4b9788c384a323c14': HTTP error 503; retrying in 2774 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/guile/repository/archive.tar.gz?ref=93ef7101fdfcc7eac6f465b4b9788c384a323c14': HTTP error 503\n"
-   ]
+   "commit": "700ac985c1c729ba1005a0a076c683e9f781526f",
+   "sha256": "0bp70i8505rd0nwl44h9n9swnvqahr2fkhnv3q6020p1hgkjvdjs"
+  },
+  "stable": {
+   "version": [
+    0,
+    16
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "700ac985c1c729ba1005a0a076c683e9f781526f",
+   "sha256": "0bp70i8505rd0nwl44h9n9swnvqahr2fkhnv3q6020p1hgkjvdjs"
   }
  },
  {
   "ename": "geiser-kawa",
-  "commit": "68690d6b011c95197af6b5a87cc21c4dbe97ff00",
-  "sha256": "0gzzab0v93vd9n14s1bya0frf3dagh0gbwg1an4mapg7gjz9ffdg",
+  "commit": "8e3f52b2b0dbd2ace92ec33caa3afc51e5c5e5cf",
+  "sha256": "0rvcpcf8znbndzm481a3477dw61rih1ifj3z2pwv33z6al6lwlh4",
   "fetcher": "gitlab",
-  "repo": "spellcard199/geiser-kawa",
+  "repo": "emacs-geiser/kawa",
   "unstable": {
    "version": [
-    20200507,
-    1305
+    20210427,
+    1626
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "b96c008e9c3b8dc210d8b536ee7b76b8690c8af6",
-   "sha256": "0j2djjgfd4hd2k60ymgxzpsy52ks6hxpd4rr81z5nh9fdg9axhrs"
+   "commit": "3d999a33deedd62dae60f3f7cedfbdb715587ea7",
+   "sha256": "1i4ywb4ggq884p2lbpmp6y53l8ys5ajma7sk21zxi1jx28nb01nm"
+  },
+  "stable": {
+   "version": [
+    0,
+    14
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "f76b53dbc1465dbd799e29bdcd2be34cc1603f50",
+   "sha256": "1i4ywb4ggq884p2lbpmp6y53l8ys5ajma7sk21zxi1jx28nb01nm"
   }
  },
  {
@@ -40163,11 +40344,18 @@
     "geiser"
    ],
    "commit": "d17394f577aaa2854a74a1a0039cb8f73378b400",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/mit/repository/archive.tar.gz?ref=d17394f577aaa2854a74a1a0039cb8f73378b400': HTTP error 503; retrying in 286 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/mit/repository/archive.tar.gz?ref=d17394f577aaa2854a74a1a0039cb8f73378b400': HTTP error 503; retrying in 541 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/mit/repository/archive.tar.gz?ref=d17394f577aaa2854a74a1a0039cb8f73378b400': HTTP error 503; retrying in 1159 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/mit/repository/archive.tar.gz?ref=d17394f577aaa2854a74a1a0039cb8f73378b400': HTTP error 503; retrying in 2059 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/mit/repository/archive.tar.gz?ref=d17394f577aaa2854a74a1a0039cb8f73378b400': HTTP error 503\n"
-   ]
+   "sha256": "0w80ifs5d49ss81j34lnq91x2sbkc44i2xswkcwx23rh62p4jvyc"
+  },
+  "stable": {
+   "version": [
+    0,
+    14
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "d17394f577aaa2854a74a1a0039cb8f73378b400",
+   "sha256": "0w80ifs5d49ss81j34lnq91x2sbkc44i2xswkcwx23rh62p4jvyc"
   }
  },
  {
@@ -40178,18 +40366,54 @@
   "repo": "emacs-geiser/racket",
   "unstable": {
    "version": [
-    20210405,
-    1929
+    20210421,
+    125
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "a87fd449cc6c7b0b17a0b08268e78d3f038f3351",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/emacs-geiser/racket/repository/archive.tar.gz?ref=a87fd449cc6c7b0b17a0b08268e78d3f038f3351': HTTP error 503; retrying in 346 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/racket/repository/archive.tar.gz?ref=a87fd449cc6c7b0b17a0b08268e78d3f038f3351': HTTP error 503; retrying in 544 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/racket/repository/archive.tar.gz?ref=a87fd449cc6c7b0b17a0b08268e78d3f038f3351': HTTP error 503; retrying in 1082 ms\nwarning: unable to download 'https://gitlab.com/emacs-geiser/racket/repository/archive.tar.gz?ref=a87fd449cc6c7b0b17a0b08268e78d3f038f3351': HTTP error 503; retrying in 2114 ms\nerror: unable to download 'https://gitlab.com/emacs-geiser/racket/repository/archive.tar.gz?ref=a87fd449cc6c7b0b17a0b08268e78d3f038f3351': HTTP error 503\n"
-   ]
+   "commit": "22e56ce80389544d3872cf4beb4008fb514b2218",
+   "sha256": "1aqsvmk1hi7kc3j4h8xlza7c6rwm71v98fv5wpw8kmyj9vsp49wx"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "42376b74ae0ad84d02c26560dfd9181493dcccd7",
+   "sha256": "1aqsvmk1hi7kc3j4h8xlza7c6rwm71v98fv5wpw8kmyj9vsp49wx"
+  }
+ },
+ {
+  "ename": "geiser-stklos",
+  "commit": "6530db79aafe4ac4cefa01f77a8cc1e259385171",
+  "sha256": "0bbxxxvzp4dd22lrlmg0lnishvqj1pcm82scds27nrkzrcdycs8s",
+  "fetcher": "gitlab",
+  "repo": "emacs-geiser/stklos",
+  "unstable": {
+   "version": [
+    20210503,
+    944
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "0e3a0570354c03c0cfa25da82fb34ad2e81c1981",
+   "sha256": "1g31cibl88g1vjfvw4z80ywxpnxy5lijhs754qdcnx36maragh07"
+  },
+  "stable": {
+   "version": [
+    1,
+    6
+   ],
+   "deps": [
+    "geiser"
+   ],
+   "commit": "0e3a0570354c03c0cfa25da82fb34ad2e81c1981",
+   "sha256": "1g31cibl88g1vjfvw4z80ywxpnxy5lijhs754qdcnx36maragh07"
   }
  },
  {
@@ -40358,8 +40582,8 @@
     "magit",
     "s"
    ],
-   "commit": "63ca93be02f830f8d65905ebde72d60a2280687a",
-   "sha256": "08s7q7br8a68gs7w55g6i4g0d6ky2mksl1ws8iigiavkh64sihkb"
+   "commit": "6a90e7233dccc2f997af2cd5c896c8d72d3c3a76",
+   "sha256": "1nmgngxgzbp1l4av6vb6fgl2nbizsffv51qnki8yaycl1f3cmrg9"
   }
  },
  {
@@ -40617,28 +40841,28 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20210327,
-    1647
+    20210427,
+    1239
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "2273c3b49a08cde0498b3b2cfae6c764629a4c93",
-   "sha256": "1pg46ycllg900cd8q5bsgv9b9mcc0bm0z5g2bw9gf5nnbw556jla"
+   "commit": "d6e6b0666104f3896d05d2b03d08d84d9dca096f",
+   "sha256": "04ifyn8pkhg6lhlikxfgj6fcnz33mgr6x24y72754szc105irb0s"
   },
   "stable": {
    "version": [
     3,
     5,
-    1
+    2
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "5fae5e31586a11a2025168030e0eb3876502611c",
-   "sha256": "0i19h9zl8wky1296f0d7dcx9dpfmfixinnaf4l1w1bf4p2xmyfiw"
+   "commit": "d6e6b0666104f3896d05d2b03d08d84d9dca096f",
+   "sha256": "04ifyn8pkhg6lhlikxfgj6fcnz33mgr6x24y72754szc105irb0s"
   }
  },
  {
@@ -40684,19 +40908,15 @@
     656
    ],
    "commit": "fa81e915c256271fa10b807a2935d5eaa4700dff",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/Ambrevar/emacs-gif-screencast/repository/archive.tar.gz?ref=fa81e915c256271fa10b807a2935d5eaa4700dff': HTTP error 503; retrying in 272 ms\nwarning: unable to download 'https://gitlab.com/Ambrevar/emacs-gif-screencast/repository/archive.tar.gz?ref=fa81e915c256271fa10b807a2935d5eaa4700dff': HTTP error 503; retrying in 546 ms\nwarning: unable to download 'https://gitlab.com/Ambrevar/emacs-gif-screencast/repository/archive.tar.gz?ref=fa81e915c256271fa10b807a2935d5eaa4700dff': HTTP error 503; retrying in 1078 ms\nwarning: unable to download 'https://gitlab.com/Ambrevar/emacs-gif-screencast/repository/archive.tar.gz?ref=fa81e915c256271fa10b807a2935d5eaa4700dff': HTTP error 503; retrying in 2648 ms\nerror: unable to download 'https://gitlab.com/Ambrevar/emacs-gif-screencast/repository/archive.tar.gz?ref=fa81e915c256271fa10b807a2935d5eaa4700dff': HTTP error 503\n"
-   ]
+   "sha256": "1yf6yipvhhna29mzaan5vb3d5qvbrkp2awr5diyf381mvxgk8akh"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
-   "commit": "9522f7e41d07b59afe21e28abbf186f78be3eab6",
-   "sha256": "1g1by8lvf8c9vzm4wwsi5kp285kaj0ahsl54048ympin4pi0njw9"
+   "commit": "fa81e915c256271fa10b807a2935d5eaa4700dff",
+   "sha256": "1yf6yipvhhna29mzaan5vb3d5qvbrkp2awr5diyf381mvxgk8akh"
   }
  },
  {
@@ -40995,8 +41215,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "5882df245d3388cd6f443bc11df219a838104df2",
-   "sha256": "08yisn699gg2mfapc1h1rfb90vm9p10vk1c9xzd4h30xa6c0299h"
+   "commit": "471c63d92ce22b8ea653f821bc1893ecea324d4d",
+   "sha256": "1qx9164hcrs5k6bq4vpymma6b3g6c14c9zq9y5g9csfnjxmjwnjw"
   },
   "stable": {
    "version": [
@@ -41206,16 +41426,16 @@
   "repo": "akirak/git-identity.el",
   "unstable": {
    "version": [
-    20201223,
-    948
+    20210430,
+    1603
    ],
    "deps": [
     "dash",
     "f",
     "hydra"
    ],
-   "commit": "1c35e1693bbb7de41a8aac820a080a7299c13c17",
-   "sha256": "136j6gbpg8qx6ry1ryh4aal41b3c8pz7g2xisyipjj6p9lmykvqi"
+   "commit": "24360718c1666a246a39aadc8a251faa8578cc66",
+   "sha256": "129xv2ddgdkc9ipkxvwprkwp245x1zq2r75liv31x8x4g4i4305i"
   },
   "stable": {
    "version": [
@@ -41480,20 +41700,20 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20180318,
-    1956
+    20210426,
+    2132
    ],
-   "commit": "14adca24eb6b0b4e311ad144c5d41972c6b044b2",
-   "sha256": "1z3xyjlbxni98hqdnd46lg89dcmcaqjsv73wv16ia4z6lrkhv5dp"
+   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
+   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
   },
   "stable": {
    "version": [
     1,
-    2,
-    8
+    3,
+    0
    ],
-   "commit": "55468314a5f6b77d2c96be62c7005ac94545e217",
-   "sha256": "08hy7rbfazs6grkpk54i82bz0i0c74zcjk96cip8970h6jn3mj72"
+   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
+   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
   }
  },
  {
@@ -41528,20 +41748,20 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20180318,
-    1956
+    20210426,
+    2132
    ],
-   "commit": "14adca24eb6b0b4e311ad144c5d41972c6b044b2",
-   "sha256": "1z3xyjlbxni98hqdnd46lg89dcmcaqjsv73wv16ia4z6lrkhv5dp"
+   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
+   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
   },
   "stable": {
    "version": [
     1,
-    2,
-    8
+    3,
+    0
    ],
-   "commit": "55468314a5f6b77d2c96be62c7005ac94545e217",
-   "sha256": "08hy7rbfazs6grkpk54i82bz0i0c74zcjk96cip8970h6jn3mj72"
+   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
+   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
   }
  },
  {
@@ -41816,20 +42036,20 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20180318,
-    1956
+    20210426,
+    2132
    ],
-   "commit": "14adca24eb6b0b4e311ad144c5d41972c6b044b2",
-   "sha256": "1z3xyjlbxni98hqdnd46lg89dcmcaqjsv73wv16ia4z6lrkhv5dp"
+   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
+   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
   },
   "stable": {
    "version": [
     1,
-    2,
-    8
+    3,
+    0
    ],
-   "commit": "55468314a5f6b77d2c96be62c7005ac94545e217",
-   "sha256": "08hy7rbfazs6grkpk54i82bz0i0c74zcjk96cip8970h6jn3mj72"
+   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
+   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
   }
  },
  {
@@ -41978,26 +42198,26 @@
   "repo": "TxGVNN/gitlab-pipeline",
   "unstable": {
    "version": [
-    20210322,
-    439
+    20210430,
+    151
    ],
    "deps": [
     "ghub"
    ],
-   "commit": "089400ac1d411a2b58cf1a64f28911079d5c898f",
-   "sha256": "0zck5488fswqcl7ahknm6nan5al8db73p2jbxnwcv2cxcia81qza"
+   "commit": "0a07b64e402fa1e25423f8f6ed38b35ff09159d9",
+   "sha256": "1611nday1mxkkjjwcz62bvl8863vlkl4bq4vf3wj6p237m4ai3ks"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "ghub"
    ],
-   "commit": "ecb3a2277f6a1c7fed73f9381834724c143c85da",
-   "sha256": "1nqrim3fpgf5npzl14sd0h6dlhi925hns2f75l4arrhbcjgcn984"
+   "commit": "078f72d52e840907aa4c568468ce25758f20eb15",
+   "sha256": "0y2dkw7dwk1g4q0z1bjycj7sv47pvna6h7kwh8padn5l4fiy0hkd"
   }
  },
  {
@@ -43528,11 +43748,11 @@
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
-   "commit": "a4e80bbf83872fa6c8ace5197693d2f81c4ff1cd",
-   "sha256": "0bh3wbaiavz033isgl0m7crjhfsb0gxsgsnh54aph7pdrffci0r6"
+   "commit": "fb01f121c4c77db3e6750303894d57b31e410b14",
+   "sha256": "0jz4p6xa8nb36g96a8pbhpc4l16jzwryddlw2c442vmkngwy9s1j"
   }
  },
  {
@@ -43561,8 +43781,8 @@
     20180130,
     1736
    ],
-   "commit": "845e4f9a15a794071457e74c1fa99be2c68d75fe",
-   "sha256": "130bjw6bpizf0wq48d8n1cvgpdrq31d8ryd6wmah8a5vbwnczf6y"
+   "commit": "15fddd2eaf0fd656434b9ea72b374b29ffec7344",
+   "sha256": "0wya5sp4a4w2kg4c2pl26lpyxh8fvsmapry2sn8r996cd8lkdkra"
   }
  },
  {
@@ -43921,14 +44141,14 @@
     "magit-popup",
     "s"
    ],
-   "commit": "52c75aa6b3d8eeacfede11b314e20514ca7c75a4",
-   "sha256": "1a2nzbxhqwpjxfm4sr1l2pyjxhvfwd3ralxmldgsdpssqx64lvsn"
+   "commit": "82b771e4e219cd826d73291913eb2291ff2d8bfd",
+   "sha256": "0dprikwq6cna3zrgl7l706p4rhccn2sdp42ynbsza2kaiyz4ar7a"
   },
   "stable": {
    "version": [
     0,
-    24,
-    1
+    25,
+    0
    ],
    "deps": [
     "dash",
@@ -43936,8 +44156,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "f49dcf5ec6e16562de30674b36b18e6bdcd47411",
-   "sha256": "1slw2pawlcx9zfvsazsir2kj32g30b80c7a0yiqyrd7cv1hjnr8g"
+   "commit": "bb0307eb84ae981cfca7fc8d680821a2c2be3c6d",
+   "sha256": "0jwfk4kqz8jzxlhdihb0wvyiza1zfwcwr2p9frk0cw50p6fjqbs6"
   }
  },
  {
@@ -44156,8 +44376,8 @@
     "s",
     "websocket"
    ],
-   "commit": "e11a5a67307f05e08812be190b23460a1bf97687",
-   "sha256": "10ral5vipq3jvg3l8l2vgia97dpsjzkjvidp63n5z6mpjdwblka1"
+   "commit": "175e68d7ce9fd4c44d1eb808954cf0ba66b59599",
+   "sha256": "1ylynb295p5c26ayb8kdxqfbj9z61vinnd6bdlwsynr1wncbwyy4"
   },
   "stable": {
    "version": [
@@ -44534,11 +44754,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20200725,
-    725
+    20210428,
+    1052
    ],
-   "commit": "98d566db769b865f102a0c6802a08ebce8ae5e7f",
-   "sha256": "0dh0a2msrbr31lzrp9b0xrp78g4h02qcsxjjzgmqyb6fqzhbr3kd"
+   "commit": "28552059c4643f571ef0883ad543270a48241572",
+   "sha256": "00prmjyfcnslb8b2gynlsrg80z6ns6jjyj87qniwj0rfmbfnh0qa"
   },
   "stable": {
    "version": [
@@ -44878,8 +45098,8 @@
     20200416,
     2136
    ],
-   "commit": "4462a5ab071ec001734e92d1ac2e5fa9721b94bd",
-   "sha256": "0v2h846k9xv47am66nv4piqhvn74xijhp2bq84v3wpls4msvfk70"
+   "commit": "fa0609b93f1ece777c0593529870390f21f5a788",
+   "sha256": "0aclxzxsh0ixibnw86d8gcyq5yzbfqzmz02rh2djk7l27yg50f10"
   },
   "stable": {
    "version": [
@@ -45606,11 +45826,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20210407,
-    214
+    20210502,
+    155
    ],
-   "commit": "426e28bbee7853734664d75a7e5f960c6c15ee67",
-   "sha256": "01qrrbb2rgr780xna4a1ncv92y8af76kvj0hjdl3qa1mdn0ypc3j"
+   "commit": "886795c15036d566aeced66f9508ae61ec0287ec",
+   "sha256": "1m8wlm12n32kv9pfxsz0xlpzmwn6icwyjj5fansq9v212wawq2b8"
   },
   "stable": {
    "version": [
@@ -45940,16 +46160,16 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210409,
-    1016
+    20210426,
+    551
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "4f16ec21f5ac4d0b9e36768c27abd453a959388d",
-   "sha256": "07v5gr61pvm5nh8xfi79i7ps6hjicm07zkg98m14z424dc8x6kl4"
+   "commit": "f680fcc9e771e4e798e4d2fa9aaf3708337c9289",
+   "sha256": "0rfjqcv53m7ccar7j51wfnxq6dnh75c44lxlnhaqg6i6a17gjd15"
   },
   "stable": {
    "version": [
@@ -46242,8 +46462,8 @@
     "cl-lib",
     "helm"
    ],
-   "commit": "9870333cdd4a54b309e2709af647cda6f4070a42",
-   "sha256": "02cpg60hif4rz6va2ynh3wc9dwj0nyig4fa0l6jchmzz8v2zvf86"
+   "commit": "9f6ea920a49457d85096caa0e61f086a42b2908e",
+   "sha256": "0dqf2anmjlgcz7xn4q2pw8cfmhwdhdg4fm8q41vhrp60ymbc6dik"
   },
   "stable": {
    "version": [
@@ -46848,14 +47068,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210324,
-    1445
+    20210425,
+    1928
    ],
    "deps": [
     "async"
    ],
-   "commit": "4f16ec21f5ac4d0b9e36768c27abd453a959388d",
-   "sha256": "07v5gr61pvm5nh8xfi79i7ps6hjicm07zkg98m14z424dc8x6kl4"
+   "commit": "f680fcc9e771e4e798e4d2fa9aaf3708337c9289",
+   "sha256": "0rfjqcv53m7ccar7j51wfnxq6dnh75c44lxlnhaqg6i6a17gjd15"
   },
   "stable": {
    "version": [
@@ -48391,8 +48611,8 @@
     "helm",
     "lean-mode"
    ],
-   "commit": "5a2a36356e73c74a42e49fad19a71f4f12929a90",
-   "sha256": "18lswxxwvp85yzg1kc9vxn4dpmxmj40j6g64c8ns83nb7hw9lszg"
+   "commit": "bf32bb97930ed67c5cbe0fe3d4a69dedcf68be44",
+   "sha256": "1bkv5zs38ijawvavbba0fdf2flb6fiwici3qi99ws8wvwhnbkws2"
   }
  },
  {
@@ -48538,16 +48758,16 @@
   "repo": "emacs-lsp/helm-lsp",
   "unstable": {
    "version": [
-    20210226,
-    2027
+    20210419,
+    2014
    ],
    "deps": [
     "dash",
     "helm",
     "lsp-mode"
    ],
-   "commit": "74a02f89088484c42ffc184ece338b73abd4d6f6",
-   "sha256": "1p130xj03wh3pqwf1bb3xl86pqnv1kpmn90mwfg0g52jwl0grv6b"
+   "commit": "c2c6974dadfac459b1a69a1217441283874cea92",
+   "sha256": "0xpz9qrcbxknnncqf0hw7hs9k6sv9dckzsf081k2zmsks3l5qh4p"
   },
   "stable": {
    "version": [
@@ -49210,15 +49430,15 @@
   "repo": "tumashu/helm-posframe",
   "unstable": {
    "version": [
-    20200512,
-    1146
+    20210412,
+    1147
    ],
    "deps": [
     "helm",
     "posframe"
    ],
-   "commit": "b107e64eedef6292c49d590f30d320c29b64190b",
-   "sha256": "09y98ij4wkqh771ahwi3b7nsg6yb2b69n94v3ad41kp4q0c2rscd"
+   "commit": "2412e5b3c584c7683982a7e9cfa10a67427f2567",
+   "sha256": "0k4lmgvrxm4lswafc3fb8aab3ax0gnkkq64vg3vmiry85kih2cqb"
   }
  },
  {
@@ -50170,14 +50390,14 @@
   "repo": "emacsorphanage/helm-swoop",
   "unstable": {
    "version": [
-    20200814,
-    448
+    20210426,
+    547
    ],
    "deps": [
     "helm"
    ],
-   "commit": "1f7d3cf0d742b199e4ce13fcb8b19c977a44611e",
-   "sha256": "1r03d3ivmi0r5knsrlfx2cq5jljjl36h2l5n0mbs3sc6iad9wz20"
+   "commit": "1b3285791f1dc1fde548fe67aec07214d698fd57",
+   "sha256": "0wgi7pk2s4syi3fc8l60zcnz34f8ik9y558la0d5ryci4fssrl7i"
   },
   "stable": {
    "version": [
@@ -51037,10 +51257,10 @@
    "version": [
     0,
     1,
-    5
+    6
    ],
-   "commit": "9cc03c7136b56c04ea053fbe08a3a4a6af26b90e",
-   "sha256": "08czwa165rnd5z0dwwdddn7zi5w63sdk31l47bj0598kbly01n7r"
+   "commit": "4420bdda419875dacb065468aafe273b2022580e",
+   "sha256": "0a9nn1jnbgv93kz1iz5iay34d0p7lkpd8ic619ysk8qcksc0yn2i"
   }
  },
  {
@@ -51195,23 +51415,20 @@
   "url": "https://git.sr.ht/~tsdh/highlight-parentheses.el",
   "unstable": {
    "version": [
-    20210410,
-    1932
+    20210420,
+    1924
    ],
-   "commit": "fdabfda5f6300f8dd4d2a62c49359605798cc001",
-   "sha256": "0x833ahd5m4rlqrgr7n5xj477vbs7mmp267in22hw0cxi9aan08q"
+   "commit": "891538de31524956136e1419e1206af0c8befe02",
+   "sha256": "08l5gb73ibs1mmfifnks5gxrcg8x8azw9g10jj2f8vn8viwwa7m0"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    2
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "e18f2c2b240d7586ff7ffdc2881079e2dd8944ca",
-   "sha256": "1agdsqn3g18s9nicp23mlwvshxqskkbfzs9lgjmzxsa5628rxixc"
+   "commit": "fdabfda5f6300f8dd4d2a62c49359605798cc001",
+   "sha256": "0x833ahd5m4rlqrgr7n5xj477vbs7mmp267in22hw0cxi9aan08q"
   }
  },
  {
@@ -51605,6 +51822,21 @@
   }
  },
  {
+  "ename": "hl-prog-extra",
+  "commit": "d4ababc787d4dd173c65cc1b4b4a0fc0bb6e6d07",
+  "sha256": "1dgjskhz1jq01j19dmy8d3fzrg1d8jzrycdsxmkjlc2h05285wkg",
+  "fetcher": "gitlab",
+  "repo": "ideasman42/emacs-hl-prog-extra",
+  "unstable": {
+   "version": [
+    20210422,
+    56
+   ],
+   "commit": "42dee82058e49a7eae5490af2b6b4147600e87ed",
+   "sha256": "1csvhvjzhq1w9384i9n78qv8x0c2y8mdqig6fa2k5qi84cgsh8zp"
+  }
+ },
+ {
   "ename": "hl-sentence",
   "commit": "cae2ac3513e371a256be0f1a7468e38e686c2487",
   "sha256": "16sjfs0nnpwzj1cqfna9vhmxgznwwhb2qdmjci25hlgrdxwwyahs",
@@ -51634,11 +51866,11 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20210117,
-    1140
+    20210503,
+    1419
    ],
-   "commit": "4d18ccde596aef84ef278aa60144390ab41f0046",
-   "sha256": "0r9yz485g393yh4nh1a8nqhk1yxjapq2dzjs3l13ld34hql776yc"
+   "commit": "d83f28ed95c04adf764acc6bd6faaa5f8ecfaea0",
+   "sha256": "1b864qf7n195sw3pkyp905px9p90cdacax74464if8n06l5m57a0"
   },
   "stable": {
    "version": [
@@ -52412,11 +52644,11 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20210106,
-    2120
+    20210422,
+    1351
    ],
-   "commit": "c1f9989bcecd1d93a2d7469d6b5c812bd35fe0f3",
-   "sha256": "180hj0ww30kjr4nrnlp5r59xr6qpi7xhw19cp91syqhclzylkpqr"
+   "commit": "1ce4f09af216f5bb643454da1a3f66beb4a26a55",
+   "sha256": "0f1aqkd9vxf32mafpd7hdbkj9wy5g4y2gqqlvgpy7j50iqkdcm5h"
   }
  },
  {
@@ -52984,11 +53216,11 @@
   "repo": "oantolin/icomplete-vertical",
   "unstable": {
    "version": [
-    20210411,
-    1913
+    20210424,
+    1811
    ],
-   "commit": "a258ff1033dd3d3cb894a039ac13ff3a85b96f57",
-   "sha256": "1r6cpq6nm3hhxhim4i0alcwmrvq17n7gh5dri9lfpcq6c7wqf0qi"
+   "commit": "d7ab5e5de18a027375666755e6610ea26c35ac16",
+   "sha256": "1jkykgf56091w2xb4mgnrfprarbjkqlmac3d388f9ckmiiyyqyrp"
   },
   "stable": {
    "version": [
@@ -53846,11 +54078,11 @@
   "repo": "QiangF/imbot",
   "unstable": {
    "version": [
-    20210319,
-    126
+    20210423,
+    731
    ],
-   "commit": "0fdc71bfa66ecc1f8a54cdcd2458eb47eab41ecd",
-   "sha256": "1ibd9i75x6gb0nprbdi0giklllfwsmvghi3fm19qm7hiw3kg9j3m"
+   "commit": "01bf1e1101ac9cd34bfda7016ce0f82f97a3de35",
+   "sha256": "08w76awwg1g7n67b2rvbwg0i366zshqnhvlp6zyfagjg2bz5gdmf"
   }
  },
  {
@@ -53915,11 +54147,11 @@
   "repo": "bmag/imenu-list",
   "unstable": {
    "version": [
-    20210411,
-    1703
+    20210420,
+    1200
    ],
-   "commit": "1447cdc8c0268e332fb4adc0c643702245d31bde",
-   "sha256": "1fhfxwwf622mjl3slnzyj0zzmbx15qhq6xv8p7fpw88dx1dki113"
+   "commit": "76f2335ee6f2f066d87fe4e4729219d70c9bc70d",
+   "sha256": "0b7q6h7ky7n20w1p471fmnwyfmc59c9ihgnl72m11dnciiz325wa"
   },
   "stable": {
    "version": [
@@ -54089,8 +54321,8 @@
    "deps": [
     "impatient-mode"
    ],
-   "commit": "9ad16da9f78ae242b0a6fb1de388d5f4f1264207",
-   "sha256": "0h665wxnz3l97dxgk2rw3v0sdhb2lr30iqmf4q304wk7ljxg6lig"
+   "commit": "60ae30d07b857c074e2918680805cb37249de0ad",
+   "sha256": "0brj34ijgsgkbawp097wjwiaka2b082aypl5pal0298mpk97zxq0"
   },
   "stable": {
    "version": [
@@ -54418,8 +54650,8 @@
    "deps": [
     "clojure-mode"
    ],
-   "commit": "c3ff2f40fdcedf3357cde868c278474767b65adb",
-   "sha256": "0ljxpjhm3v0wb851zfqvkr5cv4hblg29rz3a5lw48jwz9ijpapq9"
+   "commit": "a2cebf5362fe583538dda8dcf6348a8d73b462a2",
+   "sha256": "0sfn6x08i7sd2k6z4swpd8hxaab3ly0gfyapcaq768chi0grr0gw"
   },
   "stable": {
    "version": [
@@ -54511,11 +54743,11 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20210314,
-    123
+    20210427,
+    1755
    ],
-   "commit": "c6990a60c740b2d69495e34e95b29f13014b3cde",
-   "sha256": "05nz7hvly47n7d945gdb1x8xgzla5r9k629if81rgjh99w24dpgc"
+   "commit": "92d5d122fa172bc49b5ec9ee1891aa9c84805c92",
+   "sha256": "1dn8wml7jwf3dx2nbkjpf2v6k88apiin8wqmz4yix5d2k3x2qm46"
   },
   "stable": {
    "version": [
@@ -54564,11 +54796,11 @@
   "repo": "dakra/info-beamer.el",
   "unstable": {
    "version": [
-    20180604,
-    2122
+    20210427,
+    1033
    ],
-   "commit": "97db34d23cb05b23e50c15875ee84f5d3236e0db",
-   "sha256": "0z1cya3mhgh5ibj3dgwzii1fkbzsq7zjjzg6hfdv3pd4a7722qlx"
+   "commit": "6b4cc29f1aec72d8e23b2c25a99cdd84e6cdc92b",
+   "sha256": "064igpiip1b037rs32z8w1g3w7rywyhabi1h92p1zkx3gjlqgpp2"
   },
   "stable": {
    "version": [
@@ -54860,11 +55092,11 @@
   "repo": "ideasman42/emacs-inkpot-theme",
   "unstable": {
    "version": [
-    20210109,
-    1112
+    20210427,
+    1337
    ],
-   "commit": "e8ae7b2345b8b21dd866fc043906ceecd40832c7",
-   "sha256": "19fxqb6x05480wa4dp4mv2a6cw5sgc8bsm3syqpbhmflymfvxnsy"
+   "commit": "7c3a0a76fa00db41a4d3d990cc98a1c6b088df3d",
+   "sha256": "17x0afwfcr4k0nmliqajswmvaiglk1xl33r3j215w214xp6dqrp2"
   }
  },
  {
@@ -55121,30 +55353,6 @@
    ],
    "commit": "a49a06746d4df6bcfceec3c48dece065d635f9f9",
    "sha256": "1vmaj14k5idx1ykkp1yl0b9qr4fimwagz7p6c00xi9klvjsx566y"
-  }
- },
- {
-  "ename": "interleave",
-  "commit": "6c43d4aaaf4fca17f2bc0ee90a21c51071886ae2",
-  "sha256": "18b3fpxn07y5abkcnaw9is9ihdhik7xjdj6kzl1pz958lk9f4hfy",
-  "fetcher": "github",
-  "repo": "rudolfochrist/interleave",
-  "unstable": {
-   "version": [
-    20191129,
-    958
-   ],
-   "commit": "e1791a96a2633a9f5ea99fc0a20ebacedcefdaaa",
-   "sha256": "1biysf8cqfw4q7d2dnlisviign3n5knvrb0g6zdalzv8pnd1cxqr"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    0
-   ],
-   "commit": "6b28363eac939227c6cdc8a73a1d3ea5b002442d",
-   "sha256": "1qs6j9cz152wfy54c5d1a558l0df6wxv3djlvfl2mx58wf0sk73h"
   }
  },
  {
@@ -55713,11 +55921,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210404,
-    1241
+    20210503,
+    1143
    ],
-   "commit": "471d644d6bdd7d5dc6ca4efb405e6a6389dff245",
-   "sha256": "0zw5sypr9kwb65627b8wrgl542gyq0xh7pwhghbkwfpwx7rjvk36"
+   "commit": "4ffee1c37340a432b9d94a2aa3c870c0a8203dcc",
+   "sha256": "02d5a8s263lp2zvy39mxkyr7qy5475i4ic2bpm2qm0ixr4fkfdy8"
   },
   "stable": {
    "version": [
@@ -55744,8 +55952,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "471d644d6bdd7d5dc6ca4efb405e6a6389dff245",
-   "sha256": "0zw5sypr9kwb65627b8wrgl542gyq0xh7pwhghbkwfpwx7rjvk36"
+   "commit": "4ffee1c37340a432b9d94a2aa3c870c0a8203dcc",
+   "sha256": "02d5a8s263lp2zvy39mxkyr7qy5475i4ic2bpm2qm0ixr4fkfdy8"
   },
   "stable": {
    "version": [
@@ -55777,8 +55985,8 @@
     "cl-lib",
     "swiper"
    ],
-   "commit": "9870333cdd4a54b309e2709af647cda6f4070a42",
-   "sha256": "02cpg60hif4rz6va2ynh3wc9dwj0nyig4fa0l6jchmzz8v2zvf86"
+   "commit": "9f6ea920a49457d85096caa0e61f086a42b2908e",
+   "sha256": "0dqf2anmjlgcz7xn4q2pw8cfmhwdhdg4fm8q41vhrp60ymbc6dik"
   },
   "stable": {
    "version": [
@@ -55847,16 +56055,16 @@
   "repo": "jixiuf/ivy-dired-history",
   "unstable": {
    "version": [
-    20170626,
-    556
+    20210418,
+    1444
    ],
    "deps": [
     "cl-lib",
     "counsel",
     "ivy"
    ],
-   "commit": "c9c67ea1ee5e68443f0e6006ba162d6c8d868b69",
-   "sha256": "1lim9zi57w011df5zppb18yjkaxkgfy796pc6i01p4dl32x0rpfv"
+   "commit": "1ffa9b705c52a9d5b03c97150addb4f746c08380",
+   "sha256": "1li8vh94w1mkwqbh1f0i1mmv5advrbh1183vpjc2zbmmk02pynkf"
   },
   "stable": {
    "version": [
@@ -56112,8 +56320,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "471d644d6bdd7d5dc6ca4efb405e6a6389dff245",
-   "sha256": "0zw5sypr9kwb65627b8wrgl542gyq0xh7pwhghbkwfpwx7rjvk36"
+   "commit": "4ffee1c37340a432b9d94a2aa3c870c0a8203dcc",
+   "sha256": "02d5a8s263lp2zvy39mxkyr7qy5475i4ic2bpm2qm0ixr4fkfdy8"
   },
   "stable": {
    "version": [
@@ -56156,28 +56364,30 @@
   "repo": "ROCKTAKEY/ivy-migemo",
   "unstable": {
    "version": [
-    20210206,
-    919
+    20210425,
+    613
    ],
    "deps": [
     "ivy",
-    "migemo"
+    "migemo",
+    "nadvice"
    ],
-   "commit": "9cdf3823b3303d69c0c77dfee91136817da12aea",
-   "sha256": "0nxk1i208zm6p666920gh1nmrfhfqglhgs07b5ir4b7mz3m5caab"
+   "commit": "a2ce15abe6a30fae63ed457ab25a80455704f28e",
+   "sha256": "18j3h2ndrw92gpbd9q5ji6q8qrwqmzw2xw8yds8f0fd8aybkw8zz"
   },
   "stable": {
    "version": [
     1,
-    1,
+    4,
     0
    ],
    "deps": [
     "ivy",
-    "migemo"
+    "migemo",
+    "nadvice"
    ],
-   "commit": "fc4f44750466ba9385e3313c85adf83a8e55a1fa",
-   "sha256": "0lax72js89k5g007ra6ngy9gnphny4bgjggnl9d3j3mizw9cynvn"
+   "commit": "2d44f7bbc1eb5f95162db889b889488b65bc0042",
+   "sha256": "14jmxg56w6jxz9i4wllbr18c25ximdrbi8w4qcc8lxr9yjlakl15"
   }
  },
  {
@@ -56279,15 +56489,15 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20210410,
-    530
+    20210426,
+    2144
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "7f1ab7890040c4b8dc4e9645c824cd35210e1121",
-   "sha256": "053irrmqvlzs7597grsq0fn06w3apqkgma45xv5pfb2wqin2kx2w"
+   "commit": "084cc59ea2cd62afaa51445ada3d00404749a541",
+   "sha256": "170z5akdwxzrn0b4cbk6v8a3dqz229b7pj9n0534y1a7ydvcyv9h"
   },
   "stable": {
    "version": [
@@ -56311,15 +56521,15 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210227,
-    600
+    20210425,
+    1720
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "ed2b762241bbea03e374dc9dcd4fbe207c6b2ea4",
-   "sha256": "03c0dmblixh5mx8365b6608l7z3vcgp6pzdflwqf8nfwj2c5rm0w"
+   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
+   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
   },
   "stable": {
    "version": [
@@ -57059,8 +57269,8 @@
     "auto-complete",
     "jedi-core"
    ],
-   "commit": "3a9c503c35359d6bca6ff90c384c104c8743cdab",
-   "sha256": "1rx3qiicgg9p0chbfx8v1aypk93p6r5wlkia0b2sqr796r7xdn35"
+   "commit": "e942a0e410cbb2a214c9cb30aaf0e47eb0895b78",
+   "sha256": "1c4nqgg1w2qv0mhpi6hhz3xr5kk4bbxc951fhik6dpi2c2w8p73s"
   },
   "stable": {
    "version": [
@@ -57084,16 +57294,16 @@
   "repo": "tkf/emacs-jedi",
   "unstable": {
    "version": [
-    20210202,
-    856
+    20210503,
+    1315
    ],
    "deps": [
     "cl-lib",
     "epc",
     "python-environment"
    ],
-   "commit": "3a9c503c35359d6bca6ff90c384c104c8743cdab",
-   "sha256": "1rx3qiicgg9p0chbfx8v1aypk93p6r5wlkia0b2sqr796r7xdn35"
+   "commit": "e942a0e410cbb2a214c9cb30aaf0e47eb0895b78",
+   "sha256": "1c4nqgg1w2qv0mhpi6hhz3xr5kk4bbxc951fhik6dpi2c2w8p73s"
   },
   "stable": {
    "version": [
@@ -57325,8 +57535,8 @@
     20200927,
     1317
    ],
-   "commit": "7a934115238d7b80df230a5ba7a70d866bc18c66",
-   "sha256": "087fj39m7gmi3bx2q983afal3738rc5zxnfs4d4c72z065z7gsss"
+   "commit": "b9b3c39743be5aeba17d4d8e5d379613451ddec6",
+   "sha256": "1j3dxj4cr26vir226zb84zn0jsjwnhz02xb60a69jv4k1wcl6bq9"
   },
   "stable": {
    "version": [
@@ -57829,14 +58039,14 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20201220,
-    1718
+    20210414,
+    2241
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "29979e5f3301796ba606759e39ee0b1b6a2a24f3",
-   "sha256": "1pvdzinxfd3b08d92cf5v0fk88dzlyw5r5g3hablh6gcfc9i57xx"
+   "commit": "b891edecedf30be6321e2f109fdfeb25b0edad27",
+   "sha256": "179vkwr57nibc148b961g1aim052v65qsva44imxibkm9h0n32w9"
   },
   "stable": {
    "version": [
@@ -58369,7 +58579,7 @@
     0,
     0,
     -1,
-    5
+    6
    ],
    "deps": [
     "dash",
@@ -58378,8 +58588,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "34498596550b0f819106db8dd6e80dd01332c345",
-   "sha256": "05hrvidpgsinvq7n56c3kfk23x561djchsa10vybjk027fqfvlwb"
+   "commit": "03b4296ba7151963eb3c850f3314b02644101f51",
+   "sha256": "1jgs0pz8bzqg8116kyw3z7jwbf6karrl89ks028q091ylc00nm8b"
   }
  },
  {
@@ -58396,19 +58606,19 @@
    "deps": [
     "vterm"
    ],
-   "commit": "b8a749f19bef179c58068d3fa5cd53c3db5d1ecf",
-   "sha256": "1bp3dc915zq1qd7zycz8bdjq4pz172r3zbzjn8k4rsw0lz9j6w88"
+   "commit": "d57448466c11833d4fd67f5dbbea9cb9a07a74e2",
+   "sha256": "0v7l4jxq71vcw3sjs476smbw9ln6xfrq7n3vzw26apzkrplizqyy"
   },
   "stable": {
    "version": [
     0,
-    11
+    13
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "06ee45bffb6e711278a7af5207899d2b4316706c",
-   "sha256": "1zwhbwm285gqy9bfhlaaa9wp3lz959i3d1s41msl70jxbrnjz7pw"
+   "commit": "b8a749f19bef179c58068d3fa5cd53c3db5d1ecf",
+   "sha256": "1bp3dc915zq1qd7zycz8bdjq4pz172r3zbzjn8k4rsw0lz9j6w88"
   }
  },
  {
@@ -58543,8 +58753,8 @@
   "repo": "nnicandro/emacs-jupyter",
   "unstable": {
    "version": [
-    20210407,
-    212
+    20210422,
+    1451
    ],
    "deps": [
     "cl-lib",
@@ -58552,8 +58762,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "7735d2b8fb32434992467f0d4d9d59c1a1a5dc0c",
-   "sha256": "12q70b249yygqr30l1vhgxzlbfxkcil9xaixzj8zy3xbd3vsjdns"
+   "commit": "1f0612eb936d36abab0f27b09cca691e81fc6e74",
+   "sha256": "1mpch20iahijlgwg8bjpjg7bm9hd2wyskqbknafw8jkwyj7dvng2"
   },
   "stable": {
    "version": [
@@ -58633,14 +58843,14 @@
   "repo": "TxGVNN/emacs-k8s-mode",
   "unstable": {
    "version": [
-    20210219,
-    1317
+    20210414,
+    1543
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "0df142ac98bcd072dd7017053c9c9c476345aeef",
-   "sha256": "1nxcp1hq9d1j7whfak60j4dmzsfmq2mgmdxxvlj3az7p7vannd2v"
+   "commit": "14f08627d5bc320fee5bd9926e9aabe6956f514e",
+   "sha256": "1rfglmslhv3i71fgsqs8gjcnkff06lnp0b9s182rsnfz29dnzd1a"
   },
   "stable": {
    "version": [
@@ -58924,28 +59134,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20210403,
-    749
+    20210503,
+    1257
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "367429c39e330cf2b87e8af0ca7c8883baa21ea3",
-   "sha256": "0hj21jmkcsjv7rxpfq6n77jsmm894rfgsdn80qymh6nyxznq93ym"
+   "commit": "28da5f50aa1ebe72f6b4e5bac1abeb720821a716",
+   "sha256": "0dg64wb9827wx0ax995hx4jhmxh5mn918zawasjwzi3dl92q7llb"
   },
   "stable": {
    "version": [
     1,
     6,
-    2
+    4
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "5694f27f6e17bf2d840fa04728d392b5df77e20c",
-   "sha256": "1c5hdr654f012lj3ssxsavbnij0i109nykwcsgl2c2pb9yxqr5rw"
+   "commit": "c50bc11fdd42dc98ff806d1fc7cd94619c0ab7bb",
+   "sha256": "08ypmv43vjk1l409n894jxplnja6nicn2k3qwhwaf9qxhz0yxpjr"
   }
  },
  {
@@ -59122,11 +59332,11 @@
   "repo": "Boruch-Baum/emacs-key-assist",
   "unstable": {
    "version": [
-    20201109,
-    1358
+    20210415,
+    227
    ],
-   "commit": "7fd89c306c975a1fa3ab16ba7a4d3b102130a868",
-   "sha256": "1m1p3iydn5s3dlmjv751ligbwxkg472rhcbk80q2y1lnwjsnbhdy"
+   "commit": "fae7ce265db3bcfd1c6153eb051afd8789e61a4b",
+   "sha256": "16gi43wgqqjqljnmjwap8lng1p4davv8prvpip034qw9v6vjmm2p"
   },
   "stable": {
    "version": [
@@ -59709,8 +59919,8 @@
     20210318,
     2106
    ],
-   "commit": "53b655b0ef4bdfe8bf81a2bef8f09179a4917076",
-   "sha256": "095z6dkqz6iw28ighqbl2c60i6bm6qyrkxl93yg9b31cd6yzlzin"
+   "commit": "c2b75c587abdc9594e69ef3f5069bd4920bb60e4",
+   "sha256": "16za2j07sdmb2r1r8fcpa45c66n6af41if5bnpk3maqvf1hm21zd"
   },
   "stable": {
    "version": [
@@ -60252,28 +60462,29 @@
   "repo": "tecosaur/LaTeX-auto-activating-snippets",
   "unstable": {
    "version": [
-    20210327,
-    1230
+    20210417,
+    1141
    ],
    "deps": [
     "aas",
     "auctex",
     "yasnippet"
    ],
-   "commit": "654ea30aa0263e85891ddcabc0b7a0f0144b9e27",
-   "sha256": "1z5pw9xhp4gh156n9n3yq92zm6z8gw2ik7nfrvgnip2v3yr31pfb"
+   "commit": "e9bc939237bed4ce50d3d403120f7206c835ea4a",
+   "sha256": "1z2r52x9fsjm1y2m8n0fm9ymd0dx798iw5b3x79fkhnrrw4wfq0s"
   },
   "stable": {
    "version": [
-    0,
-    2
+    1,
+    0
    ],
    "deps": [
     "aas",
+    "auctex",
     "yasnippet"
    ],
-   "commit": "94be7523159ee261077a33094775c7f73218a900",
-   "sha256": "0qyj4xwsxhn78akkv08ka9k47aa3jssd4mgws7ccbnqj68fv78gg"
+   "commit": "e9bc939237bed4ce50d3d403120f7206c835ea4a",
+   "sha256": "1z2r52x9fsjm1y2m8n0fm9ymd0dx798iw5b3x79fkhnrrw4wfq0s"
   }
  },
  {
@@ -60361,8 +60572,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "8609ec2101777362f45df493c593e0e125fe0824",
-   "sha256": "142v2yccbh5aiwy6xzxnz9656p9zj3j2vmmyy70x7vxn2jair3bl"
+   "commit": "74a47238ce1d2d86a3a62c5e8100a6198e73564b",
+   "sha256": "13cm2sgr9jkdjs649jlh4qsvi9fnma0qs48xbp2r5b29mnd4axrx"
   }
  },
  {
@@ -60974,14 +61185,14 @@
   "repo": "conao3/leaf-tree.el",
   "unstable": {
    "version": [
-    20200412,
-    2355
+    20210503,
+    531
    ],
    "deps": [
     "imenu-list"
    ],
-   "commit": "22f6c116cf1465c28d4a35d8a4587a8b614be175",
-   "sha256": "1bgjhrpq6a239v8vfi6i9qcbyrg76mpy4yykkb5da8hlp23idwy7"
+   "commit": "8126baf45c881fd4a692c2d74f9cc2eb15170401",
+   "sha256": "1vb5id0y9002yabkxijfi0l8vbibbd863kq4qk3gqax9dgbld481"
   },
   "stable": {
    "version": [
@@ -61004,8 +61215,8 @@
   "repo": "leanprover/lean-mode",
   "unstable": {
    "version": [
-    20210406,
-    1038
+    20210502,
+    2049
    ],
    "deps": [
     "dash",
@@ -61013,8 +61224,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "5a2a36356e73c74a42e49fad19a71f4f12929a90",
-   "sha256": "18lswxxwvp85yzg1kc9vxn4dpmxmj40j6g64c8ns83nb7hw9lszg"
+   "commit": "bf32bb97930ed67c5cbe0fe3d4a69dedcf68be44",
+   "sha256": "1bkv5zs38ijawvavbba0fdf2flb6fiwici3qi99ws8wvwhnbkws2"
   }
  },
  {
@@ -61080,14 +61291,14 @@
   "repo": "DamienCassou/ledger-import",
   "unstable": {
    "version": [
-    20210108,
-    728
+    20210419,
+    818
    ],
    "deps": [
     "ledger-mode"
    ],
-   "commit": "d1eda3ccafbfabbcc51be364146e31450f11745f",
-   "sha256": "0w6qgqmcv1nyrgjqrb1ah4wj94rn7zn00g0kib4vmc83wcnmyrjb"
+   "commit": "f77adf79ce67524c3e08546448ac88ea1a665b64",
+   "sha256": "1zgv3sxg1dwg7dgy0cl5df6nkxp79cg906hskxsdx6yfplxvi4px"
   },
   "stable": {
    "version": [
@@ -61110,11 +61321,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20210329,
-    2024
+    20210429,
+    134
    ],
-   "commit": "3b0fa5c22bd196dbe31a19f4b2ebbdf8f4081b20",
-   "sha256": "1igg1dmsn90crggm11xnlhrc36szr3dfc4463dn65cagwlck3g3k"
+   "commit": "58a2bf57af9289daeaac6892fa4008ea8255b205",
+   "sha256": "0sbyagz93yvr1a0y7k0nki7030drr27i3nqhwflsdrl0hy4f9iwr"
   },
   "stable": {
    "version": [
@@ -61423,8 +61634,8 @@
     20201007,
     2214
    ],
-   "commit": "5677410abffa1d1bc66b867be8918f1423fd586b",
-   "sha256": "1lcyd7gh2d72vx47dh375d50qcf7xnx888xrx76yc5zfx2df4p80"
+   "commit": "dbfd16af065b12d2dbce26ff1fbad151765243fd",
+   "sha256": "00dbbyx4m32j7qw2b83p7hx7z2ydixv8zr04l0bzalnnm34yb38s"
   },
   "stable": {
    "version": [
@@ -61670,21 +61881,17 @@
     20210303,
     1751
    ],
-   "commit": "d029f4d1738dad616df1a56b570cdf1e725cd967",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/ligolang/ligo/repository/archive.tar.gz?ref=d029f4d1738dad616df1a56b570cdf1e725cd967': HTTP error 503; retrying in 286 ms\nwarning: unable to download 'https://gitlab.com/ligolang/ligo/repository/archive.tar.gz?ref=d029f4d1738dad616df1a56b570cdf1e725cd967': HTTP error 503; retrying in 612 ms\nwarning: unable to download 'https://gitlab.com/ligolang/ligo/repository/archive.tar.gz?ref=d029f4d1738dad616df1a56b570cdf1e725cd967': HTTP error 503; retrying in 1232 ms\nwarning: unable to download 'https://gitlab.com/ligolang/ligo/repository/archive.tar.gz?ref=d029f4d1738dad616df1a56b570cdf1e725cd967': HTTP error 503; retrying in 2325 ms\nerror: unable to download 'https://gitlab.com/ligolang/ligo/repository/archive.tar.gz?ref=d029f4d1738dad616df1a56b570cdf1e725cd967': HTTP error 503\n"
-   ]
+   "commit": "09e4da2dd9f6f1ecf5e1f19b9cd7566c465c05fd",
+   "sha256": "070fq9drdb6b4zbkc6qvkd99qjy0nw3x3nlrr13xzg51lpbmzi3d"
   },
   "stable": {
    "version": [
     0,
-    12,
+    15,
     0
    ],
-   "commit": "70d42b3922d152e8be946c2415151d0551b591d4",
-   "sha256": "17k0v1nfcsq5kdfk05cdkh8nbbi5bqniydqcr6whzw3aawnjryyc"
+   "commit": "3c816a579cde789d9d6dd0a387577d4a997bfe3c",
+   "sha256": "070fq9drdb6b4zbkc6qvkd99qjy0nw3x3nlrr13xzg51lpbmzi3d"
   }
  },
  {
@@ -61695,14 +61902,15 @@
   "repo": "jcs-elpa/line-reminder",
   "unstable": {
    "version": [
-    20210216,
-    1451
+    20210426,
+    1859
    ],
    "deps": [
+    "fringe-helper",
     "indicators"
    ],
-   "commit": "bc488bbdba2172629183891758cfa9466a64182f",
-   "sha256": "1993rwd9bgr1lqxgxzwp6h2r57ljsbjh5r08f57jaalanjp4iq55"
+   "commit": "8c9f824b1dc67c8489afef05b06d9525b29dab00",
+   "sha256": "0qr7qvcl6rlsagim3y71im24z85l3f7cvj39r0g77mnhm733z9m3"
   },
   "stable": {
    "version": [
@@ -62361,11 +62569,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20210318,
-    350
+    20210424,
+    918
    ],
-   "commit": "6979fc6369d55519d52ca1e8f7d80d73ce54c383",
-   "sha256": "180lsghxcjrn21c79jl7g9kkvd4lf4xabgbwbqlck7barfj256jv"
+   "commit": "3e00b497711ac78f0ac26669e35f375451f6711a",
+   "sha256": "0gpg60xr86qx2ib5q9ig5pi9lmhk5vjsb7fh5g6kifvsch31cry3"
   },
   "stable": {
    "version": [
@@ -62458,20 +62666,20 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20210411,
-    244
+    20210413,
+    205
    ],
-   "commit": "23b4308caddf02cc0312ebe4d971e3bfab22f3f8",
-   "sha256": "1zfqdbbknjdg73g1jdy758dln6hgi1rq6j0xpyasyasj169j1nxh"
+   "commit": "d799d074300aa7f1d78024167513a2316cffc204",
+   "sha256": "0dcz2npdf51284wq3c2sw7cq9r9z13irx9y06qi1xaxxv0p4r7z2"
   },
   "stable": {
    "version": [
     4,
-    3,
+    4,
     0
    ],
-   "commit": "c6d3d34bae62f1d5e986625db74f2076af258900",
-   "sha256": "1d022chhib61ghrf847f2w9baqiscpp1s2qvj9i84zmk7bndjvag"
+   "commit": "26d51013e75ddedd5eb8600a0a3dd035319f9d3f",
+   "sha256": "10p4ijx4l56ikb10416bmdwfxbcyqfa29kk1nf48gibxyvdlwdby"
   }
  },
  {
@@ -63090,8 +63298,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20210406,
-    2012
+    20210501,
+    2348
    ],
    "deps": [
     "dap-mode",
@@ -63102,14 +63310,14 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "10e309acc31648ec9bf7ffeef0fc2ad16b2a8584",
-   "sha256": "1wm0lxllazfxrrv4cgalcnsf7g88g1cwz7b69dxfgirlcybcw9il"
+   "commit": "257d881ceda1c91d681787a9cd71d1831cda173c",
+   "sha256": "1lf8xs1z4y6a6kywykraiz0w7nqlrq9ibwwr4zpgn0bqh5fbgy5q"
   },
   "stable": {
    "version": [
     1,
     18,
-    0
+    2
    ],
    "deps": [
     "dap-mode",
@@ -63120,8 +63328,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "f3b70ec0e6adf3a51e15f9a3effb182c2363493d",
-   "sha256": "0iyp844wnvxjrp860dgkr10qrfsaj2rcssj8dv93hhv8pg91fhsk"
+   "commit": "40a86d6547c5625980201f6f772f0d28d09d1aa7",
+   "sha256": "0gwx4i4plb836hkmzvp1krx9n7vn39as3lzpmbfbnpcwny45aj3k"
   }
  },
  {
@@ -63183,8 +63391,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20210404,
-    645
+    20210418,
+    1806
    ],
    "deps": [
     "grammarly",
@@ -63193,25 +63401,24 @@
     "request",
     "s"
    ],
-   "commit": "aa2e70eec5755651ed6c9d9f4063542634760c91",
-   "sha256": "0qisz5117ifravbwvnaq2ci62v3sxl2dd1bd9giacscvshx2hw2c"
+   "commit": "aff219380a7d192a37c8c25823b6bfc816bae825",
+   "sha256": "0ghqmay00r7lfmqx57r5kkldkgr4r20fb5xqh3i440wjdw8m3i3p"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "grammarly",
     "ht",
-    "keytar",
     "lsp-mode",
     "request",
     "s"
    ],
-   "commit": "739a7efc7de6e2b0eca9e72268790431a0fb3185",
-   "sha256": "1ksa685ggp9z0zndscwy9azxjibxd9l79qzvh50i7mz4x9xzdjbd"
+   "commit": "984037557b7e445183453faffc965fbe56df12f2",
+   "sha256": "12q3j0sgsgm73m3i0sw72dzkqa55zn0dbqjgp0g2wryhfhg0zq1p"
   }
  },
  {
@@ -63292,8 +63499,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20210309,
-    1856
+    20210501,
+    500
    ],
    "deps": [
     "dap-mode",
@@ -63305,8 +63512,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "542aaf16d6d3a410b0e41861d80f3fd6b5be7bb9",
-   "sha256": "07kpx8gx9v9v6zhpl7kyg3q4dgpkxk1n089cn1hdxr5vapw7xac9"
+   "commit": "9685334086c0b09d2bb16f631fb368f4ce931764",
+   "sha256": "0lzwwamdlyynq6lybhzcg8w7hmyraz7nhawk4nib0nfjawkr9jxm"
   },
   "stable": {
    "version": [
@@ -63355,26 +63562,26 @@
   "repo": "fredcamps/lsp-jedi",
   "unstable": {
    "version": [
-    20200812,
-    1826
+    20210419,
+    2007
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "10c782261b20ad459f5d2785592c4f46f7088126",
-   "sha256": "0rip6fq5mwk2lsa0wwr573mx4myqvc8a7v4mqalmqxgwzcv9w7vb"
+   "commit": "a6a6dcfbab69caee0b88dbe4244772e0bea5531a",
+   "sha256": "0l2dawi7avzb9i1wfff4kdfbz9s7vp4443y7x3va0jrsn3v33485"
   },
   "stable": {
    "version": [
+    1,
     0,
-    0,
-    1
+    0
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "10c782261b20ad459f5d2785592c4f46f7088126",
-   "sha256": "0rip6fq5mwk2lsa0wwr573mx4myqvc8a7v4mqalmqxgwzcv9w7vb"
+   "commit": "a6a6dcfbab69caee0b88dbe4244772e0bea5531a",
+   "sha256": "0l2dawi7avzb9i1wfff4kdfbz9s7vp4443y7x3va0jrsn3v33485"
   }
  },
  {
@@ -63398,15 +63605,15 @@
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "72e26d0c1d34e3dd16ff6427af883bd0136015d3",
-   "sha256": "0f4zmvn13x468p6vpfixx3ghlrygdgdyx8xpb7nx232pv38156dn"
+   "commit": "81f7de5b9fe8e8e0e1e3a3ccc677f052edad140d",
+   "sha256": "1hwkx5ssix2si7jpsbfcg1i65v3z265l39158qjm31cxf8pk52dw"
   }
  },
  {
@@ -63447,8 +63654,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20210410,
-    615
+    20210426,
+    739
    ],
    "deps": [
     "dap-mode",
@@ -63457,28 +63664,30 @@
     "ht",
     "lsp-mode",
     "lsp-treemacs",
+    "scala-mode",
     "treemacs"
    ],
-   "commit": "a603e9ec3d5f926774a8facb045f33eaa6df9037",
-   "sha256": "1pxfvmkk64v0sd7ghwj3dmhf7bbfh8wk2apxvckdq76l1wrd8izs"
+   "commit": "5aea52dfe08b8f5936ea3982be6c25339f652eba",
+   "sha256": "0ca5xq1l3lscx36pcdnpy2axgyikjrl18naqr140kr1y500sy37s"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
    "deps": [
     "dap-mode",
     "dash",
-    "dash-functional",
     "f",
     "ht",
     "lsp-mode",
+    "lsp-treemacs",
+    "scala-mode",
     "treemacs"
    ],
-   "commit": "efefcc0e936ec463f0d19b6cae7c8336dcd186e4",
-   "sha256": "01396r17ipmp0s5k5njm8m4vqw0g1sj9rq6dpkxv7wbad1c4izmx"
+   "commit": "5aea52dfe08b8f5936ea3982be6c25339f652eba",
+   "sha256": "0ca5xq1l3lscx36pcdnpy2axgyikjrl18naqr140kr1y500sy37s"
   }
  },
  {
@@ -63489,8 +63698,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210410,
-    1801
+    20210503,
+    1350
    ],
    "deps": [
     "dash",
@@ -63500,8 +63709,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "65fb3e8d071406c4596dcc13e3f0230e1f730ec6",
-   "sha256": "1cdhgmqzg9dj491jqwfnqjdjkl4ki3gkpfn386mb5hwfl5aiv5pf"
+   "commit": "b2606d928222556552fab59a12da72e1fcbce6ed",
+   "sha256": "1yifkqhi42awvmdlq4253qn1cq8mcsrdpaz79y04jpd1a4i2wz10"
   },
   "stable": {
    "version": [
@@ -63649,16 +63858,16 @@
   "repo": "emacs-lsp/lsp-pyright",
   "unstable": {
    "version": [
-    20210220,
-    1714
+    20210430,
+    323
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "65fb14128127fb1ddf68dd4cb3140d6c7911a093",
-   "sha256": "0qhs4cv01b7aqq5r6bk91xgwsp8yg1bpn68xk90iirsxlgfb1ffq"
+   "commit": "6163527b4801c0e521d5d2e1d6ba90b8774ec946",
+   "sha256": "1c0d6cnk8w9zgq17c8aw22vvlrr38nm2gixddwcsxhkzb1gg06cf"
   }
  },
  {
@@ -63751,14 +63960,14 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20210330,
-    323
+    20210414,
+    855
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "5df10c36d3162982f5100b8c66af957dd05712cf",
-   "sha256": "0vl5gajg1w5qrzafvkqrbkb9dlja4ina2i3gs6pfv1jrn473h8p7"
+   "commit": "b95e0e2db9e1561719c7f7815e7787fe71392871",
+   "sha256": "0a0746sjq40jxgpqdv3iixwvf97fnpj8wfyy88cxg2w6sf72scdl"
   }
  },
  {
@@ -63769,8 +63978,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20210411,
-    1507
+    20210502,
+    1804
    ],
    "deps": [
     "dash",
@@ -63779,8 +63988,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "4cfb46d7fe69cc537a8a86389c5d8d9fd3fbfabe",
-   "sha256": "0ca20xdmk0c5w3hpimly6pl355sjvzjaq3nwfaw3p6qr9sx1sy9w"
+   "commit": "b07868740d6f7d364e496048cee00bce10a6ab33",
+   "sha256": "1g8qkk6g67myz8rjvwa7iysrj0xpf0kcwrcdvf4dkc3rgh3kzm2v"
   },
   "stable": {
    "version": [
@@ -64279,8 +64488,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210411,
-    2036
+    20210430,
+    404
    ],
    "deps": [
     "dash",
@@ -64288,8 +64497,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "5882df245d3388cd6f443bc11df219a838104df2",
-   "sha256": "08yisn699gg2mfapc1h1rfb90vm9p10vk1c9xzd4h30xa6c0299h"
+   "commit": "471c63d92ce22b8ea653f821bc1893ecea324d4d",
+   "sha256": "1qx9164hcrs5k6bq4vpymma6b3g6c14c9zq9y5g9csfnjxmjwnjw"
   },
   "stable": {
    "version": [
@@ -64469,14 +64678,15 @@
   "repo": "emacsorphanage/magit-gerrit",
   "unstable": {
    "version": [
-    20160226,
-    930
+    20210414,
+    1334
    ],
    "deps": [
-    "magit"
+    "magit",
+    "transient"
    ],
-   "commit": "ece6f369694aca17f3ac166ed2801b432acfe20d",
-   "sha256": "0mms0gxv9a3ns8lk5k2wjibm3088y1cmpr3axjdh6ppv7r5wdvii"
+   "commit": "31f5ce30e374716818df7deb0cdbf462ef67e679",
+   "sha256": "08pwdjknd7407922w7gli76ji87zqj9j87sinhzjc38cnlhvm77n"
   },
   "stable": {
    "version": [
@@ -64635,8 +64845,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "5882df245d3388cd6f443bc11df219a838104df2",
-   "sha256": "08yisn699gg2mfapc1h1rfb90vm9p10vk1c9xzd4h30xa6c0299h"
+   "commit": "471c63d92ce22b8ea653f821bc1893ecea324d4d",
+   "sha256": "1qx9164hcrs5k6bq4vpymma6b3g6c14c9zq9y5g9csfnjxmjwnjw"
   }
  },
  {
@@ -64790,8 +65000,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "5882df245d3388cd6f443bc11df219a838104df2",
-   "sha256": "08yisn699gg2mfapc1h1rfb90vm9p10vk1c9xzd4h30xa6c0299h"
+   "commit": "471c63d92ce22b8ea653f821bc1893ecea324d4d",
+   "sha256": "1qx9164hcrs5k6bq4vpymma6b3g6c14c9zq9y5g9csfnjxmjwnjw"
   },
   "stable": {
    "version": [
@@ -64835,26 +65045,28 @@
   "repo": "emacsorphanage/magit-svn",
   "unstable": {
    "version": [
-    20190821,
-    1455
+    20210426,
+    2114
    ],
    "deps": [
-    "magit"
+    "magit",
+    "transient"
    ],
-   "commit": "2cff1a30a30f2b3963342a7d185ec13fc12279c3",
-   "sha256": "0c4bn9wjjwb0f6hzh7d6vz33lrf75kal62329drzmbh1sla2s3h3"
+   "commit": "350493217afdb7637564e089f475909adecd9208",
+   "sha256": "1v1y4fir1plz4kj0cvkcd29wibli4dw7vp4fmbxq4df76d8iy8yd"
   },
   "stable": {
    "version": [
     2,
     2,
-    2
+    3
    ],
    "deps": [
-    "magit"
+    "magit",
+    "transient"
    ],
-   "commit": "99601f47f47a421576809595ca7463fd010760b1",
-   "sha256": "00lsfkmsz26pz1paqn73skgx747250vc2pa0n8n0h7ywxj9dkzvb"
+   "commit": "350493217afdb7637564e089f475909adecd9208",
+   "sha256": "1v1y4fir1plz4kj0cvkcd29wibli4dw7vp4fmbxq4df76d8iy8yd"
   }
  },
  {
@@ -64865,14 +65077,14 @@
   "repo": "magit/magit-tbdiff",
   "unstable": {
    "version": [
-    20210327,
-    350
+    20210503,
+    340
    ],
    "deps": [
     "magit"
    ],
-   "commit": "99cb9c0501f0f1ea7ec3ebf0fb398f3d36cddafb",
-   "sha256": "189c4hrgbrwx44nidf4xv30yyb2y7lid57by0fn9hyi21nbk2gmx"
+   "commit": "3958523f3e76254b19efd3f32b0a968685fce185",
+   "sha256": "13va4wviimkpw67p52nl8zv6sb9f738r47yk1xlf4fh0yd48bsj6"
   },
   "stable": {
    "version": [
@@ -65580,19 +65792,19 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210409,
-    2305
+    20210430,
+    1736
    ],
-   "commit": "668265af921285c726b2239dae32459bd1064d03",
-   "sha256": "1kl516mzcpdam787x5k55s0crspacvxnz2zqz5m32b13xl2pr847"
+   "commit": "d1b836db16cb693293a2cb7064e5cf9df625df2a",
+   "sha256": "02zbxkzsd7166vpkqv16kmlbxpg7l0xnf784wjay1ngkh55ihvdq"
   },
   "stable": {
    "version": [
     0,
-    4
+    5
    ],
-   "commit": "e741b243b30f6cfe85e568cc551acff9a1e5e74f",
-   "sha256": "0piwzxp1zmwp876kyca0xcgyxgn8bn4wh5fnn88dkvdzi8mcgmkh"
+   "commit": "5126ba6244e13e3e2cf608e7f3955377bcbd8c04",
+   "sha256": "07vfidgq9am07zz2ydhdifmp4jmgs9jn5l1nfqiyp16sd1br6czj"
   }
  },
  {
@@ -65700,11 +65912,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210405,
-    1349
+    20210429,
+    1605
    ],
-   "commit": "ac9ea26b941eef512a3c206375a6404625c229ed",
-   "sha256": "0nszqrx6nfdzlib3w6l5pmzmgnrwzmvzlz7hv46x4iqzyxjg2jsn"
+   "commit": "94c65e2de2e10b7f3a5e72d412c64ab83b2b1a5e",
+   "sha256": "1lbxr6g53sz0nd3za44m6ixs6770zkdayihrm1bq2ip2xidl4kh7"
   },
   "stable": {
    "version": [
@@ -66650,16 +66862,16 @@
   "repo": "DogLooksGood/meow",
   "unstable": {
    "version": [
-    20210410,
-    1837
+    20210427,
+    438
    ],
    "deps": [
     "cl-lib",
     "dash",
     "s"
    ],
-   "commit": "6eb10d223fb7e0d87ac7ab7063fdb3951934e94c",
-   "sha256": "0b1s51yfklm52j2g0gnrwdahr1jql1fv93sn7inm5c1ygx3agc7c"
+   "commit": "e05a81e3793e370f04f414de8cb52948fe38e606",
+   "sha256": "1svw39xa9i7j0qiwbzjhw5lbcnqf7ipjz0dk29jhkxjzkk41qspk"
   }
  },
  {
@@ -66673,16 +66885,18 @@
     20210408,
     1014
    ],
-   "commit": "cb1094ee0aeb5bd2bf5530911157c61cb316e6f3",
-   "sha256": "1bvym9p120sdiwc4lr2f13bhfmxr14vr3scf3g90dj6swa9k9ww8"
+   "commit": "08e24475ec498105993a3e47bf032c088fe2e302",
+   "sha256": "1j01ym40y3x83rq2fiqs9vwv06sqrwynsm4qz6z1dgfmaavd7h6m"
   },
   "stable": {
    "version": [
     4,
-    1
+    2,
+    -4,
+    412
    ],
-   "commit": "ab02f60994c81166820791b5f465f467d752b8dc",
-   "sha256": "1lsrn6739736gr72c83hnxdynqmvjbs8pq3spb74v39k7xixmh99"
+   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
+   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
   }
  },
  {
@@ -66700,8 +66914,22 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "cb1094ee0aeb5bd2bf5530911157c61cb316e6f3",
-   "sha256": "1bvym9p120sdiwc4lr2f13bhfmxr14vr3scf3g90dj6swa9k9ww8"
+   "commit": "08e24475ec498105993a3e47bf032c088fe2e302",
+   "sha256": "1j01ym40y3x83rq2fiqs9vwv06sqrwynsm4qz6z1dgfmaavd7h6m"
+  },
+  "stable": {
+   "version": [
+    4,
+    2,
+    -4,
+    412
+   ],
+   "deps": [
+    "auto-complete",
+    "merlin"
+   ],
+   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
+   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
   }
  },
  {
@@ -66719,8 +66947,22 @@
     "company",
     "merlin"
    ],
-   "commit": "cb1094ee0aeb5bd2bf5530911157c61cb316e6f3",
-   "sha256": "1bvym9p120sdiwc4lr2f13bhfmxr14vr3scf3g90dj6swa9k9ww8"
+   "commit": "08e24475ec498105993a3e47bf032c088fe2e302",
+   "sha256": "1j01ym40y3x83rq2fiqs9vwv06sqrwynsm4qz6z1dgfmaavd7h6m"
+  },
+  "stable": {
+   "version": [
+    4,
+    2,
+    -4,
+    412
+   ],
+   "deps": [
+    "company",
+    "merlin"
+   ],
+   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
+   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
   }
  },
  {
@@ -66767,8 +67009,22 @@
     "iedit",
     "merlin"
    ],
-   "commit": "cb1094ee0aeb5bd2bf5530911157c61cb316e6f3",
-   "sha256": "1bvym9p120sdiwc4lr2f13bhfmxr14vr3scf3g90dj6swa9k9ww8"
+   "commit": "08e24475ec498105993a3e47bf032c088fe2e302",
+   "sha256": "1j01ym40y3x83rq2fiqs9vwv06sqrwynsm4qz6z1dgfmaavd7h6m"
+  },
+  "stable": {
+   "version": [
+    4,
+    2,
+    -4,
+    412
+   ],
+   "deps": [
+    "iedit",
+    "merlin"
+   ],
+   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
+   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
   }
  },
  {
@@ -66963,20 +67219,20 @@
   "repo": "org2blog/org2blog",
   "unstable": {
    "version": [
-    20191018,
-    242
+    20210422,
+    326
    ],
-   "commit": "c7f72a87952ed16323fce968462af897235f1719",
-   "sha256": "0v8zkzai5gfzng9dpkikwf60rvsr1148y5nb7hw65961xms855s4"
+   "commit": "c1b386f3522054f063f4ac60730397ed1f724478",
+   "sha256": "0d0s9hxjvv39n1rik894yh7d20aw120r6cadyp4hqw4n24j8cs5q"
   },
   "stable": {
    "version": [
     1,
     1,
-    10
+    11
    ],
-   "commit": "19aa8a17428d6ee42f54e464c26eeab17a6478ab",
-   "sha256": "198ahgxji0kh6ynygrrdvllj9fwcqrnma4sd8msj2aq18xij9glr"
+   "commit": "c1b386f3522054f063f4ac60730397ed1f724478",
+   "sha256": "0d0s9hxjvv39n1rik894yh7d20aw120r6cadyp4hqw4n24j8cs5q"
   }
  },
  {
@@ -67020,11 +67276,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20210131,
-    740
+    20210416,
+    33
    ],
-   "commit": "8c6bc6bf9562beb74b3b4fda47b2fe473139eb1c",
-   "sha256": "0bf30kkrmi0qw8i0viv1dnvrd52a66rp6vcklidrnv4dh5b782n8"
+   "commit": "380d6059fa9f102e736969d086749980820a9e0e",
+   "sha256": "03fxicfl7yvxj6ac636544km1khhmrjqi97r0smwqfxvlm2gs037"
   },
   "stable": {
    "version": [
@@ -67089,11 +67345,11 @@
   "repo": "purpleidea/mgmt",
   "unstable": {
    "version": [
-    20200104,
-    108
+    20210131,
+    2152
    ],
-   "commit": "76ede10e0a0433d8aae6b3b4e132ca9dcce5ca75",
-   "sha256": "1n6avpk8ggpjqiin1qrwc3g1rjgq902cgks1kfd2r82bkri2sq1q"
+   "commit": "48fa796ab1669dc275b8c99238fff6c83ad2fcc6",
+   "sha256": "0rn7ahpj2kjkmy7gq4fj0n99af70xxxykyjqsza1nnizxfgmrpwj"
   },
   "stable": {
    "version": [
@@ -67643,11 +67899,7 @@
     1900
    ],
    "commit": "519e05f74825abf04b7d2e0e38ec040d013a125a",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/jabranham/mixed-pitch/repository/archive.tar.gz?ref=519e05f74825abf04b7d2e0e38ec040d013a125a': HTTP error 503; retrying in 301 ms\nwarning: unable to download 'https://gitlab.com/jabranham/mixed-pitch/repository/archive.tar.gz?ref=519e05f74825abf04b7d2e0e38ec040d013a125a': HTTP error 503; retrying in 515 ms\nwarning: unable to download 'https://gitlab.com/jabranham/mixed-pitch/repository/archive.tar.gz?ref=519e05f74825abf04b7d2e0e38ec040d013a125a': HTTP error 503; retrying in 1011 ms\nwarning: unable to download 'https://gitlab.com/jabranham/mixed-pitch/repository/archive.tar.gz?ref=519e05f74825abf04b7d2e0e38ec040d013a125a': HTTP error 503; retrying in 2434 ms\nerror: unable to download 'https://gitlab.com/jabranham/mixed-pitch/repository/archive.tar.gz?ref=519e05f74825abf04b7d2e0e38ec040d013a125a': HTTP error 503\n"
-   ]
+   "sha256": "1yf21gm4ziplmgx8yn7jqq45mwfiindbrman7fc5b9ifq78x9ryn"
   },
   "stable": {
    "version": [
@@ -68010,8 +68262,8 @@
     20210215,
     2345
    ],
-   "commit": "02b1da6278e43cc9cc0356110cc6bfbb37eb8241",
-   "sha256": "0ky330b2sfbzkbxbfp9b21hdywsjw26bllspglz08hrbni7jmry8"
+   "commit": "8454a5ef404c6f4fe954a10da6ce4fd4311decfa",
+   "sha256": "01aq4bgris8v7q0yfyz1928q4rh9mba3b799zw2df8slqiigbf8i"
   }
  },
  {
@@ -68118,24 +68370,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210411,
-    751
+    20210503,
+    743
    ],
-   "commit": "3c9b98f61e9b781f756ac7a329005156406cae5a",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/protesilaos/modus-themes/repository/archive.tar.gz?ref=3c9b98f61e9b781f756ac7a329005156406cae5a': HTTP error 503; retrying in 250 ms\nwarning: unable to download 'https://gitlab.com/protesilaos/modus-themes/repository/archive.tar.gz?ref=3c9b98f61e9b781f756ac7a329005156406cae5a': HTTP error 503; retrying in 595 ms\nwarning: unable to download 'https://gitlab.com/protesilaos/modus-themes/repository/archive.tar.gz?ref=3c9b98f61e9b781f756ac7a329005156406cae5a': HTTP error 503; retrying in 1101 ms\nwarning: unable to download 'https://gitlab.com/protesilaos/modus-themes/repository/archive.tar.gz?ref=3c9b98f61e9b781f756ac7a329005156406cae5a': HTTP error 503; retrying in 2792 ms\nerror: unable to download 'https://gitlab.com/protesilaos/modus-themes/repository/archive.tar.gz?ref=3c9b98f61e9b781f756ac7a329005156406cae5a': HTTP error 503\n"
-   ]
+   "commit": "29fd33c19442c0be605830f0e01fc6789e2fa9a7",
+   "sha256": "0d3i07g8sxg30llzx519ph3qp4bx0vk0xy80sxhy5vra2l30ihlj"
   },
   "stable": {
    "version": [
     1,
-    2,
-    3
+    3,
+    0
    ],
-   "commit": "0a36239baf908585cdf32c6188eb86713d9bf6c6",
-   "sha256": "1l392hz6zs6wg06x2zxnk7s0h5cpmvbkcynh68gjmqjj84l7mqrk"
+   "commit": "69248a97c9da98de786891215ab6baafcc44a55d",
+   "sha256": "0d3i07g8sxg30llzx519ph3qp4bx0vk0xy80sxhy5vra2l30ihlj"
   }
  },
  {
@@ -68170,11 +68418,11 @@
   "repo": "sergiruiztrepat/molar-mass",
   "unstable": {
    "version": [
-    20210324,
-    1832
+    20210426,
+    1754
    ],
-   "commit": "5b7d1d0004d27580e980fe8532658cd09174342e",
-   "sha256": "18s2np5wflbg0y6ffnjcbljyh3b5qsnjkma6dcl3razfr55mzmgn"
+   "commit": "27d3a305a9efe3ae8b57ec52cc644c219d0952eb",
+   "sha256": "09kmfq2klh446zdwnxa51z2i39f7p8f8f2wzcz874sm8nf10vszh"
   }
  },
  {
@@ -68290,11 +68538,11 @@
   "repo": "ananthakumaran/monky",
   "unstable": {
    "version": [
-    20201226,
-    1950
+    20210417,
+    12
    ],
-   "commit": "e04632277ef24acacc029ae29db1fadc458ae83b",
-   "sha256": "0xzn9fgxvbpgx5wky8vdhd3bw7hy6h6hngx7l8a0qspg560r7hz1"
+   "commit": "72c7cd21b7b995c476e938fd0b92a494aa25c3a7",
+   "sha256": "03khwadd3x3s9wrggdfjj8cff0nr64fj6hzc9yqbn2baxfkgrn8l"
   },
   "stable": {
    "version": [
@@ -68502,11 +68750,11 @@
   "stable": {
    "version": [
     1,
-    5,
+    6,
     0
    ],
-   "commit": "d0076ea22b2afc4c3faeea2138e836b1c8f08988",
-   "sha256": "0hz525xmv6kslss3yn8ibj6bi2xp442knad0030px7giia6y1pf6"
+   "commit": "f94cf84138a81212ffe856599834f7824a1b6e95",
+   "sha256": "0rdvcv8hwrxxbb9s8sfx5331a08kdk28x8chnnq3pj58pxqvagy3"
   }
  },
  {
@@ -68828,8 +69076,8 @@
     20210306,
     1053
    ],
-   "commit": "1ddec765e033d22079627dc14a06a204134e1b28",
-   "sha256": "0is1il0xws1k31p67s4xvpql7qm4rrv23fj2szdmfdds9f7qpp18"
+   "commit": "fc187dafa37aa9d3d9493c5506eb9089bf4eb884",
+   "sha256": "0zc81gyvp1aqjy21i298wgji4am32cmwb0ahz66ixxlz0f4zi8pz"
   },
   "stable": {
    "version": [
@@ -69426,27 +69674,31 @@
   "repo": "mihaiolteanu/mugur",
   "unstable": {
    "version": [
-    20200831,
-    702
+    20210428,
+    730
    ],
    "deps": [
     "anaphora",
+    "cl-lib",
+    "dash",
     "s"
    ],
-   "commit": "34dfba027bf11e4cca2c547ce80b73d7324c7ba6",
-   "sha256": "011qr9jc90arg3y8y49hjmv94968ym81a36db0dvxyf08hspz006"
+   "commit": "0381bda4cc6f8634131bbc0e5c3efe548703b0fb",
+   "sha256": "1k8g6xb8iw9i4dq30mm1x0534bhby93pvfbrzc2qc8lvakza6n7l"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
    "deps": [
     "anaphora",
+    "cl-lib",
+    "dash",
     "s"
    ],
-   "commit": "34dfba027bf11e4cca2c547ce80b73d7324c7ba6",
-   "sha256": "011qr9jc90arg3y8y49hjmv94968ym81a36db0dvxyf08hspz006"
+   "commit": "b8ebfd18a579b834d062082a8018f73561a0cde1",
+   "sha256": "0a7yd9y6nfyxz9qc84yrn8ii2z6359vhj8if3bx6b0hi8g03m4xl"
   }
  },
  {
@@ -69680,8 +69932,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "7b13b03c995e13ad86e499d40ec49c4dc281f889",
-   "sha256": "1fysnjbh0dai1bzx4122fp4qhbyn82m8hh3smd0xhwphjwrbnl57"
+   "commit": "616fbdd3696f99d85660ad57ebbb0c44d6c7f426",
+   "sha256": "10raq8p881zzz7si3wfpcgdnwyl8y7y9rgw28akyigjyq8knl6kf"
   },
   "stable": {
    "version": [
@@ -71117,8 +71369,8 @@
     20210318,
     1654
    ],
-   "commit": "a4d9d69442c9edac3f2cacabd2a7401dbefe7ff3",
-   "sha256": "1h828cxjacfqlhm719w2kwh91i0r1lai6wswpp7wp21wvvp28v5r"
+   "commit": "7e9ad5a617a26641988445503e235c68fa21b611",
+   "sha256": "1wy06kphgljlcnl55qx5g8hzcv9bnfrrp22pfsxpyawlrmmgxp1j"
   }
  },
  {
@@ -71245,6 +71497,21 @@
    ],
    "commit": "471a90ac96f4c94a717e5138fb0b03a167cfbf26",
    "sha256": "1bqlhkxg0faddhvxx909dq46dxdxk4mdyhdpww92dmzgxdpq38sx"
+  }
+ },
+ {
+  "ename": "nix-modeline",
+  "commit": "6257a28862614c40db5ca933338e69faf7999eab",
+  "sha256": "0c3hr7l3d7qz83hgf3d4i171aya36qmfyvc5qzq7x0qdhiwavjpz",
+  "fetcher": "github",
+  "repo": "ocelot-project/nix-modeline",
+  "unstable": {
+   "version": [
+    20210405,
+    742
+   ],
+   "commit": "611ec73a72aac156511e9e3e61ee413ade9af5c1",
+   "sha256": "0jgzji627lfc4l4lnpv0j4570b4n89jn5a7p9s7c8xhww5w04z1i"
   }
  },
  {
@@ -71388,26 +71655,6 @@
   }
  },
  {
-  "ename": "nm",
-  "commit": "cdad6565e83dd79db538d3b6a45e932864246da2",
-  "sha256": "004rjbrkc7jalbd8ih170sy97w2g16k3whqrqwywh09pzrzb05kw",
-  "fetcher": "github",
-  "repo": "tjim/nevermore",
-  "unstable": {
-   "version": [
-    20151110,
-    1910
-   ],
-   "deps": [
-    "company",
-    "notmuch",
-    "peg"
-   ],
-   "commit": "5a3f29174b3a4b2b2e7a700a862f3b16a942687e",
-   "sha256": "1skbjmyikzyiic470sngskggs05r35m8vzm69wbmrjapczginnak"
-  }
- },
- {
   "ename": "nndiscourse",
   "commit": "1d6a236cd3ff51f2d4cfca114b2791c8ac7411e8",
   "sha256": "03kfb8c7knnd1n5sxxpldmscbwi5lrnsyh6w2ji4pvaq5xhmrlxb",
@@ -71541,13 +71788,13 @@
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "96ed5b8ecad8bcdcd212aacd9957276be3cf128e",
-   "sha256": "00chkzpjcdll907vpzfzmf9p3jprisnr8i0h1x5gixidwbfc2whi"
+   "commit": "57357e15643158b4e0d9b3b4f70a82f5fc73178a",
+   "sha256": "1kbbbx1agzcxc5n1b6cavdx3wjxz6mgi9rafja8mk8cyaaiz0rkd"
   }
  },
  {
@@ -71837,17 +72084,16 @@
     20210205,
     1412
    ],
-   "commit": "1459217e17e94277495c5c644b5a4ca1651c9452",
-   "sha256": "1p1g816ansbq388pqclckcjs0cgl38p0gc77rrgmab3mccdvib2r"
+   "commit": "63413a5563450bdedee4c077f2f998578e75083a",
+   "sha256": "0n6z9858l5yp89dv9y494f1xvs52rxr8qacn4rj3fm2n6h0v63p8"
   },
   "stable": {
    "version": [
     0,
-    31,
-    4
+    32
    ],
-   "commit": "3a3208bb7b8bfca1c0bcaa5b45b6ef71aa768612",
-   "sha256": "04q9zwy6mpck82zk70xnx2knh2jmqhf676703kjw0fbvdrzw9qik"
+   "commit": "5fe92332f2dcff460dea1f2aa78717d1954df62c",
+   "sha256": "1sgjjcc53ys8pspblbif24min5gg7l71xakhrvmb4xniw4rg2qx6"
   }
  },
  {
@@ -71917,26 +72163,26 @@
   "url": "https://git.sr.ht/~tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20201028,
-    1330
+    20210416,
+    1043
    ],
    "deps": [
     "notmuch"
    ],
-   "commit": "9f3e8bbce4c8c6cd80fb71b92d315d4f3334b450",
-   "sha256": "1rrd3ymc7k8irq1w4496h4whks7lnfam7ibfwgcra074ligfrs4p"
+   "commit": "e34c470521e83c3100f0d6eb9e7402ae35e19321",
+   "sha256": "0pmikf1djkr07067nkgmdcxyn7l7ibswx6qlnai8v1v51f9h1g9q"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "notmuch"
    ],
-   "commit": "8c641d9688f20262c9dac59901aaecd2a21525d7",
-   "sha256": "1nh7vkxhwb2cmm8g7gxh3rc6lcfqlhsbf82vi3lsbdq008p1b3kh"
+   "commit": "e34c470521e83c3100f0d6eb9e7402ae35e19321",
+   "sha256": "0pmikf1djkr07067nkgmdcxyn7l7ibswx6qlnai8v1v51f9h1g9q"
   }
  },
  {
@@ -71961,14 +72207,14 @@
    "version": [
     0,
     3,
-    3
+    4
    ],
    "deps": [
     "dash",
     "esxml"
    ],
-   "commit": "0ece7ccbf79c074a3e4fbad1d1fa06647093f8e4",
-   "sha256": "116klnjyggwfwvs9nqhpv97m00k63q6lg41ph41kywsqkfy42dlk"
+   "commit": "b3c7cc28e95fe25ce7b443e5f49e2e45360944a3",
+   "sha256": "0va9xjrq30cv5kb59a4rq5mcm83ggnv774r8spmskff3hj8012wf"
   }
  },
  {
@@ -72131,6 +72377,18 @@
    ],
    "commit": "a5508d9958c2148c04ec32d7b3a9f72423e4b0aa",
    "sha256": "1d1snvxbdv0mh48jmi6dx0yr4hmblcq1aajxb1z56714702ycdgj"
+  },
+  "stable": {
+   "version": [
+    0,
+    9,
+    0
+   ],
+   "deps": [
+    "org-roam"
+   ],
+   "commit": "c150603a25445d65b7b08d658793a6019fd763ea",
+   "sha256": "0qip0vhyvif5az7zph1m41gwamz84v01ay9qzicydzbizhzp4n5i"
   }
  },
  {
@@ -72531,16 +72789,16 @@
   "repo": "astahlman/ob-async",
   "unstable": {
    "version": [
-    20200921,
-    205
+    20210428,
+    2052
    ],
    "deps": [
     "async",
     "dash",
     "org"
    ],
-   "commit": "de1cd6c93242a4cb8773bbe115b7be3d4dd6b97e",
-   "sha256": "12n6fvjiwkf02aypvj5zrbjrxhz2p0rcq2k3mfz5ravyarpvrybp"
+   "commit": "9aac486073f5c356ada20e716571be33a350a982",
+   "sha256": "0k0jcha7cckj8dc2cc1a6m2yhagsl5bmlnr3p8x3g8ij1axk533h"
   },
   "stable": {
    "version": [
@@ -72583,11 +72841,11 @@
   "repo": "corpix/ob-blockdiag.el",
   "unstable": {
    "version": [
-    20190720,
-    1858
+    20210412,
+    1541
    ],
-   "commit": "272fafcf3bc37f9de41b11beb6a33e0dbf0a1909",
-   "sha256": "0gi7vnh5fchbjb7hp7yi08z2vqkmhjrg64ssir358qxqambxvrxb"
+   "commit": "c3794bf7bdb8fdb3db90db41619dda4e7d3dd7b9",
+   "sha256": "14lw5y8djl9ff71layshz4rrmknp4kisv9lak26d9lh1l2z69fi6"
   },
   "stable": {
    "version": [
@@ -72858,28 +73116,28 @@
   "repo": "frederic-santos/ob-ess-julia",
   "unstable": {
    "version": [
-    20201109,
-    911
+    20210414,
+    1444
    ],
    "deps": [
     "ess",
     "julia-mode"
    ],
-   "commit": "b97ebf19c3d68ff946584e78ab7943f8a691ebe5",
-   "sha256": "1g9p3i6iwhgh6wj1k326lswms59nx4n1dyb7rr1qia1d0y3k1zym"
+   "commit": "147e9e7fe55c41dd77171417e92af40db3530b84",
+   "sha256": "00wplflc4pp0ffhnkya19cqm3ihz8mybfj2ywk3ii2d9x08kjnp3"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    3
    ],
    "deps": [
     "ess",
     "julia-mode"
    ],
-   "commit": "337df3eefd85c01020fe08eae3ddcf3ec3e4ac2d",
-   "sha256": "0pk4b6zg08nacds129frk3qwn0mlm4sg03gihyn42fd8iq16mjzf"
+   "commit": "147e9e7fe55c41dd77171417e92af40db3530b84",
+   "sha256": "00wplflc4pp0ffhnkya19cqm3ihz8mybfj2ywk3ii2d9x08kjnp3"
   }
  },
  {
@@ -73028,6 +73286,35 @@
    ],
    "commit": "7147455230841744fb5b95dcbe03320313a77124",
    "sha256": "1a10fc2jk37ni5sjjvf87s5nyaz2a6h2mlj5dxh4dhv5sd3bb85p"
+  }
+ },
+ {
+  "ename": "ob-julia-vterm",
+  "commit": "6e5f9703d8d4f9e5272db5be2c2bd89dfd27f32a",
+  "sha256": "0bkjqln8pi6j0lq5ch68v2r2rb2zbdch3g63kqjwskadgsypgfpj",
+  "fetcher": "github",
+  "repo": "shg/ob-julia-vterm.el",
+  "unstable": {
+   "version": [
+    20210418,
+    2306
+   ],
+   "deps": [
+    "julia-vterm"
+   ],
+   "commit": "3e7ff901687c320869c5e17e3273185af68e8cd6",
+   "sha256": "0i155p3k2xf0p00xazqjw4llylb13svgad9a9m6as6lcvrvc0zsp"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "deps": [
+    "julia-vterm"
+   ],
+   "commit": "5893d75cdb9e687b98b99b3675165f4edf0083a6",
+   "sha256": "12ya7dn7fd0szm6pi68f7h4cyb5cy56cfs43nl9f4v8v2qvlyh5y"
   }
  },
  {
@@ -73596,17 +73883,17 @@
     20201204,
     945
    ],
-   "commit": "fd078c3a37cb679dfffe890995a4e6a1f63ece15",
-   "sha256": "0vq3nnjk76i947wjmfddbr1fs6m8dkddlrqcdsvsf2xw2xfpsfvs"
+   "commit": "876682f6deef7306d7b16322464cc5ad05193494",
+   "sha256": "1jrf8jlp18pnwk99x2181b01mjgk3p6jj2ik29n5sqdg9p5q8czy"
   },
   "stable": {
    "version": [
     0,
-    17,
+    18,
     0
    ],
-   "commit": "bfd6bbe95c614d1d982244c4fd0ba494275d2245",
-   "sha256": "0vy69sjl184czpwbhcbgzyh8kgj6n3jq8ckllcbwic859aq8lqvn"
+   "commit": "3697f0f92854a681fd1156fe4f6fb97d060da1d8",
+   "sha256": "0n6363km8xr81pvyk453n6h2mb0256c5yxw3p1li4dn83f3lwxr1"
   }
  },
  {
@@ -73790,30 +74077,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20210405,
-    820
+    20210418,
+    707
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "1150feb761047e241af1c5e67333665e729a4a63",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/oer/oer-reveal/repository/archive.tar.gz?ref=1150feb761047e241af1c5e67333665e729a4a63': HTTP error 503; retrying in 298 ms\nwarning: unable to download 'https://gitlab.com/oer/oer-reveal/repository/archive.tar.gz?ref=1150feb761047e241af1c5e67333665e729a4a63': HTTP error 503; retrying in 617 ms\nwarning: unable to download 'https://gitlab.com/oer/oer-reveal/repository/archive.tar.gz?ref=1150feb761047e241af1c5e67333665e729a4a63': HTTP error 503; retrying in 1257 ms\nwarning: unable to download 'https://gitlab.com/oer/oer-reveal/repository/archive.tar.gz?ref=1150feb761047e241af1c5e67333665e729a4a63': HTTP error 503; retrying in 2660 ms\nerror: unable to download 'https://gitlab.com/oer/oer-reveal/repository/archive.tar.gz?ref=1150feb761047e241af1c5e67333665e729a4a63': HTTP error 503\n"
-   ]
+   "commit": "9f13380845c9eb69c45ad23888709cce0060d14d",
+   "sha256": "1r0l93w5lwczwl6p65yd2agvx46r06pf4znpvgcv3sg473f6hvj1"
   },
   "stable": {
    "version": [
     3,
-    17,
-    0
+    18,
+    3
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "e880c4f65ad20e22ab845fc2918ca74cc37bf39a",
-   "sha256": "197fn08xhk6cbvi4hqf51v40x0ki5n8h1896g3bpl4fasfy5zicp"
+   "commit": "9f13380845c9eb69c45ad23888709cce0060d14d",
+   "sha256": "1r0l93w5lwczwl6p65yd2agvx46r06pf4znpvgcv3sg473f6hvj1"
   }
  },
  {
@@ -73918,20 +74201,20 @@
   "repo": "rnkn/olivetti",
   "unstable": {
    "version": [
-    20210202,
-    709
+    20210503,
+    850
    ],
-   "commit": "61d26644fd9dd2d45b80b9b82f5f930ed17530d0",
-   "sha256": "1nvnahwjqs9i2cinkpwg689lg134wp7l6f9f1k1jwn0dh1amqmvp"
+   "commit": "6f6c935dabe669a95196e459c0e516d31c711e45",
+   "sha256": "07jssr5v4l20dg24m15wbjzzfn8icnypx0k04d0zqyvmzz8hwkvg"
   },
   "stable": {
    "version": [
     1,
     11,
-    3
+    4
    ],
-   "commit": "a2dbd3dc4e7000fec29febbd089cd4558a7322b9",
-   "sha256": "0zcph7l0hxisbvsyzb1dw3paq5a5sjp5lrq5nq9zggvgc6zvx7sh"
+   "commit": "6902410cd857385a3c1aa20ba391901a78d2740b",
+   "sha256": "1pw1zc0pdwwi9dv8fypfxgn6xbfvm88qzhss880lspialff1wcxn"
   }
  },
  {
@@ -74371,6 +74654,29 @@
   }
  },
  {
+  "ename": "openfoam",
+  "commit": "f184e09d370d563852da2028b9c2546d6fc162c0",
+  "sha256": "09i02kqgw3mqvwzj4p23p66rpy30ziz4gxczs8p47l6ilw5j69rz",
+  "fetcher": "github",
+  "repo": "ralph-schleicher/emacs-openfoam",
+  "unstable": {
+   "version": [
+    20210502,
+    1738
+   ],
+   "commit": "6447c666d7446865860f1490856373d1de4a11fe",
+   "sha256": "02sc61gnn25pfc38shi8ybmg8d4228vk2lyffxj7pszxz6sjya92"
+  },
+  "stable": {
+   "version": [
+    0,
+    11
+   ],
+   "commit": "2c77f46ec7bd4bd8fde694a7b009ec42730199aa",
+   "sha256": "02sc61gnn25pfc38shi8ybmg8d4228vk2lyffxj7pszxz6sjya92"
+  }
+ },
+ {
   "ename": "opensource",
   "commit": "ec4255a403e912a14a7013ea96f554d3588dfc30",
   "sha256": "17gi20s2vi7m75qqaff907x1g8ja5ny90klldpqmj258m2j6a6my",
@@ -74674,14 +74980,14 @@
   "repo": "awth13/org-appear",
   "unstable": {
    "version": [
-    20210401,
-    2114
+    20210427,
+    819
    ],
    "deps": [
     "org"
    ],
-   "commit": "2380562fbec8a17ec193891da755a502a2ccd252",
-   "sha256": "14b1x446zwdsqy8lvmz3iw1byaq1rn92v19ib5zyk18g9lf9ma7i"
+   "commit": "6ee49875f8bdefafbde849f5628d673e9740cf8c",
+   "sha256": "0qsl273qd2cc4nvv0zhsd8wn8kaw3swq6l577rkh4r6iwkqci5gf"
   }
  },
  {
@@ -74883,8 +75189,8 @@
   "stable": {
    "version": [
     0,
-    2,
-    21
+    3,
+    0
    ],
    "deps": [
     "dash",
@@ -74894,8 +75200,8 @@
     "org",
     "s"
    ],
-   "commit": "a88d39e364757594c6b3830cc36f342ee0d1b8ab",
-   "sha256": "1axzhb9k1i8l9rksk14bb04v4q4mx498f5psnalxwvn0563ngs5r"
+   "commit": "9f4ec4a981bfc5eebff993c3ad49a4bed26aebd1",
+   "sha256": "1sgckvpjdaig9r2clcvs6ckgf2kx7amikkpq26y30jbnfnbskf0v"
   }
  },
  {
@@ -75337,16 +75643,16 @@
   "repo": "phillord/org-drill",
   "unstable": {
    "version": [
-    20200412,
-    1812
+    20210427,
+    2003
    ],
    "deps": [
     "org",
     "persist",
     "seq"
    ],
-   "commit": "35c1ce349949cc213f3076799211210f49431850",
-   "sha256": "06hc98z4sml7jrwm5zvbsw5x6q5jpa335almzkh6h85g1p8syfsn"
+   "commit": "bf8fe812d44a3ce3e84361fb39b8ef28ca10fd0c",
+   "sha256": "079x6rcz50rpw0vdq5q2kjpixz95k9f3j9dwk91r5111vvr428w3"
   },
   "stable": {
    "version": [
@@ -75456,14 +75762,14 @@
   "repo": "eschulte/org-ehtml",
   "unstable": {
    "version": [
-    20150506,
-    2358
+    20210428,
+    1547
    ],
    "deps": [
     "web-server"
    ],
-   "commit": "9df85de1a0fe1e7b2d6c000777c1a0c0217f92d0",
-   "sha256": "0kqvwqmwnwg2h7r38fpjg6qlkcj9v8011df8nmsgs1w1mfdvnjsq"
+   "commit": "b4f97edf4150870b84d7ee8508088c0d375eaa83",
+   "sha256": "124fq9k7qmjvn5hp9i2b4xmrm9z18zhbc9j1rv68wpdqf0kqxkcd"
   }
  },
  {
@@ -75580,11 +75886,11 @@
   "repo": "harrybournis/org-fancy-priorities",
   "unstable": {
    "version": [
-    20180328,
-    2331
+    20210427,
+    900
    ],
-   "commit": "819bb993b71e7253cefef7047306ab4e0f9d0a86",
-   "sha256": "13cyzlx0415i953prq6ch7r5iy23c1pz116bdxi5yqags4igh4wv"
+   "commit": "44532ab8c25eb2c0028eecca7acd9e8ea8e2ff30",
+   "sha256": "1cvlyq5p505vx9gcqgvhj7qan1qhq859c2fv7a44kfs0093cb9fz"
   }
  },
  {
@@ -75625,8 +75931,8 @@
   "repo": "kidd/org-gcal.el",
   "unstable": {
    "version": [
-    20210407,
-    57
+    20210421,
+    2203
    ],
    "deps": [
     "alert",
@@ -75634,8 +75940,8 @@
     "request",
     "request-deferred"
    ],
-   "commit": "161465b9448a6413466f1dfe77844f5591fbdeae",
-   "sha256": "0pwi537cg1yb76bwx2sn1w8vkjgsjq38f7lbqvd159g9rbng7v21"
+   "commit": "4c2616a4f85adc77b91aa054bb10e76b06f706d5",
+   "sha256": "0isw9inxbdrf5rwqhjasbbz8av9sn56nwz7xxksr69nk5mv7zm17"
   },
   "stable": {
    "version": [
@@ -75752,8 +76058,8 @@
     "org-agenda-property",
     "org-edna"
    ],
-   "commit": "8d7acda24a00ef94fd14a4e2ebe2606009eb46e9",
-   "sha256": "1h9gfy2assjl2l9dfyp40ypkdm541cisx84vnapjnr6i1bxsvdck"
+   "commit": "034edc545335ecc0da20b4f1bb4aa9f048454afe",
+   "sha256": "0yhnrz7kcq81842sv7zf58fqc6wiy4ckcjyqy8m6bn2z6rwpj655"
   },
   "stable": {
    "version": [
@@ -75792,15 +76098,15 @@
   "stable": {
    "version": [
     1,
-    5,
-    7
+    6,
+    0
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "0877bd57f95ad96a342505a6ecef0c15977f6bd6",
-   "sha256": "02q343sznbw1ma9zcxnpa7sy37s85ph9phpg479pfz5c51kji09h"
+   "commit": "2cb87624238281b438cda67ed375c56403524489",
+   "sha256": "1xmbrrp1zyvij18v3rqmini6w9i6v7dl4fp103ph6wznav8x0jbl"
   }
  },
  {
@@ -75850,15 +76156,15 @@
    "version": [
     7,
     1,
-    6
+    7
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "47dda7d3dce11e8ab9a3847f8c6a1cbb8345f861",
-   "sha256": "1s1y0xlin1yx716awzbq6lvzz5c3c5i9qvacgm006bypg8qlmz1a"
+   "commit": "47805bb8dc681872f3ad5dc74711938978d5c7f2",
+   "sha256": "0iiw798clq6hmml6fs60wwd38c4rzvxrdv4xr57innj06cja4dvy"
   }
  },
  {
@@ -75875,8 +76181,8 @@
    "deps": [
     "org"
    ],
-   "commit": "f9a3321712626d2f43a8849203ceb089cf8233b1",
-   "sha256": "195bzlfqf91f7prv4xh1x1p5xnyygr0mzwqxbsw2apc0haaz6ajk"
+   "commit": "b2dfbf41efac55edacde8a8a6bd0275418de6454",
+   "sha256": "1gs62qjllsz23qbs9zq767c8xxvxwknl1x6r4ixx9090j7bsrhpd"
   },
   "stable": {
    "version": [
@@ -76149,14 +76455,14 @@
   "repo": "dfeich/org-listcruncher",
   "unstable": {
    "version": [
-    20210304,
-    1602
+    20210503,
+    802
    ],
    "deps": [
     "seq"
    ],
-   "commit": "b0269843f317b6715dbde8a4e955aac9c38cbdb6",
-   "sha256": "1ywwngjqfvppxbb0dghqzr0kg9dxyqidjgjrh4ncc0zc9iamcx2w"
+   "commit": "50c06445a837c6677da035f72dbe0f973d9e10a7",
+   "sha256": "1nw5wd781a5nh5csvsr6ycjpji66k8vkvw8z1sfa0p8xsbln9rk9"
   }
  },
  {
@@ -76264,15 +76570,15 @@
    "version": [
     5,
     6,
-    1
+    2
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "4fe1f194a8eba00858b78d611ad8a7f14392722d",
-   "sha256": "1p1k5zmc0dklbvnck0zhsxqmndask822ikaa40d1ik105w1vx3bz"
+   "commit": "5aeed6d0f7f878b20483975200df43b6fc7f32f9",
+   "sha256": "102lrlf25i30xbpszr1mh6mkxd6wwgbwg32dafccxm4dmj3v9hqq"
   }
  },
  {
@@ -76325,14 +76631,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20210409,
-    1813
+    20210429,
+    59
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "e57af9c057d97d14536cef08aca7a19bdf194830",
-   "sha256": "19m1y686jppl1j7ibigw1h6n518swgdcfgrk84r1nvd7x83vd8v0"
+   "commit": "d9a690eeca64231159cd0f3f0ee214619858490e",
+   "sha256": "1fr8nw4pxbhml1ly1wx5glybgdh5g1g87aivzmjddycdsfcx2zqi"
   }
  },
  {
@@ -77030,24 +77336,20 @@
     "org"
    ],
    "commit": "4d8a63cba537705f4ecf3f45838e3cfc83fa2369",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/oer/org-re-reveal/repository/archive.tar.gz?ref=4d8a63cba537705f4ecf3f45838e3cfc83fa2369': HTTP error 503; retrying in 327 ms\nwarning: unable to download 'https://gitlab.com/oer/org-re-reveal/repository/archive.tar.gz?ref=4d8a63cba537705f4ecf3f45838e3cfc83fa2369': HTTP error 503; retrying in 591 ms\nwarning: unable to download 'https://gitlab.com/oer/org-re-reveal/repository/archive.tar.gz?ref=4d8a63cba537705f4ecf3f45838e3cfc83fa2369': HTTP error 503; retrying in 1200 ms\nwarning: unable to download 'https://gitlab.com/oer/org-re-reveal/repository/archive.tar.gz?ref=4d8a63cba537705f4ecf3f45838e3cfc83fa2369': HTTP error 503; retrying in 2118 ms\nerror: unable to download 'https://gitlab.com/oer/org-re-reveal/repository/archive.tar.gz?ref=4d8a63cba537705f4ecf3f45838e3cfc83fa2369': HTTP error 503\n"
-   ]
+   "sha256": "0y45g2d868ayl9igzdxzbfzw8n5qymzsdm9d3giwnlchqfrp987y"
   },
   "stable": {
    "version": [
     3,
-    7,
-    0
+    8,
+    1
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "d404eb13d9e34354c081870ebdd69711937682b3",
-   "sha256": "1vzn0l8ig4rzh5h8j7kxn8kslqrij97qqv98fbnlwmrw4z87v8dr"
+   "commit": "4d8a63cba537705f4ecf3f45838e3cfc83fa2369",
+   "sha256": "0y45g2d868ayl9igzdxzbfzw8n5qymzsdm9d3giwnlchqfrp987y"
   }
  },
  {
@@ -77301,8 +77603,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20210411,
-    650
+    20210502,
+    1936
    ],
    "deps": [
     "dash",
@@ -77312,14 +77614,14 @@
     "org",
     "s"
    ],
-   "commit": "997ddcbf4b0373bb449d09f1db6cf5de6983de5e",
-   "sha256": "0dh325syjn1dkblydbdxqqy24pbyk4h3rcmr8506lycyz1xg2m2k"
+   "commit": "d2e933cc3e4f5ee843bfca9525a30eb395c60990",
+   "sha256": "09fbbji67ipfw1xn2960v9pwc6xm6w9z10j3c343f9a02aqyjwif"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    4
    ],
    "deps": [
     "dash",
@@ -77329,8 +77631,8 @@
     "org",
     "s"
    ],
-   "commit": "cc01cf346e2d832f78694320947e0788c92f49b9",
-   "sha256": "0n8c0yxqb62i39kn0d5x83s96vwc0nbg0sx5hplffnbkfbj88bba"
+   "commit": "9065f6a999b98d4b495e3d8fa1fa4424eddd25a8",
+   "sha256": "10jrnjq65lpg1x8d7lqc537yai9m6pdnfbzwr87fcyv6f8yii8xn"
   }
  },
  {
@@ -77432,8 +77734,8 @@
   "repo": "tyler-dodge/org-runbook",
   "unstable": {
    "version": [
-    20210102,
-    1627
+    20210502,
+    1732
    ],
    "deps": [
     "dash",
@@ -77444,8 +77746,8 @@
     "s",
     "seq"
    ],
-   "commit": "a05dcf6b9674406a9d616b53b4f199a3f87b3f2a",
-   "sha256": "0bj91c8zz804zclhl5ay8k2sjw9pi9mrkrjcmcs2h36klcb1x4qn"
+   "commit": "3206b4ea40614ba87a1b12f66ad0f84354bcdafb",
+   "sha256": "0b2gs6hm8k25539m7hxbhh5jza37mdfv3z763r130fxj3b646v01"
   },
   "stable": {
    "version": [
@@ -77639,7 +77941,7 @@
    "version": [
     3,
     0,
-    0
+    2
    ],
    "deps": [
     "dash",
@@ -77647,8 +77949,8 @@
     "org-ml",
     "s"
    ],
-   "commit": "1cc854e814f86bc35f536563837a97a832a06122",
-   "sha256": "1wp3d3b1wdw8v5drwbrfxrbq8psf82bs9cwjin2psfgb4n1166dy"
+   "commit": "40c8870b2ab93dde33994f46c0531b3978e25fde",
+   "sha256": "05c1hgzq69lnw59x1w5bybrdhnyli8d9pzjczixklrrahmx4ig8k"
   }
  },
  {
@@ -78325,11 +78627,11 @@
   "repo": "cadadr/elisp",
   "unstable": {
    "version": [
-    20200919,
-    1348
+    20210414,
+    1844
    ],
-   "commit": "331252334ea2e62d8e06b2dfa24be5dbd7f9c09f",
-   "sha256": "0gri6k1px53lmi5nq3zpv0m0kc3c8pbnc4h0zard5v449gmf1d5q"
+   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
+   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
   }
  },
  {
@@ -78508,8 +78810,8 @@
   "repo": "org2blog/org2blog",
   "unstable": {
    "version": [
-    20200817,
-    1842
+    20210422,
+    339
    ],
    "deps": [
     "htmlize",
@@ -78517,14 +78819,14 @@
     "metaweblog",
     "xml-rpc"
    ],
-   "commit": "c7f72a87952ed16323fce968462af897235f1719",
-   "sha256": "0v8zkzai5gfzng9dpkikwf60rvsr1148y5nb7hw65961xms855s4"
+   "commit": "c1b386f3522054f063f4ac60730397ed1f724478",
+   "sha256": "0d0s9hxjvv39n1rik894yh7d20aw120r6cadyp4hqw4n24j8cs5q"
   },
   "stable": {
    "version": [
     1,
     1,
-    10
+    11
    ],
    "deps": [
     "htmlize",
@@ -78532,8 +78834,8 @@
     "metaweblog",
     "xml-rpc"
    ],
-   "commit": "19aa8a17428d6ee42f54e464c26eeab17a6478ab",
-   "sha256": "198ahgxji0kh6ynygrrdvllj9fwcqrnma4sd8msj2aq18xij9glr"
+   "commit": "c1b386f3522054f063f4ac60730397ed1f724478",
+   "sha256": "0d0s9hxjvv39n1rik894yh7d20aw120r6cadyp4hqw4n24j8cs5q"
   }
  },
  {
@@ -78757,15 +79059,15 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20210309,
-    1906
+    20210426,
+    1746
    ],
    "deps": [
     "magit",
     "org"
    ],
-   "commit": "609fd0ccfb5268704b5bc7d7ac1014d4960b9707",
-   "sha256": "00rmp5pbn7bn4mrfzlkh9dc5m80qw72bs5jxdss9sk38v1gvxbr3"
+   "commit": "e8db8dc74106dfabe316e63cc9032dd7bb9bc598",
+   "sha256": "0dqinq1n78mjll3agiqif2rxz8ikdz4qr88hxhrwbl4222dlaagz"
   },
   "stable": {
    "version": [
@@ -78789,8 +79091,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20200621,
-    2144
+    20210426,
+    2145
    ],
    "deps": [
     "forge",
@@ -78798,8 +79100,8 @@
     "org",
     "orgit"
    ],
-   "commit": "051d92661ef12b67ffadb231324806d87d1e6a54",
-   "sha256": "0x8wmqp9x2c7qv0ipj2rvjf7bc7z0pn8s253gjxpxmakz3l8wnyk"
+   "commit": "f7c1a83efbebad3c533259a3256c85012e2d13f4",
+   "sha256": "0xc070ykg5dnq1di4912ckhyw70c68lw43b2s06b5cg20ka79i6h"
   },
   "stable": {
    "version": [
@@ -79276,19 +79578,20 @@
   "repo": "emacsorphanage/osx-trash",
   "unstable": {
    "version": [
-    20160520,
-    1300
+    20210419,
+    2229
    ],
-   "commit": "0f1dc052d0a750b8c75f14530a4897f5d4324b4e",
-   "sha256": "0f4md49175iyrgzv4pijf7qbxyddcm2yscrrlh91pg410la7fysk"
+   "commit": "af74a2055a15bf4182d8196600f7decd66eec634",
+   "sha256": "09960kif9gnfmic4iyv9d28577j6zsiji9fdrxcnhh6586hz70ri"
   },
   "stable": {
    "version": [
     0,
-    2
+    2,
+    1
    ],
-   "commit": "529619b84d21e18a38ec5255eb40f6b8ede38b2a",
-   "sha256": "1n44wdffkw14si9kb7bpkp6d9cjwjrvksfh22y9549dhs1vav6qq"
+   "commit": "af74a2055a15bf4182d8196600f7decd66eec634",
+   "sha256": "09960kif9gnfmic4iyv9d28577j6zsiji9fdrxcnhh6586hz70ri"
   }
  },
  {
@@ -79633,8 +79936,8 @@
    "deps": [
     "org"
    ],
-   "commit": "e931362e641f97d17dc738d22bb461e54045786d",
-   "sha256": "045kci7xvlp0kg8gmplnybc7ydv66hkl88dxgd113ac7ipf9zir7"
+   "commit": "efb74df1179702e19ce531f84993ac5b5039075f",
+   "sha256": "0sxwbqk6sm8qfpbcxhclin21k6xx5286df57rr0m72xrqqpdsw1p"
   }
  },
  {
@@ -79829,8 +80132,8 @@
    "deps": [
     "org"
    ],
-   "commit": "7a93b0f4b3e8e240d9451f1fa5704acfc494e9aa",
-   "sha256": "0dvhc559r9jhc8d91mv5an3vfklrfyfrpr32dqvphgk1i85kqvw4"
+   "commit": "be7fbd9f164d8937b2628719e21e8e6b4827e638",
+   "sha256": "1p074q7w3j1n98zzsmq2xb9kwbm7bb4lg8yss4q3rv9rkrrz7dk9"
   },
   "stable": {
    "version": [
@@ -80157,14 +80460,14 @@
   "repo": "DarkBuffalo/ox-report",
   "unstable": {
    "version": [
-    20210219,
-    2023
+    20210430,
+    1212
    ],
    "deps": [
     "org-msg"
    ],
-   "commit": "7e135fb51f252ab1ec5a31e05a1c7e638b656b85",
-   "sha256": "1lg00p7nr3y5wjm7r53c93gx0ycqjgsrj4w5jxw6fzrdacqdnsz9"
+   "commit": "1e730396b8b7aa5101b3e3f538d6d4c15514f415",
+   "sha256": "1firb26xnci1qprb4v4p3cp9vnmmp5bvsm3154gy0n2jr0hzvbjj"
   },
   "stable": {
    "version": [
@@ -80617,14 +80920,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20210318,
-    1411
+    20210421,
+    1333
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0f13dd6655f6d4ff71b77c6d2c93727e5f43b254",
-   "sha256": "0l4qwz2s63r26y5v02yrpncjdiyspw7pill0bjjlcawvxffykw9i"
+   "commit": "b4eec13201093070a12f37396afce83eb6771df5",
+   "sha256": "1kr9iwsrpxbalhjz91pqplwkb44msdl2qv4rwsbapz8z8hs4xzji"
   },
   "stable": {
    "version": [
@@ -80661,15 +80964,15 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20210326,
-    241
+    20210425,
+    3
    ],
    "deps": [
     "cl-lib",
     "let-alist"
    ],
-   "commit": "16e589114cc1f2514d95a58d53e1ae7c2ce941b4",
-   "sha256": "03bcnxd39r9k63zwb6gnqrhs0q629izakj2hmhk83hiy1131v7jl"
+   "commit": "bc6c0577c0c87c43095955f8210b221bb759f103",
+   "sha256": "0rg51c0nj6fcxf4lcbfh0l997s08g3k19jxmsms5xj26aavp9zj2"
   },
   "stable": {
    "version": [
@@ -80698,8 +81001,8 @@
    "deps": [
     "package-lint"
    ],
-   "commit": "16e589114cc1f2514d95a58d53e1ae7c2ce941b4",
-   "sha256": "03bcnxd39r9k63zwb6gnqrhs0q629izakj2hmhk83hiy1131v7jl"
+   "commit": "bc6c0577c0c87c43095955f8210b221bb759f103",
+   "sha256": "0rg51c0nj6fcxf4lcbfh0l997s08g3k19jxmsms5xj26aavp9zj2"
   },
   "stable": {
    "version": [
@@ -81128,8 +81431,8 @@
     20200510,
     5
    ],
-   "commit": "331252334ea2e62d8e06b2dfa24be5dbd7f9c09f",
-   "sha256": "0gri6k1px53lmi5nq3zpv0m0kc3c8pbnc4h0zard5v449gmf1d5q"
+   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
+   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
   }
  },
  {
@@ -81357,11 +81660,11 @@
   "repo": "justinbarclay/parinfer-rust-mode",
   "unstable": {
    "version": [
-    20210325,
-    1714
+    20210413,
+    2
    ],
-   "commit": "a92e39e86ec24fbc536c68765b4af6f4c6ff24c5",
-   "sha256": "1l4xvyx4r7ld7d8k18x4khagiivp5a7m647zv7fvg7ivhkq2crqd"
+   "commit": "c2c1bbec6cc7dad4f546868aa07609b8d58a78f8",
+   "sha256": "0az4qp118vsqzgsl87wgszzq91qzqkpabifd8qrr2li3sizsn049"
   },
   "stable": {
    "version": [
@@ -81644,11 +81947,11 @@
   "repo": "vandrlexay/emacs-password-genarator",
   "unstable": {
    "version": [
-    20210327,
-    1140
+    20210425,
+    2227
    ],
-   "commit": "de391a83e6a11f810f0141b7b4758dd978478234",
-   "sha256": "10yh56jlvnn01swb4pfq2gqpj2shxfp716fzij8c2c0hi52rgnbz"
+   "commit": "c1da9790d594bc745cdbcc8003153e408aa92a5f",
+   "sha256": "0nwfdf5ik7d11l2h2fg4pszifv3fncpxjzs933gj91mvjy2wrw98"
   }
  },
  {
@@ -82618,13 +82921,13 @@
   "stable": {
    "version": [
     2,
-    14
+    15
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2f2b59e693f08b8d9c81062fca25e6076b6e7f8d",
-   "sha256": "04r5h5zs5r6s22p5ynhpr860r2r552z9pyf4kbabfg1gz9jag7yp"
+   "commit": "dd2a380ac71edf1321a6462f14668baf99879e80",
+   "sha256": "0l9i7ky25d9ii04w2brgxc8dk2rky50naba8lbfqi7hcc34z8pp6"
   }
  },
  {
@@ -83065,11 +83368,11 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20210310,
-    1724
+    20210430,
+    1507
    ],
-   "commit": "a2bca9be4c34a9dc38393602cb2708df24587838",
-   "sha256": "1rc67f3jzjhqykcn16s2ibviibxmr7b9y2c20hdwg49r41ax4f9v"
+   "commit": "209913f8ce0f18898625b41e0094a99ce8accd0d",
+   "sha256": "048rnzhxsgq6vi4d64826ma1rkxsz42qbbppwqx7wiqj4nnmxshw"
   },
   "stable": {
    "version": [
@@ -83525,11 +83828,11 @@
   "repo": "EricCrosson/pine-script-mode",
   "unstable": {
    "version": [
-    20181110,
-    151
+    20210420,
+    1249
    ],
-   "commit": "f7892d373e30df0b2e8d2191e4ddb2064a92dd3c",
-   "sha256": "1zxmc2l41h28rl058lrfr8c26hjzqmp37ii8r29mpsm03hsw30fh"
+   "commit": "72d0cb20cc5c5dff363a08318ac7045f4a5f43e3",
+   "sha256": "0ry1gd1vgwnr7skalc39baqbffb5vq4bkpy5bnr2sprgj6p4mxvc"
   },
   "stable": {
    "version": [
@@ -83928,26 +84231,28 @@
   "repo": "ZachMassia/PlatformIO-Mode",
   "unstable": {
    "version": [
-    20161210,
-    1339
+    20210501,
+    1057
    ],
    "deps": [
+    "async",
     "projectile"
    ],
-   "commit": "1466aed132a77f48fcb31938d64abb1a1e58ec42",
-   "sha256": "1lfkp7df8as9gspynkyhz4dbm95kbngyba1ymg6ql67adyv79v1i"
+   "commit": "e7bde6fec31b57ffe1c0a98cd29477d5baea30f3",
+   "sha256": "0ian50v9vaz7kqzn20bhqadq50h0l3zhjkmniinpz4q9klh7drh9"
   },
   "stable": {
    "version": [
     0,
-    2,
-    2
+    3,
+    0
    ],
    "deps": [
+    "async",
     "projectile"
    ],
-   "commit": "470a80c1d764a6e1680a2b41ca5a847869a07a27",
-   "sha256": "1nznbkl06cdq4pyqmvkp9jynsjibn0fd6ai4mggz6ggcwzcixbf0"
+   "commit": "e7bde6fec31b57ffe1c0a98cd29477d5baea30f3",
+   "sha256": "0ian50v9vaz7kqzn20bhqadq50h0l3zhjkmniinpz4q9klh7drh9"
   }
  },
  {
@@ -84764,14 +85069,14 @@
   "repo": "polymode/poly-rst",
   "unstable": {
    "version": [
-    20200316,
-    1315
+    20210418,
+    1009
    ],
    "deps": [
     "polymode"
    ],
-   "commit": "8530f56fbdce01bcf4004839ff54e4156282c2b5",
-   "sha256": "088wzagwxpf2j67wb1i6agqfa944sahh2fm8my2m50spbbd9ymhl"
+   "commit": "e71f2ae6a00683cdb8006f953e5db0673043e144",
+   "sha256": "1jhj1hrb998p9n6bjfdnmsinf0rd5wspm9gwsrdb0k6il897h7lf"
   },
   "stable": {
    "version": [
@@ -84875,11 +85180,11 @@
   "repo": "polymode/polymode",
   "unstable": {
    "version": [
-    20200606,
-    1106
+    20210413,
+    2004
    ],
-   "commit": "9f4fa7971634f560e83d44b30aefc4d76d261943",
-   "sha256": "1dp3688kj89r2ywv4zwrji2qv1b0y1cj3dwhzxx1ihb9vx0bjwjn"
+   "commit": "b50ec54097d279bde6567ee3ba8a22471f466ec0",
+   "sha256": "0q2vjvz72m3nrnpck4hl059cjgcf2jdw2rl9h8fxyvbllyj0733f"
   },
   "stable": {
    "version": [
@@ -85000,8 +85305,8 @@
     "yafolding",
     "yasnippet"
    ],
-   "commit": "91ca19b2a93029a393f8873e273777b553d308e1",
-   "sha256": "07sn00k8krsb0bikbbypznvwrk13k4jdk6d66iai0a66s9dr84ys"
+   "commit": "3c011744e81263dab6a4b20e96ad1d290ef9d320",
+   "sha256": "15ach67d9n8csbsabm6lhmhli9f397pjpf6vk1rn59bfqrhdakmn"
   },
   "stable": {
    "version": [
@@ -85178,15 +85483,16 @@
   "stable": {
    "version": [
     0,
-    6
+    6,
+    1
    ],
    "deps": [
     "dash",
     "flx-ido",
     "popup"
    ],
-   "commit": "c5e2e69adbd3a630e4cb750965a1aee8c10c1f09",
-   "sha256": "0vn0jli0ya7xnapifkgzynbnh3rpnzb82j5k9bla2j4miqfc6cg8"
+   "commit": "b00c4d503cbbaf01c136b1647329e6a6257d012c",
+   "sha256": "0q081lw6zqzpbmscpk1yzyfpalr9ld5qwh962dwwy04rc5f0aq3s"
   }
  },
  {
@@ -85337,11 +85643,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20210410,
-    528
+    20210423,
+    220
    ],
-   "commit": "ae3c4ddfce698f4e24a0fcab938267e41e74da90",
-   "sha256": "1agzfliz6vk9zwvl0gm074xwzlywqrhkva9nz3d3581cjfanxqd1"
+   "commit": "739d8fd1081bdd0d20dee9e437d64df58747b871",
+   "sha256": "1hapg4dwrpa1ffkx8s3pialkh9zsh3r5jxk076c750k9rdwl3q4m"
   },
   "stable": {
    "version": [
@@ -85432,14 +85738,14 @@
   "repo": "milkypostman/powerline",
   "unstable": {
    "version": [
-    20210317,
-    110
+    20210428,
+    1229
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "cfff1cfe63793ea1a8bcfcae50c296558384cf08",
-   "sha256": "12s3mp2dyslq1ilah64gpz7a2j0ca9yls7wvj9kcmjca1931s8s3"
+   "commit": "346de84be53cae3663b4e2512222c279933846d4",
+   "sha256": "00yy96a1rqcpbkvbn1hmb1pz5i7l0pwb2bqyxcc8qry7rkmvw7gy"
   },
   "stable": {
    "version": [
@@ -85620,11 +85926,11 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210411,
-    2007
+    20210425,
+    1720
    ],
-   "commit": "ed2b762241bbea03e374dc9dcd4fbe207c6b2ea4",
-   "sha256": "03c0dmblixh5mx8365b6608l7z3vcgp6pzdflwqf8nfwj2c5rm0w"
+   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
+   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
   },
   "stable": {
    "version": [
@@ -86253,14 +86559,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20210407,
-    707
+    20210503,
+    738
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "513228f473910128efcad13f46dfc22a74976675",
-   "sha256": "19yblhr88affwmlrfmf3bi7wypf2abgy56xfxgisvwx5d5xi6v25"
+   "commit": "4126799d94b6a9a4db22976d2dd6625323221359",
+   "sha256": "1wxv2fv680s89iz9dcxdz36l3mk9icspahh8s4mska7vi607qpzd"
   },
   "stable": {
    "version": [
@@ -86522,16 +86828,16 @@
   "repo": "waymondo/projector.el",
   "unstable": {
    "version": [
-    20190703,
-    1418
+    20210421,
+    1728
    ],
    "deps": [
     "alert",
     "cl-lib",
     "projectile"
    ],
-   "commit": "bad51a81fbcae9aabe47dafc2499ba27cd7308be",
-   "sha256": "0xiwn58wqm15kvbx0pi2zmh8gc1f06zncxki03bwry4nfpqxr2d0"
+   "commit": "7bbee0ef70817d52339119d4517dbbcbab930de6",
+   "sha256": "0zmng37fl8df1d3i66fbkjssv0x0hq74x68p1j01gb8sfayw4dgf"
   }
  },
  {
@@ -86664,11 +86970,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20210408,
-    1454
+    20210502,
+    1922
    ],
-   "commit": "d0acb626eba17023c55b002921870d60e48527a5",
-   "sha256": "0yn66lxx906nry53dr7msjfha2i85yiq2zw8g25d7y1f3mhjsjpz"
+   "commit": "c3505218ebb9b5c575b537c0f15736497a6c5700",
+   "sha256": "1vpmymgar4qn6zlkfwycrdp91iy86m6xhl43rd6awp6gh25b882g"
   },
   "stable": {
    "version": [
@@ -86771,19 +87077,19 @@
     20200619,
     1742
    ],
-   "commit": "ee04809540c098718121e092107fbc0abc231725",
-   "sha256": "053j9j2axr2x7837xcvfgmdl3ddbw2px3fzflbna52fnk9bh2wkc"
+   "commit": "5e84a6169cf0f9716c9285c95c860bcb355dbdc1",
+   "sha256": "0ixs95c1f98kmkq8kjv6mv0sj9phgqlb39imjzrn4mg4w92bilfn"
   },
   "stable": {
    "version": [
-    4,
-    0,
+    3,
+    16,
     0,
     -1,
-    2
+    1
    ],
-   "commit": "6c61c1e63b9be3c36db6bed19032dfc0d63aadda",
-   "sha256": "1910pnpy0mfzqga4mv52ybjfbxrbdflgb6nsh2vbpbpsv4jl58dq"
+   "commit": "7689f00ba8d1e818f2a8e7a4bf24577d9ccd5d84",
+   "sha256": "0r5k78m23jhcxxzhi2x6zz3dpglfx75f1zmkmdwpgc9y64kscckb"
   }
  },
  {
@@ -87627,15 +87933,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20210319,
-    1102
+    20210428,
+    2307
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "f48c3edee78ba5f020bcb42830db99a14761f176",
-   "sha256": "1ld3bqvfrda6fa4dv3g0wilznrdrsv544sr370sn3a9xlmy4fwp9"
+   "commit": "9e9cee799e95f53bf2d0462260c70ce8f59ddf4d",
+   "sha256": "1yjvf6h7rr7f3h6sdk95w3c2709c7jh6dfnfb7p9y1aw18ar9pvc"
   },
   "stable": {
    "version": [
@@ -87675,21 +87981,39 @@
   }
  },
  {
-  "ename": "pyim-cangjie5dict",
-  "commit": "abad9b91bcf2dd29255a98ddcfd4b17d8847ecd5",
-  "sha256": "13sbbiqqpdplm36pa3zyqakbvlkvh7wvm7pmn0li6hnm56dwydg8",
+  "ename": "pyim-cangjiedict",
+  "commit": "a82ac773bb9bc36727314d1eb5a75610ec9ca694",
+  "sha256": "0ma99y1ijpdqrmypmj108ny7bfj9ylryav7hj7dnp9gj4b1bhxhh",
   "fetcher": "github",
-  "repo": "p1uxtar/pyim-cangjie5dict",
+  "repo": "p1uxtar/pyim-cangjiedict",
   "unstable": {
    "version": [
-    20170730,
-    246
+    20210429,
+    930
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "c8618590780b818db1a67a29bc47c5d25903517a",
-   "sha256": "0p49h2kn8wy3b51zahzyc1cy24h3b44cg5yjpmv4w23dhsr4zlz8"
+   "commit": "87f3f9447750e74cdf9525d97621c56deafb2bbf",
+   "sha256": "0pk03gfrfhj2r82ghnr840bqr0ix14nhnl7hwg1g1v89jkphps84"
+  }
+ },
+ {
+  "ename": "pyim-smzmdict",
+  "commit": "8bad2e8162f5a44bdbe1117efa31133ae7814489",
+  "sha256": "104kxd8d2b7rch0pfsdz5w98rskx1sl6fx0lqspcilir9k9my1cc",
+  "fetcher": "github",
+  "repo": "p1uxtar/pyim-smzmdict",
+  "unstable": {
+   "version": [
+    20210429,
+    216
+   ],
+   "deps": [
+    "pyim"
+   ],
+   "commit": "9bfb8713543332a05c1d76fe755ab82b5ccbba51",
+   "sha256": "0s4s5rhrbpxlp7fimqd36pnbqpdpcfd12r5xxfrcni91f1apzlns"
   }
  },
  {
@@ -87700,14 +88024,14 @@
   "repo": "tumashu/pyim-wbdict",
   "unstable": {
    "version": [
-    20210111,
-    923
+    20210428,
+    558
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "62a1bd8b6070463e872137cf8eba50122b180e2c",
-   "sha256": "03zh5sdqc32q8an8k59csc95sczcs38ganxrg3lp2i2vn5ykza7h"
+   "commit": "24ac59a7b622d1a50ecdc69f9944bd39838de22c",
+   "sha256": "0apnf289jzfz5bmn7acq9lf13nf05phncvhc3cz9milax834c3l4"
   },
   "stable": {
    "version": [
@@ -87779,8 +88103,17 @@
     20210411,
     1931
    ],
-   "commit": "38d15c98316359c7b0b190f2245a3b2e2bf62109",
-   "sha256": "1iipx981kz25iznb2p90a3cag71abw6np96r0mf99g44z8ghaapd"
+   "commit": "7cffd7ffeeaa64f57c7b617036d6d1ffd8756745",
+   "sha256": "080k3bm741338nj5d1f3rn9zn9pwaffbbgbyd20pmqh881v37m4m"
+  },
+  "stable": {
+   "version": [
+    2,
+    8,
+    2
+   ],
+   "commit": "091cb92314dc701f10390136da78fbbb362e892e",
+   "sha256": "13qiv3v8yc2b7sfvizlnx6xcam7yjicdkfjw00q50s5xqmali22p"
   }
  },
  {
@@ -87826,15 +88159,15 @@
   "repo": "dakra/pyramid.el",
   "unstable": {
    "version": [
-    20181212,
-    1204
+    20210427,
+    1032
    ],
    "deps": [
     "pythonic",
     "tablist"
    ],
-   "commit": "f0687b8aee3e685b55e2c66b16211e02ac5f9d94",
-   "sha256": "18kqqdk7yifcjmn11jgsqxvzr6izcgify1d8gm504sxw2qqc3q0i"
+   "commit": "66f54f4a9cc9fa81edf768ab433d5b3c5517363c",
+   "sha256": "0sijy6nk46yw21j49x5n93za2zjzqqrfmjm7dz3z3gj7jknk27i9"
   },
   "stable": {
    "version": [
@@ -88025,20 +88358,16 @@
     800
    ],
    "commit": "710ffadeb43136d400de0a4c9e4a94c8b7ff36f0",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/python-mode-devs/python-mode/repository/archive.tar.gz?ref=710ffadeb43136d400de0a4c9e4a94c8b7ff36f0': HTTP error 503; retrying in 326 ms\nwarning: unable to download 'https://gitlab.com/python-mode-devs/python-mode/repository/archive.tar.gz?ref=710ffadeb43136d400de0a4c9e4a94c8b7ff36f0': HTTP error 503; retrying in 558 ms\nwarning: unable to download 'https://gitlab.com/python-mode-devs/python-mode/repository/archive.tar.gz?ref=710ffadeb43136d400de0a4c9e4a94c8b7ff36f0': HTTP error 503; retrying in 1272 ms\nwarning: unable to download 'https://gitlab.com/python-mode-devs/python-mode/repository/archive.tar.gz?ref=710ffadeb43136d400de0a4c9e4a94c8b7ff36f0': HTTP error 503; retrying in 2702 ms\nerror: unable to download 'https://gitlab.com/python-mode-devs/python-mode/repository/archive.tar.gz?ref=710ffadeb43136d400de0a4c9e4a94c8b7ff36f0': HTTP error 503\n"
-   ]
+   "sha256": "1vym8nlpwv9ym7yixldjxp999b26a9pr4z0pka28fldxykfccwq0"
   },
   "stable": {
    "version": [
     6,
-    2,
-    3
+    3,
+    0
    ],
-   "commit": "a0a534639bc6142c2c2f44bd7ca5878ad5f79518",
-   "sha256": "0sj2hfjwpcdg9djsgl3y5aa3gnvl4s87477x6a9d14m11db3p7ml"
+   "commit": "906b0a107f7bcfe6e32bcfedb977e6f0f99fda59",
+   "sha256": "1vym8nlpwv9ym7yixldjxp999b26a9pr4z0pka28fldxykfccwq0"
   }
  },
  {
@@ -88371,8 +88700,8 @@
     "leaf",
     "quelpa"
    ],
-   "commit": "eacc544b93f6fdc3be69a6ffbf960380a63fc715",
-   "sha256": "0ka2qk1y7byrq4rbmyhr06kfgc76afpmpdcxk3nf4g3krgi778dw"
+   "commit": "cc13df4a6c6cdf1dea558be5b6e99b6e8d8b4065",
+   "sha256": "0jiwdz1psfkha17by281ii0adjschld0hwl439bawgvzpw1a0zi2"
   },
   "stable": {
    "version": [
@@ -88742,11 +89071,11 @@
   "repo": "istib/rainbow-blocks",
   "unstable": {
    "version": [
-    20171025,
-    1438
+    20210412,
+    1937
    ],
-   "commit": "dd435d7bb34ff6f162a5f315df308b90b7e9f842",
-   "sha256": "06yfb3i7wzvqrhkb61zib9xvpb5i00s4frizkzff66im05k0n795"
+   "commit": "ae5c11cd3dc64039c5e65c9f1804aceba5b3b209",
+   "sha256": "17ar9k2352h6cnvcknq945lna3illln87r1vf4ll1aa798azizpb"
   },
   "stable": {
    "version": [
@@ -88866,26 +89195,26 @@
   "repo": "Raku/raku-mode",
   "unstable": {
    "version": [
-    20200902,
-    2139
+    20210412,
+    2342
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "8a6e17f1749c084251d19c3d58b9c1495891db6d",
-   "sha256": "1nxv5x9ywm9zzzl69ssvvxf0lphjqjfazf5qcd3qpv4w5rqa1s3b"
+   "commit": "7496ad3a03bed613c259405ec8839ae02950fdb1",
+   "sha256": "002pkw4wx6l64c1apg6n1psq4ckp9129yj3xqkjp68ji5nz2l3bw"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "e0639c89a3a29e9196e298951da6c3a79fb944e8",
-   "sha256": "02zn1sm86srwdzdkhw53ll0h41a9hwh6c8lan72530zysjrm4x1i"
+   "commit": "7496ad3a03bed613c259405ec8839ae02950fdb1",
+   "sha256": "002pkw4wx6l64c1apg6n1psq4ckp9129yj3xqkjp68ji5nz2l3bw"
   }
  },
  {
@@ -89046,6 +89375,30 @@
   }
  },
  {
+  "ename": "rbs-mode",
+  "commit": "c8bd3d8bf771c4d5d45cf1e00a08d54941924357",
+  "sha256": "0cdd7sypbpgr9j5ydj17pqgdb2rfm2563rwyvi0p2k2xd305bcgb",
+  "fetcher": "github",
+  "repo": "ybiquitous/rbs-mode",
+  "unstable": {
+   "version": [
+    20210430,
+    135
+   ],
+   "commit": "fd766a943d5f1f0624e10ffce096b9aaba14a5f4",
+   "sha256": "1gl5wqdyaqvdv0557idycfzgr5gvzvlv11jwccq43v6dmvydam15"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    1
+   ],
+   "commit": "ad36bb138cec7396f029821d0cf755a8bc663260",
+   "sha256": "143wz47446dahp5zx9vvhjrqjadzgz4apzlvwhdbs7dgs8bgs7r7"
+  }
+ },
+ {
   "ename": "rbt",
   "commit": "ca7241985be1e8a26a454b8136a537040b7ae801",
   "sha256": "1mrb6v8zybvhh242vvq0kdvg6cvws7gabfhcydrw5g2njhyqkygm",
@@ -89183,14 +89536,14 @@
   "repo": "aaron-em/rcirc-styles.el",
   "unstable": {
    "version": [
-    20160207,
-    250
+    20210414,
+    1712
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f313bf6a7470bed314b27c7a40558cb787d7bc67",
-   "sha256": "1kwn33rxaqik5jls66c2indvswhwmxdmd60n7a1h9siqm5qhy9d6"
+   "commit": "dd06ec5fa455131788bbc885fcfaaec16b08f13b",
+   "sha256": "116qvavvw72vkahknb7g7w7knaximw3m1pq6hic7h13xj8xqxz2w"
   },
   "stable": {
    "version": [
@@ -89266,14 +89619,14 @@
   "repo": "johnmastro/react-snippets.el",
   "unstable": {
    "version": [
-    20181002,
-    1046
+    20210430,
+    1510
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "87ccb640d265fe799583ab55605b84d113223694",
-   "sha256": "0zs78mn37ngy86blmp2xfy7jr5p0s6r0qq6z3z924amrhy5bwdqc"
+   "commit": "9d0a1bb90ac36c689cded48b661e81d4544fd719",
+   "sha256": "15vnybyvz18scladfqy1qj6vrwx1ac38ra8ymdg938aayvl57354"
   },
   "stable": {
    "version": [
@@ -89348,16 +89701,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20210411,
-    1241
+    20210420,
+    953
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "a854b8d4344e4606e77c7e73cc414991e53253d5",
-   "sha256": "0f5av8ldmh54cmqzniifl853mz9mdg6wn3i0wbm7v1m6d79nli88"
+   "commit": "962b5af40c8970d09581613d67b1a5d99eaa39e7",
+   "sha256": "1rpc0viymnm5jdrl16nmvsz0y8wnca03l0nhllwidyvazbf4x5zl"
   },
   "stable": {
    "version": [
@@ -89440,15 +89793,15 @@
   "repo": "realgud/realgud-lldb",
   "unstable": {
    "version": [
-    20190912,
-    1335
+    20210417,
+    1434
    ],
    "deps": [
     "load-relative",
     "realgud"
    ],
-   "commit": "47cb0178fdde50a9d9151ab45806b41007cd758a",
-   "sha256": "11vaiq7c4iaypsgs4x4sdfycjailba36qh0pwgdprmiyf8swy8hq"
+   "commit": "abffd0d2d23f6c87be5dc5d36e948af92de5df86",
+   "sha256": "1zjrjgs9vjaqsf5h9sxw1pf2f9sfngx1gxp37lb8myan52qmhlz1"
   },
   "stable": {
    "version": [
@@ -89744,11 +90097,11 @@
   "repo": "ncaq/recentf-remove-sudo-tramp-prefix",
   "unstable": {
    "version": [
-    20180205,
-    556
+    20210502,
+    436
    ],
-   "commit": "84bbac534cb114d8d11b86790435b65d36e99e68",
-   "sha256": "0lnnh28qax4qk9n9sng7sgb0w0mnjc8abnch3bd0ba9g5x28z8bx"
+   "commit": "82e788e2c8a6834ca3db7696d5e90ccabede7587",
+   "sha256": "197a4xskmv88rbl9pdznvc5gfxskfp3zrl9larjdn5fxpiy5jmcb"
   }
  },
  {
@@ -89807,15 +90160,11 @@
   "repo": "ideasman42/emacs-recomplete",
   "unstable": {
    "version": [
-    20210404,
-    716
+    20210418,
+    925
    ],
-   "commit": "802c85b02d99bce4cf540ed4b716eaa39df45c4a",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-recomplete/repository/archive.tar.gz?ref=802c85b02d99bce4cf540ed4b716eaa39df45c4a': HTTP error 503; retrying in 301 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-recomplete/repository/archive.tar.gz?ref=802c85b02d99bce4cf540ed4b716eaa39df45c4a': HTTP error 503; retrying in 505 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-recomplete/repository/archive.tar.gz?ref=802c85b02d99bce4cf540ed4b716eaa39df45c4a': HTTP error 503; retrying in 1324 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-recomplete/repository/archive.tar.gz?ref=802c85b02d99bce4cf540ed4b716eaa39df45c4a': HTTP error 503; retrying in 2228 ms\nerror: unable to download 'https://gitlab.com/ideasman42/emacs-recomplete/repository/archive.tar.gz?ref=802c85b02d99bce4cf540ed4b716eaa39df45c4a': HTTP error 503\n"
-   ]
+   "commit": "ef800da3ff3112baa71ad20e84c752f7a56c90b9",
+   "sha256": "18m8djkbyykb6cxqayl2v3ap206jkng3w8ah6qr4bixqynkx4yg1"
   }
  },
  {
@@ -90768,8 +91117,8 @@
     20200901,
     1442
    ],
-   "commit": "abc307b965bf6720bc466281f2e204cd5ce37dc3",
-   "sha256": "0dv9was6ycwwyfabr8z71wcc3hbqnxgwbdqkdkx0iaccq2xyj07b"
+   "commit": "a97dcc486a54d947aa15eeaedaccb3481f14fd85",
+   "sha256": "0qxwmza21ys5ln8pb441a38sxm2gl29s46sf8hpyzaxcjvc6blvl"
   }
  },
  {
@@ -90787,8 +91136,8 @@
     "helm",
     "restclient"
    ],
-   "commit": "abc307b965bf6720bc466281f2e204cd5ce37dc3",
-   "sha256": "0dv9was6ycwwyfabr8z71wcc3hbqnxgwbdqkdkx0iaccq2xyj07b"
+   "commit": "a97dcc486a54d947aa15eeaedaccb3481f14fd85",
+   "sha256": "0qxwmza21ys5ln8pb441a38sxm2gl29s46sf8hpyzaxcjvc6blvl"
   }
  },
  {
@@ -90799,25 +91148,25 @@
   "repo": "simenheg/restclient-test.el",
   "unstable": {
    "version": [
-    20180106,
-    2046
+    20210422,
+    1815
    ],
    "deps": [
     "restclient"
    ],
-   "commit": "4518561bc9661fedacb6fb352e9677207f45c418",
-   "sha256": "0hbilpn77w0vykga9p4dkwaygipyna7mwn24y2kwfcahcr39pqjb"
+   "commit": "3c6661d087526510a04ea9de421c5869a1a1d061",
+   "sha256": "0bpvxv8bc671pa0sm4v8pqyla3i99y05mgpbgcjd8pdsfhiwjw7j"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "restclient"
    ],
-   "commit": "a21e41b905b423e762eeb4da3a236c8b1aea8c49",
-   "sha256": "1lan49723rpzg1q7w8x3iggazwl4zirq5l8nhpb8m5hmg21a4kih"
+   "commit": "3c6661d087526510a04ea9de421c5869a1a1d061",
+   "sha256": "0bpvxv8bc671pa0sm4v8pqyla3i99y05mgpbgcjd8pdsfhiwjw7j"
   }
  },
  {
@@ -91203,6 +91552,15 @@
    ],
    "commit": "d0cc3599129db735c23abe74d0876286a2fd6b6a",
    "sha256": "1g0na5zjsy4600jzi5zr752nggndbwkr6ihxcmq1w82w0b3600rv"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "9df603a5c63ae38ec776e27dc93d3618e2b0fabe",
+   "sha256": "1qp338v1cwlikkzclbnxy2i4g2lad88qc6aakmla9f8x22gvlpi1"
   }
  },
  {
@@ -91428,14 +91786,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20210328,
-    1228
+    20210413,
+    2202
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "0bc2645d140f65215a42f2b9365f1983cc949c6c",
-   "sha256": "0ff8zminjpgyi2lp2pmjh7cc7bgb15hii2r89zmy5xkq47slr2j4"
+   "commit": "dcde67f020d0efff35b6db9863e4687c08f1b421",
+   "sha256": "17ssr9144lnk48iyb3qn797whmvs2s526svfgs554k7bc0vl2j6x"
   },
   "stable": {
    "version": [
@@ -91458,11 +91816,11 @@
   "repo": "kopoli/robot-mode",
   "unstable": {
    "version": [
-    20201208,
-    1959
+    20210425,
+    1925
    ],
-   "commit": "e8ca45ea811a4c6758fa1a086d8f89b8812653ca",
-   "sha256": "0iji80p1llvp93s42cgyffx0py9j1kjk3bjycajcy1hxsha240xl"
+   "commit": "e7e9c4d4750d048ad771fa735621ad813fa9c128",
+   "sha256": "127lydk66n90ih39q8gxzb44rss2xllb7bn3ygxrf5m5vvl9w5rj"
   }
  },
  {
@@ -92191,11 +92549,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20210226,
-    1106
+    20210423,
+    1157
    ],
-   "commit": "e9e9e32c4f82a9b895543c120b327ab5536ec42b",
-   "sha256": "0f63lms4arkqj6161v2787dgfra23a01vi82s9dcylk9z6bqyz4v"
+   "commit": "494d59f92cbe12533eb89b202fc4f5342afcd543",
+   "sha256": "1g9hch2h3lqdx7ffabikl2ss98akhfpw5las6g5qwyj1l2lcrjbr"
   },
   "stable": {
    "version": [
@@ -92238,22 +92596,22 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20210328,
-    1426
+    20210502,
+    1646
    ],
    "deps": [
     "dash",
     "f",
-    "ht",
     "let-alist",
     "markdown-mode",
+    "project",
     "s",
     "seq",
     "spinner",
     "xterm-color"
    ],
-   "commit": "07d4d9af2c169d6cce6e2117628dfa3192937fb0",
-   "sha256": "1hv059nac1czpv367bs42qqw8lf6phpbzbiyk90n6mq996cinwrq"
+   "commit": "ed68fd3bb410869e1a4ce3943b5913ea88d9b509",
+   "sha256": "0896m5ajlq90pp7ds6iw7plqkffm6k01v3rfqfhb3qwd92nxgcf0"
   }
  },
  {
@@ -92672,8 +93030,8 @@
    "deps": [
     "cider"
    ],
-   "commit": "27f35778de9509067716a7bed14306787334a589",
-   "sha256": "01a6cvk3ycg0z1qg30rqsnx49drmdfpgd78mhf2m6avvagzf8l9s"
+   "commit": "c813d94ee8d0a85dd33d0c5dbae832c24cf37e4f",
+   "sha256": "0r0c6h7nikb4181a06bs88sqnqa68jw2f550q2zz34khl7zpr2s6"
   },
   "stable": {
    "version": [
@@ -92696,11 +93054,11 @@
   "repo": "hvesalai/emacs-sbt-mode",
   "unstable": {
    "version": [
-    20210409,
-    1528
+    20210416,
+    1845
    ],
-   "commit": "9a6a8e47b657adeada41c445c9fcda301dbdb9b3",
-   "sha256": "1h8iqamz5crflhjpxfzgjxspwwkks8cp9m3bf4b42jqsffqkypnb"
+   "commit": "e29464a82bf706ef921f4e0052ce04fc74c34c84",
+   "sha256": "1r6n1hcpcy6icy8qs98gafqavmwx4z6v4rnknvrfnnynmrv2ajvr"
   },
   "stable": {
    "version": [
@@ -92723,8 +93081,8 @@
     20200830,
     301
    ],
-   "commit": "5078c5c5e22f509338d20b7ae448b2bbe02e08f9",
-   "sha256": "03brsgbhsaynjc8xp5wpmla6cf0v4r7qc5hg0jdbp2ihnwp17i2f"
+   "commit": "d9d4a9757b4616df755c2219dfcff451f4e3c0a2",
+   "sha256": "0i8p8y2c8dvrm5a5vk1a6vf6cgfyc3ah58w095qn94mjgcdg026m"
   }
  },
  {
@@ -92753,11 +93111,11 @@
   "repo": "hvesalai/emacs-scala-mode",
   "unstable": {
    "version": [
-    20210409,
-    1441
+    20210414,
+    1126
    ],
-   "commit": "6966328dbfcbd1dfb166ff46e5deb9a68379cdf1",
-   "sha256": "0pmix0km9b7r28jxh31ig1h5j9vvvz4871irzlavzn7kl3qiqwgw"
+   "commit": "598cb680f321d9609295aa9b4679040cc703b602",
+   "sha256": "0ryr6jhl0irhaii6cz9nlly8rn4c6h5pnax6xzn9iszl8f7xgphs"
   },
   "stable": {
    "version": [
@@ -93107,11 +93465,11 @@
   "repo": "ideasman42/emacs-scroll-on-drag",
   "unstable": {
    "version": [
-    20201013,
-    123
+    20210418,
+    1318
    ],
-   "commit": "ad94790492d0d66686f3457cea1caeba8bbbdc51",
-   "sha256": "1b725iz5xhqki33jydq9vrxvrbfraxq2q79jdbrjy548rbsxzyjf"
+   "commit": "157637ba6b6cbe7a21c57f9eefb8a94fffa0085e",
+   "sha256": "195ckjmh65z4qg1afs5acz66r6xvc2g91mfnncz12kv7p8bxwrxx"
   }
  },
  {
@@ -93122,11 +93480,11 @@
   "repo": "ideasman42/emacs-scroll-on-jump",
   "unstable": {
    "version": [
-    20210103,
-    2120
+    20210426,
+    1226
    ],
-   "commit": "69c86542a148222a7571506a2515fc52529d209d",
-   "sha256": "00qddxcax55pmfai7083w08mgz6c3876jb5p7fas4j5h417c09yb"
+   "commit": "30dc5f5e50fa702eb65756304f0fe406daec2397",
+   "sha256": "02w52rcs8gkf58yig55wn6198b7g6zy6ppp5mjh7k1l07cf2kmay"
   }
  },
  {
@@ -93527,11 +93885,11 @@
   "repo": "raxod502/selectrum",
   "unstable": {
    "version": [
-    20210411,
-    1153
+    20210423,
+    1822
    ],
-   "commit": "35665560c217fc7c39ec7ef006edc6d556a4d3cf",
-   "sha256": "1w2iiparzs88z2zg8ylqdidgn6qb73x68hjl53yfqqgvrz8krs2f"
+   "commit": "c68c7f6c21877b09734a8543fee363cf2fbbecf4",
+   "sha256": "1g8y6wkmn8j5gjd37i344xmyln6x13jlry9pxdwq3kwkwzkznznm"
   },
   "stable": {
    "version": [
@@ -93550,15 +93908,15 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210411,
-    2007
+    20210425,
+    1720
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "ed2b762241bbea03e374dc9dcd4fbe207c6b2ea4",
-   "sha256": "03c0dmblixh5mx8365b6608l7z3vcgp6pzdflwqf8nfwj2c5rm0w"
+   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
+   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
   },
   "stable": {
    "version": [
@@ -93735,15 +94093,28 @@
   "repo": "twlz0ne/separedit.el",
   "unstable": {
    "version": [
-    20210403,
-    1354
+    20210420,
+    1527
    ],
    "deps": [
     "dash",
     "edit-indirect"
    ],
-   "commit": "588a5dba2b38e57b88870efbc0cd2482202f28c8",
-   "sha256": "1m3kb6lvdr8manvlvi2avhba94lw16lvxy9p7vksk1gsmdmkgc0j"
+   "commit": "424b0f260a1bca20cd9359c42a0bc64a1a5e1928",
+   "sha256": "1i85mbnh6ijycsgxiknzvkimxag72cxg8asg3d1g4bakv3gp32rr"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "dash",
+    "edit-indirect"
+   ],
+   "commit": "424b0f260a1bca20cd9359c42a0bc64a1a5e1928",
+   "sha256": "1i85mbnh6ijycsgxiknzvkimxag72cxg8asg3d1g4bakv3gp32rr"
   }
  },
  {
@@ -93754,11 +94125,11 @@
   "repo": "brannala/sequed",
   "unstable": {
    "version": [
-    20210315,
-    2012
+    20210417,
+    28
    ],
-   "commit": "50c5dca413a12fe2d8a89eae833f10967c2f38d2",
-   "sha256": "16hsjk04xw88ddr2gbwlb4v8didqmk7ffwphp1iqy3a02wf4kif6"
+   "commit": "b28e20bf3e0ec7c56c705632e38ab842083d9c49",
+   "sha256": "09bw3kjr32z8hlhrczl8i3h4yavdcmfx6bk7qxsyhn1f0vmskh03"
   }
  },
  {
@@ -94212,21 +94583,6 @@
   }
  },
  {
-  "ename": "shell-command",
-  "commit": "ae489be43b1aee93614e40f492ebdf0b98a3fbc1",
-  "sha256": "01nviashfr64wm78zi3vrqrqdqgsamp76d9kasxv0b7fqmfx7yjk",
-  "fetcher": "github",
-  "repo": "emacsorphanage/shell-command",
-  "unstable": {
-   "version": [
-    20090830,
-    1040
-   ],
-   "commit": "7e22125f746ce9ffbe9b0282d62f4b4bbbe672bd",
-   "sha256": "1my2i26a03z8xyyacsnl5wdylnbhhvazn23bpy639d3l4x4l7jzw"
-  }
- },
- {
   "ename": "shell-current-directory",
   "commit": "edcb78c3491a5999b39a40087b7f991c2b737e30",
   "sha256": "0bj2gs96ivm5x8l7gwvfckyalr1amh4cb1v2dbl323zmrqddhgkd",
@@ -94331,11 +94687,11 @@
   "repo": "DamienCassou/shell-switcher",
   "unstable": {
    "version": [
-    20161029,
-    552
+    20210501,
+    604
    ],
-   "commit": "28a7f753dd7addd2933510526f52620cb5a22048",
-   "sha256": "1x7rrf56hjasciim8rj29vfngwis4pr3mhclvxd4sbmhz9y66wm0"
+   "commit": "b16b4bdb54d807c5557f3fe95491bc611741eb37",
+   "sha256": "03fmryw522lh31jnrab8kclzzj3b1v0lr105a5qqalqh4srj6nq3"
   },
   "stable": {
    "version": [
@@ -94531,8 +94887,8 @@
     20210329,
     149
    ],
-   "commit": "8bab3dc89d36b55ba26ae5941f294c57805d24b2",
-   "sha256": "15kp2lsfci6p8wkrda12m4vf12p13xd9x5rh3ypc6yvz1snypgyy"
+   "commit": "a395147050674ff88f03a6ac354a84ccbdc23f1e",
+   "sha256": "1gpbmnfxc5z2nm03d5989z8mb91wlq8788vvsl9kf2yl8s4fg5a0"
   }
  },
  {
@@ -94718,15 +95074,15 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20210321,
-    844
+    20210502,
+    1350
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "a73268705e3558ee91dc05674c5c3bed7fe28202",
-   "sha256": "1jjs0pclv0ya4d65wzafkvgb7lmg7f13jj0pihs1ch507fyiw3gp"
+   "commit": "fb0fee03dfbebc21f2b9ce142764d04479cfaa58",
+   "sha256": "1m3kf8730brldx6l59xv92m9946aqb2b42pgjj8bl0l1x757ijk5"
   },
   "stable": {
    "version": [
@@ -94927,11 +95283,11 @@
   "repo": "rnkn/side-notes",
   "unstable": {
    "version": [
-    20210201,
-    724
+    20210502,
+    935
    ],
-   "commit": "3993e8de44c141420efbec3cdb4c5620b862a200",
-   "sha256": "1ivm2xr7mc8hp7g1l6l3a4mm5byn2cp7m6bv2g222997xbpk0il5"
+   "commit": "ca73cec33880322c5bbab407825d502d87f4cf0f",
+   "sha256": "1qnrk8kib4rndgbljqxq7cmskgxwcc9d8wdbdr3mgkgbg08xv5gq"
   },
   "stable": {
    "version": [
@@ -95575,15 +95931,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20210214,
-    2243
+    20210430,
+    1239
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "68c58c0194ff03cd147fcec99f0ee90ba9178875",
-   "sha256": "0lammq7116hm79nldxlghi978m7bldccfdc9vy1rlfjj4mhnrlq0"
+   "commit": "a4c9c4cc5318fa0f023089755f81f2d2d2281d9b",
+   "sha256": "1ah15zagmsd65qfiwspcb0l2frza05iq4dw7hcrdlyqpx5rmhpd9"
   },
   "stable": {
    "version": [
@@ -95638,28 +95994,28 @@
   "repo": "cl-docker-images/slime-docker",
   "unstable": {
    "version": [
-    20210124,
-    2145
+    20210426,
+    1422
    ],
    "deps": [
     "docker-tramp",
     "slime"
    ],
-   "commit": "903470fe3860402794a4f268c1efffd44a30f273",
-   "sha256": "089yskdbkr7k25sns5vms7f0hqdbpnjg3ih95nhia1nghxcqj482"
+   "commit": "c7d073720f2bd8e9f72a20309fff2afa4c4e798d",
+   "sha256": "03jm0964qqggqia2fkvqgrx8r4knj1qgqr8vimr0x4q2j73lj12a"
   },
   "stable": {
    "version": [
     0,
     8,
-    2
+    3
    ],
    "deps": [
     "docker-tramp",
     "slime"
    ],
-   "commit": "903470fe3860402794a4f268c1efffd44a30f273",
-   "sha256": "089yskdbkr7k25sns5vms7f0hqdbpnjg3ih95nhia1nghxcqj482"
+   "commit": "c7d073720f2bd8e9f72a20309fff2afa4c4e798d",
+   "sha256": "03jm0964qqggqia2fkvqgrx8r4knj1qgqr8vimr0x4q2j73lj12a"
   }
  },
  {
@@ -96007,11 +96363,11 @@
   "repo": "malsyned/smart-dash",
   "unstable": {
    "version": [
-    20201202,
-    1616
+    20210427,
+    1709
    ],
-   "commit": "b4a298572e7acc3f39a908997fdcfa356bac0591",
-   "sha256": "1lkld9g53064wz2m3xxpjpf8vs75fa8kxxnvgpipvzq55sl1j9v7"
+   "commit": "bc740889dd81e7dc8a90a33d1f075f21aba9b2d3",
+   "sha256": "0kadfyvvzfk66d5k263j8cykqh9lbwrdqizs2mag6ahnadpahhyy"
   }
  },
  {
@@ -96100,14 +96456,14 @@
   "repo": "Malabarba/smart-mode-line",
   "unstable": {
    "version": [
-    20190527,
-    1156
+    20210428,
+    1641
    ],
    "deps": [
     "rich-minority"
    ],
-   "commit": "999be065b195f2eddb4e1b629f99038d832d44b7",
-   "sha256": "0jyvyn7pkqvyyv1rga3i10f4cwfbb0miacbib8lsrrhayrnal186"
+   "commit": "744ee1a9479a7901cedd6f0d59e6c6c86b20a78d",
+   "sha256": "18bf6f5yd8gympf5z8fs904qnjjdijapxpincjbpiyb2429yb34a"
   },
   "stable": {
    "version": [
@@ -96154,8 +96510,8 @@
     "powerline",
     "smart-mode-line"
    ],
-   "commit": "999be065b195f2eddb4e1b629f99038d832d44b7",
-   "sha256": "0jyvyn7pkqvyyv1rga3i10f4cwfbb0miacbib8lsrrhayrnal186"
+   "commit": "744ee1a9479a7901cedd6f0d59e6c6c86b20a78d",
+   "sha256": "18bf6f5yd8gympf5z8fs904qnjjdijapxpincjbpiyb2429yb34a"
   },
   "stable": {
    "version": [
@@ -96778,15 +97134,15 @@
   "repo": "SpringHan/sniem",
   "unstable": {
    "version": [
-    20210410,
-    1115
+    20210503,
+    659
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "7518cf3e1d6ca67e9ee8d9d1e930e1866f460c92",
-   "sha256": "05ncmknzrqsx8l3c1r3lm4b810m6hnrixbbzkik2brnyzqpqfphj"
+   "commit": "aef9dcb8b007c59525100fb989c7f8fc6dec71cf",
+   "sha256": "10fp0wlwla4y94kvl5ajk3jxvcr9k01y2s1f7q3fj1lr31zh7c6f"
   }
  },
  {
@@ -97178,11 +97534,11 @@
   "repo": "mssola/soria",
   "unstable": {
    "version": [
-    20210201,
-    1830
+    20210426,
+    1433
    ],
-   "commit": "f765f193ccaf4ad438e1d9be842efd2f4394efa4",
-   "sha256": "1p6kzsci8hgccpjcy6swwa6yk741l6ay48rb35gmf03j04abszm0"
+   "commit": "12d3472e6823ff1bdc1591984367e2ed769afcb7",
+   "sha256": "1vyg73svawi8g1mq6v5y5g9hw0vnks2nhbwdkbn6d53b7bcr0hpx"
   },
   "stable": {
    "version": [
@@ -97381,16 +97737,15 @@
   "repo": "nathankot/company-sourcekit",
   "unstable": {
    "version": [
-    20180101,
-    834
+    20210430,
+    2155
    ],
    "deps": [
     "dash",
-    "dash-functional",
     "request"
    ],
-   "commit": "abf9bc5a0102eb666d3aa6d6bf22f6efcc852781",
-   "sha256": "1g8a4fgy2c5nqk8gysbnzn5jvfw6ynmfhc6j3hkrbswgf9188v5n"
+   "commit": "a1860ad4dd3a542acd2fa0dfac2a388cbdf4af0c",
+   "sha256": "18pv1hcilj7kndr7a29jjskp21khh1sd0wy01h8y8y9mf70kikg6"
   },
   "stable": {
    "version": [
@@ -97706,11 +98061,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20210306,
-    1600
+    20210415,
+    1821
    ],
-   "commit": "b9f49bab9551e8ca1232582acffdd0a90aaa35f3",
-   "sha256": "0k9dlkxns8yhv1yzfjlr5gkfc26ihhqjfsjchqg9fvfxqnd39pic"
+   "commit": "86c223a2db529768fd815dc0635ed432c1a215e8",
+   "sha256": "1bz6186w83xmajnw489dc1la7b6gly9vrp40mh58gknk5fjdx86w"
   }
  },
  {
@@ -97837,15 +98192,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20210328,
-    413
+    20210415,
+    1326
    ],
-   "commit": "c566ed568aae0a73202a51e97a73c5e4af0053d2",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-spell-fu/repository/archive.tar.gz?ref=c566ed568aae0a73202a51e97a73c5e4af0053d2': HTTP error 503; retrying in 265 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-spell-fu/repository/archive.tar.gz?ref=c566ed568aae0a73202a51e97a73c5e4af0053d2': HTTP error 503; retrying in 703 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-spell-fu/repository/archive.tar.gz?ref=c566ed568aae0a73202a51e97a73c5e4af0053d2': HTTP error 503; retrying in 1251 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-spell-fu/repository/archive.tar.gz?ref=c566ed568aae0a73202a51e97a73c5e4af0053d2': HTTP error 503; retrying in 2299 ms\nerror: unable to download 'https://gitlab.com/ideasman42/emacs-spell-fu/repository/archive.tar.gz?ref=c566ed568aae0a73202a51e97a73c5e4af0053d2': HTTP error 503\n"
-   ]
+   "commit": "fae15427a1027e5eafdff7e5627cd399f73dbc37",
+   "sha256": "05xarav1dw4315rh4qchvf6p9vsdyg09nm9rc6k657n4r8ip725c"
   }
  },
  {
@@ -98429,11 +98780,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20210325,
-    445
+    20210502,
+    1549
    ],
-   "commit": "633a0ff419438987f6271ff5a5da26307950a3cd",
-   "sha256": "070p4wyphhm7115afvq7lhxkb69c7l7fz3q5nkwbpjsdp5s8isns"
+   "commit": "688d55eeaedef9f95a123db130bfb456c94c587d",
+   "sha256": "0n633q3jv0l2klxf590lp9a3dy0wpmh37xl0fii9afsvaydrdww7"
   },
   "stable": {
    "version": [
@@ -98546,11 +98897,11 @@
   "repo": "jhgorrell/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20210401,
-    243
+    20210428,
+    1752
    ],
-   "commit": "6d4f8d12c6a7e7ff776271f3656be5f3ba5a784e",
-   "sha256": "1pxpm24rlrrdzmy129c6naz9zxfsjrk6hgx3qcizd25kq86sfy4g"
+   "commit": "4e5c9bf04394438a6256ea7b320df3b0ed129fe6",
+   "sha256": "19ls9cm4bswxp5zfwxf7mdpf0gcmnpqi8vzyw94j5hmakx89l3kz"
   }
  },
  {
@@ -98857,16 +99208,16 @@
     20200606,
     1308
    ],
-   "commit": "6af99af232c90d1629ac71be500eef2241245c81",
-   "sha256": "03wl804pacmzr2gjdz6ssq0l03hs68hadlgjdn6hinp2k0r90pxw"
+   "commit": "68f949852ab7f0e8bb52c6a6fc2ece2a74ded824",
+   "sha256": "129mms7gd0kxqcg3gb2rp5f61420ldlhb0iwslkm7iv64kbxzww1"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
-   "commit": "11aa5944459e464a96f41d934e23da5320c13333",
-   "sha256": "0nc388hi362rks9q60yvs2gbbf9v6qp031c0linv29wdqvavwva1"
+   "commit": "68f949852ab7f0e8bb52c6a6fc2ece2a74ded824",
+   "sha256": "129mms7gd0kxqcg3gb2rp5f61420ldlhb0iwslkm7iv64kbxzww1"
   }
  },
  {
@@ -98907,11 +99258,11 @@
   "repo": "motform/stimmung-themes",
   "unstable": {
    "version": [
-    20210331,
-    1140
+    20210430,
+    839
    ],
-   "commit": "0dc71ec178c3dab8973c90758fa730c70df01554",
-   "sha256": "0glp3h5anrsvm89zs99gdyp3rpc0g41va30nxw5pn02yv7cqz7hd"
+   "commit": "eac0f54da5ff116622a6448b68057b45c337f2de",
+   "sha256": "0b7glyq3z98vi7f79zg0phqm6ibc30lq2m4mwy22gg0941rr2zja"
   }
  },
  {
@@ -99340,30 +99691,6 @@
   }
  },
  {
-  "ename": "sudden-death",
-  "commit": "3f20f389a2d7ddf49ca64d945b41584a7c120faf",
-  "sha256": "1wrhb3d27j07i64hvjggyajm752w4mhrhq09lfvyhz6ykp1ly3fh",
-  "fetcher": "github",
-  "repo": "yewton/sudden-death.el",
-  "unstable": {
-   "version": [
-    20180217,
-    23
-   ],
-   "commit": "791a63d3f4df192e71f4232a9a4c5588f4b43dfb",
-   "sha256": "0z3adwd6ymapkdniny3ax2i3wzxp11g6in4bghbcr9bfdxcsf7ps"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    1
-   ],
-   "commit": "791a63d3f4df192e71f4232a9a4c5588f4b43dfb",
-   "sha256": "0z3adwd6ymapkdniny3ax2i3wzxp11g6in4bghbcr9bfdxcsf7ps"
-  }
- },
- {
   "ename": "sudo-edit",
   "commit": "3b08d4bbdb23b988db5ed7cb5a2a925b7c2e242e",
   "sha256": "10vz7q8m0l2dyhiy9r9nj17qlwyv032glshzljzhm1n20w8y1fq4",
@@ -99784,6 +100111,36 @@
   }
  },
  {
+  "ename": "sway",
+  "commit": "4c2d1eec09d5f69fbec99c6d190cc78882d8a74c",
+  "sha256": "00jysn6x6n54xpj6vwrp582p001bjbkjilqs4gsxs5r829cr3zyw",
+  "fetcher": "github",
+  "repo": "thblt/sway.el",
+  "unstable": {
+   "version": [
+    20210501,
+    2201
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "8a4d9cc1a469efa707cf67b57b752f28547e331e",
+   "sha256": "0x5w3f07dsgbl7qlcqpmpm3831lrv5jx59g7xnv25giwc3w21d2d"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    4
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "8a4d9cc1a469efa707cf67b57b752f28547e331e",
+   "sha256": "0x5w3f07dsgbl7qlcqpmpm3831lrv5jx59g7xnv25giwc3w21d2d"
+  }
+ },
+ {
   "ename": "sweet-theme",
   "commit": "a149448c38504bdf6f782a10cb1440da9102990f",
   "sha256": "1ca56disxyr30anvpqahh33s062y35w003yxi1rhdrknka2cnl5q",
@@ -99855,15 +100212,15 @@
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "swift-mode"
    ],
-   "commit": "661e6fe419948419da4abf916b193b331b80a3be",
-   "sha256": "08w9h12y54aj2q6k48p9fglacppb5mlqh18h43n45hd7rcph3j93"
+   "commit": "ed36ea3d8cd80159f7f90b144c4503411b74ae3e",
+   "sha256": "0bcrnslqhgz122mv6br6w848a3x3g4jkz1pkdpb4726xssfzz8zk"
   }
  },
  {
@@ -99880,20 +100237,20 @@
    "deps": [
     "seq"
    ],
-   "commit": "fd3c824c3622aef4ad29983667f34ebad91e9f69",
-   "sha256": "1s60j7778n8vl53capi1bs5mbb1g2vwaaa4y7wdv6ajrlxh95a5x"
+   "commit": "ad12a3025156873995318b6a0480cd2459063bf7",
+   "sha256": "1cr484b8pixnk9rk2046wiq7i05r3sr6wmk0qiad1vibzlynz83q"
   },
   "stable": {
    "version": [
     8,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "e65a80a659c74d0a62b00dff183a0f7fc8385ce1",
-   "sha256": "18i6m2zys0nc9j29f7bkzjcfp7rcaycr473ykhprsfikfcgwkj3y"
+   "commit": "fd3c824c3622aef4ad29983667f34ebad91e9f69",
+   "sha256": "1s60j7778n8vl53capi1bs5mbb1g2vwaaa4y7wdv6ajrlxh95a5x"
   }
  },
  {
@@ -99904,8 +100261,8 @@
   "repo": "michael.sanders/swift-playground-mode",
   "unstable": {
    "version": [
-    20190730,
-    1707
+    20190717,
+    2223
    ],
    "deps": [
     "seq"
@@ -99964,8 +100321,8 @@
    "deps": [
     "ivy"
    ],
-   "commit": "471d644d6bdd7d5dc6ca4efb405e6a6389dff245",
-   "sha256": "0zw5sypr9kwb65627b8wrgl542gyq0xh7pwhghbkwfpwx7rjvk36"
+   "commit": "4ffee1c37340a432b9d94a2aa3c870c0a8203dcc",
+   "sha256": "02d5a8s263lp2zvy39mxkyr7qy5475i4ic2bpm2qm0ixr4fkfdy8"
   },
   "stable": {
    "version": [
@@ -100225,14 +100582,14 @@
   "repo": "wolray/symbol-overlay",
   "unstable": {
    "version": [
-    20210118,
-    807
+    20210422,
+    2110
    ],
    "deps": [
     "seq"
    ],
-   "commit": "5bcd6d7e3f3b6501ccec3e6c378f33f7e7488c99",
-   "sha256": "10n0871xzycifyqp73xnbqmrgy60imlb26yhm3p6vfj3d84mg1b2"
+   "commit": "4231a36e39b7393d639e9cdef19f311d780deeab",
+   "sha256": "0q2x39s3g5kmjf5q47qpqcnzdscnj112dfd7qqb2z0iq0sh2nbrd"
   },
   "stable": {
    "version": [
@@ -100280,8 +100637,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20210408,
-    1839
+    20210416,
+    353
    ],
    "deps": [
     "evil",
@@ -100293,8 +100650,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "feaf6d847bbff6642cd3c4926899eee3cbac261b",
-   "sha256": "1k4b8aqwglgavj3rsjj0macmppjsgb5ykpl388434crn067rlfpz"
+   "commit": "3af93352a522bf8b88841a0d7114789a11741bb2",
+   "sha256": "1rrhzq9kixvvjjlb8xan5dd3g9jpygl83l77sl9r5ddv0flg6ali"
   },
   "stable": {
    "version": [
@@ -100672,11 +101029,11 @@
   "repo": "fritzgrabo/tab-bar-echo-area",
   "unstable": {
    "version": [
-    20210315,
-    1609
+    20210424,
+    1927
    ],
-   "commit": "d2ff6b1acb553bf1546e730640397b9e33ca5279",
-   "sha256": "1agjb68bjfjzgacrip2mjwzfdbvj3xn8cs3f6q5kdjg5v7lg9c9h"
+   "commit": "c60fceca7f0e7e400e4d660b23e6c64b178d9a06",
+   "sha256": "11h14wp0c30wc0y0y9qp5r9gwma09wl54bg0a1vxn037llwnfiv1"
   }
  },
  {
@@ -100687,14 +101044,14 @@
   "repo": "fritzgrabo/tab-bar-groups",
   "unstable": {
    "version": [
-    20210321,
-    2129
+    20210419,
+    2057
    ],
    "deps": [
     "s"
    ],
-   "commit": "b83315c9a63ba2f6bbeaaa449a3b78b84a87ec1c",
-   "sha256": "03pc85g5f5ys0s45ccg3z7dni4cxngs3532xf9ng94a421yhxmkr"
+   "commit": "509b3a3909b074faa9677509de0becb9cc054a37",
+   "sha256": "1bnhxzbpk7xi0vi5m2mwwss97pzhwbxqn6k59028ibwxs3hvaq1c"
   }
  },
  {
@@ -100941,11 +101298,11 @@
   "repo": "11111000000/tao-theme-emacs",
   "unstable": {
    "version": [
-    20201222,
-    602
+    20210417,
+    626
    ],
-   "commit": "468ee4f6ba7afb9dbfc8855ae2c333cb16ca4408",
-   "sha256": "0yqibx6wcdsj5k6130c3qp0hmj6zwhfjrrvw98lny23ksw6k0s3s"
+   "commit": "d5ccf6f53d65e80083acdfb0bced6bcd678c6ea9",
+   "sha256": "1wgk0xngamwgh242wfmxizi5r1ji5dxmr8s542g3p7rgfv5w0qs8"
   },
   "stable": {
    "version": [
@@ -100965,11 +101322,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20210310,
-    1632
+    20210415,
+    1322
    ],
-   "commit": "d6edb345f31a13918d603d44b90a4ce30b34632b",
-   "sha256": "0jx095yjpsh28r6a23w2fxqv0rysbwz49c22vri2s8hzw011m55p"
+   "commit": "1c0028d6c406cf4884e6aa35313e82041b7e857f",
+   "sha256": "0gv1iychm7xzdf99l1kiyvqfdhl9s8g900jjq7bj2kkd3r3c22ki"
   },
   "stable": {
    "version": [
@@ -101156,28 +101513,28 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20210409,
-    2343
+    20210429,
+    1950
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "88e10161e1aa2a7c83ebc41ba8492d84d8e64e26",
-   "sha256": "010jlhbidl3vny9z4dp4mhix827p2aa76ja2v822sdlszcb8vh9x"
+   "commit": "cc3c22a22e02a5606407d70e76ec221d5ec82533",
+   "sha256": "0j0zrravv4whakzgxvprisyxnlpcbmdywljq5vnvww2j1f75vwj7"
   },
   "stable": {
    "version": [
     0,
     7,
-    22
+    24
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "3ed57544faf0fdd17dd8762126466b15dc471f8f",
-   "sha256": "1frljw1gipsr9l6cpb1skwi5b566x9yx3dhcc7bxfq11inh7bc74"
+   "commit": "9187e6e3d903474645f3e64806bc62ef687ec205",
+   "sha256": "1ra04cp49zzx8vy8aswd00l46ixyc44sxh1s3nw880b4ywzxmc6j"
   }
  },
  {
@@ -101295,20 +101652,20 @@
   "repo": "clarete/templatel",
   "unstable": {
    "version": [
-    20210327,
-    2307
+    20210425,
+    2215
    ],
-   "commit": "dd7e76919f36da9f8efe7f9e3d84098f3c7c6644",
-   "sha256": "0apv1r756d984a47d9pvqzgcs652fdwy3swf4js9dki3nzljy756"
+   "commit": "3ee3761d9dd30b1c6af74dc393d43b9a91a75951",
+   "sha256": "1c58m2x4frwqxbi8n884c4l69pfwzdxsrig8p35y7mbywlwf1s2l"
   },
   "stable": {
    "version": [
     0,
     1,
-    5
+    6
    ],
-   "commit": "971153aa43addf88bfe0922bcac19cb0edd3f86d",
-   "sha256": "0ldb01sxzrvchjy160karvmksinicw3d14jazriy84dxks8i6w8a"
+   "commit": "8374097a129b2cd13c449568f95ee7380b36b307",
+   "sha256": "03n7amd2mfr4jmc4s1ar5ckm86knr7qarxxlkdhbnw3svy5kbc57"
   }
  },
  {
@@ -101419,22 +101776,22 @@
  },
  {
   "ename": "term-alert",
-  "commit": "0d77aee0b1b2eb7834436bdfa339f95cb97da140",
-  "sha256": "02qvfhklysfk1fd4ibdngf4crp9k5ab11zgg90hi1sp429a53f3m",
+  "commit": "8bcf021a68579f1b9c02dc959c525de0c6ca1fb0",
+  "sha256": "1hk1gzszqc3ijzarzi9d5hiw8ya19qp5jyb7alnsx7sn9pw6a612",
   "fetcher": "github",
-  "repo": "CallumCameron/term-alert",
+  "repo": "calliecameron/term-alert",
   "unstable": {
    "version": [
-    20161119,
-    945
+    20210414,
+    1638
    ],
    "deps": [
     "alert",
     "f",
     "term-cmd"
    ],
-   "commit": "1166c39cc3fb1cb7808eb8955b7f9f6094a306cd",
-   "sha256": "1hbyiwqv9waynf8gm3c717mph0p9mfi2x1wfpvdzzr25r0fz8xr0"
+   "commit": "ca1b48ad911bc972b049f48fe0531e702dbc553c",
+   "sha256": "0jnv1011y521pc4rrjyrv1la6r1q2sb120lxf1nbns17wv86d0cd"
   },
   "stable": {
    "version": [
@@ -101452,21 +101809,21 @@
  },
  {
   "ename": "term-cmd",
-  "commit": "e08ea89cf193414cce5073fc9c312f2b382bc842",
-  "sha256": "0pbz9fy9rjfpzspwq78ggf1wcvjslwvj8fvc05w4g56ydza0gqi4",
+  "commit": "8bcf021a68579f1b9c02dc959c525de0c6ca1fb0",
+  "sha256": "0jcn77hcjykvd1778948pj2qr03n1w4q8alz50gnlwg3y031y92y",
   "fetcher": "github",
-  "repo": "CallumCameron/term-cmd",
+  "repo": "calliecameron/term-cmd",
   "unstable": {
    "version": [
-    20160517,
-    1045
+    20210417,
+    1447
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "552aa58965aab9b78e46934462bafe54c0396ffb",
-   "sha256": "0l5xk8npc23c716fjckd65xq83hjwnvpyxixc9brxfz4ybngzwhy"
+   "commit": "281b9a6d864ca85dc1451dc46baca98f48dc3f60",
+   "sha256": "1knijk9l8ipb882h8awwx18lh3q1yy13dyjp5gm36nw06212qxx2"
   },
   "stable": {
    "version": [
@@ -101764,11 +102121,11 @@
   "stable": {
    "version": [
     1,
-    0,
-    1
+    1,
+    0
    ],
-   "commit": "d609290021ea7f2d10caadffc9131663838f8ad4",
-   "sha256": "1gvydmi37d7jxibn7nfg1rhb6phfn3kgrlmq250g7321g15j1q3v"
+   "commit": "77181c75cbde5954542688659cd4f2352ed29fbe",
+   "sha256": "1bcwja7hm11hxd1nmf1z93hkzcvkkpxavvbivg6j336ygzr1r82g"
   }
  },
  {
@@ -102247,18 +102604,18 @@
     20200212,
     1903
    ],
-   "commit": "9c6323483c9feaa9ffba8ceb98f54281733ed50c",
-   "sha256": "0qjx9arygjh7h3wjrfcwc7jw1jxah2jf6wfinprv7b6jg1n8k6vy"
+   "commit": "e7c2e64c404b5cba6b27948ffaf36b56992e4580",
+   "sha256": "0mshmbbl3v3f0qjmw9g1z5pkr2183j091wxr8nc1ksr28y2q6vnr"
   },
   "stable": {
    "version": [
     2021,
+    5,
     3,
-    15,
     0
    ],
-   "commit": "6d68811e7ee75f8e0b450b9b1778bfad2c44c715",
-   "sha256": "16yixl9qq6zh47zjnad9rv2vbjq936ms212j0wfdax7qhg094af8"
+   "commit": "5d2501709782c10358b73c85d8911880d34c7fa3",
+   "sha256": "022sgd9hsgmqr586xmzdbzmxfqaq69ps2ghq430h4ad992wanvkz"
   }
  },
  {
@@ -102314,20 +102671,20 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "4f7bbb325631968d6e7b82b25ece810959d4b87f",
-   "sha256": "1p4w48zz25fym40l3wijr06qfd4drhkynbhf2nx2yh766yv8icmg"
+   "commit": "ce6d01ac1f41b9121e414cfcf6253cbbff4c034e",
+   "sha256": "0i12lswqpdfnbmq7q4vdds33qkm4f4lyh02c27y82c74aymh81d0"
   },
   "stable": {
    "version": [
     1,
     7,
-    2
+    4
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "223b0f4388dce62c82eb2fb86cf1351d42aef198",
-   "sha256": "0k93i9smhw5bws2xiybha15g26mwyq0zj6xzxccwh0bfpl76xzqq"
+   "commit": "652d7a4e374d3c171278e6bdfccfa41c7621d4d3",
+   "sha256": "11590ifnh9ynwcfv31f5m59wr6ckrm3xi2g40wvk4ddxslj4yxnh"
   }
  },
  {
@@ -102338,8 +102695,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20210327,
-    1928
+    20210412,
+    1650
    ],
    "deps": [
     "cl-lib",
@@ -102348,14 +102705,14 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "ad6fa78911d5d7e85c0851c0c1afc01f3cbde7c1",
-   "sha256": "1b815gxmn31x5b59mmlv5di72mz3vdm19crrpcnvb18vl2ak2vw3"
+   "commit": "ccff099e94beda9f5378ffc2b412cb4257111e8d",
+   "sha256": "17fb6zkz5d568151ypw8jkhnpikcrpwn3kc2w1mm9hs2g3hbigid"
   },
   "stable": {
    "version": [
     4,
-    0,
-    2
+    2,
+    3
    ],
    "deps": [
     "cl-lib",
@@ -102364,8 +102721,8 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "dafb6befd83e5eea2e2c7f79ab89bc4877001b6d",
-   "sha256": "1n2dihpl53a48jis3l4rry581wpr5lxjd433drlkaa4lqgx8cw67"
+   "commit": "2a3ac4f38472d66e2d8a6bbe5dadb52bc008acbd",
+   "sha256": "1fj2fghiycnzds2zxfxgj1d9mdzsvs9rvl9bwy2f1vwawqk1m48w"
   }
  },
  {
@@ -102726,10 +103083,10 @@
   "repo": "snosov1/toc-org",
   "unstable": {
    "version": [
-    20210323,
-    1256
+    20210421,
+    657
    ],
-   "commit": "c4c61c5a382f94a3a4537e254243006dec2dcca4",
+   "commit": "df4ad6ff15e3b02f6322305638a441a636b9b37e",
    "sha256": "00a2al7ghrlabf65kfj1mk30p2pl37h6ppwlgghbgiy7rwlzkdbm"
   },
   "stable": {
@@ -102824,8 +103181,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "74e1fcbeca25734235afec9c6a4d0cf73736b62c",
-   "sha256": "0yrcsr4360v222klahbccfq3vb4kp5xdsibydwircv36xhxplzq3"
+   "commit": "2d76365d2aa13543121d5c623df465adb68b76f7",
+   "sha256": "1n247g5dq73rkxf0wys5lsbvma44y5qlh577s3rcx7l0yrylwdry"
   }
  },
  {
@@ -103124,8 +103481,8 @@
    "deps": [
     "w32-ime"
    ],
-   "commit": "809215eccfe8ff33d461c7ff980ed64c621a84bb",
-   "sha256": "1915v2x45cx9ydb53aw98da00wmqymn96af0wan9k46527ck54lg"
+   "commit": "92591f7c0b94f8b1875f1078d1ba3be40848f0b8",
+   "sha256": "0r5cmj8ih8n7m37fqwyymmd0swyxr6g124cw9cz24ri0dyiwi73k"
   },
   "stable": {
    "version": [
@@ -103193,8 +103550,8 @@
     20201101,
     1045
    ],
-   "commit": "e67e2d1149ebf3e79cd2162e78802af3ed5f82da",
-   "sha256": "0jrpa8kndq2v69nr9jva970q0n3662x2g0chg89nd2d3gbv693mw"
+   "commit": "2f70aa236878d9c3726c31d6ba922e2d7076951d",
+   "sha256": "1fi0qc8qbcgkjjvi5iysifammqcc6nwcrwjhwi713zykd5cir180"
   },
   "stable": {
    "version": [
@@ -103297,20 +103654,20 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210315,
-    1902
+    20210426,
+    2141
    ],
-   "commit": "cc16a5eaa73617a281b0bbf71b24432c38994e30",
-   "sha256": "15ah0h7i96wn4w5321gydr6pxahb8mc8dk58b9paqv06klp5q2cd"
+   "commit": "6ceddc4d8c7a3c13d78c459213c796d2c19234c6",
+   "sha256": "0dhz5ca9i83vgi3pvkbvwanxbi1ibzwbmnhm8ymxdvzn508rlswl"
   },
   "stable": {
    "version": [
     0,
     3,
-    0
+    2
    ],
-   "commit": "9ca983bab26d1a8e189a8c44471d9575284b268d",
-   "sha256": "0g694ydmb9zjn99hxgfjd3m73kpmnkbrgqhr73b4crbxza5sl29c"
+   "commit": "162698aa9d40ecafefcb1af7bdf602954d766970",
+   "sha256": "1766hdqzg95k62nqhadfv502mpnjlx1l59ppqmc6r0las82dc6a8"
   }
  },
  {
@@ -103671,8 +104028,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210411,
-    1031
+    20210422,
+    2011
    ],
    "deps": [
     "ace-window",
@@ -103684,8 +104041,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   },
   "stable": {
    "version": [
@@ -103721,8 +104078,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   }
  },
  {
@@ -103733,15 +104090,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210107,
-    1251
+    20210419,
+    1753
    ],
    "deps": [
     "evil",
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   },
   "stable": {
    "version": [
@@ -103770,8 +104127,8 @@
    "deps": [
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   },
   "stable": {
    "version": [
@@ -103802,8 +104159,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   },
   "stable": {
    "version": [
@@ -103835,8 +104192,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   },
   "stable": {
    "version": [
@@ -103868,8 +104225,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   }
  },
  {
@@ -103887,8 +104244,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "b92d43aa6974c8581ea7a4f4b3586041a7f44f32",
-   "sha256": "18laa2ym4zqwl218flj73ik1s0ffiq3q7nszzp7qphhv4bkqjdik"
+   "commit": "f13249866b300ec3a4908bf132d984c6354e3fcf",
+   "sha256": "1wbn0jb21jvsi11gwhb1y8igkxvw54gyndamdgrngsyqjck5mxz9"
   },
   "stable": {
    "version": [
@@ -103994,20 +104351,20 @@
   "repo": "ianpan870102/tron-legacy-emacs-theme",
   "unstable": {
    "version": [
-    20210315,
-    712
+    20210420,
+    1201
    ],
-   "commit": "4d543fbb9cb2098af1be0f5b10e1e4cd5245a9d0",
-   "sha256": "0fyprvi4s331r6a54xa4dljw0k330kiyhzcfnnjhbsqxc86264pz"
+   "commit": "e7d16ebe4a824e7d7766fb34ffe4ea3b002f3d23",
+   "sha256": "15njpd9923rl07lq4mxs611glgnw3qyr21wk6xak6n1cminvy81g"
   },
   "stable": {
    "version": [
     2,
-    5,
+    6,
     0
    ],
-   "commit": "cdc052b044448654109bfb7d9b3d8bbfcf49042d",
-   "sha256": "0q1i2q6pkld8rz938yj9g68a55041d9vnps05nn4v1l8rx1x8jif"
+   "commit": "74e0cf066392c6fa99327e42b24caf4ed2fc414f",
+   "sha256": "1vc50y7a248f0b4bk6mawb6f7n5dd6skrln8asall2m834bzzg37"
   }
  },
  {
@@ -104886,15 +105243,11 @@
   "repo": "ideasman42/emacs-undo-fu",
   "unstable": {
    "version": [
-    20200701,
-    1435
+    20210418,
+    920
    ],
-   "commit": "7cbc3f852bcc1a22ce279cf36c89328841692493",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu/repository/archive.tar.gz?ref=7cbc3f852bcc1a22ce279cf36c89328841692493': HTTP error 503; retrying in 296 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu/repository/archive.tar.gz?ref=7cbc3f852bcc1a22ce279cf36c89328841692493': HTTP error 503; retrying in 553 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu/repository/archive.tar.gz?ref=7cbc3f852bcc1a22ce279cf36c89328841692493': HTTP error 503; retrying in 1293 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu/repository/archive.tar.gz?ref=7cbc3f852bcc1a22ce279cf36c89328841692493': HTTP error 503; retrying in 2555 ms\nerror: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu/repository/archive.tar.gz?ref=7cbc3f852bcc1a22ce279cf36c89328841692493': HTTP error 503\n"
-   ]
+   "commit": "e0ad06b5ef2ac2733dad2ad48e3957b5c36edfa5",
+   "sha256": "0xix4ghri62xdqlh48pydhih1zsnfsy7ncrk6w2wrnz4fa033pia"
   }
  },
  {
@@ -104905,15 +105258,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20210407,
-    326
+    20210418,
+    920
    ],
-   "commit": "b2d8874bc8ce892a6702b4136626bd65e0ad7760",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu-session/repository/archive.tar.gz?ref=b2d8874bc8ce892a6702b4136626bd65e0ad7760': HTTP error 503; retrying in 283 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu-session/repository/archive.tar.gz?ref=b2d8874bc8ce892a6702b4136626bd65e0ad7760': HTTP error 503; retrying in 562 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu-session/repository/archive.tar.gz?ref=b2d8874bc8ce892a6702b4136626bd65e0ad7760': HTTP error 503; retrying in 1339 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu-session/repository/archive.tar.gz?ref=b2d8874bc8ce892a6702b4136626bd65e0ad7760': HTTP error 503; retrying in 2016 ms\nerror: unable to download 'https://gitlab.com/ideasman42/emacs-undo-fu-session/repository/archive.tar.gz?ref=b2d8874bc8ce892a6702b4136626bd65e0ad7760': HTTP error 503\n"
-   ]
+   "commit": "243d93b4c7c1224e7067cd323f64d23dfdfe7c0e",
+   "sha256": "1gdx6kir0a0v7q2ai59miibch9hccqlnx2y88qswfpqr9pf7z6vm"
   }
  },
  {
@@ -105778,11 +106127,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20210124,
-    138
+    20210418,
+    1050
    ],
-   "commit": "d4b2014c5684b33ff73b4940bdff7b1138c1f85d",
-   "sha256": "00cx125pq6jad1v8pxq016hzg6wz1d06l4pc6z9r60l89y2m9hm2"
+   "commit": "21e74953a88ea5a0a17b86a951bf649dc9a0eaf4",
+   "sha256": "14hn22ld61l4w4livl83fjf4w59kzwn9qy2pc94p05qpgp8x2hy8"
   }
  },
  {
@@ -105858,15 +106207,15 @@
   "repo": "damon-kwok/v-mode",
   "unstable": {
    "version": [
-    20200823,
-    535
+    20210425,
+    411
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "d97fb8de5ab19359029dec1195f3d5b87aeb27b1",
-   "sha256": "1rhk9bcrn43gv0cz92cbvhhjvbifyq7lkdg3hcrla87b2dm4rp3l"
+   "commit": "96ca8dad3a3a402a44bf9066591fe27fa2e4fd9a",
+   "sha256": "08n577b8xr1pv2mdzqzdbkd5j0pih7zd4z4p5y5w4hq72mcid43q"
   }
  },
  {
@@ -106000,11 +106349,11 @@
   "repo": "arthurgleckler/validate-html",
   "unstable": {
    "version": [
-    20210131,
-    1704
+    20210420,
+    2344
    ],
-   "commit": "39890f7d00579954a660fc3b1c0195231325efd6",
-   "sha256": "0xb1gnf0f408z9p6iscb9g5c5xj2d460gyzk1mr0wjm847b9cs42"
+   "commit": "748e874d50c3a95c61590ae293778e26de05c5f9",
+   "sha256": "0b2b5dm85jwgkqvga23r3vfya07vxv2n7a3a6r1pxpk8asqlw41c"
   }
  },
  {
@@ -106263,14 +106612,14 @@
   "repo": "justbur/emacs-vdiff",
   "unstable": {
    "version": [
-    20201103,
-    1427
+    20210426,
+    155
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "007e44be19d068fd6b49874b6e9b8df8b1f552bd",
-   "sha256": "197xrwph1llrzjgkhlvagiwdgfp68pb45w5afg89ndahpqc2725s"
+   "commit": "84b8243d9f5d8082b05794dbc998d43dbdd7676a",
+   "sha256": "0lv9d9g8lnc3rzqi4v9iqr1ck5df8d52yh81cxzy7x2375b2mfgm"
   },
   "stable": {
    "version": [
@@ -106487,20 +106836,20 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20210402,
-    1621
+    20210429,
+    2113
    ],
-   "commit": "f9e69bf42eb8108aeee020ed3f58f456e042967f",
-   "sha256": "1hycs3aaqw6ss3ccbjd8p3fpb4aslm9hk3b9cwqnz4lxcxvqbfvj"
+   "commit": "a6e46f436495fb54ba57832450995425ad8dbc26",
+   "sha256": "0zm3ks1j60vdm9fqspa06fcgcz5mmz1pz4fgr21q001bi3wg8vfq"
   },
   "stable": {
    "version": [
     2,
-    13,
-    1
+    14,
+    0
    ],
-   "commit": "91827971f655936d8a8df95c9d2f39eaee667c97",
-   "sha256": "1bvvj25shkasy4b14ifkvh195w401xggmhjkflld5frzp7pm6zvp"
+   "commit": "0d7f7d36f6ae8130a9bd40845f156a3e3b30eb49",
+   "sha256": "1bpfxfgq5q022rx592wkigj5chq8ihry8lgrni4rsqbbmbrc1h4b"
   }
  },
  {
@@ -106984,19 +107333,19 @@
   "repo": "joostkremers/visual-fill-column",
   "unstable": {
    "version": [
-    20210404,
-    2152
+    20210419,
+    857
    ],
-   "commit": "6854932d7fe689caf5cbc1ab65271fcfd46590bd",
-   "sha256": "02ijylplnv8qzh6r2ci6h4sdm61vn0d2iajmbqyn91hs0695661j"
+   "commit": "6fa9e7912af412533aec0da8b8f62c227f9f3f54",
+   "sha256": "1wfww6bqdphv871in80fc84ml8gkl04il6w51z2ycx99km8b723l"
   },
   "stable": {
    "version": [
     2,
-    2
+    4
    ],
-   "commit": "68784162d758fbe6a91d04e9caa8f05683fb6ba9",
-   "sha256": "1wjb4zm9mx07v0qx2fxmclg4pg0ssgnf8lp89wc56kmc0s40jhii"
+   "commit": "6fa9e7912af412533aec0da8b8f62c227f9f3f54",
+   "sha256": "1wfww6bqdphv871in80fc84ml8gkl04il6w51z2ycx99km8b723l"
   }
  },
  {
@@ -107007,14 +107356,14 @@
   "repo": "benma/visual-regexp.el",
   "unstable": {
    "version": [
-    20190414,
-    814
+    20210502,
+    2019
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3e3ed81a3cbadef1f1f4cb16f9112a58641d70ca",
-   "sha256": "12p3rlhdphwmx1kxsjzcl2wj3i6qgpvw8iwhg1whs6yqgaxivixd"
+   "commit": "48457d42a5e0fe10fa3a9c15854f1f127ade09b5",
+   "sha256": "1z2cz6f8ymzrb7fdmw6824y7n5y7rmac5ljl03a6csdhp1yz5c2z"
   },
   "stable": {
    "version": [
@@ -107189,11 +107538,11 @@
   "repo": "jcs-elpa/vs-dark-theme",
   "unstable": {
    "version": [
-    20201025,
-    1148
+    20210427,
+    727
    ],
-   "commit": "3d087e1c48872b5b623ac72c85a9bd3d80ec02cd",
-   "sha256": "1j326w78drqsr4bxq2sjfnf3ax3hwk1k63flbqj8vfq5w1pc5iy0"
+   "commit": "5a826e6ea3e9edd9241e3253ce97333955c8ae1a",
+   "sha256": "0q94crd6m6m000gjxwv92jz9rphmnr5wg7jzf6yig1hlhfqjgw9v"
   },
   "stable": {
    "version": [
@@ -107212,11 +107561,11 @@
   "repo": "jcs-elpa/vs-light-theme",
   "unstable": {
    "version": [
-    20201025,
-    1148
+    20210427,
+    727
    ],
-   "commit": "4e6501118bafb62ecfca8797b6c6d81310d95fd2",
-   "sha256": "17n9c6fj70rgrc63g72vdxnv8xjnqa6w0rrvh6ih3z2xmky91b2a"
+   "commit": "e324120248c1d513a6516edff250d161f876aad9",
+   "sha256": "1jw9cbbvm76ijvcrkkn27r3n6qw14jxbirdc0bryv4k12yiwla9m"
   },
   "stable": {
    "version": [
@@ -107250,20 +107599,20 @@
   "repo": "ianpan870102/vscode-dark-plus-emacs-theme",
   "unstable": {
    "version": [
-    20210331,
-    1541
+    20210430,
+    819
    ],
-   "commit": "3c349f64ff8f12348b865b8c6896db05386cdc49",
-   "sha256": "0f2dlgjczy45dygyw6was5m74fldrbf3l29bss370qcaj3h2bm3z"
+   "commit": "24c4cb28042b3b9cc8f4e5294d7597f986aa6fae",
+   "sha256": "0b85sm6n2ahyyj220k5mqd5ar3x8204p0cfxjyhlk2f989jvfm3i"
   },
   "stable": {
    "version": [
-    1,
-    5,
+    2,
+    0,
     0
    ],
-   "commit": "c64d5f7088f1295df0bd8f1dc87a532e00647fbe",
-   "sha256": "09a6plb2dqayj4m456ldh43a654jbkg8zjiky7bkj5m0kpdc5426"
+   "commit": "41772165b3b1195a7e86747ea5b316b16be4c7ef",
+   "sha256": "1vcaqvhdgr91pr7kqskbscs8awm8jp6dkh79h6w36i9ipmc4l4hl"
   }
  },
  {
@@ -107432,20 +107781,21 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20210329,
-    605
+    20210503,
+    624
    ],
    "deps": [
     "org",
     "org-roam",
     "s"
    ],
-   "commit": "b394b82cb463f67932dae0fbe3a67daa4d647ea6",
-   "sha256": "0ssh12jrqfk7llfcfdf6dn9pq0hiqi5f7zp75v1j56qfpijzcbl0"
+   "commit": "c4f39b853c54cbfab48876812012e040b56838ee",
+   "sha256": "1dgmxbdvyb9vdha2swg4ahai6xvfvlr7d03y3c2c3db2jbr00aw5"
   },
   "stable": {
    "version": [
     0,
+    1,
     1
    ],
    "deps": [
@@ -107453,8 +107803,8 @@
     "org-roam",
     "s"
    ],
-   "commit": "4088c95bdd64ca1afbc59bacee571c7260988175",
-   "sha256": "03kynwkl4q91xz9wsmyx8g3aqgls1r8p5dxhixg586sr9xr4xck0"
+   "commit": "c4f39b853c54cbfab48876812012e040b56838ee",
+   "sha256": "1dgmxbdvyb9vdha2swg4ahai6xvfvlr7d03y3c2c3db2jbr00aw5"
   }
  },
  {
@@ -107524,11 +107874,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210409,
-    626
+    20210420,
+    1048
    ],
-   "commit": "8bab3dc89d36b55ba26ae5941f294c57805d24b2",
-   "sha256": "15kp2lsfci6p8wkrda12m4vf12p13xd9x5rh3ypc6yvz1snypgyy"
+   "commit": "a395147050674ff88f03a6ac354a84ccbdc23f1e",
+   "sha256": "1gpbmnfxc5z2nm03d5989z8mb91wlq8788vvsl9kf2yl8s4fg5a0"
   }
  },
  {
@@ -107837,19 +108187,20 @@
   "repo": "bnbeckwith/wc-mode",
   "unstable": {
    "version": [
-    20200108,
-    1841
+    20210418,
+    47
    ],
-   "commit": "79107d1130e8be3e1db4619373b98045b4fd9033",
-   "sha256": "01icd63mb2hg1bgbmkq3jm8kc3ic8whfy2awcgx53zqkmyz87qxc"
+   "commit": "63be1433b8a63cdc3239cc751e36360429c42b51",
+   "sha256": "1wzgb4z2qyyv223x5fc7ff2fn5xpz4s7lr1q1y33q8878a7w9d45"
   },
   "stable": {
    "version": [
     1,
-    4
+    4,
+    1
    ],
-   "commit": "79107d1130e8be3e1db4619373b98045b4fd9033",
-   "sha256": "01icd63mb2hg1bgbmkq3jm8kc3ic8whfy2awcgx53zqkmyz87qxc"
+   "commit": "63be1433b8a63cdc3239cc751e36360429c42b51",
+   "sha256": "1wzgb4z2qyyv223x5fc7ff2fn5xpz4s7lr1q1y33q8878a7w9d45"
   }
  },
  {
@@ -108141,14 +108492,14 @@
   "repo": "emacs-love/weblorg",
   "unstable": {
    "version": [
-    20210410,
-    421
+    20210430,
+    2251
    ],
    "deps": [
     "templatel"
    ],
-   "commit": "66bf957ace451ad0140e77d2fea235aefcd9ae26",
-   "sha256": "0qjrwpdi1zg8xbi9xnq5kpiw8dns1g899jh9vrsfqmkvr9vsm220"
+   "commit": "11ec801222eeb468878e6585efb55721592dbfe8",
+   "sha256": "01ipk5fwx5phsd6kr7kvdckhd19hly4szwlwl1a0jaxy0ab6iv54"
   },
   "stable": {
    "version": [
@@ -108327,11 +108678,11 @@
   "repo": "jstaursky/weyland-yutani-theme",
   "unstable": {
    "version": [
-    20210331,
-    1857
+    20210426,
+    2101
    ],
-   "commit": "998c171becf2e589e65aae0283ebfee90c03d6df",
-   "sha256": "18zbawhrv9904frg686hlvqr4zqx62ay85igrwm8fr41wipxxhz6"
+   "commit": "ba042c41554cb46593ef67b40a5523487cf9c6f6",
+   "sha256": "1k2fyy8kdlpb9vqqm0izxjwqqh84ih78wkc2xpmck771a5xzggf8"
   }
  },
  {
@@ -108511,10 +108862,10 @@
    "version": [
     3,
     5,
-    1
+    2
    ],
-   "commit": "c0608e812a8d1bc7aefeacdfaeb56a7272eabf44",
-   "sha256": "1g07i6hyv9glhk6xq1z9vn81vi2f0byy7dp3rg4gw22sm6f6d1al"
+   "commit": "5fb30301cb3b4fca5a0e1ce8ec1ef59290b79199",
+   "sha256": "1wgygby4zwlbx6ry6asraaixl169qdz092zgk1brvg63w7f8vkkb"
   }
  },
  {
@@ -108660,19 +109011,19 @@
   "repo": "lassik/emacs-whois",
   "unstable": {
    "version": [
-    20200715,
-    1715
+    20210429,
+    805
    ],
-   "commit": "11d01c483ab3ba78b6ea1e195bda65b5e35f2d4c",
-   "sha256": "14w1cchij7i8a9m9z71dsz76aphidmvp8lbai4gaxxi4qiyvkcn3"
+   "commit": "6ce65ec5c992b1e1cb538610f1c3708e9d467c39",
+   "sha256": "0cz5c0zy4lz0534nfr2xf7p0d09ppcfdmry4335gx19vz47fj60n"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "7cc7e2734ec823bed6eb923387b3b33a1cde0c86",
-   "sha256": "0d8q8as85fjn2v65i25xv9bzg03mlk4jhxrbqrcg5ywjiv5i2ljg"
+   "commit": "6ce65ec5c992b1e1cb538610f1c3708e9d467c39",
+   "sha256": "0cz5c0zy4lz0534nfr2xf7p0d09ppcfdmry4335gx19vz47fj60n"
   }
  },
  {
@@ -109012,27 +109363,27 @@
   "repo": "bmag/emacs-purpose",
   "unstable": {
    "version": [
-    20210411,
-    1700
+    20210423,
+    454
    ],
    "deps": [
     "imenu-list",
     "let-alist"
    ],
-   "commit": "dc4f8a00a8b0c1cf6242e1bf47f82e08c508a51e",
-   "sha256": "0h5s448dgpqi24fpmkbalw4w96jf9ny5gar8qjw0kqmcfxxny9b0"
+   "commit": "1a556294131a78b557f88bd28d42b43d5c6bd79a",
+   "sha256": "15v3225irmgg6zsv4h3zyqrbcgx9kbr6rzx5v5hgf9h16fgibi8j"
   },
   "stable": {
    "version": [
     1,
-    7
+    8
    ],
    "deps": [
     "imenu-list",
     "let-alist"
    ],
-   "commit": "a302340e183d20baa4445858d321f43449298829",
-   "sha256": "1dpy8hkjn87wbdkzyabhay4jx4dgc0ab2flyf0rjq1qaazk393sc"
+   "commit": "8f84defbb4d80ecaada37a2bbde2c1d8699f98af",
+   "sha256": "1bq0s56wj6ibyh625zfnisy8yniz72dpg4mcgq55azsbnd4fblqq"
   }
  },
  {
@@ -109211,8 +109562,8 @@
     20210405,
     1410
    ],
-   "commit": "4b4a8f05401bd08092518ddccdf35461f1124f5a",
-   "sha256": "16aknbzmh3a4lb0bzkljl70yx8v8g74vfji4h4iqvx013vwvqyp2"
+   "commit": "c67784cc0c44dc7c590f1f1f5a979a36b1e8c11d",
+   "sha256": "0pisq1b2yjfplv64xn33lw38ymmpr8wah84pfnwvzqnlfsn5s1hs"
   }
  },
  {
@@ -109253,11 +109604,11 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20210319,
-    1930
+    20210427,
+    1244
    ],
-   "commit": "ebcbd3b137154e6c5a2b976bacbb89d48ddfa242",
-   "sha256": "0qir7kzvnlchpvmpl8gj11yqly6j5m260mmxny9xxwx0dzwaya4k"
+   "commit": "86bdff68a106bc9d383fdab3bbf1ad4b703a52f0",
+   "sha256": "1rk8vza2g8gxybhjk10xj3pw9whc80cs9qv4avyv926g7dw60as9"
   },
   "stable": {
    "version": [
@@ -109580,8 +109931,8 @@
   "repo": "abo-abo/worf",
   "unstable": {
    "version": [
-    20210309,
-    1513
+    20210429,
+    1645
    ],
    "deps": [
     "ace-link",
@@ -109589,8 +109940,8 @@
     "swiper",
     "zoutline"
    ],
-   "commit": "fff12d4d3bb1ddf70cd0abb78aecd9133b367990",
-   "sha256": "1fbi0rv9pvh9bf72fjc3pfql9xfnw7zif0rsw0r2gn4sdn7202id"
+   "commit": "7ed797cacf8949928b97bc0fab0bf0f80931b055",
+   "sha256": "0yp2z5j7vqjfk7s3pid44y2ygccvpgqxazzly3z9q4swjw59p5j8"
   },
   "stable": {
    "version": [
@@ -109630,11 +109981,11 @@
   "repo": "pashinin/workgroups2",
   "unstable": {
    "version": [
-    20210402,
-    1450
+    20210426,
+    1223
    ],
-   "commit": "b182bf853ec408de014ba35527177c7cab90d620",
-   "sha256": "11rmv6wc7brw1la73y9dvmmx2pqaxxwm4087qkgr9vjg5h02k67d"
+   "commit": "1d9de2d23ff4ebb61964b399a19bdb460cadd32f",
+   "sha256": "18hh6v15fjixjain9br26jdysdph4c1bb3wq9q1wmq62wb9x8n9d"
   },
   "stable": {
    "version": [
@@ -109740,20 +110091,20 @@
   "repo": "bnbeckwith/writegood-mode",
   "unstable": {
    "version": [
-    20180525,
-    1343
+    20210418,
+    110
    ],
-   "commit": "b71757ec337e226909fb0422f0224e31acc71733",
-   "sha256": "038gliy6l931r02bf2dbhmp188sgk1rq46ngg9nhf5q5rkf3pi8p"
+   "commit": "ed42d918d98826ad88928b7af9f2597502afc6b0",
+   "sha256": "1nwngnddlkcvix7qx39fadab7hqzg8snb0k63kwpr8v57lyrm48z"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    4
    ],
-   "commit": "b71757ec337e226909fb0422f0224e31acc71733",
-   "sha256": "038gliy6l931r02bf2dbhmp188sgk1rq46ngg9nhf5q5rkf3pi8p"
+   "commit": "ed42d918d98826ad88928b7af9f2597502afc6b0",
+   "sha256": "1nwngnddlkcvix7qx39fadab7hqzg8snb0k63kwpr8v57lyrm48z"
   }
  },
  {
@@ -109894,11 +110245,11 @@
   "repo": "ag91/writer-word-goals",
   "unstable": {
    "version": [
-    20210405,
-    1155
+    20210503,
+    656
    ],
-   "commit": "77435ca396e7cc2685f4962e959070dbe1f70db1",
-   "sha256": "0kblcf1qfa06bwqm6pwwdmmpcipn3yjcjw09hmryipzhgf97zfxa"
+   "commit": "ef94f78b2c4e4fcf1a59d492637cbc84396cb032",
+   "sha256": "0xf2nvwvag21ds566r90rlf98hf80mz3zj2svhwmqrj6nm70p6z3"
   }
  },
  {
@@ -109979,26 +110330,26 @@
   "repo": "skeeto/x86-lookup",
   "unstable": {
    "version": [
-    20210409,
-    2313
+    20210412,
+    2022
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "5e194fdac8a1e12d87b8ed4edeb887eb5543c34d",
-   "sha256": "0f76qsb8hiryfgwkpymw5sicbmz1p48s0dxai1fmjlvaimrw56mm"
+   "commit": "1573d61cc4457737b94624598a891c837fb52c16",
+   "sha256": "16y13bwsfx4mm8p1n09f4443kh03hl7jvfvkbwdrm6dlbywiqq8m"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "609b2ba70dc5a246ac9b4b5f89eb5ef4331519bf",
-   "sha256": "19zgq7mcc3wx847xc911fibvphbsws99m2l3k54xdjp8mb5qfdzm"
+   "commit": "1573d61cc4457737b94624598a891c837fb52c16",
+   "sha256": "16y13bwsfx4mm8p1n09f4443kh03hl7jvfvkbwdrm6dlbywiqq8m"
   }
  },
  {
@@ -110099,11 +110450,11 @@
   "repo": "xahlee/xah-math-input",
   "unstable": {
    "version": [
-    20210403,
-    2312
+    20210419,
+    1833
    ],
-   "commit": "bc1ff04a11be7c3b728aa012324377305d48e087",
-   "sha256": "0q9civwf4mxapmq6hzrf3wimc7pfp28yipx007abchwimpdxvwws"
+   "commit": "6ccd3ca21aa71a2c1f831fabbdfc9e32c02e180d",
+   "sha256": "1bibdx0sawgsdzdiivy4x7rf4s5hnz2ypllwz9sk2fdmjyv8d08c"
   }
  },
  {
@@ -110560,11 +110911,7 @@
     1123
    ],
    "commit": "8d8e00352e6f7e86d38d9ea4330f6cb2380fb2ec",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-xref-rst/repository/archive.tar.gz?ref=8d8e00352e6f7e86d38d9ea4330f6cb2380fb2ec': HTTP error 503; retrying in 322 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-xref-rst/repository/archive.tar.gz?ref=8d8e00352e6f7e86d38d9ea4330f6cb2380fb2ec': HTTP error 503; retrying in 540 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-xref-rst/repository/archive.tar.gz?ref=8d8e00352e6f7e86d38d9ea4330f6cb2380fb2ec': HTTP error 503; retrying in 1079 ms\nwarning: unable to download 'https://gitlab.com/ideasman42/emacs-xref-rst/repository/archive.tar.gz?ref=8d8e00352e6f7e86d38d9ea4330f6cb2380fb2ec': HTTP error 503; retrying in 2268 ms\nerror: unable to download 'https://gitlab.com/ideasman42/emacs-xref-rst/repository/archive.tar.gz?ref=8d8e00352e6f7e86d38d9ea4330f6cb2380fb2ec': HTTP error 503\n"
-   ]
+   "sha256": "07i9x2f1mgfr3d5v507ln5z8mh59zdzqv53yyyrcbhvr7j9vi1p3"
   }
  },
  {
@@ -110859,8 +111206,17 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20210406,
-    156
+    20210424,
+    2033
+   ],
+   "commit": "d0abc17e3ddf42624d87fa6d2d3e1ba1dd175035",
+   "sha256": "19937d26gvj5ir1absb8rxyv35ac85xwvgb0nqcldmnqxqa2h66p"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
    ],
    "commit": "d8ac09e8cad7f67339e19c53e77da1cd0ff98d36",
    "sha256": "0wkrvhb5yhb38sf7w1njxij1x0pfxp56hn97j2bk4w58dz94fxir"
@@ -111108,11 +111464,11 @@
   "repo": "emacsorphanage/yascroll",
   "unstable": {
    "version": [
-    20210108,
-    1826
+    20210427,
+    645
    ],
-   "commit": "b9061340cc15a3ace3ca8c6e54512b481c71acf1",
-   "sha256": "1vr0p3q5pnnqpdfvnz29v8sjsldp22hghqb16gmj7l0n2xnlvyv3"
+   "commit": "bd20a61ab7cd610625137c051c7f15e7404b7829",
+   "sha256": "0mxl8qxj9vdr8cg9xkh2v901n8m1drk0wzf4di34vkgkmrlkigyg"
   },
   "stable": {
    "version": [
@@ -111192,14 +111548,13 @@
   "stable": {
    "version": [
     0,
-    23
+    24
    ],
    "deps": [
-    "s",
     "yasnippet"
    ],
-   "commit": "e5ebfcdb38eb79a6d6705107d07f7bab2e2b5c38",
-   "sha256": "18pcnjnqvcky6i49p38vy3ms5xiisn27vy47pc3vsgr3r2n87mqb"
+   "commit": "be823d7e1a1a46454d60a9f3dabb16b68b5dd853",
+   "sha256": "0ak0drxlg3m2v4ya5chpgl82rcl7ic2nmnybhpw1qk51mcmv643y"
   }
  },
  {
@@ -111942,11 +112297,11 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20201022,
-    955
+    20210412,
+    1428
    ],
-   "commit": "6f10653cc17b9c74150ac2f6833eaaaf55488398",
-   "sha256": "00mz9z181ppr6ad9614k24vlzi4b6flqzzwc1f8vlp7ixnk9i47g"
+   "commit": "2d0eb23e6b5c12b946f12c23803157605c90f02f",
+   "sha256": "0lpsqclk37nx8i9jfskbnvxrhvh6vaflgh63xijhv9ajx2iwpw0r"
   }
  },
  {
@@ -112012,14 +112367,14 @@
   "repo": "nnicandro/emacs-zmq",
   "unstable": {
    "version": [
-    20210402,
-    2340
+    20210424,
+    1943
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0a186a732b78aeb86599ea8123b36c4885789c7d",
-   "sha256": "0i6ghqwh35gnyz5b8ipbk030byibcmiy207pvplgszz39sjjjfp6"
+   "commit": "790033363cf0e78c616cfe117a2f681381e96f29",
+   "sha256": "0vssi5d02s7f9rhsgqnbh4ql2nvjcc4hsrmihwrk1ij50pn927yj"
   },
   "stable": {
    "version": [
@@ -112048,8 +112403,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "e795739ec182d217ffaf3c595819c308911540ee",
-   "sha256": "108bw2k255rkngfkp5iff1frsirc06j70ar1gcrh9lc3fcxdawlp"
+   "commit": "57d89fc1e17d94a8e9f3365b0d647a80520cc4a8",
+   "sha256": "0vbpc5lav8pw7caa4442z15a5s1l9wzjv68dgrbjnjvpn6yz3pay"
   }
  },
  {
@@ -112296,11 +112651,21 @@
     "s"
    ],
    "commit": "bee8196c5db26b75abc1359a5a7cb8a2b1f192ad",
-   "error": [
-    "exited abnormally with code 1\n",
-    "",
-    "warning: unknown setting 'experimental-features'\nwarning: unable to download 'https://gitlab.com/fvdbeek/emacs-zotero/repository/archive.tar.gz?ref=bee8196c5db26b75abc1359a5a7cb8a2b1f192ad': HTTP error 503; retrying in 324 ms\nwarning: unable to download 'https://gitlab.com/fvdbeek/emacs-zotero/repository/archive.tar.gz?ref=bee8196c5db26b75abc1359a5a7cb8a2b1f192ad': HTTP error 503; retrying in 632 ms\nwarning: unable to download 'https://gitlab.com/fvdbeek/emacs-zotero/repository/archive.tar.gz?ref=bee8196c5db26b75abc1359a5a7cb8a2b1f192ad': HTTP error 503; retrying in 1159 ms\nwarning: unable to download 'https://gitlab.com/fvdbeek/emacs-zotero/repository/archive.tar.gz?ref=bee8196c5db26b75abc1359a5a7cb8a2b1f192ad': HTTP error 503; retrying in 2278 ms\nerror: unable to download 'https://gitlab.com/fvdbeek/emacs-zotero/repository/archive.tar.gz?ref=bee8196c5db26b75abc1359a5a7cb8a2b1f192ad': HTTP error 503\n"
-   ]
+   "sha256": "1n0y6wap2yvqa75jf5yvdb9dy304c7i5g28g5lqj20ikj914wai7"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "ht",
+    "oauth",
+    "s"
+   ],
+   "commit": "bee8196c5db26b75abc1359a5a7cb8a2b1f192ad",
+   "sha256": "1n0y6wap2yvqa75jf5yvdb9dy304c7i5g28g5lqj20ikj914wai7"
   }
  },
  {
@@ -112318,8 +112683,8 @@
     "deferred",
     "request"
    ],
-   "commit": "a760009b9ecfa0b3362e77a6b44453821768d02e",
-   "sha256": "0vfdpgb0ln3xrx4i32mqisaj7qm2yx73rhagx6adr8hjw78gysfy"
+   "commit": "45961801f9e0350d7457d0d84c5004f63aed9070",
+   "sha256": "18hi6m2ngl9yz599q5bhifafi4vz1adc06bjl0bhb3rs62vbkwk2"
   },
   "stable": {
    "version": [
@@ -112417,14 +112782,14 @@
   "repo": "fourier/ztree",
   "unstable": {
    "version": [
-    20210409,
-    1841
+    20210415,
+    1947
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c9ad9136d52ca5a81475693864e255d29448f43f",
-   "sha256": "03i5pa3nfdz6g0yrdk7r2qcn679w0s85cc5kcmgrwlnhdzakgr80"
+   "commit": "f05677f9696e573c8c607e8876fb4a0cccbc491f",
+   "sha256": "1kav7xiarm0dgvgxf49qqcy2jp388b51x3qb92dyd3i73n6bk09j"
   }
  },
  {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This change updates recipes for emacs packages.
Changes generated by:
```
cd pkgs/applications/editors/emacs-modes
./update-melpa
./update-elpa
./update-org
```

Since the merge of #120354, it also fixes the following packages so they are no longer broken:

```
fennel-mode
geiser
geiser-chez
geiser-chibi
geiser-chicken
geiser-gambit
geiser-guile
geiser-mit
geiser-racket
gif-screencast
ligo-mode
mixed-pitch
modus-themes
oer-reveal
org-re-reveal
python-mode
recomplete
spell-fu
undo-fu
undo-fu-session
xref-rst
zotero
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
