### PR TITLE
libreoffice-fresh: 7.1.2.2 -> 7.1.3.2

### DIFF
--- a/pkgs/applications/office/libreoffice/src-fresh/download.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/download.nix
@@ -637,11 +637,11 @@
     md5name = "a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
   }
   {
-    name = "neon-0.31.1.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/neon-0.31.1.tar.gz";
-    sha256 = "c9dfcee723050df37ce18ba449d7707b78e7ab8230f3a4c59d9112e17dc2718d";
+    name = "neon-0.31.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/neon-0.31.2.tar.gz";
+    sha256 = "cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678";
     md5 = "";
-    md5name = "c9dfcee723050df37ce18ba449d7707b78e7ab8230f3a4c59d9112e17dc2718d-neon-0.31.1.tar.gz";
+    md5name = "cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678-neon-0.31.2.tar.gz";
   }
   {
     name = "nss-3.55-with-nspr-4.27.tar.gz";

--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -8,7 +8,7 @@ rec {
 
   major = "7";
   minor = "1";
-  patch = "2";
+  patch = "3";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1y19p9701msf6jjzp9d5ighvmyjzj68qzhm2bk3l5p16ys8qk9bb";
+    sha256 = "1gr9c8kv7nc9kaag1sw9r36843pfba1my80afx7p0lxj0k8pzbrm";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "1j5251lbc35d521d92w52lgps0v5pg8mhr8y3r6x2nl9p0gvw957";
+    sha256 = "09xkr6jmnwq55savw9xjsy8l8zcyflnsg4nfwhknvm3ls8sqj4w6";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "1bsrkmzhhpyrmi7akmdfvz4zb543fc093az9965k14rp8l6rhnvf";
+    sha256 = "0dc981vmxfdwlyfgq84axkr99d8chm1ypknj39v0cmaqn56lpwg0";
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).