### PR TITLE
sweethome3d: 6.4.2 -> 6.5.2, also bump editors, use fetchurl and fix build

### DIFF
--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -1,19 +1,17 @@
 { lib
 , stdenv
 , fetchurl
-, fetchsvn
 , makeWrapper
 , makeDesktopItem
-# sweethome3d 6.4.2 does not yet build with jdk 9 and later.
-# this is fixed on trunk (7699?) but let's build with jdk8 until then.
+# sweethome3d 6.5.2 does not yet fully build&run with jdk 9 and later?
 , jdk8
-# it can run on the latest stable jre fine though
-, jre
+, jre8
 , ant
 , gtk3
 , gsettings-desktop-schemas
 , p7zip
 , libXxf86vm
+, unzip
 }:
 
 let
@@ -49,7 +47,7 @@ let
       patchelf --set-rpath ${libXxf86vm}/lib lib/java3d-1.6/linux/i586/libnativewindow_x11.so
     '';
 
-    nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ makeWrapper unzip ];
     buildInputs = [ ant jdk8 p7zip gtk3 gsettings-desktop-schemas ];
 
     buildPhase = ''
@@ -77,7 +75,7 @@ let
       # without it a "Profiles [GL4bc, GL3bc, GL2, GLES1] not available on device null"
       # exception is thrown on startup.
       # https://discourse.nixos.org/t/glx-not-recognised-after-mesa-update/6753
-      makeWrapper ${jre}/bin/java $out/bin/$exec \
+      makeWrapper ${jre8}/bin/java $out/bin/$exec \
         --set MESA_GL_VERSION_OVERRIDE 2.1 \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gsettings-desktop-schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-Dsun.java2d.opengl=true -jar $out/share/java/${module}-${version}.jar -cp $out/share/java/Furniture.jar:$out/share/java/Textures.jar:$out/share/java/Help.jar -d${toString stdenv.hostPlatform.parsed.cpu.bits}"
