### PR TITLE
python3Packages.spacy: Add dependencies for 3.0.5

### DIFF
--- a/pkgs/development/python-modules/pathy/default.nix
+++ b/pkgs/development/python-modules/pathy/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, typer
+, dataclasses
+, smart_open
+, pytest
+, mock
+, google-cloud-storage
+}:
+
+buildPythonPackage rec {
+  pname = "pathy";
+  version = "0.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-nb8my/5rkc7thuHnXZHe1Hg8j+sLBlYyJcLHWrrKZ5M=";
+  };
+
+  propagatedBuildInputs = [ smart_open typer google-cloud-storage ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "smart-open>=2.2.0,<4.0.0" "smart-open>=2.2.0"
+  '';
+
+  checkInputs = [ pytestCheckHook mock ];
+
+  # Exclude tests that require provider credentials
+  pytestFlagsArray = [
+    "--ignore=pathy/_tests/test_clients.py"
+    "--ignore=pathy/_tests/test_gcs.py"
+    "--ignore=pathy/_tests/test_s3.py"
+  ];
+
+  meta = with lib; {
+    description = "A Path interface for local and cloud bucket storage";
+    homepage = "https://github.com/justindujardin/pathy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/development/python-modules/pathy/default.nix
+++ b/pkgs/development/python-modules/pathy/default.nix
@@ -22,7 +22,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ smart_open typer google-cloud-storage ];
 
   postPatch = ''
-    substituteInPlace requirements.txt --replace "smart-open>=2.2.0,<4.0.0" "smart-open>=2.2.0"
+    substituteInPlace requirements.txt \
+      --replace "smart-open>=2.2.0,<4.0.0" "smart-open>=2.2.0"
   '';
 
   checkInputs = [ pytestCheckHook mock ];

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -7,6 +7,7 @@
 , blis
 , catalogue
 , cymem
+, jinja2
 , jsonschema
 , murmurhash
 , numpy
@@ -19,6 +20,9 @@
 , spacy-legacy
 , thinc
 , wasabi
+, packaging
+, pathy
+, pydantic
 }:
 
 buildPythonPackage rec {
@@ -34,6 +38,7 @@ buildPythonPackage rec {
     blis
     catalogue
     cymem
+    jinja2
     jsonschema
     murmurhash
     numpy
@@ -45,6 +50,9 @@ buildPythonPackage rec {
     spacy-legacy
     thinc
     wasabi
+    packaging
+    pathy
+    pydantic
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   checkInputs = [
@@ -62,7 +70,8 @@ buildPythonPackage rec {
       --replace "catalogue>=0.0.7,<1.1.0" "catalogue>=0.0.7,<3.0" \
       --replace "plac>=0.9.6,<1.2.0" "plac>=0.9.6,<2.0" \
       --replace "srsly>=1.0.2,<1.1.0" "srsly>=1.0.2,<3.0" \
-      --replace "thinc>=7.4.1,<7.5.0" "thinc>=7.4.1,<8"
+      --replace "thinc>=7.4.1,<7.5.0" "thinc>=7.4.1,<8" \
+      --replace "pydantic>=1.7.1,<1.8.0" "pydantic>=1.7.1,<1.8.3"
   '';
 
   pythonImportsCheck = [ "spacy" ];

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -16,6 +16,7 @@
 , requests
 , setuptools
 , srsly
+, spacy-legacy
 , thinc
 , wasabi
 }:
@@ -41,6 +42,7 @@ buildPythonPackage rec {
     requests
     setuptools
     srsly
+    spacy-legacy
     thinc
     wasabi
   ] ++ lib.optional (pythonOlder "3.4") pathlib;

--- a/pkgs/development/python-modules/spacy/legacy.nix
+++ b/pkgs/development/python-modules/spacy/legacy.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "spacy-legacy";
+  version = "3.0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Uy94rjFllSj622RTzd6UJaQmIniCw4gpeq/X57QcIpA=";
+  };
+
+  # checkInputs = [ pytestCheckHook spacy ];
+  doCheck = false;
+  pythonImportsCheck = [ "spacy_legacy" ];
+
+  meta = with lib; {
+    description = "A Path interface for local and cloud bucket storage";
+    homepage = "https://github.com/justindujardin/pathy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7613,6 +7613,8 @@ in {
 
   spacy = callPackage ../development/python-modules/spacy { };
 
+  spacy-legacy = callPackage ../development/python-modules/spacy/legacy.nix { };
+
   spacy_models = callPackage ../development/python-modules/spacy/models.nix { };
 
   spake2 = callPackage ../development/python-modules/spake2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4827,6 +4827,8 @@ in {
 
   pathvalidate = callPackage ../development/python-modules/pathvalidate { };
 
+  pathy = callPackage ../development/python-modules/pathy/default.nix { };
+
   patiencediff = callPackage ../development/python-modules/patiencediff { };
 
   patool = callPackage ../development/python-modules/patool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/a19dxg5y85pl6i7lqkiayfg5nam2bs2s-python3.8-spacy-3.0.5.drv

Adds dependencies required for spaCy 3.0.5.

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [X] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
