### PR TITLE
t-rec: init at 0.5.2

### DIFF
--- a/pkgs/misc/t-rec/default.nix
+++ b/pkgs/misc/t-rec/default.nix
@@ -1,0 +1,34 @@
+{ lib, imagemagick, ffmpeg, rustPlatform, fetchFromGitHub, makeWrapper }:
+
+let
+  binPath = lib.makeBinPath [
+    imagemagick
+    ffmpeg
+  ];
+in
+rustPlatform.buildRustPackage rec {
+  pname = "t-rec";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "sassman";
+    repo = "t-rec-rs";
+    rev = "v${version}";
+    sha256 = "InArrBqfhDrsonjmCIPTBVOA/s2vYml9Ay6cdrKLd7c=";
+  };
+
+  buildInputs = [ imagemagick ];
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram "$out/bin/t-rec" --prefix PATH : "${binPath}"
+  '';
+
+  cargoSha256 = "4gwfrC65YlXV6Wu2ninK1TvMNUkY1GstVYPr0FK+xLU=";
+
+  meta = with lib; {
+    description = "Blazingly fast terminal recorder that generates animated gif images for the web written in rust";
+    homepage = "https://github.com/sassman/t-rec-rs";
+    license = with licenses; [ gpl3Only ];
+    maintainers = [ maintainers.hoverbear ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26424,6 +26424,8 @@ in
 
   lavalauncher = callPackage ../applications/misc/lavalauncher { };
 
+  t-rec = callPackage ../misc/t-rec { };
+
   ulauncher = callPackage ../applications/misc/ulauncher { };
 
   twinkle = qt5.callPackage ../applications/networking/instant-messengers/twinkle { };


### PR DESCRIPTION
###### Motivation for this change

Introduce [`t-rec`](https://github.com/sassman/t-rec-rs), a terminal recorder by @sassman.

Usage:

```bash
nix run .#t-rec
```

Upon exit, `t-rec` will save recordings of the session to disk in GIF
and MP4.

Here are some samples:

![t-rec](https://user-images.githubusercontent.com/130903/117020332-32681880-acab-11eb-81e3-7204244e52b7.gif)

https://user-images.githubusercontent.com/130903/117020346-34ca7280-acab-11eb-9767-86791440b6e5.mp4



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
