### PR TITLE
sublime-music: 0.11.11 -> 0.11.12

### DIFF
--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -1,5 +1,4 @@
 { fetchFromGitLab
-, fetchpatch
 , lib
 , python3Packages
 , gobject-introspection
@@ -16,25 +15,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sublime-music";
-  version = "0.11.11";
+  version = "0.11.12";
   format = "pyproject";
 
   src = fetchFromGitLab {
     owner = "sublime-music";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-r4Tn/7CGDny8Aa4kF4PM5ZKMYthMJ7801X3zPdvXh4Q=";
+    sha256 = "sha256-fcEdpht+xKJRTaD3gKoRdf6O2SAPlZHZ61Jy8bdTKjs=";
   };
-
-  patches = [
-    # Switch to poetry-core:
-    # https://gitlab.com/sublime-music/sublime-music/-/merge_requests/60
-    (fetchpatch {
-      name = "use-poetry-core.patch";
-      url = "https://gitlab.com/sublime-music/sublime-music/-/commit/9b0af19dbdfdcc5a0fa23e73bb34c7135a8c2855.patch";
-      sha256 = "sha256-cXG0RvrnBpme6yKWM0nfqMqoK0qPT6spflJ9AaaslVg=";
-    })
-  ];
 
   nativeBuildInputs = [
     gobject-introspection


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.com/sublime-music/sublime-music/-/releases/v0.11.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
