### PR TITLE
rtl8812au: 5.6.4.2_35491.20200702 -> 5.9.3.2_20210427

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "5.6.4.2_35491.20200702";
+  version = "5.9.3.2_20210427";
 
   src = fetchFromGitHub {
     owner = "gordboy";
-    repo = "rtl8812au-5.6.4.2";
-    rev = "3110ad65d0f03532bd97b1017cae67ca86dd34f6";
-    sha256 = "0p0cv67dfr41npxn0c1frr0k9wiv0pdbvlzlmclgixn39xc6n5qz";
+    repo = "rtl8812au-5.9.3.2";
+    rev = "6ef5d8fcdb0b94b7490a9a38353877708fca2cd4";
+    sha256 = "02hzgaw9mjwqi61l56akldbwcanwh4a9sn4x23bzx7gliizk2cbk";
   };
 
   nativeBuildInputs = [ bc nukeReferences ];
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
-    homepage = "https://github.com/gordboy/rtl8812au-5.6.4.2";
+    homepage = "https://github.com/gordboy/rtl8812au-5.9.3.2";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ danielfullmer ];

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/gordboy/rtl8812au-5.9.3.2";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ danielfullmer ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updated to latest version, which includes fixes for kernels >= 5.10.  For ZHF #122042

Ran `nixpkgs-review`, and it now builds against all kernels except `linux_hardened`.

Also removed myself from maintainers, since I no longer actively use these devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
