### PR TITLE
stgit: enable tests and install documentation

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/stgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/stgit/default.nix
@@ -1,4 +1,13 @@
-{ lib, python3Packages, fetchFromGitHub, git, installShellFiles }:
+{ lib
+, fetchFromGitHub
+, installShellFiles
+, python3Packages
+, asciidoc
+, docbook_xsl
+, git
+, perl
+, xmlto
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "stgit";
@@ -11,15 +20,40 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-gfPf1yRmx1Mn1TyCBWmjQJBgXLlZrDcew32C9o6uNYk=";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles asciidoc xmlto docbook_xsl ];
 
-  checkInputs = [ git ];
+  format = "other";
 
-  postInstall = ''
-    installShellCompletion $out/share/stgit/completion/stg.fish
-    installShellCompletion --name stg $out/share/stgit/completion/stgit.bash
-    installShellCompletion --name _stg $out/share/stgit/completion/stgit.zsh
+  checkInputs = [ git perl ];
+
+  postPatch = ''
+    for f in Documentation/*.xsl; do
+      substituteInPlace $f \
+        --replace http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl \
+                  ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl \
+        --replace http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl \
+                  ${docbook_xsl}/xml/xsl/docbook/html/docbook.xsl
+    done
   '';
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "MAN_BASE_URL=${placeholder "out"}/share/man"
+    "XMLTO_EXTRA=--skip-validation"
+  ];
+
+  buildFlags = [ "all" "doc" ];
+
+  checkTarget = "test";
+  checkFlags = [ "PERL_PATH=${perl}/bin/perl" ];
+
+  installTargets = [ "install" "install-doc" ];
+  postInstall = ''
+    installShellCompletion --cmd stg \
+      --fish $out/share/stgit/completion/stg.fish \
+      --bash $out/share/stgit/completion/stgit.bash \
+      --zsh $out/share/stgit/completion/stgit.zsh
+    '';
 
   meta = with lib; {
     description = "A patch manager implemented on top of Git";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

stgit uses a non-standard build process that `buildPythonApplication` doesn't understand. This PR will customise the build phases to install the man pages for stg and subcommands and run the tests.

I'm not sure whether the build is non-standard enough to justify not using `buildPythonApplication` at all and just using `stdenv.makeDerivationNoCC` or something like that. In particular, I don't like that I have to manually specify `$makeFlags` in each build phase; any tips on how to avoid needing that would be welcome from reviewers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
