### PR TITLE
kinect-audio-setup: init at 0.5

### DIFF
--- a/pkgs/os-specific/linux/kinect-audio-setup/default.nix
+++ b/pkgs/os-specific/linux/kinect-audio-setup/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchgit
+, requireFile
+, pkg-config
+, libusb1
+, p7zip
+}:
+
+let
+  # The last known good firmware package to have been tested
+  # by the upstream projet.
+  # The firmware URL is hardcoded in the upstream project's installation script
+  firmwareUrl = "https://download.microsoft.com/download/F/9/9/F99791F2-D5BE-478A-B77A-830AD14950C3/KinectSDK-v1.0-beta2-x86.msi";
+  # The original URL "https://research.microsoft.com/en-us/um/legal/kinectsdk-tou_noncommercial.htm"
+  # redirects to the following url:
+  licenseUrl = "https://www.microsoft.com/en-us/legal/terms-of-use";
+in
+stdenv.mkDerivation rec {
+  pname = "kinect-audio-setup";
+
+  # On update: Make sure that the `firmwareURL` is still in sync with upstream.
+  # If the project structure hasn't changed you can find the URL in the
+  # `kinect_fetch_fw` file in the project source.
+  version = "0.5";
+
+  # This is an MSI or CAB file
+  FIRMWARE = requireFile rec {
+    name = "UACFirmware";
+    sha256 = "08a2vpgd061cmc6h3h8i6qj3sjvjr1fwcnwccwywqypz3icn8xw1";
+    message = ''
+      In order to install the Kinect Audio Firmware, you need to download the
+      non-redistributable firmware from Microsoft.
+      The firmware is available at ${firmwareUrl} and the license at ${licenseUrl} .
+      Save the file as UACFirmware and use "nix-prefetch-url file://\$PWD/UACFirmware" to
+      add it to the Nix store.
+    '';
+  };
+
+  src = fetchgit {
+    url = "git://git.ao2.it/kinect-audio-setup.git";
+    rev = "v${version}";
+    sha256 = "sha256-bFwmWh822KvFwP/0Gu097nF5K2uCwCLMB1RtP7k+Zt0=";
+  };
+
+  # These patches are not upstream because the project has seen no
+  # activity since 2016
+  patches = [
+    ./libusb-1-import-path.patch
+    ./udev-rules-extra-devices.patch
+  ];
+
+  nativeBuildInputs = [ p7zip libusb1 pkg-config ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "DESTDIR=$(out)"
+    "FIRMWARE_PATH=$(out)/lib/firmware/UACFirmware"
+    "LOADER_PATH=$(out)/libexec/kinect_upload_fw"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make -C kinect_upload_fw kinect_upload_fw $makeFlags "''${makeFlagsArray[@]}"
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/libexec/ $out/lib/firmware $out/lib/udev/rules.d
+
+    install -Dm755 kinect_upload_fw/kinect_upload_fw $out/libexec/
+
+    # 7z extract "assume yes on all queries" "only extract/keep files/directories matching UACFIRMWARE.* recursively"
+    7z e -y -r "${FIRMWARE}" "UACFirmware.*" >/dev/null
+    # The filename is bound to change with the Firmware SDK
+    mv UACFirmware.* $out/lib/firmware/UACFirmware
+
+    make install_udev_rules $makeFlags "''${makeFlagsArray[@]}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tools to enable audio input from the Microsoft Kinect sensor device";
+    homepage = "https://git.ao2.it/kinect-audio-setup.git";
+    maintainers = with maintainers; [ berbiche ];
+    platforms = platforms.linux;
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/os-specific/linux/kinect-audio-setup/libusb-1-import-path.patch
+++ b/pkgs/os-specific/linux/kinect-audio-setup/libusb-1-import-path.patch
@@ -1,0 +1,23 @@
+commit 02fd6c4355809e1bff7c66d478e88f30bedde13b
+Author: Nicolas Berbiche <nicolas@normie.dev>
+Date:   Wed May 5 23:14:56 2021 -0400
+
+    fix libusb include for Linux
+
+diff --git a/kinect_upload_fw/kinect_upload_fw.c b/kinect_upload_fw/kinect_upload_fw.c
+index 1bd4102..351c94f 100644
+--- a/kinect_upload_fw/kinect_upload_fw.c
++++ b/kinect_upload_fw/kinect_upload_fw.c
+@@ -35,7 +35,12 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <errno.h>
++
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(_WIN32)
+ #include <libusb.h>
++#else
++#include <libusb-1.0/libusb.h>
++#endif
+ 
+ #include "endian.h"
+ 

--- a/pkgs/os-specific/linux/kinect-audio-setup/udev-rules-extra-devices.patch
+++ b/pkgs/os-specific/linux/kinect-audio-setup/udev-rules-extra-devices.patch
@@ -1,0 +1,15 @@
+commit afaaa77b0a03811f86428cf264397b60dd795549
+Author: Nicolas Berbiche <nicolas@normie.dev>
+Date:   Thu May 6 00:10:37 2021 -0400
+
+    Add support for other Kinect device in udev
+
+diff --git a/contrib/55-kinect_audio.rules.in b/contrib/55-kinect_audio.rules.in
+index 25ea713..9e1b69f 100644
+--- a/contrib/55-kinect_audio.rules.in
++++ b/contrib/55-kinect_audio.rules.in
+@@ -1,2 +1,4 @@
+ # Rule to load the Kinect UAC firmware on the "generic" usb device
+ ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02ad", RUN+="@LOADER_PATH@ @FIRMWARE_PATH@"
++# Rule to load the Kinect UAC firmware on another supported device
++ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02bb", RUN+="@LOADER_PATH@ @FIRMWARE_PATH@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20583,6 +20583,8 @@ in
 
   kbdlight = callPackage ../os-specific/linux/kbdlight { };
 
+  kinect-audio-setup = callPackage ../os-specific/linux/kinect-audio-setup { };
+
   kmscon = callPackage ../os-specific/linux/kmscon { };
 
   kmscube = callPackage ../os-specific/linux/kmscube { };


### PR DESCRIPTION
###### Motivation for this change

kinect-audio-setup is a small project with a single binary who's role is to upload a Kinect firmware on Kinect v1 devices.
This tool will automatically flash my Kinect using a udev rule.
~~I haven't tested yet whether the flash persists after a reboot.~~ It does.

The firmware must be downloaded manually from Microsoft. This information is provided using the `requireFile` derivation.

To use this in your configuration, add the following:

```
{
  # ...
  services.udev.packages = [ pkgs.kinect-audio-setup ];
  # ...
}
```

The supported devices by kinect-audio-setup are:
- `045e:02ad`
- `045e:02bb` (this is one that I use and tested)

![2021-05-06-00 03 50](https://user-images.githubusercontent.com/20448408/117241505-4faefb00-ae01-11eb-9e9a-f797d59addb7.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
