### PR TITLE
python3.pkgs.rtoml: init at 0.6.1

### DIFF
--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools-rust
+, rustPlatform
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "rtoml";
+  version = "0.6.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "samuelcolvin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07bf30if1wmbqjp5n4ib43n6frx8ybyxc9fndxncq7aylkrhd7hy";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "1q082sdac5vm4l3b45rfjp4vppp9y9qhagdjqqfdz8gdhm1k8yyy";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    setuptools-rust
+    rust.rustc
+    rust.cargo
+    cargoSetupHook
+  ];
+
+  pythonImportsCheck = [ "rtoml" ];
+
+  checkInputs = [ pytestCheckHook ];
+  preCheck = ''
+    cd tests
+  '';
+
+  meta = with lib; {
+    description = "Rust based TOML library for python";
+    homepage = "https://github.com/samuelcolvin/rtoml";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7160,6 +7160,8 @@ in {
 
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
 
+  rtoml = callPackage ../development/python-modules/rtoml { };
+
   Rtree = callPackage ../development/python-modules/Rtree {
     inherit (pkgs) libspatialindex;
   };


### PR DESCRIPTION
###### Motivation for this change
i wanted to compare its performance between `toml`, `rtoml`, `pytomlpp`, `json`, `simplejson`, `yaml`, `pyyaml` and `ruamel yaml`
(results can be reproduced [here](https://gitlab.com/evils/py-dict-file-bench))
and someone was asking about this on IRC

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/1m6j3nd2x59xk9ghjj7n1wdz3573r702-python3.8-rtoml-0.6.1	   99024384`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
