### PR TITLE
pythonRemoveTestsDirHook: also remove /test

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-remove-tests-dir-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-remove-tests-dir-hook.sh
@@ -5,6 +5,7 @@ pythonRemoveTestsDir() {
     echo "Executing pythonRemoveTestsDir"
 
     rm -rf $out/@pythonSitePackages@/tests
+    rm -rf $out/@pythonSitePackages@/test
 
     echo "Finished executing pythonRemoveTestsDir"
 }
@@ -12,4 +13,3 @@ pythonRemoveTestsDir() {
 if [ -z "${dontUsePythonRemoveTestsDir-}" ]; then
     postFixupHooks+=(pythonRemoveTestsDir)
 fi
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Python packages tend to have their tests installed at either ``./test`` or ``./tests``. Previously, we had only covered the second case, ignoring the first. I just ran into a collision between two packages' ``/test`` directory, and thought it would be worth adding.

I didn't run tests because this is going to rebuild every single python package...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
