### PR TITLE
python3Packages.pyialarm: init at 1.5

### DIFF
--- a/pkgs/development/python-modules/pyialarm/default.nix
+++ b/pkgs/development/python-modules/pyialarm/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, dicttoxml
+, fetchFromGitHub
+, pythonOlder
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "pyialarm";
+  version = "1.5";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "RyuzakiKK";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vpscc2h13mmwscvjpm0bfd80x94mzh4d204v6n421mdz3ddhjqp";
+  };
+
+  propagatedBuildInputs = [
+    dicttoxml
+    xmltodict
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyialarm" ];
+
+  meta = with lib; {
+    description = "Python library to interface with Antifurto365 iAlarm systems";
+    homepage = "https://github.com/RyuzakiKK/pyialarm";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5617,6 +5617,8 @@ in {
 
   pyi2cflash = callPackage ../development/python-modules/pyi2cflash { };
 
+  pyialarm = callPackage ../development/python-modules/pyialarm { };
+
   pyicloud = callPackage ../development/python-modules/pyicloud { };
 
   PyICU = callPackage ../development/python-modules/pyicu { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to interface with Antifurto365 iAlarm systems

https://github.com/RyuzakiKK/pyialarm

This is a new Home Assistant dependency (> 2021.5.x)

ToDo:

- [ ] Update component-packages
- [ ] Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
