### PR TITLE
xfce.xfce4-clipman-plugin: 1.6.1 -> 1.6.2

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-clipman-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-clipman-plugin/default.nix
@@ -3,15 +3,10 @@
 mkXfceDerivation {
   category = "panel-plugins";
   pname = "xfce4-clipman-plugin";
-  version = "1.6.1";
-  sha256 = "03akijvry1n1fkziyvxwcksl4vy4lmnpgd5izjs8jai5sndhsszl";
+  version = "1.6.2";
+  sha256 = "0pm4pzq3imc0m09mg0zk6kwcn5yzdgiqgdbpws01q3xz58jmb4a6";
 
   buildInputs = [ libXtst libxfce4ui xfce4-panel xfconf ];
-
-  postPatch = ''
-    # exo-csource has been dropped from exo
-    substituteInPlace panel-plugin/Makefile.am --replace exo-csource xdt-csource
-  '';
 
   meta = {
     description = "Clipboard manager for Xfce panel";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [1.6.2](https://gitlab.xfce.org/panel-plugins/xfce4-clipman-plugin/-/tags/xfce4-clipman-plugin-1.6.2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
