### PR TITLE
python3Packages.openhomedevice: 1.0.0 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/openhomedevice/default.nix
+++ b/pkgs/development/python-modules/openhomedevice/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "openhomedevice";
-  version = "1.0.0";
+  version = "2.0.1";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "bazwilliams";
     repo = pname;
     rev = version;
-    sha256 = "04qdlyzc8xsk7qxyn9l59pbwnlw49zknw0r5lqwx402va12g4ra0";
+    sha256 = "sha256-BQgwXg15+xEGfPm0HJWpKXbNuCgc0VcAD5AuVSDXd8g=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.1

There are no Home Assistant tests for `openhome`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
