### PR TITLE
python3Packages.denonavr: 0.9.10 -> 0.10.7

### DIFF
--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "denonavr";
-  version = "0.10.6";
+  version = "0.10.7";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "scarface-4711";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jcbjExcyZSE+qVPuYiMmuneugDMBoYz4apY/lz4JnMI=";
+    sha256 = "sha256-IGfU9nnlfZf8U6pCzG7cegmqxmDNONom0U14PZHHaYY=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.10.7

Change log: https://github.com/scarface-4711/denonavr/releases/tag/0.10.7

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50288
- Target Home Assistant release: 2021.5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
