### PR TITLE
opsdroid: init at 0.22.0 + dependencies

### DIFF
--- a/pkgs/applications/networking/opsdroid/default.nix
+++ b/pkgs/applications/networking/opsdroid/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "opsdroid";
+  version = "0.22.0";
+
+  src = fetchFromGitHub {
+    owner = "opsdroid";
+    repo = "opsdroid";
+    rev = "v${version}";
+    sha256 = "003gpzdjfz2jrwx2bkkd1k2mr7yjpaw5s7fy5l0hw72f9zimznd0";
+  };
+
+  disabled = !python3Packages.isPy3k;
+
+  # tests folder is not included in release
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    click Babel opsdroid_get_image_size slackclient webexteamssdk bleach
+    parse emoji puremagic yamale nbformat websockets pycron nbconvert
+    aiohttp matrix-api-async aioredis aiosqlite arrow pyyaml motor regex
+    mattermostdriver setuptools voluptuous ibm-watson tailer multidict
+    watchgod get-video-properties appdirs bitstring matrix-nio
+  ];
+
+  passthru.python = python3Packages.python;
+
+  meta = with lib; {
+    description = "An open source chat-ops bot framework";
+    homepage = "https://opsdroid.dev";
+    maintainers = with maintainers; [ fpletz globin willibutz lheckemann ];
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/delorean/default.nix
+++ b/pkgs/development/python-modules/delorean/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, Babel
+, humanize
+, python-dateutil
+, tzlocal
+}:
+
+buildPythonPackage rec {
+  pname = "Delorean";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d31ay7yq2w7xz7m3ssk5phjbm64b2k8hmgcif22719k29p7hrzy";
+  };
+
+  propagatedBuildInputs = [ Babel humanize python-dateutil tzlocal ];
+
+  pythonImportsCheck = [ "delorean" ];
+
+  # test data not included
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Delorean: Time Travel Made Easy";
+    homepage = "https://github.com/myusuf3/delorean";
+    license = licenses.mit;
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/get-video-properties/default.nix
+++ b/pkgs/development/python-modules/get-video-properties/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, ffmpeg
+}:
+
+buildPythonPackage rec {
+  pname = "get-video-properties";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "mvasilkov";
+    repo = "python-get-video-properties";
+    rev = "944c68addbc27e320ebc6313d3f016fb69b5e880";
+    sha256 = "18aslx7amaiw31bl9gambmvzry7hp5nqab6kgp8sg3mz9ih4lzal";
+  };
+
+  # no tests
+  doCheck = false;
+
+  postPatch = ''
+    substituteInPlace videoprops/__init__.py \
+      --replace "which('ffprobe')" "'${ffmpeg}/bin/ffprobe'"
+  '';
+
+  pythonImportsCheck = [ "videoprops" ];
+
+  meta = with lib; {
+    description = "Get video properties";
+    homepage = "https://github.com/mvasilkov/python-get-video-properties";
+    license = licenses.mit;
+    maintainers = with maintainers; [ globin ];
+  };
+
+}

--- a/pkgs/development/python-modules/ibm-cloud-sdk-core/default.nix
+++ b/pkgs/development/python-modules/ibm-cloud-sdk-core/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, codecov
+, pyjwt
+, pylint
+, pytestCheckHook
+, pytestcov
+, python-dateutil
+, requests
+, responses
+, tox
+}:
+
+buildPythonPackage rec {
+  pname = "ibm-cloud-sdk-core";
+  version = "3.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gwx0z6yqlym9af6wnzq5alcrx8pfsywxn18a0yxhm1j00rkyh2i";
+  };
+
+  checkInputs = [
+    codecov
+    pylint
+    pytestCheckHook
+    pytestcov
+    responses
+    tox
+  ];
+
+  propagatedBuildInputs = [
+    pyjwt
+    python-dateutil
+    requests
+  ];
+
+  # Various tests try to access credential files which are not included with the source distribution
+  disabledTests = [
+    "test_iam" "test_cwd" "test_configure_service" "test_get_authenticator"
+    "test_read_external_sources_2" "test_files_duplicate_parts" "test_files_list"
+    "test_files_dict" "test_retry_config_external" "test_gzip_compression_external"
+  ];
+
+  meta = with lib; {
+    description = "Client library for the IBM Cloud services";
+    homepage = "https://github.com/IBM/python-sdk-core";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ globin lheckemann ];
+  };
+}

