### PR TITLE
python3Packages.kmapper: fix tests

### DIFF
--- a/pkgs/development/python-modules/kmapper/default.nix
+++ b/pkgs/development/python-modules/kmapper/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , scikitlearn
 , numpy
 , scipy
@@ -17,9 +17,11 @@ buildPythonPackage rec {
   pname = "kmapper";
   version = "2.0.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3708d889f96f6bbe89c52000dd9378ca4c35638180ff894b64ebbdfcfe62aab2";
+  src = fetchFromGitHub {
+    owner = "scikit-tda";
+    repo = "kepler-mapper";
+    rev = "v${version}";
+    sha256 = "0djm27si2bn18khrbb7rwhflc5ma6g9smhikhk5i1apwn5avm6l4";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
sdist wasn't distributing conftest.py

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
