### PR TITLE
spiped: 1.5.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/networking/spiped/default.nix
+++ b/pkgs/tools/networking/spiped/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace libcperciva/cpusupport/Build/cpusupport.sh \
       --replace "dirname" "${coreutils}/bin/dirname" \
       --replace "2>/dev/null" "2>stderr.log"
@@ -27,8 +27,10 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin $out/share/man/man1
     make install BINDIR=$out/bin MAN1DIR=$out/share/man/man1
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/tools/networking/spiped/default.nix
+++ b/pkgs/tools/networking/spiped/default.nix
@@ -20,11 +20,6 @@ stdenv.mkDerivation rec {
       --replace "rm" "${coreutils}/bin/rm"   \
       --replace "2>/dev/null" "2>stderr.log"
 
-    substituteInPlace POSIX/posix-cflags.sh  \
-      --replace "rm" "${coreutils}/bin/rm"   \
-      --replace ">/dev/stderr" ">stderr.log" \
-      --replace "2>/dev/null" "2>stderr.log"
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/networking/spiped/default.nix
+++ b/pkgs/tools/networking/spiped/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     substituteInPlace libcperciva/POSIX/posix-l.sh       \
       --replace "rm" "${coreutils}/bin/rm"   \
       --replace "2>/dev/null" "2>stderr.log"
-
+   '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/networking/spiped/default.nix
+++ b/pkgs/tools/networking/spiped/default.nix
@@ -2,22 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "spiped";
-  version = "1.5.0";
+  version = "1.6.1";
 
   src = fetchurl {
     url    = "https://www.tarsnap.com/spiped/${pname}-${version}.tgz";
-    sha256 = "1mxcbxifr3bnj6ga8lz88y4bhff016i6kjdzwbb3gzb2zcs4pxxj";
+    sha256 = "8d7089979db79a531a0ecc507b113ac6f2cf5f19305571eff1d3413e0ab33713";
   };
 
   buildInputs = [ openssl ];
 
   patchPhase = ''
     substituteInPlace libcperciva/cpusupport/Build/cpusupport.sh \
+      --replace "dirname" "${coreutils}/bin/dirname" \
       --replace "2>/dev/null" "2>stderr.log"
 
-    substituteInPlace POSIX/posix-l.sh       \
+    substituteInPlace libcperciva/POSIX/posix-l.sh       \
       --replace "rm" "${coreutils}/bin/rm"   \
-      --replace ">/dev/stderr" ">stderr.log" \
       --replace "2>/dev/null" "2>stderr.log"
 
     substituteInPlace POSIX/posix-cflags.sh  \


### PR DESCRIPTION
upgrade spiped from 1.5.0 to 1.6.1

This is my first PR to nix, so please let me know if I messed something up!



<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

upgrade spiped from 1.5.0 to 1.6.1, which is the new stable version per: https://www.tarsnap.com/spiped.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
