### PR TITLE
libsForQt5.mauikit: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/applications/misc/index-fm/default.nix
+++ b/pkgs/applications/misc/index-fm/default.nix
@@ -3,27 +3,28 @@
 , fetchFromGitLab
 , cmake
 , extra-cmake-modules
-, breeze-icons
+, applet-window-buttons
 , karchive
 , kcoreaddons
 , ki18n
 , kio
 , kirigami2
 , mauikit
+, mauikit-filebrowsing
 , qtmultimedia
 , qtquickcontrols2
 }:
 
 mkDerivation rec {
   pname = "index";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "index-fm";
     rev = "v${version}";
-    sha256 = "1v6z44c88cqgr3b758yq6l5d2zj1vhlnaq7v8rrhs7s5dsimzlx8";
+    sha256 = "sha256-N9/Jt18QRqDMWtEfxWn22e5Ud3YMwJ9B7OQRwTvwX8g=";
   };
 
   nativeBuildInputs = [
@@ -32,13 +33,14 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    breeze-icons
+    applet-window-buttons
     karchive
     kcoreaddons
     ki18n
     kio
     kirigami2
     mauikit
+    mauikit-filebrowsing
     qtmultimedia
     qtquickcontrols2
   ];

--- a/pkgs/development/libraries/applet-window-buttons/default.nix
+++ b/pkgs/development/libraries/applet-window-buttons/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, extra-cmake-modules
+, kcoreaddons
+, kdeclarative
+, kdecoration
+, plasma-framework
+}:
+
+mkDerivation rec {
+  pname = "applet-window-buttons";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "psifidotos";
+    repo = "applet-window-buttons";
+    rev = version;
+    sha256 = "0r1h4kbdv6pxj15w4n1w50g8zsl0jrc4808dyfygzwf87mghziyz";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-compilation-error-with-plasma-5.21.patch";
+      url = "https://github.com/psifidotos/applet-window-buttons/commit/dc5ed862fa3cb943f9c0d561c864ff461156a19e.patch";
+      sha256 = "17bdkkmy7k402viynj2bpw281qzsn0f1w8gf98gq65wkm4sf4j6k";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    kdeclarative
+    kdecoration
+    plasma-framework
+  ];
+
+  meta = with lib; {
+    description = "Plasma 5 applet in order to show window buttons in your panels";
+    homepage = "https://github.com/psifidotos/applet-window-buttons";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/mauikit-filebrowsing/default.nix
+++ b/pkgs/development/libraries/mauikit-filebrowsing/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, kconfig
+, kio
+, mauikit
+}:
+
+mkDerivation rec {
+  pname = "mauikit-filebrowsing";
+  version = "1.2.2";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "mauikit-filebrowsing";
+    rev = "v${version}";
+    sha256 = "1m56lil7w884wn8qycl7y55abvw2vanfy8c4g786200p6acsh3kl";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    kio
+    mauikit
+  ];
+
+  meta = with lib; {
+    homepage = "https://invent.kde.org/maui/mauikit-filebrowsing";
+    description = "MauiKit File Browsing utilities and controls";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/libraries/mauikit/default.nix
+++ b/pkgs/development/libraries/mauikit/default.nix
@@ -3,22 +3,23 @@
 , fetchFromGitLab
 , cmake
 , extra-cmake-modules
-, kio
+, kconfig
+, kcoreaddons
+, ki18n
 , qtbase
 , qtquickcontrols2
-, syntax-highlighting
 }:
 
 mkDerivation rec {
   pname = "mauikit";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "mauikit";
     rev = "v${version}";
-    sha256 = "1wimbpbn9yqqdcjd59x83z0mw2fycjz09py2rwimfi8ldmvi5lgy";
+    sha256 = "1jz0a65bbznjg7aaq19rdyp956wn6xc1x4xigfkhj6mwsvnb49av";
   };
 
   nativeBuildInputs = [
@@ -27,9 +28,10 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    kio
+    kconfig
+    kcoreaddons
+    ki18n
     qtquickcontrols2
-    syntax-highlighting
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -53,6 +53,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // 
 
   alkimia = callPackage ../development/libraries/alkimia { };
 
+  applet-window-buttons = callPackage ../development/libraries/applet-window-buttons { };
+
   appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
 
   dxflib = callPackage ../development/libraries/dxflib {};

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -121,6 +121,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeApplications // qt5 // 
 
   mauikit = callPackage ../development/libraries/mauikit { };
 
+  mauikit-filebrowsing = callPackage ../development/libraries/mauikit-filebrowsing { };
+
   mlt = callPackage ../development/libraries/mlt/qt-5.nix { };
 
   openbr = callPackage ../development/libraries/openbr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Index fails to run with
```
URL recived is not a local file QUrl("/home/rschuetz/.local/share/maui/accounts.db")
ACCOUNTS LIST QVector()
QFileSystemWatcher::addPaths: list is empty
QQmlApplicationEngine failed to load component
qrc:/main.qml:14:1: module "org.kde.mauikit" is not installed
```
and I have no clue why, so I filed an upstream issue: https://invent.kde.org/maui/index-fm/-/issues/42.