### PR TITLE
python38Packages.pika: add missing test input gevent

### DIFF
--- a/pkgs/development/python-modules/pika/default.nix
+++ b/pkgs/development/python-modules/pika/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , gevent
 , nose
 , mock
@@ -12,12 +12,20 @@ buildPythonPackage rec {
   pname = "pika";
   version = "1.2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f023d6ac581086b124190cb3dc81dd581a149d216fa4540ac34f9be1e3970b89";
+  src = fetchFromGitHub {
+    owner = "pika";
+    repo = "pika";
+    rev = version;
+    sha256 = "sha256-Wog6Wxa8V/zv/bBrFOigZi6KE5qRf82bf1GK2XwvpDI=";
   };
 
-  checkInputs = [ gevent mock nose tornado twisted ];
+  propagatedBuildInputs = [ gevent tornado twisted ];
+  
+  checkInputs = [ nose mock ];
+
+  checkPhase = ''
+    PIKA_TEST_TLS=true nosetests
+  '';
 
   meta = with lib; {
     description = "Pure-Python implementation of the AMQP 0-9-1 protocol";

--- a/pkgs/development/python-modules/pika/default.nix
+++ b/pkgs/development/python-modules/pika/default.nix
@@ -20,11 +20,25 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ gevent tornado twisted ];
-  
+
   checkInputs = [ nose mock ];
 
+  postPatch = ''
+    # don't stop at first test failure
+    # don't run acceptance tests because they access the network
+    # don't report test coverage
+    substituteInPlace setup.cfg \
+      --replace "stop = 1" "stop = 0" \
+      --replace "tests=tests/unit,tests/acceptance" "tests=tests/unit" \
+      --replace "with-coverage = 1" "with-coverage = 0"
+  '';
+
   checkPhase = ''
+    runHook preCheck
+
     PIKA_TEST_TLS=true nosetests
+
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pika/default.nix
+++ b/pkgs/development/python-modules/pika/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "f023d6ac581086b124190cb3dc81dd581a149d216fa4540ac34f9be1e3970b89";
   };
 
-  checkInputs = [ nose mock twisted tornado gevent ];
+  checkInputs = [ gevent mock nose tornado twisted ];
 
   meta = with lib; {
     description = "Pure-Python implementation of the AMQP 0-9-1 protocol";


### PR DESCRIPTION
ZHF: #122042

Add missing check input `gevent`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
