### PR TITLE
mpich: fix darwin build

### DIFF
--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -1,15 +1,13 @@
 { stdenv, lib, fetchurl, perl, gfortran
 , openssh, hwloc, autoconf, automake, libtool
-# device options are ch3 or ch4
-, device ? "ch4"
-# backend option are libfabric or ucx
-, ch4backend ? "libfabric"
-, ucx, libfabric
+# either libfabric or ucx work for ch4backend on linux. On darwin, neither of
+# these libraries currently build so this argument is ignored on Darwin.
+, ch4backend
 # Process manager to build
 , withPm ? "hydra:gforker"
 } :
 
-assert (ch4backend == "ucx" || ch4backend == "libfabric");
+assert (ch4backend.pname == "ucx" || ch4backend.pname == "libfabric");
 
 stdenv.mkDerivation  rec {
   pname = "mpich";
@@ -45,8 +43,7 @@ stdenv.mkDerivation  rec {
   enableParallelBuilding = true;
 
   buildInputs = [ perl gfortran openssh hwloc ]
-    ++ lib.optional (ch4backend == "ucx") ucx
-    ++ lib.optional (ch4backend == "libfabric") libfabric;
+    ++ lib.optional (!stdenv.isDarwin) ch4backend;
 
   doCheck = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16711,7 +16711,9 @@ in
 
   libmpc = callPackage ../development/libraries/libmpc { };
 
-  mpich = callPackage ../development/libraries/mpich { };
+  mpich = callPackage ../development/libraries/mpich {
+    ch4backend = libfabric;
+  };
 
   mstpd = callPackage ../os-specific/linux/mstpd { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The darwin build was failing because neither of the ch4backend libraries
succesfully build on that OS.

Resolves #121978


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
