### PR TITLE
routino: fix on darwin

### DIFF
--- a/pkgs/tools/misc/routino/default.nix
+++ b/pkgs/tools/misc/routino/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile.conf \
+      --subst-var-by PREFIX $out
+  '';
+
   nativeBuildInputs = [ perl ];
 
   buildInputs = [ zlib bzip2 ];
@@ -34,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.routino.org/";
     description = "OpenStreetMap Routing Software";
-    license = licenses.agpl3;
+    license = licenses.agpl3Plus;
     maintainers = with maintainers; [ dotlambda ];
     platforms = with platforms; linux ++ darwin;
   };


### PR DESCRIPTION
###### Motivation for this change
Steps to reproduce:
```
$ nix-shell -p routino --run "router+lib --version"
dyld: Library not loaded: @PREFIX@/lib/libroutino.dylib
  Referenced from: /nix/store/v3q3c61b84b1c2xnipxqzi4hd8ar3a41-routino-3.3.3/bin/router+lib
  Reason: image not found
/private/var/folders/wf/qxrs82v946n91pb5s71n3dy80000gp/T/nix-shell-80704-0/rc: line 1: 80710 Abort trap: 6           router+lib --version
$ nix-shell -p routino --run "otool -L `which router+lib` | grep libroutino"
    @PREFIX@/lib/libroutino.dylib (compatibility version 0.0.0, current version 0.0.0)
```
Fixed:
```
$ result/bin/router+lib --version
Routino version 3.3.3 <http://www.routino.org/> [Library version: 3.3.3, API version: 8]
$ otool -L result/bin/router+lib | grep libroutino
	/nix/store/hkkajcpv3phn5sn0q109x0l569dh2if4-routino-3.3.3/lib/libroutino.dylib (compatibility version 0.0.0, current version 0.0.0)
```

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
