### PR TITLE
optparse-bash: Init at 2021-06-13

### DIFF
--- a/pkgs/development/libraries/optparse-bash/default.nix
+++ b/pkgs/development/libraries/optparse-bash/default.nix
@@ -1,0 +1,63 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, bash
+, gnused
+, gawk
+, coreutils
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "optparse-bash-unstable";
+  version = "2021-06-13";
+
+  src = fetchFromGitHub {
+    owner = "nk412";
+    repo = "optparse";
+    rev = "d86ec17d15368e5b54eb2d47b001b0b61d68bbd0";
+    sha256 = "sha256-vs7Jo1+sV0tPse4Wu2xtzSX1IkahwLgO3e4Riz3uMmI=";
+  };
+
+  postPatch = ''
+    substituteInPlace optparse.bash \
+      --replace sed "${gnused}/bin/sed" \
+      --replace awk "${gawk}/bin/awk" \
+      --replace printf "${coreutils}/bin/printf"
+'';
+
+  dontBuild = true;
+
+  doCheck = true;
+
+  checkInputs = [ bash ];
+
+  # `#!/usr/bin/env` isn't okay for OfBorg
+  # Need external bash to run
+  checkPhase = ''
+    runHook preCheck
+    bash ./sample_head.sh -v --file README.md
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv optparse.bash $out/bin/
+    mkdir -p $out/share/doc/optparse-bash
+    mv README.md sample_head.sh $out/share/doc/optparse-bash/
+    runHook postInstall
+  '';
+
+  # As example code,
+  # sample_head.sh shows how users can use opt-parse in their script,
+  # and its shebang (`/usr/bin/env bash`) should not be patched.
+  dontPatchShebangs = true;
+
+  meta = with lib; {
+    description = "A BASH wrapper for getopts, for simple command-line argument parsing";
+    homepage = "https://github.com/nk412/optparse";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17798,6 +17798,8 @@ in
 
   openrct2 = callPackage ../games/openrct2 { };
 
+  optparse-bash = callPackage ../development/libraries/optparse-bash { };
+
   orcania = callPackage ../development/libraries/orcania { };
 
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[Optparse](https://github.com/nk412/optparse) provides a wrapper of the POSIX `getopts` as a clean and easy-to-use command-line argument parser. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
