### PR TITLE
python3Packages.pyjwt: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/msal/default.nix
+++ b/pkgs/development/python-modules/msal/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "msal";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "582e92e3b9fa68084dca6ecfd8db866ddc75cd9043de267c79d6b6277dd27f55";
+    sha256 = "sha256-RnrwK7lKh6G2lbUb+GdmfoKKzA3Twd5fpUP2kALbSfo=";
   };
 
   propagatedBuildInputs = [
@@ -22,15 +22,15 @@ buildPythonPackage rec {
   ];
 
   # Tests assume Network Connectivity:
-  #   https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/e2958961e8ec16d0af4199f60c36c3f913497e48/tests/test_authority.py#L73
+  # https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/e2958961e8ec16d0af4199f60c36c3f913497e48/tests/test_authority.py#L73
   doCheck = false;
+
+  pythonImportsCheck = [ "msal" ];
 
   meta = with lib; {
     description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect";
     homepage = "https://github.com/AzureAD/microsoft-authentication-library-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      kamadorueda
-    ];
+    maintainers = with maintainers; [ kamadorueda ];
   };
 }

--- a/pkgs/development/python-modules/mwoauth/default.nix
+++ b/pkgs/development/python-modules/mwoauth/default.nix
@@ -17,14 +17,28 @@ buildPythonPackage rec {
     sha256 = "9e0d70a1fa6f452584de1cb853ae6c11f41233549f7839cfb879f99410f6ad46";
   };
 
-  # package has no tests
+  propagatedBuildInputs = [
+    oauthlib
+    pyjwt
+    requests
+    requests_oauthlib
+    six
+  ];
+
+  postPatch = ''
+    # https://github.com/mediawiki-utilities/python-mwoauth/pull/43
+    substituteInPlace setup.py --replace "PyJWT>=1.0.1,<2.0.0" "PyJWT>=1.0.1"
+  '';
+
+  # PyPI source has no tests included
+  # https://github.com/mediawiki-utilities/python-mwoauth/issues/44
   doCheck = false;
 
-  propagatedBuildInputs = [ six pyjwt requests oauthlib requests_oauthlib ];
+  pythonImportsCheck = [ "mwoauth" ];
 
   meta = with lib; {
-    description = "A library designed to provide a simple means to performing an OAuth handshake with a MediaWiki installation with the OAuth Extension installed.";
-    homepage =  "https://github.com/mediawiki-utilities/python-mwoauth";
+    description = "Python library to perform OAuth handshakes with a MediaWiki installation";
+    homepage = "https://github.com/mediawiki-utilities/python-mwoauth";
     license = licenses.mit;
     maintainers = with maintainers; [ ixxie ];
   };

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -14,19 +14,17 @@
 
 buildPythonPackage rec {
   pname = "oauthenticator";
-  version = "0.13.0";
+  version = "14.0.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5202adcd96ddbbccbc267da02f2d14e977300c81291aaa77be4fd9f2e27cfa37";
+    sha256 = "1zfcl3dq9ladqg7fnpx6kgxf1ckjzlc8v3j6wa8w6iwglm40ax4r";
   };
 
   propagatedBuildInputs = [
     jupyterhub
   ];
