### PR TITLE
python39Packages.blist: fix build

### DIFF
--- a/pkgs/development/python-modules/blist/default.nix
+++ b/pkgs/development/python-modules/blist/default.nix
@@ -22,6 +22,12 @@ buildPythonPackage rec {
       url = "https://github.com/DanielStutzbach/blist/commit/2dc1ec28ed68611fcec9ac1c68070c782d6b4b4e.patch";
       sha256 = "0ma0z6ga80w3wzh3sidwd8ckfbgx4j1y7cc29q6j9ddrvxpf276y";
     })
+
+    # Fixes compatibility for Python 3.9 https://github.com/DanielStutzbach/blist/pull/91
+    (fetchpatch {
+      url = "https://github.com/DanielStutzbach/blist/pull/91/commits/e63514f805e42dc6a5708e629e4153d91bc90bff.patch";
+      sha256 = "1prx8znk7008v4ky7q2lx0pi6hzqd4kxgfdwbsr4zylwbrdqvsga";
+    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/zapd8y0apr9crzr8kwk1vf891f2z4160-python3.9-blist-1.3.6.drv
ZHF: #122042

I suppose [there's a dependency on this package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/instant-messengers/mirage/default.nix#L10), but otherwise this seems like a good candidate for removal, as upstream hasn't been updates since 2014.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
