### PR TITLE
wayland{.bin,-scanner}: Add a pkg-config file for cross-compilation

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -5,7 +5,7 @@
 , meson
 , pkg-config
 , ninja
-, wayland
+, wayland-scanner
 , expat
 , libxml2
 , withLibraries ? stdenv.isLinux
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     pkg-config
     ninja
   ] ++ lib.optionals isCross [
-    wayland # For wayland-scanner during the build
+    wayland-scanner
   ] ++ lib.optionals withDocumentation [
     (graphviz-nox.override { pango = null; }) # To avoid an infinite recursion
     doxygen
@@ -84,6 +84,18 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_45
     docbook_xml_dtd_42
   ];
+
+  postFixup = ''
+    # The pkg-config file is required for cross-compilation:
+    mkdir -p $bin/lib/pkgconfig/
+    cat <<EOF > $bin/lib/pkgconfig/wayland-scanner.pc
+    wayland_scanner=$bin/bin/wayland-scanner
+
+    Name: Wayland Scanner
+    Description: Wayland scanner
+    Version: ${version}
+    EOF
+  '';
 
   meta = with lib; {
     description = "Core Wayland window system code and protocol";


### PR DESCRIPTION
Only "wayland_scanner" and "Version" are required so it's easier to
create wayland-scanner.pc manually than to copy it from $dev and avoid
dependency cycles.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
