### PR TITLE
pycm: add two necessary dependencies

### DIFF
--- a/pkgs/development/python-modules/pycm/default.nix
+++ b/pkgs/development/python-modules/pycm/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, numpy, pytest }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, matplotlib, numpy, pytest, seaborn }:
 
 buildPythonPackage rec {
   pname = "pycm";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ pytest ];
-  propagatedBuildInputs = [ numpy ];
+  propagatedBuildInputs = [ matplotlib numpy seaborn ];
 
   checkPhase = ''
     pytest Test/


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042 

Adds two dependencies necessary to build/test. Hydra failure: https://hydra.nixos.org/build/142057098/nixlog/2

Note from pycm README:

> warning Plotting capability requires Matplotlib (>= 3.0.0) or Seaborn (>= 0.9.1)

CC @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
