### PR TITLE
privacyidea: fix eval & build

### DIFF
--- a/pkgs/development/python-modules/ldaptor/19.nix
+++ b/pkgs/development/python-modules/ldaptor/19.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, twisted
+, passlib
+, pyopenssl
+, pyparsing
+, service-identity
+, zope_interface
+, isPy3k
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "ldaptor";
+  version = "19.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "64c7b870c77e34e4f5f9cfdf330b9702e89b4dd0f64275704f86c1468312c755";
+  };
+
+  propagatedBuildInputs = [
+    twisted passlib pyopenssl pyparsing service-identity zope_interface
+  ];
+
+  disabled = isPy3k;
+
+  doCheck = false;
+
+  meta = {
+    description = "A Pure-Python Twisted library for LDAP";
+    homepage = "https://github.com/twisted/ldaptor";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/privacyidea/default.nix
+++ b/pkgs/development/python-modules/privacyidea/default.nix
@@ -1,10 +1,10 @@
 { lib, buildPythonPackage, fetchFromGitHub, cacert, openssl, python, nixosTests
 
 , cryptography, pyrad, pymysql, python-dateutil, flask-versioned, flask_script
-, defusedxml, croniter, flask_migrate, pyjwt, configobj, sqlsoup, pillow
+, defusedxml, croniter, flask_migrate, pyjwt1, configobj, sqlsoup, pillow
 , python-gnupg, passlib, pyopenssl, beautifulsoup4, smpplib, flask-babel
 , ldap3, huey, pyyaml, qrcode, oauth2client, requests, lxml, cbor2, psycopg2
-, pydash
+, pydash, ecdsa
 
 , mock, pytestCheckHook, responses, testfixtures
 }:
@@ -29,10 +29,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cryptography pyrad pymysql python-dateutil flask-versioned flask_script
-    defusedxml croniter flask_migrate pyjwt configobj sqlsoup pillow
+    defusedxml croniter flask_migrate pyjwt1 configobj sqlsoup pillow
     python-gnupg passlib pyopenssl beautifulsoup4 smpplib flask-babel
     ldap3 huey pyyaml qrcode oauth2client requests lxml cbor2 psycopg2
-    pydash
+    pydash ecdsa
   ];
 
   passthru.tests = { inherit (nixosTests) privacyidea; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5177,7 +5177,9 @@ in {
 
   prison = callPackage ../development/python-modules/prison { };
 
-  privacyidea-ldap-proxy = callPackage ../development/python-modules/privacyidea/ldap-proxy.nix { };
+  privacyidea = callPackage ../development/python-modules/privacyidea { };
+
+  pyjwt1 = callPackage ../development/python-modules/pyjwt/1.nix { };
 
   proboscis = callPackage ../development/python-modules/proboscis { };
 

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -385,6 +385,8 @@ with self; with super; {
 
   privacyidea-ldap-proxy = callPackage ../development/python-modules/privacyidea/ldap-proxy.nix { };
 
+  ldaptor = callPackage ../development/python-modules/ldaptor/19.nix { };
+
   progressbar231 = callPackage ../development/python-modules/progressbar231 { };
 
   prompt_toolkit = callPackage ../development/python-modules/prompt_toolkit/1.nix { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -383,7 +383,7 @@ with self; with super; {
 
   prettytable = callPackage ../development/python-modules/prettytable/1.nix { };
 
-  privacyidea = callPackage ../development/python-modules/privacyidea { };
+  privacyidea-ldap-proxy = callPackage ../development/python-modules/privacyidea/ldap-proxy.nix { };
 
   progressbar231 = callPackage ../development/python-modules/progressbar231 { };
 


### PR DESCRIPTION

###### Motivation for this change

* Privacyidea can be built with python3, but requires pyjwt v1
* `privacyidea-ldap-proxy` requires python2 and an older `ldaptor` version.
* Closes #122250

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
