### PR TITLE
maintainers/check-hydra-by-maintainer: use `pkgs.hydra-check` from package set itself

### DIFF
--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -48,6 +48,7 @@ let
 in
 pkgs.stdenv.mkDerivation {
   name = "nixpkgs-update-script";
+  buildInputs = [ pkgs.hydra-check ];
   buildCommand = ''
     echo ""
     echo "----------------------------------------------------------------"


### PR DESCRIPTION


###### Motivation for this change

Helpful so that one doesn't have to install it on their own for instance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
