### PR TITLE
tapview: init at 1.1

### DIFF
--- a/pkgs/development/tools/tapview/default.nix
+++ b/pkgs/development/tools/tapview/default.nix
@@ -1,0 +1,32 @@
+{ asciidoctor
+, fetchFromGitLab
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tapview";
+  version = "1.1";
+
+  nativeBuildInputs = [ asciidoctor ];
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-inrxICNglZU/tup+YnHaDiVss32K2OXht/7f8lOZI4g=";
+  };
+
+  # Remove unecessary `echo` checks: `/bin/echo` fails, and `echo -n` works as expected.
+  patches = [ ./dont_check_echo.patch ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "A minimalist pure consumer for TAP (Test Anything Protocol)";
+    homepage = "https://gitlab.com/esr/tapview";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/development/tools/tapview/dont_check_echo.patch
+++ b/pkgs/development/tools/tapview/dont_check_echo.patch
@@ -1,0 +1,44 @@
+diff --git a/tapview b/tapview
+index ad6a33a66d1..4cf9545d42f 100644
+--- a/tapview
++++ b/tapview
+@@ -13,21 +13,6 @@
+ #
+ # This is version 1.1
+ # A newer version may be available at https://gitlab.com/esr/tapview
+-#
+-# POSIX allows but does not mandate that -n suppresses emission of a
+-# trailing newline in echo. Thus, some shell builtin echos don't do
+-# that.  Cope gracefully.
+-# shellcheck disable=SC2039
+-if [ "$(echo -n "a"; echo "b")" != "ab" ]
+-then
+-    ECHO="echo"
+-elif [ "$(/bin/echo -n "a"; /bin/echo "b")" = "ab" ]
+-then
+-    ECHO="/bin/echo"
+-else
+-    echo "tapview: bailing out, your echo lacks -n support."
+-    exit 3
+-fi
+ 
+ OK="."
+ FAIL="F"
+@@ -37,7 +22,7 @@ TODO_OK="u"
+ 
+ ship_char() {
+     # shellcheck disable=SC2039
+-    "${ECHO}" -n "$1"
++    echo -n "$1"
+ }
+ 
+ ship_line() {
+@@ -155,7 +140,7 @@ do
+     fi
+ done
+ 
+-/bin/echo ""
++echo ""
+ 
+ if [ -z "$expect" ]
+ then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -411,6 +411,8 @@ in
 
   pkger = callPackage ../development/libraries/pkger { };
 
+  tapview = callPackage ../development/tools/tapview { };
+
   run = callPackage ../development/tools/run { };
 
   mod = callPackage ../development/tools/mod { };


### PR DESCRIPTION
Signed-off-by: Pamplemousse <xav.maso@gmail.com>

###### Motivation for this change

Consume TAP output in the shell. Example:

```bash
cat | ./result/bin/tapview << __EOF__
TAP version 13
# beep
ok 1 should be equal
ok 2 should be equivalent
# boop
ok 3 should be equal
ok 4 (unnamed assert)

1..4
# tests 4
# pass  4

# ok
__EOF__
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
