### PR TITLE
hashcat: fixup opencl support

### DIFF
--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -28,7 +28,9 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     for f in $out/share/hashcat/OpenCL/*.cl; do
+      # Rewrite files to be included for compilation at runtime for opencl offload
       sed "s|#include \"\(.*\)\"|#include \"$out/share/hashcat/OpenCL/\1\"|g" -i "$f"
+      sed "s|#define COMPARE_\([SM]\) \"\(.*\.cl\)\"|#define COMPARE_\1 \"$out/share/hashcat/OpenCL/\2\"|g" -i "$f"
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change

This fixes the following compilation error:
```
clBuildProgram(): CL_BUILD_PROGRAM_FAILURE

/run/user/1000/comgr-64ff7f/input/CompileSource:2252:18: fatal error:
cannot open file
'/run/user/1000/comgr-64ff7f/input/inc_comp_multi_bs.cl': No such file
or directory
        #include COMPARE_M
                 ^
/run/user/1000/comgr-64ff7f/input/CompileSource:16:19: note: expanded
from macro 'COMPARE_M'
                  ^
1 error generated.
Error: Failed to compile opencl source (from CL or HIP source to LLVM
IR).
```

see #113968




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
