### PR TITLE
r-modules: autoset bioconductor ver to match R ver

### DIFF
--- a/doc/languages-frameworks/r.section.md
+++ b/doc/languages-frameworks/r.section.md
@@ -99,20 +99,23 @@ re-enter the shell.
 nix-shell generate-shell.nix
 
 Rscript generate-r-packages.R cran  > cran-packages.nix.new
-mv cran-packages.nix.new cran-packages.nix
-
 Rscript generate-r-packages.R bioc  > bioc-packages.nix.new
-mv bioc-packages.nix.new bioc-packages.nix
-
 Rscript generate-r-packages.R bioc-annotation > bioc-annotation-packages.nix.new
-mv bioc-annotation-packages.nix.new bioc-annotation-packages.nix
-
 Rscript generate-r-packages.R bioc-experiment > bioc-experiment-packages.nix.new
+
+sleep 1
+
+mv cran-packages.nix.new cran-packages.nix
+mv bioc-packages.nix.new bioc-packages.nix
+mv bioc-annotation-packages.nix.new bioc-annotation-packages.nix
 mv bioc-experiment-packages.nix.new bioc-experiment-packages.nix
 ```
 
-`generate-r-packages.R <repo>` reads  `<repo>-packages.nix`, therefor the renaming.
+`generate-r-packages.R <repo>` reads  `<repo>-packages.nix`, therefor the renaming, but sometimes a delay is needed for the OS to release locks on the new file. 
 
+If `nix-shell generate-shell.nix` is causing a large number of packages to rebuild from source and taking too long, then any environment with both `R` and `nix-hash` should work as a substitute, as long as the packages `data.table`, `parallel` and `BiocManager` are installed and the `R` version matches master.
+
+If some packages will not evaluate because the `sha256` field is empty, delete the entries and re-run the script above.
 
 ## Testing if the Nix-expression could be evaluated
 

--- a/doc/languages-frameworks/r.section.md
+++ b/doc/languages-frameworks/r.section.md
@@ -111,7 +111,7 @@ mv bioc-annotation-packages.nix.new bioc-annotation-packages.nix
 mv bioc-experiment-packages.nix.new bioc-experiment-packages.nix
 ```
 
