### PR TITLE
chatty: init at 0.3.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatty/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatty/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, appstream-glib
+, desktop-file-utils
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+, evolution-data-server
+, feedbackd
+, gtk3
+, json-glib
+, libgcrypt
+, libhandy
+, libphonenumber
+, olm
+, pidgin
+, protobuf
+, sqlite
+, plugins ? [ ]
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chatty";
+  version = "0.3.2";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "Librem5";
+    repo = "chatty";
+    rev = "v${version}";
+    sha256 = "sha256-/l8hysfBmXLbs2COIVjdr2JC1qX/c66DqOm2Gyqb9s8=";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux/meson
+  '';
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    evolution-data-server
+    feedbackd
+    gtk3
+    json-glib
+    libgcrypt
+    libhandy
+    libphonenumber
+    olm
+    pidgin
+    protobuf
+    sqlite
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PURPLE_PLUGIN_PATH : ${pidgin.makePluginPath plugins}
+      ${lib.concatMapStringsSep " " (p: p.wrapArgs or "") plugins}
+    )
+  '';
+
+  meta = with lib; {
+    description = "XMPP and SMS messaging via libpurple and ModemManager";
+    homepage = "https://source.puri.sm/Librem5/chatty";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -87,6 +87,10 @@ let unwrapped = stdenv.mkDerivation rec {
     done
   '';
 
+  passthru = {
+    makePluginPath = lib.makeSearchPathOutput "lib" "lib/purple-${majorVersion}";
+  };
+
   meta = with lib; {
     description = "Multi-protocol instant messaging client";
     homepage = "http://pidgin.im";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23728,6 +23728,8 @@ with pkgs;
     inherit (python3Packages) python wrapPython pygments markdown;
   };
 
+  chatty = callPackage ../applications/networking/instant-messengers/chatty { };
+
   chirp = callPackage ../applications/radio/chirp { };
 
   browsh = callPackage ../applications/networking/browsers/browsh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
continuation of https://github.com/NixOS/nixpkgs/pull/94820
I decided against the wrapper approach as that makes it hard to override other things and chatty doesn't take long to build. If a wrapper is preferred though, I'll change it of course.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I still have to do extensive testing of all the plugins.

It would be nice if libpurple were separate from pidgin.