### PR TITLE
esphome: 1.16.0 -> 1.17.1

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -1,35 +1,59 @@
-{ lib, python3, platformio, esptool, git, protobuf3_12, fetchpatch }:
+{ lib
+, python3
+, fetchFromGitHub
+, platformio
+, esptool
+, git
+}:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-      protobuf = super.protobuf.override {
-        protobuf = protobuf3_12;
-      };
-    };
-  };
-
-in python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "1.16.0";
+  version = "1.17.1";
 
-  src = python.pkgs.fetchPypi {
-    inherit pname version;
-    sha256 = "0pvwzkdcpjqdf7lh1k3xv1la5v60lhjixzykapl7f2xh71fbm144";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0483glwi155ca1wnffwhmwn17d7kwk4hjwmckb8zs197rfqmb55v";
   };
 
+  postPatch = ''
+    # remove all version pinning (E.g tornado==5.1.1 -> tornado)
+    sed -i -e "s/==[0-9.]*//" requirements.txt
+
+    # drop coverage testing
+    sed -i '/--cov/d' pytest.ini
+
+    # migrate use of hypothesis internals to be compatible with hypothesis>=5.32.1
+    # https://github.com/esphome/issues/issues/2021
+    substituteInPlace tests/unit_tests/strategies.py --replace \
+      "@st.defines_strategy_with_reusable_values" \
+      "@st.defines_strategy(force_reusable_values=True)"
+  '';
+
+  # Remove esptool and platformio from requirements
   ESPHOME_USE_SUBPROCESS = "";
 
-  propagatedBuildInputs = with python.pkgs; [
-    voluptuous pyyaml paho-mqtt colorlog colorama
-    tornado protobuf tzlocal pyserial ifaddr
-    protobuf click
+  # esphome has optional dependencies it does not declare, they are
+  # loaded when certain config blocks are used, like `font`, `image`
+  # or `animation`.
+  # They have validation functions like:
+  # - validate_cryptography_installed
+  # - validate_pillow_installed
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    colorama
+    cryptography
+    ifaddr
+    paho-mqtt
+    pillow
+    protobuf
+    pyserial
+    pyyaml
+    tornado
+    tzlocal
+    voluptuous
   ];
-
-  # remove all version pinning (E.g tornado==5.1.1 -> tornado)
-  postPatch = ''
-    sed -i -e "s/==[0-9.]*//" requirements.txt
-  '';
 
   makeWrapperArgs = [
     # platformio is used in esphomeyaml/platformio_api.py
@@ -39,16 +63,24 @@ in python.pkgs.buildPythonApplication rec {
     "--set ESPHOME_USE_SUBPROCESS ''"
   ];
 
-  # Platformio will try to access the network
-  # Instead, run the executable
-  checkPhase = ''
+  checkInputs = with python3.pkgs; [
+    hypothesis
+    mock
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  postCheck = ''
     $out/bin/esphome --help > /dev/null
   '';
 
   meta = with lib; {
     description = "Make creating custom firmwares for ESP32/ESP8266 super easy";
     homepage = "https://esphome.io/";
-    license = licenses.mit;
+    license = with licenses; [
+      mit # The C++/runtime codebase of the ESPHome project (file extensions .c, .cpp, .h, .hpp, .tcc, .ino)
+      gpl3Only # The python codebase and all other parts of this codebase
+    ];
     maintainers = with maintainers; [ globin elseym hexa ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/esphome/esphome/releases/tag/v1.17.0
https://github.com/esphome/esphome/releases/tag/v1.16.2
https://github.com/esphome/esphome/releases/tag/v1.16.1

Update licensing, enable test suite.

<s>Not tested against an actual device yet.</s>

```
[17:56:18][I][app:105]: ESPHome version 1.17.0 compiled on May  4 2021, 17:54:20
[...]
[17:56:31][D][api.connection:617]: Client 'Home Assistant 2021.4.6 (172.23.42.122)' connected successfully!
[...]
[17:57:05][D][switch:029]: '208393_relay' Toggling ON.
[17:57:06][D][switch:045]: '208393_relay': Sending state ON
[17:57:06][D][light:265]: 'led' Setting:
[17:57:06][D][light:274]:   State: ON
[17:57:06][D][light:304]:   Transition Length: 1.0s
[17:57:07][D][switch:029]: '208393_relay' Toggling OFF.
[17:57:07][D][switch:045]: '208393_relay': Sending state OFF
[17:57:07][D][light:265]: 'led' Setting:
[17:57:07][D][light:274]:   State: OFF
[17:57:07][D][light:304]:   Transition Length: 1.0s
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
