### PR TITLE
presage: init at 0.9.1

### DIFF
--- a/pkgs/development/libraries/presage/default.nix
+++ b/pkgs/development/libraries/presage/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, autoreconfHook
+, dbus
+, doxygen
+, fontconfig
+, gettext
+, graphviz
+, help2man
+, pkg-config
+, sqlite
+, tinyxml
+, cppunit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "presage";
+  version = "0.9.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/presage/presage/${version}/presage-${version}.tar.gz";
+    sha256 = "0rm3b3zaf6bd7hia0lr1wyvi1rrvxkn7hg05r5r1saj0a3ingmay";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://git.alpinelinux.org/aports/plain/community/presage/gcc6.patch";
+      sha256 = "0243nx1ygggmsly7057vndb4pkjxg9rpay5gyqqrq9jjzjzh63dj";
+    })
+    ./fixed-cppunit-detection.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    doxygen
+    fontconfig
+    gettext
+    graphviz
+    help2man
+    pkg-config
+  ];
+
+  preBuild = ''
+    export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
+  '';
+
+  buildInputs = [
+    dbus
+    sqlite
+    tinyxml
+  ];
+
+  checkInputs = [
+    cppunit
+  ];
+
+  doCheck = true;
+
+  checkTarget = "check";
+
+  meta = with lib; {
+    description = "An intelligent predictive text entry system";
+    homepage = "https://presage.sourceforge.io/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/presage/fixed-cppunit-detection.patch
+++ b/pkgs/development/libraries/presage/fixed-cppunit-detection.patch
@@ -1,0 +1,46 @@
+From 5624aa156c551ab2b81bb86279844397ed690653 Mon Sep 17 00:00:00 2001
+From: Matteo Vescovi <matteo.vescovi@yahoo.co.uk>
+Date: Sun, 21 Jan 2018 17:17:12 +0000
+Subject: [PATCH] Fixed cppunit detection.
+
+---
+ configure.ac | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index a02e9f1..1538a51 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -204,10 +204,16 @@ AM_CONDITIONAL([USE_SQLITE], [test "x$use_sqlite" = "xyes"])
+ dnl ==================
+ dnl Checks for CppUnit
+ dnl ==================
+-AM_PATH_CPPUNIT([1.9.6],
+-                [],
+-                [AC_MSG_WARN([CppUnit not found. Unit tests will not be built. CppUnit can be obtained from http://cppunit.sourceforge.net.])])
+-AM_CONDITIONAL([HAVE_CPPUNIT], [test "$CPPUNIT_LIBS"])
++PKG_CHECK_MODULES([CPPUNIT],
++                  [cppunit >= 1.9],
++                  [have_cppunit=yes],
++                  [AM_PATH_CPPUNIT([1.9],
++                                   [have_cppunit=yes],
++                                   [AC_MSG_WARN([CppUnit not found. Unit tests will not be built. CppUnit can be obtained from http://cppunit.sourceforge.net.])])
++                  ])
++AC_SUBST([CPPUNIT_CFLAGS])
++AC_SUBST([CPPUNIT_LIBS])
++AM_CONDITIONAL([HAVE_CPPUNIT], [test "x$have_cppunit" = "xyes"])
+ 
+ 
+ dnl ============================
+@@ -592,7 +598,7 @@ then
+ else
+     build_demo_application="no"
+ fi
+-if test "$CPPUNIT_LIBS"
++if test "x$have_cppunit" = "xyes"
+ then
+     build_unit_tests="yes"
+ else
+-- 
+2.31.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17102,6 +17102,8 @@ in
 
   portmidi = callPackage ../development/libraries/portmidi {};
 
+  presage = callPackage ../development/libraries/presage { };
+
   prime-server = callPackage ../development/libraries/prime-server { };
 
   primesieve = callPackage ../development/libraries/science/math/primesieve { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
useful for https://github.com/NixOS/nixpkgs/pull/121345

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Building the curses demo wouldn't work due to https://github.com/NixOS/nixpkgs/issues/54112.