### PR TITLE
installer images: Add available modules to stage-1 on ARM platforms

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image-aarch64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64.nix
@@ -18,13 +18,6 @@
   # - ttyAMA0: for QEMU's -machine virt
   boot.kernelParams = ["console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
-  boot.initrd.availableKernelModules = [
-    # Allows early (earlier) modesetting for the Raspberry Pi
-    "vc4" "bcm2835_dma" "i2c_bcm2835"
-    # Allows early (earlier) modesetting for Allwinner SoCs
-    "sun4i_drm" "sun8i_drm_hdmi" "sun8i_mixer"
-  ];
-
   sdImage = {
     populateFirmwareCommands = let
       configTxt = pkgs.writeText "config.txt" ''

--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -29,6 +29,7 @@ in
   imports = [
     (mkRemovedOptionModule [ "sdImage" "bootPartitionID" ] "The FAT partition for SD image now only holds the Raspberry Pi firmware files. Use firmwarePartitionID to configure that partition's ID.")
     (mkRemovedOptionModule [ "sdImage" "bootSize" ] "The boot files for SD image have been moved to the main ext4 partition. The FAT partition now only holds the Raspberry Pi firmware files. Changing its size may not be required.")
+    ../../profiles/all-hardware.nix
   ];
 
   options.sdImage = {

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -67,6 +67,10 @@ in
 
       # PWM for the backlight
       "pwm-sun4i"
+
+      # Broadcom
+
+      "vc4"
     ] ++ lib.optionals pkgs.stdenv.isAarch64 [
       # Most of the following falls into two categories:
       #  - early KMS / early display

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -74,6 +74,11 @@ in
       "panel-simple"
       "pwm-bl"
 
+      # Power supply drivers, some platforms need them for USB
+      "axp20x-ac-power"
+      "axp20x-battery"
+      "pinctrl-axp209"
+
       # Misc "weak" dependencies
       "analogix-anx6345" # For DP or eDP (e.g. integrated display)
     ];

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -72,6 +72,14 @@ in
 
       "pcie-brcmstb"
 
+      # Rockchip
+      "dw-hdmi"
+      "dw-mipi-dsi"
+      "rockchipdrm"
+      "rockchip-rga"
+      "phy-rockchip-pcie"
+      "pcie-rockchip-host"
+
       # Misc. uncategorized hardware
 
       # Used for some platform's integrated displays

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -46,7 +46,7 @@ in
       # VMware support.
       "mptspi" "vmxnet3" "vsock"
     ] ++ lib.optional platform.isx86 "vmw_balloon"
-    ++ lib.optionals (!platform.isAarch64) [ # not sure where else they're missing
+    ++ lib.optionals (!platform.isAarch64 && !platform.isAarch32) [ # not sure where else they're missing
       "vmw_vmci" "vmwgfx" "vmw_vsock_vmci_transport"
 
       # Hyper-V support.

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -90,6 +90,7 @@ in
       "axp20x-ac-power"
       "axp20x-battery"
       "pinctrl-axp209"
+      "mp8859"
 
       # USB drivers
       "xhci-pci-renesas"

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -51,6 +51,13 @@ in
 
       # Hyper-V support.
       "hv_storvsc"
+    ] ++ lib.optionals pkgs.stdenv.isAarch64 [
+      # Most of the following falls into two categories:
+      #  - early KMS / early display
+      #  - early storage (e.g. USB) support
+
+      # Allows using framebuffer configured by the initial boot firmware
+      "simplefb"
     ];
 
   # Include lots of firmware.

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -58,6 +58,15 @@ in
 
       # Allows using framebuffer configured by the initial boot firmware
       "simplefb"
+
+      # Allwinner support
+
+      # Required for early KMS
+      "sun4i-drm"
+      "sun8i-mixer" # Audio, but required for kms
+
+      # PWM for the backlight
+      "pwm-sun4i"
     ];
 
   # Include lots of firmware.

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -96,6 +96,7 @@ in
       "xhci-pci-renesas"
 
       # Misc "weak" dependencies
+      "analogix-dp"
       "analogix-anx6345" # For DP or eDP (e.g. integrated display)
     ];
 

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -51,7 +51,7 @@ in
 
       # Hyper-V support.
       "hv_storvsc"
