### PR TITLE
xine-lib: unbreak

### DIFF
--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , aalib
 , alsaLib
 , ffmpeg
@@ -16,6 +15,7 @@
 , libtheora
 , libv4l
 , libvorbis
+, ncurses
 , perl
 , pkg-config
 , speex
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     libtheora
     libv4l
     libvorbis
+    ncurses
     perl
     speex
     vcdimager
@@ -64,18 +65,10 @@ stdenv.mkDerivation rec {
     libxcb
   ]);
 
-  patches = [
-    # splitting path plugin
-    (fetchpatch {
-      name = "0001-fix-XINE_PLUGIN_PATH-splitting.patch";
-      url = "https://sourceforge.net/p/xine/mailman/attachment/32394053-5e27-6558-f0c9-49e0da0bc3cc%40gmx.de/1/";
-      sha256 = "sha256-LJedxrD8JWITDo9pnS9BCmy7wiPTyJyoQ1puX49tOls=";
-    })
-  ];
+  enableParallelBuilding = true;
 
   NIX_LDFLAGS = "-lxcb-shm";
 
-  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "http://www.xinehq.de/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
