### PR TITLE
xcd: init at 1.2

### DIFF
--- a/pkgs/tools/misc/xcd/default.nix
+++ b/pkgs/tools/misc/xcd/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "xcd";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "https://www.muppetlabs.com/~breadbox/pub/software/${pname}-${version}.tar.gz";
+    sha256 = "1cgwspy08q05rhxbp7m1yrrix252i9jzfcfbzmhdvlgf5bfpl25g";
+  };
+
+  buildInputs = [ ncurses ];
+  installPhase = ''
+    runHook preInstall
+    install -D $pname $out/bin/$pname
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Colorized hexdump tool";
+    homepage = "https://www.muppetlabs.com/~breadbox/software/xcd.html";
+    maintainers = [ maintainers.xfnw ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -808,6 +808,8 @@ in
 
   tfk8s = callPackage ../tools/misc/tfk8s { };
 
+  xcd = callPackage ../tools/misc/xcd { };
+
   xtrt = callPackage ../tools/archivers/xtrt { };
 
   yabridge = callPackage ../tools/audio/yabridge {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
package the xcd hexdump utility

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
