### PR TITLE
filebot: fix source by using web archive

### DIFF
--- a/pkgs/applications/video/filebot/default.nix
+++ b/pkgs/applications/video/filebot/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   version = "4.9.3";
 
   src = fetchurl {
-    url = "https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
-    sha256 = "sha256-xgdCjo2RLp+EtUTfSiys7PURhnC00R9IOLPtz3427pA=";
+    url = "https://web.archive.org/web/20210326102451/https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
+    sha256 = "sha256-T+y8k757/qFCVOCc/SNc7a+KmyscPlowubNQYzMr8jY=";
   };
 
   unpackPhase = "tar xvf $src";


### PR DESCRIPTION
###### Motivation for this change
As noted [here](https://github.com/NixOS/nixpkgs/pull/114200#issuecomment-796231097) filebot's releases are updated with minor bug fixes without changing their version. They're published on the same URL which changes the hash.
Since the hash has already changed at least twice since inclusion of filebot in nixpkgs I'm replacing the source url with one from web archive as was also suggested in the original issue.

This issue is relevant for #122042.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
