### PR TITLE
gnuapl: Fix build

### DIFF
--- a/pkgs/development/interpreters/gnu-apl/default.nix
+++ b/pkgs/development/interpreters/gnu-apl/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     "-Wno-error=class-memaccess"
     "-Wno-error=restrict"
     "-Wno-error=format-truncation"
+    # Needed with GCC 10
+    "-Wno-error=maybe-uninitialized"
    ]) ++ optional stdenv.cc.isClang "-Wno-error=null-dereference");
 
   patchPhase = lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042

Global suppression of a warning that occurs once during build, where source comments indicate that this is not an actual issue. Alternatively, we could patch in pragma to ignore the specific instance, but this seems easier and more in line with earlier suppressions.

@NixOS/nixos-release-managers

@KoviRobi 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
