### PR TITLE
nixos/keycloak: Revert databaseUsername behavior and document custom local database use

### DIFF
--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -168,10 +168,9 @@ in
       type = lib.types.str;
       default = "keycloak";
       description = ''
-        Username to use when connecting to the database.
-        This is also used for automatic provisioning of the database.
-        Changing this after the initial installation doesn't delete the
-        old user and can cause further problems.
+        Username to use when connecting to an external or manually
+        provisioned database; has no effect when a local database is
+        automatically provisioned.
       '';
     };
 
@@ -588,8 +587,8 @@ in
             PSQL=${config.services.postgresql.package}/bin/psql
 
             db_password="$(<'${cfg.databasePasswordFile}')"
-            $PSQL -tAc "SELECT 1 FROM pg_roles WHERE rolname='${cfg.databaseUsername}'" | grep -q 1 || $PSQL -tAc "CREATE ROLE ${cfg.databaseUsername} WITH LOGIN PASSWORD '$db_password' CREATEDB"
-            $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = 'keycloak'" | grep -q 1 || $PSQL -tAc 'CREATE DATABASE "keycloak" OWNER "${cfg.databaseUsername}"'
+            $PSQL -tAc "SELECT 1 FROM pg_roles WHERE rolname='keycloak'" | grep -q 1 || $PSQL -tAc "CREATE ROLE keycloak WITH LOGIN PASSWORD '$db_password' CREATEDB"
+            $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = 'keycloak'" | grep -q 1 || $PSQL -tAc 'CREATE DATABASE "keycloak" OWNER "keycloak"'
           '';
         };
 
@@ -607,9 +606,9 @@ in
             set -eu
 
             db_password="$(<'${cfg.databasePasswordFile}')"
-            ( echo "CREATE USER IF NOT EXISTS '${cfg.databaseUsername}'@'localhost' IDENTIFIED BY '$db_password';"
+            ( echo "CREATE USER IF NOT EXISTS 'keycloak'@'localhost' IDENTIFIED BY '$db_password';"
               echo "CREATE DATABASE keycloak CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
-              echo "GRANT ALL PRIVILEGES ON keycloak.* TO '${cfg.databaseUsername}'@'localhost';"
+              echo "GRANT ALL PRIVILEGES ON keycloak.* TO 'keycloak'@'localhost';"
             ) | ${config.services.mysql.package}/bin/mysql -N
           '';
         };

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -171,6 +171,12 @@ in
         Username to use when connecting to an external or manually
         provisioned database; has no effect when a local database is
         automatically provisioned.
+
+        To use this with a local database, set <xref
+        linkend="opt-services.keycloak.databaseCreateLocally" /> to
+        <literal>false</literal> and create the database and user
+        manually. The database should be called
+        <literal>keycloak</literal>.
       '';
     };
 

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -20,6 +20,7 @@ let
           services.keycloak = {
             enable = true;
             inherit frontendUrl databaseType initialAdminPassword;
+            databaseUsername = "bogus";
             databasePasswordFile = pkgs.writeText "dbPassword" "wzf6vOCbPp6cqTH";
           };
           environment.systemPackages = with pkgs; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Revert the change introduced in #117072: it's broken, since it doesn't configure the proper database username in keycloak when provisioning a local database with a custom username. Its intended behavior is also potentially confusing and dangerous, so rather than fixing it, let's revert to the old one and document how to use a custom local database instead. Also, change the test to make sure this doesn't happen again.

cc @em0lar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
