### PR TITLE
python3Packages.pyaftership: fix build

### DIFF
--- a/pkgs/development/python-modules/pyaftership/default.nix
+++ b/pkgs/development/python-modules/pyaftership/default.nix
@@ -1,4 +1,13 @@
-{ aiohttp, async-timeout, buildPythonPackage, fetchPypi, isPy3k, lib }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, aiohttp
+, async-timeout
+, aresponses
+, pytest-asyncio
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pyaftership";
@@ -6,16 +15,17 @@ buildPythonPackage rec {
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "28b62c323d06492399b60d8135a58d6feaa1d60837eddc14e57ea2b69d356c0a";
+  src = fetchFromGitHub {
+    owner = "ludeeus";
+    repo = pname;
+    rev = version;
+    sha256 = "0jyzgwaijkp80whi58a0hgjzmnlczmd9vwn11z2m0j01kbdwznn5";
   };
 
   propagatedBuildInputs = [ aiohttp async-timeout ];
 
-  # No tests
-  doCheck = false;
-  pythonImportsCheck = [ "pyaftership.tracker" ];
+  checkInputs = [ pytestCheckHook aresponses pytest-asyncio ];
+  pythonImportsCheck = [ "pyaftership" ];
 
   meta = with lib; {
     description = "Python wrapper package for the AfterShip API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/hgm701pwhspvgwl28i8y57rm67sf6b0p-python3.9-pyaftership-21.1.0.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
