### PR TITLE
python3Packages.pomegranate: 0.11.2 -> 0.13.5

### DIFF
--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -1,19 +1,41 @@
-{ lib, buildPythonPackage, fetchFromGitHub, numpy, scipy, cython, networkx, joblib, nose, pyyaml }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, numpy
+, scipy
+, cython
+, networkx
+, joblib
+, pandas
+, nose
+, pyyaml
+}:
+
 
 buildPythonPackage rec {
   pname = "pomegranate";
-  version = "0.11.2";
+  version = "0.13.5";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "jmschrei";
     rev = "v${version}";
-    sha256 = "070ciwww1lhjmfwd5n1kcwgxwbgdfvmhjs4l156bnf08z9dlrafl";
+    sha256 = "1hbxchp3daykkf1fa79a9mh34p78bygqcf1nv4qwkql3gw0pd6l7";
   };
+
+  patches = lib.optionals (lib.versionOlder version "13.6") [
+    # Fix compatibility with recent joblib release, will be part of the next
+    # pomegranate release after 0.13.5
+    (fetchpatch {
+      url = "https://github.com/jmschrei/pomegranate/commit/42d14bebc44ffd4a778b2a6430aa845591b7c3b7.patch";
+      sha256 = "0f9cx0fj9xkr3hch7jyrn76zjypilh5bqw734caaw6g2m49lvbff";
+    })
+  ];
 
   propagatedBuildInputs = [ numpy scipy cython networkx joblib pyyaml ];
 
-  checkInputs = [ nose ];
+  checkInputs = [ pandas nose ];  # as of 0.13.5, it depends explicitly on nose, rather than pytest.
 
   meta = with lib; {
     description = "Probabilistic and graphical models for Python, implemented in cython for speed";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix a [build failure on hydra](https://hydra.nixos.org/build/142024543) caused by an API change in a recent update to a dependency (joblib). I bumped this package to its latest version, and then added the necessary patch from the unreleased master branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
