### PR TITLE
python3Packages.pip-tools: 6.0.1 -> 6.1.0

### DIFF
--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -1,45 +1,36 @@
-{ lib, fetchPypi, buildPythonPackage, pip, pytest, click, six
-, setuptools_scm, git, glibcLocales, mock }:
+{ lib
+, fetchPypi
+, pythonOlder
+, buildPythonPackage
+, pip
+, pytest
+, pytest-xdist
+, click
+, setuptools-scm
+, git
+, glibcLocales
+, mock
+, pep517
+}:
 
 buildPythonPackage rec {
   pname = "pip-tools";
-  version = "6.0.1";
+  version = "6.1.0";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3b0c7b95e8d3dfb011bb42cb38f356fcf5d0630480462b59c4d0a112b8d90281";
+    sha256 = "sha256-QAv3finMpIwxq8IQBCkyu1LcwTjvTqTVLF20KaqK5u4=";
   };
 
   LC_ALL = "en_US.UTF-8";
-  checkInputs = [ pytest git glibcLocales mock ];
-  propagatedBuildInputs = [ pip click six setuptools_scm ];
-
-  disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) [
-    # Depend on network tests:
-    "test_allow_unsafe_option" #paramaterized, but all fail
-    "test_annotate_option" #paramaterized, but all fail
-    "test_editable_package_vcs"
-    "test_editable_top_level_deps_preserved" # can't figure out how to select only one parameter to ignore
-    "test_filter_pip_markers"
-    "test_filter_pip_markes"
-    "test_generate_hashes_all_platforms"
-    "test_generate_hashes_verbose"
-    "test_generate_hashes_with_editable"
-    "test_generate_hashes_with_url"
-    "test_generate_hashes_without_interfering_with_each_other"
-    "test_get_file_hash_without_interfering_with_each_other"
-    "test_get_hashes_local_repository_cache_miss"
-    "test_realistic_complex_sub_dependencies"
-    "test_stdin"
-    "test_upgrade_packages_option"
-    "test_url_package"
-    "test_editable_package"
-    "test_locally_available_editable_package_is_not_archived_in_cache_dir"
-  ];
+  checkInputs = [ pytest git glibcLocales mock pytest-xdist ];
+  propagatedBuildInputs = [ pip click setuptools-scm pep517 ];
 
   checkPhase = ''
     export HOME=$(mktemp -d) VIRTUAL_ENV=1
-    py.test -k "${disabledTests}"
+    py.test -m "not network"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/i54ms4dal5gfr3vxxr0ha38xi9h4dcyl-python3.8-pip-tools-6.0.1.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