--- a/pkgs/development/python-modules/ibm-watson/default.nix
+++ b/pkgs/development/python-modules/ibm-watson/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, responses
+, pytestCheckHook
+, python-dotenv
+, pytest-rerunfailures
+, tox
+, requests
+, python-dateutil
+, websocket_client
+, ibm-cloud-sdk-core
+}:
+
+buildPythonPackage rec {
+  pname = "ibm-watson";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "watson-developer-cloud";
+    repo = "python-sdk";
+    rev = "v${version}";
+    sha256 = "sha256:16llw7kybwndgf2ryrg5698v4j3rhrdx52lf3kdzhxdi0q3kmwdn";
+  };
+
+  checkInputs = [
+    responses
+    pytestCheckHook
+    python-dotenv
+    pytest-rerunfailures
+    tox
+  ];
+
+  propagatedBuildInputs = [
+    requests
+    python-dateutil
+    websocket_client
+    ibm-cloud-sdk-core
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace websocket-client==0.48.0 websocket-client>=0.48.0 \
+      --replace ibm_cloud_sdk_core==3.3.6 ibm_cloud_sdk_core>=3.3.6
+  '';
+
+  meta = with lib; {
+    description = "Client library to use the IBM Watson Services";
+    homepage = "https://github.com/watson-developer-cloud/python-sdk";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ globin lheckemann ];
+  };
+}

--- a/pkgs/development/python-modules/matrix-api-async/default.nix
+++ b/pkgs/development/python-modules/matrix-api-async/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, matrix-client }:
+
+buildPythonPackage rec {
+  pname = "matrix_api_async";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xdx8fci0lar3x09dwqgka6ssz9d3g7gsfx4yyr13sdwza7zsqc3";
+  };
+
+  propagatedBuildInputs = [ matrix-client ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "matrix_api_async" ];
+
+  meta = with lib; {
+    description = "An asyncio wrapper of matrix_client.api";
+    license = licenses.mit;
+    homepage = "https://github.com/Cadair/matrix_api_async";
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/mattermostdriver/default.nix
+++ b/pkgs/development/python-modules/mattermostdriver/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, websockets
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "mattermostdriver";
+  version = "7.3.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17jqcpa1xd9n7bf4d5l7wmscls34kymv27gi17pyyfjxbwk5gsga";
+  };
+
+  propagatedBuildInputs = [ websockets requests ];
+
+  pythonImportsCheck = [ "mattermostdriver" ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Python Mattermost Driver";
+    homepage = "https://github.com/Vaelor/python-mattermost-driver";
+    license = licenses.mit;
+    maintainers = with maintainers; [ globin lheckemann ];
+  };
+}

