### PR TITLE
[staging-20.09] flac: fix out of bound reads due to heap buffer overflow

### DIFF
--- a/pkgs/applications/audio/flac/default.nix
+++ b/pkgs/applications/audio/flac/default.nix
@@ -1,12 +1,21 @@
-{ stdenv, fetchurl, libogg }:
+{ stdenv, fetchurl, fetchpatch, libogg }:
 
 stdenv.mkDerivation rec {
-  name = "flac-1.3.3";
+  pname = "flac";
+  version = "1.3.3";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/flac/${name}.tar.xz";
+    url = "http://downloads.xiph.org/releases/flac/${pname}-${version}.tar.xz";
     sha256 = "0j0p9sf56a2fm2hkjnf7x3py5ir49jyavg4q5zdyd7bcf6yq4gi1";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-0499.patch";
+      url = "https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4.patch";
+      sha256 = "160qzq9ms5addz7sx06pnyjjkqrffr54r4wd8735vy4x008z71ah";
+    })
+  ];
 
   buildInputs = [ libogg ];
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: CVE-2020-0499
(cherry picked from commit 279bdc9dcec7af555dfc32087cf1054603778f89)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
