### PR TITLE
python3Packages.plugwise: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/plugwise/default.nix
+++ b/pkgs/development/python-modules/plugwise/default.nix
@@ -1,31 +1,31 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
 , aiohttp
 , async-timeout
+, buildPythonPackage
 , crcmod
 , defusedxml
-, pyserial
-, pytz
-, python-dateutil
-, semver
+, fetchFromGitHub
 , jsonpickle
+, munch
 , mypy
+, pyserial
 , pytest-aiohttp
 , pytest-asyncio
-, pytest-cov
 , pytestCheckHook
+, python-dateutil
+, pytz
+, semver
 }:
 
 buildPythonPackage rec {
   pname = "plugwise";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "python-plugwise";
     rev = version;
-    sha256 = "sha256-MZ4R55vGUyWmR0Md83eNerzsgtYMch1vfQ3sqbm12bM=";
+    sha256 = "sha256-5r+Xe3EKLjuR7mPGEPOKzhE7G6OzNEClf847Px9VdWU=";
   };
 
   propagatedBuildInputs = [
@@ -33,9 +33,10 @@ buildPythonPackage rec {
     async-timeout
     crcmod
     defusedxml
+    munch
     pyserial
-    pytz
     python-dateutil
+    pytz
     semver
   ];
 
@@ -43,8 +44,6 @@ buildPythonPackage rec {
     jsonpickle
     mypy
     pytest-aiohttp
-    pytest-asyncio
-    pytest-cov
     pytest-asyncio
     pytestCheckHook
   ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -330,6 +330,7 @@ in with py.pkgs; buildPythonApplication rec {
     "persistent_notification"
     "person"
     "plaato"
+    "plugwise"
     "prometheus"
     "proximity"
     "push"

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -182,17 +182,17 @@ in with py.pkgs; buildPythonApplication rec {
   doCheck = stdenv.isLinux;
 
   checkInputs = [
-    # test infrastructure
-    asynctest
+    # test infrastructure (selectively from requirement_test.txt)
     pytest-aiohttp
     pytest-mock
     pytest-rerunfailures
     pytest-xdist
     pytestCheckHook
     requests-mock
-    # component dependencies
-    pyotp
+    jsonpickle
     respx
+    # required by tests/auth/mfa_modules
+    pyotp
   ] ++ lib.concatMap (component: getPackages component py.pkgs) componentTests;
 
   # We can reasonably test components that don't communicate with any network


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.4

Change log: https://github.com/plugwise/python-plugwise/releases/tag/0.9.4

Incl. cleaning up and Home Assistant test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
