### PR TITLE
wayland-protocols: Switch to Meson

### DIFF
--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -1,15 +1,29 @@
-{ lib, stdenv, fetchurl, wayland-scanner }:
+{ lib, stdenv, fetchurl
+, pkg-config
+, meson, ninja, wayland-scanner
+, python3, wayland
+}:
 
 stdenv.mkDerivation rec {
   pname = "wayland-protocols";
   version = "1.21";
+
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   src = fetchurl {
     url = "https://wayland.freedesktop.org/releases/${pname}-${version}.tar.xz";
     sha256 = "1rfdlkzz67qsb955zqb8jbw3m22pl6ppvrvfq8bqiqcb5n24b6dr";
   };
 
-  nativeBuildInputs = [ wayland-scanner ];
+  postPatch = lib.optionalString doCheck ''
+    patchShebangs tests/
+  '';
+
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ meson ninja wayland-scanner ];
+  checkInputs = [ python3 wayland ];
+
+  mesonFlags = [ "-Dtests=${lib.boolToString doCheck}" ];
 
   meta = {
     description = "Wayland protocol extensions";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

According to diffoscope this is fine (only the Nix store path changes).

Cross-compilation with doCheck=true is broken (requires pkg-config in
nativeBuildInputs but doesn't play nicely with checkInputs).

###### Motivation for this change

Marked as draft as #121726 should be merged first other than that it's final and reviews are already welcome.

https://lists.freedesktop.org/archives/wayland-devel/2021-April/041815.html
> This release introduces support for installing using meson instead of
autotools. The aim is to in a later release remove support for
installing using autotools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
