### PR TITLE
nixos/testing-python.nix: Disable formatting, but keep black checks

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -148,6 +148,7 @@ rec {
           {
             buildInputs = [ makeWrapper ];
             testScript = testScript';
+            passAsFile = ["testScript"];
             preferLocalBuild = true;
             testName = name;
             passthru = passthru // {
@@ -157,7 +158,7 @@ rec {
           ''
             mkdir -p $out/bin
 
-            echo -n "$testScript" > $out/test-script
+            (echo "# fmt: off"; cat $testScriptPath) > $out/test-script
             ${lib.optionalString (!skipLint) ''
               ${python3Packages.black}/bin/black --check --diff $out/test-script
             ''}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Motivation: see https://github.com/NixOS/nixpkgs/pull/122197

This is a follow-up with @aszlig's suggestion.

It runs a syntax check early, and potentially other checks, although I doubt that it could be called a linter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
