### PR TITLE
pythonPackages.b2sdk: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/arrow/0.nix
+++ b/pkgs/development/python-modules/arrow/0.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
-, nose, chai, simplejson, backports_functools_lru_cache
+{ lib, buildPythonPackage, fetchPypi, isPy3k
+, simplejson, backports_functools_lru_cache
 , python-dateutil, pytz, pytest-mock, sphinx, dateparser, pytestcov
 , pytestCheckHook
 }:
@@ -8,13 +8,14 @@ buildPythonPackage rec {
   pname = "arrow";
   version = "0.17.0";
 
+  disabled = isPy3k;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "ff08d10cda1d36c68657d6ad20d74fbea493d980f8b2d45344e00d6ed2bf6ed4";
   };
 
-  propagatedBuildInputs = [ python-dateutil ]
-    ++ lib.optionals isPy27 [ backports_functools_lru_cache ];
+  propagatedBuildInputs = [ python-dateutil backports_functools_lru_cache ];
 
   checkInputs = [
     dateparser

--- a/pkgs/development/python-modules/b2sdk/0001-Upgrade-arrow.patch
+++ b/pkgs/development/python-modules/b2sdk/0001-Upgrade-arrow.patch
@@ -1,0 +1,22 @@
+From 2490984b0bf5828971c24a4bd94e5f9f02ed01a9 Mon Sep 17 00:00:00 2001
+From: Uri Baghin <uri@canva.com>
+Date: Sat, 8 May 2021 16:14:01 +1000
+Subject: [PATCH] Upgrade arrow.
+
+---
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index 39f861c..73a67e5 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,4 +1,4 @@
+-arrow>=0.8.0,<1.0.0
++arrow>=1.0.0,<2.0.0
+ importlib-metadata>=2.1.1,<3.0.0; python_version <= '3.5'
+ importlib-metadata>=3.3.0; python_version > '3.5' and python_version < '3.8'
+ logfury>=0.1.2
+-- 
+2.31.1
+

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -1,15 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, setuptools-scm, isPy27, pytestCheckHook
-, requests, arrow, logfury, tqdm }:
+{ lib, buildPythonPackage, fetchPypi, setuptools-scm, isPy27
+, arrow, logfury, requests, rst2ansi, tqdm }:
 
 buildPythonPackage rec {
   pname = "b2sdk";
-  version = "1.6.0";
+  version = "1.7.0";
 
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-6fjreuMUC056ljddfAidfBbJkvEDndB/dIkx1bF7efs=";
+    sha256 = "1zkjwz2r9jlf31gj5bnw6h9mqapjn8rndxmz7wsr5iaj3wp5fzpi";
   };
 
   postPatch = ''
@@ -22,7 +22,18 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "b2sdk" ];
 
   nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ requests arrow logfury tqdm ];
+  propagatedBuildInputs = [
+    arrow
+    logfury
+    requests
+    rst2ansi
+    tqdm
+  ];
+
+  patches = [
+    # https://github.com/Backblaze/b2-sdk-python/issues/201
+    ./0001-Upgrade-arrow.patch
+  ];
 
   # requires unpackaged dependencies like liccheck
   doCheck = false;
@@ -31,5 +42,6 @@ buildPythonPackage rec {
     description = "Client library and utilities for access to B2 Cloud Storage (backblaze).";
     homepage = "https://github.com/Backblaze/b2-sdk-python";
     license = licenses.mit;
+    maintainers = [ maintainers.uri-canva ];
   };
 }

--- a/pkgs/development/python-modules/rst2ansi/default.nix
+++ b/pkgs/development/python-modules/rst2ansi/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, docutils
+}:
+
+buildPythonPackage rec {
+  pname = "rst2ansi";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vzy6gd60l79ff750scl0sz48r1laalkl6md6dwzah4dcadgn5qv";
+  };
+
+  propagatedBuildInputs = [ docutils ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/Snaipe/python-rst-to-ansi";
+    license = licenses.mit;
+    description = "A rst converter to ansi-decorated console output";
+    maintainers = [ maintainers.uri-canva ];
+  };
+}

--- a/pkgs/development/tools/backblaze-b2/0001-Upgrade-arrow.patch
+++ b/pkgs/development/tools/backblaze-b2/0001-Upgrade-arrow.patch
@@ -1,0 +1,36 @@
+From 3086ce1f5aa0e142191e62e60bb0d4f36742c94e Mon Sep 17 00:00:00 2001
+From: Uri Baghin <uri@canva.com>
+Date: Sat, 8 May 2021 16:26:47 +1000
+Subject: [PATCH] Upgrade arrow.
+
+---
+ b2/arg_parser.py | 2 +-
+ requirements.txt | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/b2/arg_parser.py b/b2/arg_parser.py
+index cdfa1da..11c9c2c 100644
+--- a/b2/arg_parser.py
++++ b/b2/arg_parser.py
+@@ -91,7 +91,7 @@ def parse_millis_from_float_timestamp(s):
+     """
+     Parse timestamp, e.g. 1367900664 or 1367900664.152
+     """
+-    return int(arrow.get(float(s)).format('XSSS'))
++    return int(arrow.get(float(s)).float_timestamp * 1000)
+ 
+ 
+ def parse_range(s):
+diff --git a/requirements.txt b/requirements.txt
+index 3cc8006..354125f 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,4 +1,4 @@
+-arrow>=0.8.0,<1.0.0
++arrow>=1.0.0,<2.0.0
+ b2sdk>=1.7.0,<2.0.0
+ docutils==0.16
+ importlib-metadata>=2.1.1,<3.0.0; python_version <= '3.5'
+-- 
+2.31.1
+

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "backblaze-b2";
-  version = "2.1.0";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
     rev = "v${version}";
-    sha256 = "1kkpvxqgh5pw4kr8lh5gy9d7960hv9zvajbjiqhj6xgykwbpbgmq";
+    sha256 = "1x2rpvzprar9cbkg5v5s03vk0jy639k0k70jz84q8fs52p1l6ir9";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -19,6 +19,13 @@ python3Packages.buildPythonApplication rec {
   ];
 
   checkInputs = with python3Packages; [ pytestCheckHook ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  patches = [
+    # https://github.com/Backblaze/B2_Command_Line_Tool/issues/687
+    ./0001-Upgrade-arrow.patch
+  ];
 
   disabledTests = [
     "test_files_headers"

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -55,16 +55,16 @@ pythonPackages.buildPythonApplication rec {
     cffi
     cryptography
     ecdsa
-    idna
-    pygobject3
     fasteners
+    future
+    idna
     ipaddress
     lockfile
     paramiko
     pyasn1
     pycrypto
     pydrive
-    future
+    pygobject3
   ] ++ lib.optionals (!isPy3k) [
     enum
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7169,6 +7169,8 @@ in {
 
   rsa = callPackage ../development/python-modules/rsa { };
 
+  rst2ansi = callPackage ../development/python-modules/rst2ansi { };
+
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
 
   Rtree = callPackage ../development/python-modules/Rtree {

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -16,7 +16,7 @@ with self; with super; {
 
   application = callPackage ../development/python-modules/application { };
 
-  arrow = callPackage ../development/python-modules/arrow/2.nix { };
+  arrow = callPackage ../development/python-modules/arrow/0.nix { };
 
   ase = callPackage ../development/python-modules/ase/3.17.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade b2sdk.
Fix backblaze-b2 on darwin.
Failure: https://hydra.nixos.org/build/142494474
ZHF: https://github.com/NixOS/nixpkgs/issues/122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
