### PR TITLE
inkscape/textext: init at 1.8.1

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -3,6 +3,7 @@
 , runCommand
 , inkcut
 , callPackage
+, texlive
 }:
 
 {
@@ -43,4 +44,8 @@
     mkdir -p $out/share/inkscape/extensions
     cp ${inkcut}/share/inkscape/extensions/* $out/share/inkscape/extensions
   '');
+  textext = callPackage ./extensions/textext {
+    pdflatex = texlive.combined.scheme-basic;
+    lualatex = texlive.combined.scheme-basic;
+  };
 }

--- a/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
@@ -1,0 +1,125 @@
+{ lib
+, writeScript
+, fetchFromGitHub
+, substituteAll
+, inkscape
+, pdflatex
+, lualatex
+, python3
+, wrapGAppsHook
+, gobject-introspection
+, gtk3
+, gtksourceview3
+}:
+
+let
+  launchScript = writeScript "launch.sh" ''
+    cd $(dirname $0)
+    ./__main__.py $*
+  '';
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "textext";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "textext";
+    repo = "textext";
+    rev = version;
+    sha256 = "sha256-Qzd39X0X3DdwZ3pIIGvEbNjl6dxjDf3idzjwCkp3WRg=";
+  };
+
+  patches = [
+    # Make sure we can point directly to pdflatex in the extension,
+    # instead of relying on the PATH (which might not have it)
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit pdflatex lualatex;
+    })
+
+    # Since we are wrapping the extension, we need to change the interpreter
+    # from Python to Bash.
+    ./interpreter.patch
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    gtksourceview3
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.pygobject3
+    # lxml, cssselect and numpy are required by inkex but is not inherited from inkscape when we use custom Python interpreter:
+    python3.pkgs.lxml
+    python3.pkgs.cssselect
+    python3.pkgs.numpy
+  ];
+
+  # strictDeps do not play nicely with introspection setup hooks.
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  # TexText doesn’t have a 'bdist_wheel' target.
+  dontUseSetuptoolsBuild = true;
+
+  # TexText doesn’t have a 'test' target.
+  doCheck = false;
+
+  # Avoid wrapping two times by just using Python’s wrapping.
+  dontWrapGApps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir dist
+
+    # source/setup.py creates a config file in HOME (that we ignore)
+    mkdir buildhome
+    export HOME=$(pwd)/buildhome
+
+    python setup.py \
+      --inkscape-executable=${inkscape}/bin/inkscape \
+      --pdflatex-executable=${pdflatex}/bin/pdflatex \
+      --lualatex-executable=${lualatex}/bin/lualatex \
+      --inkscape-extensions-path=dist
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/inkscape/extensions
+    cp -r dist/textext $out/share/inkscape/extensions
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # Prepare for wrapping
+    chmod +x "$out/share/inkscape/extensions/textext/__main__.py"
+    sed -i '1i#!/usr/bin/env python3' "$out/share/inkscape/extensions/textext/__main__.py"
+
+    # Include gobject-introspection typelibs in the wrapper.
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postFixup = ''
+    # Wrap the project so it can find runtime dependencies.
+    wrapPythonProgramsIn "$out/share/inkscape/extensions/textext" "$out $pythonPath"
+    cp ${launchScript} $out/share/inkscape/extensions/textext/launch.sh
+  '';
+
+  meta = with lib; {
+    description = "Re-editable LaTeX graphics for Inkscape";
+    homepage = "https://textext.github.io/textext/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.raboof ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/inkscape/extensions/textext/fix-paths.patch
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/fix-paths.patch
@@ -1,0 +1,19 @@
+--- a/textext/base.py
++++ b/textext/base.py
+@@ -95,7 +95,16 @@ class TexText(inkex.EffectExtension):
+     def __init__(self):
+ 
+         self.config = Settings(directory=defaults.textext_config_path)
++        # config.json is stored in ~/.config/inkscape/extensions/textext for
++        # the next invocation, but since that next invocation could be using
++        # a different latex derivation, make sure we overwrite the executable
++        # paths with updated ones:
++        self.config["pdflatex-executable"] = "@pdflatex@/bin/pdflatex";
++        self.config["lualatex-executable"] = "@lualatex@/bin/lualatex";
+         self.cache = Cache(directory=defaults.textext_config_path)
++        if "requirements_checker" in self.cache.values:
++            self.cache["requirements_checker"]["available_tex_to_pdf_converters"]["pdflatex"] = "@pdflatex@/bin/pdflatex";
++            self.cache["requirements_checker"]["available_tex_to_pdf_converters"]["lualatex"] = "@lualatex@/bin/lualatex";
+         previous_exit_code = self.cache.get("previous_exit_code", None)
+ 
+         if previous_exit_code is None:

--- a/pkgs/applications/graphics/inkscape/extensions/textext/interpreter.patch
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/interpreter.patch
@@ -1,0 +1,10 @@
+--- a/textext/textext.inx
++++ b/textext/textext.inx
+@@ -8,6 +8,6 @@
+     </effects-menu>
+   </effect>
+   <script>
+-    <command location="inx" interpreter="python">__main__.py</command>
++    <command location="inx" interpreter="shell">launch.sh</command>
+   </script>
+ </inkscape-extension>


### PR DESCRIPTION
###### Motivation for this change

Introduce the 'textext' extension for including LaTeX graphics in Inkscape

Test it with `nix-shell -p "inkscape-with-extensions.override { inkscapeExtensions = [ inkscape-extensions.textext ]; }" --run inkscape`

Alternative approach to #100565

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).