### PR TITLE
python3Packages.discordpy: 1.7.1 -> 1.7.2

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -5,25 +5,23 @@
 , libopus
 , pynacl
 , pythonOlder
-, websockets
 , withVoice ? true
 }:
 
 buildPythonPackage rec {
   pname = "discord.py";
-  version = "1.7.1";
+  version = "1.7.2";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Rapptz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-dpASIqe6rJEyiWJyPbQhq9M54lX1ilfp4UuGnbJcFLo=";
+    sha256 = "sha256-NY1/RKp8w9gAqGYXnCNhNZqR/inGMvUvxjJ1MMs62B8=";
   };
 
   propagatedBuildInputs = [
     aiohttp
-    websockets
   ] ++ lib.optionalString withVoice [
     libopus
     pynacl


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.7.2

Change log: https://discordpy.readthedocs.io/en/stable/whats_new.html#v1-7-2

1.7.2 contains only bugfixes.

Home Assistant bump: https://github.com/home-assistant/core/pull/50201

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
