### PR TITLE
vulkan: 1.2.162.0 → 1.2.176.0

### DIFF
--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.2.162.0";
+  version = "1.2.176.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    sha256 = "057c49w1138l02v9gqsk1z8wdz0iilp96jblnldycwm9jc1a1ipq";
+    sha256 = "07i5p73f5n1qxd435495a3c6ss6j9f4gljq5h4i8b5p5isgh6zvd";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,23 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3, vulkan-headers, pkg-config
-, xlibsWrapper, libxcb, libXrandr, libXext, wayland, addOpenGLRunpath }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libX11, libxcb
+, libXrandr, wayland, vulkan-headers, addOpenGLRunpath }:
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.2.162.0";
+  version = "1.2.176.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Loader";
     rev = "sdk-${version}";
-    sha256 = "0w9i2pliw4ccmjyfzff4i2f3hxwsfd54jg7ahv2v634qmx59bsbi";
+    sha256 = "0b0gn4p1nz4m1lmfm8hf8xyw2fkk6c7iq6c9lg57i8z0l8crwa57";
   };
 
-  nativeBuildInputs = [ pkg-config cmake ];
-  buildInputs = [ python3 xlibsWrapper libxcb libXrandr libXext wayland ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libX11 libxcb libXrandr vulkan-headers wayland ];
 
   cmakeFlags = [
     "-DSYSCONFDIR=${addOpenGLRunpath.driverLink}/share"
-    "-DVULKAN_HEADERS_INSTALL_DIR=${vulkan-headers}"
     "-DCMAKE_INSTALL_INCLUDEDIR=${vulkan-headers}/include"
   ];
 

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -1,31 +1,29 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , cmake
-, writeText
-, python3
+, glslang
+, libX11
+, libxcb
+, libXrandr
 , spirv-headers
 , spirv-tools
 , vulkan-headers
-, vulkan-loader
-, glslang
-, pkg-config
-, xlibsWrapper
-, libxcb
-, libXrandr
 , wayland
 }:
-# vulkan-validation-layers requires a custom glslang version, while glslang requires
-# custom versions for spirv-tools and spirv-headers. The git hashes required for all
-# of these deps is documented upstream here:
-# https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/scripts/known_good.json
 
 let
+  # vulkan-validation-layers requires a custom glslang & robin-hood-hashing
+  # version, while glslang requires custom versions for spirv-tools and spirv-headers.
+  #
+  # The git hashes required for all of these deps is documented upstream here:
+  # https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/scripts/known_good.json
   localSpirvHeaders = spirv-headers.overrideAttrs (_: {
     src = fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "SPIRV-Headers";
-      rev = "f027d53ded7e230e008d37c8b47ede7cd308e19d";
-      sha256 = "12gp2mqcar6jj57jw9isfr62yn72kmvdcl0zga4gvrlyfhnf582q";
+      rev = "75b30a659c8a4979104986652c54cc421fc51129";
+      sha256 = "1yzdp3m50zxabkg93j1lmazs45wjp20szvxiv8ifgcdjxmyzi5ji";
     };
   });
   localGlslang = (glslang.override {
@@ -33,8 +31,8 @@ let
       src = fetchFromGitHub {
         owner = "KhronosGroup";
         repo = "SPIRV-Tools";
-        rev = "c9c1f54330d13a0bec1aa3f08d436249d8e35596";
-        sha256 = "0r5whsw9x8j4199xwxv293ar2ga73pm2s7rngw732ylh6rw3bkly";
+        rev = "c79edd260c2b503f0eca57310057b4a100999cc5";
+        sha256 = "01qq5g2a8c5ljn1j6yqh3v90kbhavibh45dcnasixvpf5q7k2ary";
       };
     });
     argSpirv-headers = localSpirvHeaders;
@@ -42,15 +40,20 @@ let
     src = fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "glslang";
