### PR TITLE
_1password: 1.8.0 -> 1.9.1

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "1.8.0";
+  version = "1.9.1";
   src =
     if stdenv.isLinux then fetchzip {
       url = {
@@ -11,14 +11,14 @@ stdenv.mkDerivation rec {
         "aarch64-linux" = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_arm_v${version}.zip";
       }.${stdenv.hostPlatform.system};
       sha256 = {
-        "i686-linux" = "teoxscan+EZ76Q0sfKT6nt1w/LSsmDoiN2oh+NGO/4A=";
-        "x86_64-linux" = "nRK2GSwhQe5OgcAdR1fg0vUp3fzEkhwU/teIwsEEemw=";
-        "aarch64-linux" = "0932bspm1likky1n0rg15d01gspkm1fns2ma82qyb91yr6d18ddk";
+        "i686-linux" = "1x5khnp6yqrjf513x3y6l38rb121nib7d4aiz4cz7fh029kxjhd1";
+        "x86_64-linux" = "1ar8lzkndl7xzcinv93rzg8q25vb23fggbjkhgchgc5x9wkwk8hw";
+        "aarch64-linux" = "1q81pk6qmp96p1dbhx1ijln8f54rac8r81d4ghqx9v756s9szrr1";
       }.${stdenv.hostPlatform.system};
       stripRoot = false;
     } else fetchurl {
       url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.pkg";
-      sha256 = "0pycia75vdfh6gxfd2hr32cxrryfxydid804n0v76l2fpr9v9v3d";
+      sha256 = "0904wwy3wdhfvbkvpdap8141a9gqmn0dw45ikrzsqpg7pv1r2zch";
     };
 
   buildInputs = lib.optionals stdenv.isDarwin [ xar cpio ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Just to update the 1password cli. They added secrets automation to the 1.9.0 release and this is just the latest release anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @joelburget @marsam

I just want to also include that we can probably use `passthru.updateScript`, but I'm not sure how to do so correctly. The 1password docs also mentions verifying the binaries with their provided signature https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool - but I had errors with gpg receiving keys (I manually verified instead). How can we automate this for the update script? I drafted this so far, but it errors:

```bash
#!/usr/bin/env nix-shell
#!nix-shell -i bash -p curl pup gnused common-updater-scripts

set -eu -o pipefail

version="$(curl -Ls https://app-updates.agilebits.com/product_history/CLI | \
  pup '.cli-archs .linux a attr{href}' | head -n 1 | \
  sed -E 's/.+_v(.+)\.zip$/\1/')"
update-source-version _1password "$version"
```