### PR TITLE
Cargo-binutils: add explanation

### DIFF
--- a/pkgs/development/tools/rust/cargo-binutils/default.nix
+++ b/pkgs/development/tools/rust/cargo-binutils/default.nix
@@ -5,13 +5,14 @@ rustPlatform.buildRustPackage rec {
   version = "0.3.3";
 
   # Upstream doesn't commit `Cargo.lock`, see https://github.com/rust-embedded/cargo-binutils/pull/99
-  src = let
-    repo = fetchFromGitHub {
-      owner = "rust-embedded";
-      repo = pname;
-      rev = "v${version}";
-      sha256 = "sha256-Dgn+f4aSsDSh+RC8yvt3ydkdtwib5jEVsnZkod5c7Vo=";
-    };
+  src =
+    let
+      repo = fetchFromGitHub {
+        owner = "rust-embedded";
+        repo = pname;
+        rev = "v${version}";
+        sha256 = "sha256-Dgn+f4aSsDSh+RC8yvt3ydkdtwib5jEVsnZkod5c7Vo=";
+      };
   in runCommand "source" { } ''
     cp -R ${repo} $out
     chmod -R +w $out

--- a/pkgs/development/tools/rust/cargo-binutils/default.nix
+++ b/pkgs/development/tools/rust/cargo-binutils/default.nix
@@ -13,16 +13,20 @@ rustPlatform.buildRustPackage rec {
         rev = "v${version}";
         sha256 = "sha256-Dgn+f4aSsDSh+RC8yvt3ydkdtwib5jEVsnZkod5c7Vo=";
       };
-  in runCommand "source" { } ''
-    cp -R ${repo} $out
-    chmod -R +w $out
-    cp ${./Cargo.lock} $out/Cargo.lock
-  '';
+    in
+    runCommand "source" { } ''
+      cp -R ${repo} $out
+      chmod -R +w $out
+      cp ${./Cargo.lock} $out/Cargo.lock
+    '';
 
   cargoSha256 = "sha256-Zrl269PacPi81TrGTIDzmVndgGY5i5lYyspiOj43rpw=";
 
   meta = with lib; {
-    description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain";
+    description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain.";
+    longDescription = ''
+      In order for this to work, you either need to run `rustup component add llvm-tools-preview` or install the `llvm-tools-preview` component using your Nix library (e.g. nixpkgs-mozilla, or rust-overlay)
+    '';
     homepage = "https://github.com/rust-embedded/cargo-binutils";
     license = with licenses; [ asl20 mit ];
     maintainers = with maintainers; [ stupremee ];


### PR DESCRIPTION
###### Motivation for this change
cargo-binutils doesn't work out of the box. This adds a small explanation on what is needed to make it work


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@Stupremee Let me know what you think.

closes #122166 
