### PR TITLE
test-utilities: version test

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -2,6 +2,7 @@
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg, djvulibre
 , lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp, libheif
 , ApplicationServices
+, testVersion, imagemagick
 }:
 
 let
@@ -71,6 +72,9 @@ stdenv.mkDerivation rec {
       sed 's|-lgs|-L${lib.getLib ghostscript}/lib -lgs|' -i $la
     done
   '';
+
+  passthru.tests.version =
+    testVersion { package = imagemagick; };
 
   meta = with lib; {
     homepage = "http://www.imagemagick.org/";

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+, testVersion
+, hello
+}:
 
 stdenv.mkDerivation rec {
   pname = "hello";
@@ -10,6 +15,9 @@ stdenv.mkDerivation rec {
   };
 
   doCheck = true;
+
+  passthru.tests.version =
+    testVersion { package = hello; };
 
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";

--- a/pkgs/applications/networking/seaweedfs/default.nix
+++ b/pkgs/applications/networking/seaweedfs/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
-, runCommand
+, testVersion
 , seaweedfs
 }:
 
@@ -20,10 +20,8 @@ buildGoModule rec {
 
   subPackages = [ "weed" ];
 
-  passthru.tests.check-version = runCommand "weed-version" { meta.timeout = 3; } ''
-    ${seaweedfs}/bin/weed version | grep -Fw ${version}
-    touch $out
-  '';
+  passthru.tests.version =
+    testVersion { package = seaweedfs; command = "weed version"; };
 
   meta = with lib; {
     description = "Simple and highly scalable distributed file system";

--- a/pkgs/applications/science/logic/key/default.nix
+++ b/pkgs/applications/science/logic/key/default.nix
@@ -5,7 +5,7 @@
 , ant
 , jre
 , makeWrapper
-, runCommand
+, testVersion
 , key
 }:
 
@@ -51,10 +51,13 @@ in stdenv.mkDerivation rec {
       --add-flags "-cp $out/share/java/KeY.jar de.uka.ilkd.key.core.Main"
   '';
 
-  passthru.tests.check-version = runCommand "key-help" {} ''
-    ${key}/bin/KeY --help | grep 2.5 # Wrong version in the code. On next version change to ${version}
-    touch $out
-  '';
+  passthru.tests.version =
+    testVersion {
+      package = key;
+      command = "KeY --help";
+      # Wrong '2.5' version in the code. On next version change to ${version}
+      version = "2.5";
+    };
 
   meta = with lib; {
     description = "Java formal verification tool";

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -541,4 +541,37 @@ rec {
       phases = "unpackPhase patchPhase installPhase";
       installPhase = "cp -R ./ $out";
     };
+
+  /* Checks the command output contains the specified version
+   *
+   * Although simplistic, this test assures that the main program
+   * can run. While there's no substitute for a real test case,
+   * it does catch dynamic linking errors and such. It also provides
+   * some protection against accidentally building the wrong version,
+   * for example when using an 'old' hash in a fixed-output derivation.
+   *
+   * Examples:
+   *
+   * passthru.tests.version = testVersion { package = hello; };
+   *
+   * passthru.tests.version = testVersion {
+   *   package = seaweedfs;
+   *   command = "weed version";
+   * };
+   *
+   * passthru.tests.version = testVersion {
+   *   package = key;
+   *   command = "KeY --help";
+   *   # Wrong '2.5' version in the code. Drop on next version.
+   *   version = "2.5";
+   * };
+   */
+  testVersion =
+    { package,
+      command ? "${package.meta.mainProgram or package.pname or package.name} --version",
+      version ? package.version,
+    }: runCommand "test-version" { nativeBuildInputs = [ package ]; meta.timeout = 60; } ''
+      ${command} | grep -Fw ${version}
+      touch $out
+    '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make adding version tests more likely by making it easier, as
discussed in https://github.com/NixOS/nixpkgs/pull/119636#issuecomment-826137021

Long-term I hope 'upstreaming' the tests could replace the functionality
in nixpkgs-update as discussed in
https://github.com/ryantm/nixpkgs-update/issues/260

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).