### PR TITLE
python3Packages.androidtv: 0.0.58 -> 0.0.59

### DIFF
--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "androidtv";
-  version = "0.0.58";
+  version = "0.0.59";
 
   # pypi does not contain tests, using github sources instead
   src = fetchFromGitHub {
     owner = "JeffLIrion";
     repo = "python-androidtv";
     rev = "v${version}";
-    sha256 = "sha256-/5sYiYRFa8XJJ4QSxLzJBHaKfAKsGETiVDHerNQ79U8=";
+    sha256 = "sha256-QuKWOo+QMBpVJglwvaSMbKKYMN/MW31E7BgIMchESG8=";
   };
 
   propagatedBuildInputs = [ adb-shell pure-python-adb ]

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -193,6 +193,7 @@ in with py.pkgs; buildPythonApplication rec {
     "accuweather"
     "airly"
     "analytics"
+    "androidtv"
     "alert"
     "api"
     "auth"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.59

Change log: https://github.com/JeffLIrion/python-androidtv/compare/v0.0.58..v0.0.59

Enable Home Assistant tests.

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50367
- Target Home Assistant release: current, only dependency update no changes
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
