### PR TITLE
python3Packages.databases: 0.2.6 -> 0.4.3

### DIFF
--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -4,7 +4,8 @@
 , sqlalchemy
 , aiocontextvars
 , isPy27
-, pytest
+, pytestCheckHook
+, pymysql
 , asyncpg
 , aiomysql
 , aiosqlite
@@ -12,33 +13,37 @@
 
 buildPythonPackage rec {
   pname = "databases";
-  version = "0.2.6";
+  version = "0.4.3";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "0cdb4vln4zdmqbbcj7711b81b2l64jg1miihqcg8gpi35v404h2q";
+    sha256 = "0aq88k7d9036cy6qvlfv9p2dxd6p6fic3j0az43gn6k1ardhdsgf";
   };
 
   propagatedBuildInputs = [
-    sqlalchemy
     aiocontextvars
+    sqlalchemy
   ];
 
   checkInputs = [
-    pytest
-    asyncpg
     aiomysql
     aiosqlite
+    asyncpg
+    pymysql
+    pytestCheckHook
   ];
 
-  # big chunk to tests depend on existing posgresql and mysql databases
-  # some tests are better than no tests
-  checkPhase = ''
-    pytest --ignore=tests/test_integration.py --ignore=tests/test_databases.py
-  '';
+  disabledTestPaths = [
+    # ModuleNotFoundError: No module named 'aiopg'
+    "tests/test_connection_options.py"
+    # circular dependency on starlette
+    "tests/test_integration.py"
+    # TEST_DATABASE_URLS is not set.
+    "tests/test_databases.py"
+  ];
 
   meta = with lib; {
     description = "Async database support for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

2019/11 -> 2021/03

https://github.com/encode/databases/releases

The future!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
