### PR TITLE
timew-sync-server: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/timew-sync-server/default.nix
+++ b/pkgs/applications/misc/timew-sync-server/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "timew-sync-server";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "timewarrior-synchronize";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "041j618c2bcryhgi2j2w5zlfcxcklgbir2xj3px4w7jxbbg6p68n";
+  };
+
+  vendorSha256 = "0wbd4cpswgbr839sk8qwly8gjq4lqmq448m624akll192mzm9wj7";
+
+  meta = with lib; {
+    homepage = "https://github.com/timewarrior-synchronize/timew-sync-server";
+    description = "Server component of timewarrior synchronization application";
+    license = licenses.mit;
+    maintainers = [ maintainers.joachimschmidt557 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26409,6 +26409,8 @@ in
 
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
+  timew-sync-server = callPackage ../applications/misc/timew-sync-server { };
+
   timg = callPackage ../tools/graphics/timg { };
 
   timidity = callPackage ../tools/misc/timidity { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Timewarrior Synchronize is an application which allows synchronizing intervals tracked by `timewarrior`. `timew-sync-server` is the respective server component.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
