### PR TITLE
python3Packages.ipydatawidgets: unbreak

### DIFF
--- a/pkgs/development/python-modules/ipydatawidgets/default.nix
+++ b/pkgs/development/python-modules/ipydatawidgets/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "ipydatawidgets";
-  version = "4.2.0";
+  version = "4.1.0";
 
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d0e4b58b59b508165e8562b8f5d1dbfcd739855847ec0477bd9185a5e9b7c5bc";
+    sha256 = "d9f94828c11e3b40350fb14a02e027f42670a7c372bcb30db18d552dcfab7c01";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
ZHF: #122042

Package version has been bumped by: https://github.com/NixOS/nixpkgs/pull/117452

New version fails during setup requiring npm. It didn't seem trivial to get rid of the npm requirement.
Nothing depends on this package and last version worked fine, so I just downgraded the package. Is this allowed?


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
