### PR TITLE
pick-colour-picker: unstable-2019-10-11 -> unstable-2021-01-19

### DIFF
--- a/pkgs/applications/graphics/pick-colour-picker/default.nix
+++ b/pkgs/applications/graphics/pick-colour-picker/default.nix
@@ -12,13 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pick-colour-picker";
-  version = "unstable-2019-10-11"; # "1.5.0-3ec940"
+  version = "unstable-2021-01-19";
 
   src = fetchFromGitHub {
     owner = "stuartlangridge";
     repo = "ColourPicker";
-    rev = "3ec9406d787ce373f6db0d520ed38a921edb9473";
-    sha256 = "04l8ch9297nhkgcmyhsbg0il424c8vy0isns1c7aypn0zp0dc4zd";
+    rev = "dec8f144918aa7964aaf86a346161beb7e997f09";
+    sha256 = "hW2rarfchZ3M0JVfz5RbJRvMhv2PpyLNEMyMAp2gC+o=";
+    fetchSubmodules = false;
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Progress

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
