### PR TITLE
[20.09] nixUnstable: 2.4pre20210326_dd77f71 -> 2.4pre20210503_6d2553a; hydra-unstable: 2021-03-29 -> 2021-05-03

### DIFF
--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -37,6 +37,8 @@ let
         CatalystViewTT
         CatalystXScriptServerStarman
         CatalystXRoleApplicator
+        CryptPassphrase
+        CryptPassphraseArgon2
         CryptRandPasswd
         DBDPg
         DBDSQLite
@@ -61,6 +63,7 @@ let
         SQLSplitStatement
         SetScalar
         Starman
+        StringCompareConstantTime
         SysHostnameLong
         TermSizeAny
         TextDiff

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -24,12 +24,12 @@
   # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
   hydra-unstable = callPackage ./common.nix {
-    version = "2021-04-29";
+    version = "2021-05-03";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "6047b1dd04d44acff9343b6b971ab609b73099d5";
-      sha256 = "sha256-E7JOHhSd4gIzE6FvSZVMxZE9WagbBkrfZVoibkanaYE=";
+      rev = "886e6f85e45a1f757e9b77d2a9e4539fbde29468";
+      sha256 = "t7Qb57Xjc0Ou+VDGC1N5u9AmeODW6MVOwKSrYRJq5f0=";
     };
     nix = nixFlakes;
 

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -24,12 +24,12 @@
   # so when having an older version, `pkgs.hydra-migration` should be deployed first.
 
   hydra-unstable = callPackage ./common.nix {
-    version = "2021-03-10";
+    version = "2021-04-29";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "930f05c38eeac63ad6c3e3250de2667e2df2e96e";
-      sha256 = "06s2lg119p96i1j4rdbg3z097n25bgvq8ljdn4vcwcw3yz0lnswm";
+      rev = "6047b1dd04d44acff9343b6b971ab609b73099d5";
+      sha256 = "sha256-E7JOHhSd4gIzE6FvSZVMxZE9WagbBkrfZVoibkanaYE=";
     };
     nix = nixFlakes;
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -208,13 +208,13 @@ in rec {
 
   nixUnstable = lib.lowPrio (callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20210326_dd77f71";
+    suffix = "pre20210503_6d2553a";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "dd77f71afe6733e9790dd001125c423cb648b7ce";
-      sha256 = "rVHzrsCtdiWjyLuHnDplG2mx+7dw5VyzZ9ReXxuCvHY=";
+      rev = "6d2553ae1496288554e871c530836428f405fd67";
+      sha256 = "sha256-YeSeyOKhBAXHlkzo4mwYr8QIjIP9AgdpJ7YdhqOO2CA=";
     };
 
     inherit storeDir stateDir confDir boehmgc;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3683,6 +3683,20 @@ let
     };
   };
 
+  CryptArgon2 = perlPackages.buildPerlModule {
+    pname = "Crypt-Argon2";
+    version = "0.010";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Argon2-0.010.tar.gz";
+      sha256 = "3ea1c006f10ef66fd417e502a569df15c4cc1c776b084e35639751c41ce6671a";
+    };
+    nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
+    meta = {
+      description = "Perl interface to the Argon2 key derivation functions";
+      license = stdenv.lib.licenses.cc0;
+    };
+  };
+
   CryptBlowfish = buildPerlPackage {
     pname = "Crypt-Blowfish";
     version = "2.14";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3856,6 +3856,19 @@ let
     };
   };
 
+  CryptPassphrase = buildPerlPackage {
+    pname = "Crypt-Passphrase";
+    version = "0.003";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-0.003.tar.gz";
+      sha256 = "685aa090f8179a86d6896212ccf8ccfde7a79cce857199bb14e2277a10d240ad";
+    };
+    meta = {
+      description = "A module for managing passwords in a cryptographically agile manner";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   CryptPasswdMD5 = buildPerlModule {
     pname = "Crypt-PasswdMD5";
     version = "1.40";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17778,6 +17778,19 @@ let
     };
   };
 
+  StringCompareConstantTime = buildPerlPackage {
+    pname = "String-Compare-ConstantTime";
+    version = "0.321";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/F/FR/FRACTAL/String-Compare-ConstantTime-0.321.tar.gz";
+      sha256 = "0b26ba2b121d8004425d4485d1d46f59001c83763aa26624dff6220d7735d7f7";
+    };
+    meta = {
+      description = "Timing side-channel protected string compare";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   StringCRC32 = buildPerlPackage {
     pname = "String-CRC32";
     version = "1.8";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3869,6 +3869,20 @@ let
     };
   };
 
+  CryptPassphraseArgon2 = buildPerlPackage {
+    pname = "Crypt-Passphrase-Argon2";
+    version = "0.002";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-Argon2-0.002.tar.gz";
+      sha256 = "3906ff81697d13804ee21bd5ab78ffb1c4408b4822ce020e92ecf4737ba1f3a8";
+    };
+    propagatedBuildInputs = with perlPackages; [ CryptArgon2 CryptPassphrase ];
+    meta = {
+      description = "An Argon2 encoder for Crypt::Passphrase";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   CryptPasswdMD5 = buildPerlModule {
     pname = "Crypt-PasswdMD5";
     version = "1.40";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3865,7 +3865,7 @@ let
     };
     meta = {
       description = "A module for managing passwords in a cryptographically agile manner";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -3879,7 +3879,7 @@ let
     propagatedBuildInputs = with perlPackages; [ CryptArgon2 CryptPassphrase ];
     meta = {
       description = "An Argon2 encoder for Crypt::Passphrase";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -17787,7 +17787,7 @@ let
     };
     meta = {
       description = "Timing side-channel protected string compare";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 


### PR DESCRIPTION

###### Motivation for this change

Backport PR for https://github.com/NixOS/nixpkgs/pull/121263, https://github.com/NixOS/nixpkgs/pull/121731

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
