### PR TITLE
megacmd: 1.2.0 -> 1.4.0

### DIFF
--- a/pkgs/applications/misc/megacmd/default.nix
+++ b/pkgs/applications/misc/megacmd/default.nix
@@ -1,11 +1,12 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , autoconf
 , automake
 , c-ares
 , cryptopp
 , curl
 , fetchFromGitHub
-, ffmpeg_3
+, ffmpeg_3 # build fails with latest ffmpeg, see https://github.com/meganz/MEGAcmd/issues/523
 , freeimage
 , gcc-unwrapped
 , libmediainfo
@@ -22,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "megacmd";
-  version = "1.2.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "meganz";
     repo = "MEGAcmd";
     rev = "${version}_Linux";
-    sha256 = "0czyhsms0a0237d6h9b21n9p4nm4zkjanhhbvw26k6266g6c1nyr";
+    sha256 = "sha256-Q1SZSDTPGgBA/W/ZVYfTQsiP41RE1LJ+esQ3PK9EjIc=";
     fetchSubmodules = true;
   };
 
@@ -49,7 +50,6 @@ stdenv.mkDerivation rec {
     libmediainfo
     libraw
     libsodium
-    libtool
     libuv
     libzen
     pcre-cpp
@@ -80,9 +80,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "MEGA Command Line Interactive and Scriptable Application";
-    homepage    = "https://mega.nz/";
-    license     = licenses.unfree;
-    platforms   = [ "i686-linux" "x86_64-linux" ];
-    maintainers = [ maintainers.wedens ];
+    homepage = "https://mega.nz/cmd";
+    license = with licenses; [ bsd2 gpl3Only ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ lunik1 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updates MEGAcmd from 1.2.0 to 1.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
