### PR TITLE
arduino-cli: 0.12.1 -> 0.18.1 ; fix darwin build

### DIFF
--- a/pkgs/development/arduino/arduino-cli/default.nix
+++ b/pkgs/development/arduino/arduino-cli/default.nix
@@ -4,18 +4,18 @@ let
 
   pkg = buildGoModule rec {
     pname = "arduino-cli";
-    version = "0.12.1";
+    version = "0.18.1";
 
     src = fetchFromGitHub {
       owner = "arduino";
       repo = pname;
       rev = version;
-      sha256 = "1jlxs4szss2250zp8rz4bislgnzvqhxyp6z48dhx7zaam03hyf0w";
+      sha256 = "sha256-EtkONrP/uaetsdC47WsyQOE71Gsz0wKUiTiYThj8Kq8=";
     };
 
     subPackages = [ "." ];
 
-    vendorSha256 = "03yj2iar63qm10fw3jh9fvz57c2sqcmngb0mj5jkhbnwf8nl7mhc";
+    vendorSha256 = "sha256-kPIhG6lsH+0IrYfdlzdv/X/cUQb22Xza9Q6ywjKae/4=";
 
     doCheck = false;
 
@@ -32,15 +32,20 @@ let
 
   };
 
+in
+if stdenv.isLinux then
 # buildFHSUserEnv is needed because the arduino-cli downloads compiler
 # toolchains from the internet that have their interpreters pointed at
 # /lib64/ld-linux-x86-64.so.2
-in buildFHSUserEnv {
-  inherit (pkg) name meta;
+  buildFHSUserEnv
+  {
+    inherit (pkg) name meta;
 
-  runScript = "${pkg.outPath}/bin/arduino-cli";
+    runScript = "${pkg.outPath}/bin/arduino-cli";
 
-  extraInstallCommands = ''
-    mv $out/bin/$name $out/bin/arduino-cli
-  '';
-}
+    extraInstallCommands = ''
+      mv $out/bin/$name $out/bin/arduino-cli
+    '';
+  }
+else
+  pkg


### PR DESCRIPTION
###### Motivation for this change

add arduino-cli to darwin and update dep

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@ryantm 

I tried adding dependencies and it seems that arduino-cli automatically detects that it is on macos and adds the file in the right place
```
❯ ./arduino-cli config init
Config file written to: /Users/raphael/Library/Arduino15/arduino-cli.yaml
```
I haven't done extensive testing, but at first glance it seems to work.