### PR TITLE
xfce.thunar: patch code execution vulnerability

### DIFF
--- a/pkgs/desktops/xfce/core/thunar/default.nix
+++ b/pkgs/desktops/xfce/core/thunar/default.nix
@@ -1,5 +1,6 @@
 { mkXfceDerivation
 , lib
+, fetchpatch
 , docbook_xsl
 , exo
 , gdk-pixbuf
@@ -44,6 +45,16 @@ let unwrapped = mkXfceDerivation {
 
   patches = [
     ./thunarx_plugins_directory.patch
+    #  Dont execute files, passed via command line due to security risks, remove >=4.17.3
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/xfce/thunar/-/commit/9165a61f95e43cc0b5abf9b98eee2818a0191e0b.patch";
+      sha256 = "1yi26xyyr6c0xsmrpvlk72v4szlmqhwz83q719afbq5yr3ycyd50";
+    })
+    # Regression: Activating Desktop Icon does not Use Default Application, remove >=4.17.3
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/xfce/thunar/-/commit/3b54d9d7dbd7fd16235e2141c43a7f18718f5664.patch";
+      sha256 = "02xzpirgaq37fzsazzhnb80bqw1r4h71yhdy35pp50vs8wfb9al1";
+    })
   ];
 
   # the desktop file … is in an insecure location»


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When called with a regular file as command line argument, Thunar
would delegate to some other program without user confirmation
based on the file type. This could be exploited to trigger code
execution in a chain of vulnerabilities.

The patch for the vulnerability introduced a regression, which is why we
apply a second patch.

Both can be removed when thunar>=4.17.3.

https://www.openwall.com/lists/oss-security/2021/05/09/2

There has not been assigned a CVE yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
