### PR TITLE
wayst: unstable-2020-10-12 -> unstable-2021-04-05

### DIFF
--- a/pkgs/applications/terminal-emulators/wayst/default.nix
+++ b/pkgs/applications/terminal-emulators/wayst/default.nix
@@ -34,13 +34,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wayst";
-  version = "unstable-2020-10-12";
+  version = "unstable-2021-04-05";
 
   src = fetchFromGitHub {
     owner = "91861";
     repo = pname;
-    rev = "b8c7ca00a785a748026ed1ba08bf3d19916ced18";
-    hash = "sha256-wHAU1yxukxApzhLLLctZ/AYqF7t21HQc5omPBZyxra0=";
+    rev = "e72ca78ef72c7b1e92473a98d435a3c85d7eab98";
+    hash = "sha256-UXAVSfVpk/8KSg4oMw2tVWImD6HqJ7gEioR2MqhUUoQ=";
   };
 
   makeFlags = [ "INSTALL_DIR=\${out}/bin" ];

--- a/pkgs/applications/terminal-emulators/wayst/default.nix
+++ b/pkgs/applications/terminal-emulators/wayst/default.nix
@@ -83,6 +83,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A simple terminal emulator";
+    mainProgram = "wayst";
     homepage = "https://github.com/91861/wayst";
     license = licenses.mit;
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Update wayst.
50 commits were added between these two revisions: https://github.com/91861/wayst/compare/b8c7ca00a785a748026ed1ba08bf3d19916ced18...e72ca78ef72c7b1e92473a98d435a3c85d7eab98

Add the `meta.mainProgram` attribute for tools like `nix run`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
