### PR TITLE
python3Packages.pyflume: fix build

### DIFF
--- a/pkgs/development/python-modules/pyflume/default.nix
+++ b/pkgs/development/python-modules/pyflume/default.nix
@@ -22,6 +22,13 @@ buildPythonPackage rec {
     sha256 = "1dm560hh6fl1waiwsq8m31apmvvwhc3y95bfdb7449bs8k96dmxq";
   };
 
+  prePatch = ''
+    substituteInPlace setup.py --replace 'pyjwt==2.0.1' 'pyjwt>=2.0.1'
+    substituteInPlace setup.py --replace 'ratelimit==2.2.1' 'ratelimit>=2.2.1'
+    substituteInPlace setup.py --replace 'pytz==2019.2' 'pytz>=2019.2'
+    substituteInPlace setup.py --replace 'requests==2.24.0' 'requests>=2.24.0'
+  '';
+
   propagatedBuildInputs = [
     pyjwt
     ratelimit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/f6cf68qnd5v4101zqq05g67afx6f44g4-python3.8-pyflume-0.6.4.drv
Package is extremely tight about version bounds: https://github.com/ChrisMandich/PyFlume/blob/master/setup.py#L23-L26
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
