### PR TITLE
Update ledger-autosync

### DIFF
--- a/pkgs/applications/office/ledger-autosync/default.nix
+++ b/pkgs/applications/office/ledger-autosync/default.nix
@@ -2,15 +2,23 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ledger-autosync";
-  version = "1.0.2";
+  version = "unstable-2021-04-01";
 
-# no tests included in PyPI tarball
+  # no tests included in PyPI tarball
   src = fetchFromGitHub {
     owner = "egh";
     repo = "ledger-autosync";
-    rev = "v${version}";
-    sha256 = "0sh32jcf8iznnbg1kqlrswbzfmn4h3gkw32q20xwxzz4935pz1qk";
+    rev = "0b674c57c833f75b1a36d8caf78e1567c8e2180c";
+    sha256 = "0q404gr85caib5hg83cnmgx4684l72w9slxyxrwsiwhlf7gm443q";
   };
+
+  patches = [
+    # ledger-autosync specifies an URL for its ofxparse
+    # dependency. This patch removes the URL to only use the
+    # `ofxparse` name. This works because nixpkgs' version of ofxparse
+    # is more recent than the latest release.
+    ./fix-ofxparse-dependency.patch
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     asn1crypto

--- a/pkgs/applications/office/ledger-autosync/fix-ofxparse-dependency.patch
+++ b/pkgs/applications/office/ledger-autosync/fix-ofxparse-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index eda6db5..ed6b90b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -38,7 +38,7 @@ setup(
+     install_requires=[
+         'setuptools>=26',
+         'ofxclient',
+-        "ofxparse @ https://github.com/jseutter/ofxparse/tarball/3236cfd96434feb6bc79a8b66f3400f18e2ad3c4"
++        'ofxparse'
+     ],
+ 
+     extras_require={

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -864,6 +864,20 @@ self: super: {
   snap-templates = doJailbreak super.snap-templates; # https://github.com/snapframework/snap-templates/issues/22
   swagger2 = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontHaddock (dontCheck super.swagger2) else super.swagger2;
 
+  # hledger-lib requires the latest version of pretty-simple
+  hledger-lib = appendPatch super.hledger-lib
+    # This patch has been merged but not released yet:
+    # https://github.com/simonmichael/hledger/pull/1512. It is
+    # important for ledger-autosync test suite:
+    # https://github.com/egh/ledger-autosync/issues/123
+    (pkgs.fetchpatch {
+      name   = "hledger-properly-escape-quotes-csv.patch";
+      url    = "https://github.com/simonmichael/hledger/commit/c9a72e1615e2ddc2824f2e248456e1042eb31e1d.patch";
+      sha256 = "10knvrd5bl9nrmi27i0pm82sfr64jy04xgbjp228qywyijpr3pqv";
+      includes = [ "Hledger/Read/CsvReader.hs" ];
+      stripLen = 1;
+    });
+
   # Copy hledger man pages from data directory into the proper place. This code
   # should be moved into the cabal2nix generator.
   hledger = overrideCabal super.hledger (drv: {

--- a/pkgs/development/python-modules/ofxparse/default.nix
+++ b/pkgs/development/python-modules/ofxparse/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , six
 , beautifulsoup4
 , lxml
@@ -8,11 +8,15 @@
 
 buildPythonPackage rec {
   pname = "ofxparse";
-  version = "0.20";
+  version = "unstable-2020-02-05";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0zn3grc6xhgzcc81qc3dxkkwk731cjjqqhb46smw12lk09cdnigb";
+  # The newer changes haven't been released yet and ledger-autosync
+  # depends on them:
+  src = fetchFromGitHub {
+    owner = "jseutter";
+    repo = "ofxparse";
+    rev = "3236cfd96434feb6bc79a8b66f3400f18e2ad3c4";
+    sha256 = "1rkp174102q7hwjrg3na0qnfd612xb3r360b9blkbprjhzxy7gr7";
   };
 
   propagatedBuildInputs = [ six beautifulsoup4 lxml ];


### PR DESCRIPTION
###### Motivation for this change

- ledger-autosync doesn't build anymore
- it's version is out of date (but more [recent commits are unreleased yet](https://github.com/egh/ledger-autosync/issues/122))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
