### PR TITLE
idrisPackages.sdl2: fix sources sha256

### DIFF
--- a/pkgs/development/idris-modules/sdl2.nix
+++ b/pkgs/development/idris-modules/sdl2.nix
@@ -12,8 +12,11 @@ build-idris-package rec {
 
   idrisDeps = [ effects ];
 
-  extraBuildInputs = [
+  nativeBuildInputs = [
     pkg-config
+  ];
+
+  extraBuildInputs = [
     SDL2
     SDL2_gfx
   ];
@@ -24,7 +27,7 @@ build-idris-package rec {
     owner = "steshaw";
     repo = "idris-sdl2";
     rev = version;
-    sha256 = "0hqhg7l6wpkdbzrdjvrbqymmahziri07ba0hvbii7dd2p0h248fv";
+    sha256 = "1jslnlzyw04dcvcd7xsdjqa7waxzkm5znddv76sv291jc94xhl4a";
   };
 
   meta = {


### PR DESCRIPTION
This is weird
b7ddbd52bd1ab9365436573c0c5b6d1edcc1919f
replaced idris-modules/sdl2.nix hash with that of pkgs/applications/networking/instant-messengers/quaternion/default.nix

Build log says [sdl2.ipkg](https://github.com/steshaw/idris-sdl2/blob/0.1.1/sdl2.ipkg) isn't found, which is kind of correct message for using wrong archive
https://hydra.nixos.org/build/142426623/nixlog/2

How do we make sure all other replaced hashes are correct?

ZHF: #122042

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
