### PR TITLE
pycflow2dot: init at 0.2.3

### DIFF
--- a/pkgs/development/python-modules/pycflow2dot/default.nix
+++ b/pkgs/development/python-modules/pycflow2dot/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cflow
+, graphviz
+, pydot
+, networkx
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "pycflow2dot";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zm8x2pd0q6zza0fw7hg9g1qvybfnjq6ql9b8mh2fc45l7l25655";
+  };
+
+  propagatedBuildInputs = [
+    cflow
+    graphviz
+    pydot
+    networkx
+    which
+  ];
+
+  pythonImportsCheck = [ "pycflow2dot" ];
+  checkPhase = ''
+    cd tests
+    export PATH=$out/bin:$PATH
+    make all
+  '';
+
+  meta = with lib; {
+    description = "Layout C call graphs from cflow using GraphViz dot";
+    homepage    = "https://github.com/johnyf/pycflow2dot";
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7794,6 +7794,8 @@ in
 
   pycangjie = pythonPackages.pycangjie;
 
+  pycflow2dot = with python.pkgs; toPythonApplication pycflow2dot;
+
   pydb = callPackage ../development/tools/pydb { };
 
   pydf = callPackage ../applications/misc/pydf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5372,6 +5372,10 @@ in {
 
   pycfdns = callPackage ../development/python-modules/pycfdns { };
 
+  pycflow2dot = callPackage ../development/python-modules/pycflow2dot {
+    inherit (pkgs) graphviz;
+  };
+
   pychannels = callPackage ../development/python-modules/pychannels { };
 
   pychart = callPackage ../development/python-modules/pychart { };


### PR DESCRIPTION
###### Motivation for this change
<details><summary>pretty graphs</summary>

![image](https://user-images.githubusercontent.com/30512529/117562154-172b4d80-b09d-11eb-8089-fe45e7ba0d6d.png)
</details>


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/b7pzfnwx37z1571vzjjnszvwh9hbnniy-python2.7-pycflow2dot-0.2.3	  358191208`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
