### PR TITLE
python3Packages.zigpy-znp: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -3,32 +3,34 @@
 , asynctest
 , buildPythonPackage
 , coloredlogs
-, coveralls
 , fetchFromGitHub
+, jsonschema
 , pyserial
 , pyserial-asyncio
 , pytest-asyncio
 , pytest-mock
 , pytest-timeout
-, pytestcov
 , pytestCheckHook
+, pythonOlder
 , voluptuous
-, zigpy }:
+, zigpy
+}:
 
 buildPythonPackage rec {
   pname = "zigpy-znp";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
-    owner = "zha-ng";
-    repo = "zigpy-znp";
+    owner = "zigpy";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1g5jssdnibhb4i4k1js9iy9w40cipf1gdnyp847x0bv6wblzx8rl";
+    sha256 = "152d803jfrvkj4namni41fnbbnq85wd7zsqjhmkwrrmn2gvqjiln";
   };
 
   propagatedBuildInputs = [
     async-timeout
     coloredlogs
+    jsonschema
     pyserial
     pyserial-asyncio
     voluptuous
@@ -36,18 +38,19 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    asynctest
-    coveralls
     pytest-asyncio
     pytest-mock
     pytest-timeout
-    pytestcov
     pytestCheckHook
+  ]  ++ lib.optionals (pythonOlder "3.8") [
+    asynctest
   ];
 
+  pythonImportsCheck = [ "zigpy_znp" ];
+
   meta = with lib; {
-    description = "A library for zigpy which communicates with TI ZNP radios";
-    homepage = "https://github.com/zha-ng/zigpy-znp";
+    description = "Python library for zigpy which communicates with TI ZNP radios";
+    homepage = "https://github.com/zigpy/zigpy-znp";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ mvnetbiz ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.1

Change log:
- https://github.com/zigpy/zigpy-znp/releases/tag/v0.5.1
- https://github.com/zigpy/zigpy-znp/releases/tag/v0.5.0 (contains breaking changes)

Will be part of Home Assistant 2021.6.x (https://github.com/home-assistant/core/pull/50086).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
