### PR TITLE
python3.pkgs.pytomlpp: init at 0.3.5

### DIFF
--- a/pkgs/development/python-modules/pytomlpp/default.nix
+++ b/pkgs/development/python-modules/pytomlpp/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pybind11
+, pytestCheckHook
+, dateutil
+, doxygen
+, python
+, pelican
+, matplotlib
+}:
+
+buildPythonPackage rec {
+  pname = "pytomlpp";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "bobfang1992";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "1h06a2r0f5q4mml485113mn7a7585zmhqsk2p1apcybyydllcqda";
+  };
+
+  buildInputs = [ pybind11 ];
+
+  checkInputs = [
+    pytestCheckHook
+
+    dateutil
+    doxygen
+    python
+    pelican
+    matplotlib
+  ];
+
+  # pelican requires > 2.7
+  doCheck = !pythonOlder "3.6";
+
+  preCheck = ''
+    cd tests
+  '';
+
+  pythonImportsCheck = [ "pytomlpp" ];
+
+  meta = with lib; {
+    description = "A python wrapper for tomlplusplus";
+    homepage = "https://github.com/bobfang1992/pytomlpp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evils ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6684,6 +6684,8 @@ in {
 
   pytoml = callPackage ../development/python-modules/pytoml { };
 
+  pytomlpp = callPackage ../development/python-modules/pytomlpp { };
+
   pytools = callPackage ../development/python-modules/pytools { };
 
   pytorch = callPackage ../development/python-modules/pytorch {


### PR DESCRIPTION
###### Motivation for this change
same as #122400 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/ajc7l7icrmnaabzv4vjfz5aw8fj5s3sr-python3.8-pytomlpp-0.3.5	  104723184`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
