### PR TITLE
multus-cni: init at 3.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7451,6 +7451,12 @@
     githubId = 1538622;
     name = "Michael Reilly";
   };
+  onixie = {
+    email = "onixie@gmail.com";
+    github = "onixie";
+    githubId = 817073;
+    name = "Yc. Shen";
+  };
   onsails = {
     email = "andrey@onsails.com";
     github = "onsails";

--- a/pkgs/applications/networking/cluster/multus-cni/default.nix
+++ b/pkgs/applications/networking/cluster/multus-cni/default.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "multus-cni";
+  version = "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "k8snetworkplumbingwg";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04rn7ypd0cw2c33wqb9wqy1dp6ajvcp7rcv7zybffb1d40mdlds1";
+  };
+
+  buildFlagsArray = let
+    multus = "gopkg.in/intel/multus-cni.v3/pkg/multus";
+    commit = "f6298a3a294a79f9fbda0b8f175e521799d5f8d7";
+  in [
+    "-ldflags=-s -w -X '${multus}.version=v${version}' -X '${multus}.commit=${commit}'"
+  ];
+
+  preInstall = ''
+      mv $GOPATH/bin/cmd $GOPATH/bin/multus
+  '';
+
+  vendorSha256 = null;
+
+  # Some of the tests require accessing a k8s cluster
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Multus CNI is a container network interface (CNI) plugin for Kubernetes that enables attaching multiple network interfaces to pods. ";
+    homepage = "https://github.com/k8snetworkplumbingwg/multus-cni";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ onixie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22627,6 +22627,8 @@ in
   cni = callPackage ../applications/networking/cluster/cni {};
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix {};
 
+  multus-cni = callPackage ../applications/networking/cluster/multus-cni {};
+
   cntr = callPackage ../applications/virtualization/cntr { };
 
   communi = libsForQt5.callPackage ../applications/networking/irc/communi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Multus CNI is a container network interface (CNI) plugin for Kubernetes that enables attaching multiple network interfaces to pods.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
