### PR TITLE
python3Packages.jq: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/development/python-modules/jq/default.nix
+++ b/pkgs/development/python-modules/jq/default.nix
@@ -2,14 +2,17 @@
 
 buildPythonPackage rec {
   pname = "jq";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "77e747c6ad10ce65479f5f9064ab036483bf307bf71fdd7d6235ef895fcc506e";
+    sha256 = "1ryxcll7601ki9rwlnryhhxpmwwnxs2qxq7kjm2b0xcqgzx1vv7r";
   };
 
-  patches = [ ./jq-py-setup.patch ];
+  patches = [
+    # Removes vendoring
+    ./jq-py-setup.patch
+  ];
 
   buildInputs = [ jq ];
 

--- a/pkgs/development/python-modules/jq/jq-py-setup.patch
+++ b/pkgs/development/python-modules/jq/jq-py-setup.patch
@@ -1,17 +1,17 @@
-From 968ddf2bd773e800e46737fced743bd00af9aa0d Mon Sep 17 00:00:00 2001
-From: William Kral <william.kral@gmail.com>
-Date: Tue, 8 Sep 2020 22:04:24 -0700
-Subject: [PATCH] Vastly simplify setup.py for distro compatibility
+From bef841b73ba7c9a79211146798ac888fce9bb55a Mon Sep 17 00:00:00 2001
+From: "Robert T. McGibbon" <rmcgibbo@gmail.com>
+Date: Fri, 7 May 2021 19:14:20 -0400
+Subject: [PATCH 1/1] Vastly simplify setup.py for distro compatibility
 
 ---
- setup.py | 101 ++-----------------------------------------------------
- 1 file changed, 2 insertions(+), 99 deletions(-)
+ setup.py | 98 +-------------------------------------------------------
+ 1 file changed, 1 insertion(+), 97 deletions(-)
 
 diff --git a/setup.py b/setup.py
-index cb63f60..87380ed 100644
+index 663792c..3ebcabe 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -1,114 +1,19 @@
+@@ -1,113 +1,19 @@
  #!/usr/bin/env python
  
  import os
@@ -79,8 +79,7 @@ index cb63f60..87380ed 100644
 -            tarball_path=jq_lib_tarball_path,
 -            lib_dir=jq_lib_dir,
 -            commands=[
--                ["autoreconf", "-i"],
--                ["./configure", "CFLAGS=-fPIC", "--disable-maintainer-mode", "--with-oniguruma=" + oniguruma_lib_install_dir],
+-                ["./configure", "CFLAGS=-fPIC -pthread", "--disable-maintainer-mode", "--with-oniguruma=" + oniguruma_lib_install_dir],
 -                ["make"],
 -            ])
 -
@@ -93,7 +92,7 @@ index cb63f60..87380ed 100644
 -
 -        macosx_deployment_target = sysconfig.get_config_var("MACOSX_DEPLOYMENT_TARGET")
 -        if macosx_deployment_target:
--            os.environ['MACOSX_DEPLOYMENT_TARGET'] = macosx_deployment_target
+-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = str(macosx_deployment_target)
 -
 -        def run_command(args):
 -            print("Executing: %s" % ' '.join(args))
@@ -127,21 +126,19 @@ index cb63f60..87380ed 100644
  )
  
  setup(
-@@ -120,8 +25,7 @@ setup(
-     url='http://github.com/mwilliamson/jq.py',
+@@ -120,7 +26,6 @@ setup(
      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
      license='BSD 2-Clause',
--    ext_modules = [jq_extension],
+     ext_modules = [jq_extension],
 -    cmdclass={"build_ext": jq_build_ext},
-+    ext_modules=[jq_extension],
      classifiers=[
          'Development Status :: 5 - Production/Stable',
          'Intended Audience :: Developers',
-@@ -137,4 +41,3 @@ setup(
-         'Programming Language :: Python :: 3.8',
+@@ -137,4 +42,3 @@ setup(
+         'Programming Language :: Python :: 3.9',
      ],
  )
 -
 -- 
-2.28.0
+2.29.3
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/jk2sj5dcihjkz5kzwpfb3cz9asr643pl-python3.8-jq-1.1.2.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
