### PR TITLE
python3Packages.gpapi: unbreak

### DIFF
--- a/pkgs/development/python-modules/gpapi/default.nix
+++ b/pkgs/development/python-modules/gpapi/default.nix
@@ -1,7 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
-, requests
+{ buildPythonPackage
+, cryptography
+, fetchPypi
+, lib
+, pythonOlder
 , protobuf
 , pycryptodome
+, requests
 }:
 
 buildPythonPackage rec {
@@ -14,11 +18,15 @@ buildPythonPackage rec {
     sha256 = "0ampvsv97r3hy1cakif4kmyk1ynf3scbvh4fbk02x7xrxn4kl38w";
   };
 
-  propagatedBuildInputs = [ requests protobuf pycryptodome ];
+  doCheck = false;
+
+  pythonImportsCheck = [ "gpapi.googleplay" ];
+
+  propagatedBuildInputs = [ cryptography protobuf pycryptodome requests ];
 
   meta = with lib; {
     homepage = "https://github.com/NoMore201/googleplay-api";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     description = "Google Play Unofficial Python API";
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/gpapi/default.nix
+++ b/pkgs/development/python-modules/gpapi/default.nix
@@ -18,6 +18,8 @@ buildPythonPackage rec {
     sha256 = "0ampvsv97r3hy1cakif4kmyk1ynf3scbvh4fbk02x7xrxn4kl38w";
   };
 
+  # package doesn't contain unit tests
+  # scripts in ./test require networking
   doCheck = false;
 
   pythonImportsCheck = [ "gpapi.googleplay" ];


### PR DESCRIPTION
ZHF: #122042

Upstream project seems unmaintained since Nov 2019. Should this package better be removed?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
