### PR TITLE
python3Packages.seabreeze: fix build, enable tests

### DIFF
--- a/pkgs/development/python-modules/seabreeze/default.nix
+++ b/pkgs/development/python-modules/seabreeze/default.nix
@@ -1,8 +1,17 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
-, pyusb
+, cython
+, git
+, pkgconfig
+, pytest-runner
+, setuptools-scm
+, future
 , numpy
+, pyusb
+, mock
+, pytestCheckHook
+, zipp
 }:
 
 ## Usage
@@ -18,19 +27,35 @@ buildPythonPackage rec {
     owner = "ap--";
     repo = "python-seabreeze";
     rev = "v${version}";
-    sha256 = "1lna3w1vsci35dhyi7qjvbb99gxvzk23k195c7by7kkrps844q1j";
+    sha256 = "1hm9aalpb9sdp8s7ckn75xvyiacp5678pv9maybm5nz0z2h29ibq";
+    leaveDotGit = true;
   };
+
+  nativeBuildInputs = [
+    cython
+    git
+    pkgconfig
+    pytest-runner
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    future
+    numpy
+    pyusb
+  ];
 
   postInstall = ''
     mkdir -p $out/etc/udev/rules.d
-    cp misc/10-oceanoptics.rules $out/etc/udev/rules.d/10-oceanoptics.rules
+    cp os_support/10-oceanoptics.rules $out/etc/udev/rules.d/10-oceanoptics.rules
   '';
 
-  # underlying c libraries are tested and fail
-  # (c libs are used with anaconda, which we don't care about as we use the alternative path, being that of pyusb).
-  doCheck = false;
-
-  propagatedBuildInputs = [ pyusb numpy ];
+  # few backends enabled, but still some tests
+  checkInputs = [
+    pytestCheckHook
+    mock
+    zipp
+  ];
 
   setupPyBuildFlags = [ "--without-cseabreeze" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nix-cache.s3.amazonaws.com/log/yir46s0cdzfvzsrn8fkh4ra7d7rl95y9-python3.8-seabreeze-1.3.0.drv

ZHF: #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
