### PR TITLE
python3Packages.pyjwt: disable failing test for 1.7.1

### DIFF
--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -29,6 +29,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = lib.optionals (lib.versionOlder version "2.0") [
+    # ecdsa changed internal behavior, required if one does 1.7.1 overriding
+    "ec_verify_should_return_false_if_signature_invalid"
+  ];
+
   pythonImportsCheck = [ "jwt" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
With the update to > 2.x a couple of packages need to override PyJWT. In #121891 the check part was updated.

```bash
[...]
builder for '/nix/store/8g424yx2j95dm4x7ivl32f4pzljbbns8-python3.8-pyjwt-1.7.1.drv' failed with exit code 1; last 10 log lines:
  tests/test_exceptions.py                 4      0   100%
  tests/test_jwt.py                        8      0   100%
  tests/test_utils.py                     16      0   100%
  tests/utils.py                          21     11    48%   20-34
  ------------------------------------------------------------------
  TOTAL                                 2026    195    90%
  
  =========================== short test summary info ============================
  FAILED tests/contrib/test_algorithms.py::TestEcdsaAlgorithms::test_ec_verify_should_return_false_if_signature_invalid
  ====== 1 failed, 178 passed, 8 skipped, 1 xfailed, 140 warnings in 1.19s =======
```

The failing test passes if PyJWT is > 2.0 but not on 1.7.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
