### PR TITLE
python39Packages.python-toolbox: unbreak

### DIFF
--- a/pkgs/development/python-modules/python-toolbox/default.nix
+++ b/pkgs/development/python-modules/python-toolbox/default.nix
@@ -3,8 +3,7 @@
 , docutils
 , fetchFromGitHub
 , isPy27
-, nose
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -21,7 +20,13 @@ buildPythonPackage rec {
 
   checkInputs = [
     docutils
-    pytest
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # file imports 'dummy_threading', which was deprecated since py37
+    # and removed in py39
+    "test_python_toolbox/test_cute_profile/test_cute_profile.py"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/kn0pzfc39sdqh7d9149by93mqjyv1vf7-python3.9-python_toolbox-1.0.10.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
