### PR TITLE
python3Packages.spidev: set platforms to linux only

### DIFF
--- a/pkgs/development/python-modules/spidev/default.nix
+++ b/pkgs/development/python-modules/spidev/default.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
     description = "Python bindings for Linux SPI access through spidev";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
+    platforms = platforms.linux;
   };
 
 }


### PR DESCRIPTION
The module interfaces with the linux kernel and its sysfs, so it is
unsupported on anything but Linux.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/5wz5jillb1nlj45xsc626zlrnp06fdam-python3.8-spidev-3.5.drv

ZHF #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
