### PR TITLE
mamba: 1.8 -> 2.2

### DIFF
--- a/pkgs/applications/audio/mamba/default.nix
+++ b/pkgs/applications/audio/mamba/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchFromGitHub
 , pkg-config
+, xxd
 , cairo
 , fluidsynth
 , libX11
@@ -13,17 +14,17 @@
 
 stdenv.mkDerivation rec {
   pname = "mamba";
-  version = "1.8";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "Mamba";
     rev = "v${version}";
-    sha256 = "049gvdvvv3hkh1b47h0bia02g1p71agwh6g7q0n4yxz4d81b8kha";
+    sha256 = "1885qxyfkpslzk0aaaaws0x73b10h9nbr04jkk7xhkya25gf280m";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config xxd ];
   buildInputs = [ cairo fluidsynth libX11 libjack2 alsaLib liblo libsigcxx libsmf ];
 
   makeFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
###### Motivation for this change

Fixes recent build failure due to glib update.

Depends on `xxd` from vim during the build: `cd ../xputty/resources/ && xxd -i approved.png > ../../Build/approved.c`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
