### PR TITLE
haskell.packages: move platform specific overrides into own configuration files

### DIFF
--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -1,0 +1,71 @@
+# ARM-SPECIFIC OVERRIDES FOR THE HASKELL PACKAGE SET IN NIXPKGS
+#
+# This extension is applied to all haskell package sets in nixpkgs
+# if `stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64`
+# to apply arm specific workarounds or fixes.
+#
+# The file is split into three parts:
+#
+# * Overrides that are applied for all arm platforms
+# * Overrides for aarch32 platforms
+# * Overrides for aarch64 platforms
+#
+# This may be extended in the future to also include compiler-
+# specific sections as compiler and linker related bugs may
+# get fixed subsequently.
+#
+# When adding new overrides, try to research which section they
+# belong into. Most likely we'll be favouring aarch64 overrides
+# in practice since that is the only platform we can test on
+# Hydra. Also take care to group overrides by the issue they
+# solve, so refactors and updates to this file are less tedious.
+{ pkgs, haskellLib }:
+
+let
+  inherit (pkgs) lib;
+in
+
+with haskellLib;
+
+self: super: {
+  # COMMON ARM OVERRIDES
+
+  # moved here from configuration-common.nix, no reason given.
+  servant-docs = dontCheck super.servant-docs;
+  swagger2 = dontHaddock (dontCheck super.swagger2);
+
+  # Similar to https://ghc.haskell.org/trac/ghc/ticket/13062
+  happy = dontCheck super.happy;
+
+} // lib.optionalAttrs pkgs.stdenv.hostPlatform.isAarch64 {
+  # AARCH64-SPECIFIC OVERRIDES
+
+  # Doctests fail on aarch64 due to a GHCi linking bug
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/15275#note_295437
+  # TODO: figure out if needed on aarch32 as well
+  language-nix = dontCheck super.language-nix;
+  trifecta = dontCheck super.trifecta;
+  ad = dontCheck super.ad;
+  vinyl = dontCheck super.vinyl;
+  BNFC = dontCheck super.BNFC;
+  C-structs = dontCheck super.C-structs;
+  accelerate = dontCheck super.accelerate;
+  focuslist = dontCheck super.focuslist;
+  flight-kml = dontCheck super.flight-kml;
+  exact-real = dontCheck super.exact-real;
+  autoapply = dontCheck super.autoapply;
+  hint = dontCheck super.hint;
+  hgeometry = dontCheck super.hgeometry;
+  headroom = dontCheck super.headroom;
+  haskell-time-range = dontCheck super.haskell-time-range;
+  hsakamai = dontCheck super.hsakamai;
+  hsemail-ns = dontCheck super.hsemail-ns;
+  openapi3 = dontCheck super.openapi3;
+
+  # https://github.com/ekmett/half/issues/35
+  half = dontCheck super.half;
+
+} // lib.optionalAttrs pkgs.stdenv.hostPlatform.isAarch32 {
+  # AARCH32-SPECIFIC OVERRIDES
+
+}

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -75,10 +75,6 @@ self: super: {
   # Fix test trying to access /home directory
   shell-conduit = overrideCabal super.shell-conduit (drv: {
     postPatch = "sed -i s/home/tmp/ test/Spec.hs";
-
-    # the tests for shell-conduit on Darwin illegitimatey assume non-GNU echo
-    # see: https://github.com/psibi/shell-conduit/issues/12
-    doCheck = !pkgs.stdenv.isDarwin;
   });
 
   # https://github.com/froozen/kademlia/issues/2
@@ -117,15 +113,6 @@ self: super: {
   # Jailbreak is necessary for QuickCheck dependency.
   vector = doJailbreak (if pkgs.stdenv.isi686 then appendConfigureFlag super.vector "--ghc-options=-msse2" else super.vector);
 
-  conduit-extra = if pkgs.stdenv.isDarwin
-    then super.conduit-extra.overrideAttrs (drv: { __darwinAllowLocalNetworking = true; })
-    else super.conduit-extra;
-
-  # Fix Darwin build.
-  halive = if pkgs.stdenv.isDarwin
-    then addBuildDepend super.halive pkgs.darwin.apple_sdk.frameworks.AppKit
-    else super.halive;
-
   # Test suite fails due golden tests checking text representation
   # of normalized dhall expressions, and newer dhall versions format
   # differently.
@@ -133,19 +120,6 @@ self: super: {
     if pkgs.lib.versionOlder "0.5.2" super.hpack-dhall.version
     then throw "Drop dontCheck override for hpack-dhall > 0.5.2"
     else dontCheck super.hpack-dhall;
-
-  barbly = addBuildDepend super.barbly pkgs.darwin.apple_sdk.frameworks.AppKit;
-
-  # Hakyll's tests are broken on Darwin (3 failures); and they require util-linux
-  hakyll = if pkgs.stdenv.isDarwin
-    then dontCheck (overrideCabal super.hakyll (drv: {
-      testToolDepends = [];
-    }))
-    else super.hakyll;
-
-  double-conversion = if !pkgs.stdenv.isDarwin
-    then super.double-conversion
-    else addExtraLibrary super.double-conversion pkgs.libcxx;
 
   inline-c-cpp = overrideCabal super.inline-c-cpp (drv: {
     postPatch = (drv.postPatch or "") + ''
@@ -311,18 +285,12 @@ self: super: {
   ldap-client = dontCheck super.ldap-client;
   lensref = dontCheck super.lensref;
   lvmrun = disableHardening (dontCheck super.lvmrun) ["format"];
-  math-functions = if pkgs.stdenv.isDarwin
-    then dontCheck super.math-functions # "erf table" test fails on Darwin https://github.com/bos/math-functions/issues/63
-    else super.math-functions;
   matplotlib = dontCheck super.matplotlib;
   # https://github.com/matterhorn-chat/matterhorn/issues/679 they do not want to be on stackage
   matterhorn = doJailbreak super.matterhorn; # this is needed until the end of time :')
   memcache = dontCheck super.memcache;
   metrics = dontCheck super.metrics;
   milena = dontCheck super.milena;
-  mockery = if pkgs.stdenv.isDarwin
-    then overrideCabal super.mockery (drv: { preCheck = "export TRAVIS=true"; }) # darwin doesn't have sub-second resolution https://github.com/hspec/mockery/issues/11
-    else super.mockery;
   modular-arithmetic = dontCheck super.modular-arithmetic; # tests require a very old Glob (0.7.*)
   nats-queue = dontCheck super.nats-queue;
   netpbm = dontCheck super.netpbm;
@@ -463,9 +431,8 @@ self: super: {
   # https://github.com/andrewthad/haskell-ip/issues/67
   ip = dontCheck super.ip;
 
-  # https://github.com/ndmitchell/shake/issues/206
-  # https://github.com/ndmitchell/shake/issues/267
-  shake = overrideCabal super.shake (drv: { doCheck = !pkgs.stdenv.isDarwin && false; });
+  # https://github.com/ndmitchell/shake/issues/804
+  shake = dontCheck super.shake;
 
   # https://github.com/nushio3/doctest-prop/issues/1
   doctest-prop = dontCheck super.doctest-prop;
@@ -840,7 +807,6 @@ self: super: {
   # With ghc-8.2.x haddock would time out for unknown reason
   # See https://github.com/haskell/haddock/issues/679
   language-puppet = dontHaddock super.language-puppet;
-  filecache = overrideCabal super.filecache (drv: { doCheck = !pkgs.stdenv.isDarwin; });
 
   # https://github.com/alphaHeavy/protobuf/issues/34
   protobuf = dontCheck super.protobuf;
@@ -1154,11 +1120,6 @@ self: super: {
       substituteInPlace hledger-flow.cabal --replace "-static" ""
     '';
   });
-
-  # gtk/gtk3 needs to be told on Darwin to use the Quartz
-  # rather than X11 backend (see eg https://github.com/gtk2hs/gtk2hs/issues/249).
-  gtk3 = appendConfigureFlags super.gtk3 (pkgs.lib.optional pkgs.stdenv.isDarwin "-f have-quartz-gtk");
-  gtk = appendConfigureFlags super.gtk (pkgs.lib.optional pkgs.stdenv.isDarwin "-f have-quartz-gtk");
 
   # Chart-tests needs and compiles some modules from Chart itself
   Chart-tests = (addExtraLibrary super.Chart-tests self.QuickCheck).overrideAttrs (old: {
@@ -1571,10 +1532,6 @@ self: super: {
 
   # https://github.com/yesodweb/yesod/issues/1714
   yesod-core = dontCheck super.yesod-core;
-
-  # Add ApplicationServices on darwin
-  apecs-physics = addPkgconfigDepends super.apecs-physics
-    (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.ApplicationServices);
 
   # Break out of overspecified constraint on QuickCheck.
   algebraic-graphs = dontCheck super.algebraic-graphs;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -307,7 +307,6 @@ self: super: {
   integer-roots = dontCheck super.integer-roots; # requires an old version of smallcheck, will be fixed in > 1.0
   itanium-abi = dontCheck super.itanium-abi;
   katt = dontCheck super.katt;
-  language-nix = if (pkgs.stdenv.hostPlatform.isAarch64 || pkgs.stdenv.hostPlatform.isi686) then dontCheck super.language-nix else super.language-nix; # aarch64: https://ghc.haskell.org/trac/ghc/ticket/15275
   language-slice = dontCheck super.language-slice;
   ldap-client = dontCheck super.ldap-client;
   lensref = dontCheck super.lensref;
@@ -852,16 +851,9 @@ self: super: {
     configureFlags = ["--ghc-option=-DU_DEFINE_FALSE_AND_TRUE=1"]; # https://github.com/haskell/text-icu/issues/49
   });
 
-  # aarch64 and armv7l fixes.
-  happy = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.happy else super.happy; # Similar to https://ghc.haskell.org/trac/ghc/ticket/13062
-  servant-docs =
-    let
-      f = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64)
-          then dontCheck
-          else pkgs.lib.id;
-    in doJailbreak (f super.servant-docs); # jailbreak tasty < 1.2 until servant-docs > 0.11.3 is on hackage.
+  # jailbreak tasty < 1.2 until servant-docs > 0.11.3 is on hackage.
+  servant-docs = doJailbreak super.servant-docs;
   snap-templates = doJailbreak super.snap-templates; # https://github.com/snapframework/snap-templates/issues/22
-  swagger2 = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontHaddock (dontCheck super.swagger2) else super.swagger2;
 
   # hledger-lib requires the latest version of pretty-simple
   hledger-lib = appendPatch super.hledger-lib
@@ -1526,11 +1518,6 @@ self: super: {
   # Due to tests restricting base in 0.8.0.0 release
   http-media = doJailbreak super.http-media;
 
-  # https://github.com/ekmett/half/issues/35
-  half = if pkgs.stdenv.isAarch64
-    then dontCheck super.half
-    else super.half;
-
   # 2020-11-19: Jailbreaking until: https://github.com/snapframework/heist/pull/124
   heist = doJailbreak super.heist;
 
@@ -1875,58 +1862,6 @@ self: super: {
       sed -i 's/ref-tf.*,/ref-tf,/' jsaddle.cabal
     '' + (drv.postPatch or "");
   });
-
-  # Doctests fail on aarch64 due to a GHCi linking bug
-  # https://gitlab.haskell.org/ghc/ghc/-/issues/15275#note_295437
-  ad = overrideCabal super.ad {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  trifecta = if pkgs.stdenv.hostPlatform.isAarch64 then dontCheck super.trifecta else super.trifecta;
-  vinyl = overrideCabal super.vinyl {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  BNFC = overrideCabal super.BNFC {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  C-structs = overrideCabal super.C-structs {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  accelerate = overrideCabal super.accelerate {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  focuslist = overrideCabal super.focuslist {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  flight-kml = overrideCabal super.flight-kml {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  exact-real = overrideCabal super.exact-real {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  autoapply = overrideCabal super.autoapply {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  hint = overrideCabal super.hint {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  hgeometry = overrideCabal super.hgeometry {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  headroom = overrideCabal super.headroom {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  haskell-time-range = overrideCabal super.haskell-time-range {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  hsakamai = overrideCabal super.hsakamai {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  hsemail-ns = overrideCabal super.hsemail-ns {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
-  openapi3 = overrideCabal super.openapi3 {
-    doCheck = !pkgs.stdenv.hostPlatform.isAarch64;
-  };
 
   # Tests need to lookup target triple x86_64-unknown-linux
   # https://github.com/llvm-hs/llvm-hs/issues/334

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -1,0 +1,164 @@
+# DARWIN-SPECIFIC OVERRIDES FOR THE HASKELL PACKAGE SET IN NIXPKGS
+
+{ pkgs, haskellLib }:
+
+let
+  inherit (pkgs) lib darwin;
+in
+
+with haskellLib;
+
+self: super: {
+
+  # the tests for shell-conduit on Darwin illegitimatey assume non-GNU echo
+  # see: https://github.com/psibi/shell-conduit/issues/12
+  shell-conduit = dontCheck super.shell-conduit;
+
+  conduit-extra = super.conduit-extra.overrideAttrs (drv: {
+    __darwinAllowLocalNetworking = true;
+  });
+
+  halive = addBuildDepend super.halive darwin.apple_sdk.frameworks.AppKit;
+
+  # Hakyll's tests are broken on Darwin (3 failures); and they require util-linux
+  hakyll = overrideCabal super.hakyll {
+    testToolDepends = [];
+    doCheck = false;
+  };
+
+  barbly = addBuildDepend super.barbly darwin.apple_sdk.frameworks.AppKit;
+
+  double-conversion = addExtraLibrary super.double-conversion pkgs.libcxx;
+
+  apecs-physics = addPkgconfigDepends super.apecs-physics [
+    darwin.apple_sdk.frameworks.ApplicationServices
+  ];
+
+  # "erf table" test fails on Darwin
+  # https://github.com/bos/math-functions/issues/63
+  math-functions = dontCheck super.math-functions;
+
+  # darwin doesn't have sub-second resolution
+  # https://github.com/hspec/mockery/issues/11
+  mockery = overrideCabal super.mockery (drv: {
+    preCheck = ''
+      export TRAVIS=true
+    '' + (drv.preCheck or "");
+  });
+
+  # https://github.com/ndmitchell/shake/issues/206
+  shake = dontCheck super.shake;
+
+  filecache = dontCheck super.filecache;
+
+  # gtk/gtk3 needs to be told on Darwin to use the Quartz
+  # rather than X11 backend (see eg https://github.com/gtk2hs/gtk2hs/issues/249).
+  gtk3 = appendConfigureFlag super.gtk3 "-f have-quartz-gtk";
+  gtk = appendConfigureFlag super.gtk "-f have-quartz-gtk";
+
+  OpenAL = addExtraLibrary super.OpenAL darwin.apple_sdk.frameworks.OpenAL;
+
+  proteaaudio = addExtraLibrary super.proteaaudio darwin.apple_sdk.frameworks.AudioToolbox;
+
+  # the system-fileio tests use canonicalizePath, which fails in the sandbox
+  system-fileio = dontCheck super.system-fileio;
+
+  # Prevents needing to add `security_tool` as a run-time dependency for
+  # everything using x509-system to give access to the `security` executable.
+  #
+  # darwin.security_tool is broken in Mojave (#45042)
+  #
+  # We will use the system provided security for now.
+  # Beware this WILL break in sandboxes!
+  #
+  # TODO(matthewbauer): If someone really needs this to work in sandboxes,
+  # I think we can add a propagatedImpureHost dep here, but I’m hoping to
+  # get a proper fix available soonish.
+  x509-system = overrideCabal super.x509-system (drv:
+    lib.optionalAttrs (!pkgs.stdenv.cc.nativeLibc) {
+      postPatch = ''
+        substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
+      '' + (drv.postPatch or "");
+    });
+
+  # https://github.com/haskell-foundation/foundation/pull/412
+  foundation = dontCheck super.foundation;
+
+  llvm-hs = overrideCabal super.llvm-hs (oldAttrs: {
+    # One test fails on darwin.
+    doCheck = false;
+    # llvm-hs's Setup.hs file tries to add the lib/ directory from LLVM8 to
+    # the DYLD_LIBRARY_PATH environment variable.  This messes up clang
+    # when called from GHC, probably because clang is version 7, but we are
+    # using LLVM8.
+    preCompileBuildDriver = ''
+      substituteInPlace Setup.hs --replace "addToLdLibraryPath libDir" "pure ()"
+    '' + (oldAttrs.preCompileBuildDriver or "");
+  });
+
+  yesod-bin = addBuildDepend super.yesod-bin darwin.apple_sdk.frameworks.Cocoa;
+
+  hmatrix = addBuildDepend super.hmatrix darwin.apple_sdk.frameworks.Accelerate;
+
+  # Ensure the necessary frameworks are propagatedBuildInputs on darwin
+  OpenGLRaw = overrideCabal super.OpenGLRaw (drv: {
+    librarySystemDepends = [];
+    libraryHaskellDepends = drv.libraryHaskellDepends ++ [
+      darwin.apple_sdk.frameworks.OpenGL
+    ];
+    preConfigure = ''
+      frameworkPaths=($(for i in $nativeBuildInputs; do if [ -d "$i"/Library/Frameworks ]; then echo "-F$i/Library/Frameworks"; fi done))
+      frameworkPaths=$(IFS=, ; echo "''${frameworkPaths[@]}")
+      configureFlags+=$(if [ -n "$frameworkPaths" ]; then echo -n "--ghc-options=-optl=$frameworkPaths"; fi)
+    '' + (drv.preConfigure or "");
+  });
+  GLURaw = overrideCabal super.GLURaw (drv: {
+    librarySystemDepends = [];
+    libraryHaskellDepends = drv.libraryHaskellDepends ++ [
+      darwin.apple_sdk.frameworks.OpenGL
+    ];
+  });
+  bindings-GLFW = overrideCabal super.bindings-GLFW (drv: {
+    librarySystemDepends = [];
+    libraryHaskellDepends = drv.libraryHaskellDepends ++ [
+      darwin.apple_sdk.frameworks.AGL
+      darwin.apple_sdk.frameworks.Cocoa
+      darwin.apple_sdk.frameworks.OpenGL
+      darwin.apple_sdk.frameworks.IOKit
+      darwin.apple_sdk.frameworks.Kernel
+      darwin.apple_sdk.frameworks.CoreVideo
+      darwin.CF
+    ];
+  });
+  OpenCL = overrideCabal super.OpenCL (drv: {
+    librarySystemDepends = [];
+    libraryHaskellDepends = drv.libraryHaskellDepends ++ [
+      darwin.apple_sdk.frameworks.OpenCL
+    ];
+  });
+
+  # cabal2nix likes to generate dependencies on hinotify when hfsevents is
+  # really required on darwin: https://github.com/NixOS/cabal2nix/issues/146.
+  hinotify = self.hfsevents;
+
+  # FSEvents API is very buggy and tests are unreliable. See
+  # http://openradar.appspot.com/10207999 and similar issues.
+  fsnotify = addBuildDepend (dontCheck super.fsnotify)
+    darwin.apple_sdk.frameworks.Cocoa;
+
+  FractalArt = overrideCabal super.FractalArt (drv: {
+    librarySystemDepends = [
+      darwin.libobjc
+      darwin.apple_sdk.frameworks.AppKit
+    ] ++ (drv.librarySystemDepends or []);
+  });
+
+  arbtt = overrideCabal super.arbtt (drv: {
+    librarySystemDepends = [
+      darwin.apple_sdk.frameworks.Foundation
+      darwin.apple_sdk.frameworks.Carbon
+      darwin.apple_sdk.frameworks.IOKit
+    ] ++ (drv.librarySystemDepends or []);
+  });
+
+}

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -238,6 +238,7 @@ self: super: builtins.intersectAttrs super {
   # Uses OpenGL in testing
   caramia = dontCheck super.caramia;
 
+  # requires llvm 9 specifically https://github.com/llvm-hs/llvm-hs/#building-from-source
   llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm_9; };
 
   # Needs help finding LLVM.

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -101,17 +101,6 @@ self: super: builtins.intersectAttrs super {
   ormolu = enableSeparateBinOutput super.ormolu;
   ghcid = enableSeparateBinOutput super.ghcid;
 
-  # Ensure the necessary frameworks for Darwin.
-  OpenAL = if pkgs.stdenv.isDarwin
-    then addExtraLibrary super.OpenAL pkgs.darwin.apple_sdk.frameworks.OpenAL
-    else super.OpenAL;
-
-  # Ensure the necessary frameworks for Darwin.
-  proteaaudio = if pkgs.stdenv.isDarwin
-    then addExtraLibrary super.proteaaudio pkgs.darwin.apple_sdk.frameworks.AudioToolbox
-    else super.proteaaudio;
-
-
   hzk = overrideCabal super.hzk (drv: {
     preConfigure = "sed -i -e /include-dirs/d hzk.cabal";
     configureFlags = [ "--extra-include-dirs=${pkgs.zookeeper_mt}/include/zookeeper" ];
@@ -131,38 +120,10 @@ self: super: builtins.intersectAttrs super {
   # Foreign dependency name clashes with another Haskell package.
   libarchive-conduit = super.libarchive-conduit.override { archive = pkgs.libarchive; };
 
-  # Fix Darwin build.
-  halive = if pkgs.stdenv.isDarwin
-    then addBuildDepend super.halive pkgs.darwin.apple_sdk.frameworks.AppKit
-    else super.halive;
-
   # Heist's test suite requires system pandoc
   heist = overrideCabal super.heist (drv: {
     testToolDepends = [pkgs.pandoc];
   });
-
-  # the system-fileio tests use canonicalizePath, which fails in the sandbox
-  system-fileio = if pkgs.stdenv.isDarwin then dontCheck super.system-fileio else super.system-fileio;
-
-  # Prevents needing to add `security_tool` as a run-time dependency for
-  # everything using x509-system to give access to the `security` executable.
-  x509-system =
-    if pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc
-    then
-      # darwin.security_tool is broken in Mojave (#45042)
-
-      # We will use the system provided security for now.
-      # Beware this WILL break in sandboxes!
-
-      # TODO(matthewbauer): If someone really needs this to work in sandboxes,
-      # I think we can add a propagatedImpureHost dep here, but I’m hoping to
-      # get a proper fix available soonish.
-      overrideCabal super.x509-system (drv: {
-        postPatch = (drv.postPatch or "") + ''
-          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
-        '';
-      })
-    else super.x509-system;
 
   # https://github.com/NixOS/cabal2nix/issues/136 and https://github.com/NixOS/cabal2nix/issues/216
   gio = disableHardening (addPkgconfigDepend (addBuildTool super.gio self.buildHaskellPackages.gtk2hs-buildtools) pkgs.glib) ["fortify"];
@@ -266,12 +227,6 @@ self: super: builtins.intersectAttrs super {
   # /homeless-shelter. Disabled.
   purescript = dontCheck super.purescript;
 
-  # https://github.com/haskell-foundation/foundation/pull/412
-  foundation =
-    if pkgs.stdenv.isDarwin
-    then dontCheck super.foundation
-    else super.foundation;
-
   # Hardcoded include path
   poppler = overrideCabal super.poppler (drv: {
     postPatch = ''
@@ -283,23 +238,7 @@ self: super: builtins.intersectAttrs super {
   # Uses OpenGL in testing
   caramia = dontCheck super.caramia;
 
-  llvm-hs =
-    let llvmHsWithLlvm9 = super.llvm-hs.override { llvm-config = pkgs.llvm_9; };
-    in
-    if pkgs.stdenv.isDarwin
-    then
-      overrideCabal llvmHsWithLlvm9 (oldAttrs: {
-        # One test fails on darwin.
-        doCheck = false;
-        # llvm-hs's Setup.hs file tries to add the lib/ directory from LLVM8 to
-        # the DYLD_LIBRARY_PATH environment variable.  This messes up clang
-        # when called from GHC, probably because clang is version 7, but we are
-        # using LLVM8.
-        preCompileBuildDriver = oldAttrs.preCompileBuildDriver or "" + ''
-          substituteInPlace Setup.hs --replace "addToLdLibraryPath libDir" "pure ()"
-        '';
-      })
-    else llvmHsWithLlvm9;
+  llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm_9; };
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool super.spaceprobe self.llvmPackages.llvm;
@@ -321,14 +260,6 @@ self: super: builtins.intersectAttrs super {
 
   # Patch to consider NIX_GHC just like xmonad does
   dyre = appendPatch super.dyre ./patches/dyre-nix.patch;
-
-  yesod-bin = if pkgs.stdenv.isDarwin
-    then addBuildDepend super.yesod-bin pkgs.darwin.apple_sdk.frameworks.Cocoa
-    else super.yesod-bin;
-
-  hmatrix = if pkgs.stdenv.isDarwin
-    then addBuildDepend super.hmatrix pkgs.darwin.apple_sdk.frameworks.Accelerate
-    else super.hmatrix;
 
   # https://github.com/edwinb/EpiVM/issues/13
   # https://github.com/edwinb/EpiVM/issues/14
@@ -405,43 +336,8 @@ self: super: builtins.intersectAttrs super {
   # Looks like Avahi provides the missing library
   dnssd = super.dnssd.override { dns_sd = pkgs.avahi.override { withLibdnssdCompat = true; }; };
 
-  # Ensure the necessary frameworks are propagatedBuildInputs on darwin
-  OpenGLRaw = overrideCabal super.OpenGLRaw (drv: {
-    librarySystemDepends =
-      pkgs.lib.optionals (!pkgs.stdenv.isDarwin) drv.librarySystemDepends;
-    libraryHaskellDepends = drv.libraryHaskellDepends
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-                            [ pkgs.darwin.apple_sdk.frameworks.OpenGL ];
-    preConfigure = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-      frameworkPaths=($(for i in $nativeBuildInputs; do if [ -d "$i"/Library/Frameworks ]; then echo "-F$i/Library/Frameworks"; fi done))
-      frameworkPaths=$(IFS=, ; echo "''${frameworkPaths[@]}")
-      configureFlags+=$(if [ -n "$frameworkPaths" ]; then echo -n "--ghc-options=-optl=$frameworkPaths"; fi)
-    '';
-  });
-  GLURaw = overrideCabal super.GLURaw (drv: {
-    librarySystemDepends =
-      pkgs.lib.optionals (!pkgs.stdenv.isDarwin) drv.librarySystemDepends;
-    libraryHaskellDepends = drv.libraryHaskellDepends
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-                            [ pkgs.darwin.apple_sdk.frameworks.OpenGL ];
-  });
-  bindings-GLFW = overrideCabal super.bindings-GLFW (drv: {
-    doCheck = false; # requires an active X11 display
-    librarySystemDepends =
-      pkgs.lib.optionals (!pkgs.stdenv.isDarwin) drv.librarySystemDepends;
-    libraryHaskellDepends = drv.libraryHaskellDepends
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-                            (with pkgs.darwin.apple_sdk.frameworks;
-                             [ AGL Cocoa OpenGL IOKit Kernel CoreVideo
-                               pkgs.darwin.CF ]);
-  });
-  OpenCL = overrideCabal super.OpenCL (drv: {
-    librarySystemDepends =
-      pkgs.lib.optionals (!pkgs.stdenv.isDarwin) drv.librarySystemDepends;
-    libraryHaskellDepends = drv.libraryHaskellDepends
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-                            [ pkgs.darwin.apple_sdk.frameworks.OpenCL ];
-  });
+  # requires an X11 display
+  bindings-GLFW = dontCheck super.bindings-GLFW;
 
   # requires an X11 display in test suite
   gi-gtk-declarative = dontCheck super.gi-gtk-declarative;
@@ -474,16 +370,8 @@ self: super: builtins.intersectAttrs super {
     testHaskellDepends = (drv.testHaskellDepends or []) ++ [ self.test-framework self.test-framework-hunit ];
   });
 
-  # cabal2nix likes to generate dependencies on hinotify when hfsevents is really required
-  # on darwin: https://github.com/NixOS/cabal2nix/issues/146.
-  hinotify = if pkgs.stdenv.isDarwin then self.hfsevents else super.hinotify;
-
-  # FSEvents API is very buggy and tests are unreliable. See
-  # http://openradar.appspot.com/10207999 and similar issues.
   # https://github.com/haskell-fswatch/hfsnotify/issues/62
-  fsnotify = if pkgs.stdenv.isDarwin
-    then addBuildDepend (dontCheck super.fsnotify) pkgs.darwin.apple_sdk.frameworks.Cocoa
-    else dontCheck super.fsnotify;
+  fsnotify = dontCheck super.fsnotify;
 
   hidapi = addExtraLibrary super.hidapi pkgs.udev;
 
@@ -843,21 +731,6 @@ self: super: builtins.intersectAttrs super {
         install -D man/pnbackup.1 $out/share/man/man1/pnbackup.1
       '' + (drv.postInstall or "");
     });
-
-  FractalArt = overrideCabal super.FractalArt (drv: {
-    librarySystemDepends = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-      pkgs.darwin.libobjc
-      pkgs.darwin.apple_sdk.frameworks.AppKit
-    ] ++ (drv.librarySystemDepends or []);
-  });
-
-  arbtt = overrideCabal super.arbtt (drv: {
-    librarySystemDepends = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-      pkgs.darwin.apple_sdk.frameworks.Foundation
-      pkgs.darwin.apple_sdk.frameworks.Carbon
-      pkgs.darwin.apple_sdk.frameworks.IOKit
-    ] ++ (drv.librarySystemDepends or []);
-  });
 
   # set more accurate set of platforms instead of maintaining
   # an ever growing list of platforms to exclude via unsupported-platforms

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -8,6 +8,7 @@
 , configurationCommon ? import ./configuration-common.nix
 , configurationNix ? import ./configuration-nix.nix
 , configurationArm ? import ./configuration-arm.nix
+, configurationDarwin ? import ./configuration-darwin.nix
 }:
 
 let
@@ -23,6 +24,8 @@ let
   isArm = with stdenv.hostPlatform; isAarch64 || isAarch32;
   platformConfigurations = lib.optionals isArm [
     (configurationArm { inherit pkgs haskellLib; })
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (configurationDarwin { inherit pkgs haskellLib; })
   ];
 
   extensions = lib.composeManyExtensions ([

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -7,6 +7,7 @@
 , nonHackagePackages ? import ./non-hackage-packages.nix
 , configurationCommon ? import ./configuration-common.nix
 , configurationNix ? import ./configuration-nix.nix
+, configurationArm ? import ./configuration-arm.nix
 }:
 
 let
@@ -19,14 +20,20 @@ let
     inherit stdenv haskellLib ghc buildHaskellPackages extensible-self all-cabal-hashes;
   };
 
-  extensions = lib.composeManyExtensions [
+  isArm = with stdenv.hostPlatform; isAarch64 || isAarch32;
+  platformConfigurations = lib.optionals isArm [
+    (configurationArm { inherit pkgs haskellLib; })
+  ];
+
+  extensions = lib.composeManyExtensions ([
     nonHackagePackages
     (configurationNix { inherit pkgs haskellLib; })
     (configurationCommon { inherit pkgs haskellLib; })
+  ] ++ platformConfigurations ++ [
     compilerConfig
     packageSetConfig
     overrides
-  ];
+  ]);
 
   extensible-self = makeExtensible (extends extensions haskellPackages);
 

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -19,17 +19,16 @@ let
     inherit stdenv haskellLib ghc buildHaskellPackages extensible-self all-cabal-hashes;
   };
 
-  commonConfiguration = configurationCommon { inherit pkgs haskellLib; };
-  nixConfiguration = configurationNix { inherit pkgs haskellLib; };
+  extensions = lib.composeManyExtensions [
+    nonHackagePackages
+    (configurationNix { inherit pkgs haskellLib; })
+    (configurationCommon { inherit pkgs haskellLib; })
+    compilerConfig
+    packageSetConfig
+    overrides
+  ];
 
-  extensible-self = makeExtensible
-    (extends overrides
-      (extends packageSetConfig
-        (extends compilerConfig
-          (extends commonConfiguration
-            (extends nixConfiguration
-              (extends nonHackagePackages
-                haskellPackages))))));
+  extensible-self = makeExtensible (extends extensions haskellPackages);
 
 in
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