-    ] ++ lib.optionals pkgs.stdenv.isAarch64 [
+    ] ++ lib.optionals (pkgs.stdenv.isAarch32 || pkgs.stdenv.isAarch64) [
       # Most of the following falls into two categories:
       #  - early KMS / early display
       #  - early storage (e.g. USB) support
@@ -67,6 +67,10 @@ in
 
       # PWM for the backlight
       "pwm-sun4i"
+    ] ++ lib.optionals pkgs.stdenv.isAarch64 [
+      # Most of the following falls into two categories:
+      #  - early KMS / early display
+      #  - early storage (e.g. USB) support
 
       # Broadcom
 

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -68,6 +68,10 @@ in
       # PWM for the backlight
       "pwm-sun4i"
 
+      # Broadcom
+
+      "pcie-brcmstb"
+
       # Misc. uncategorized hardware
 
       # Used for some platform's integrated displays
@@ -78,6 +82,9 @@ in
       "axp20x-ac-power"
       "axp20x-battery"
       "pinctrl-axp209"
+
+      # USB drivers
+      "xhci-pci-renesas"
 
       # Misc "weak" dependencies
       "analogix-anx6345" # For DP or eDP (e.g. integrated display)

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -67,6 +67,15 @@ in
 
       # PWM for the backlight
       "pwm-sun4i"
+
+      # Misc. uncategorized hardware
+
+      # Used for some platform's integrated displays
+      "panel-simple"
+      "pwm-bl"
+
+      # Misc "weak" dependencies
+      "analogix-anx6345" # For DP or eDP (e.g. integrated display)
     ];
 
   # Include lots of firmware.

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -871,6 +871,11 @@ let
       # The kernel command line will override a platform-specific configuration from its device tree.
       # https://github.com/torvalds/linux/blob/856deb866d16e29bd65952e0289066f6078af773/kernel/dma/contiguous.c#L35-L44
       CMA_SIZE_MBYTES = freeform "32";
+
+      # Many ARM SBCs hand off a pre-configured framebuffer.
+      # This always can can be replaced by the actual native driver.
+      # Keeping it a built-in ensures it will be used if possible.
+      FB_SIMPLE = yes;
     };
   };
 in

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -859,7 +859,7 @@ let
       # Bump the maximum number of CPUs to support systems like EC2 x1.*
       # instances and Xeon Phi.
       NR_CPUS = freeform "384";
-    } // optionalAttrs (stdenv.hostPlatform.system == "aarch64-linux") {
+    } // optionalAttrs (stdenv.hostPlatform.system == "armv7l-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enables support for the Allwinner Display Engine 2.0
       SUN8I_DE2_CCU = whenAtLeast "4.13" yes;
 
@@ -876,6 +876,9 @@ let
       # This always can can be replaced by the actual native driver.
       # Keeping it a built-in ensures it will be used if possible.
       FB_SIMPLE = yes;
+
+    } // optionalAttrs (stdenv.hostPlatform.system == "armv7l-linux") {
+      ARM_LPAE = yes;
     };
   };
 in


### PR DESCRIPTION
See relevant PRs

 - ~~#119974~~
 - #121450

###### Motivation for this change

There are two main classes of modules this adds:

 - graphics enablement
 - storage enablement

Graphics is to give end-users feedback about the current boot. If and when things fail in stage-1, it is helpful for users.

Storage is to allow loading stage-2! All of the additions here are for USB support in stage-1. This allows using a USB drive to write either of the "SD" image or the UEFI iso installer.

This was tested on

 - Pinebook (A64)
 - Pine A64-LTS
 - Raspberry Pi 3B
 - Raspberry Pi 4B
 - Libre Computer AML-S805X-AC (La Frite)

Special note:

 - Pinebook Pro (the UEFI iso seems to break rockchipdrm or something else in the display chain, SD image on USB works fine)
 - Orange Pi PC (armv7l)

Testing, for aarch64 included installing from the UEFI iso (except for the Pinebook Pro).

Testing, for armv7l was limited to running the UEFI iso. Installing requires a complete native build due to the lack of native compilation.

**But... how were the images built?**

Using this commit (branch tip might move), which includes some cross-compilation fixes:

 - https://github.com/samueldr/nixpkgs/commit/b2a67fa784c819b15e21e0072842f564f67964ec

Using my recently refactored ["cross-system" repo](https://github.com/samueldr/cross-system).

```
 # Assuming <nixpkgs> is correct, or `--arg pkgs` is given
 $ nix-build -A aarch64-linux -A armv7l-linux
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
