### PR TITLE
python3Packages.pytest-ordering: mark as broken

### DIFF
--- a/pkgs/development/python-modules/pytest-ordering/default.nix
+++ b/pkgs/development/python-modules/pytest-ordering/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/ftobia/pytest-ordering";
     description = "Pytest plugin to run your tests in a specific order";
     license = licenses.mit;
+    broken = true;  # See https://github.com/NixOS/nixpkgs/pull/122264
     maintainers = with maintainers; [ eadwu ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* https://nix-cache.s3.amazonaws.com/log/0zm7d1929ar59bghi7s5pa3iyga5hhwq-python3.9-pytest-ordering-unstable-2019-06-19.drv
* https://nix-cache.s3.amazonaws.com/log/0x5jdp5gnzvlaps1ipm6cxjvrpq7z1gj-python3.8-pytest-ordering-unstable-2019-06-19.drv
* hasn't been updated in 2 years: https://github.com/ftobia/pytest-ordering
* nixpkgs already contains a comment about how this package is unmaintained and broken: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/ipfshttpclient/default.nix#L59
* no dependencies in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
