### PR TITLE
pythonPackages.matrix-nio: 0.15.2 -> 0.18.0, update build system and dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, buildPythonApplication, fetchFromGitHub, pythonOlder,
   attrs, aiohttp, appdirs, click, keyring, Logbook, peewee, janus,
   prompt_toolkit, matrix-nio, dbus-python, pydbus, notify2, pygobject3,
-  setuptools,
+  setuptools, fetchpatch,
 
   pytest, faker, pytest-aiohttp, aioresponses,
 
@@ -10,7 +10,7 @@
 
 buildPythonApplication rec {
   pname = "pantalaimon";
-  version = "0.8.0";
+  version = "0.9.2";
 
   disabled = pythonOlder "3.6";
 
@@ -19,8 +19,16 @@ buildPythonApplication rec {
     owner = "matrix-org";
     repo = pname;
     rev = version;
-    sha256 = "0n86cdpw85qzlcr1ynvar0f0zbphmdz1jia9r75lmj07iw4r5hk9";
+    sha256 = "11dfv5b2slqybisq6npmrqxrzslh4bjs4093vrc05s94046d9d9n";
   };
+
+  patches = [
+    # accept newer matrix-nio versions
+    (fetchpatch {
+      url = "https://github.com/matrix-org/pantalaimon/commit/73f68c76fb05037bd7fe71688ce39eb1f526a385.patch";
+      sha256 = "0wvqcfan8yp67p6khsqkynbkifksp2422b9jy511mvhpy51sqykl";
+    })
+  ];
 
   propagatedBuildInputs = [
     aiohttp

--- a/pkgs/development/python-modules/aiohttp-socks/default.nix
+++ b/pkgs/development/python-modules/aiohttp-socks/default.nix
@@ -1,16 +1,16 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder, aiohttp, attrs }:
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, aiohttp, python-socks, attrs }:
 
 buildPythonPackage rec {
   pname = "aiohttp-socks";
-  version = "0.3.9";
+  version = "0.6.0";
 
   src = fetchPypi {
     inherit version;
     pname = "aiohttp_socks";
-    sha256 = "1mn2ng66951mri49f99zh3660j83kvqhr6dpx90s9fkjwk83hmjy";
+    sha256 = "04w010bvi719ifpc3sshav95k10hf9nq8czn9yglkj206yxcypdr";
   };
 
-  propagatedBuildInputs = [ aiohttp attrs ];
+  propagatedBuildInputs = [ aiohttp attrs python-socks ];
 
   # Checks needs internet access
   doCheck = false;

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -18,6 +18,12 @@
 , peewee
 , cachetools
 , atomicwrites
+, pytestCheckHook
+, faker
+, aioresponses
+, hypothesis
+, pytest-aiohttp
+, pytest-benchmark
 }:
 
 buildPythonPackage rec {
@@ -35,6 +41,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     git
     poetry-core
+    pytestCheckHook
   ];
 
   propagatedBuildInputs = [
@@ -55,7 +62,20 @@ buildPythonPackage rec {
     atomicwrites
   ];
 
-  doCheck = false;
+  checkInputs = [
+    faker
+    aioresponses
+    hypothesis
+    pytest-aiohttp
+    pytest-benchmark
+  ];
+
+  disabledTests = [
+    # touches network
+    "test_connect_wrapper"
+    # time dependent and flaky
+    "test_transfer_monitor_callbacks"
+  ];
 
   meta = with lib; {
     description = "A Python Matrix client library, designed according to sans I/O principles";

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -2,9 +2,11 @@
 , buildPythonPackage
 , fetchFromGitHub
 , git
+, poetry-core
 , attrs
 , future
 , aiohttp
+, aiohttp-socks
 , aiofiles
 , h11
 , h2
@@ -20,23 +22,26 @@
 
 buildPythonPackage rec {
   pname = "matrix-nio";
-  version = "0.15.2";
+  version = "0.18.0";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "poljar";
     repo = "matrix-nio";
     rev = version;
-    sha256 = "190xw3cvk4amr9pl8ip2i7k3xdjd0231kn2zl6chny5axx22p1dv";
+    sha256 = "1rn5lz81y4bvgjhxzd57qhr0lmkm5xljl4bj9w10lnm4f7ls0xdi";
   };
 
   nativeBuildInputs = [
     git
+    poetry-core
   ];
 
   propagatedBuildInputs = [
     attrs
     future
     aiohttp
+    aiohttp-socks
     aiofiles
     h11
     h2

--- a/pkgs/development/python-modules/peewee/default.nix
+++ b/pkgs/development/python-modules/peewee/default.nix
@@ -12,14 +12,14 @@
 buildPythonPackage rec {
 
   pname = "peewee";
-  version = "3.13.3";
+  version = "3.14.4";
 
   # pypi release does not provide tests
   src = fetchFromGitHub {
     owner = "coleifer";
     repo = pname;
     rev = version;
-    sha256 = "1r67hxb9m6v0xbnbqfnsw6dahmdr94pf81b4x51jfw6x9sa4izi4";
+    sha256 = "0x85swpaffysc05kka0mab87cnilzw1lpacfhcx5ayabh0i2qsh6";
   };
 
 

--- a/pkgs/development/python-modules/python-socks/default.nix
+++ b/pkgs/development/python-modules/python-socks/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, trio, curio, async-timeout, fetchPypi, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "python-socks";
+  version = "1.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1n6xb18jy41ybgkmamakg6psp3qididd45qknxiggngaiibz43kx";
+  };
+
+  disabled = pythonOlder "3.6.1";
+
+  propagatedBuildInputs = [ trio curio async-timeout ];
+
+  meta = with lib; {
+    description = "Core proxy client (SOCKS4, SOCKS5, HTTP) functionality for Python";
+    homepage = "https://github.com/romis2012/python-socks";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mjlbach ];
+  };
+}

--- a/pkgs/development/python-modules/unpaddedbase64/default.nix
+++ b/pkgs/development/python-modules/unpaddedbase64/default.nix
@@ -1,18 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, poetry-core
 }:
 
 buildPythonPackage rec {
   pname = "unpaddedbase64";
-  version = "1.1.0";
+  version = "2.1.0";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "python-${pname}";
     rev = "refs/tags/v${version}";
-    sha256 = "0if3fjfxga0bwdq47v77fs9hrcqpmwdxry2i2a7pdqsp95258nxd";
+    sha256 = "1n6har8pxv0mqb96lanzihp1xf76aa17jw3977drb1fgz947pnmz";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/matrix-org/python-unpaddedbase64";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6634,6 +6634,8 @@ in {
 
   python-socketio_4 = callPackage ../development/python-modules/python-socketio/4.nix { };
 
+  python-socks = callPackage ../development/python-modules/python-socks { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };


### PR DESCRIPTION
###### Motivation for this change

I added an upstream patch for matrix-nio so that it can A) be used for dendrite (generally) and B) can be used for nixos tests for dendrite (and synapse) since the python matrix SDK is not actively maintained.

I'm happy to split this PR out into multiple PRs, but the changes are all linked together.

###### Things done
1. add python-socks, a new depdency of aiohttp-socks
2. update aiohttp-socks
3. update unpaddedbase64, update build system to poetry
3. update matrix-nio, update build system to poetry 

cc: 
matrix-weechat maintainers @tilpner @emily

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [] macOS
   -  [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
