### PR TITLE
haskellPackages.phonetic-languages-phonetics-basics: fix haddockPhase

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1899,4 +1899,6 @@ self: super: {
   # https://github.com/travitch/haggle/issues/4
   haggle = doJailbreak super.haggle;
 
+  phonetic-languages-phonetics-basics = appendPatch super.phonetic-languages-phonetics-basics ./patches/phonetic-languages-phonetics-basics-haddock.patch;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/patches/phonetic-languages-phonetics-basics-haddock.patch
+++ b/pkgs/development/haskell-modules/patches/phonetic-languages-phonetics-basics-haddock.patch
@@ -1,0 +1,46 @@
+diff -ru phonetic-languages-phonetics-basics-0.5.1.0/Data/Phonetic/Languages/SpecificationsRead.hs phonetic-languages-phonetics-basics-0.5.1.0/Data/Phonetic/Languages/SpecificationsRead.hs
+--- phonetic-languages-phonetics-basics-0.5.1.0/Data/Phonetic/Languages/SpecificationsRead.hs	2021-04-30 17:45:52.000000000 +0200
++++ phonetic-languages-phonetics-basics-0.5.1.0/Data/Phonetic/Languages/SpecificationsRead.hs	2021-05-08 18:16:15.054951952 +0200
+@@ -1,11 +1,11 @@
+--- |
+--- Module      :  Data.Phonetic.Languages.SpecificationsRead
+--- Copyright   :  (c) OleksandrZhabenko 2021
+--- License     :  MIT
+--- Stability   :  Experimental
+--- Maintainer  :  olexandr543@yahoo.com
+---
+-{-| Provides functions to read data specifications for other modules from textual files.
++{-|
++Module      :  Data.Phonetic.Languages.SpecificationsRead
++Copyright   :  (c) OleksandrZhabenko 2021
++License     :  MIT
++Stability   :  Experimental
++Maintainer  :  olexandr543@yahoo.com
++
++Provides functions to read data specifications for other modules from textual files.
+ -}
+ 
+ module Data.Phonetic.Languages.SpecificationsRead where
+diff -ru phonetic-languages-phonetics-basics-0.5.1.0/Main.hs phonetic-languages-phonetics-basics-0.5.1.0/Main.hs
+--- phonetic-languages-phonetics-basics-0.5.1.0/Main.hs	2021-04-30 17:45:52.000000000 +0200
++++ phonetic-languages-phonetics-basics-0.5.1.0/Main.hs	2021-05-08 18:14:06.344145599 +0200
+@@ -1,11 +1,11 @@
+--- |
+--- Module      :  Main
+--- Copyright   :  (c) OleksandrZhabenko 2020-2021
+--- License     :  MIT
+--- Stability   :  Experimental
+--- Maintainer  :  olexandr543@yahoo.com
+---
+-{-| Can be used to calculate the durations of the approximations of the phonemes
++{-|
++Module      :  Main
++Copyright   :  (c) OleksandrZhabenko 2020-2021
++License     :  MIT
++Stability   :  Experimental
++Maintainer  :  olexandr543@yahoo.com
++
++Can be used to calculate the durations of the approximations of the phonemes
+ using some prepared text with its correct (at least mostly) pronunciation.
+ The prepared text is located in the same directory and contains lines -the
+ phonetic language word and its duration in seconds separated with whitespace.


### PR DESCRIPTION
haddock 2.24.0 rejects double doc-comments on module
https://hydra.nixos.org/build/142423054/nixlog/2

Haven't found upstream repository so patching in-place (@OleksandrZhabenko is it on github?)
https://hackage.haskell.org/package/phonetic-languages-phonetics-basics

ZHF: #122042

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
