### PR TITLE
libsForQt5.qtfeedback: init at unstable-2018-09-03

### DIFF
--- a/pkgs/applications/networking/browsers/angelfish/default.nix
+++ b/pkgs/applications/networking/browsers/angelfish/default.nix
@@ -1,6 +1,6 @@
 { lib
 , mkDerivation
-, fetchFromGitLab
+, fetchurl
 , cmake
 , corrosion
 , extra-cmake-modules
@@ -12,6 +12,7 @@
 , knotifications
 , kpurpose
 , kwindowsystem
+, qtfeedback
 , qtquickcontrols2
 , qtwebengine
 , rustPlatform
@@ -19,20 +20,17 @@
 
 mkDerivation rec {
   pname = "angelfish";
-  version = "1.8.0";
+  version = "21.05";
 
-  src = fetchFromGitLab {
-    domain = "invent.kde.org";
-    owner = "plasma-mobile";
-    repo = "angelfish";
-    rev = "v${version}";
-    sha256 = "0pj2kw7lmxh7diwdcmk24qxqslavhvf23r2i6h549gbllbzk219f";
+  src = fetchurl {
+    url = "mirror://kde/stable/plasma-mobile/${version}/angelfish-${version}.tar.xz";
+    sha256 = "11jd5dwy0xa7kh5z5rc29xy3wfn20hm31908zjax4x83qqjrm075";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "0cyrmhlg0kjr14842ckbjdljc2zc28al0y9i8w5l0qzr18krgc0m";
+    sha256 = "05xvh7yxndqm2bqpm06jsxiv4v02mqxaazll8wllp367qapvr21g";
   };
 
   nativeBuildInputs = [
@@ -58,6 +56,7 @@ mkDerivation rec {
     knotifications
     kpurpose
     kwindowsystem
+    qtfeedback
     qtquickcontrols2
     qtwebengine
   ];

--- a/pkgs/development/libraries/qtfeedback/default.nix
+++ b/pkgs/development/libraries/qtfeedback/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, perl
+, qmake
+, qtbase
+, qtdeclarative
+}:
+
+mkDerivation rec {
+  pname = "qtfeedback";
+  version = "unstable-2018-09-03";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "qt";
+    repo = "qtfeedback";
+    rev = "a14bd0bb1373cde86e09e3619fb9dc70f34c71f2";
+    sha256 = "0kiiffvriagql1cark6g1qxy7l9c3q3s13cx3s2plbz19nlnikj7";
+  };
+
+  nativeBuildInputs = [
+    perl
+    qmake
+  ];
+
+  buildInputs = [
+    qtdeclarative
+  ];
+
+  qmakeFlags = [ "CONFIG+=git_build" ];
+
+  doCheck = true;
+
+  postFixup = ''
+    # Drop QMAKE_PRL_BUILD_DIR because it references the build dir
+    find "$out/lib" -type f -name '*.prl' \
+      -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+  '';
+
+  meta = with lib; {
+    description = "Qt Tactile Feedback";
+    homepage = "https://github.com/qt/qtfeedback";
+    license = with licenses; [ lgpl3Only /* or */ gpl2Plus ];
+    maintainers = with maintainers; [ dotlambda OPNA2608 ];
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -165,6 +165,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // 
     withQt5 = true;
   };
 
+  qtfeedback = callPackage ../development/libraries/qtfeedback { };
+
   qtutilities = callPackage ../development/libraries/qtutilities { };
 
   qtinstaller = callPackage ../development/libraries/qtinstaller { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
useful for https://github.com/NixOS/nixpkgs/pull/121345

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I got the `preConfigure` line from https://github.com/OpenMandrivaAssociation/qt5-qtfeedback/blob/master/qt5-qtfeedback.spec and the `postFixup` one from https://git.alpinelinux.org/aports/tree/community/qt5-qtfeedback/APKBUILD.
The licenses are really confusing, but what I put is conforming to the header of e.g. https://github.com/qt/qtfeedback/blob/a14bd0bb1373cde86e09e3619fb9dc70f34c71f2/src/feedback/qfeedbackglobal.h.
I have no idea how to make the tests actually do something.
cc @NixOS/qt-kde 