### PR TITLE
python3Packages.roombapy: 1.6.2-1 -> 1.6.3

### DIFF
--- a/pkgs/development/python-modules/amqtt/default.nix
+++ b/pkgs/development/python-modules/amqtt/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, docopt
+, fetchFromGitHub
+, hypothesis
+, passlib
+, poetry-core
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, pyyaml
+, transitions
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "amqtt";
+  version = "0.10.0-alpha.3";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Yakifo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wz85ykjgi2174qcdgpakmc4m0p96v62az7pvc9hyallq1v1k4n6";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    docopt
+    passlib
+    pyyaml
+    transitions
+    websockets
+  ];
+
+  checkInputs = [
+    hypothesis
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Test are not ported from hbmqtt yet
+    "tests/test_cli.py"
+    "tests/test_client.py"
+  ];
+
+  disabledTests = [
+    # Requires network access
+    "test_connect_tcp"
+  ];
+
+  pythonImportsCheck = [ "amqtt" ];
+
+  meta = with lib; {
+    description = "Python MQTT client and broker implementation";
+    homepage = "https://amqtt.readthedocs.io/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -1,31 +1,41 @@
-{ buildPythonPackage
+{ lib
+, amqtt
+, buildPythonPackage
 , fetchFromGitHub
-, hbmqtt
-, lib
 , paho-mqtt
-, poetry
+, poetry-core
 , pytest-asyncio
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "roombapy";
-  version = "1.6.2-1";
+  version = "1.6.3";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pschmitt";
     repo = "roombapy";
     rev = version;
-    sha256 = "14k7bys479xwpa4alpdwphzmxm3x8kc48nfqnshn1wj94vyxc425";
+    sha256 = "sha256-GkDfIC2jx4Mpguk/Wu45pZw0czhabJwTz58WYSLCOV8=";
   };
 
-  format = "pyproject";
+  nativeBuildInputs = [ poetry-core ];
 
-  nativeBuildInputs = [ poetry ];
   propagatedBuildInputs = [ paho-mqtt ];
 
-  checkInputs = [ hbmqtt pytest-asyncio pytestCheckHook ];
-  pytestFlagsArray = [ "tests/" "--ignore=tests/test_discovery.py" ];
+  checkInputs = [
+    amqtt
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/" ];
+
+  disabledTestPaths = [ "tests/test_discovery.py" ];
+
   pythonImportsCheck = [ "roombapy" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -32,9 +32,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/" ];
-
-  disabledTestPaths = [ "tests/test_discovery.py" ];
+  disabledTestPaths = [
+    # Requires network access
+    "tests/test_discovery.py"
+  ];
 
   pythonImportsCheck = [ "roombapy" ];
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -354,6 +354,7 @@ in with py.pkgs; buildPythonApplication rec {
     "rituals_perfume_genie"
     "rmvtransport"
     "roku"
+    "roomba"
     "rss_feed_template"
     "ruckus_unleashed"
     "safe_mode"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -383,6 +383,8 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib { };
 
+  amqtt = callPackage ../development/python-modules/amqtt { };
+
   android-backup = callPackage ../development/python-modules/android-backup { };
 
   androidtv = callPackage ../development/python-modules/androidtv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.6.3

Change log: https://github.com/pschmitt/roombapy/releases/tag/1.6.3

Requires now `amqtt` (https://github.com/Yakifo/amqtt).

Along with the update for 1.6.3 were some changes in Home Assistant introduced (https://github.com/home-assistant/core/pull/49416). Tests are failing with 2021.4.x

```bash
building '/nix/store/qgmpvzn64pph608ph6afxpsvns0630kh-homeassistant-2021.4.6.drv'...
builder for '/nix/store/qgmpvzn64pph608ph6afxpsvns0630kh-homeassistant-2021.4.6.drv' failed with exit code 1; last 10 log lines:
      gc.collect()
  
  tests/components/shell_command/test_init.py::test_do_no_run_forever[pyloop]
    /nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/lib/python3.8/asyncio/unix_events.py:917: RuntimeWarning: A loop is being detached from a child watcher with pending handlers
      warnings.warn(
  
  -- Docs: https://docs.pytest.org/en/stable/warnings.html
  =========================== short test summary info ============================
  ERROR tests/components/roomba/test_config_flow.py
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
