### PR TITLE
Fixes ssm-agent for 21.05

### DIFF
--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -22,8 +22,8 @@ in {
     package = mkOption {
       type = types.path;
       description = "The SSM agent package to use";
-      default = pkgs.ssm-agent;
-      defaultText = "pkgs.ssm-agent";
+      default = pkgs.ssm-agent.override { overrideEtc = false; };
+      defaultText = "pkgs.ssm-agent.override { overrideEtc = false; }";
     };
   };
 
@@ -37,8 +37,10 @@ in {
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/amazon-ssm-agent";
         KillMode = "process";
-        Restart = "on-failure";
-        RestartSec = "15min";
+        # We want this restating pretty frequently. It could be our only means
+        # of accessing the instance.
+        Restart = "always";
+        RestartSec = "1min";
       };
     };
 
@@ -62,5 +64,10 @@ in {
       isNormalUser = true;
       group = "ssm-user";
     };
+
+    environment.etc."amazon/ssm/seelog.xml".source = "${cfg.package}/seelog.xml.template";
+
+    environment.etc."amazon/ssm/amazon-ssm-agent.json".source =  "${cfg.package}/etc/amazon/ssm/amazon-ssm-agent.json.template";
+
   };
 }

--- a/pkgs/applications/networking/cluster/ssm-agent/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-agent/default.nix
@@ -8,6 +8,7 @@
 , dmidecode
 , util-linux
 , bashInteractive
+, overrideEtc ? true
 }:
 
 let
@@ -63,10 +64,10 @@ buildGoPackage rec {
     substituteInPlace agent/session/shell/shell_unix.go \
         --replace '"script"' '"${util-linux}/bin/script"'
 
-    substituteInPlace agent/appconfig/constants_unix.go \
-        --replace '"/etc/amazon/ssm/"' '"${placeholder "out"}/etc/amazon/ssm/"'
-
     echo "${version}" > VERSION
+  '' + lib.optionalString overrideEtc ''
+    substituteInPlace agent/appconfig/constants_unix.go \
+      --replace '"/etc/amazon/ssm/"' '"${placeholder "out"}/etc/amazon/ssm/"'
   '';
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change
ssm-agent wasn't starting on ec2 with a 21.05 AMI/

###### Things done
It turns out that ssm-agent expects a few files in `/etc/amazon/ssm`:
* amazon-ssm-agent.json.template
* seelog.xml.template

Unfortunately, the `/etc/amazon/ssm` is hardcoded; however, we've got `substituteInPlace` so I swapped in an ENV var `SSM_AGENT_ETC` and added that to the wrapper script.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of ~all~ binary files (usually in `./result/bin/`)
    - tested the wrapper, which launches the other bins
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Most importantly, I built an AMI with this package and removed the /etc/amazon/ssm entries in my `configuration.nix`.

The instance is reachable via ssm :tada: 