### PR TITLE
Patch arrow version

### DIFF
--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -46,7 +46,8 @@ python3Packages.buildPythonApplication rec {
       --replace "cryptography==3.2.1" "cryptography" \
       --replace "pyOpenSSL==19.1.0" "pyOpenSSL" \
       --replace "PyYAML==5.3.1" "PyYAML" \
-      --replace "six==1.14.0" "six"
+      --replace "six==1.14.0" "six" \
+      --replace "arrow==0.17.0" "arrow"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
For ZHF: #122042 I noticed that it can't find arrow 0.17.0 and it looks like in [this change](https://github.com/NixOS/nixpkgs/commit/66ebf2b76d42885ca0cf57f66319df2948c91b59#diff-5d2214d585ec8b549f1bd00d407779465a755db49308f5ca7145c8999a34dca2) arrow 0.17.0 was removed and replaced with arrow 1. There is a separate `arrow_1` package so I do wonder if it's not better to revert the 0.17 -> 1 change but anyway, this should fix this one case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
