### PR TITLE
python3Packages.py-cpuinfo: 7.0.0 -> 8.0.0

### DIFF
--- a/pkgs/development/python-modules/py-cpuinfo/default.nix
+++ b/pkgs/development/python-modules/py-cpuinfo/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , buildPythonPackage
 , pytestCheckHook
 , sysctl
@@ -9,27 +8,14 @@
 
 buildPythonPackage rec {
   pname = "py-cpuinfo";
-  version = "7.0.0";
+  version = "8.0.0";
 
   src = fetchFromGitHub {
      owner = "workhorsy";
      repo = pname;
      rev = "v${version}";
-     sha256 = "10qfaibyb2syiwiyv74l7d97vnmlk079qirgnw3ncklqjs0s3gbi";
+     sha256 = "sha256-Mgzj1HTasUNHeHMVwV6d+TeyVqnBNUwCJ1EC3kfovf8=";
   };
-
-  patches = [
-    # Make it detect Apple Silicon, remove after https://github.com/workhorsy/py-cpuinfo/pull/161 is merged.
-    (fetchpatch {
-      url = "https://github.com/workhorsy/py-cpuinfo/commit/54c32da6678f9d75ec5acf4534056cdc85c2a04d.patch";
-      sha256 = "sha256-3R46KrpACAQ1V0CQtz48V5mQXxvplUQrXnACtiE8WqY=";
-    })
-    # Continuation of the patch above
-    (fetchpatch {
-      url = "https://github.com/workhorsy/py-cpuinfo/commit/0d00f4b99750f292c85ff23e1039ea9489cb7ec8.patch";
-      sha256 = "sha256-mHoXoCAEG2v3xpQppRFWzSvhYCp5i9CZkbEgtiLVzMs=";
-    })
-  ];
 
   checkInputs = [
     pytestCheckHook
@@ -42,17 +28,19 @@ buildPythonPackage rec {
       --replace "_run_and_get_stdout(['sysctl'" "_run_and_get_stdout(['${sysctl}/bin/sysctl'"
   '';
 
-  meta = {
-    description = "Get CPU info with pure Python 2 & 3";
+  pythonImportsCheck = [ "cpuinfo" ];
+
+  meta = with lib; {
+    description = "Get CPU info with pure Python";
     longDescription = ''
       Py-cpuinfo gets CPU info with pure Python and should work without any
       extra programs or libraries, beyond what your OS provides. It does not
       require any compilation (C/C++, assembly, etc.) to use and works with
-      Python 2 and 3.
+      Python.
     '';
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/workhorsy/py-cpuinfo";
     changelog = "https://github.com/workhorsy/py-cpuinfo/blob/v${version}/ChangeLog";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ costrouc ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 8.0.0

Change log: https://github.com/workhorsy/py-cpuinfo/blob/master/ChangeLog

Home Assistant uses 8.0.0 with 2021.6.x (https://github.com/home-assistant/core/pull/49833).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
