### PR TITLE
dogecoin: 1.14.2 -> 1.14.3

### DIFF
--- a/pkgs/applications/blockchains/dogecoin.nix
+++ b/pkgs/applications/blockchains/dogecoin.nix
@@ -2,7 +2,8 @@
 , pkg-config, autoreconfHook
 , db5, openssl, boost, zlib, miniupnpc, libevent
 , protobuf, util-linux, qt4, qrencode
-, withGui }:
+, withGui, withUpnp ? true, withUtils ? true, withWallet ? true
+, withZmq ? true, zeromq }:
 
 with lib;
 stdenv.mkDerivation rec {
@@ -17,12 +18,20 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook util-linux ];
-  buildInputs = [ openssl db5 openssl protobuf boost zlib miniupnpc libevent ]
-                  ++ optionals withGui [ qt4 qrencode ];
+  buildInputs = [ openssl protobuf boost zlib libevent ]
+    ++ optionals withGui [ qt4 qrencode ]
+    ++ optionals withUpnp [ miniupnpc ]
+    ++ optionals withWallet [ db5 ]
+    ++ optionals withZmq [ zeromq ];
 
-  configureFlags = [ "--with-incompatible-bdb"
-                     "--with-boost-libdir=${boost.out}/lib" ]
-                     ++ optionals withGui [ "--with-gui" ];
+  configureFlags = [
+    "--with-incompatible-bdb"
+    "--with-boost-libdir=${boost.out}/lib"
+  ] ++ optionals (!withGui) [ "--with-gui=no" ]
+    ++ optionals (!withUpnp) [ "--without-miniupnpc" ]
+    ++ optionals (!withUtils) [ "--without-utils" ]
+    ++ optionals (!withWallet) [ "--disable-wallet" ]
+    ++ optionals (!withZmq) [ "--disable-zmq" ];
 
   meta = {
     description = "Wow, such coin, much shiba, very rich";

--- a/pkgs/applications/blockchains/dogecoin.nix
+++ b/pkgs/applications/blockchains/dogecoin.nix
@@ -7,13 +7,13 @@
 with lib;
 stdenv.mkDerivation rec {
   name = "dogecoin" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "1.14.2";
+  version = "1.14.3";
 
   src = fetchFromGitHub {
     owner = "dogecoin";
     repo = "dogecoin";
     rev = "v${version}";
-    sha256 = "1gw46q63mjzwvb17ck6p1bap2xpdrap08szw2kjhasa3yvd5swyy";
+    sha256 = "15yjzyvgic96pybadfk37zb032xvra0v37iphbnh15dci2fd934j";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];

--- a/pkgs/applications/blockchains/dogecoin.nix
+++ b/pkgs/applications/blockchains/dogecoin.nix
@@ -16,9 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "15yjzyvgic96pybadfk37zb032xvra0v37iphbnh15dci2fd934j";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs = [ openssl db5 openssl util-linux
-                  protobuf boost zlib miniupnpc libevent ]
+  nativeBuildInputs = [ pkg-config autoreconfHook util-linux ];
+  buildInputs = [ openssl db5 openssl protobuf boost zlib miniupnpc libevent ]
                   ++ optionals withGui [ qt4 qrencode ];
 
   configureFlags = [ "--with-incompatible-bdb"


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest version.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
