### PR TITLE
netdata: 1.29.3 -> 1.30.1

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -183,6 +183,9 @@ in {
         ConfigurationDirectory = "netdata";
         ConfigurationDirectoryMode = "0755";
         # Capabilities
+        AmbientCapabilities = [
+          "CAP_SETUID"            # is required for cgroups and cgroups-network plugins
+        ];
         CapabilityBoundingSet = [
           "CAP_DAC_OVERRIDE"      # is required for freeipmi and slabinfo plugins
           "CAP_DAC_READ_SEARCH"   # is required for apps plugin
@@ -192,6 +195,8 @@ in {
           "CAP_SYS_PTRACE"        # is required for apps plugin
           "CAP_SYS_RESOURCE"      # is required for ebpf plugin
           "CAP_NET_RAW"           # is required for fping app
+          "CAP_SYS_CHROOT"        # is required for cgroups plugin
+          "CAP_SETUID"            # is required for cgroups and cgroups-network plugins
         ];
         # Sandboxing
         ProtectSystem = "full";

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -149,8 +149,9 @@ in {
       description = "Real time performance monitoring";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = (with pkgs; [ curl gawk which ]) ++ lib.optional cfg.python.enable
-        (pkgs.python3.withPackages cfg.python.extraPackages);
+      path = (with pkgs; [ curl gawk iproute2 which ])
+        ++ lib.optional cfg.python.enable (pkgs.python3.withPackages cfg.python.extraPackages)
+        ++ lib.optional config.virtualisation.libvirtd.enable (config.virtualisation.libvirtd.package);
       environment = {
         PYTHONPATH = "${cfg.package}/libexec/netdata/python.d/python_modules";
       } // lib.optionalAttrs (!cfg.enableAnalyticsReporting) {

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -15,14 +15,14 @@ with lib;
 let
   go-d-plugin = callPackage ./go.d.plugin.nix {};
 in stdenv.mkDerivation rec {
-  version = "1.29.3";
+  version = "1.30.1";
   pname = "netdata";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "netdata";
     rev = "v${version}";
-    sha256 = "sha256-GWIQZEC5agJ+Zw7l58IIAJhXP6dxirCmWVBJulzBO5Q=";
+    sha256 = "0cp6gbn38f1cr0jkr64vvwz005cvnwj3hgfxs147wap9w228k46r";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -8,6 +8,7 @@
 , withNetfilter ? (!stdenv.isDarwin), libmnl, libnetfilter_acct
 , withSsl ? true, openssl
 , withDebug ? false
+, fetchpatch
 }:
 
 with lib;
@@ -39,6 +40,11 @@ in stdenv.mkDerivation rec {
     # required to prevent plugins from relying on /etc
     # and /var
     ./no-files-in-etc-and-var.patch
+    # cgroups: fix network interfaces detection when using virsh
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/netdata/netdata/pull/11096.patch";
+      sha256 = "0f2rd7kgbwbyq9wyn085d213ifvivnpl3qlx1gjrg42rkbi4n8jj";
+    })
   ];
 
   NIX_CFLAGS_COMPILE = optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";

--- a/pkgs/tools/system/netdata/go.d.plugin.nix
+++ b/pkgs/tools/system/netdata/go.d.plugin.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "netdata-go.d.plugin";
-  version = "0.26.2";
+  version = "0.28.1";
 
   src = fetchFromGitHub {
     owner = "netdata";
     repo = "go.d.plugin";
     rev = "v${version}";
-    sha256 = "1jy5pc1ihyrg6sqyw0d48bsqa7kr7kqz10k3845g958vgfmfig59";
+    sha256 = "0i77nvqi3dcby0gr3b06bai170q2ibp5390qfjijrk1yqz6x6sd5";
   };
 
-  vendorSha256 = "16b6i9cpk8j7292qgjvida70rg7nixi6g94wayzikx01vmdbis5r";
+  vendorSha256 = "1q8z4smaxzqd5iwvbnkkr33c3b94rjwa3xjirwlr595g0wn93wc7";
 
   doCheck = false;
 

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,28 +1,8 @@
-From 4ecc1475be94a384c122594b5f7d455beb64a2f0 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
-Date: Sat, 22 Feb 2020 06:42:14 +0000
-Subject: [PATCH] no files in etc and var
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
-
-Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
----
- collectors/Makefile.am                 | 2 +-
- collectors/charts.d.plugin/Makefile.am | 2 +-
- collectors/node.d.plugin/Makefile.am   | 2 +-
- collectors/python.d.plugin/Makefile.am | 2 +-
- collectors/statsd.plugin/Makefile.am   | 2 +-
- health/Makefile.am                     | 2 +-
- system/Makefile.am                     | 3 +--
- web/Makefile.am                        | 2 +-
- 8 files changed, 8 insertions(+), 9 deletions(-)
-
 diff --git a/collectors/Makefile.am b/collectors/Makefile.am
-index 9bb52958..c9799165 100644
+index 021e2ff23..115b88277 100644
 --- a/collectors/Makefile.am
 +++ b/collectors/Makefile.am
-@@ -32,7 +32,7 @@ usercustompluginsconfigdir=$(configdir)/custom-plugins.d
+@@ -33,7 +33,7 @@ usercustompluginsconfigdir=$(configdir)/custom-plugins.d
  usergoconfigdir=$(configdir)/go.d
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -32,7 +12,7 @@ index 9bb52958..c9799165 100644
  	$(INSTALL) -d $(DESTDIR)$(usergoconfigdir)
  
 diff --git a/collectors/charts.d.plugin/Makefile.am b/collectors/charts.d.plugin/Makefile.am
-index 03c7f0a9..01985db0 100644
+index 03c7f0a94..01985db01 100644
 --- a/collectors/charts.d.plugin/Makefile.am
 +++ b/collectors/charts.d.plugin/Makefile.am
 @@ -34,7 +34,7 @@ dist_userchartsconfig_DATA = \
@@ -44,8 +24,21 @@ index 03c7f0a9..01985db0 100644
  	$(INSTALL) -d $(DESTDIR)$(userchartsconfigdir)
  
  chartsconfigdir=$(libconfigdir)/charts.d
+diff --git a/collectors/ebpf.plugin/Makefile.am b/collectors/ebpf.plugin/Makefile.am
+index 18b1fc6c8..b4b0c7852 100644
+--- a/collectors/ebpf.plugin/Makefile.am
++++ b/collectors/ebpf.plugin/Makefile.am
+@@ -13,7 +13,7 @@ SUFFIXES = .in
+ userebpfconfigdir=$(configdir)/ebpf.d
+ 
+ # Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
++no-install-exec-local:
+ 	$(INSTALL) -d $(DESTDIR)$(userebpfconfigdir)
+ 
+ dist_plugins_SCRIPTS = \
 diff --git a/collectors/node.d.plugin/Makefile.am b/collectors/node.d.plugin/Makefile.am
-index c3142d43..95e32445 100644
+index c3142d433..95e324455 100644
 --- a/collectors/node.d.plugin/Makefile.am
 +++ b/collectors/node.d.plugin/Makefile.am
 @@ -26,7 +26,7 @@ dist_usernodeconfig_DATA = \
@@ -58,7 +51,7 @@ index c3142d43..95e32445 100644
  
  nodeconfigdir=$(libconfigdir)/node.d
 diff --git a/collectors/python.d.plugin/Makefile.am b/collectors/python.d.plugin/Makefile.am
-index e678f86a..29a319da 100644
+index 38eb90f79..ce7079441 100644
 --- a/collectors/python.d.plugin/Makefile.am
 +++ b/collectors/python.d.plugin/Makefile.am
 @@ -32,7 +32,7 @@ dist_userpythonconfig_DATA = \
@@ -71,10 +64,10 @@ index e678f86a..29a319da 100644
  
  pythonconfigdir=$(libconfigdir)/python.d
 diff --git a/collectors/statsd.plugin/Makefile.am b/collectors/statsd.plugin/Makefile.am
-index b01302d1..f5b77da4 100644
+index 71f2d468d..2c9ced2bf 100644
 --- a/collectors/statsd.plugin/Makefile.am
 +++ b/collectors/statsd.plugin/Makefile.am
-@@ -17,5 +17,5 @@ dist_userstatsdconfig_DATA = \
+@@ -18,5 +18,5 @@ dist_userstatsdconfig_DATA = \
      $(NULL)
  
  # Explicitly install directories to avoid permission issues due to umask
@@ -82,7 +75,7 @@ index b01302d1..f5b77da4 100644
 +no-install-exec-local:
  	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)
 diff --git a/health/Makefile.am b/health/Makefile.am
