### PR TITLE
neovim: set g:loaded_python_provider = 0

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -58,10 +58,11 @@ let
       # add to nvim's 'embedded rc' this:
       #    let g:<key>_host_prog=$out/bin/nvim-<key>
       # Or this:
-      #    let g:loaded_${prog}_provider=1
+      #    let g:loaded_${prog}_provider=0
       # While the latter tells nvim that this provider is not available
       hostprog_check_table = {
         node = withNodeJs;
+        python = false;
         python3 = withPython3;
         ruby = withRuby;
       };
@@ -107,7 +108,7 @@ let
       if withProg then
         "let g:${prog}_host_prog='${placeholder "out"}/bin/nvim-${prog}'"
       else
-        "let g:loaded_${prog}_provider=1"
+        "let g:loaded_${prog}_provider=0"
     ;
 
   # to keep backwards compatibility


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Support for python2 provider was dropped so we need to disable it in the config.
Also changed value 1 => 0 because that what docs says https://neovim.io/doc/user/provider.html#g:loaded_python_provider

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
