### PR TITLE
kronosnet: 1.20 -> 1.21

### DIFF
--- a/pkgs/development/libraries/kronosnet/default.nix
+++ b/pkgs/development/libraries/kronosnet/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "kronosnet";
-  version = "1.20";
+  version = "1.21";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lP5W+4b9McU2Uqibh2SucIu2y4KluO3B1RpAJKgYq/M=";
+    sha256 = "14i4fl3g60gn5ay3dbwjcay3dnmnqr16zcp3g0wv9a3hjwh1if28";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config doxygen ];


### PR DESCRIPTION
###### Motivation for this change
got a hash mismatch in  #121298

closes:  #121298

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
