### PR TITLE
python3Packages.mwoauth: remve restriction PyJWT < 2.0.0

### DIFF
--- a/pkgs/development/python-modules/mwoauth/default.nix
+++ b/pkgs/development/python-modules/mwoauth/default.nix
@@ -1,11 +1,13 @@
-{ lib
-, buildPythonPackage
-, six
-, pyjwt
-, requests
-, oauthlib
-, requests_oauthlib
+{ buildPythonPackage
 , fetchPypi
+, flask
+, lib
+, oauthlib
+, pyjwt
+, pytest
+, requests
+, requests_oauthlib
+, six
 }:
 
 buildPythonPackage rec {
@@ -17,8 +19,11 @@ buildPythonPackage rec {
     sha256 = "9e0d70a1fa6f452584de1cb853ae6c11f41233549f7839cfb879f99410f6ad46";
   };
 
-  # package has no tests
-  doCheck = false;
+  checkInputs = [ flask pytest ];
+
+  patchPhase = ''
+    sed -i 's/PyJWT>=1.0.1,<2.0.0/PyJWT>=1.0.1,<3.0.0/g' setup.py
+  '';
 
   propagatedBuildInputs = [ six pyjwt requests oauthlib requests_oauthlib ];
 


### PR DESCRIPTION
ZHF: #122042

According to an open PR on their github the library is compatible with PyJWT 2.0 (https://github.com/mediawiki-utilities/python-mwoauth/pull/43)

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
