### PR TITLE
mariadb-galera: remove unused code

### DIFF
--- a/pkgs/servers/sql/mariadb/galera/default.nix
+++ b/pkgs/servers/sql/mariadb/galera/default.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # for backwards compatibility
-    ln -s . $out/lib/galera
+    mkdir $out/lib/galera
+    ln -s $out/lib/libgalera_smm.so $out/lib/galera/libgalera_smm.so
   '';
 
   meta = with lib; {

--- a/pkgs/servers/sql/mariadb/galera/default.nix
+++ b/pkgs/servers/sql/mariadb/galera/default.nix
@@ -2,13 +2,7 @@
 , asio, boost, check, openssl, cmake
 }:
 
-let
-  galeraLibs = buildEnv {
-    name = "galera-lib-inputs-united";
-    paths = [ openssl.out boost check ];
-  };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mariadb-galera";
   version = "26.4.8";
 


### PR DESCRIPTION
###### Motivation for this change
Follow-up to #122132

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
