### PR TITLE
haskellPackages.hercules-ci-optparse-applicative: 2021-03-05 -> 2021-03-18

### DIFF
--- a/pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
+++ b/pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
@@ -6,9 +6,8 @@ mkDerivation {
   version = "0.16.1.0";
   src = fetchgit {
     url = "https://github.com/hercules-ci/optparse-applicative.git";
-    sha256 = "0v0r11jaav95im82if976256kncp0ji7nfdrlpbgmwxnkj1hxl48";
-    rev = "f9d1242f9889d2e09ff852db9dc2d231d9a3e8d8";
-    fetchSubmodules = true;
+    sha256 = "05vchaw2rf46hh2128qjpky686iy5hff964mbdhcyiz612jjflyp";
+    rev = "9e2968c09a7c5b29d04578dc68d81ce5aec0591e";
   };
   libraryHaskellDepends = [
     ansi-wl-pprint base process transformers transformers-compat


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the Hercules CI CLI build.

For context, no other packages use this fork of optparse-applicative.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
