### PR TITLE
python3Packages.tld: fix on darwin

### DIFF
--- a/pkgs/development/python-modules/tld/default.nix
+++ b/pkgs/development/python-modules/tld/default.nix
@@ -26,6 +26,12 @@ buildPythonPackage rec {
     tox
   ];
 
+  # these tests require network access, but disabledTestPaths doesn't work.
+  # the file needs to be `import`ed by another python test file, so it
+  # can't simply be removed.
+  preCheck = ''
+    echo > src/tld/tests/test_commands.py
+  '';
   pythonImportsCheck = [ "tld" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/iq0p4cjq7f8wnz1qimk8ah5dmh1i6p86-python3.8-tld-0.12.5.drv
The initial error looks like it can be fixed by adding these scripts to $PATH, but then when doing so that triggers another error because these tests require network access. So I just disabled these two tests. But for some reason, [disabledTestPaths doesn't work](https://gist.github.com/rmcgibbo/ce86d8c61b4e26a25872ae05de62ceba), so I just cleared the file.

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
