### PR TITLE
colobot: Fix build

### DIFF
--- a/pkgs/games/colobot/default.nix
+++ b/pkgs/games/colobot/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, boost, SDL2, SDL2_image, SDL2_ttf, libpng
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, boost, SDL2, SDL2_image, SDL2_ttf, libpng
 , glew, gettext, libsndfile, libvorbis, libogg, physfs, openal
 , xmlstarlet, doxygen, python3, callPackage }:
 
@@ -17,6 +17,15 @@ stdenv.mkDerivation rec {
     rev = "colobot-gold-${version}";
     sha256 = "0viq5s4zqs33an7rdmc3anf74ml7mwwcwf60alhvp9hj5jr547s2";
   };
+
+  patches = [
+    # Fix issue with newer compilers, like used in nixpkgs
+    # https://github.com/colobot/colobot/pull/1291
+    (fetchpatch {
+      url = "https://github.com/colobot/colobot/commit/fc2bd68876ac6302dbc8e91e8ffa33592db14b21.patch";
+      sha256 = "sha256-PKe8jeyHpTT86tprSafQhNqTYBrSonz+r2fL1lVJdfo=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake xmlstarlet doxygen python3 ];
   buildInputs = [ boost SDL2 SDL2_image SDL2_ttf libpng glew gettext libsndfile libvorbis libogg physfs openal ];


### PR DESCRIPTION
###### Motivation for this change

Seems recent compilers don't like the code anymore - upstream has a patch for this though.

ZHF: #122042

@NixOS/nixos-release-managers

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
