### PR TITLE
cargo-limit: fix build on darwin

### DIFF
--- a/pkgs/development/tools/rust/cargo-limit/default.nix
+++ b/pkgs/development/tools/rust/cargo-limit/default.nix
@@ -2,6 +2,8 @@
 , rustPlatform
 , fetchFromGitHub
 , nix-update-script
+, stdenv
+, libiconv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,6 +18,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-LxqxRtMKUKZeuvk1caoYy8rv1bkEOQBM8i5SXMF4GXc=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
