### PR TITLE
superTuxKart: Fix aarch64-linux build

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -54,7 +54,12 @@ let
     "libsquish"
     # Not packaged to this date
     "sheenbidi"
-  ];
+  ]
+  # Our system angelscript causes linking error on ARM
+  # ld: libangelscript.so: undefined reference to
+  # `CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned int*, void*, unsigned long&, void*)'
+  # Bundled angelscript compiles fine
+  ++ lib.optional stdenv.hostPlatform.isAarch64 "angelscript";
 in
 stdenv.mkDerivation rec {
 
@@ -100,15 +105,15 @@ stdenv.mkDerivation rec {
     harfbuzz
     mcpp
     wiiuse
-    angelscript
-  ];
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isAarch64) angelscript;
 
   cmakeFlags = [
     "-DBUILD_RECORDER=OFF" # libopenglrecorder is not in nixpkgs
-    "-DUSE_SYSTEM_ANGELSCRIPT=OFF" # doesn't work with 2.31.2 or 2.32.0
+    # doesn't work with our 2.35.0 on aarch64-linux
+    "-DUSE_SYSTEM_ANGELSCRIPT=${if !stdenv.hostPlatform.isAarch64 then "ON" else "OFF"}"
     "-DCHECK_ASSETS=OFF"
     "-DUSE_SYSTEM_WIIUSE=ON"
-    "-DUSE_SYSTEM_ANGELSCRIPT=ON"
     "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 


### PR DESCRIPTION
###### Motivation for this change
ZHF: #122042
Failing Hydra build: https://hydra.nixos.org/build/141595056

The final linking against our system `angelscript` errors out on aarch64-linux. There was already a line in `cmakeFlags` that explicitly disabled the use of system angelscript, but it was explicitly re-enabled with a second line further down.

```
[100%] Linking CXX executable bin/supertuxkart
/nix/store/ppvq7f8cx4q4c7xjhp7ghs7pb5i8j7z9-binutils-2.35.1/bin/ld: /nix/store/2y9qxxkib7dhk9967qwj4ffd1v2snr5r-angelscript-2.35.0/lib/libangelscript.so: undefined reference to `CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned int*, void*, unsigned long&, void*)'
collect2: error: ld returned 1 exit status
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
