### PR TITLE
openxray: 784-october-preview -> 822-december-preview

### DIFF
--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -3,14 +3,14 @@
 , pcre, makeWrapper, fetchpatch }:
 
 let
-  version = "784-october-preview";
+  version = "822-december-preview";
 
   src = fetchFromGitHub {
     owner = "OpenXRay";
     repo = "xray-16";
     rev = version;
-    sha256 = "0q0h70gbpscdvn45wpxicljj4ji3cd2maijd5b7jhr1695h61q5y";
     fetchSubmodules = true;
+    sha256 = "06f3zjnib7hipyl3hnc6mwcj9f50kbwn522wzdjydz8qgdg60h3m";
   };
 
   # https://github.com/OpenXRay/xray-16/issues/518
@@ -20,7 +20,7 @@ let
 
     inherit src;
 
-    postUnpack = "sourceRoot+=/Externals/cryptopp";
+    sourceRoot = "source/Externals/cryptopp";
 
     makeFlags = [ "PREFIX=${placeholder "out"}" ];
     enableParallelBuilding = true;
@@ -35,25 +35,30 @@ let
     };
   };
 in stdenv.mkDerivation rec {
-  pname = "OpenXRay";
+  pname = "openxray";
   inherit version src;
 
-  hardeningDisable = [ "format" ];
-  cmakeFlags = [ "-DCMAKE_INCLUDE_PATH=${cryptopp}/include/cryptopp" ];
-
+  # TODO https://github.com/OpenXRay/GameSpy/pull/6, check if merged in version > 822
+  # Fixes format hardening
   patches = [
     (fetchpatch {
-      url = "https://github.com/OpenXRay/xray-16/commit/4532cba11e98808c92e56e246188863261ef9201.patch";
-      sha256 = "1hrm4rkkg946ai95krzpf3isryzbb2vips63gxf481plv4vlcfc9";
+      url = "https://github.com/OpenXRay/GameSpy/pull/6/commits/155af876281f5d94f0142886693314d97deb2d4c.patch";
+      sha256 = "1l0vcgvzzx8n56shpblpfdhvpr6c12fcqf35r0mflaiql8q7wn88";
+      stripLen = 1;
+      extraPrefix = "Externals/GameSpy/";
     })
   ];
+
+  cmakeFlags = [ "-DCMAKE_INCLUDE_PATH=${cryptopp}/include/cryptopp" ];
 
   buildInputs = [
     glew freeimage liblockfile openal cryptopp libtheora SDL2 lzo
     libjpeg libogg tbb pcre
   ];
+
   nativeBuildInputs = [ cmake makeWrapper ];
 
+  # https://github.com/OpenXRay/xray-16/issues/786
   preConfigure = ''
     substituteInPlace src/xrCore/xrCore.cpp \
       --replace /usr/share $out/share
@@ -71,7 +76,7 @@ in stdenv.mkDerivation rec {
     license = licenses.unfree // {
       url = "https://github.com/OpenXRay/xray-16/blob/xd_dev/License.txt";
     };
-    maintainers = [ ];
+    maintainers = with maintainers; [ OPNA2608 ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Closes #119299

Done:
- Bump
- Fixing pname not matching name in all-packages.nix
- Fixing format hardening
- Removing @gnidorah (account deleted) and adding myself as maintainer
- Tested with game files

![Bildschirmfoto von 2021-05-05 23-14-44](https://user-images.githubusercontent.com/23431373/117210312-cc3cdc00-adf7-11eb-83fa-4800a637fd1a.png)


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
