### PR TITLE
minipro: init at 0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1322,6 +1322,12 @@
     github = "bmilanov";
     githubId = 30090366;
   };
+  bmwalters = {
+    name = "Bradley Walters";
+    email = "oss@walters.app";
+    github = "bmwalters";
+    githubId = 4380777;
+  };
   bobakker = {
     email = "bobakk3r@gmail.com";
     github = "bobakker";

--- a/pkgs/tools/misc/minipro/default.nix
+++ b/pkgs/tools/misc/minipro/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, pkg-config
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "minipro";
+  version = "0.5";
+
+  src = fetchFromGitLab {
+    owner = "DavidGriffith";
+    repo = "minipro";
+    rev = version;
+    sha256 = "sha256-Hyj2LyY7W8opjigH+QLHHbDyelC0LMgGgdN+u3nNoJc=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libusb1 ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "UDEV_DIR=$(out)/lib/udev"
+    "COMPLETIONS_DIR=$(out)/share/bash-completion/completions"
+    "PKG_CONFIG=${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/DavidGriffith/minipro";
+    description = "An open source program for controlling the MiniPRO TL866xx series of chip programmers";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.bmwalters ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6203,6 +6203,8 @@ in
 
   minidlna = callPackage ../tools/networking/minidlna { };
 
+  minipro = callPackage ../tools/misc/minipro { };
+
   minisign = callPackage ../tools/security/minisign { };
 
   ministat = callPackage ../tools/misc/ministat { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

minipro is a useful command line utility for controlling TL866xx chip programmers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
