### PR TITLE
dua: 2.11.2 -> 2.11.3

### DIFF
--- a/pkgs/tools/misc/dua/default.nix
+++ b/pkgs/tools/misc/dua/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "dua";
-  version = "2.11.2";
+  version = "2.11.3";
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
     owner = "Byron";
     repo = "dua-cli";
     rev = "v${version}";
-    sha256 = "sha256-sT4hg5MC6xuhSKeNxaVY9vOlMEx23uwxgK6UMLO4kVs=";
+    sha256 = "sha256-rwbeWjYhAgZhQDg1/Pux08Kw+7NQG7dJlhZnwlaEjJ4=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     extraPostFetch = ''
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
     '';
   };
 
-  cargoSha256 = "sha256-DOotIN8XScgHR9L6aFgky2B18piGIKfLWx1GTdYnCB0=";
+  cargoSha256 = "sha256-ta5mHTfSs72HUz3ezZhVvU61ECvyWY3Sba7/UoJGc8U=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

minor version update
here is the changelog
https://github.com/Byron/dua-cli/blob/v2.11.3/CHANGELOG.md
leaving this open for 12 hours in case @killercup you want to have a look.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
