### PR TITLE
python39Packages.slimit: mark as disabled

### DIFF
--- a/pkgs/development/python-modules/slimit/default.nix
+++ b/pkgs/development/python-modules/slimit/default.nix
@@ -1,8 +1,19 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, fetchpatch, python, ply }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, fetchpatch
+, python
+, ply
+, pythonAtLeast }:
 
 buildPythonPackage rec {
   pname = "slimit";
   version = "0.8.1";
+
+  # Unmaintained; last release in 2013, doesn't support python changes
+  # introduced in python3.9
+  disabled = pythonAtLeast "3.9";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/bpcbn0r22yi810l673ir99pmb9x6aq1b-python3.9-slimit-0.8.1.drv
Upstream has not made a release or responded to github issues since 2013.
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
