### PR TITLE
pythonPackages.pwntools: add bash completions

### DIFF
--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -2,9 +2,7 @@
 , buildPythonPackage
 , debugger
 , fetchPypi
-, isPy3k
 , Mako
-, makeWrapper
 , packaging
 , pysocks
 , pygments
@@ -20,7 +18,7 @@
 , tox
 , unicorn
 , intervaltree
-, fetchpatch
+, installShellFiles
 }:
 
 buildPythonPackage rec {
@@ -38,6 +36,10 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i 's/unicorn>=1.0.2rc1,<1.0.2rc4/unicorn>=1.0.2rc1/' setup.py
   '';
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   propagatedBuildInputs = [
     Mako
@@ -59,6 +61,10 @@ buildPythonPackage rec {
   ];
 
   doCheck = false; # no setuptools tests for the package
+
+  postInstall = ''
+    installShellCompletion --bash extra/bash_completion.d/shellcraft
+  '';
 
   postFixup = ''
     mkdir -p "$out/bin"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Install shellcraft completions. Note that they don't work with `nix-shell -p` since no completions does (#26031), but I have run and tested them using `mkShell`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
