### PR TITLE
feedbackd: unstable-2021-01-25 -> 0.0.0+git20210426

### DIFF
--- a/pkgs/applications/misc/feedbackd/default.nix
+++ b/pkgs/applications/misc/feedbackd/default.nix
@@ -1,45 +1,64 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, docbook-xsl-nons
+, gobject-introspection
+, gtk-doc
+, libxslt
 , meson
 , ninja
 , pkg-config
+, vala
 , wrapGAppsHook
 , glib
 , gsound
-, libgudev
 , json-glib
-, vala
-, gobject-introspection
+, libgudev
+, dbus
 }:
 
 stdenv.mkDerivation rec {
-  pname = "feedbackd-unstable";
-  version = "2021-01-25";
+  pname = "feedbackd";
+  # Not an actual upstream project release,
+  # only a Debian package release that is tagged in the upstream repo
+  version = "0.0.0+git20210426";
+
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "feedbackd";
-    rev = "v0.0.0+git${builtins.replaceStrings ["-"] [""] version}";
-    sha256 = "184ag10sfzrka533inv6f38x6z769kq5jj56vdkcm65j5h786w5v";
+    rev = "v${version}";
+    sha256 = "12kdchv11c5ynpv6fbagcx755x5p2kd7acpwjxi9khwdwjsqxlmn";
   };
 
   nativeBuildInputs = [
+    docbook-xsl-nons
+    gobject-introspection
+    gtk-doc
+    libxslt
     meson
     ninja
     pkg-config
-    wrapGAppsHook
     vala
-    gobject-introspection
+    wrapGAppsHook
   ];
 
   buildInputs = [
     glib
     gsound
-    libgudev
     json-glib
+    libgudev
   ];
+
+  mesonFlags = [ "-Dgtk_doc=true" "-Dman=true" ];
+
+  checkInputs = [
+    dbus
+  ];
+
+  doCheck = true;
 
   postInstall = ''
     mkdir -p $out/lib/udev/rules.d
@@ -54,4 +73,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Align version scheme with upstream and other distros.
Also split outputs and build man pages as well as documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @masipcat 