### PR TITLE
perceptualdiff: fix darwin support

### DIFF
--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchsvn, darwin, libtiff
 , libpng, zlib, libwebp, libraw, openexr, openjpeg
-, libjpeg, jxrlib, pkg-config }:
+, libjpeg, jxrlib, pkg-config
+, fixDarwinDylibNames }:
 
 stdenv.mkDerivation {
   pname = "freeimage";
@@ -17,7 +18,12 @@ stdenv.mkDerivation {
   prePatch = "rm -rf Source/Lib* Source/OpenEXR Source/ZLib";
   patches = [ ./unbundle.diff ];
 
-  nativeBuildInputs = [ pkg-config ] ++ lib.optional stdenv.isDarwin darwin.cctools;
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.cctools
+    fixDarwinDylibNames
+  ];
   buildInputs = [ libtiff libtiff.dev_private libpng zlib libwebp libraw openexr openjpeg libjpeg libjpeg.dev_private jxrlib ];
 
   postBuild = lib.optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/libraries/jxrlib/default.nix
+++ b/pkgs/development/libraries/jxrlib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3 }:
+{ lib, stdenv, fetchFromGitHub, python3, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   pname = "jxrlib";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       --replace '.so' '.dylib'
   '';
 
-  nativeBuildInputs = [ python3 ];
+  nativeBuildInputs = [ python3 ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   strictDeps = true;
 

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, buildPackages
 , fetchFromGitHub
 , zlib
 , ilmbase

--- a/pkgs/tools/graphics/perceptualdiff/default.nix
+++ b/pkgs/tools/graphics/perceptualdiff/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A program that compares two images using a perceptually based image metric";
     homepage = "https://github.com/myint/perceptualdiff";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ uri-canva ];
     platforms = platforms.x86;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix `perceptualdiff` on darwin.

Closes #121550.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
