### PR TITLE
python3Packages.monty: add missing pydanctic and tqdm dependencies

### DIFF
--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -1,22 +1,20 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
+, pythonOlder
+, msgpack
 , nose
 , numpy
-, six
-, ruamel_yaml
-, msgpack
-, coverage
-, coveralls
+, pydantic
 , pymongo
-, lsof
+, ruamel_yaml
+, tqdm
 }:
 
 buildPythonPackage rec {
   pname = "monty";
   version = "2021.3.3";
-  disabled = isPy27; # uses type annotations
+  disabled = pythonOlder "3.5"; # uses type annotations
 
   # No tests in Pypi
   src = fetchFromGitHub {
@@ -26,19 +24,28 @@ buildPythonPackage rec {
     sha256 = "1nbv0ys0fv70rgzskkk8gsfr9dsmm7ykim5wv36li840zsj83b1l";
   };
 
-  checkInputs = [ lsof nose numpy msgpack coverage coveralls pymongo];
-  propagatedBuildInputs = [ six ruamel_yaml ];
+  propagatedBuildInputs = [
+    ruamel_yaml
+    tqdm
+    msgpack
+  ];
 
-  # test suite tries to decode bytes, but msgpack now returns a str
-  # https://github.com/materialsvirtuallab/monty/pull/121
-  postPatch = ''
-    substituteInPlace tests/test_serialization.py \
-      --replace ".decode('utf-8')" ""
-  '';
+  checkInputs = [
+    nose
+    numpy
+    pydantic
+    pymongo
+  ];
 
   preCheck = ''
     substituteInPlace tests/test_os.py \
       --replace 'self.assertEqual("/usr/bin/find", which("/usr/bin/find"))' '#'
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    nosetests -v
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nix-cache.s3.amazonaws.com/log/jlz2mql8x2v3smdy2ccyh5g47cn378p2-python3.8-monty-2021.3.3.drv

ZHF: #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
