### PR TITLE
gnomeExtensions.disable-unredirect: unstable-2021-01-17 -> unstable-2021-04-13

### DIFF
--- a/pkgs/desktops/gnome/extensions/disable-unredirect/default.nix
+++ b/pkgs/desktops/gnome/extensions/disable-unredirect/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-disable-unredirect";
-  version = "unstable-2021-01-17";
+  version = "unstable-2021-04-13";
 
   src = fetchFromGitHub {
     owner = "kazysmaster";
     repo = "gnome-shell-extension-disable-unredirect";
-    rev = "2ecb2f489ea3316b77d04f03a0c885f322c67e79";
-    sha256 = "1rjyrg8qya0asndxr7189a9npww0rcxk02wkxrxjy7fdp5m89p7y";
+    rev = "2a4c0e6a7a7a5f1aad9907ee2cf43d0725e10c19";
+    sha256 = "06hbyy20xz0bvzg0vs5w4092nyfpg372c86cdm1akcjm72m5sim9";
   };
 
   uuid = "unredirect@vaina.lt";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Enables support for GNOME 40

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
