### PR TITLE
megapixels: 0.16.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -5,8 +5,8 @@
 , ninja
 , pkg-config
 , wrapGAppsHook
-, gtk3
-, gnome
+, epoxy
+, gtk4
 , zbar
 , tiffSupport ? true
 , libraw
@@ -26,20 +26,22 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "megapixels";
-  version = "0.16.0";
+  version = "1.0.1";
 
   src = fetchFromSourcehut {
     owner = "~martijnbraam";
     repo = "megapixels";
     rev = version;
-    sha256 = "0z7sx76x18yqf7carq6mg9lib0zbz0yrd1dsg9qd6hbf5niqis37";
+    sha256 = "0k9a5dpr5z0g7ngbhk4j22sbs1ffxiwg8wmbzgggdc9xvwmkgppr";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
 
-  buildInputs = [ gtk3 gnome.adwaita-icon-theme zbar ]
-  ++ optional tiffSupport libraw
-  ++ optional jpgSupport graphicsmagick;
+  buildInputs = [
+    epoxy
+    gtk4
+    zbar
+  ];
 
   preFixup = optionalString (tiffSupport || jpgSupport) ''
     gappsWrapperArgs+=(
@@ -52,7 +54,7 @@ stdenv.mkDerivation rec {
     homepage = "https://sr.ht/~martijnbraam/Megapixels";
     changelog = "https://git.sr.ht/~martijnbraam/megapixels/refs/${version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
+    maintainers = with maintainers; [ OPNA2608 dotlambda ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://git.sr.ht/~martijnbraam/megapixels/refs/1.0.0
https://git.sr.ht/~martijnbraam/megapixels/refs/1.0.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I could not test this on my PinePhone yet.