### PR TITLE
emacs: adapt to renamed native-comp variables

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -94,8 +94,8 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
         ]));
     in ''
       substituteInPlace lisp/emacs-lisp/comp.el --replace \
-        "(defcustom comp-native-driver-options nil" \
-        "(defcustom comp-native-driver-options '(${backendPath})"
+        "(defcustom native-comp-driver-options nil" \
+        "(defcustom native-comp-driver-options '(${backendPath})"
     ''))
     ""
   ];
@@ -175,7 +175,7 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
           (comp-trampoline-compile (intern (pop argv))))"
     mkdir -p $out/share/emacs/native-lisp
     $out/bin/emacs --batch \
-      --eval "(add-to-list 'comp-eln-load-path \"$out/share/emacs/native-lisp\")" \
+      --eval "(add-to-list 'native-comp-eln-load-path \"$out/share/emacs/native-lisp\")" \
       -f batch-native-compile $out/share/emacs/site-lisp/site-start.el
   '';
 

--- a/pkgs/applications/editors/emacs/site-start.el
+++ b/pkgs/applications/editors/emacs/site-start.el
@@ -47,11 +47,11 @@ least specific (the system profile)"
 ;;; Set up native-comp load path.
 (when (featurep 'comp)
   ;; Append native-comp subdirectories from `NIX_PROFILES'.
-  (setq comp-eln-load-path
+  (setq native-comp-eln-load-path
         (append (mapcar (lambda (profile-dir)
                           (concat profile-dir "/share/emacs/native-lisp/"))
                         (nix--profile-paths))
-                comp-eln-load-path)))
+                native-comp-eln-load-path)))
 
 ;;; Make `woman' find the man pages
 (defvar woman-manpath)

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -159,7 +159,7 @@ runCommand
         (add-to-list 'load-path "$out/share/emacs/site-lisp")
         (add-to-list 'exec-path "$out/bin")
         ${optionalString nativeComp ''
-          (add-to-list 'comp-eln-load-path "$out/share/emacs/native-lisp/")
+          (add-to-list 'native-comp-eln-load-path "$out/share/emacs/native-lisp/")
         ''}
         EOF
         # Link subdirs.el from the emacs distribution
@@ -170,7 +170,7 @@ runCommand
 
         ${optionalString nativeComp ''
           $emacs/bin/emacs --batch \
-            --eval "(add-to-list 'comp-eln-load-path \"$out/share/emacs/native-lisp/\")" \
+            --eval "(add-to-list 'native-comp-eln-load-path \"$out/share/emacs/native-lisp/\")" \
             -f batch-native-compile "$siteStart" "$subdirs"
         ''}
       '';


### PR DESCRIPTION
###### Motivation for this change

https://lists.gnu.org/archive/html/emacs-devel/2021-05/msg00271.html

Note that `comp-trampoline-compile` was not renamed, probably since it's not as public as the other variables.

(Warning for testers: https://github.com/nix-community/emacs-overlay/issues/146 is an unrelated upstream problem currently causing visual bugs in emacs.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
