### PR TITLE
nzbhydra2: 3.13.2 -> 3.14.1

### DIFF
--- a/pkgs/servers/nzbhydra2/default.nix
+++ b/pkgs/servers/nzbhydra2/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nzbhydra2";
-  version = "3.13.2";
+  version = "3.14.1";
 
   src = fetchzip {
     url = "https://github.com/theotherp/${pname}/releases/download/v${version}/${pname}-${version}-linux.zip";
-    sha512 = "2pi91y966qnq6q9qqnhglmbj4610jxyyqxiwa8zfmb8r48mzwzy3q5ga00h9qbhi6a8ghrfh1yvj4h9m17gk7l3rc5fw0r3mrk437nj";
+    sha512 = "2mfrqqwrfjvr48vm4r0spda3vlg1h511r6hrlv7k9233ps97bjjir6hms82lgqnlirsixayxs47cldjy8amdn3vc6kxsifmbd6a924p";
     stripRoot = false;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release https://github.com/theotherp/nzbhydra2/releases/tag/v3.14.1 ([changes](https://github.com/theotherp/nzbhydra2/compare/v3.13.2...v3.14.1)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/72xsbby3qfqikshnrdb9cr0wmlp21vss-nzbhydra2-3.13.2	 1339757776
/nix/store/7gq5hyzw7zxasn6f5lvxfg7rrb132z8x-nzbhydra2-3.14.1	 1340430696
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
