### PR TITLE
async-profiler: fix darwin build

### DIFF
--- a/pkgs/development/tools/async-profiler/0001-Fix-darwin-build.patch
+++ b/pkgs/development/tools/async-profiler/0001-Fix-darwin-build.patch
@@ -1,0 +1,27 @@
+From e54c17899118ea940c36bc17a48d8ff759243f16 Mon Sep 17 00:00:00 2001
+From: Uri Baghin <uri@canva.com>
+Date: Sat, 8 May 2021 09:49:18 +1000
+Subject: [PATCH] Fix darwin build.
+
+---
+ src/itimer.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/itimer.cpp b/src/itimer.cpp
+index 08c46d1..52628ef 100644
+--- a/src/itimer.cpp
++++ b/src/itimer.cpp
+@@ -52,8 +52,8 @@ Error ITimer::start(Arguments& args) {
+ 
+     OS::installSignalHandler(SIGPROF, signalHandler);
+ 
+-    long sec = _interval / 1000000000;
+-    long usec = (_interval % 1000000000) / 1000;
++    time_t sec = _interval / 1000000000;
++    suseconds_t usec = (_interval % 1000000000) / 1000;
+     struct itimerval tv = {{sec, usec}, {sec, usec}};
+     
+     if (setitimer(ITIMER_PROF, &tv, NULL) != 0) {
+-- 
+2.31.1
+

--- a/pkgs/development/tools/async-profiler/default.nix
+++ b/pkgs/development/tools/async-profiler/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  patches = [
+    # https://github.com/jvm-profiling-tools/async-profiler/pull/428
+    ./0001-Fix-darwin-build.patch
+  ];
+
   fixupPhase = ''
     substituteInPlace $out/bin/async-profiler \
       --replace 'JATTACH=$SCRIPT_DIR/build/jattach' \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix build on darwin.
Failure: https://hydra.nixos.org/build/142022256
ZHF: https://github.com/NixOS/nixpkgs/issues/122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
