### PR TITLE
dockerTools testing update

### DIFF
--- a/nixos/tests/docker-tools-cross.nix
+++ b/nixos/tests/docker-tools-cross.nix
@@ -73,4 +73,7 @@ in {
             "docker rmi ${hello2.imageName}",
         )
   '';
+
+  # Remove when the formatter has been removed and a linter has been added
+  skipLint = true;
 })

--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "docker-tools-overlay";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ lnl7 ];
+    maintainers = [ lnl7 roberth ];
   };
 
   nodes = {

--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -30,4 +30,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       # drw------- 99 0 0 100 Apr 14 11:36 /nix/store
       docker.succeed("docker run --rm -u 1000:1000 ${pkgs.dockerTools.examples.bash.imageName} bash --version")
     '';
+
+  # Remove when the formatter has been removed and a linter has been added
+  skipLint = true;
 })

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -3,7 +3,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "docker-tools";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ lnl7 ];
+    maintainers = [ lnl7 roberth ];
   };
 
   nodes = {

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -365,4 +365,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             "docker run --rm ${examples.layeredImageWithFakeRootCommands.imageName} sh -c 'stat -c '%u' /home/jane | grep -E ^1000$'"
         )
   '';
+
+  # Remove when the formatter has been removed and a linter has been added
+  skipLint = true;
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - I forgot to add myself as maintainer earlier (although it's the PR reviews that matter; I don't think it caused any confusion)
 - Useless formatter is slowing progress of contributors: https://github.com/NixOS/nixpkgs/pull/80068#issuecomment-835324157
 - _Don't make me choose between contributors and tests!_

Yes, this is a unilateral decision. If you have been maintaining dockerTools tests and you disagree about the formatter, please let me know. Otherwise, make yourself useful. Thank you for understanding.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
