### PR TITLE
turbo-geth: 2021.04.05 -> 2021.05.01

### DIFF
--- a/pkgs/applications/blockchains/turbo-geth.nix
+++ b/pkgs/applications/blockchains/turbo-geth.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "turbo-geth";
-  version = "2021.04.05";
+  version = "2021.05.01";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-RTPNJASNFyZ6tDJj0WOqALyxRsOLJzPy0qA1c2sSxys=";
+    sha256 = "sha256-zvxtBK0/6fShxAZfU4gTV0XiP6TzhKFNsADSZA9gv0Y=";
   };
 
-  vendorSha256 = "01c7lb6n00ws60dfybir0z5dbn6h68p5s4hbq0ga2g7drf3l3y0p";
+  vendorSha256 = "0c8p6djs0zcci8sh4zgzky89155mr4cfqlax025618x8vngrsxf2";
   runVend = true;
 
   subPackages = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[new version](https://github.com/ledgerwatch/turbo-geth/releases/tag/v2021.05.01) :sparkles: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
