### PR TITLE
haskellPackages.streamly-lmdb: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10657,7 +10657,6 @@ broken-packages:
   - streaming-utils
   - streaming-with
   - streamly-fsnotify
-  - streamly-lmdb
   - streamproc
   - strelka
   - strict-base-types


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The latest version of streamly-lmdb (0.2.1) is not broken at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested compilation of all pkgs that depend on this change using `nix-build --no-out-link -A haskellPackages.streamly-lmdb --arg config '{ allowBroken = true; }'`
- [x] Ran `maintainers/scripts/haskell/regenerate-hackage-packages.sh` and included the result in the commit.