-`generate-r-packages.R <repo>` reads  `<repo>-packages.nix`, therefor the renaming, but sometimes a delay is needed for the OS to release locks on the new file. 
+`generate-r-packages.R <repo>` reads  `<repo>-packages.nix`, therefor the renaming, but sometimes a delay is needed for the OS to release locks on the new file.
 
 If `nix-shell generate-shell.nix` is causing a large number of packages to rebuild from source and taking too long, then any environment with both `R` and `nix-hash` should work as a substitute, as long as the packages `data.table`, `parallel` and `BiocManager` are installed and the `R` version matches master.
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -44,8 +44,8 @@ let
   deriveBioc = mkDerive {
     mkHomepage = {name, biocVersion, ...}: "https://bioconductor.org/packages/${biocVersion}/bioc/html/${name}.html";
     mkUrls = {name, version, biocVersion}: [ "mirror://bioc/${biocVersion}/bioc/src/contrib/${name}_${version}.tar.gz"
-                                             "mirror://bioc/${biocVersion}/bioc/src/contrib/Archive/${name}/${name}_${version}.tar.gz"
-                                             "mirror://bioc/${biocVersion}/bioc/src/contrib/Archive/${name}_${version}.tar.gz" ];
+                                              "mirror://bioc/${biocVersion}/bioc/src/contrib/Archive/${name}/${name}_${version}.tar.gz"
+                                              "mirror://bioc/${biocVersion}/bioc/src/contrib/Archive/${name}_${version}.tar.gz" ];
   };
   deriveBiocAnn = mkDerive {
     mkHomepage = {name, ...}: "http://www.bioconductor.org/packages/${name}.html";

--- a/pkgs/development/r-modules/generate-r-packages.R
+++ b/pkgs/development/r-modules/generate-r-packages.R
@@ -1,9 +1,11 @@
 #!/usr/bin/env Rscript
 library(data.table)
 library(parallel)
+library(BiocManager)
 cl <- makeCluster(10)
 
-biocVersion <- 3.11
+biocVersion <- BiocManager:::.version_map()
+biocVersion <-  as.numeric(as.character(max(biocVersion[biocVersion$R == getRversion()[, 1:2], "Bioc"])))
 snapshotDate <- Sys.Date()-1
 
 mirrorUrls <- list( bioc=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/bioc/src/contrib/")
@@ -72,8 +74,8 @@ pkgs <- as.data.table(available.packages(mirrorUrl, filters=c("R_version", "OS_t
 pkgs <- pkgs[order(Package)]
 
 write(paste("updating", mirrorType, "packages"), stderr())
-pkgs$sha256 <- parApply(cl, pkgs, 1, function(p) nixPrefetch(p[1], p[2]))
-nix <- apply(pkgs, 1, function(p) formatPackage(p[1], p[2], p[18], p[4], p[5], p[6]))
+pkgs$sha256 <- parApply(cl, pkgs, 1, function(p) as.character(nixPrefetch(p[1], p[2])))
+nix <- apply(pkgs, 1, function(p) formatPackage(p[[1]], p[[2]], p[[18]], p[[4]], p[[5]], p[[6]]))
 write("done", stderr())
 
 cat("# This file is generated from generate-r-packages.R. DO NOT EDIT.\n")

--- a/pkgs/development/r-modules/generate-r-packages.R
+++ b/pkgs/development/r-modules/generate-r-packages.R
@@ -9,10 +9,10 @@ biocVersion <-  as.numeric(as.character(max(biocVersion[biocVersion$R == getRver
 snapshotDate <- Sys.Date()-1
 
 mirrorUrls <- list( bioc=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/bioc/src/contrib/")
-                  , "bioc-annotation"=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/data/annotation/src/contrib/")
-                  , "bioc-experiment"=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/data/experiment/src/contrib/")
-                  , cran=paste0("http://mran.revolutionanalytics.com/snapshot/", snapshotDate, "/src/contrib/")
-                  )
+                 , "bioc-annotation"=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/data/annotation/src/contrib/")
+                 , "bioc-experiment"=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/data/experiment/src/contrib/")
+                 , cran=paste0("http://mran.revolutionanalytics.com/snapshot/", snapshotDate, "/src/contrib/")
+                   )
 
 mirrorType <- commandArgs(trailingOnly=TRUE)[1]
 stopifnot(mirrorType %in% names(mirrorUrls))
@@ -33,7 +33,7 @@ nixPrefetch <- function(name, version) {
     as.character(readFormatted$V6[ prevV ])
 
   else {
-    # avoid nix-prefetch-url because it often fails to fetch/hash large files
+                                        # avoid nix-prefetch-url because it often fails to fetch/hash large files
     url <- paste0(mirrorUrl, name, "_", version, ".tar.gz")
     tmp <- tempfile(pattern=paste0(name, "_", version), fileext=".tar.gz")
     cmd <- paste0("wget -q -O '", tmp, "' '", url, "'")
@@ -46,26 +46,26 @@ nixPrefetch <- function(name, version) {
 }
 
 escapeName <- function(name) {
-    switch(name, "import" = "r_import", "assert" = "r_assert", name)
+  switch(name, "import" = "r_import", "assert" = "r_assert", name)
 }
 
 formatPackage <- function(name, version, sha256, depends, imports, linkingTo) {
-    name <- escapeName(name)
-    attr <- gsub(".", "_", name, fixed=TRUE)
-    options(warn=5)
-    depends <- paste( if (is.na(depends)) "" else gsub("[ \t\n]+", "", depends)
-                    , if (is.na(imports)) "" else gsub("[ \t\n]+", "", imports)
-                    , if (is.na(linkingTo)) "" else gsub("[ \t\n]+", "", linkingTo)
-                    , sep=","
-                    )
-    depends <- unlist(strsplit(depends, split=",", fixed=TRUE))
-    depends <- lapply(depends, gsub, pattern="([^ \t\n(]+).*", replacement="\\1")
-    depends <- lapply(depends, gsub, pattern=".", replacement="_", fixed=TRUE)
-    depends <- depends[depends %in% knownPackages]
-    depends <- lapply(depends, escapeName)
-    depends <- paste(depends)
-    depends <- paste(sort(unique(depends)), collapse=" ")
-    paste0("  ", attr, " = derive2 { name=\"", name, "\"; version=\"", version, "\"; sha256=\"", sha256, "\"; depends=[", depends, "]; };")
+  name <- escapeName(name)
+  attr <- gsub(".", "_", name, fixed=TRUE)
+  options(warn=5)
+  depends <- paste( if (is.na(depends)) "" else gsub("[ \t\n]+", "", depends)
+                 , if (is.na(imports)) "" else gsub("[ \t\n]+", "", imports)
+                 , if (is.na(linkingTo)) "" else gsub("[ \t\n]+", "", linkingTo)
+                 , sep=","
+                   )
+  depends <- unlist(strsplit(depends, split=",", fixed=TRUE))
+  depends <- lapply(depends, gsub, pattern="([^ \t\n(]+).*", replacement="\\1")
+  depends <- lapply(depends, gsub, pattern=".", replacement="_", fixed=TRUE)
+  depends <- depends[depends %in% knownPackages]
+  depends <- lapply(depends, escapeName)
+  depends <- paste(depends)
+  depends <- paste(sort(unique(depends)), collapse=" ")
+  paste0("  ", attr, " = derive2 { name=\"", name, "\"; version=\"", version, "\"; sha256=\"", sha256, "\"; depends=[", depends, "]; };")
 }
 
 clusterExport(cl, c("nixPrefetch","readFormatted", "mirrorUrl", "knownPackages"))

--- a/pkgs/development/r-modules/generate-shell.nix
+++ b/pkgs/development/r-modules/generate-shell.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation {
       packages = with rPackages; [
         data_table
         parallel
+        BiocManager
       ];
     })
   ];


### PR DESCRIPTION
BioConductor releases are tied to specific R releases.

Updating the package set now automatically selects the
correct version of bioconductor to match the current version of
R.

Also update language documentation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I updated the r-module package set (PR coming very soon) and encountered  a few issues. 

Bioconductor needed to have a version set in `generate-r-packages.R`, and the version must be compatible with the version of R, but that was not mentioned in the documentation. I have automated the version matching so the correct version of bioconductor will be chosen depending on the version of R used to update the packages. The maintainer should not have to update  `generate-r-packages.R` before bumping anymore, as long as they use the R version in master.

I also had issues with some packages in bioc-experiment failing to get a hash. Re-running the scripts seemed to work most of the time.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