--- a/pkgs/development/python-modules/mockupdb/default.nix
+++ b/pkgs/development/python-modules/mockupdb/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi
+, pymongo
+}:
+
+buildPythonPackage rec {
+  pname = "mockupdb";
+  version = "1.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "130z5g96r52h362qc5jbf1g3gw3irb2wr946xlhgcv9ww9z64cl8";
+  };
+
+  propagatedBuildInputs = [ pymongo ];
+
+  pythonImportsCheck = [ "mockupdb" ];
+
+  meta = with lib; {
+    description = "Simulate a MongoDB server";
+    license = licenses.asl20;
+    homepage = "https://github.com/ajdavis/mongo-mockup-db";
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/motor/default.nix
+++ b/pkgs/development/python-modules/motor/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, pymongo, mockupdb
+}:
+
+buildPythonPackage rec {
+  pname = "motor";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "mongodb";
+    repo = pname;
+    rev = version;
+    sha256 = "1sgaqg98h35lazzdi015q1i60ig7krid8b10a5rm6lf755y8yj2c";
+  };
+
+  propagatedBuildInputs = [ pymongo ];
+
+  # network connections
+  doCheck = false;
+  checkInputs = [ mockupdb ];
+
+  pythonImportsCheck = [ "motor" ];
+
+  meta = with lib; {
+    description = "Non-blocking MongoDB driver for Tornado or asyncio";
+    license = licenses.asl20;
+    homepage = "https://github.com/mongodb/motor";
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/opsdroid_get_image_size/default.nix
+++ b/pkgs/development/python-modules/opsdroid_get_image_size/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "opsdroid_get_image_size";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "124j2xvfxv09q42qfb8nqlcn55y7f09iayrix3yfyrs2qyzav78a";
+  };
+
+  # test data not included on pypi
+  doCheck = false;
+
+  pythonImportsCheck = [ "get_image_size" ];
+
+  meta = with lib; {
+    description = "Get image width and height given a file path using minimal dependencies";
+    license = licenses.mit;
+    homepage = "https://github.com/opsdroid/image_size";
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/puremagic/default.nix
+++ b/pkgs/development/python-modules/puremagic/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "puremagic";
+  version = "1.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "025ih5q1qa40x88j7ngsdr5sf0dp400kwlfzz60i7v6fh0ms1zkg";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"argparse"' ""
+  '';
+
+  # test data not included on pypi
+  doCheck = false;
+
+  pythonImportsCheck = [ "puremagic" ];
+
+  meta = with lib; {
+    description = "Pure python implementation of magic file detection";
+    license = licenses.mit;
+    homepage = "https://github.com/cdgriffith/puremagic";
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/pycron/default.nix
+++ b/pkgs/development/python-modules/pycron/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub, udatetime, pytz, pendulum, nose
+, delorean, coveralls, arrow
+}:
+
+buildPythonPackage rec {
+  pname = "pycron";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kipe";
+    repo = pname;
+    rev = version;
+    sha256 = "12hkqrdfg3jbqkmck8i00ssyaw1c4hhvdhjxkmh2gm9pd99z5bpv";
+  };
+
+  checkInputs = [ arrow coveralls delorean nose pendulum pytz udatetime ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  pythonImportsCheck = [ "pycron" ];
+
+  meta = with lib; {
+    description = "Simple cron-like parser for Python, which determines if current datetime matches conditions";
+    license = licenses.mit;
+    homepage = "https://github.com/kipe/pycron";
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/udatetime/default.nix
+++ b/pkgs/development/python-modules/udatetime/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+}:
+
+buildPythonPackage rec {
+  pname = "udatetime";
+  version = "0.0.16";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09vlcskvaxnfk73l9w5xgl2ks9l62g1b24yrm0xxb7gn93qxglw2";
+  };
+
+  patches = [
+    # fix build with python 3.9
+    (fetchpatch {
+      url = "https://github.com/freach/udatetime/pull/33.patch";
+      sha256 = "02wm7ivkv1viqn2wflgd10dgpddfqfrwacmrldigb1mwb79n554j";
+    })
+  ];
+
+  # tests not included on pypi
+  doCheck = false;
+
+  pythonImportsCheck = [ "udatetime" ];
+
+  meta = with lib; {
+    description = "Fast RFC3339 compliant Python date-time library";
+    homepage = "https://github.com/freach/udatetime";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/development/python-modules/watchgod/default.nix
+++ b/pkgs/development/python-modules/watchgod/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "watchgod";
+  version = "0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0aagm0n5fkpzdsfgl0r21gkz5qaicgq3f4rqz2fdvsgbn1i0s528";
+  };
+
+  # no tests in release
+  doCheck = false;
+
+  pythonImportsCheck = [ "watchgod" ];
+
+  meta = with lib; {
+    description = "Simple, modern file watching and code reload in python";
+    homepage = "https://github.com/samuelcolvin/watchgod";
+    license = licenses.mit;
+    maintainers = with maintainers; [ globin ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24977,6 +24977,8 @@ in
 
   openshift = callPackage ../applications/networking/cluster/openshift { };
 
+  opsdroid = callPackage ../applications/networking/opsdroid { };
+
   oroborus = callPackage ../applications/window-managers/oroborus {};
 
   osm2pgsql = callPackage ../tools/misc/osm2pgsql { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4099,6 +4099,8 @@ in {
 
   matrix-nio = callPackage ../development/python-modules/matrix-nio { };
 
+  mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
+
   mautrix = callPackage ../development/python-modules/mautrix { };
 
   mautrix-appservice = self.mautrix; # alias 2019-12-28

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5451,6 +5451,8 @@ in {
 
   pycrc = callPackage ../development/python-modules/pycrc { };
 
+  pycron = callPackage ../development/python-modules/pycron { };
+
   pycrypto = callPackage ../development/python-modules/pycrypto { };
 
   pycryptodome = callPackage ../development/python-modules/pycryptodome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5275,6 +5275,8 @@ in {
 
   pure-python-adb-homeassistant = callPackage ../development/python-modules/pure-python-adb-homeassistant { };
 
+  puremagic = callPackage ../development/python-modules/puremagic { };
+
   purl = callPackage ../development/python-modules/purl { };
 
   pushbullet = callPackage ../development/python-modules/pushbullet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8336,6 +8336,8 @@ in {
 
   uarray = callPackage ../development/python-modules/uarray { };
 
+  udatetime = callPackage ../development/python-modules/udatetime { };
+
   ueberzug = callPackage ../development/python-modules/ueberzug {
     inherit (pkgs.xorg) libX11 libXext;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4700,6 +4700,8 @@ in {
 
   opt-einsum = callPackage ../development/python-modules/opt-einsum { };
 
+  opsdroid_get_image_size = callPackage ../development/python-modules/opsdroid_get_image_size { };
+
   optuna = callPackage ../development/python-modules/optuna { };
 
   opuslib = callPackage ../development/python-modules/opuslib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4272,6 +4272,8 @@ in {
 
   moto = callPackage ../development/python-modules/moto { };
 
+  motor = callPackage ../development/python-modules/motor { };
+
   moviepy = callPackage ../development/python-modules/moviepy { };
 
   mox3 = callPackage ../development/python-modules/mox3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1759,6 +1759,8 @@ in {
 
   delegator-py = callPackage ../development/python-modules/delegator-py { };
 
+  delorean = callPackage ../development/python-modules/delorean { };
+
   deltachat = callPackage ../development/python-modules/deltachat { };
 
   deluge-client = callPackage ../development/python-modules/deluge-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2675,6 +2675,8 @@ in {
 
   getkey = callPackage ../development/python-modules/getkey { };
 
+  get-video-properties = callPackage ../development/python-modules/get-video-properties { };
+
   gevent = callPackage ../development/python-modules/gevent { };
 
   geventhttpclient = callPackage ../development/python-modules/geventhttpclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3197,6 +3197,8 @@ in {
 
   ibis-framework = callPackage ../development/python-modules/ibis-framework { };
 
+  ibm-cloud-sdk-core = callPackage ../development/python-modules/ibm-cloud-sdk-core { };
+
   icalendar = callPackage ../development/python-modules/icalendar { };
 
   icecream = callPackage ../development/python-modules/icecream { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3199,6 +3199,8 @@ in {
 
   ibm-cloud-sdk-core = callPackage ../development/python-modules/ibm-cloud-sdk-core { };
 
+  ibm-watson = callPackage ../development/python-modules/ibm-watson { };
+
   icalendar = callPackage ../development/python-modules/icalendar { };
 
   icecream = callPackage ../development/python-modules/icecream { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4093,6 +4093,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  matrix-api-async = callPackage ../development/python-modules/matrix-api-async { };
+
   matrix-client = callPackage ../development/python-modules/matrix-client { };
 
   matrix-nio = callPackage ../development/python-modules/matrix-nio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8592,6 +8592,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  watchgod = callPackage ../development/python-modules/watchgod { };
+
   waterfurnace = callPackage ../development/python-modules/waterfurnace { };
 
   WazeRouteCalculator = callPackage ../development/python-modules/WazeRouteCalculator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4235,6 +4235,8 @@ in {
 
   mock-services = callPackage ../development/python-modules/mock-services { };
 
+  mockupdb = callPackage ../development/python-modules/mockupdb { };
+
   modeled = callPackage ../development/python-modules/modeled { };
 
   moderngl = callPackage ../development/python-modules/moderngl { };


### PR DESCRIPTION
###### Motivation for this change
Package opsdroid.

Based on staging because it depends on `python.pkgs.Babel` upgrade.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
