### PR TITLE
treewide: remove explicit enableParallelBuilding = true in Meson builds

### DIFF
--- a/pkgs/applications/audio/gradio/default.nix
+++ b/pkgs/applications/audio/gradio/default.nix
@@ -55,7 +55,6 @@ in stdenv.mkDerivation {
     gsettings-desktop-schemas
   ] ++ gst_plugins;
 
-  enableParallelBuilding = true;
   postInstall = ''
     glib-compile-schemas "$out"/share/glib-2.0/schemas
   '';

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = false;
-  enableParallelBuilding = true;
 
   buildPhase = ''
     export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -112,8 +112,6 @@ _EOF
   # look at ./make/configure.py search "enable_nvenc"
   ++ lib.optional stdenv.isLinux nv-codec-headers;
 
-  enableParallelBuilding = true;
-
   configureFlags = [
     "--disable-df-fetch"
     "--disable-df-verify"

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-builddir" ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     patchShebangs .
   '';

--- a/pkgs/development/libraries/gcr/default.nix
+++ b/pkgs/development/libraries/gcr/default.nix
@@ -74,8 +74,6 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails 21 out of 603 tests, needs dbus daemon
 
-  enableParallelBuilding = true;
-
   preFixup = ''
     wrapProgram "$out/bin/gcr-viewer" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   ]);
   propagatedBuildInputs = [ glib libsigcxx ];
 
-  enableParallelBuilding = true;
-
   doCheck = false; # fails. one test needs the net, another /etc/fstab
 
   passthru = {

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glibmm gtk3 atkmm cairomm pangomm ];
 
-  enableParallelBuilding = true;
-
   # https://bugzilla.gnome.org/show_bug.cgi?id=764521
   doCheck = false;
 

--- a/pkgs/development/libraries/lyra/default.nix
+++ b/pkgs/development/libraries/lyra/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja ];
 
-  enableParallelBuilding = true;
-
   postPatch = "sed -i s#/usr#$out#g meson.build";
 
   postInstall = ''

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -145,7 +145,6 @@ self = stdenv.mkDerivation {
   ] ++ optional stdenv.isLinux libdrm
     ++ optionals stdenv.isDarwin [ OpenGL Xplugin ];
 
-  enableParallelBuilding = true;
   doCheck = false;
 
   postInstall = ''

--- a/pkgs/development/libraries/spdk/default.nix
+++ b/pkgs/development/libraries/spdk/default.nix
@@ -55,8 +55,6 @@ in stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-mssse3"; # Necessary to compile.
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Set of libraries for fast user-mode storage";
     homepage = "https://spdk.io/";

--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "12hpn7zcdvp30ldpw2zf115yjqv55n1ldjbids7vx0lvbpr06dm1";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
   buildInputs = [ SDL2 zlib gtk3 libxml2 libXv epoxy minizip pulseaudio portaudio ];
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -63,8 +63,6 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" ] ++ lib.optional mod "kmod";
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Set of libraries and drivers for fast packet processing";
     homepage = "http://dpdk.org/";

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -82,8 +82,6 @@ in stdenv.mkDerivation rec {
     cp ${fusePackages.fuse_3.common}/etc/udev/rules.d/99-fuse.rules etc/udev/rules.d/99-fuse.rules
   '');
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Library that allows filesystems to be implemented in user space";
     longDescription = ''

--- a/pkgs/os-specific/linux/miraclecast/default.nix
+++ b/pkgs/os-specific/linux/miraclecast/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ glib pcre readline systemd udev ];
 
-  enableParallelBuilding = true;
-
   mesonFlags = [
     "-Drely-udev=true"
     "-Dbuild-tests=true"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -508,8 +508,6 @@ stdenv.mkDerivation {
     rm -rf $out/share/doc
   '';
 
-  enableParallelBuilding = true;
-
   # The interface version prevents NixOS from switching to an
   # incompatible systemd at runtime.  (Switching across reboots is
   # fine, of course.)  It should be increased whenever systemd changes

--- a/pkgs/tools/compression/bzip2/1_1.nix
+++ b/pkgs/tools/compression/bzip2/1_1.nix
@@ -34,8 +34,6 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "High-quality data compression program";
     license = licenses.bsdOriginal;

--- a/pkgs/tools/networking/fastd/default.nix
+++ b/pkgs/tools/networking/fastd/default.nix
@@ -45,8 +45,6 @@ stdenv.mkDerivation rec {
     "-Dmac_ghash_pclmulqdq=disabled"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Fast and Secure Tunneling Daemon";
     homepage = "https://projects.universe-factory.net/projects/fastd/wiki";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Clean up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
