### PR TITLE
python3Packages.sqlalchemy: 1.3.23 -> 1.4.13

### DIFF
--- a/pkgs/development/python-modules/marshmallow-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/marshmallow-sqlalchemy/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 , marshmallow
 , sqlalchemy
@@ -9,16 +10,21 @@
 
 buildPythonPackage rec {
   pname = "marshmallow-sqlalchemy";
-  version = "0.24.2";
+  version = "0.25.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ee3ead3b83de6608c6850ff60515691b0dc556ca226680f8a82b9f785cdb71b1";
+    sha256 = "0i39ckrixh1w9fmkm0wl868gvza72j5la0x6dd0cij9shf1iyjgi";
   };
 
   propagatedBuildInputs = [
     marshmallow
     sqlalchemy
+  ];
+
+  pythonImportsCheck = [
+    "marshmallow_sqlalchemy"
   ];
 
   checkInputs = [
@@ -28,7 +34,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/marshmallow-code/marshmallow-sqlalchemy";
-    description = "SQLAlchemy integration with marshmallow ";
+    description = "SQLAlchemy integration with marshmallow";
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/marshmallow/default.nix
+++ b/pkgs/development/python-modules/marshmallow/default.nix
@@ -1,27 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi,
-  dateutil, simplejson, isPy27
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pytestCheckHook
+, pytz
+, simplejson
 }:
 
 buildPythonPackage rec {
   pname = "marshmallow";
-  version = "3.10.0";
-  disabled = isPy27;
+  version = "3.11.1";
+  disabled = pythonOlder "3.5";
 
-  meta = {
-    homepage = "https://github.com/marshmallow-code/marshmallow";
+  src = fetchFromGitHub {
+    owner = "marshmallow-code";
+    repo = pname;
+    rev = version;
+    sha256 = "1ypm142y3giaqydc7fkigm9r057yp2sd1ng5zr2x3w3wbbj5yfm6";
+  };
+
+  pythonImportsCheck = [
+    "marshmallow"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytz
+    simplejson
+  ];
+
+  meta = with lib; {
     description = ''
       A lightweight library for converting complex objects to and from
       simple Python datatypes.
     '';
-    license = lib.licenses.mit;
+    homepage = "https://github.com/marshmallow-code/marshmallow";
+    license = licenses.mit;
   };
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "4ab2fdb7f36eb61c3665da67a7ce281c8900db08d72ba6bf0e695828253581f7";
-  };
-
-  propagatedBuildInputs = [ dateutil simplejson ];
-
-  doCheck = false;
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<s>Required for home-assistant v2021.5.0.</s> Will add an override for home-assistant. Probably too big before the release.

https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html
https://docs.sqlalchemy.org/en/14/changelog/changelog_13.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
