### PR TITLE
python39Packages.random2: fix build

### DIFF
--- a/pkgs/development/python-modules/random2/default.nix
+++ b/pkgs/development/python-modules/random2/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , isPyPy
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -14,6 +15,14 @@ buildPythonPackage rec {
     extension = "zip";
     sha256 = "34ad30aac341039872401595df9ab2c9dc36d0b7c077db1cea9ade430ed1c007";
   };
+
+  patches = [
+    # Patch test suite for python >= 3.9
+    (fetchpatch {
+      url = "https://github.com/strichter/random2/pull/3/commits/1bac6355d9c65de847cc445d782c466778b94fbd.patch";
+      sha256 = "064137pg1ilv3f9r10123lqbqz45070jca8pjjyp6gpfd0yk74pi";
+    })
+  ];
 
   meta = with lib; {
     homepage = "http://pypi.python.org/pypi/random2";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/kjpv4iq3cc0gjjzhdj0128bq1nac47mj-python3.9-random2-1.0.1.drv
ZHF: #122042
Patch: https://github.com/strichter/random2/pull/3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
