### PR TITLE
gweled: unstable-2018-02-15 -> unstable-2021-02-11

### DIFF
--- a/pkgs/games/gweled/default.nix
+++ b/pkgs/games/gweled/default.nix
@@ -1,20 +1,24 @@
-{ lib, stdenv, fetchbzr, intltool
+{ lib, stdenv, fetchbzr, gettext
 , gtk2, wrapGAppsHook, autoreconfHook, pkg-config
 , libmikmod, librsvg, libcanberra-gtk2, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "gweled";
-  version = "unstable-2018-02-15";
+  version = "unstable-2021-02-11";
 
   src = fetchbzr {
     url = "lp:gweled";
-    rev = "94";
-    sha256 = "01c38y4df5a06wqbsmsn8ysxx7hav9yvw6zdwbc9m5m55z7vmdb8";
+    rev = "108";
+    sha256 = "sha256-rM4dgbYfSrVqZwi+xzKuEtmtjK3HVvqeutmni1vleLo=";
   };
 
   doCheck = false;
 
-  nativeBuildInputs = [ wrapGAppsHook intltool autoreconfHook pkg-config ];
+  postPatch = ''
+    substituteInPlace configure.ac --replace "AM_GNU_GETTEXT_VERSION([0.19.8])" "AM_GNU_GETTEXT_VERSION([${gettext.version}])"
+  '';
+
+  nativeBuildInputs = [ wrapGAppsHook gettext autoreconfHook pkg-config ];
 
   buildInputs = [ gtk2 libmikmod librsvg hicolor-icon-theme libcanberra-gtk2 ];
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042

Updated to latest version, which introduces a dependency on gettext, with a hardcoded version in the autoconf file.
After this update and fix, the game builds and I can run the executable, but I'm seeing graphics corruption in the game itself.

Currently there are no maintainers and I don't particularly feel like becoming the new one and debugging this issue, so if others are also seeing these graphics issues maybe the package should be dropped instead.

@NixOS/nixos-release-managers 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
