### PR TITLE
haskellPackages.streamly-archive: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10656,7 +10656,6 @@ broken-packages:
   - streaming-sort
   - streaming-utils
   - streaming-with
-  - streamly-archive
   - streamly-fsnotify
   - streamly-lmdb
   - streamproc

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -864,4 +864,7 @@ self: super: builtins.intersectAttrs super {
   cpuid = overrideCabal super.cpuid {
     platforms = pkgs.lib.platforms.x86;
   };
+
+  # Pass the correct libarchive into the package.
+  streamly-archive = super.streamly-archive.override { archive = pkgs.libarchive; };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The correct libarchive is now being passed into the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested compilation of all pkgs that depend on this change using `nix-build --no-out-link -A haskellPackages.streamly-archive --arg config '{ allowBroken = true; }'`
- [x] Ran `maintainers/scripts/haskell/regenerate-hackage-packages.sh` and included the result in the PR.