### PR TITLE
[staging-next] haproxy: fix lua lib name, fix build

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     "USE_PCRE_JIT=yes"
   ] ++ lib.optionals useLua [
     "USE_LUA=yes"
+    "LUA_LIB_NAME=lua"
     "LUA_LIB=${lua5_3}/lib"
     "LUA_INC=${lua5_3}/include"
   ] ++ lib.optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change
Not sure when this started failing, but `haproxy` is an important networking tool.

```
  build flags: -j32 -l32 SHELL=/nix/store/75d0ra57gdcsmgqrrx42lrpvx97bvynb-bash-4.4-p23/bin/bash PREFIX=\$\{out\} TARGET=linux-glibc USE_OPENSSL=yes USE_ZLIB=yes USE_PCRE=yes USE_PCRE_JIT=yes USE_LUA=yes LUA_LIB=/nix/store/s8hkgf21kr74sg5raixwi44fph4d5clz-lua-5.3.6/lib LUA_INC=/nix/store/s8hkgf21kr74sg5raixwi44fph4d5clz-lua-5.3.6/include USE_SYSTEMD=yes USE_GETADDRINFO=1 EXTRA_OBJS=contrib/prometheus-exporter/service-prometheus.o CC=cc
  Makefile:584: *** unable to automatically detect the Lua library name, you can enforce its name with LUA_LIB_NAME=<name> (where <name> can be lua5.3, lua53, lua, ...).  Stop.
```

related: #122042 #122068

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
