### PR TITLE
python3Packages.pykoplenti: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/pykoplenti/default.nix
+++ b/pkgs/development/python-modules/pykoplenti/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, prompt_toolkit
+, pycryptodome
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pykoplenti";
+  version = "1.0.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "stegm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12nsyz8a49vhby1jp991vaky82fm93jrgcsjzwa2rixwg1zql4sw";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    click
+    prompt_toolkit
+    pycryptodome
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pykoplenti" ];
+
+  meta = with lib; {
+    description = "Python REST client API for Kostal Plenticore Inverters";
+    homepage = "https://github.com/stegm/pykoplenti/";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5665,6 +5665,8 @@ in {
 
   pykodi = callPackage ../development/python-modules/pykodi { };
 
+  pykoplenti = callPackage ../development/python-modules/pykoplenti { };
+
   pykwalify = callPackage ../development/python-modules/pykwalify { };
 
   pylacrosse = callPackage ../development/python-modules/pylacrosse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python REST client API for Kostal Plenticore Inverters

https://github.com/stegm/pykoplenti

This is a new Home Assistant dependency (> 2021.5.x). Home Assistant uses `kostal-plenticore-0.2.0` but with 1.0.0 the module was renamed.

ToDo:

- [ ] Update component-packages
- [ ] Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
