### PR TITLE
python3Packages.python-redis-lock: disable failing test

### DIFF
--- a/pkgs/development/python-modules/python-redis-lock/default.nix
+++ b/pkgs/development/python-modules/python-redis-lock/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , redis
-, pytest
+, pytestCheckHook
 , process-tests
 , pkgs
 , withDjango ? false, django_redis
@@ -17,15 +17,20 @@ buildPythonPackage rec {
     sha256 = "4265a476e39d476a8acf5c2766485c44c75f3a1bd6cf73bb195f3079153b8374";
   };
 
-  checkInputs = [ pytest process-tests pkgs.redis ];
+  propagatedBuildInputs = [
+    redis
+  ] ++ lib.optional withDjango django_redis;
 
-  checkPhase = ''
-    pytest tests/
-  '';
+  checkInputs = [
+    pytestCheckHook
+    process-tests
+    pkgs.redis
+  ];
 
-  propagatedBuildInputs = [ redis ]
-  ++ lib.optional withDjango django_redis;
-
+  disabledTests = [
+    # https://github.com/ionelmc/python-redis-lock/issues/86
+    "test_no_overlap2"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/ionelmc/python-redis-lock";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/ionelmc/python-redis-lock/issues/86

ZHF: #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
