### PR TITLE
bat-extras: fix build on Darwin

### DIFF
--- a/pkgs/tools/misc/bat-extras/default.nix
+++ b/pkgs/tools/misc/bat-extras/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub, bash, makeWrapper, bat
 # batdiff, batgrep, and batwatch
 , coreutils
+, getconf
 , less
 # batgrep
 , ripgrep
@@ -48,6 +49,7 @@ let
 
     # Run the library tests as they don't have external dependencies
     doCheck = true;
+    checkInputs = lib.optionals stdenv.isDarwin [ getconf ];
     checkPhase = ''
       runHook preCheck
       # test list repeats suites. Unique them
@@ -104,6 +106,7 @@ let
       dontBuild = true; # we've already built
 
       doCheck = true;
+      checkInputs = lib.optionals stdenv.isDarwin [ getconf ];
       checkPhase = ''
         runHook preCheck
         bash ./test.sh --compiled --suite ${name}


### PR DESCRIPTION
###### Motivation for this change

fix build failure ([#119987](https://github.com/NixOS/nixpkgs/issues/119987)) on Darwin introduced by [#119689](https://github.com/NixOS/nixpkgs/pull/119689)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-build -I nixpkgs=$(pwd) --no-out-link -A bat-extras.batgrep '<nixpkgs>'`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
