### PR TITLE
python3Packages.runway-python: fix build, enable tests

### DIFF
--- a/pkgs/development/python-modules/runway-python/default.nix
+++ b/pkgs/development/python-modules/runway-python/default.nix
@@ -1,33 +1,43 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, pythonAtLeast
+, fetchFromGitHub
+, colorcet
+, cryptography
 , flask
 , flask-compress
 , flask-cors
 , flask-sockets
+, gevent
 , imageio
 , numpy
-, scipy
 , pillow
-, gevent
-, wget
+, pyopenssl
+, scipy
 , six
-, colorcet
 , unidecode
 , urllib3
+, wget
+, deepdiff
+, pytestCheckHook
+, pytestcov
+, websocket_client
 }:
 
 buildPythonPackage rec {
   pname = "runway-python";
   version = "0.6.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "66cf1517dd817bf6db3792608920274f964dd0ced8dabecd925b8bc17aa95740";
+  src = fetchFromGitHub {
+    owner = "runwayml";
+    repo = "model-sdk";
+    rev = version;
+    sha256 = "1ww2wai1qnly8i7g42vhkkbs4yp7wi9x4fjdxsg9fl3izjra0zs2";
   };
 
   propagatedBuildInputs = [
     colorcet
+    cryptography
     flask
     flask-compress
     flask-cors
@@ -36,6 +46,7 @@ buildPythonPackage rec {
     imageio
     numpy
     pillow
+    pyopenssl
     scipy
     six
     unidecode
@@ -43,11 +54,28 @@ buildPythonPackage rec {
     wget
   ];
 
-  # tests are not packaged in the released tarball
-  doCheck = false;
-
   pythonImportsCheck = [
     "runway"
+  ];
+
+  checkInputs = [
+    deepdiff
+    pytestCheckHook
+    pytestcov
+    websocket_client
+  ];
+
+  disabledTests = [
+    # these tests require network
+    "test_file_deserialization_remote"
+    "test_file_deserialization_absolute_directory"
+    "test_file_deserialization_remote_directory"
+  ] ++ lib.optionals (pythonAtLeast "3.9") [
+     # AttributeError: module 'base64' has no attribute 'decodestring
+     # https://github.com/runwayml/model-sdk/issues/99
+     "test_image_serialize_and_deserialize"
+     "test_segmentation_serialize_and_deserialize_colormap"
+     "test_segmentation_serialize_and_deserialize_labelmap"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Fetch source from GitHub and enable tests
- Add missing dependencies cryptography and pyOpenSSL

https://hydra.nixos.org/build/142599298

ZHF: #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
