### PR TITLE
gb-backup: 2021-03-06 -> 2021-04-07

### DIFF
--- a/pkgs/tools/backup/gamerbackup/default.nix
+++ b/pkgs/tools/backup/gamerbackup/default.nix
@@ -1,24 +1,30 @@
-{ lib, buildGoModule, fetchFromGitHub, lepton }:
+{ lib, makeWrapper, buildGoModule, fetchFromGitHub, lepton }:
 
 buildGoModule {
   pname = "gb-backup";
-  version = "unstable-2021-03-06";
+  version = "unstable-2021-04-07";
 
   src = fetchFromGitHub {
     owner = "leijurv";
     repo = "gb";
-    rev = "5a94e60148628fc7796d15c53d0ed87184322053";
-    sha256 = "07skhwnxvm6yngb2665gkh5qbiyp7hb7av8dkckzypmd4k8z93cm";
+    rev = "904813bf0bbce048af5795618d58c0b1953f9ff8";
+    sha256 = "111jrcv4x38sc19xha5q3pd2297s13qh1maa7sa1k09hgypvgsxf";
   };
 
   vendorSha256 = "0m2aa6p04b4fs7zncar1mlykc94pp527phv71cdsbx58jgsm1jnx";
 
-  buildInputs = [ lepton ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  checkInputs = [ lepton ];
+
+  postFixup = ''
+    wrapProgram $out/bin/gb --prefix PATH : ${lib.makeBinPath [ lepton ]}
+  '';
 
   meta = with lib; {
     description = "Gamer Backup, a super opinionated cloud backup system";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ babbaj ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Along with updating the version I fixed lepton not actually being added to the PATH because I misunderstood what buildInputs did and changed the platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
