### PR TITLE
minipro: init at 0.5

### DIFF
--- a/pkgs/tools/misc/minipro/default.nix
+++ b/pkgs/tools/misc/minipro/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config, which
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "minipro";
+  version = "0.5";
+
+  src = fetchurl {
+    url = "https://gitlab.com/DavidGriffith/minipro/-/archive/master/minipro-${version}.tar.bz2";
+    sha256 = "sha256-ewLW4PxZaXHfNVyY9xJHcAxGcTL9YejOCIa32xhmSj4=";
+  };
+
+  nativeBuildInputs = [ pkg-config which ];
+  buildInputs = [ libusb1 ];
+
+  makeFlags = [
+    "PREFIX=/"
+    "DESTDIR=${placeholder "out"}"
+    "UDEV_RULES_INSTDIR=${placeholder "out"}/lib/udev/rules.d" "UDEV_DIR=/"
+  ]; 
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/DavidGriffith/minipro/";
+    description = "An open source program for controlling the MiniPRO TL866xx series of chip programmers";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ baloo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6686,6 +6686,8 @@ in
 
   minetime = callPackage ../applications/office/minetime { };
 
+  minipro = callPackage ../tools/misc/minipro { };
+
   minio-client = callPackage ../tools/networking/minio-client { };
 
   minissdpd = callPackage ../tools/networking/minissdpd { };


### PR DESCRIPTION
###### Motivation for this change

Minipro is used to program flash devices with a tl866ii programmer.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
