### PR TITLE
conan: unbreak by downgrading pyjwt

### DIFF
--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -28,6 +28,14 @@ let newPython = python3.override {
         sha256 = "18hpzh1am1dqx81fypn57r2wk565fi4g14292qrc5jm1h9dalzld";
       };
     });
+    # https://github.com/conan-io/conan/issues/8876
+    pyjwt = super.pyjwt.overridePythonAttrs (oldAttrs: rec {
+      version = "1.7.1";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96";
+      };
+    });
   };
 };
 


### PR DESCRIPTION
###### Motivation for this change
Pin pyjwt to 1.7.1 (the last of the 1.x series) to fix building conan:

  ERROR: Could not find a version that satisfies the requirement PyJWT<2.0.0,>=1.4.0 (from conan)

Ref. upstream issue https://github.com/conan-io/conan/issues/8876.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
