### PR TITLE
qmediathekview: 2019-01-06 -> 0.2.1

### DIFF
--- a/pkgs/applications/video/qmediathekview/default.nix
+++ b/pkgs/applications/video/qmediathekview/default.nix
@@ -1,13 +1,22 @@
-{ mkDerivation, lib, fetchFromGitHub, qtbase, qttools, xz, boost, qmake, pkg-config }:
+{ lib
+, stdenv
+, mkDerivation
+, fetchFromGitHub
+, boost
+, qtbase
+, xz
+, qmake
+, pkg-config
+}:
 
 mkDerivation rec {
   pname = "QMediathekView";
-  version = "2019-01-06";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "adamreichold";
     repo = pname;
-    rev = "e098aaec552ec4e367078bf19953a08067316b4b";
+    rev = "v${version}";
     sha256 = "0i9hac9alaajbra3lx23m0iiq6ww4is00lpbzg5x70agjrwj0nd6";
   };
 
@@ -16,7 +25,7 @@ mkDerivation rec {
       --replace /usr ""
   '';
 
-  buildInputs = [ qtbase qttools xz boost ];
+  buildInputs = [ qtbase xz boost ];
 
   nativeBuildInputs = [ qmake pkg-config ];
 
@@ -28,5 +37,6 @@ mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ dotlambda ];
+    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
