### PR TITLE
tf2pulumi: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/development/tools/tf2pulumi/default.nix
+++ b/pkgs/development/tools/tf2pulumi/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "tf2pulumi";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "tf2pulumi";
     rev = "v${version}";
-    sha256 = "199c4hd236mfz9c44rpzpbr3w3fjj8pbw656jd9k3v2igzw942c7";
+    sha256 = "0dd44z78iqh9asa2jh9am2z5fbmn0gch7lfij3h9ngia25h5fpsb";
   };
 
-  vendorSha256 = "1cwyag67q0361szfjv1cyi51cg1bbmkpy34y33hn53aa55pkm1fw";
+  vendorSha256 = "17rn0pshfm4mpqxk3klni4qrw4rvz8vi42s5kidblpf576n0vj62";
 
   buildFlagsArray = ''
     -ldflags=-s -w -X=github.com/pulumi/tf2pulumi/version.Version=${src.rev}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
New version 0.11.0 released:
https://github.com/pulumi/tf2pulumi/releases/tag/v0.11.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>tf2pulumi</li>
  </ul>
</details>