### PR TITLE
pythonPackages.debugpy: 1.2.1 → 1.3.0

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.2.1";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1dgjbbhy228w2zbfq5pf0hkai7742zw8mmybnzjdc9l6pw7360rq";
+    hash = "sha256-YGzc9mMIzPTmUgIXuZROLdYKjUm69x9SR+JtYRVpn24=";
   };
 
   patches = [
@@ -33,6 +33,7 @@ buildPythonPackage rec {
       inherit gdb;
     })
 
+    # Use nixpkgs version instead of versioneer
     (substituteAll {
       src = ./hardcode-version.patch;
       inherit version;
@@ -86,6 +87,8 @@ buildPythonPackage rec {
     # gevent fails to import zope.interface with Python 2.7
     "gevent"
   ];
+
+  pythonImportsCheck = [ "debugpy" ];
 
   meta = with lib; {
     description = "An implementation of the Debug Adapter Protocol for Python";

--- a/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
+++ b/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/debug/session.py b/tests/debug/session.py
-index 2b39106..6d45a10 100644
+index 101492f..4ee7cfb 100644
 --- a/tests/debug/session.py
 +++ b/tests/debug/session.py
-@@ -625,6 +625,7 @@ class Session(object):
+@@ -630,6 +630,7 @@ class Session(object):
          if "PYTHONPATH" in self.config.env:
              # If specified, launcher will use it in lieu of PYTHONPATH it inherited
              # from the adapter when spawning debuggee, so we need to adjust again.


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/microsoft/debugpy/releases/tag/v1.3.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, only a Python library.
  Tested through `dap-mode` in Emacs.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).