### PR TITLE
maintainers/build: enable cross builds

### DIFF
--- a/maintainers/scripts/build.nix
+++ b/maintainers/scripts/build.nix
@@ -1,10 +1,18 @@
-{ maintainer }:
+{ maintainer
+, localSystem ? { system = args.system or builtins.currentSystem; }
+, system ? localSystem.system
+, crossSystem ? localSystem
+, ...
+}@args:
 
 # based on update.nix
 # nix-build build.nix --argstr maintainer <yourname>
 
+# to build for aarch64-linux using boot.binfmt.emulatedSystems:
+# nix-build build.nix --argstr maintainer <yourname> --argstr system aarch64-linux
+
 let
-  pkgs = import ./../../default.nix {};
+  pkgs = import ./../../default.nix (removeAttrs args [ "maintainer" ]);
   maintainer_ = pkgs.lib.maintainers.${maintainer};
   packagesWith = cond: return: set:
     (pkgs.lib.flatten


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I want to test my packages on aarch64-linux.

ZHF: #122042
cc @NixOS/release-engineers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
