### PR TITLE
opera: 68.0.3618.36 → 76.0.4017.94

### DIFF
--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -30,6 +30,7 @@
 , libnotify
 , libpulseaudio
 , libuuid
+, libxshmfence
 , mesa
 , nspr
 , nss
@@ -49,11 +50,11 @@ let
 in stdenv.mkDerivation rec {
 
   pname = "opera";
-  version = "68.0.3618.63";
+  version = "76.0.4017.94";
 
   src = fetchurl {
     url = "${mirror}/${version}/linux/${pname}-stable_${version}_amd64.deb";
-    sha256 = "1643043ywz94x2yr7xyw7krfq53iwkr8qxlbydzq6zb2zina7jxd";
+    sha256 = "sha256-vjSfzkl1jIQ9P1ARDa0eOuD8CmKHIEZ+IwMB2wIVjE8=";
   };
 
   unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";
@@ -94,6 +95,7 @@ in stdenv.mkDerivation rec {
     libnotify
     libuuid
     libxcb
+    libxshmfence
     mesa
     nspr
     nss


### PR DESCRIPTION
###### Motivation for this change

Update Opera from 68.0.3618.36 to 76.0.4017.94 and adds new required dependency on libxshmfence.

Supersedes #104250

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
