### PR TITLE
python3Packages.flask-appbuilder: unbreak

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -6,6 +6,7 @@
 , colorama
 , click
 , email_validator
+, fetchpatch
 , flask
 , flask-babel
 , flask_login
@@ -20,21 +21,27 @@
 , python-dateutil
 , prison
 , pyjwt
+, pyyaml
 , sqlalchemy-utils
 }:
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "3.1.1";
+  version = "3.2.3";
 
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "076b020b0ba125339a2e710e74eab52648cde2b18599f7cb0fa1eada9bbb648c";
+    sha256 = "sha256-+ZYrn2LnVORyYsnZtsH3JX+4XbGgAZZ/Eh6O5gUP+y4=";
   };
 
-  checkInputs = [
-    nose
+  patches = [
+    (fetchpatch {
+      name = "flask_jwt_extended-and-pyjwt-patch";
+      url = "https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch";
+      sha256 = "sha256-ZpY8+2Hoz3z01GVtw2OIbQcsmAwa7iwilFWzgcGhY1w=";
+      includes = [ "flask_appbuilder/security/manager.py" "setup.py" ];
+    })
   ];
 
   propagatedBuildInputs = [
@@ -56,21 +63,22 @@ buildPythonPackage rec {
     python-dateutil
     prison
     pyjwt
+    pyyaml
     sqlalchemy-utils
   ];
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "apispec[yaml]>=3.3, <4" "apispec" \
-      --replace "Flask-Login>=0.3, <0.5" "Flask-Login" \
-      --replace "Flask-Babel>=1, <2" "Flask-Babel" \
-      --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy" \
-      --replace "prison>=0.1.3, <1.0.0" "prison"
+      --replace "apispec[yaml]>=3.3, <4" "apispec[yaml] >=3.3, <5" \
+      --replace "Flask-Login>=0.3, <0.5" "Flask-Login >=0.3, <0.6" \
+      --replace "Flask-Babel>=1, <2" "Flask-Babel >=1, <3" \
+      --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy >=0.22.0, <0.25.0"
   '';
-
 
   # majority of tests require network access or mongo
   doCheck = false;
+
+  pythonImportsCheck = [ "flask_appbuilder" ];
 
   meta = with lib; {
     description = "Simple and rapid application development framework, built on top of Flask";

--- a/pkgs/development/python-modules/prison/default.nix
+++ b/pkgs/development/python-modules/prison/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "prison";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "betodealmeida";
     repo = "python-rison";
     rev = version;
-    sha256 = "14vb468iznf9416z993bbqihywp9ibyslw5vp67wfr200zyxjwak";
+    sha256 = "sha256-qor40vUQeTdlO3vwug3GGNX5vkNaF0H7EWlRdsY4bvc=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
ZHF: #122042

- bumped `prison` from 0.1.2 to 0.1.3
- included patch from upstream PR: https://github.com/dpgaspar/Flask-AppBuilder/pull/1610 (modified)
- limited the restrictions set in postPatch a bit more, to prevent accidental future breakages

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
