### PR TITLE
tnat64: init at 0.05

### DIFF
--- a/pkgs/tools/networking/tnat64/default.nix
+++ b/pkgs/tools/networking/tnat64/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "tnat64";
+  version = "0.05";
+
+  src = fetchFromGitHub {
+    owner = "andrewshadura";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "07lmzidbrd3aahk2jvv93cic9gf36pwmgfd63gmy6hjkxf9a6fw9";
+  };
+
+  postPatch = ''
+    # Fix usage of deprecated sys_errlist
+    substituteInPlace tnat64.c --replace 'sys_errlist[errno]' 'strerror(errno)'
+  '';
+
+  configureFlags = [ "--libdir=$(out)/lib" ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "IPv4 to IPv6 interceptor";
+    homepage = "https://github.com/andrewshadura/tnat64";
+    license = licenses.gpl2Plus;
+    longDescription = ''
+      TNAT64 is an interceptor which redirects outgoing TCPv4 connections
+      through NAT64, thus enabling an application running on an IPv6-only host
+      to communicate with the IPv4 world, even if that application does not
+      support IPv6 at all.
+    '';
+    platforms = platforms.unix;
+    badPlatforms = platforms.darwin;
+    maintainers = [ maintainers.rnhmjoj ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -810,6 +810,8 @@ in
 
   tfk8s = callPackage ../tools/misc/tfk8s { };
 
+  tnat64 = callPackage ../tools/networking/tnat64 { };
+
   xcd = callPackage ../tools/misc/xcd { };
 
   xtrt = callPackage ../tools/archivers/xtrt { };


### PR DESCRIPTION
###### Motivation for this change

It's an old software but it checks out.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested it works via `env LD_PRELOAD=$(nix-build -A tnat64 --no-out-link)/lib/tnat64/libtnat64.so nc <ip> <port>`
- [x] Tested execution of all binary files
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: careful with LD_PRELOAD: if your main glibc doesn't match the one in nixpkgs master, it will crash.