### PR TITLE
hyper-haskell: 0.1.0.2 -> 0.2.3.0, fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1806,4 +1806,8 @@ self: super: {
   ihaskell-display = doJailbreak super.ihaskell-display;
   ihaskell-basic = doJailbreak super.ihaskell-basic;
 
+  # too strict bounds on QuickCheck
+  # https://github.com/HeinrichApfelmus/hyper-haskell/issues/42
+  hyper-extra = doJailbreak super.hyper-extra;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7111,8 +7111,6 @@ broken-packages:
   - hylolib
   - hylotab
   - hyloutils
-  - hyper-extra
-  - hyper-haskell-server
   - hyperdrive
   - hyperfunctions
   - hyperion

--- a/pkgs/development/tools/haskell/hyper-haskell/default.nix
+++ b/pkgs/development/tools/haskell/hyper-haskell/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, jshon, electron_10
+{ lib, stdenvNoCC, fetchFromGitHub, jshon, electron_10
 , runtimeShell, hyper-haskell-server, extra-packages ? [] }:
 
 let
   binPath = lib.makeBinPath ([ hyper-haskell-server ] ++ extra-packages);
   electron = electron_10;
-in stdenv.mkDerivation rec {
+in stdenvNoCC.mkDerivation rec {
   pname = "hyper-haskell";
   version = "0.2.3.0";
 
@@ -17,19 +17,21 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = extra-packages;
 
-  buildCommand = ''
+  dontBuild = true;
+
+  installPhase = ''
     mkdir -p $out/bin $out/share/hyper-haskell/worksheets $out/share/applications $out/share/icons/hicolor/scalable/apps $out/share/mime/packages
 
     # Electron app
-    cp -R $src/app $out
+    cp -R app $out
 
     # Desktop Launcher
-    cp $src/resources/hyper-haskell.desktop $out/share/applications/hyper-haskell.desktop
-    cp $src/resources/icons/icon.svg $out/share/icons/hicolor/scalable/apps/hyper-haskell.svg
-    cp $src/resources/shared-mime-info.xml $out/share/mime/packages/hyper-haskell.xml
+    cp resources/hyper-haskell.desktop $out/share/applications/hyper-haskell.desktop
+    cp resources/icons/icon.svg $out/share/icons/hicolor/scalable/apps/hyper-haskell.svg
+    cp resources/shared-mime-info.xml $out/share/mime/packages/hyper-haskell.xml
 
     # install example worksheets with backend set to nix
-    for worksheet in "$src/worksheets/"*.hhs; do
+    for worksheet in "worksheets/"*.hhs; do
       ${jshon}/bin/jshon -e settings -s nix -i packageTool -p < $worksheet > $out/share/hyper-haskell/worksheets/`basename $worksheet`
     done
 

--- a/pkgs/development/tools/haskell/hyper-haskell/default.nix
+++ b/pkgs/development/tools/haskell/hyper-haskell/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, jshon, electron_3
+{ lib, stdenv, fetchFromGitHub, jshon, electron_10
 , runtimeShell, hyper-haskell-server, extra-packages ? [] }:
 
 let
   binPath = lib.makeBinPath ([ hyper-haskell-server ] ++ extra-packages);
-  electron = electron_3;
+  electron = electron_10;
 in stdenv.mkDerivation rec {
   pname = "hyper-haskell";
-  version = "0.1.0.2";
+  version = "0.2.3.0";
 
   src = fetchFromGitHub {
     owner = "HeinrichApfelmus";
     repo = "hyper-haskell";
     rev = "v${version}";
-    sha256 = "1k38h7qx12z7463z8466pji0nwfkp4qkg7q83kns2mzmwmw5jnmb";
+    sha256 = "1nmkry4wh6a2dy98fcs81mq2p7zhxp1k0f4m3szr6fm3j1zwrd43";
   };
 
   propagatedBuildInputs = extra-packages;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Remaining issue is that `hyper-haskell` doesn't use the nix backend by default, so it doesn't find the server by default. It is relatively easy to change this in the workspace settings, so I can't be bothered to find out where you can patch the default value in the source currently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
