### PR TITLE
init nimbo at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -428,6 +428,12 @@
     githubId = 782180;
     name = "Alex Vorobiev";
   };
+  alex-eyre = {
+    email = "A.Eyre@sms.ed.ac.uk";
+    github = "alex-eyre";
+    githubId = 38869148;
+    name = "Alex Eyre";
+  };
   algorith = {
     email = "dries_van_daele@telenet.be";
     name = "Dries Van Daele";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7249,6 +7249,12 @@
     githubId = 40049608;
     name = "Andy Chun";
   };
+  noreferences = {
+    email = "norkus@norkus.net";
+    github = "noreferences";
+    githubId = 13085275;
+    name = "Juozas Norkus";
+  };
   norfair = {
     email = "syd@cs-syd.eu";
     github = "NorfairKing";

--- a/pkgs/applications/misc/nimbo/default.nix
+++ b/pkgs/applications/misc/nimbo/default.nix
@@ -1,0 +1,28 @@
+{ lib, setuptools, boto3, requests, click, pyyaml, pydantic, buildPythonApplication
+, pythonOlder, fetchFromGitHub, awscli }:
+
+buildPythonApplication rec {
+  pname = "nimbo";
+  version = "0.2.4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "nimbo-sh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fs28s9ynfxrb4rzba6cmik0kl0q0vkpb4zdappsq62jqf960k24";
+  };
+
+  propagatedBuildInputs = [ setuptools boto3 awscli requests click pyyaml pydantic ];
+
+  # nimbo tests require an AWS instance
+  doCheck = false;
+  pythonImportsCheck = [ "nimbo" ];
+
+  meta = with lib; {
+    description = "Run machine learning jobs on AWS with a single command";
+    homepage = "https://github.com/nimbo-sh/nimbo";
+    license = licenses.bsl11;
+    maintainers = with maintainers; [ alex-eyre noreferences ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13286,6 +13286,8 @@ in
 
   ninja = callPackage ../development/tools/build-managers/ninja { };
 
+  nimbo = with python3Packages; callPackage ../applications/misc/nimbo { };
+
   gn = callPackage ../development/tools/build-managers/gn { };
 
   nixbang = callPackage ../development/tools/misc/nixbang {


### PR DESCRIPTION
###### Motivation for this change

Nimbo is a dead-simple wrapper for the AWS CLI that allows you to run jobs on AWS with a single command. All you need is a tiny config file, and Nimbo handles all the instance, environment, data, and IAM management. It also provides many useful commands to make it easier than ever to work with AWS from your terminal.

Apologies about the duplicate pull request (#121061), finals had me at the end of my rope (and I totally messed up that rebase heh)

I've tried to implement the feedback given on the previous PR, but if I've missed anything, and I probably have, I'll try and fix it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).