### PR TITLE
lightworks: 14.0.0 -> 2021.2

### DIFF
--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, dpkg, makeWrapper, buildFHSUserEnv
 , gtk3, gdk-pixbuf, cairo, libjpeg_original, glib, pango, libGLU
-, nvidia_cg_toolkit, zlib, openssl, portaudio
+, libGL, nvidia_cg_toolkit, zlib, openssl, libuuid , alsaLib, udev
 }:
 let
   fullPath = lib.makeLibraryPath [
@@ -11,22 +11,25 @@ let
     libjpeg_original
     glib
     pango
+    libGL
     libGLU
     nvidia_cg_toolkit
     zlib
     openssl
-    portaudio
+    libuuid
+    alsaLib
+    udev
   ];
 
   lightworks = stdenv.mkDerivation rec {
-    version = "14.0.0";
+    version = "2021.2";
     pname = "lightworks";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
-          url = "http://downloads.lwks.com/v14/lwks-14.0.0-amd64.deb";
-          sha256 = "66eb9f9678d979db76199f1c99a71df0ddc017bb47dfda976b508849ab305033";
+          url = "https://cdn.lwks.com/releases/2021.2/lightworks_2021.2_r128258.deb";
+          sha256 = "sha256-IRzoysfGh/P+Xr50+cIjjaKuxdSzgCmJDICFtekfE3Y=";
         }
       else throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";
 

--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -85,7 +85,7 @@ in buildFHSUserEnv {
     description = "Professional Non-Linear Video Editor";
     homepage = "https://www.lwks.com/";
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.antonxy ];
+    maintainers = with lib.maintainers; [ antonxy vojta001 ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -22,14 +22,15 @@ let
   ];
 
   lightworks = stdenv.mkDerivation rec {
-    version = "2021.2";
+    version = "2021.2.1";
+    rev = "128456";
     pname = "lightworks";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
-          url = "https://cdn.lwks.com/releases/2021.2/lightworks_2021.2_r128258.deb";
-          sha256 = "sha256-IRzoysfGh/P+Xr50+cIjjaKuxdSzgCmJDICFtekfE3Y=";
+          url = "https://cdn.lwks.com/releases/${version}/lightworks_${lib.versions.majorMinor version}_r${rev}.deb";
+          sha256 = "sha256-GkTg43IUF1NgEm/wT9CZw68Dw/R2BYBU/F4bsCxQowQ=";
         }
       else throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24412,9 +24412,7 @@ in
 
   liferea = callPackage ../applications/networking/newsreaders/liferea { };
 
-  lightworks = callPackage ../applications/video/lightworks {
-    portaudio = portaudio2014;
-  };
+  lightworks = callPackage ../applications/video/lightworks { };
 
   lingot = callPackage ../applications/audio/lingot { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Fixes #80535. Supersedes #83702.

###### Motivation for this change
The old version is broken in nixpkgs, because libjpeg got updated in the meantime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
