### PR TITLE
haskellPackages.hnix: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -197,7 +197,19 @@ self: super: {
   digit = doJailbreak super.digit;
 
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`
-  hnix = generateOptparseApplicativeCompletion "hnix" (dontCheck super.hnix);
+  hnix = generateOptparseApplicativeCompletion "hnix"
+    (overrideCabal super.hnix (drv: {
+      doCheck = false;
+      prePatch = ''
+        # fix encoding problems when patching
+        ${pkgs.dos2unix}/bin/dos2unix hnix.cabal
+      '' + (drv.prePatch or "");
+      patches = [
+        # support ref-tf in hnix 0.12.0.1, can be removed after
+        # https://github.com/haskell-nix/hnix/pull/918
+        ./patches/hnix-ref-tf-0.5-support.patch
+      ] ++ (drv.patches or []);
+    }));
 
   # Fails for non-obvious reasons while attempting to use doctest.
   search = dontCheck super.search;

--- a/pkgs/development/haskell-modules/patches/hnix-ref-tf-0.5-support.patch
+++ b/pkgs/development/haskell-modules/patches/hnix-ref-tf-0.5-support.patch
@@ -1,0 +1,34 @@
+diff '--color=auto' '--color=never' -r --unified hnix-0.12.0.1/hnix.cabal hnix-patched/hnix.cabal
+--- hnix-0.12.0.1/hnix.cabal	2001-09-09 03:46:40.000000000 +0200
++++ hnix-patched/hnix.cabal	2021-05-05 12:07:38.388267353 +0200
+@@ -430,7 +430,7 @@
+     , parser-combinators >= 1.0.1 && < 1.3
+     , prettyprinter >= 1.7.0 && < 1.8
+     , process >= 1.6.3 && < 1.7
+-    , ref-tf >= 0.4.0 && < 0.5
++    , ref-tf >= 0.5
+     , regex-tdfa >= 1.2.3 && < 1.4
+     , scientific >= 0.3.6 && < 0.4
+     , semialign >= 1 && < 1.2
+diff '--color=auto' '--color=never' -r --unified hnix-0.12.0.1/src/Nix/Fresh.hs hnix-patched/src/Nix/Fresh.hs
+--- hnix-0.12.0.1/src/Nix/Fresh.hs	2001-09-09 03:46:40.000000000 +0200
++++ hnix-patched/src/Nix/Fresh.hs	2021-05-05 12:07:45.841267497 +0200
+@@ -65,18 +65,3 @@
+ 
+ runFreshIdT :: Functor m => Var m i -> FreshIdT i m a -> m a
+ runFreshIdT i m = runReaderT (unFreshIdT m) i
+-
+--- Orphan instance needed by Infer.hs and Lint.hs
+-
+--- Since there's no forking, it's automatically atomic.
+-instance MonadAtomicRef (ST s) where
+-  atomicModifyRef r f = do
+-    v <- readRef r
+-    let (a, b) = f v
+-    writeRef r a
+-    return b
+-  atomicModifyRef' r f = do
+-    v <- readRef r
+-    let (a, b) = f v
+-    writeRef r $! a
+-    return b


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
