### PR TITLE
python38Packages.atlassian-python-api: switch to fetching from GitHub

### DIFF
--- a/pkgs/development/python-modules/atlassian-python-api/default.nix
+++ b/pkgs/development/python-modules/atlassian-python-api/default.nix
@@ -1,30 +1,28 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, isPy3k
-, certifi
-, chardet
+, fetchFromGitHub
 , deprecated
-, idna
 , oauthlib
 , requests
 , requests_oauthlib
 , six
-, urllib3
-, pytestrunner
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "atlassian-python-api";
   version = "3.8.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "7ef384a91a790c807336e2bd6b7554284691aadd6d7413d199baf752dd84c53e";
+  src = fetchFromGitHub {
+    owner = "atlassian-api";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-J0/CtfBtOdWReKQS/VvOL/3r+j4zJfnv/ICIXepKUvc=";
   };
 
-  checkInputs = [ pytestrunner pytest ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   propagatedBuildInputs = [ deprecated oauthlib requests requests_oauthlib six ];
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042 

The pypi source doesn't contain the response stubs necessary for
the tests to pass

Hydra failure: https://hydra.nixos.org/build/142607813/nixlog/1

CC @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
