### PR TITLE
yoda: fix a functionality regression in 1.9.0

### DIFF
--- a/pkgs/development/libraries/physics/yoda/default.nix
+++ b/pkgs/development/libraries/physics/yoda/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python, root, makeWrapper, zlib, withRootSupport ? false }:
+{ lib, stdenv, fetchurl, fetchpatch, python, root, makeWrapper, zlib, withRootSupport ? false }:
 
 stdenv.mkDerivation rec {
   pname = "yoda";
@@ -8,6 +8,24 @@ stdenv.mkDerivation rec {
     url = "https://www.hepforge.org/archive/yoda/YODA-${version}.tar.bz2";
     sha256 = "1x7xi6w7lb92x8202kbaxgqg1sly534wana4f38l3gpbzw9dwmcs";
   };
+
+  patches = [
+    # fix a minor bug
+    # https://gitlab.com/hepcedar/yoda/-/merge_requests/38
+    (fetchpatch {
+      name = "yoda-fix-fuzzy-compare-bin2d.patch";
+      url = "https://gitlab.com/hepcedar/yoda/-/commit/a2999d78cb3d9ed874f367bad375dc39a1a11148.diff";
+      sha256 = "sha256-BsaVm+4VtCvRoEuN4r6A4bj9XwgMe75UesKzN+b56Qw=";
+    })
+    # fix a regression
+    # https://gitlab.com/hepcedar/yoda/-/merge_requests/40
+    (fetchpatch {
+      name = "yoda-fix-for-yodagz.patch";
+      url = "https://gitlab.com/hepcedar/yoda/-/commit/3338ba5a7466599ac6969e4ae462f133d6cf4fd8.diff";
+      sha256 = "sha256-MZTOIt468bdPCS7UVfr5hQZUsVy3TpY/TjRrNySIL70=";
+      excludes = [ "ChangeLog" ];
+    })
+  ];
 
   nativeBuildInputs = with python.pkgs; [ cython makeWrapper ];
   buildInputs = [ python ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
