### PR TITLE
mkShell: introduce packages argument

### DIFF
--- a/doc/builders/special/mkshell.section.md
+++ b/doc/builders/special/mkshell.section.md
@@ -1,15 +1,17 @@
 # pkgs.mkShell {#sec-pkgs-mkShell}
 
-`pkgs.mkShell` is a special kind of derivation that is only useful when using it combined with `nix-shell`. It will in fact fail to instantiate when invoked with `nix-build`.
+`pkgs.mkShell` is a special kind of derivation that is only useful when using
+it combined with `nix-shell`. It will in fact fail to instantiate when invoked
+with `nix-build`.
 
 ## Usage {#sec-pkgs-mkShell-usage}
 
 ```nix
 { pkgs ? import <nixpkgs> {} }:
 pkgs.mkShell {
-  # this will make all the build inputs from hello and gnutar
-  # available to the shell environment
+  # specify which packages to add to the shell environment
+  packages = [ pkgs.gnumake ];
+  # add all the dependencies, of the given packages, to the shell environment
   inputsFrom = with pkgs; [ hello gnutar ];
-  buildInputs = [ pkgs.gnumake ];
 }
 ```

--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -10,7 +10,7 @@ with import <nixpkgs> {};
 
 mkShell {
   name = "dotnet-env";
-  buildInputs = [
+  packages = [
     dotnet-sdk_3
   ];
 }
@@ -25,7 +25,7 @@ with import <nixpkgs> {};
 
 mkShell {
   name = "dotnet-env";
-  buildInputs = [
+  packages = [
     (with dotnetCorePackages; combinePackages [
       sdk_3_1
       sdk_3_0

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -245,7 +245,7 @@ let
     ps.toolz
   ]);
 in mkShell {
-  buildInputs = [
+  packages = [
     pythonEnv
 
     black

--- a/doc/languages-frameworks/ruby.section.md
+++ b/doc/languages-frameworks/ruby.section.md
@@ -106,7 +106,7 @@ let
     name = "gems-for-some-project";
     gemdir = ./.;
   };
-in mkShell { buildInputs = [ gems gems.wrappedRuby ]; }
+in mkShell { packages = [ gems gems.wrappedRuby ]; }
 ```
 
 With this file in your directory, you can run `nix-shell` to build and use the gems. The important parts here are `bundlerEnv` and `wrappedRuby`.

--- a/maintainers/scripts/update-luarocks-shell.nix
+++ b/maintainers/scripts/update-luarocks-shell.nix
@@ -2,8 +2,11 @@
 }:
 with nixpkgs;
 mkShell {
-  buildInputs = [
-    bash luarocks-nix nix-prefetch-scripts parallel
+  packages = [
+    bash
+    luarocks-nix
+    nix-prefetch-scripts
+    parallel
   ];
   LUAROCKS_NIXPKGS_PATH = toString nixpkgs.path;
 }

--- a/nixos/doc/manual/shell.nix
+++ b/nixos/doc/manual/shell.nix
@@ -4,5 +4,5 @@ in
 pkgs.mkShell {
   name = "nixos-manual";
 
-  buildInputs = with pkgs; [ xmlformat jing xmloscopy ruby ];
+  packages = with pkgs; [ xmlformat jing xmloscopy ruby ];
 }

--- a/pkgs/applications/editors/emacs-modes/emacs2nix.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs2nix.nix
@@ -7,10 +7,10 @@ let
     rev = "860da04ca91cbb69c9b881a54248d16bdaaf9923";
     sha256 = "1r3xmyk9rfgx7ln69dk8mgbnh3awcalm3r1c5ia2shlsrymvv1df";
   };
+in
+pkgs.mkShell {
 
-in pkgs.mkShell {
-
-  buildInputs = [
+  packages = [
     pkgs.bash
   ];
 

--- a/pkgs/applications/editors/emacs-modes/updater-emacs.nix
+++ b/pkgs/applications/editors/emacs-modes/updater-emacs.nix
@@ -29,7 +29,7 @@ let
   in [ promise semaphore ]);
 
 in pkgs.mkShell {
-  buildInputs = [
+  packages = [
     pkgs.git
     pkgs.nix
     pkgs.bash

--- a/pkgs/applications/networking/cluster/nixops/shell.nix
+++ b/pkgs/applications/networking/cluster/nixops/shell.nix
@@ -1,7 +1,7 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 pkgs.mkShell {
-  buildInputs = [
+  packages = [
     pkgs.poetry2nix.cli
     pkgs.pkg-config
     pkgs.libvirt

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -1,6 +1,6 @@
 # Builder for Agda packages.
 
-{ stdenv, lib, self, Agda, runCommandNoCC, makeWrapper, writeText, mkShell, ghcWithPackages, nixosTests }:
+{ stdenv, lib, self, Agda, runCommandNoCC, makeWrapper, writeText, ghcWithPackages, nixosTests }:
 
 with lib.strings;
 

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -3,18 +3,22 @@
 # A special kind of derivation that is only meant to be consumed by the
 # nix-shell.
 {
-  inputsFrom ? [], # a list of derivations whose inputs will be made available to the environment
-  buildInputs ? [],
-  nativeBuildInputs ? [],
-  propagatedBuildInputs ? [],
-  propagatedNativeBuildInputs ? [],
-  ...
+  # a list of packages to add to the shell environment
+  packages ? [ ]
+, # propagate all the inputs from the given derivations
+  inputsFrom ? [ ]
+, buildInputs ? [ ]
+, nativeBuildInputs ? [ ]
+, propagatedBuildInputs ? [ ]
+, propagatedNativeBuildInputs ? [ ]
+, ...
 }@attrs:
 let
   mergeInputs = name: lib.concatLists (lib.catAttrs name
-    ([attrs] ++ inputsFrom));
+    ([ attrs ] ++ inputsFrom));
 
   rest = builtins.removeAttrs attrs [
+    "packages"
     "inputsFrom"
     "buildInputs"
     "nativeBuildInputs"
@@ -26,15 +30,15 @@ in
 
 stdenv.mkDerivation ({
   name = "nix-shell";
-  phases = ["nobuildPhase"];
+  phases = [ "nobuildPhase" ];
 
   buildInputs = mergeInputs "buildInputs";
-  nativeBuildInputs = mergeInputs "nativeBuildInputs";
+  nativeBuildInputs = packages ++ (mergeInputs "nativeBuildInputs");
   propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
   propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
 
   shellHook = lib.concatStringsSep "\n" (lib.catAttrs "shellHook"
-    (lib.reverseList inputsFrom ++ [attrs]));
+    (lib.reverseList inputsFrom ++ [ attrs ]));
 
   nobuildPhase = ''
     echo

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -115,7 +115,7 @@ let
 in
 pkgs.mkShell rec {
   name = "androidenv-demo";
-  buildInputs = [ androidSdk platformTools jdk pkgs.android-studio ];
+  packages = [ androidSdk platformTools jdk pkgs.android-studio ];
 
   LANG = "C.UTF-8";
   LC_ALL = "C.UTF-8";

--- a/pkgs/tools/X11/opentabletdriver/shell.nix
+++ b/pkgs/tools/X11/opentabletdriver/shell.nix
@@ -1,9 +1,9 @@
-{ pkgs ? import ../../../../. {} }:
+{ pkgs ? import ../../../../. { } }:
 
 with pkgs;
 
 mkShell {
-  buildInputs = [
+  packages = [
     common-updater-scripts
     curl
     dotnetCorePackages.sdk_5_0


### PR DESCRIPTION
###### Motivation for this change

The distinction between the inputs doesn't really make sense in the
mkShell context.  Technically speaking, we should be using the
nativeBuildInputs most of the time.

So in order to make this function more beginner-friendly, add "packages"
as an attribute, that maps to nativeBuildInputs.

This commit also updates all the uses in nixpkgs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).