### PR TITLE
nixos/_6tunnel: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -638,6 +638,7 @@
   ./services/network-filesystems/xtreemfs.nix
   ./services/network-filesystems/ceph.nix
   ./services/networking/3proxy.nix
+  ./services/networking/6tunnel.nix
   ./services/networking/adguardhome.nix
   ./services/networking/amuled.nix
   ./services/networking/aria2.nix

--- a/nixos/modules/services/networking/6tunnel.nix
+++ b/nixos/modules/services/networking/6tunnel.nix
@@ -1,0 +1,112 @@
+{ lib, config, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services._6tunnel;
+
+in {
+  options.services._6tunnel = {
+
+    tunnels = mkOption {
+      default = [];
+      description = "Which tunnels to create.";
+      type = with types; listOf (submodule {
+        options = {
+          port = mkOption {
+            description = "Local port to open.";
+            type = types.port;
+          };
+          remoteHost = mkOption {
+            description = "Remote host to tunnel to.";
+            type = types.str;
+          };
+          remotePort = mkOption {
+            default = null;
+            description = "Port on remote host. If null (default), it uses the the local port.";
+            type = with types; nullOr port;
+          };
+          restart = mkOption {
+            default = null;
+            description = ''
+              Whether to restart the tunnel periodically, which is useful for non-static IP addresses.
+              The format is described in SYSTEMD.TIME(7).
+
+              If null (default), the tunnel won't restart periodically.
+            '';
+            type = with types; nullOr str;
+          };
+        };
+      });
+      example = [
+        { port = 8080; remoteHost = "192.168.0.2"; remotePort = 80; }
+        { port = 443; remoteHost = "www.example.com"; }
+        { port = 8053; remoteHost = "dynamicip.example.com"; restart = "1h"; }
+      ];
+    };
+
+    openFirewall = mkOption {
+      default = false;
+      description = "Whether to open the local ports in the firewall.";
+      type = types.bool;
+    };
+
+  };
+
+  config = mkIf (cfg.tunnels != []) {
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall (map (tunnel: tunnel.port) cfg.tunnels);
+    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall (map (tunnel: tunnel.port) cfg.tunnels);
+
+    systemd.services = listToAttrs (map (tunnel:
+      nameValuePair "6tunnel-${toString tunnel.port}" {
+        description = "6tunnel from ${toString tunnel.port} to ${tunnel.remoteHost}${optionalString (tunnel.remotePort != null) ":${toString tunnel.remotePort}"}";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = ''
+            ${pkgs._6tunnel}/bin/6tunnel -d ${toString tunnel.port} "${tunnel.remoteHost}" ${optionalString (tunnel.remotePort != null) (toString tunnel.remotePort)}
+          '';
+          Restart = "always";
+          RuntimeMaxSec = mkIf (tunnel.restart != null) tunnel.restart;
+
+          # Hardening options, sorted by occurrence in https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+          ProtectProc = "invisible";
+          DynamicUser = true;
+          CapabilityBoundingSet = [];
+          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateNetwork = false; # needs full network access
+          PrivateUsers = false; # prevents binding to privileged ports
+          ProtectHostname = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@resources"
+          ];
+          SystemCallArchitectures = "native";
+          DevicePolicy = "closed";
+        };
+      }
+    ) cfg.tunnels);
+
+  };
+
+  meta.maintainers = with maintainers; [ ymarkus ];
+}

--- a/nixos/tests/6tunnel.nix
+++ b/nixos/tests/6tunnel.nix
@@ -1,0 +1,45 @@
+import ./make-test-python.nix ({ pkgs, lib, ... } : {
+  name = "6tunnel";
+  meta.maintainers = with pkgs.lib.maintainers; [ ymarkus ];
+
+  nodes = {
+
+    client = { ... }: {
+      networking.enableIPv6 = false;
+    };
+
+    tunnel = { ... }: {
+      services._6tunnel = {
+        tunnels = [
+          # to check if CAP_NET_BIND_SERVICE works
+          { port = 80; remoteHost = "webhost"; }
+          # to check if "remotePort" works
+          { port = 8080; remoteHost = "webhost"; remotePort = 80; }
+        ];
+        openFirewall = true;
+      };
+    };
+
+    webhost = { ... }: {
+      networking.firewall.enable = false;
+      services.httpd = {
+        enable = true;
+        adminAddr = "foo@example.org";
+      };
+    };
+
+  };
+
+  testScript = ''
+    start_all()
+
+    client.wait_for_unit("network.target")
+    tunnel.wait_for_unit("6tunnel-80")
+    tunnel.wait_for_unit("6tunnel-8080")
+    webhost.wait_for_unit("httpd")
+
+    # test if we can curl the webserver
+    client.succeed("curl http://tunnel:80/")
+    client.succeed("curl http://tunnel:8080/")
+  '';
+})

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -22,6 +22,7 @@ let
 in
 {
   _3proxy = handleTest ./3proxy.nix {};
+  _6tunnel = handleTest ./6tunnel.nix {};
   acme = handleTest ./acme.nix {};
   agda = handleTest ./agda.nix {};
   airsonic = handleTest ./airsonic.nix {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

> 6tunnel allows you to use services provided by IPv6 hosts with IPv4-only applications and vice-versa. It can bind to any of your IPv4 (default) or IPv6 addresses and forward all data to IPv4 or IPv6 (default) host.

There was a package already, but a module was missing


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
