### PR TITLE
xjobs: init at 20200726

### DIFF
--- a/pkgs/tools/misc/xjobs/default.nix
+++ b/pkgs/tools/misc/xjobs/default.nix
@@ -1,0 +1,65 @@
+{ lib, stdenv, fetchurl
+, flex, installShellFiles, ncurses, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xjobs";
+  version = "20200726";
+
+  src = fetchurl {
+    url = "mirror://sourceforge//xjobs/files/${pname}-${version}.tgz";
+    sha256 = "0ay6gn43pnm7r1jamwgpycl67bjg5n87ncl27jb01w2x6x70z0i3";
+  };
+
+  nativeBuildInputs = [
+    flex
+    installShellFiles
+    which
+  ];
+  buildInputs = [
+    ncurses
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ./${pname} -V
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,etc}
+    install -m755 ${pname} $out/bin/${pname}
+    install -m644 ${pname}.rc $out/etc/${pname}.rc
+    installManPage ${pname}.1
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A program which reads job descriptions line by line and executes them in parallel";
+    homepage = "https://www.maier-komor.de/xjobs.html";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.siriobalmelli ];
+    longDescription = ''
+      xjobs reads job descriptions line by line and executes them in parallel.
+
+      It limits the number of parallel executing jobs and starts new jobs when jobs finish.
+
+      Therefore, it combines the arguments from every input line with the utility
+      and arguments given on the command line.
+      If no utility is given as an argument to xjobs,
+      then the first argument on every job line will be used as utility.
+      To execute utility xjobs searches the directories given in the PATH environment variable
+      and uses the first file found in these directories.
+
+      xjobs is most useful on multi-processor/core machines when one needs to execute
+      several time consuming command several that could possibly be run in parallel.
+      With xjobs this can be achieved easily, and it is possible to limit the load
+      of the machine to a useful value.
+
+      It works similar to xargs, but starts several processes simultaneously
+      and gives only one line of arguments to each utility call.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4307,6 +4307,8 @@ in
 
   xkcdpass = with python3Packages; toPythonApplication xkcdpass;
 
+  xjobs = callPackage ../tools/misc/xjobs { };
+
   xob = callPackage ../tools/X11/xob { };
 
   z-lua = callPackage ../tools/misc/z-lua { };


### PR DESCRIPTION
xjobs reads job descriptions line by line and executes them in parallel.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

need xjobs for a project I maintain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [N/A] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
