### PR TITLE
python3Packages.mutesync: init at 0.0.1

### DIFF
--- a/pkgs/development/python-modules/mutesync/default.nix
+++ b/pkgs/development/python-modules/mutesync/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, aiohttp
+, async-timeout
+, buildPythonPackage
+, fetchpatch
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "mutesync";
+  version = "0.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05r8maq59glwgysg98y1vrysfb1mkh9jpbag3ixl13n8jw8clp85";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+  ];
+
+  patches = [
+    # Don't parse requirements.txt, https://github.com/currentoor/pymutesync/pull/1
+    (fetchpatch {
+      name = "add-requirements.patch";
+      url = "https://github.com/currentoor/pymutesync/commit/d66910fc83b1ae3060cdb3fe22a6f91fb70a67f0.patch";
+      sha256 = "0axhgriyyv31b1r1yidxcrv0nyrqbb63xw5qrmv2iy2h0v96ijsk";
+    })
+  ];
+
+  # Project has not published tests yet
+  doCheck = false;
+  pythonImportsCheck = [ "mutesync" ];
+
+  meta = with lib; {
+    description = "Python module for interacting with mutesync buttons";
+    homepage = "https://github.com/currentoor/pymutesync";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -531,7 +531,7 @@
     "mqtt_statestream" = ps: with ps; [ aiohttp-cors paho-mqtt ];
     "msteams" = ps: with ps; [ pymsteams ];
     "mullvad" = ps: with ps; [ mullvad-api ];
-    "mutesync" = ps: with ps; [ ]; # missing inputs: mutesync
+    "mutesync" = ps: with ps; [ mutesync ];
     "mvglive" = ps: with ps; [ PyMVGLive ];
     "my" = ps: with ps; [ aiohttp-cors pillow ];
     "mychevy" = ps: with ps; [ ]; # missing inputs: mychevy

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -301,6 +301,7 @@ in with py.pkgs; buildPythonApplication rec {
     "mqtt_room"
     "mqtt_statestream"
     "mullvad"
+    "mutesync"
     "nexia"
     "notify"
     "notion"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4317,6 +4317,8 @@ in {
 
   mutatormath = callPackage ../development/python-modules/mutatormath { };
 
+  mutesync = callPackage ../development/python-modules/mutesync { };
+
   mwclient = callPackage ../development/python-modules/mwclient { };
 
   mwdblib = callPackage ../development/python-modules/mwdblib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for interacting with mutesync buttons

https://github.com/currentoor/pymutesync

This is a new Home Assistant dependency (> 2021.5.x)

ToDo:

- [x] Update component-packages
- [x] Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
