### PR TITLE
python3Packages.pykerberos: 1.2.1 -> 1.2.3.dev0

### DIFF
--- a/pkgs/development/python-modules/pykerberos/default.nix
+++ b/pkgs/development/python-modules/pykerberos/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pykerberos";
-  version = "1.2.1";
+  version = "1.2.3.dev0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0v47p840myqgc7hr4lir72xshcfpa0w8j9n077h3njpqyn6wlbag";
+    sha256 = "17zjiw6rqgfic32px86qls1i3z7anp15dgb3sprbdvywy98alryn";
   };
 
   nativeBuildInputs = [ krb5 ]; # for krb5-config
@@ -15,6 +15,7 @@ buildPythonPackage rec {
 
   # there are no tests
   doCheck = false;
+  pythonImportsCheck = [ "kerberos" ];
 
   meta = with lib; {
     description = "High-level interface to Kerberos";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
1. Noticed requests-kerberos failing: https://nix-cache.s3.amazonaws.com/log/l5apq8lx0zaag6d109xsmsg2w1msiadk-python3.8-requests-kerberos-0.12.0.drv
2. The bug was actually in pykerberos, https://github.com/02strich/pykerberos/issues/37.
3. Upgraded to the latest pypi release to fix, and added an import check

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
