### PR TITLE
python3Packages.rfc3339-validator: fix on darwin

### DIFF
--- a/pkgs/development/python-modules/rfc3339-validator/default.nix
+++ b/pkgs/development/python-modules/rfc3339-validator/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , pytestCheckHook
 , hypothesis
@@ -16,6 +17,15 @@ buildPythonPackage rec {
     inherit version;
     sha256 = "7a578aa0740e9ee2b48356fe1f347139190c4c72e27f303b3617054efd15df32";
   };
+
+  patches = [
+    # Fixes test failure on darwin. Filed upstream: https://github.com/naimetti/rfc3339-validator/pull/3.
+    # Not yet merged.
+    (fetchpatch {
+      url = "https://github.com/rmcgibbo/rfc3339-validator/commit/4b6bb62c30bd158d3b4663690dcba1084ac31770.patch";
+      sha256 = "0h9k82hhmp2xfzn49n3i47ws3rpm9lvfs2rjrds7hgx5blivpwl6";
+    })
+  ];
 
   propagatedBuildInputs = [ six ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes this package on darwin by pulling in a patch I filed upstream.
https://nix-cache.s3.amazonaws.com/log/z095m9zik39gh3miqp3w03z8dxbynnqx-python3.9-rfc3339-validator-0.1.3.drv

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
