### PR TITLE
python3Packages.aiomysql: fix dependency on PyMySQL

### DIFF
--- a/pkgs/development/python-modules/aiomysql/default.nix
+++ b/pkgs/development/python-modules/aiomysql/default.nix
@@ -4,6 +4,7 @@
 , pymysql
 , pytest
 , isPy27
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -17,6 +18,14 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1qvy3phbsxp55161dnppjfx2m1kn82v0irc3xzqw0adfd81vaiad";
   };
+
+  patches = [
+    (fetchpatch {
+      # vendor functions previously provided by pymysql.util
+      url = "https://github.com/aio-libs/aiomysql/pull/554/commits/919b997a9de7f53d721af76762fba425e306531e.patch";
+      sha256 = "V1VYyqr6RwTXoVoGVyMuJst6uqTuuHbpMOpLoVZO1XA=";
+    })
+  ];
 
   propagatedBuildInputs = [
     pymysql


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

pythonPackages.databases tests break on import error https://hydra.nixos.org/build/142623477 
ZHF: #122042

Applied patch from https://github.com/aio-libs/aiomysql/pull/554/commits/919b997a9de7f53d721af76762fba425e306531e that just copy paste from:
1. https://github.com/PyMySQL/PyMySQL/blob/37fd1e1b0126d75d80eef59c053f80634b09bd75/pymysql/connections.py#L96-L113
2. https://github.com/PyMySQL/PyMySQL/blob/v0.10.1/pymysql/util.py

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
