### PR TITLE
eukleides: Fix build, expose tex package

### DIFF
--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -1,21 +1,49 @@
-{ lib, stdenv, fetchurl, bison, flex, texinfo, readline, texLive }:
+{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo, readline, texLive }:
 
-let
-  name    = "eukleides";
+lib.fix (eukleides: stdenv.mkDerivation rec {
+  pname = "eukleides";
   version = "1.5.4";
-in
-stdenv.mkDerivation {
-  name = "${name}-${version}";
 
   src = fetchurl {
-    url = "http://www.eukleides.org/files/${name}-${version}.tar.bz2";
+    url = "http://www.eukleides.org/files/${pname}-${version}.tar.bz2";
     sha256 = "0s8cyh75hdj89v6kpm3z24i48yzpkr8qf0cwxbs9ijxj1i38ki0q";
   };
 
-  buildInputs = [bison flex texinfo readline texLive];
+  nativeBuildInputs = [ bison flex texinfo makeWrapper ];
 
-  preConfigure = "sed -i 's/ginstall-info/install-info/g' doc/Makefile";
-  installPhase = "mkdir -p $out/bin ; make PREFIX=$out install";
+  buildInputs = [ readline texLive ];
+
+  preConfigure = ''
+    substituteInPlace Makefile \
+      --replace mktexlsr true
+
+    substituteInPlace doc/Makefile \
+      --replace ginstall-info install-info
+
+    substituteInPlace Config \
+      --replace '/usr/local' "$out" \
+      --replace '$(SHARE_DIR)/texmf' "$tex"
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/euktoeps \
+      --set-default TEXINPUTS : \
+      --prefix TEXINPUTS : "$tex/tex/latex/eukleides" \
+      --prefix PATH : "${texLive}/bin"
+    wrapProgram $out/bin/euktopdf \
+      --set-default TEXINPUTS : \
+      --prefix TEXINPUTS : "$tex/tex/latex/eukleides" \
+      --prefix PATH : "${texLive}/bin"
+  '';
+
+  outputs = [ "out" "doc" "tex" ];
+
+  passthru.tlType = "run";
+  passthru.pkgs = [ eukleides.tex ];
 
   meta = {
     description = "Geometry Drawing Language";
@@ -34,4 +62,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.peti ];
   };
-}
+})

--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -48,7 +48,7 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
   meta = {
     description = "Geometry Drawing Language";
     homepage = "http://www.eukleides.org/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl3Plus;
 
     longDescription = ''
       Eukleides is a computer language devoted to elementary plane


### PR DESCRIPTION
##### Motivation for this change

ZHF: #122042

Also: #122118

This PR as it stands fixes the build by removing the mktexls call that was broken by the upgrade to texlive 2020.
It also allows the LaTeX style part of the package to be used to create a combined texlive environment.

However, this package installs a shell script that invokes latex, and I think the correct solution would be to rewrite that invocation to point at a combined texlive that includes eukleides itself, but I keep running into recursion problems.

Not pinging the release managers on this yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