-      rev = "dd69df7f3dac26362e10b0f38efb9e47990f7537";
-      sha256 = "1iafbh524avsjg4pjiq156b62pck2rwlfl2pjnml8sjy285506rk";
+      rev = "e56beaee736863ce48455955158f1839e6e4c1a1";
+      sha256 = "062v3zq88dvgpy3xlb86lj4skk9472jh7hv835d8gs8zbyy0s3aw";
     };
   });
+  robin-hood-hashing = fetchFromGitHub {
+    owner = "martinus";
+    repo = "robin-hood-hashing";
+    rev = "eee46f9985c3c65a05b35660c6866f8f8f1a3ba3";
+    sha256 = "0h2ljqxnc1gr3p3iqk627n65c7pixpzxhd9vaybr24f90f069lmw";
+  };
 in
-
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.2.162.0";
+  version = "1.2.176.0";
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
@@ -61,36 +64,39 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
     rev = "sdk-${version}";
-    sha256 = "1mpqmxh9zm20jdar59lp4yjpqfzxn2pwds6bkvnzihfy0pymf15k";
+    sha256 = "1mp110a686lwl6wfplg79vwnlrvbz2pd5mjkgyg9i3jyfs65lr33";
   };
 
+  # Include absolute paths to layer libraries in their associated
+  # layer definition json files.
+  postPatch = ''
+    sed "s|\([[:space:]]*set(INSTALL_DEFINES \''${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY=\"\)\(\$<TARGET_FILE_NAME:\''${TARGET_NAME}>\")\)|\1$out/lib/\2|" -i layers/CMakeLists.txt
+  '';
+
   nativeBuildInputs = [
-    pkg-config
     cmake
-    python3
   ];
 
   buildInputs = [
-    localGlslang
-    localGlslang.spirv-headers
-    vulkan-headers
-    vulkan-loader
+    libX11
     libxcb
     libXrandr
+    vulkan-headers
     wayland
   ];
 
   cmakeFlags = [
     "-DGLSLANG_INSTALL_DIR=${localGlslang}"
     "-DSPIRV_HEADERS_INSTALL_DIR=${localSpirvHeaders}"
+    "-DROBIN_HOOD_HASHING_INSTALL_DIR=${robin-hood-hashing}"
     "-DBUILD_LAYER_SUPPORT_FILES=ON"
+    # Hide dev warnings that are useless for packaging
+    "-Wno-dev"
   ];
 
-  # Include absolute paths to layer libraries in their associated
-  # layer definition json files.
-  patchPhase = ''
-    sed "s|\([[:space:]]*set(INSTALL_DEFINES \''${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY=\"\)\(\$<TARGET_FILE_NAME:\''${TARGET_NAME}>\")\)|\1$out/lib/\2|" -i layers/CMakeLists.txt
-  '';
+  # Tests require access to vulkan-compatible GPU, which isn't
+  # available in Nix sandbox. Fails with VK_ERROR_INCOMPATIBLE_DRIVER.
+  doCheck = false;
 
   meta = with lib; {
     description = "The official Khronos Vulkan validation layers";

--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "2020-11-20";
+  version = "1.2.176.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ExtensionLayer";
-    rev = "7474cb8e1f70e9f4a8bf382708a7f15465453af5";
-    sha256 = "1lxkgcnv32wqk4hlckv13xy84g38jzgc4qxp9vsbkrgz87hkdvwj";
+    rev = "sdk-${version}";
+    sha256 = "04zybnha7qnw9dqqlhb4q77d7pb8dq7b5y8qvid2dnjwf6ymirdn";
   };
 
   nativeBuildInputs = [ cmake jq ];

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -1,26 +1,44 @@
-{ stdenv, cmake, expat, fetchFromGitHub, jq, lib, libXdmcp, libXrandr, libffi
-, libxcb, pkg-config, python3, symlinkJoin, vulkan-headers, vulkan-loader
-, vulkan-validation-layers, wayland, writeText, xcbutilkeysyms, xcbutilwm
-, xlibsWrapper }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+, jq
+, expat
+, libX11
+, libXdmcp
+, libXrandr
+, libffi
+, libxcb
+, wayland
+, xcbutilkeysyms
+, xcbutilwm
+, vulkan-headers
+, vulkan-loader
+, symlinkJoin
+, vulkan-validation-layers
+, writeText
+}:
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools-lunarg";
   # The version must match that in vulkan-headers
