### PR TITLE
secp256k1: (unstable-)2020-08-16 -> unstable-2021-06-06

### DIFF
--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -1,45 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, jdk
-
-# Enable ECDSA pubkey recovery module
-, enableRecovery ? true
-
-# Enable ECDH shared secret computation (disabled by default because it is
-# experimental)
-, enableECDH ? false
-
-# Enable libsecp256k1_jni (disabled by default because it requires a jdk,
-# which is a large dependency)
-, enableJNI ? false
-
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
 }:
-
-let inherit (lib) optionals; in
 
 stdenv.mkDerivation {
   pname = "secp256k1";
 
   # I can't find any version numbers, so we're just using the date of the
   # last commit.
-  version = "2020-08-16";
+  version = "unstable-2021-06-06";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "secp256k1";
-    rev = "670cdd3f8be25f81472b2d16dcd228b0d24a5c45";
-    sha256 = "0ak2hrr0wznl5d9s905qwn5yds7k22i28d2jp957l4a8yf8cqv3s";
+    rev = "7973576f6e3ab27d036a09397152b124d747f4ae";
+    sha256 = "0vjk55dv0mkph4k6bqgkykmxn05ngzvhc4rzjnvn33xzi8dzlvah";
   };
-
-  buildInputs = optionals enableJNI [ jdk ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags =
-    [ "--enable-benchmark=no" "--enable-tests=yes" "--enable-exhaustive-tests=no" ] ++
-    optionals enableECDH [ "--enable-module-ecdh" "--enable-experimental" ] ++
-    optionals enableRecovery [ "--enable-module-recovery" ] ++
-    optionals enableJNI [ "--enable-jni" ];
+  configureFlags = [
+    "--enable-benchmark=no"
+    "--enable-exhaustive-tests=no"
+    "--enable-experimental"
+    "--enable-module-ecdh"
+    "--enable-module-recovery"
+    "--enable-module-schnorrsig"
+    "--enable-tests=yes"
+  ];
 
   doCheck = true;
+
   checkPhase = "./tests";
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22703,10 +22703,7 @@ in
 
   jnetmap = callPackage ../applications/networking/jnetmap {};
 
-  libbitcoin = callPackage ../tools/misc/libbitcoin/libbitcoin.nix {
-    secp256k1 = secp256k1.override { enableECDH = true; };
-  };
-
+  libbitcoin = callPackage ../tools/misc/libbitcoin/libbitcoin.nix { };
   libbitcoin-protocol = callPackage ../tools/misc/libbitcoin/libbitcoin-protocol.nix { };
   libbitcoin-client   = callPackage ../tools/misc/libbitcoin/libbitcoin-client.nix { };
   libbitcoin-network  = callPackage ../tools/misc/libbitcoin/libbitcoin-network.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- update to latest
- use sane defaults
- drop JNI option which is not available anymore bitcoin-core/secp256k1#682

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
