### PR TITLE
eid-mw: 4.4.27 -> 5.0.21

### DIFF
--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "eid-mw";
-  version = "5.0.14";
+  version = "5.0.21";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    sha256 = "1hyxsbxjjn9hh5p7jlcfb5yplf3n8dg49dfgi8fjp95phis3gbd4";
+    sha256 = "1sz7996q6gd6vbdxqgyx1jwjznpki1k9zbgaj1j1a51y6w0g0kdh";
     repo = "eid-mw";
     owner = "Fedict";
   };

--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     substituteInPlace plugins_tools/eid-viewer/Makefile.in \
       --replace "c_rehash" "openssl rehash"
   '';
+  # pinentry uses hardcoded `/usr/bin/pinentry`, so use the built-in (uglier) dialogs for pinentry.
   configureFlags = [ "--disable-pinentry" ];
 
   postPatch = ''

--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation rec {
           firefox.override { pkcs11Modules = [ pkgs.eid-mw ]; }
     '';
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bfortz ];
+    maintainers = with maintainers; [ bfortz chvp ];
   };
 }

--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -20,6 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "eid-mw";
+  # NOTE: Don't just blindly update to the latest version/tag. Releases are always for a specific OS.
   version = "5.0.21";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Package bump. I also added myself as a maintainer, since I actively use this package and want to commit to keeping it up to date. Note that this is currently not the latest version (that would be 5.0.19), but unfortunately there is a failing test in the latest version.

EDIT: Actually, they do something weird with their releases. Each tag is a release for a specific OS. 5.0.14 is the latest tag for Linux, so I've changed it to that.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