-  version = "1.2.162.0";
+  version = "1.2.176.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "LunarG";
       repo = "VulkanTools";
       rev = "sdk-${version}";
-      sha256 = "13v4202bfd7d7nwi8w12ja9k1vi10p9xxypzkpi063hmsgzxm5k5";
+      sha256 = "0p527nml2aj10rra2588dhvjmz63i6b69mc84x9s5wp85sazxxl1";
       fetchSubmodules = true;
     });
 
-  nativeBuildInputs = [ cmake pkg-config python3 jq ];
+  nativeBuildInputs = [ cmake python3 jq ];
 
   buildInputs = [
     expat
+    libX11
     libXdmcp
     libXrandr
     libffi
@@ -28,7 +46,6 @@ stdenv.mkDerivation rec {
     wayland
     xcbutilkeysyms
     xcbutilwm
-    xlibsWrapper
   ];
 
   cmakeFlags = [
@@ -40,6 +57,8 @@ stdenv.mkDerivation rec {
         paths = [ vulkan-validation-layers.headers vulkan-validation-layers ];
       }
     }"
+    # Hide dev warnings that are useless for packaging
+    "-Wno-dev"
   ];
 
   preConfigure = ''
@@ -63,7 +82,6 @@ stdenv.mkDerivation rec {
   '';
 
   # Same as vulkan-validation-layers
-  libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
   dontPatchELF = true;
 
   # Help vulkan-loader find the validation layers

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -1,20 +1,19 @@
-{ stdenv, lib, fetchFromGitHub, cmake, python3, vulkan-loader,
- vulkan-headers, glslang, pkg-config, xlibsWrapper, libxcb,
- libXrandr, wayland }:
+{ stdenv, lib, fetchFromGitHub, cmake, glslang, libX11, libxcb
+, libXrandr, vulkan-headers, vulkan-loader, wayland }:
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.2.162.0";
+  version = "1.2.176.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Tools";
     rev = "sdk-${version}";
-    sha256 = "088vqh956zma3p1qc3p6rsygf5s395b6cv8b1x0whp2a0a1y81xz";
+    sha256 = "15jkjn3ildam4ad2x0d8ysm3i2l6nrvqv0h44spkipf13bqiq5wg";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ python3 vulkan-headers vulkan-loader xlibsWrapper libxcb libXrandr wayland ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ glslang libX11 libxcb libXrandr vulkan-headers vulkan-loader wayland ];
 
   libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
 
@@ -23,9 +22,10 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     # Don't build the mock ICD as it may get used instead of other drivers, if installed
     "-DBUILD_ICD=OFF"
-    "-DGLSLANG_INSTALL_DIR=${glslang}"
     # vulkaninfo loads libvulkan using dlopen, so we have to add it manually to RPATH
     "-DCMAKE_INSTALL_RPATH=${libraryPath}"
+    # Hide dev warnings that are useless for packaging
+    "-Wno-dev"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Update to the latest sdk version: https://github.com/KhronosGroup/Vulkan-Loader/releases/tag/sdk-1.2.176.0

This includes a change in `vulkan-loader` to support multiple Vulkan layers with the same name, but different library architectures: KhronosGroup/Vulkan-Loader#525. This can be used by `MangoHud` & `vkBasalt` to support 32bit Vulkan layers as a workaround for #101597.

@ralith @expipiplus1 @zeratax @Atemu 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  I tried this, but ran out of disk space, which is why I'm submitting this to staging. I was able to build my NixOS system with these changes and I haven't noticed any runtime problems.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).