### PR TITLE
python3Packages.lark-parser: 0.11.2 -> 0.11.3, python3Packages.cassandra-driver: 3.24.0 -> 3.25.0, pythonPackages.gremlinpython: unbreak

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, buildPythonPackage, fetchFromGitHub, python, pythonOlder
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
 , cython
 , eventlet
 , futures ? null
@@ -21,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "cassandra-driver";
-  version = "3.24.0";
+  version = "3.25.0";
 
   # pypi tarball doesn't include tests
   src = fetchFromGitHub {
     owner = "datastax";
     repo = "python-driver";
     rev = version;
-    sha256 = "1rr69hly5q810xpn8rkzxwzlq55wxxp7kwki9vfri3gh674d2wip";
+    sha256 = "1dn7iiavsrhh6i9hcyw0mk8j95r5ym0gbrvdca998hx2rnz5ark6";
   };
 
   nativeBuildInputs = [ cython ];
@@ -66,8 +70,10 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "tests/unit"
+  ];
+  disabledTestPaths = [
     # requires puresasl
-    "--ignore=tests/unit/advanced/test_auth.py"
+    "tests/unit/advanced/test_auth.py"
   ];
   disabledTests = [
     # doesn't seem to be intended to be run directly

--- a/pkgs/development/python-modules/gremlinpython/default.nix
+++ b/pkgs/development/python-modules/gremlinpython/default.nix
@@ -1,6 +1,15 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, pytestCheckHook, pyhamcrest, pytestrunner
-, six, isodate, tornado, aenum, radish-bdd, mock
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aenum
+, importlib-metadata
+, isodate
+, six
+, tornado
+, pytestCheckHook
+, mock
+, pyhamcrest
+, radish-bdd
 }:
 
 buildPythonPackage rec {
@@ -22,13 +31,28 @@ buildPythonPackage rec {
       --replace 'PyHamcrest>=1.9.0,<2.0.0' 'PyHamcrest' \
       --replace 'radish-bdd==0.8.6' 'radish-bdd' \
       --replace 'mock>=3.0.5,<4.0.0' 'mock' \
-      --replace 'pytest>=4.6.4,<5.0.0' 'pytest'
+      --replace 'pytest>=4.6.4,<5.0.0' 'pytest' \
+      --replace 'importlib-metadata<3.0.0' 'importlib-metadata' \
+      --replace 'pytest-runner==5.2' ' '
   '';
 
-  nativeBuildInputs = [ pytestrunner ];  # simply to placate requirements
-  propagatedBuildInputs = [ six isodate tornado aenum ];
+  # setup-requires requirements
+  nativeBuildInputs = [
+    importlib-metadata
+  ];
+  propagatedBuildInputs = [
+    aenum
+    isodate
+    six
+    tornado
+  ];
 
-  checkInputs = [ pytestCheckHook pyhamcrest radish-bdd mock ];
+  checkInputs = [
+    pytestCheckHook
+    mock
+    pyhamcrest
+    radish-bdd
+  ];
 
   # disable custom pytest report generation
   preCheck = ''
@@ -36,12 +60,14 @@ buildPythonPackage rec {
   '';
 
   # many tests expect a running tinkerpop server
+  disabledTestPaths = [
+    "tests/driver/test_client.py"
+    "tests/driver/test_driver_remote_connection.py"
+    "tests/driver/test_driver_remote_connection_threaded.py"
+    "tests/process/test_dsl.py"
+    "tests/structure/io/test_functionalityio.py"
+  ];
   pytestFlagsArray = [
-    "--ignore=tests/driver/test_client.py"
-    "--ignore=tests/driver/test_driver_remote_connection.py"
-    "--ignore=tests/driver/test_driver_remote_connection_threaded.py"
-    "--ignore=tests/process/test_dsl.py"
-    "--ignore=tests/structure/io/test_functionalityio.py"
     # disabledTests doesn't quite allow us to be precise enough for this
     "-k 'not (TestFunctionalGraphSONIO and (test_timestamp or test_datetime or test_uuid))'"
   ];

--- a/pkgs/development/python-modules/lark-parser/default.nix
+++ b/pkgs/development/python-modules/lark-parser/default.nix
@@ -1,35 +1,38 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, python
 , regex
-  # Test inputs
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "lark-parser";
-  version = "0.11.2";
+  version = "0.11.3";
 
   src = fetchFromGitHub {
     owner = "lark-parser";
     repo = "lark";
     rev = version;
-    sha256 = "1v1piaxpz4780km2z5i6sr9ygi9wpn09yyh999b3f4y0dcz20pbd";
+    sha256 = "1ggvlzpdzlrxl46fgi8cfq2rzlwn21shpdkm4pknnhfjlsinv913";
   };
 
+  # Optional import, but fixes some re known bugs & allows advanced regex features
   propagatedBuildInputs = [ regex ];
 
-  checkInputs = [ pytestCheckHook ];
-  disabledTestPaths = [
-    "tests/test_nearley" # requires Js2Py package (not in nixpkgs)
-  ];
-  disabledTests = [
-    "test_override_rule"  # has issue with file access paths
-  ];
+  checkPhase = ''
+    runHook preCheck
+
+    # Official way to run the tests. Runs unittest internally.
+    # pytest produces issues with some test resource paths (relies on __main__)
+    ${python.interpreter} -m tests
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "A modern parsing library for Python, implementing Earley & LALR(1) and an easy interface";
-    homepage = "https://github.com/lark-parser/lark";
+    homepage = "https://lark-parser.readthedocs.io/";
+    changelog = "https://github.com/lark-parser/lark/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fridh drewrisinger ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Update lark-parser to latest version
* unbreak downstream packages that came up while reviewing this:
	* Unbreak ``pythonPackages.gremlinpython``
	* Update ``python3Packages.cassandra-driver: 3.24.0 -> 3.25.0``.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
