### PR TITLE
python3Packages.uvloop: disable problematic test on aarch64

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -44,8 +44,15 @@ buildPythonPackage rec {
     "--assert=plain"
     "--strict"
     "--tb=native"
+  ] ++ lib.optionals (stdenv.isAarch64) [
+    # test gets stuck in epoll_pwait on hydras aarch64 builders
+    # https://github.com/MagicStack/uvloop/issues/412
+    "--deselect" "tests/test_tcp.py::Test_AIO_TCPSSL::test_remote_shutdown_receives_trailing_data"
+  ];
+
+  disabledTestPaths = [
     # ignore code linting tests
-    "--ignore=tests/test_sourcecode.py"
+    "tests/test_sourcecode.py"
   ];
 
   # force using installed/compiled uvloop vs source by moving tests to temp dir


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This test case gets stuck on our aarch64 builder since the 0.15.0
upgrade, and so the package has not been in the cache for aarch64,
since the job reliably timed out.

The issue didn't get noticed earlier because the package does in fact
build on some aarch64 machines, like my raspberry pi 4.

Reported upstream at https://github.com/MagicStack/uvloop/issues/412.

ZHF #122042 

cc #118770

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (literally tested on the hydra builder that reproducibly got stuck on this test)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
============================= test session starts ==============================
platform linux -- Python 3.8.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /build/tmp.Tl3h685wCE
collected 489 items / 1 deselected / 488 selected                              

tests/test_aiohttp.py ....
tests/test_base.py ...............................................................................s...
tests/test_context.py ..................s....s......
tests/test_cython.py .
tests/test_dealloc.py .
tests/test_dns.py ....................s..............................
tests/test_executors.py ....
tests/test_pipes.py ............
tests/test_process.py ...............................................................................
tests/test_process_spawning.py .
tests/test_regr1.py .
tests/test_signals.py s...................
tests/test_sockets.py ...............s.........ss..s.....
tests/test_tcp.py ..............................s.................................................s.s.ss.ssssss..s..ssssssss
tests/test_testbase.py ...
tests/test_udp.py .......................
tests/test_unix.py ..................................

=============================== warnings summary ===============================
../../nix/store/z5jg2q4h3smqfbxddsnxg25h89g6088p-python3.8-pytest-6.2.3/lib/python3.8/site-packages/_pytest/config/__init__.py:1183
  /nix/store/z5jg2q4h3smqfbxddsnxg25h89g6088p-python3.8-pytest-6.2.3/lib/python3.8/site-packages/_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===== 459 passed, 29 skipped, 1 deselected, 1 warning in 118.16s (0:01:58) =====
/build/uvloop-0.15.2
Finished executing pytestCheckPhase
pytestcachePhase
/nix/store/mpcpl3ml06x0p3ac76f74yl32xwp0kmj-python3.8-uvloop-0.15.2
```