### PR TITLE
top-level/release-haskell.nix: merge jobs using lib.recursiveUpdate

### DIFF
--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -75,191 +75,197 @@ let
       _: v: builtins.length (v.meta.maintainers or []) > 0
     ) set);
 
-  jobs = mapTestOn {
-    haskellPackages = packagePlatforms pkgs.haskellPackages;
-    haskell.compiler = packagePlatforms pkgs.haskell.compiler;
+  recursiveUpdateMany = builtins.foldl' lib.recursiveUpdate {};
 
-    tests = let
-      testPlatforms = packagePlatforms pkgs.tests;
-    in {
-      haskell = testPlatforms.haskell;
-      writers = testPlatforms.writers;
-    };
+  jobs = mapTestOn (recursiveUpdateMany [
+    {
+      haskellPackages = packagePlatforms pkgs.haskellPackages;
+      haskell.compiler = packagePlatforms pkgs.haskell.compiler;
 
-    # top-level packages that depend on haskellPackages
-    inherit (pkgsPlatforms)
-      agda
-      arion
-      bench
-      bustle
-      blucontrol
-      cabal-install
-      cabal2nix
-      cachix
-      carp
-      cedille
-      client-ip-echo
-      darcs
-      dconf2nix
-      dhall
-      dhall-bash
-      dhall-docs
-      dhall-lsp-server
-      dhall-json
-      dhall-nix
-      dhall-text
-      diagrams-builder
-      elm2nix
-      fffuu
-      futhark
-      ghcid
-      git-annex
-      git-brunch
-      gitit
-      glirc
-      hadolint
-      haskell-ci
-      haskell-language-server
-      hasura-graphql-engine
-      hci
-      hercules-ci-agent
-      hinit
-      hedgewars
-      hledger
-      hledger-iadd
-      hledger-interest
-      hledger-ui
-      hledger-web
-      hlint
-      hpack
-      hyper-haskell
-      hyper-haskell-server-with-packages
-      icepeak
-      idris
-      ihaskell
-      jl
-      koka
-      krank
-      lambdabot
-      ldgallery
-      madlang
-      matterhorn
-      mueval
-      neuron-notes
-      niv
-      nix-delegate
-      nix-deploy
-      nix-diff
-      nix-linter
-      nix-output-monitor
-      nix-script
-      nix-tree
-      nixfmt
-      nota
-      ormolu
-      pandoc
-      pakcs
-      petrinizer
-      place-cursor-at
-      pinboard-notes-backup
-      pretty-simple
-      shake
-      shellcheck
-      sourceAndTags
-      spacecookie
-      spago
-      splot
-      stack
-      stack2nix
-      stutter
-      stylish-haskell
-      taffybar
-      tamarin-prover
-      taskell
-      termonad-with-packages
-      tldr-hs
-      tweet-hs
-      update-nix-fetchgit
-      uqm
-      uuagc
-      vaultenv
-      wstunnel
-      xmobar
-      xmonad-with-packages
-      yi
-      zsh-git-prompt
-      ;
-
-    elmPackages.elm = pkgsPlatforms.elmPackages.elm;
-  } // versionedCompilerJobs {
-    # Packages which should be checked on more than the
-    # default GHC version. This list can be used to test
-    # the state of the package set with newer compilers
-    # and to confirm that critical packages for the
-    # package sets (like Cabal, jailbreak-cabal) are
-    # working as expected.
-    cabal-install = all;
-    Cabal_3_4_0_0 = with compilerNames; [ ghc884 ghc8104 ];
-    funcmp = all;
-    haskell-language-server = all;
-    hoogle = all;
-    hsdns = all;
-    jailbreak-cabal = all;
-    language-nix = all;
-    nix-paths = all;
-    titlecase = all;
-  } // {
-    mergeable = pkgs.releaseTools.aggregate {
-      name = "haskell-updates-mergeable";
-      meta = {
-        description = ''
-          Critical haskell packages that should work at all times,
-          serves as minimum requirement for an update merge
-        '';
-        maintainers = lib.teams.haskell.members;
+      tests = let
+        testPlatforms = packagePlatforms pkgs.tests;
+      in {
+        haskell = testPlatforms.haskell;
+        writers = testPlatforms.writers;
       };
-      constituents = accumulateDerivations [
-        # haskell specific tests
-        jobs.tests.haskell
-        jobs.tests.writers # writeHaskell{,Bin}
-        # important top-level packages
-        jobs.cabal-install
-        jobs.cabal2nix
-        jobs.cachix
-        jobs.darcs
-        jobs.haskell-language-server
-        jobs.hledger
-        jobs.hledger-ui
-        jobs.hpack
-        jobs.niv
-        jobs.pandoc
-        jobs.stack
-        jobs.stylish-haskell
-        # important haskell (library) packages
-        jobs.haskellPackages.cabal-plan
-        jobs.haskellPackages.distribution-nixpkgs
-        jobs.haskellPackages.hackage-db
-        jobs.haskellPackages.policeman
-        jobs.haskellPackages.xmonad
-        jobs.haskellPackages.xmonad-contrib
-        # haskell packages maintained by @peti
-        # imported from the old hydra jobset
-        jobs.haskellPackages.hopenssl
-        jobs.haskellPackages.hsemail
-        jobs.haskellPackages.hsyslog
-      ];
-    };
-    maintained = pkgs.releaseTools.aggregate {
-      name = "maintained-haskell-packages";
-      meta = {
-        description = "Aggregate jobset of all haskell packages with a maintainer";
-        maintainers = lib.teams.haskell.members;
+
+      # top-level packages that depend on haskellPackages
+      inherit (pkgsPlatforms)
+        agda
+        arion
+        bench
+        bustle
+        blucontrol
+        cabal-install
+        cabal2nix
+        cachix
+        carp
+        cedille
+        client-ip-echo
+        darcs
+        dconf2nix
+        dhall
+        dhall-bash
+        dhall-docs
+        dhall-lsp-server
+        dhall-json
+        dhall-nix
+        dhall-text
+        diagrams-builder
+        elm2nix
+        fffuu
+        futhark
+        ghcid
+        git-annex
+        git-brunch
+        gitit
+        glirc
+        hadolint
+        haskell-ci
+        haskell-language-server
+        hasura-graphql-engine
+        hci
+        hercules-ci-agent
+        hinit
+        hedgewars
+        hledger
+        hledger-iadd
+        hledger-interest
+        hledger-ui
+        hledger-web
+        hlint
+        hpack
+        hyper-haskell
+        hyper-haskell-server-with-packages
+        icepeak
+        idris
+        ihaskell
+        jl
+        koka
+        krank
+        lambdabot
+        ldgallery
+        madlang
+        matterhorn
+        mueval
+        neuron-notes
+        niv
+        nix-delegate
+        nix-deploy
+        nix-diff
+        nix-linter
+        nix-output-monitor
+        nix-script
+        nix-tree
+        nixfmt
+        nota
+        ormolu
+        pandoc
+        pakcs
+        petrinizer
+        place-cursor-at
+        pinboard-notes-backup
+        pretty-simple
+        shake
+        shellcheck
+        sourceAndTags
+        spacecookie
+        spago
+        splot
+        stack
+        stack2nix
+        stutter
+        stylish-haskell
+        taffybar
+        tamarin-prover
+        taskell
+        termonad-with-packages
+        tldr-hs
+        tweet-hs
+        update-nix-fetchgit
+        uqm
+        uuagc
+        vaultenv
+        wstunnel
+        xmobar
+        xmonad-with-packages
+        yi
+        zsh-git-prompt
+        ;
+
+      elmPackages.elm = pkgsPlatforms.elmPackages.elm;
+    }
+    (versionedCompilerJobs {
+      # Packages which should be checked on more than the
+      # default GHC version. This list can be used to test
+      # the state of the package set with newer compilers
+      # and to confirm that critical packages for the
+      # package sets (like Cabal, jailbreak-cabal) are
+      # working as expected.
+      cabal-install = all;
+      Cabal_3_4_0_0 = with compilerNames; [ ghc884 ghc8104 ];
+      funcmp = all;
+      haskell-language-server = all;
+      hoogle = all;
+      hsdns = all;
+      jailbreak-cabal = all;
+      language-nix = all;
+      nix-paths = all;
+      titlecase = all;
+    })
+    {
+      mergeable = pkgs.releaseTools.aggregate {
+        name = "haskell-updates-mergeable";
+        meta = {
+          description = ''
+            Critical haskell packages that should work at all times,
+            serves as minimum requirement for an update merge
+          '';
+          maintainers = lib.teams.haskell.members;
+        };
+        constituents = accumulateDerivations [
+          # haskell specific tests
+          jobs.tests.haskell
+          jobs.tests.writers # writeHaskell{,Bin}
+          # important top-level packages
+          jobs.cabal-install
+          jobs.cabal2nix
+          jobs.cachix
+          jobs.darcs
+          jobs.haskell-language-server
+          jobs.hledger
+          jobs.hledger-ui
+          jobs.hpack
+          jobs.niv
+          jobs.pandoc
+          jobs.stack
+          jobs.stylish-haskell
+          # important haskell (library) packages
+          jobs.haskellPackages.cabal-plan
+          jobs.haskellPackages.distribution-nixpkgs
+          jobs.haskellPackages.hackage-db
+          jobs.haskellPackages.policeman
+          jobs.haskellPackages.xmonad
+          jobs.haskellPackages.xmonad-contrib
+          # haskell packages maintained by @peti
+          # imported from the old hydra jobset
+          jobs.haskellPackages.hopenssl
+          jobs.haskellPackages.hsemail
+          jobs.haskellPackages.hsyslog
+        ];
       };
-      constituents = accumulateDerivations
-        (builtins.map
-          (name: jobs.haskellPackages."${name}")
-          (maintainedPkgNames pkgs.haskellPackages));
-    };
-  };
+      maintained = pkgs.releaseTools.aggregate {
+        name = "maintained-haskell-packages";
+        meta = {
+          description = "Aggregate jobset of all haskell packages with a maintainer";
+          maintainers = lib.teams.haskell.members;
+        };
+        constituents = accumulateDerivations
+          (builtins.map
+            (name: jobs.haskellPackages."${name}")
+            (maintainedPkgNames pkgs.haskellPackages));
+      };
+    }
+  ]);
 
 in jobs


### PR DESCRIPTION
We have different attribute sets defining jobs: The list of base jobs,
the ones generated by versionedCompilerJobs and our added aggregate
jobs. During this we define `haskell` twice: Once for `haskell.compiler`
and once for `haskell.packages.*`. The `//` operator throws a way the
former which is fixed by using lib.recursiveUpdate.

Unfortunately makes the expression less pretty, but at least we have our
compiler jobs back.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
