### PR TITLE
dwl: 0.2 -> 0.2.1 and fix build

### DIFF
--- a/pkgs/applications/window-managers/dwl/default.nix
+++ b/pkgs/applications/window-managers/dwl/default.nix
@@ -17,32 +17,18 @@
 }:
 
 let
-  # Add two patches to fix compile errors with wlroots 0.13:
-  totalPatches = patches ++ [
-    # Fix the renamed constant WLR_KEY_PRESSED => WL_KEYBOARD_KEY_STATE_PRESSED
-    # https://github.com/djpohly/dwl/pull/66
-    (fetchpatch {
-      url = "https://github.com/djpohly/dwl/commit/a42613db9d9f6debfa4fb2363d75af9457d238ed.patch";
-      sha256 = "0h76hx1fhazi07gqg7sljh13f91v6bvjy7m9qqmimhvqgfwdcc0j";
-    })
-    # Use the new signature for wlr_backend_autocreate, which removes an argument:
-    # https://github.com/djpohly/dwl/pull/76
-    (fetchpatch {
-      url = "https://github.com/djpohly/dwl/commit/0ff13cf216056a36a261f4eed53c6a864989a9fb.patch";
-      sha256 = "18clpdb4il1vxf1b0cx0qrwild68s9dism8ab66zpmvxs5qag2dm";
-    })
-  ];
+  totalPatches = patches ++ [ ];
 in
 
 stdenv.mkDerivation rec {
   pname = "dwl";
-  version = "0.2";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "djpohly";
     repo = pname;
     rev = "v${version}";
-    sha256 = "gUaFTkpIQDswEubllMgvxPfCaEYFO7mODzjPyW7XsGQ=";
+    sha256 = "sha256-lfUAymLA4+E9kULZIueA+9gyVZYgaVS0oTX0LJjsSEs=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/applications/window-managers/dwl/default.nix
+++ b/pkgs/applications/window-managers/dwl/default.nix
@@ -5,6 +5,7 @@
 , libinput
 , libxcb
 , libxkbcommon
+, pixman
 , wayland
 , wayland-protocols
 , wlroots
@@ -49,6 +50,7 @@ stdenv.mkDerivation rec {
     libinput
     libxcb
     libxkbcommon
+    pixman
     wayland
     wayland-protocols
     wlroots


### PR DESCRIPTION
###### Motivation for this change

Add missing dependency.

ZHF: #122042

@NixOS/nixos-release-managers

Also bump version @AndersonTorres 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
