### PR TITLE
nixos/transmission: add a missing apparmor rule

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -402,6 +402,7 @@ in
           mr ${getLib pkgs.util-linuxMinimal.out}/lib/libuuid.so*,
           mr ${getLib pkgs.xz}/lib/liblzma*.so*,
           mr ${getLib pkgs.zlib}/lib/libz*.so*,
+          mr ${getLib pkgs.brotli}/lib/libbrotli*.so*,
 
           r @{PROC}/sys/kernel/random/uuid,
           r @{PROC}/sys/vm/overcommit_memory,


### PR DESCRIPTION
Hello, this tiny patch should fix transmission for apparmor users.
For the details:
libbrotli wasn't listed as a dependency for the AppArmor profile of the transmission-daemon binary.
As a result, transmission wouldn't run and would fail, logging this audit message to dmesg:
`audit[11595]: AVC apparmor=DENIED operation=open profile=/nix/store/08i1rmakmnpwyxpvp0sfc5hcm106am7w-transmission-3.00/bin/transmission-daemon name=/proc/11595/environ pid=11595 comm=transmission-da requested_mask=r denied_mask=r fsuid=70 ouid=70`
This patch whitelists `libbrotli*.so` for use as libraries within the `transmission-daemon` binary.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Transmission wouldn't run and would crash instantly at startup if AppArmor is enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> only the `transmission-daemon` is impacted, and it appears to work with that change
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
