### PR TITLE
python3Packages.pillow-simd: 7.0.0.post3 -> 8.1.2 

### DIFF
--- a/pkgs/development/python-modules/pillow-simd/default.nix
+++ b/pkgs/development/python-modules/pillow-simd/default.nix
@@ -1,19 +1,20 @@
 { lib, stdenv, buildPythonPackage, fetchFromGitHub, isPyPy, isPy3k
 , olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2
-, tk, libX11, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
+, libxcb, tk, libX11, openjpeg, libimagequant, pyroma, numpy
+, pytestCheckHook
 }@args:
 
 import ../pillow/generic.nix (rec {
   pname = "Pillow-SIMD";
-  version = "7.0.0.post3";
+  version = "8.1.2";
 
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "uploadcare";
     repo = "pillow-simd";
-    rev = "v${version}";
-    sha256 = "1h832xp1bzf951hr4dmjmxqfsv28sx9lr2cq96qdz1c72k40zj1h";
+    rev = version;
+    sha256 = "1z0c1qpx7l1bhj71ww7za7kl29j5wdraqr2pdhv4dp1q74kgrr0m";
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/1x45s1cghzw1fnwmsbprjlspsnmj6xh1-python3.8-Pillow-SIMD-7.0.0.post3.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
