### PR TITLE
python3Packaegs.sphinx-autobuild: add missing colorama dependency

### DIFF
--- a/pkgs/development/python-modules/sphinx-autobuild/default.nix
+++ b/pkgs/development/python-modules/sphinx-autobuild/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, colorama
 , sphinx
 , livereload
 }:
@@ -14,10 +15,15 @@ buildPythonPackage rec {
     sha256 = "de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05";
   };
 
-  propagatedBuildInputs = [ sphinx livereload ];
+  propagatedBuildInputs = [
+    colorama
+    sphinx
+    livereload
+  ];
 
   # No tests included.
   doCheck = false;
+
   pythonImportsCheck = [ "sphinx_autobuild" ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17665,6 +17665,8 @@ in
 
   sphinx = with python3Packages; toPythonApplication sphinx;
 
+  sphinx-autobuild = with python3Packages; toPythonApplication sphinx-autobuild;
+
   sphinx-serve = with python3Packages; toPythonApplication sphinx-serve;
 
   sphinxbase = callPackage ../development/libraries/sphinxbase { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nix-cache.s3.amazonaws.com/log/wlgvk8b5hf2bnxx3d667gmds80cc0f3w-python3.8-sphinx-autobuild-2021.3.14.drv

Also, since there is $out/bin, I added a toplevel attribute.

ZHF #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
