### PR TITLE
pdf2djvu: unbreak

### DIFF
--- a/pkgs/tools/typesetting/pdf2djvu/default.nix
+++ b/pkgs/tools/typesetting/pdf2djvu/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , gettext
 , libtool
@@ -24,6 +25,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1igabfy3fd7qndihmkfk9incc15pjxpxh2cn5pfw5fxfwrpjrarn";
   };
+
+  patches = [
+    # Not included in 0.9.17.1, but will be in the next version.
+    (fetchpatch {
+      name = "no-poppler-splash.patch";
+      url = "https://github.com/jwilk/pdf2djvu/commit/2ec7eee57a47bbfd296badaa03dc20bf71b50201.patch";
+      sha256 = "03kap7k2j29r16qgl781cxpswzg3r2yn513cqycgl0vax2xj3gly";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 


### PR DESCRIPTION
ZHF: #122042

###### Motivation for this change

The released version requires "poppler-splash", but as of 20.12, that package is not part of poppler, it seems. The included patch is [already merged](https://github.com/jwilk/pdf2djvu/commit/2ec7eee57a47bbfd296badaa03dc20bf71b50201) to jwilk/pdf2jdvu:master, and simply changes the requirement to "poppler" only.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after): size: 461.11 MiB (vs 439.71 MiB from [last good build](https://hydra.nixos.org/build/133675840)) (output size is 392.13 KiB)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also ran `make test` after hacking up the build env to be able to run it. I can add the relevant `checkInputs` to the build if you like; I'm not sure what the convention is there for smaller packages like this one.
