### PR TITLE
open-vm-tools: fix building with glib 2.68

### DIFF
--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, autoreconfHook,
+{ stdenv, lib, fetchFromGitHub, makeWrapper, autoreconfHook, fetchpatch,
   fuse, libmspack, openssl, pam, xercesc, icu, libdnet, procps, libtirpc, rpcsvc-proto,
   libX11, libXext, libXinerama, libXi, libXrender, libXrandr, libXtst,
   pkg-config, glib, gdk-pixbuf-xlib, gtk3, gtkmm3, iproute2, dbus, systemd, which,
@@ -22,6 +22,18 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config ];
   buildInputs = [ fuse glib icu libdnet libmspack libtirpc openssl pam procps rpcsvc-proto xercesc ]
       ++ lib.optionals withX [ gdk-pixbuf-xlib gtk3 gtkmm3 libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
+
+  patches = [
+    # Fix building with glib 2.68. Remove after next release.
+    # We drop AUTHORS due to conflicts when applying.
+    # https://github.com/vmware/open-vm-tools/pull/505
+    (fetchpatch {
+      url = "https://github.com/vmware/open-vm-tools/commit/82931a1bcb39d5132910c7fb2ddc086c51d06662.patch";
+      stripLen = 1;
+      excludes = [ "AUTHORS" ];
+      sha256 = "0yz5hnngr5vd4416hvmh8734a9vxa18d2xd37kl7if0p9vik6zlg";
+    })
+  ];
 
   postPatch = ''
      # Build bugfix for 10.1.0, stolen from Arch PKGBUILD


### PR DESCRIPTION
###### Motivation for this change
Fixes building open-vm-tools with glib 2.68 with upstream patch. The patch should be dropped with the next release.

cc @endocrimes 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
