### PR TITLE
ferdi: 5.5.0 -> 5.6.0-beta.5

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ferdi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdi/default.nix
@@ -3,10 +3,10 @@
 mkFranzDerivation rec {
   pname = "ferdi";
   name = "Ferdi";
-  version = "5.5.0";
+  version = "5.6.0-beta.5";
   src = fetchurl {
     url = "https://github.com/getferdi/ferdi/releases/download/v${version}/ferdi_${version}_amd64.deb";
-    sha256 = "0i24vcnq4iz5amqmn2fgk92ff9x9y7fg8jhc3g6ksvmcfly7af3k";
+    sha256 = "sha256-fDUzYir53OQ3O4o9eG70sGD+FJ0/4SDNsTfh97WFRnQ=";
   };
   meta = with lib; {
     description = "Combine your favorite messaging services into one application";

--- a/pkgs/applications/networking/instant-messengers/ferdi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdi/default.nix
@@ -11,7 +11,7 @@ mkFranzDerivation rec {
   meta = with lib; {
     description = "Combine your favorite messaging services into one application";
     homepage = "https://getferdi.com/";
-    license = licenses.free;
+    license = licenses.asl20;
     maintainers = [ maintainers.davidtwco ];
     platforms = [ "x86_64-linux" ];
     hydraPlatforms = [ ];

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -23,6 +23,7 @@
 , udev
 , libnotify
 , xdg-utils
+, mesa
 }:
 
 # Helper function for building a derivation for Franz and forks.
@@ -48,6 +49,7 @@ stdenv.mkDerivation rec {
     libXtst
     libXScrnSaver
   ]) ++ [
+    mesa #libgbm
     gtk3
     atk
     glib


### PR DESCRIPTION
Since no official release from the project since 26 Apr 2020 (5.5.0) I have decided to update to the latest beta, it fixed a lot of strange behavior in my part, on master it is not building with this override, so I needed to add mesa (libgbm) to buildInputs at mkFranzDerivation to fix build of latest beta on master.

Also for some reason, the Hydra URL for it is blank https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.ferdi.x86_64-linux, maybe I am searching in the wrong place?

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
