### PR TITLE
webkitgtk: Fix bubblewrap opengl-driver path

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -53,6 +53,7 @@
 , xdg-dbus-proxy
 , substituteAll
 , glib
+, addOpenGLRunpath
 }:
 
 assert enableGeoLocation -> geoclue2 != null;
@@ -76,6 +77,7 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-bubblewrap-paths.patch;
       inherit (builtins) storeDir;
+      inherit (addOpenGLRunpath) driverLink;
     })
     ./libglvnd-headers.patch
   ];

--- a/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
+++ b/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
@@ -1,16 +1,7 @@
 diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
 --- old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp	2019-09-09 04:47:07.000000000 -0400
 +++ webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp	2019-09-20 21:14:10.537921173 -0400
-@@ -585,7 +585,7 @@
-         { SCMP_SYS(keyctl), nullptr },
-         { SCMP_SYS(request_key), nullptr },
- 
--        // Scary VM/NUMA ops 
-+        // Scary VM/NUMA ops
-         { SCMP_SYS(move_pages), nullptr },
-         { SCMP_SYS(mbind), nullptr },
-         { SCMP_SYS(get_mempolicy), nullptr },
-@@ -724,6 +724,11 @@
+@@ -724,6 +724,12 @@
          "--ro-bind-try", "/usr/local/lib64", "/usr/local/lib64",
  
          "--ro-bind-try", PKGLIBEXECDIR, PKGLIBEXECDIR,
@@ -18,7 +9,8 @@ diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLa
 +        // Nix Directories
 +        "--ro-bind", "@storeDir@", "@storeDir@",
 +        "--ro-bind", "/run/current-system", "/run/current-system",
-+        "--ro-bind", "/run/opengl-driver", "/run/opengl-driver",
++        "--ro-bind-try", "@driverLink@/lib", "@driverLink@/lib",
++        "--ro-bind-try", "@driverLink@/share", "@driverLink@/share",
      };
      // We would have to parse ld config files for more info.
      bindPathVar(sandboxArgs, "LD_LIBRARY_PATH");


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
If `/run/opengl-driver/lib` is in `LD_LIBRARY_PATH`, bwrap will try to mount it into the already bind mounted `/run/opengl-driver`. To prevent this, we instead specify the subpaths of `/run/opengl-driver`we're interested in.

Fixes #121603.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
