### PR TITLE
python3Packages.datclasses-json: 0.5.2 -> 0.5.3

### DIFF
--- a/pkgs/development/python-modules/dataclasses-json/default.nix
+++ b/pkgs/development/python-modules/dataclasses-json/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "dataclasses-json";
-  version = "0.5.2";
+  version = "0.5.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "56ec931959ede74b5dedf65cf20772e6a79764d20c404794cce0111c88c085ff";
+    sha256 = "sha256-/hfak0z8TseS6+fpowNDTs9PX42KdwWs+758y9NL8a4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/dataclasses-json/default.nix
+++ b/pkgs/development/python-modules/dataclasses-json/default.nix
@@ -1,18 +1,21 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , stringcase
 , typing-inspect
 , marshmallow-enum
+, python3Packages
 }:
 
 buildPythonPackage rec {
   pname = "dataclasses-json";
   version = "0.5.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-/hfak0z8TseS6+fpowNDTs9PX42KdwWs+758y9NL8a4=";
+  src = fetchFromGitHub {
+    owner = "lidatong";
+    repo = "dataclasses-json";
+    rev = "v${version}";
+    sha256 = "sha256-4Jh79aoGQzgjBqHiWrmeyIlU+jPnsBgvdpwyh5tAd4I=";
   };
 
   propagatedBuildInputs = [
@@ -20,6 +23,15 @@ buildPythonPackage rec {
     typing-inspect
     marshmallow-enum
   ];
+
+  checkInputs = with python3Packages; [
+    hypothesis
+    mypy
+    pytest
+  ];
+  # Ignoring the tests/test_annotations test because it fails due to not being
+  # able to find a library stub for 'mypy.main'.
+  checkPhase = "pytest --ignore tests/test_annotations.py";
 
   meta = with lib; {
     description = "Simple API for encoding and decoding dataclasses to and from JSON";

--- a/pkgs/development/python-modules/dataclasses-json/default.nix
+++ b/pkgs/development/python-modules/dataclasses-json/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "Simple API for encoding and decoding dataclasses to and from JSON";
     homepage = "https://github.com/lidatong/dataclasses-json";
     license = licenses.mit;
-    maintainers = with maintainers; [ albakham ];
+    maintainers = with maintainers; [ albakham sumnerevans ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/lidatong/dataclasses-json/releases/tag/v0.5.3

Also converts to build from source and run the tests from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