@@ -102,14 +100,13 @@ in {
 
   application = mkSweetHome3D rec {
     pname = lib.toLower module + "-application";
-    version = "6.4.2";
+    version = "6.5.2";
     module = "SweetHome3D";
     description = "Design and visualize your future home";
     license = lib.licenses.gpl2Plus;
-    src = fetchsvn {
-      url = "https://svn.code.sf.net/p/sweethome3d/code/tags/V_" + d2u version + "/SweetHome3D/";
-      sha256 = "13rczayakwb5246hqnp8lnw61p0p7ywr2294bnlp4zwsrz1in9z4";
-      rev = "7504";
+    src = fetchurl {
+      url = "mirror://sourceforge/sweethome3d/${module}-${version}-src.zip";
+      sha256 = "1j0xm2vmcxxjmf12k8rfnisq9hd7hqaiyxrfbrbjxis9iq3kycp3";
     };
     desktopName = "Sweet Home 3D";
     icons = {

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -1,17 +1,17 @@
 { lib
 , stdenv
-, fetchcvs
+, fetchurl
 , makeWrapper
 , makeDesktopItem
-# sweethome3d 6.4.2 does not yet build with jdk 9 and later.
-# this is fixed on trunk (7699?) but let's build with jdk8 until then.
+# sweethome3d 6.5.2 does not yet fully build&run with jdk 9 and later?
 , jdk8
-# it can run on the latest stable jre fine though
-, jre
+, jre8
 , ant
 , gtk3
 , gsettings-desktop-schemas
-, sweethome3dApp }:
+, sweethome3dApp
+, unzip
+}:
 
 let
 
@@ -19,6 +19,14 @@ let
     m: "sweethome3d-"
     + removeSuffix "libraryeditor" (toLower m)
     + "-editor";
+
+  applicationSrc = stdenv.mkDerivation {
+    name = "application-src";
+    src = sweethome3dApp.src;
+    nativeBuildInputs = [ unzip ];
+    buildPhase = "";
+    installPhase = "cp -r . $out";
+  };
 
   mkEditorProject =
   { pname, module, version, src, license, description, desktopName }:
@@ -35,18 +43,18 @@ let
       categories = "Graphics;2DGraphics;3DGraphics;";
     };
 
-    nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ ant jre jdk8 gtk3 gsettings-desktop-schemas ];
+    nativeBuildInputs = [ makeWrapper unzip ];
+    buildInputs = [ ant jre8 jdk8 gtk3 gsettings-desktop-schemas ];
 
     postPatch = ''
-      sed -i -e 's,../SweetHome3D,${application.src},g' build.xml
+      sed -i -e 's,../SweetHome3D,${applicationSrc},g' build.xml
       sed -i -e 's,lib/macosx/java3d-1.6/jogl-all.jar,lib/java3d-1.6/jogl-all.jar,g' build.xml
     '';
 
     buildPhase = ''
       runHook preBuild
 
-      ant -lib ${application.src}/libtest -lib ${application.src}/lib -lib ${jdk8}/lib
+      ant -lib ${applicationSrc}/libtest -lib ${applicationSrc}/lib -lib ${jdk8}/lib
 
       runHook postBuild
     '';
@@ -56,7 +64,7 @@ let
       mkdir -p $out/share/{java,applications}
       cp ${module}-${version}.jar $out/share/java/.
       cp "${editorItem}/share/applications/"* $out/share/applications
-      makeWrapper ${jre}/bin/java $out/bin/$exec \
+      makeWrapper ${jre8}/bin/java $out/bin/$exec \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gsettings-desktop-schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-jar $out/share/java/${module}-${version}.jar -d${toString stdenv.hostPlatform.parsed.cpu.bits}"
     '';
@@ -78,31 +86,27 @@ let
 in {
 
   textures-editor = mkEditorProject rec {
-    version = "1.5";
+    version = "1.7";
     module = "TexturesLibraryEditor";
     pname = module;
     description = "Easily create SH3T files and edit the properties of the texture images it contain";
     license = lib.licenses.gpl2Plus;
-    src = fetchcvs {
-      cvsRoot = ":pserver:anonymous@sweethome3d.cvs.sourceforge.net:/cvsroot/sweethome3d";
-      sha256 = "15wxdns3hc8yq362x0rj53bcxran2iynxznfcb9js85psd94zq7h";
-      module = module;
-      tag = "V_" + d2u version;
+    src = fetchurl {
+      url = "mirror://sourceforge/sweethome3d/${module}-${version}-src.zip";
+      sha256 = "03vb9y645qzffxxdhgbjb0d98k3lafxckg2vh2s86j62b6357d0h";
     };
     desktopName = "Sweet Home 3D - Textures Library Editor";
   };
 
   furniture-editor = mkEditorProject rec {
-    version = "1.19";
+    version = "1.27";
     module = "FurnitureLibraryEditor";
     pname = module;
     description = "Quickly create SH3F files and edit the properties of the 3D models it contain";
     license = lib.licenses.gpl2;
-    src = fetchcvs {
-      cvsRoot = ":pserver:anonymous@sweethome3d.cvs.sourceforge.net:/cvsroot/sweethome3d";
-      sha256 = "0rr4nqil1mngak3ds5vz7f1whrgcgzpk6fb0qcr5ljms0jx0ylvs";
-      module = module;
-      tag = "V_" + d2u version;
+    src = fetchurl {
+      url = "mirror://sourceforge/sweethome3d/${module}-${version}-src.zip";
+      sha256 = "1zxbcn9awgax8lalzkc05f5yfwbgnrayc17fkyv5i19j4qb3r2a0";
     };
     desktopName = "Sweet Home 3D - Furniture Library Editor";
   };


### PR DESCRIPTION
fixes build failures
https://hydra.nixos.org/build/142550788/nixlog/2
https://hydra.nixos.org/build/142549864/nixlog/2

newer versions should have java 9+ support
http://www.sweethome3d.com/history.jsp

Replaces fetchsvn/fetchcvs with fetchurl because fetchcvs wasn't able to fetch newer versions.

jre8 seems to be required due to InaccessibleObjectException/IllegalAccessException on app start on jdk9+

~~Locally I was able to launch sweethome3d.{textures,furniture}-editor but not sweethome3d app.
App shows splash screen and logs InaccessibleObjectException/IllegalAccessException, but that is also the case with jdk8 or older version of app for me.~~

~~Could someone validate app start or investigate the issue further? Maybe we can start with fixing the build and then filing a bug on app not properly starting?~~

ZHF: #122042

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
