### PR TITLE
snapdragon-profiler: init at v2021.2

### DIFF
--- a/pkgs/tools/graphics/snapdragon-profiler/default.nix
+++ b/pkgs/tools/graphics/snapdragon-profiler/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, icoutils
+, mono6
+, jre
+, androidenv
+, gtk-sharp-2_0
+, gtk2
+, libcxx
+, libcxxabi
+, coreutils
+, requireFile
+, archive ? requireFile {
+    name = "snapdragonprofiler_external_linux.tar.gz";
+    message = ''
+      This nix expression requires that "snapdragonprofiler_external_linux.tar.gz" is
+      already part of the store. To get this archive, you need to download it from:
+        https://developer.qualcomm.com/software/snapdragon-profiler
+      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
+    '';
+    sha256 = "c6731c417ca39fa9b0f190bd80c99b1603cf97d23becab9e47db6beafd6206b7";
+  }
+}:
+
+stdenv.mkDerivation rec {
+  pname = "snapdragon-profiler";
+  version = "v2021.2";
+
+  src = archive;
+
+  nativeBuildInputs = [
+    makeWrapper
+    icoutils
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    mono6
+    gtk-sharp-2_0
+    gtk2
+    libcxx
+    libcxxabi
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib/snapdragon-profiler}
+    mkdir -p $out/share/icons/hicolor/{16x16,32x32,48x48}/apps
+
+    mv *.so $out/lib
+    cp -r * $out/lib/snapdragon-profiler
+    makeWrapper "${mono6}/bin/mono" $out/bin/snapdragon-profiler \
+      --add-flags "$out/lib/snapdragon-profiler/SnapdragonProfiler.exe" \
+      --suffix PATH : ${lib.makeBinPath [ jre androidenv.androidPkgs_9_0.platform-tools coreutils ]} \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
+      --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //') \
+      --run "cd $out/lib/snapdragon-profiler" # Fixes themes not loading correctly
+
+    wrestool -x -t 14 SnapdragonProfiler.exe > snapdragon-profiler.ico
+    icotool -x -i 1 -o $out/share/icons/hicolor/16x16/apps/snapdragon-profiler.png snapdragon-profiler.ico
+    icotool -x -i 2 -o $out/share/icons/hicolor/32x32/apps/snapdragon-profiler.png snapdragon-profiler.ico
+    icotool -x -i 3 -o $out/share/icons/hicolor/48x48/apps/snapdragon-profiler.png snapdragon-profiler.ico
+
+    runHook postInstall
+  '';
+
+  desktopItems = [(makeDesktopItem {
+    name = pname;
+    desktopName = "Snapdragon Profiler";
+    exec = "$out/bin/snapdragon-profiler";
+    icon = "snapdragon-profiler";
+    type = "Application";
+    comment = meta.description;
+    categories = "Development;Debugger;Graphics;3DGraphics";
+    terminal = "false";
+  })];
+
+  dontStrip = true; # Always needed on Mono
+  dontPatchELF = true; # Certain libraries are to be deployed to the remote device, they should not be patched
+
+  meta = with lib; {
+    homepage = "https://developer.qualcomm.com/software/snapdragon-profiler";
+    description = "An profiler for Android devices running Snapdragon chips";
+    license = licenses.unfree;
+    maintainers = [ maintainers.ivar ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8458,6 +8458,8 @@ in
 
   snapcast = callPackage ../applications/audio/snapcast { };
 
+  snapdragon-profiler = callPackage ../tools/graphics/snapdragon-profiler { };
+
   sng = callPackage ../tools/graphics/sng {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change
This package is a bit of a pain to get running on nix, so me and @PixelyIon packaged it together.

Note that directly downloading `src` is against their license, and you need an account to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
