### PR TITLE
maturin: fix passthru test

### DIFF
--- a/pkgs/development/tools/rust/maturin/pyo3-test/generic.nix
+++ b/pkgs/development/tools/rust/maturin/pyo3-test/generic.nix
@@ -27,7 +27,7 @@ python.pkgs.buildPythonPackage rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src patches;
     name = "${pname}-${version}";
-    hash = "sha256-//TmozgWy9zrSpMKX92XdHj4fw/T1Elfgn4YhhR7ot0=";
+    hash = "sha256-u3L9nXHKILznyZTgxdvZyOCQZFZhuADrtI7zXYQzrbE=";
   };
 
   patches = [ ./Cargo.lock.patch ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Seems like this was affected by vendoring permission normalization,
see #121259.

@ofborg build maturin python3Packages.setuptools-rust

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
