### PR TITLE
python38Packages.dask-image ignore more flake8 failures

### DIFF
--- a/pkgs/development/python-modules/dask-image/default.nix
+++ b/pkgs/development/python-modules/dask-image/default.nix
@@ -2,12 +2,10 @@
 , buildPythonPackage
 , fetchPypi
 , dask
-, numpy, toolz # dask[array]
 , scipy
 , pims
-, pytest
-, pytest-flake8
 , scikitimage
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,24 +17,17 @@ buildPythonPackage rec {
     sha256 = "0bf7ea8dcd9d795505b498bd632394720c048f50761e23c574d9a6bacfb27cbb";
   };
 
-  nativeBuildInputs = [ pytest-flake8 ];
-  propagatedBuildInputs = [ dask numpy toolz scipy pims ];
+  propagatedBuildInputs = [ dask scipy pims ];
+
+  prePatch = ''
+    substituteInPlace setup.cfg --replace "--flake8" ""
+  '';
+
   checkInputs = [
-    pytest
+    pytestCheckHook
     scikitimage
   ];
 
-  # ignore errors from newer versions of flake8
-  prePatch = ''
-    substituteInPlace setup.cfg \
-      --replace "docs/conf.py,versioneer.py" \
-        "docs/conf.py,versioneer.py,dask_image/ndfilters/_utils.py"
-  '';
-
-  # scikit.external is not exported
-  checkPhase = ''
-    pytest --ignore=tests/test_dask_image/
-  '';
   pythonImportsCheck = [ "dask_image" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042 

Switch from `pytest-flake8` to `pytestCheckHook`, seems we no longer need to ignore the test that was being ignored here either.

Hydra failure: https://hydra.nixos.org/build/142598376/nixlog/1

CC @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
