### PR TITLE
beamerpresenter: 0.1.3 -> 0.2.0

### DIFF
--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -1,39 +1,44 @@
 { lib, mkDerivation, fetchFromGitHub, installShellFiles,
-  qmake, qtbase, poppler, qtmultimedia }:
+  qmake, qtbase, qtmultimedia,
+  poppler, mupdf, jbig2dec, openjpeg, gumbo,
+  renderer ? "mupdf" }:
 
-mkDerivation rec {
+let
+  renderers = {
+    mupdf.buildInputs = [ mupdf jbig2dec openjpeg gumbo ];
+    poppler.buildInputs = [ poppler ];
+  };
+
+in mkDerivation rec {
   pname = "beamerpresenter";
-  version = "0.1.3";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "stiglers-eponym";
     repo = "BeamerPresenter";
     rev = "v${version}";
-    sha256 = "1nbcqrfdjcsc6czqk1v163whka4x1w883b1298aws8yi7vac4f1i";
+    sha256 = "10i5nc5b5syaqvsixam4lmfiz3b5cphbjfgfqavi5jilq769792a";
   };
 
   nativeBuildInputs = [ qmake installShellFiles ];
-  buildInputs = [ qtbase qtmultimedia poppler ];
+  buildInputs = [ qtbase qtmultimedia ] ++ renderers.${renderer}.buildInputs;
+
+  qmakeFlags = [ "RENDERER=${renderer}" ];
 
   postPatch = ''
-    # Fix location of poppler-*.h
     shopt -s globstar
-    for f in **/*.{h,cpp}; do
-      substituteInPlace $f --replace '#include <poppler-' '#include <poppler/qt5/poppler-'
+    for f in **/*.{pro,conf,h,cpp}; do
+      substituteInPlace "$f" \
+        --replace "/usr/" "$out/" \
+        --replace "/etc/" "$out/etc/" \
+        --replace '$${GUI_CONFIG_PATH}' "$out/etc/xdg/beamerpresenter/gui.json"
     done
   '';
 
-  installPhase = ''
-    install -m755 beamerpresenter -Dt $out/bin/
-    install -m644 src/icons/beamerpresenter.svg -Dt $out/share/icons/hicolor/scalable/apps/
-    install -m644 share/applications/beamerpresenter.desktop -Dt $out/share/applications/
-    installManPage man/*.{1,5}
-  '';
-
   meta = with lib; {
-    description = "Simple dual screen pdf presentation software";
+    description = "Modular multi screen pdf presentation software respecting your window manager";
     homepage = "https://github.com/stiglers-eponym/BeamerPresenter";
-    license = licenses.gpl3Plus;
+    license = licenses.agpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ pacien ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3214,7 +3214,14 @@ in
 
   bdsync = callPackage ../tools/backup/bdsync { };
 
-  beamerpresenter = libsForQt5.callPackage ../applications/office/beamerpresenter { };
+  beamerpresenter = libsForQt5.callPackage ../applications/office/beamerpresenter {
+    # developed for a compiler with C++20 support
+    stdenv =
+      if stdenv.isDarwin then
+        overrideCC stdenv clang_10
+      else
+        stdenv;
+  };
 
   beanstalkd = callPackage ../servers/beanstalkd { };
 


### PR DESCRIPTION
###### Motivation for this change

This updates the `beamerpresenter` package to its latest release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Opened some PDF and used the app
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
