### PR TITLE
compiler-rt: Revert passing `COMPILER_RT_OS_DIR` and not symlinking libs

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -81,7 +80,9 @@ stdenv.mkDerivation rec {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o

--- a/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -84,7 +83,9 @@ stdenv.mkDerivation rec {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o

--- a/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -84,7 +83,9 @@ stdenv.mkDerivation rec {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o

--- a/pkgs/development/compilers/llvm/5/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -78,7 +77,9 @@ stdenv.mkDerivation {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o

--- a/pkgs/development/compilers/llvm/6/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -80,7 +79,9 @@ stdenv.mkDerivation {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o

--- a/pkgs/development/compilers/llvm/7/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -81,7 +80,9 @@ stdenv.mkDerivation {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/linux/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o

--- a/pkgs/development/compilers/llvm/8/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -81,7 +80,9 @@ stdenv.mkDerivation {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o

--- a/pkgs/development/compilers/llvm/9/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCOMPILER_RT_OS_DIR="
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
@@ -80,7 +79,9 @@ stdenv.mkDerivation rec {
   '';
 
   # Hack around weird upsream RPATH bug
-  postInstall = lib.optionalString (useLLVM) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWasm) ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o


### PR DESCRIPTION
###### Motivation for this change

In 7869d1654517c028aa76fc1dedc9b5ac301a867a I got rid of the symlinking
by forcing `COMPILER_RT_OS_DIR` to always be the empty string. I thought
this was good because it just make compiler-rt be installed in a normal
way.

However, various LLVM tools expect the `COMPILER_RT_OS_DIR` to be set
normally, and fail to find things when they aren't in the expected lib
subdir.

Maybe it would be best to patch that too in the long term, but for now
we just undo this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
