### PR TITLE
python3Packages.hg-commitsigs: init at unstable-2021-01-08

### DIFF
--- a/pkgs/development/python-modules/hg-commitsigs/default.nix
+++ b/pkgs/development/python-modules/hg-commitsigs/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchhg
+, stdenv
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hg-commitsigs";
+  # Latest tag is 11 years old.
+  version = "unstable-2021-01-08";
+
+  src = fetchhg {
+    url = "https://foss.heptapod.net/mercurial/commitsigs";
+    rev = "b53eb6862bff";
+    sha256 = "sha256-PS1OhC9MiVFD7WYlIn6FavD5TyhM50WoV6YagI2pLxU=";
+  };
+
+  # Not sure how the tests are supposed to be run, and they 10 years old...
+  doCheck = false;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/${python3.libPrefix}/site-packages/hgext3rd/
+    install -D $src/commitsigs.py \
+               $out/lib/${python3.libPrefix}/site-packages/hgext3rd/
+  '';
+
+  meta = with lib; {
+    description = "Automatic signing of changeset hashes";
+    longDescription = ''
+      This packages provides a Mercurial extension that lets you sign
+      the changeset hash when you commit.  The signature is embedded
+      directly in the changeset itself; there wont be any extra
+      commits.  Either GnuPG or OpenSSL can be used to sign the hashes.
+    '';
+    homepage = "https://foss.heptapod.net/mercurial/commitsigs";
+    maintainers = with maintainers; [ yoctocell ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix; # same as Mercurial
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3025,6 +3025,8 @@ in {
 
   heudiconv = callPackage ../development/python-modules/heudiconv { };
 
+  hg-commitsigs = callPackage ../development/python-modules/hg-commitsigs { };
+
   hg-evolve = callPackage ../development/python-modules/hg-evolve { };
 
   hglib = callPackage ../development/python-modules/hglib { };


### PR DESCRIPTION
A Mercurial extension for signing changesets.

If people want to be able to use this extension they have to manually
set their `PYTHONPATH` to
`/nix/store/...-profile/lib/python3.8/site-packages/hgext3rd`.  It
would be nice if we could make the Mercurial package automatically
read things from this directory without any intervention from the
user.

CC: @lukegb 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
