### PR TITLE
altair-graphql-client: init at version 4.0.2

### DIFF
--- a/pkgs/development/tools/altair-graphql-client/default.nix
+++ b/pkgs/development/tools/altair-graphql-client/default.nix
@@ -1,0 +1,38 @@
+{ lib, appimageTools, fetchurl, gsettings-desktop-schemas, gtk3 }:
+
+let
+  pname = "altair";
+  version = "4.0.2";
+  name = "${pname}-v${version}";
+
+  src = fetchurl {
+    url = "https://github.com/imolorhe/altair/releases/download/v${version}/altair_${version}_x86_64_linux.AppImage";
+    sha256 = "sha256-HCoK+ljcTmyBZSCDe6u2x2urqrQfi3DIlXfCqGWvl3E=";
+  };
+
+  appimageContents = appimageTools.extract { inherit name src; };
+in
+appimageTools.wrapType2 {
+  inherit src name;
+
+  profile = ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "A feature-rich GraphQL Client IDE";
+    homepage = "https://github.com/imolorhe/altair";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evalexpr ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12354,6 +12354,8 @@ in
     alloy5
     alloy;
 
+  altair = callPackage ../development/tools/altair-graphql-client { };
+
   ameba = callPackage ../development/tools/ameba { };
 
   augeas = callPackage ../tools/system/augeas { };


### PR DESCRIPTION
###### Motivation for this change

Adds a nice GraphQL Client frontend similar to GraphiQL which was a package that users were looking for: https://github.com/NixOS/nixpkgs/issues/56404. GraphiQL seems unmaintained and this is a replacement I've been using for a while - so I decided to add it to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
