### PR TITLE
python3Packages.pipx: 0.16.1.0 -> 0.16.2.1

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pipx";
-  version = "0.16.1.0";
+  version = "0.16.2.1";
 
   disabled = pythonOlder "3.6";
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "pipxproject";
     repo = pname;
     rev = version;
-    sha256 = "081raqsaq7i2x4yxhxppv930jhajdwmngin5wazy7vqhiy3xc669";
+    sha256 = "1agdp8j4lw6z0lk2vv1m8d49r5vwfkpal3hdgq67vnjyp9904pf6";
   };
 
   propagatedBuildInputs = [
@@ -54,6 +54,7 @@ buildPythonPackage rec {
     "suffix"
     "legacy_venv"
     "determination"
+    "json"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the latest version: https://github.com/pipxproject/pipx/releases/tag/0.16.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
