### PR TITLE
pythonPackages.drf-nested-routers: 0.92.5 -> 0.93.3

### DIFF
--- a/pkgs/development/python-modules/drf-nested-routers/default.nix
+++ b/pkgs/development/python-modules/drf-nested-routers/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "drf-nested-routers";
-  version = "0.92.5";
+  version = "0.93.3";
 
   src = fetchFromGitHub {
     owner = "alanjds";
     repo = "drf-nested-routers";
     rev = "v${version}";
-    sha256 = "1l1jza8xz6xcm3gwxh1k6pc8fs95cq3v751gxj497y1a83d26j8i";
+    sha256 = "1gmw6gwiqzfysx8qn7aan7xgkizxy64db94z30pm3bvn6jxv08si";
   };
 
   propagatedBuildInputs = [ django djangorestframework setuptools ];


### PR DESCRIPTION
###### Motivation for this change
New version was released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
