### PR TITLE
hdfview: Fix build

### DIFF
--- a/pkgs/tools/misc/hdf5/1.10.nix
+++ b/pkgs/tools/misc/hdf5/1.10.nix
@@ -3,6 +3,8 @@
 , removeReferencesTo
 , zlib ? null
 , enableShared ? !stdenv.hostPlatform.isStatic
+, javaSupport ? false
+, jdk
 }:
 
 let inherit (lib) optional optionals; in
@@ -17,11 +19,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  buildInputs = optional javaSupport jdk;
+
   nativeBuildInputs = [ removeReferencesTo ];
 
   propagatedBuildInputs = optional (zlib != null) zlib;
 
-  configureFlags = optional enableShared "--enable-shared";
+  configureFlags = []
+    ++ optional enableShared "--enable-shared"
+    ++ optional javaSupport "--enable-java";
 
   patches = [
     ./bin-mv.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5474,7 +5474,9 @@ in
 
   hdf5-blosc = callPackage ../development/libraries/hdf5-blosc { };
 
-  hdfview = callPackage ../tools/misc/hdfview { };
+  hdfview = callPackage ../tools/misc/hdfview {
+    hdf5 = hdf5_1_10;
+  };
 
   hecate = callPackage ../applications/editors/hecate { };
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042

Looks like hdfview is not compatible with HDF5 1.12.x so it needs the 1.10.x version.
However, it also needs Java, so I've (re-?)added that option to the 1.10.x version.

@NixOS/nixos-release-managers 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
