### PR TITLE
nixos/testing-python.nix: Add skipFormatter

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -83,8 +83,10 @@ rec {
     { testScript
     , enableOCR ? false
     , name ? "unnamed"
-      # Skip linting (mainly intended for faster dev cycles)
+      # Skip linting (not advisable)
     , skipLint ? false
+      # Skip formatting check
+    , skipFormatter ? false
     , passthru ? {}
     , # For meta.position
       pos ? # position used in error messages and for meta.position
@@ -158,7 +160,7 @@ rec {
             mkdir -p $out/bin
 
             echo -n "$testScript" > $out/test-script
-            ${lib.optionalString (!skipLint) ''
+            ${lib.optionalString (!skipLint && !skipFormatter) ''
               ${python3Packages.black}/bin/black --check --diff $out/test-script
             ''}
 


### PR DESCRIPTION

###### Motivation for this change

Allow skipping the formatter without skipping the linters.

Python's `black` is not a linter, but a formatter.

> Black is the uncompromising Python code formatter.

-- [the black readme](https://github.com/psf/black)

Linting is a broader and more useful concept, with the goal of _improving_ code rather than _enforcing syntactic preferences_.

> lint, or a linter, is a static code analysis tool used to flag programming errors, bugs, stylistic errors and suspicious constructs.

-- [wikipedia](https://en.wikipedia.org/wiki/Lint_(software))

Unlike formatters, linters convey useful knowledge about potential problems, so those are actually useful.
That's not to say that enforcing a style isn't useful in general; it's just that it doesn't work well for our _generated_ code. The actual process of formatting can not currently be automated, so the annoyance of matching the expected layout by hand outweighs the annoyance of reading code in an inconsistent style _sometimes_.

Contributing to Nixpkgs shouldn't be needlessly unpleasant, especially if we want to be serious about testing. (Which we do)
Many developers don't enjoy writing tests in their free time, yet tests are crucial for the ability to improve existing code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
