### PR TITLE
nixos/tt-rss: remove old files on update

### DIFF
--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -590,8 +590,16 @@ let
               else "";
 
         in ''
-          rm -rf "${cfg.root}/*"
+          # writing permission to wipe the folder
+          chmod -R u+w "${cfg.root}"
+          # so that the glob just after does not fail
+          touch "${cfg.root}/some_file"
+          # wipe the folder
+          rm -r "${cfg.root}"/*
+          # repopulate it, copy is read only
           cp -r "${pkgs.tt-rss}/"* "${cfg.root}"
+          # make directories writable because tt-rss needs it
+          find "${cfg.root}" -type d -execdir chmod ug+w '{}' ';'
           ${optionalString (cfg.pluginPackages != []) ''
             for plugin in ${concatStringsSep " " cfg.pluginPackages}; do
               cp -r "$plugin"/* "${cfg.root}/plugins.local/"
@@ -603,7 +611,6 @@ let
             done
           ''}
           ln -sf "${tt-rss-config}" "${cfg.root}/config.php"
-          chmod -R 755 "${cfg.root}"
         ''
 
         + (optionalString (cfg.database.type == "pgsql") ''


### PR DESCRIPTION
current code would only remove one file called "*" in /var/lib/tt-rss
instead of cleaning the directory.

En passant, only make directories writable (to allow new file creation)
instead of all files. tt-rss works fine without self-modifying php
code;)


I've been using this for a few days without issues.

cc @globin @zohl as maintainers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
