### PR TITLE
nixos/unbound: Coerce all single settings values to lists

### DIFF
--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -101,9 +101,10 @@ in {
 
           freeformType = let
             validSettingsPrimitiveTypes = oneOf [ int str bool float ];
-            validSettingsTypes = oneOf [ validSettingsPrimitiveTypes (listOf validSettingsPrimitiveTypes) ];
-            settingsType = (attrsOf validSettingsTypes);
-          in attrsOf (oneOf [ string settingsType (listOf settingsType) ])
+            coercedList = t: coercedTo t singleton (listOf t);
+            validSettingsTypes = coercedList validSettingsPrimitiveTypes;
+            settingsType = coercedList (attrsOf validSettingsTypes);
+          in attrsOf (oneOf [ string settingsType ])
               // { description = ''
                 unbound.conf configuration type. The format consist of an attribute
                 set of settings. Each settings can be either one value, a list of


### PR DESCRIPTION
###### Motivation for this change
Makes composability much better, as it allows mixing single values together without having to declare them as lists. This allows the following to work:

```nix
{
  services.unbound = {
    enable = true;
    settings.server = lib.mkMerge [
      {
        local-zone = ''"local." static'';
        local-zone-tag = ''"local." "local_net"'';
        local-data = [
          "router.local. IN A 10.0.0.1"
          "server.local. IN A 10.0.0.10"
        ];
        local-data-ptr = [
          "10.0.0.1 router.local."
          "10.0.0.10 server.local."
        ];
      }
      {
        local-zone = ''"foo." static'';
        local-zone-tag = ''"foo." "local_net"'';
        local-data = [
         "router.foo. IN A 10.0.0.2"
          "server.foo. IN A 10.0.0.20"
        ];
        local-data-ptr = [
          "10.0.0.2 router.foo."
          "10.0.0.20 server.foo."
        ];
      }
    ];
  };
}
```

I was motivated to improve this after @pennae and @andir had some complaints on IRC :)

The `settings` approach was introduced in #89572, ping @rissson @lovesegfault 

###### Things done

I have not tested this other than making sure that above configuration evaluates properly. I'd like to defer testing to @pennae and @andir as they are actually using this module.