### PR TITLE
python3Packages.surepy: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -6,7 +6,7 @@
 , colorama
 , dataclasses
 , ipywidgets
-, poetry
+, poetry-core
 , pygments
 , typing-extensions
 , pytestCheckHook
@@ -14,27 +14,33 @@
 
 buildPythonPackage rec {
   pname = "rich";
-  version = "9.13.0";
+  version = "10.1.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
 
-  # tests not included in pypi tarball
   src = fetchFromGitHub {
     owner = "willmcgugan";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0si3rzhg8wfxw4aakkp8sr6nbzfa54rl0w92macd1338q90ha4ly";
+    sha256 = "sha256-HH+k9uiK34yoqu83rknCIe2DpoqJRHkcqABuj8zjzqs=";
   };
-  format = "pyproject";
 
-  nativeBuildInputs = [ poetry ];
+  nativeBuildInputs = [ poetry-core ];
+
   propagatedBuildInputs = [
     CommonMark
     colorama
     ipywidgets
     pygments
     typing-extensions
-  ] ++ lib.optional (pythonOlder "3.7") dataclasses;
+  ] ++ lib.optional (pythonOlder "3.7") [
+    dataclasses
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [ "rich" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/surepy/default.nix
+++ b/pkgs/development/python-modules/surepy/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "surepy";
-  version = "0.5.0";
+  version = "0.6.0";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "benleb";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1adsnjya142bxdhfxqsi2qa35ylvdcibigs1wafjlxazlxs3mg0j";
+    sha256 = "sha256-XoYiZPBc9SybyKocui1HqSA+YPiPpbupJWMCfmQT5RU=";
   };
 
   nativeBuildInputs = [ poetry-core ];
@@ -42,11 +42,6 @@ buildPythonPackage rec {
     requests
     rich
   ];
-
-  postPatch = ''
-    # halo is out-dated, https://github.com/benleb/surepy/pull/7
-    substituteInPlace pyproject.toml --replace "^0.0.30" "^0.0.31"
-  '';
 
   # Project has no tests
   doCheck = false;

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -358,6 +358,7 @@ in with py.pkgs; buildPythonApplication rec {
     "stream"
     "subaru"
     "sun"
+    "surepetcare"
     "switch"
     "system_health"
     "system_log"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6.0

Change log: https://github.com/benleb/surepy/releases/tag/v0.6.0

Requires later `rich` release.
- https://github.com/willmcgugan/rich/releases/tag/v10.1.0
- https://github.com/willmcgugan/rich/releases/tag/v10.0.1
- https://github.com/willmcgugan/rich/releases/tag/v10.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
