### PR TITLE
radarr: 3.0.2.4552 -> 3.1.1.4954

### DIFF
--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -9,14 +9,14 @@ let
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   hash = {
-    x64-linux_hash = "sha256-bTh+Z5w5ZkL2iPteStqVcoFDGZIbpVjuXn20TZsfgtY=";
-    arm64-linux_hash = "sha256-aIzVSIRuGNiIFJPToXCQwYsbICKuPtwKATnQhkxvJuA=";
-    x64-osx_hash = "sha256-FxRSAJvRQya2x1kei6yRceGcyQ2mCaFveyeMGw0Jqw4=";
+    x64-linux_hash = "sha256-5W4X1E7794hFVPo4+s826CNIrw6Z/n0cDjj6pmsj2Dk=";
+    arm64-linux_hash = "sha256-gqCgToAVIS+IEulFY4mo2Mtcb3nyFpzDBqVEewREQcs=";
+    x64-osx_hash = "sha256-MFpIzSYAvAWVHMdEd+aP67s3po+yb3qWzSd/Ko++5Jc=";
   }."${arch}-${os}_hash";
 
 in stdenv.mkDerivation rec {
   pname = "radarr";
-  version = "3.0.2.4552";
+  version = "3.1.1.4954";
 
   src = fetchurl {
     url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.master.${version}.${os}-core-${arch}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/Radarr/Radarr/releases/tag/v3.1.1.4954

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
