### PR TITLE
[staging-next] python3Packages.sphinx: fix build, enable tests, cleanup

### DIFF
--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -1,24 +1,18 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pytest
-, simplejson
-, mock
-, glibcLocales
-, html5lib
 , pythonOlder
-, enum34
-, python
-, docutils
-, jinja2
-, pygments
-, alabaster
+, fetchFromGitHub
+# propagatedBuildInputs
 , Babel
-, snowballstemmer
-, six
-, whoosh
+, alabaster
+, docutils
 , imagesize
+, jinja2
+, packaging
+, pygments
 , requests
+, setuptools
+, snowballstemmer
 , sphinxcontrib-applehelp
 , sphinxcontrib-devhelp
 , sphinxcontrib-htmlhelp
@@ -26,56 +20,70 @@
 , sphinxcontrib-qthelp
 , sphinxcontrib-serializinghtml
 , sphinxcontrib-websupport
-, typing ? null
-, setuptools
-, packaging
+# check phase
+, html5lib
+, imagemagick
+, pytestCheckHook
+, typed-ast
 }:
 
 buildPythonPackage rec {
   pname = "sphinx";
   version = "3.5.4";
-  src = fetchPypi {
-    pname = "Sphinx";
-    inherit version;
-    sha256 = "19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1";
-  };
-  LC_ALL = "en_US.UTF-8";
+  disabled = pythonOlder "3.5";
 
-  checkInputs = [ pytest ];
-  buildInputs = [ simplejson mock glibcLocales html5lib ] ++ lib.optional (pythonOlder "3.4") enum34;
-  # Disable two tests that require network access.
-  checkPhase = ''
-    cd tests; ${python.interpreter} run.py --ignore py35 -k 'not test_defaults and not test_anchors_ignored'
-  '';
+  src = fetchFromGitHub {
+    owner = "sphinx-doc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xjii3dl01rq8x2bsxc6zywiy1s7arfgxrg5l8ml54w1748shadd";
+  };
+
   propagatedBuildInputs = [
-    docutils
-    jinja2
-    pygments
-    alabaster
     Babel
+    alabaster
+    docutils
+    imagesize
+    jinja2
     packaging
+    pygments
+    requests
     setuptools
     snowballstemmer
-    six
-    whoosh
-    imagesize
-    requests
     sphinxcontrib-applehelp
     sphinxcontrib-devhelp
     sphinxcontrib-htmlhelp
     sphinxcontrib-jsmath
     sphinxcontrib-qthelp
     sphinxcontrib-serializinghtml
+    # extra[docs]
     sphinxcontrib-websupport
-  ] ++ lib.optional (pythonOlder "3.5") typing;
+  ];
 
-  # Lots of tests. Needs network as well at some point.
-  doCheck = false;
+  checkInputs = [
+    imagemagick
+    html5lib
+    pytestCheckHook
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typed-ast
+  ];
 
-  meta = {
-    description = "A tool that makes it easy to create intelligent and beautiful documentation for Python projects";
+  disabledTests = [
+    # requires network access
+    "test_anchors_ignored"
+    "test_defaults"
+    "test_defaults_json"
+    "test_latex_images"
+  ];
+
+  meta = with lib; {
+    description = "Python documentation generator";
+    longDescription = ''
+      A tool that makes it easy to create intelligent and beautiful
+      documentation for Python projects
+    '';
     homepage = "https://www.sphinx-doc.org";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ nand0p ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nand0p ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The sphinx package looks wholly undermaintained and broke due to an unnecessary dependency on `python3Packages.whoosh`.

https://hydra.nixos.org/build/142649615

staging-next #122068
ZHF #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
