### PR TITLE
numberstation: init at 0.4.0

### DIFF
--- a/pkgs/applications/misc/numberstation/default.nix
+++ b/pkgs/applications/misc/numberstation/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, python3
+, fetchFromSourcehut
+, desktop-file-utils
+, glib
+, gobject-introspection
+, gtk3
+, libhandy
+, librsvg
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "numberstation";
+  version = "0.4.0";
+
+  format = "other";
+
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = "numberstation";
+    rev = version;
+    sha256 = "038yyffqknr274f7jh5z12y68pjxr37f8y2cn2pwhf605jmbmpwv";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux/meson
+  '';
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    glib
+    gtk3
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    gtk3
+    libhandy
+    librsvg
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    keyring
+    pygobject3
+    pyotp
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    description = "TOTP Authentication application for mobile";
+    homepage = "https://sr.ht/~martijnbraam/numberstation/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7002,6 +7002,8 @@ in
 
   ntlmrecon = callPackage ../tools/security/ntlmrecon { };
 
+  numberstation = callPackage ../applications/misc/numberstation { };
+
   nvchecker = with python3Packages; toPythonApplication nvchecker;
 
   miller = callPackage ../tools/text/miller { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

~I haven't tested this yet cause I don't run a keyring.~
Tested now, also opening an `otpauth://` URL.