### PR TITLE
croc.passthru.tests: partially revert 77c0a490

### DIFF
--- a/pkgs/tools/networking/croc/test-local-relay.nix
+++ b/pkgs/tools/networking/croc/test-local-relay.nix
@@ -12,8 +12,7 @@ stdenv.mkDerivation {
           ${croc}/bin/croc --relay localhost:11111 send --code correct-horse-battery-staple --text "$MSG" &
           # wait for things to settle
           sleep 1
-          # receive, as of croc 9 --overwrite is required for noninteractive use
-          MSG2=$(${croc}/bin/croc --overwrite --relay localhost:11111 --yes correct-horse-battery-staple)
+          MSG2=$(${croc}/bin/croc --relay localhost:11111 --yes correct-horse-battery-staple)
           # compare
           [ "$MSG" = "$MSG2" ] && touch $out
   '';


### PR DESCRIPTION
`--overwrite` is no longer needed for receiving text

The workaround introduced in https://github.com/NixOS/nixpkgs/pull/121078 is no longer needed. The issue was fixed upstream.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
