### PR TITLE
linuxPackages.anbox: 2019-11-15 -> 2020-06-14, mark broken for kernels not supported

### DIFF
--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "anbox-modules";
-  version = "2019-11-15-" + kernel.version;
+  version = "2020-06-14-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "anbox";
     repo = "anbox-modules";
-    rev = "e0a237e571989987806b32881044c539db25e3e1";
-    sha256 = "1km1nslp4f5znwskh4bb1b61r1inw1dlbwiyyq3rrh0f0agf8d0v";
+    rev = "98f0f3b3b1eeb5a6954ca15ec43e150b76369086";
+    sha256 = "sha256-6xDJQ4YItdbYqle/9VNfOc7D80yFGd9cFyF+CuABaF0=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -34,10 +34,9 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Anbox ashmem and binder drivers.";
     homepage = "https://github.com/anbox/anbox-modules";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
-    broken = (versionOlder kernel.version "4.4");
+    broken = kernel.kernelOlder "4.4" || kernel.kernelAtLeast "5.5";
     maintainers = with maintainers; [ edwtjo ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
