### PR TITLE
nixos/sudo: add option execWheelOnly

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -61,6 +61,17 @@ in
         '';
       };
 
+    security.sudo.execWheelOnly = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Only allow members of the <code>wheel</code> group to execute sudo by
+        setting the executable's permissions accordingly.
+        This prevents users that are not members of <code>wheel</code> from
+        exploiting vulnerabilities in sudo such as CVE-2021-3156.
+      '';
+    };
+
     security.sudo.configFile = mkOption {
       type = types.lines;
       # Note: if syntax errors are detected in this file, the NixOS
@@ -216,9 +227,20 @@ in
         ${cfg.extraConfig}
       '';
 
-    security.wrappers = {
-      sudo.source = "${cfg.package.out}/bin/sudo";
-      sudoedit.source = "${cfg.package.out}/bin/sudoedit";
+    security.wrappers = let
+      owner = "root";
+      group = if cfg.execWheelOnly then "wheel" else "root";
+      setuid = true;
+      permissions = if cfg.execWheelOnly then "u+rx,g+x" else "u+rx,g+x,o+x";
+    in {
+      sudo = {
+        source = "${cfg.package.out}/bin/sudo";
+        inherit owner group setuid permissions;
+      };
+      sudoedit = {
+        source = "${cfg.package.out}/bin/sudoedit";
+        inherit owner group setuid permissions;
+      };
     };
 
     environment.systemPackages = [ sudo ];

--- a/nixos/tests/sudo.nix
+++ b/nixos/tests/sudo.nix
@@ -10,7 +10,7 @@ in
       maintainers = [ lschuermann ];
     };
 
-    machine =
+    nodes.machine =
       { lib, ... }:
       with lib;
       {
@@ -48,6 +48,19 @@ in
         };
       };
 
+    nodes.strict = { ... }: {
+      users.users = {
+        admin = { isNormalUser = true; extraGroups = [ "wheel" ]; };
+        noadmin = { isNormalUser = true; };
+      };
+
+      security.sudo = {
+        enable = true;
+        wheelNeedsPassword = false;
+        execWheelOnly = true;
+      };
+    };
+
     testScript =
       ''
         with subtest("users in wheel group should have passwordless sudo"):
@@ -79,5 +92,11 @@ in
 
         with subtest("users in group 'barfoo' should not be able to keep their environment"):
             machine.fail("sudo -u test3 sudo -n -E -u root true")
+
+        with subtest("users in wheel should be able to run sudo despite execWheelOnly"):
+            strict.succeed('su - admin -c "sudo -u root true"')
+
+        with subtest("non-wheel users should be unable to run sudo thanks to execWheelOnly"):
+            strict.fail('su - noadmin -c "sudo --help"')
       '';
   })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
By setting the executable's group to wheel and permissions to 4510, we make sure that only members of the wheel group can execute sudo.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I don't know if this is a thing we want in NixOS since it seems very non-standard. But I want to hear people's opinions on it.

One problem is that if users that aren't members of wheel try to run sudo, they will find `/run/current-system/sw/bin/sudo` because they don't have permissions to execute `/run/wrappers/bin/sudo` and then sudo will print
```
sudo: /run/current-system/sw/bin/sudo must be owned by uid 0 and have the setuid bit set
```