-index 853ed0d7..210330a6 100644
+index b963ea0cd..6979e69bf 100644
 --- a/health/Makefile.am
 +++ b/health/Makefile.am
 @@ -19,7 +19,7 @@ dist_userhealthconfig_DATA = \
@@ -95,10 +88,10 @@ index 853ed0d7..210330a6 100644
  
  healthconfigdir=$(libconfigdir)/health.d
 diff --git a/system/Makefile.am b/system/Makefile.am
-index ad68c655..74f032f9 100644
+index 5323738c9..06e1b6a73 100644
 --- a/system/Makefile.am
 +++ b/system/Makefile.am
-@@ -17,11 +17,10 @@ include $(top_srcdir)/build/subst.inc
+@@ -20,11 +20,10 @@ include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  
  dist_config_SCRIPTS = \
@@ -112,7 +105,7 @@ index ad68c655..74f032f9 100644
  
  nodist_noinst_DATA = \
 diff --git a/web/Makefile.am b/web/Makefile.am
-index ccaccd76..16a2977e 100644
+index ccaccd764..16a2977e5 100644
 --- a/web/Makefile.am
 +++ b/web/Makefile.am
 @@ -12,7 +12,7 @@ SUBDIRS = \
@@ -124,6 +117,3 @@ index ccaccd76..16a2977e 100644
  	$(INSTALL) -d $(DESTDIR)$(usersslconfigdir)
  
  dist_noinst_DATA = \
--- 
-2.25.0
-


### PR DESCRIPTION
###### Motivation for this change
Update netdata to version `1.30.1`
Added required packages - `ip` and `virsh` needed to script `collectors/cgroups.plugin/cgroup-network-helper.sh`
Update capabilities.
Added patch to fix network interfaces detection when using virsh.

cc @Mic92 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
