### PR TITLE
python3Packages.wordfeq: 2.3.2 -> 2.5

### DIFF
--- a/pkgs/development/python-modules/wordfreq/default.nix
+++ b/pkgs/development/python-modules/wordfreq/default.nix
@@ -6,38 +6,43 @@
 , msgpack
 , mecab-python3
 , jieba
-, pytest
-, pythonOlder
+, pytestCheckHook
+, isPy27
 , fetchFromGitHub
 }:
 
 buildPythonPackage rec {
   pname = "wordfreq";
-  version = "2.3.2";
-  disabled = pythonOlder "3";
+  version = "2.5";
+  disabled = isPy27;
 
    src = fetchFromGitHub {
     owner = "LuminosoInsight";
     repo = "wordfreq";
-    # upstream don't tag by version
     rev = "v${version}";
-    sha256 = "078657iiksrqzcc2wvwhiilf3xxq5vlinsv0kz03qzqr1qyvbmas";
+    sha256 = "09wzraddbdw3781pk2sxlz8knax9jrcl24ymz54wx6sk0gvq95i7";
    };
 
-  propagatedBuildInputs = [ regex langcodes ftfy msgpack mecab-python3 jieba ];
+  propagatedBuildInputs = [
+    regex
+    langcodes
+    ftfy
+    msgpack
+    mecab-python3
+    jieba
+  ];
 
-  # patch to relax version requirements for regex
-  # dependency to prevent break in upgrade
   postPatch = ''
     substituteInPlace setup.py --replace "regex ==" "regex >="
   '';
 
-  checkInputs = [ pytest ];
-
-  checkPhase = ''
-    # These languages require additional dictionaries
-    pytest tests -k 'not test_japanese and not test_korean and not test_languages and not test_french_and_related'
-  '';
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # These languages require additional dictionaries that aren't packaged
+    "test_languages"
+    "test_japanese"
+    "test_korean"
+  ];
 
   meta = with lib; {
     description = "A library for looking up the frequencies of words in many languages, based on many sources of data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/3wr5wfjmrh5wyh9v014xdp1wj71xmha2-python3.8-wordfreq-2.3.2.drv
ZHF: 122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
