### PR TITLE
mariadb: 10.5.8 -> 10.5.10

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -22,14 +22,14 @@ mariadb = server // {
 };
 
 common = rec { # attributes common to both builds
-  version = "10.5.8";
+  version = "10.5.10";
 
   src = fetchurl {
     urls = [
       "https://downloads.mariadb.org/f/mariadb-${version}/source/mariadb-${version}.tar.gz"
       "https://downloads.mariadb.com/MariaDB/mariadb-${version}/source/mariadb-${version}.tar.gz"
     ];
-    sha256 = "1s3vfm73911cddjhgpcbkya6nz7ag2zygg56qqzwscn5ybv28j7b";
+    sha256 = "1fxsq2xgcb8j81z043bifpmxblj6nb3wqjm9rgsnpwmazkwk5zx5";
     name   = "mariadb-${version}.tar.gz";
   };
 

--- a/pkgs/servers/sql/mariadb/galera/default.nix
+++ b/pkgs/servers/sql/mariadb/galera/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, buildEnv
-, asio, boost, check, openssl, scons
+, asio, boost, check, openssl, cmake
 }:
 
 let
@@ -10,50 +10,33 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "mariadb-galera";
-  version = "26.4.7";
+  version = "26.4.8";
 
   src = fetchFromGitHub {
     owner = "codership";
     repo = "galera";
     rev = "release_${version}";
-    sha256 = "0h7s670pcasq8wzprhyxqfca2cghi62b8xz2kikb2a86wd453qil";
+    sha256 = "0rx710dfijiykpi41rhxx8vafk07bffv2nbl3d4ggc32rzv88369";
     fetchSubmodules = true;
   };
 
-  buildInputs = [ asio boost check openssl scons ];
-
-  postPatch = ''
-    substituteInPlace SConstruct \
-      --replace "boost_library_path = '''" "boost_library_path = '${boost}/lib'"
-  '';
+  buildInputs = [ asio boost check openssl cmake ];
 
   preConfigure = ''
-    export CPPFLAGS="-I${asio}/include -I${boost.dev}/include -I${check}/include -I${openssl.dev}/include"
-    export LIBPATH="${galeraLibs}/lib"
+    # make sure bundled asio cannot be used, but leave behind license, because it gets installed
+    rm -r asio/{asio,asio.hpp}
   '';
 
-  sconsFlags = "ssl=1 system_asio=1 strict_build_flags=0";
-
-  enableParallelBuilding = true;
-
-  installPhase = ''
-    # copied with modifications from scripts/packages/freebsd.sh
-    GALERA_LICENSE_DIR="$share/licenses/${pname}-${version}"
-    install -d $out/{bin,lib/galera,share/doc/galera,$GALERA_LICENSE_DIR}
-    install -m 555 "garb/garbd"                       "$out/bin/garbd"
-    install -m 444 "libgalera_smm.so"                 "$out/lib/galera/libgalera_smm.so"
-    install -m 444 "scripts/packages/README"          "$out/share/doc/galera/"
-    install -m 444 "scripts/packages/README-MySQL"    "$out/share/doc/galera/"
-    install -m 444 "scripts/packages/freebsd/LICENSE" "$out/$GALERA_LICENSE_DIR"
-    install -m 444 "LICENSE"                          "$out/$GALERA_LICENSE_DIR/GPLv2"
-    install -m 444 "asio/LICENSE_1_0.txt"             "$out/$GALERA_LICENSE_DIR/LICENSE.asio"
+  postInstall = ''
+    # for backwards compatibility
+    ln -s . $out/lib/galera
   '';
 
   meta = with lib; {
     description = "Galera 3 wsrep provider library";
     homepage = "https://galeracluster.com/";
-    license = licenses.lgpl2;
-    maintainers = with maintainers; [ izorkin ];
+    license = licenses.lgpl2Only;
+    maintainers = with maintainers; [ ajs124 izorkin ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Supersedes #113971

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change: 
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
