### PR TITLE
prism: init at 0.1.1

### DIFF
--- a/pkgs/applications/video/prism/default.nix
+++ b/pkgs/applications/video/prism/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "prism";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "muesli";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256:0q7q7aj3fm45bnx6hgl9c1ll8na16x6p7qapr0c4a6dhxwd7n511";
+  };
+
+  vendorSha256 = "sha256:1mkd1s9zgzy9agy2rjjk8wfdga7nzv9cmwgiarfi4xrqzj4mbaxq";
+
+  meta = with stdenv.lib; {
+    description = "An RTMP stream recaster/splitter";
+    homepage = "https://github.com/muesli/prism";
+    license = licenses.mit;
+    maintainers = with maintainers; [ paperdigits ];
+  };
+}

--- a/pkgs/applications/video/prism/default.nix
+++ b/pkgs/applications/video/prism/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ stdenv, lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "prism";

--- a/pkgs/applications/video/prism/default.nix
+++ b/pkgs/applications/video/prism/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     owner = "muesli";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256:0q7q7aj3fm45bnx6hgl9c1ll8na16x6p7qapr0c4a6dhxwd7n511";
+    sha256 = "0q7q7aj3fm45bnx6hgl9c1ll8na16x6p7qapr0c4a6dhxwd7n511";
   };
 
-  vendorSha256 = "sha256:1mkd1s9zgzy9agy2rjjk8wfdga7nzv9cmwgiarfi4xrqzj4mbaxq";
+  vendorSha256 = "1mkd1s9zgzy9agy2rjjk8wfdga7nzv9cmwgiarfi4xrqzj4mbaxq";
 
   meta = with lib; {
     description = "An RTMP stream recaster/splitter";

--- a/pkgs/applications/video/prism/default.nix
+++ b/pkgs/applications/video/prism/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   vendorSha256 = "sha256:1mkd1s9zgzy9agy2rjjk8wfdga7nzv9cmwgiarfi4xrqzj4mbaxq";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "An RTMP stream recaster/splitter";
     homepage = "https://github.com/muesli/prism";
     license = licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7451,6 +7451,8 @@ in
 
   pitivi = callPackage ../applications/video/pitivi { };
 
+  prism = callPackage ../applications/video/prism { };
+
   pulumi-bin = callPackage ../tools/admin/pulumi { };
 
   p0f = callPackage ../tools/security/p0f { };


### PR DESCRIPTION
###### Motivation for this change
To include this package in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