-
-  pytestFlagsArray = [ "oauthenticator/tests" ];
 
   checkInputs = [
     google-api-python-client
@@ -37,6 +35,20 @@ buildPythonPackage rec {
     pytestCheckHook
     requests-mock
   ];
+
+  postPatch = ''
+  # The constraint was removed. No longer needed for > 14.0.0
+  # https://github.com/jupyterhub/oauthenticator/pull/431
+    substituteInPlace test-requirements.txt --replace "pyjwt>=1.7,<2.0" "pyjwt"
+  '';
+
+  disabledTests = [
+    # Test are outdated, https://github.com/jupyterhub/oauthenticator/issues/432
+    "test_azuread"
+    "test_mediawiki"
+  ];
+
+  pythonImportsCheck = [ "oauthenticator" ];
 
   meta = with lib; {
     description = "Authenticate JupyterHub users with common OAuth providers, including GitHub, Bitbucket, and more.";

--- a/pkgs/development/python-modules/pyflume/default.nix
+++ b/pkgs/development/python-modules/pyflume/default.nix
@@ -41,6 +41,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    # https://github.com/ChrisMandich/PyFlume/issues/18
+    substituteInPlace setup.py \
+      --replace "pyjwt==2.0.1" "pyjwt>=2.0.1" \
+      --replace "ratelimit==2.2.1" "ratelimit>=2.2.1" \
+      --replace "pytz==2019.2" "pytz>=2019.2" \
+      --replace "requests==2.24.0" "requests>=2.24.0"
+  '';
+
   pythonImportsCheck = [ "pyflume" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -9,12 +9,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "PyJWT";
-  version = "2.0.1";
+  pname = "pyjwt";
+  version = "2.1.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "a5c70a06e1f33d81ef25eecd50d50bd30e34de1ca8b2b9fa3fe0daaabcf69bf7";
+    pname = "PyJWT";
+    inherit version;
+    sha256 = "sha256-+6ROeJi7yhYKKytQH0koJPyDgkhdOm8Rul0MGTfOYTA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -1,6 +1,12 @@
-{ lib, buildPythonPackage, fetchPypi
-, cryptography, ecdsa
-, pytestrunner, pytestcov, pytest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cryptography
+, ecdsa
+, pytest-cov
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "PyJWT";
@@ -11,18 +17,17 @@ buildPythonPackage rec {
     sha256 = "a5c70a06e1f33d81ef25eecd50d50bd30e34de1ca8b2b9fa3fe0daaabcf69bf7";
   };
 
-  propagatedBuildInputs = [ cryptography ecdsa ];
+  propagatedBuildInputs = [
+    cryptography
+    ecdsa
+  ];
 
-  checkInputs = [ pytestrunner pytestcov pytest ];
+  checkInputs = [
+    pytest-cov
+    pytestCheckHook
+  ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "pytest>=4.0.1,<5.0.0" "pytest"
-  '';
-
-  # ecdsa changed internal behavior
-  checkPhase = ''
-    pytest tests -k 'not ec_verify_should_return_false_if_signature_invalid'
-  '';
+  pythonImportsCheck = [ "jwt" ];
 
   meta = with lib; {
     description = "JSON Web Token implementation in Python";

--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -1,5 +1,6 @@
-{ buildPythonPackage
-, isPy27
+{ lib
+, buildPythonPackage
+, pythonOlder
 , asn1crypto
 , azure-storage-blob
 , boto3
@@ -10,7 +11,6 @@
 , idna
 , ijson
 , isPy3k
-, lib
 , oscrypto
 , pyarrow
 , pyasn1-modules
@@ -25,19 +25,13 @@
 
 buildPythonPackage rec {
   pname = "snowflake-connector-python";
-  version = "2.4.1";
-  disabled = isPy27;
+  version = "2.4.3";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5c9180e61202a7beb1df83231688423091ca0a04ee559d2a78ff77f9c727baae";
+    sha256 = "sha256-+jAfUwaofWM5Ef1kk4AEAbBM/UES8/ZzLd4QJfkEQsM=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'pyOpenSSL>=16.2.0,<20.0.0'," "'pyOpenSSL'," \
-      --replace 'pytz<2021.0' 'pytz'
-  '';
 
   propagatedBuildInputs = [
     azure-storage-blob
@@ -55,16 +49,26 @@ buildPythonPackage rec {
     pytz
     requests
     six
-  ] ++ lib.optionals (!isPy3k) [
     pyarrow
     pyasn1-modules
     urllib3
   ];
 
-  # tests require encrypted secrets, see
+  postPatch = ''
+    # https://github.com/snowflakedb/snowflake-connector-python/issues/705
+    substituteInPlace setup.py \
+      --replace "idna>=2.5,<3" "idna" \
+      --replace "chardet>=3.0.2,<4" "chardet"
+  '';
+
+  # Tests require encrypted secrets, see
   # https://github.com/snowflakedb/snowflake-connector-python/tree/master/.github/workflows/parameters
   doCheck = false;
-  pythonImportsCheck = [ "snowflake" "snowflake.connector" ];
+
+  pythonImportsCheck = [
+    "snowflake"
+    "snowflake.connector"
+  ];
 
   meta = with lib; {
     description = "Snowflake Connector for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.0

Change log: https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst#v210

- With 2.0.0 support for Python 2 [was dropped](https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst#v200).
- Switch to `pytestCheckHook`
- Run all tests

Related to #121883

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
