### PR TITLE
openconnect: fix paths to systemd tools in vpnc-script

### DIFF
--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -34,7 +34,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "VPN Client for Cisco's AnyConnect SSL VPN";
     homepage = "http://www.infradead.org/openconnect/";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     maintainers = with maintainers; [ pradeepchhetri tricktron ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The vpnc-script looks for a bunch of tools in fixed FHS paths. Since it won’t find them it’ll use the fallback mechanism to update DNS information, which means it’ll just change `/etc/resolv.conf`. This doesn’t work too well with systemd.

There’s also #105020, which this should fix.

###### Things done

- Updated `vpnc-scripts` to the latest version from Git.
- Changed the `vpnc-scripts` build to just install `vpnc-script` and fix the paths in it.
- Changed license to `lgpl21Only` per Robot Robert’s suggestion.
  The license headers in OpenConnect sources have some occurrences of “or later version” but most of them do not contain that text. So, I am assuming the stricter(?) interpretation applies.

Didn’t run `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` since that would build a rather sizable portion of the desktop (GNOME/KDE) world.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
