### PR TITLE
nixos/keycloak: Security fixes + misc

### DIFF
--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -54,6 +54,7 @@ in
 
     frontendUrl = lib.mkOption {
       type = lib.types.str;
+      apply = x: if lib.hasSuffix "/" x then x else x + "/";
       example = "keycloak.example.com/auth";
       description = ''
         The public URL used as base for all frontend requests. Should

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -712,4 +712,5 @@ in
       };
 
   meta.doc = ./keycloak.xml;
+  meta.maintainers = [ lib.maintainers.talyz ];
 }

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -588,7 +588,8 @@ in
             Group = "postgres";
           };
           script = ''
-            set -eu
+            set -o errexit -o pipefail -o nounset -o errtrace
+            shopt -s inherit_errexit
 
             PSQL=${config.services.postgresql.package}/bin/psql
 
@@ -612,7 +613,8 @@ in
             Group = config.services.mysql.group;
           };
           script = ''
-            set -eu
+            set -o errexit -o pipefail -o nounset -o errtrace
+            shopt -s inherit_errexit
 
             db_password="$(<'${cfg.databasePasswordFile}')"
             ( echo "CREATE USER IF NOT EXISTS 'keycloak'@'localhost' IDENTIFIED BY '$db_password';"
@@ -647,14 +649,16 @@ in
             serviceConfig = {
               ExecStartPre = let
                 startPreFullPrivileges = ''
-                  set -eu
+                  set -o errexit -o pipefail -o nounset -o errtrace
+                  shopt -s inherit_errexit
 
                   install -T -m 0400 -o keycloak -g keycloak '${cfg.databasePasswordFile}' /run/keycloak/secrets/db_password
                 '' + lib.optionalString (cfg.certificatePrivateKeyBundle != null) ''
                   install -T -m 0400 -o keycloak -g keycloak '${cfg.certificatePrivateKeyBundle}' /run/keycloak/secrets/ssl_cert_pk_bundle
                 '';
                 startPre = ''
-                  set -eu
+                  set -o errexit -o pipefail -o nounset -o errtrace
+                  shopt -s inherit_errexit
 
                   install -m 0600 ${cfg.package}/standalone/configuration/*.properties /run/keycloak/configuration
                   install -T -m 0600 ${keycloakConfig} /run/keycloak/configuration/standalone.xml

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -652,6 +652,8 @@ in
                   set -o errexit -o pipefail -o nounset -o errtrace
                   shopt -s inherit_errexit
 
+                  umask u=rwx,g=,o=
+
                   install -T -m 0400 -o keycloak -g keycloak '${cfg.databasePasswordFile}' /run/keycloak/secrets/db_password
                 '' + lib.optionalString (cfg.certificatePrivateKeyBundle != null) ''
                   install -T -m 0400 -o keycloak -g keycloak '${cfg.certificatePrivateKeyBundle}' /run/keycloak/secrets/ssl_cert_pk_bundle
@@ -659,6 +661,8 @@ in
                 startPre = ''
                   set -o errexit -o pipefail -o nounset -o errtrace
                   shopt -s inherit_errexit
+
+                  umask u=rwx,g=,o=
 
                   install -m 0600 ${cfg.package}/standalone/configuration/*.properties /run/keycloak/configuration
                   install -T -m 0600 ${keycloakConfig} /run/keycloak/configuration/standalone.xml

--- a/nixos/modules/services/web-apps/keycloak.xml
+++ b/nixos/modules/services/web-apps/keycloak.xml
@@ -41,31 +41,31 @@
        <productname>PostgreSQL</productname> or
        <productname>MySQL</productname>. Which one is used can be
        configured in <xref
-       linkend="opt-services.keycloak.databaseType" />. The selected
+       linkend="opt-services.keycloak.database.type" />. The selected
        database will automatically be enabled and a database and role
        created unless <xref
-       linkend="opt-services.keycloak.databaseHost" /> is changed from
+       linkend="opt-services.keycloak.database.host" /> is changed from
        its default of <literal>localhost</literal> or <xref
-       linkend="opt-services.keycloak.databaseCreateLocally" /> is set
+       linkend="opt-services.keycloak.database.createLocally" /> is set
        to <literal>false</literal>.
      </para>
 
      <para>
        External database access can also be configured by setting
-       <xref linkend="opt-services.keycloak.databaseHost" />, <xref
-       linkend="opt-services.keycloak.databaseUsername" />, <xref
-       linkend="opt-services.keycloak.databaseUseSSL" /> and <xref
-       linkend="opt-services.keycloak.databaseCaCert" /> as
+       <xref linkend="opt-services.keycloak.database.host" />, <xref
+       linkend="opt-services.keycloak.database.username" />, <xref
+       linkend="opt-services.keycloak.database.useSSL" /> and <xref
+       linkend="opt-services.keycloak.database.caCert" /> as
        appropriate. Note that you need to manually create a database
        called <literal>keycloak</literal> and allow the configured
        database user full access to it.
      </para>
 
      <para>
-       <xref linkend="opt-services.keycloak.databasePasswordFile" />
+       <xref linkend="opt-services.keycloak.database.passwordFile" />
        must be set to the path to a file containing the password used
-       to log in to the database. If <xref linkend="opt-services.keycloak.databaseHost" />
-       and <xref linkend="opt-services.keycloak.databaseCreateLocally" />
+       to log in to the database. If <xref linkend="opt-services.keycloak.database.host" />
+       and <xref linkend="opt-services.keycloak.database.createLocally" />
        are kept at their defaults, the database role
        <literal>keycloak</literal> with that password is provisioned
        on the local database instance.
@@ -196,7 +196,7 @@ services.keycloak = {
   <link linkend="opt-services.keycloak.frontendUrl">frontendUrl</link> = "https://keycloak.example.com/auth";
   <link linkend="opt-services.keycloak.forceBackendUrlToFrontendUrl">forceBackendUrlToFrontendUrl</link> = true;
   <link linkend="opt-services.keycloak.certificatePrivateKeyBundle">certificatePrivateKeyBundle</link> = "/run/keys/ssl_cert";
-  <link linkend="opt-services.keycloak.databasePasswordFile">databasePasswordFile</link> = "/run/keys/db_password";
+  <link linkend="opt-services.keycloak.database.passwordFile">database.passwordFile</link> = "/run/keys/db_password";
 };
 </programlisting>
      </para>

--- a/nixos/modules/services/web-apps/keycloak.xml
+++ b/nixos/modules/services/web-apps/keycloak.xml
@@ -115,17 +115,17 @@
      </para>
 
      <para>
-       For HTTPS support, a TLS certificate and private key is
-       required. They should be <link
+       HTTPS support requires a TLS/SSL certificate and a private key,
+       both <link
        xlink:href="https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail">PEM
-       formatted</link> and concatenated into a single file. The path
-       to this file should be configured in
-       <xref linkend="opt-services.keycloak.certificatePrivateKeyBundle" />.
+       formatted</link>. Their paths should be set through <xref
+       linkend="opt-services.keycloak.sslCertificate" /> and <xref
+       linkend="opt-services.keycloak.sslCertificateKey" />.
      </para>
 
      <warning>
        <para>
-         The path should be provided as a string, not a Nix path,
+         The paths should be provided as a strings, not a Nix paths,
          since Nix paths are copied into the world readable Nix store.
        </para>
      </warning>
@@ -195,7 +195,8 @@ services.keycloak = {
   <link linkend="opt-services.keycloak.initialAdminPassword">initialAdminPassword</link> = "e6Wcm0RrtegMEHl";  # change on first login
   <link linkend="opt-services.keycloak.frontendUrl">frontendUrl</link> = "https://keycloak.example.com/auth";
   <link linkend="opt-services.keycloak.forceBackendUrlToFrontendUrl">forceBackendUrlToFrontendUrl</link> = true;
-  <link linkend="opt-services.keycloak.certificatePrivateKeyBundle">certificatePrivateKeyBundle</link> = "/run/keys/ssl_cert";
+  <link linkend="opt-services.keycloak.sslCertificate">sslCertificate</link> = "/run/keys/ssl_cert";
+  <link linkend="opt-services.keycloak.sslCertificateKey">sslCertificateKey</link> = "/run/keys/ssl_key";
   <link linkend="opt-services.keycloak.database.passwordFile">database.passwordFile</link> = "/run/keys/db_password";
 };
 </programlisting>

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -19,9 +19,12 @@ let
           virtualisation.memorySize = 1024;
           services.keycloak = {
             enable = true;
-            inherit frontendUrl databaseType initialAdminPassword;
-            databaseUsername = "bogus";
-            databasePasswordFile = pkgs.writeText "dbPassword" "wzf6vOCbPp6cqTH";
+            inherit frontendUrl initialAdminPassword;
+            database = {
+              type = databaseType;
+              username = "bogus";
+              passwordFile = pkgs.writeText "dbPassword" "wzf6vOCbPp6cqTH";
+            };
           };
           environment.systemPackages = with pkgs; [
             xmlstarlet

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -3,7 +3,8 @@
 # client using their Keycloak login.
 
 let
-  frontendUrl = "http://keycloak/auth";
+  certs = import ./common/acme/server/snakeoil-certs.nix;
+  frontendUrl = "https://${certs.domain}/auth";
   initialAdminPassword = "h4IhoJFnt2iQIR9";
 
   keycloakTest = import ./make-test-python.nix (
@@ -17,15 +18,27 @@ let
       nodes = {
         keycloak = { ... }: {
           virtualisation.memorySize = 1024;
+
+          security.pki.certificateFiles = [
+            certs.ca.cert
+          ];
+
+          networking.extraHosts = ''
+            127.0.0.1 ${certs.domain}
+          '';
+
           services.keycloak = {
             enable = true;
             inherit frontendUrl initialAdminPassword;
+            sslCertificate = certs.${certs.domain}.cert;
+            sslCertificateKey = certs.${certs.domain}.key;
             database = {
               type = databaseType;
               username = "bogus";
               passwordFile = pkgs.writeText "dbPassword" "wzf6vOCbPp6cqTH";
             };
           };
+
           environment.systemPackages = with pkgs; [
             xmlstarlet
             libtidy


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Security fixes for the `keycloak` module:

- Set umask before copying sensitive files (see  #121293)
- Set the postgres database password securely

Miscellaneous improvements:
- Implement better bash error handling
- Move all `database*`-options into a `database` group / attribute
- Split the `certificatePrivateKeyBundle` option into `sslCertificate` and `sslCertificateKey`
- Improve readability by adding executables to PATH instead of referring to them directly
- Test the HTTPS support
- Add myself as module maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
