### PR TITLE
nushell: fix darwin build

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -10,6 +10,8 @@
 , libiconv
 , AppKit
 , Security
+, nghttp2
+, libgit2
 , withStableFeatures ? true
 }:
 
@@ -32,7 +34,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ zlib libiconv Security ]
     ++ lib.optionals (withStableFeatures && stdenv.isLinux) [ xorg.libX11 ]
-    ++ lib.optionals (withStableFeatures && stdenv.isDarwin) [ AppKit ];
+    ++ lib.optionals (withStableFeatures && stdenv.isDarwin) [ AppKit nghttp2 libgit2 ];
 
   cargoBuildFlags = lib.optional withStableFeatures "--features stable";
 

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -38,6 +38,11 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = lib.optional withStableFeatures "--features stable";
 
+  # TODO investigate why tests are broken on darwin
+  # failures show that tests try to write to paths
+  # outside of TMPDIR
+  doCheck = ! stdenv.isDarwin;
+
   checkPhase = ''
     runHook preCheck
     echo "Running cargo test"


### PR DESCRIPTION
###### Motivation for this change

darwin build is broken

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The dependency is building but I'm getting some failing tests

```
failures:

---- shell::environment::configuration::config_path stdout ----
thread 'shell::environment::configuration::config_path' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: /private/tmp/nix-build-nushell-0.30.0.drv-0/.tmp8A0jFC/config_path_test/config.toml

', tests/shell/environment/configuration.rs:116:9

---- shell::environment::configuration::clears_the_configuration stdout ----
thread 'shell::environment::configuration::clears_the_configuration' panicked at 'assertion failed: nu.pipeline(\"config clear\").execute().is_ok()', tests/shell/environment/configuration.rs:23:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- shell::environment::configuration::removes_config_values stdout ----
thread 'shell::environment::configuration::removes_config_values' panicked at 'assertion failed: nu.pipeline(\"config remove skip_welcome_message\").execute().is_ok()', tests/shell/environment/configuration.rs:136:9

---- shell::environment::configuration::retrieves_config_values stdout ----
thread 'shell::environment::configuration::retrieves_config_values' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: yellow

', tests/shell/environment/configuration.rs:44:9

---- shell::environment::configuration::sets_a_config_value stdout ----
thread 'shell::environment::configuration::sets_a_config_value' panicked at 'assertion failed: nu.pipeline(\"config set nu.meal \'arepa\'\").execute().is_ok()', tests/shell/environment/configuration.rs:67:9

---- shell::environment::configuration::sets_config_values_into_one_property stdout ----
thread 'shell::environment::configuration::sets_config_values_into_one_property' panicked at 'assertion failed: nu.pipeline(&input(r#\"\n            echo [\"amarillo\", \"blanco\"]\n            | config set_into arepa_colors\n        \"#)).execute().is_ok()', tests/shell/environment/configuration.rs:86:9

---- shell::environment::in_sync::environment_values_present_in_configuration_overwrites_inherited_environment_values stdout ----
thread 'shell::environment::in_sync::environment_values_present_in_configuration_overwrites_inherited_environment_values' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: /usr/bin/you_already_made_the_nu_choice

', tests/shell/environment/in_sync.rs:74:9

---- shell::environment::in_sync::inherited_environment_path_values_not_present_in_configuration_should_pick_up_into_in_memory_environment stdout ----
thread 'shell::environment::in_sync::inherited_environment_path_values_not_present_in_configuration_should_pick_up_into_in_memory_environment' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: /Users/andresrobalino/.volta/bin-/Users/mosqueteros/bin-/path/to/be/added

', tests/shell/environment/in_sync.rs:108:9

---- shell::environment::in_sync::inherited_environment_values_not_present_in_configuration_should_pick_up_into_in_memory_environment stdout ----
thread 'shell::environment::in_sync::inherited_environment_values_not_present_in_configuration_should_pick_up_into_in_memory_environment' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: NUNO

', tests/shell/environment/in_sync.rs:53:9

---- shell::environment::in_sync::setting_environment_value_to_configuration_should_pick_up_into_in_memory_environment_on_runtime stdout ----
thread 'shell::environment::in_sync::setting_environment_value_to_configuration_should_pick_up_into_in_memory_environment_on_runtime' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: NUNO

', tests/shell/environment/in_sync.rs:27:9

---- shell::runs_configuration_startup_commands stdout ----
thread 'shell::runs_configuration_startup_commands' panicked at '
Expected: play
    but: not equal:
    actual: Error loading keybindings: ShellError { error: UntaggedRuntimeError { reason: "Couldn\'t create config path:\nOperation not permitted (os error 1)" }, cause: None }Welcome to Nushell 0.30.0 (type 'help' for more info)
  expected: Nu World

', tests/shell/mod.rs:21:9


failures:
    shell::environment::configuration::clears_the_configuration
    shell::environment::configuration::config_path
    shell::environment::configuration::removes_config_values
    shell::environment::configuration::retrieves_config_values
    shell::environment::configuration::sets_a_config_value
    shell::environment::configuration::sets_config_values_into_one_property
    shell::environment::in_sync::environment_values_present_in_configuration_overwrites_inherited_environment_values
    shell::environment::in_sync::inherited_environment_path_values_not_present_in_configuration_should_pick_up_into_in_memory_environment
    shell::environment::in_sync::inherited_environment_values_not_present_in_configuration_should_pick_up_into_in_memory_environment
    shell::environment::in_sync::setting_environment_value_to_configuration_should_pick_up_into_in_memory_environment_on_runtime
    shell::runs_configuration_startup_commands

test result: FAILED(B. 102 passed; 11 failed; 1 ignored; 0 measured; 0 filtered out; finished in 24.04s

error: test failed, to rerun pass '--test main'
error: builder for '/nix/store/wnbg5k8xdiw6s3nzzxa46vsxna6642sq-nushell-0.30.0.drv' failed with exit code 101;
       last 10 log lines:
       >     shell::environment::configuration::sets_config_values_into_one_property
       >     shell::environment::in_sync::environment_values_present_in_configuration_overwrites_inherited_environment_values
       >     shell::environment::in_sync::inherited_environment_path_values_not_present_in_configuration_should_pick_up_into_in_memory_environment
       >     shell::environment::in_sync::inherited_environment_values_not_present_in_configuration_should_pick_up_into_in_memory_environment
       >     shell::environment::in_sync::setting_environment_value_to_configuration_should_pick_up_into_in_memory_environment_on_runtime
       >     shell::runs_configuration_startup_commands
       >
       > test result: FAILED(B. 102 passed; 11 failed; 1 ignored; 0 measured; 0 filtered out; finished in 24.04s
       >
```

   it looks like a matter of having a writable home. However since `    HOME=$TMPDIR cargo test` is in the check phase I'm not sure why it fails. If you have ideas to try, I'm open.

@Br1ght0ne @JohnTitor @marsam 
