### PR TITLE
python3Packages.pyexcel-xls: unbreak

### DIFF
--- a/pkgs/development/python-modules/pyexcel-xls/default.nix
+++ b/pkgs/development/python-modules/pyexcel-xls/default.nix
@@ -30,7 +30,11 @@ buildPythonPackage rec {
     mock
   ];
 
-  checkPhase = "nosetests";
+  postPatch = ''
+    substituteInPlace setup.py --replace "xlrd<2" "xlrd<3"
+  '';
+
+  checkPhase = "nosetests --exclude test_issue_151";
 
   meta = {
     description = "A wrapper library to read, manipulate and write data in xls using xlrd and xlwt";


### PR DESCRIPTION
ZHF: #122042

Removed the `<2` restriction for the xlrd dependency.
Related upstream issue: https://github.com/pyexcel/pyexcel-xls/issues/46
Since xlrd 2 dropped support for the .xlsx format, I had to remove one test involving the xlsx format.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
