### PR TITLE
scli: init at 0.6.1

### DIFF
--- a/pkgs/applications/misc/scli/default.nix
+++ b/pkgs/applications/misc/scli/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonApplication, fetchFromGitHub, signal-cli, urwid
+, urwid-readline, dbus }:
+
+buildPythonApplication rec {
+  pname = "scli";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "isamert";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-hWzpqj/sxPq/doxdmytnj5rh2qKQE71WMB0ugomWhHg";
+  };
+
+  propagatedBuildInputs = [ signal-cli urwid urwid-readline dbus ];
+  dontBuild = true;
+
+  checkPhase = ''
+    # scli attempts to write to these directories, make sure they're writeable
+    export XDG_DATA_HOME=$(mktemp -d)
+    export XDG_CONFIG_HOME=$(mktemp -d)
+    ./scli --help > /dev/null # don't spam nix-build log
+    test $? == 0
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    patchShebangs scli
+    install -m755 -D scli $out/bin/scli
+  '';
+
+  meta = with lib; {
+    description = "Simple terminal user interface for Signal";
+    homepage = "https://github.com/isamert/scli";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ alex-eyre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26244,6 +26244,8 @@ in
 
   scite = callPackage ../applications/editors/scite { };
 
+  scli = with python3Packages; callPackage ../applications/misc/scli { };
+
   scribus = callPackage ../applications/office/scribus {
     inherit (gnome2) libart_lgpl;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Response to #120615

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Improvements To-Do
- Find a way to implement a useful checkPhase