### PR TITLE
river: unstable-2021-04-27 > unstable-2021-05-07

### DIFF
--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -6,37 +6,41 @@
 
 stdenv.mkDerivation rec {
   pname = "river";
-  version = "unstable-2021-04-27";
+  version = "unstable-2021-05-07";
 
   src = fetchFromGitHub {
     owner = "ifreund";
     repo = pname;
-    rev = "0c8e718d95a6a621b9cba0caa9158915e567b076";
-    sha256 = "1jjh0dzxi7hy4mg8vag6ipfwb9qxm5lfc07njp1mx6m81nq76ybk";
+    rev = "7ffa2f4b9e7abf7d152134f555373c2b63ccfc1d";
+    sha256 = "1z5qjid73lfn654f2k74nwgvpr88fpdfpbzhihybx9cyy1mqfz7j";
     fetchSubmodules = true;
   };
 
-  buildInputs = [ xwayland wayland-protocols wlroots pixman
+  buildInputs = [ wayland-protocols wlroots pixman
     libxkbcommon pixman udev libevdev libX11 libGL
   ];
+
+  dontConfigure = true;
 
   preBuild = ''
     export HOME=$TMPDIR
   '';
   installPhase = ''
+    runHook preInstall
     zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install
+    runHook postInstall
   '';
 
-  nativeBuildInputs = [ zig wayland scdoc pkg-config ];
+  nativeBuildInputs = [ zig wayland xwayland scdoc pkg-config ];
 
+  # Builder patch install dir into river to get default config
+  # When installFlags is removed, river becomes half broken
+  # see https://github.com/ifreund/river/blob/7ffa2f4b9e7abf7d152134f555373c2b63ccfc1d/river/main.zig#L56
   installFlags = [ "DESTDIR=$(out)" ];
 
   meta = with lib; {
-    description = "A dynamic tiling wayland compositor";
-    longDescription = ''
-      river is a dynamic tiling wayland compositor that takes inspiration from dwm and bspwm.
-    '';
     homepage = "https://github.com/ifreund/river";
+    description = "A dynamic tiling wayland compositor";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ branwright1 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updated to new version, added dontConfigure and explaination why installFlags cannot be removed

also noted here
 Builder patch install dir into river to get default config, when installFlags is removed, river becomes half broken
 see https://github.com/ifreund/river/blob/7ffa2f4b9e7abf7d152134f555373c2b63ccfc1d/river/main.zig#L56

if necessary I can just link screenshot or link to message with explaination from river author on zig's discord server

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
