### PR TITLE
python3Packages.cvxpy: fix Darwin build

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -9,7 +9,7 @@
 , osqp
 , scipy
 , scs
-, useOpenmp ? true
+, useOpenmp ? (!stdenv.isDarwin)
   # Check inputs
 , pytestCheckHook
 }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

(try to) fix build on Darwin by disabling OpenMP features. Untested b/c I don't have a Darwin machine.
No build changes on x86-64-linux which is all I can test currently. Reviewers appreciated.

Build was previously failing due to unrecognized ``LDFLAGS="-lgomp"`` that I'd written for OpenMP support on Linux, which fails due to Clang not having the GCC OpenMP library available. https://nix-cache.s3.amazonaws.com/log/xszi62glzv55lnzvw5bynbivr7phgrxj-python3.8-cvxpy-1.1.12.drv

ZHF: #122042

The upstream doesn't support OpenMP on Darwin (see https://github.com/cvxpy/cvxpy/blob/ef0f6702f7db865e0beb1550477780fd323fbac8/.travis.yml#L23-L26).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
