### PR TITLE
solvespace: 3.0rc2 → 3.0

### DIFF
--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -3,12 +3,12 @@
 }:
 stdenv.mkDerivation rec {
   pname = "solvespace";
-  version = "v3.0.rc2";
+  version = "v3.0";
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1z0873gwcr0hybrpqy4hwislir6k2zb4s62lbsivq5nbkizy7gjm";
+    sha256 = "04aympdsjp37vp0p13mb8nwkc080hp9cdrjpyy5m1mhwkm8jm9k9";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update `solvespace` to a stable version, numerous bugfixes.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~  N/A
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
