### PR TITLE
Add a few KDE applications

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5160,6 +5160,16 @@
     githubId = 37185887;
     name = "Calvin Kim";
   };
+  kennyballou = {
+    email = "kb@devnulllabs.io";
+    github = "kennyballou";
+    githubId = 2186188;
+    name = "Kenny Ballou";
+    keys = [{
+      longkeyid = "rsa4096/0xB0CAA28A02958308";
+      fingerprint = "932F 3E8E 1C0F 4A98 95D7  B8B8 B0CA A28A 0295 8308";
+    }];
+  };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
     github = "kentjames";

--- a/pkgs/applications/kde/akonadi-calendar-tools.nix
+++ b/pkgs/applications/kde/akonadi-calendar-tools.nix
@@ -1,0 +1,24 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, kdoctools
+, akonadi
+, calendarsupport
+}:
+
+mkDerivation {
+  pname = "akonadi-calendar-tools";
+  meta = {
+    homepage = "https://github.com/KDE/akonadi-calendar-tools";
+    description = "Console applications and utilities for managing calendars in Akonadi";
+    license = with lib.licenses; [ gpl2Plus cc0 ];
+    maintainers = with lib.maintainers; [ kennyballou ];
+    platforms = lib.platforms.linux;
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    akonadi
+    calendarsupport
+  ];
+  outputs = [ "out" "dev" ];
+}

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -62,6 +62,7 @@ let
     in {
       akonadi = callPackage ./akonadi {};
       akonadi-calendar = callPackage ./akonadi-calendar.nix {};
+      akonadi-calendar-tools = callPackage ./akonadi-calendar-tools.nix {};
       akonadi-contacts = callPackage ./akonadi-contacts.nix {};
       akonadi-import-wizard = callPackage ./akonadi-import-wizard.nix {};
       akonadi-mime = callPackage ./akonadi-mime.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -133,6 +133,7 @@ let
       kipi-plugins = callPackage ./kipi-plugins.nix {};
       kitinerary = callPackage ./kitinerary.nix {};
       kio-extras = callPackage ./kio-extras.nix {};
+      kio-gdrive = callPackage ./kio-gdrive.nix {};
       kldap = callPackage ./kldap.nix {};
       kleopatra = callPackage ./kleopatra.nix {};
       klettres = callPackage ./klettres.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -88,6 +88,7 @@ let
       incidenceeditor = callPackage ./incidenceeditor.nix {};
       k3b = callPackage ./k3b.nix {};
       kaccounts-integration = callPackage ./kaccounts-integration.nix {};
+      kaccounts-providers = callPackage ./kaccounts-providers.nix {};
       kaddressbook = callPackage ./kaddressbook.nix {};
       kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};

--- a/pkgs/applications/kde/kaccounts-providers.nix
+++ b/pkgs/applications/kde/kaccounts-providers.nix
@@ -1,0 +1,44 @@
+{ mkDerivation
+, lib
+, accounts-qt
+, extra-cmake-modules
+, intltool
+, kaccounts-integration
+, kcmutils
+, kcoreaddons
+, kdeclarative
+, kdoctools
+, kio
+, kpackage
+, kwallet
+, qtwebengine
+, signond
+}:
+
+mkDerivation {
+  pname = "kaccounts-providers";
+  meta = with lib; {
+    homepage = "https://community.kde.org/KTp/Setting_up_KAccounts";
+    description = "Online account providers";
+    maintainers = with maintainers; [ kennyballou ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+  nativeBuildInputs = [
+    extra-cmake-modules
+    intltool
+    kdoctools
+  ];
+  buildInputs = [
+    accounts-qt
+    kaccounts-integration
+    kcmutils
+    kcoreaddons
+    kdeclarative
+    kio
+    kpackage
+    kwallet
+    qtwebengine
+    signond
+  ];
+}

--- a/pkgs/applications/kde/kio-gdrive.nix
+++ b/pkgs/applications/kde/kio-gdrive.nix
@@ -1,0 +1,36 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, kdoctools
+, kio
+, libkgapi
+, kcalendarcore
+, kcontacts
+, qtkeychain
+, libsecret
+, kaccounts-integration
+}:
+
+mkDerivation {
+  pname = "kio-gdrive";
+  meta = with lib; {
+    homepage = "https://github.com/KDE/kio-gdrive";
+    description = "KIO slave for Google APIs";
+    maintainers = with maintainers; [ kennyballou ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+  buildInputs = [
+    kcalendarcore
+    kcontacts
+    kaccounts-integration
+    libkgapi
+    libsecret
+    kio
+    qtkeychain
+  ];
+}


### PR DESCRIPTION
###### Motivation for this change

Add several KDE applications to bring some parity between Gnome and KDE/Plasma environments, specifically, `kaccounts-providers` and `kio-gdrive`.

These changes were ported out of NixOS/nixpkgs#98212.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
