### PR TITLE
zile: 2.6.1 -> 2.6.2

### DIFF
--- a/pkgs/applications/editors/zile/default.nix
+++ b/pkgs/applications/editors/zile/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "zile";
-  version = "2.6.1";
+  version = "2.6.2";
 
   src = fetchurl {
     url = "mirror://gnu/zile/${pname}-${version}.tar.gz";
-    hash = "sha256-v7rN33aOORc6J0Z5JP5AmZCj6XvjYyoCl5hl+7mvAnc=";
+    hash = "sha256-d+t9r/PJi9yI2qGsBA3MynK4HcMvwxZuB53Xpj5Cx0E=";
   };
 
   buildInputs = [


### PR DESCRIPTION

###### Motivation for this change

See https://lists.gnu.org/archive/html/info-gnu/2021-05/msg00000.html
for release information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
