### PR TITLE
fedora-backgrounds.f34: init at 34.0.1

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -20,4 +20,15 @@ in {
     # Fix broken symlinks in the Xfce background directory.
     patches = [ ./f33-fix-xfce-path.patch ];
   };
+
+  f34 = fedoraBackground rec {
+    version = "34.0.1";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-0gotgQ4N0yE8WZbsu7B3jmUIZrycbqjEMxZl01JcJj4=";
+    };
+    # Fix broken symlinks in the Xfce background directory.
+    patches = [ ./f34-fix-xfce-path.patch ];
+  };
+
 }

--- a/pkgs/data/misc/fedora-backgrounds/f34-fix-xfce-path.patch
+++ b/pkgs/data/misc/fedora-backgrounds/f34-fix-xfce-path.patch
@@ -1,0 +1,13 @@
+diff --git a/default/Makefile b/default/Makefile
+index 172d5d9..540a1c0 100644
+--- a/default/Makefile
++++ b/default/Makefile
+@@ -1,7 +1,7 @@
+ WP_NAME=f34
+ WP_BIGNAME=F34
+ WP_DIR=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
+-WP_DIR_LN=/usr/share/backgrounds/$(WP_NAME)
++WP_DIR_LN=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
+ GNOME_BG_DIR=$(DESTDIR)/usr/share/gnome-background-properties
+ KDE_BG_DIR=$(DESTDIR)/usr/share/wallpapers
+ MATE_BG_DIR=$(DESTDIR)/usr/share/mate-background-properties


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tested dynamic background with GNOME.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
