### PR TITLE
aegisub: fix x86_64-linux build

### DIFF
--- a/pkgs/applications/video/aegisub/default.nix
+++ b/pkgs/applications/video/aegisub/default.nix
@@ -76,6 +76,20 @@ stdenv.mkDerivation rec {
       url = "https://github.com/Aegisub/Aegisub/commit/6bd3f4c26b8fc1f76a8b797fcee11e7611d59a39.patch";
       sha256 = "sha256-rG8RJokd4V4aSYOQw2utWnrWPVrkqSV3TAvnGXNhLOk=";
     })
+
+    # Compatibility with ffms2
+    (fetchpatch {
+      url = "https://github.com/Aegisub/Aegisub/commit/1aa9215e7fc360de05da9b7ec2cd68f1940af8b2.patch";
+      sha256 = "sha256-JsuI4hQTcT0TEqHHoSsGbuiTg4hMCH3Cxp061oLk8Go=";
+    })
+
+    ./update-ffms2.patch
+
+    # Compatibility with X11
+    (fetchpatch {
+      url = "https://github.com/Aegisub/Aegisub/commit/7a6da26be6a830f4e1255091952cc0a1326a4520.patch";
+      sha256 = "sha256-/aTcIjFlZY4N9+IyHL4nwR0hUR4HTJM7ibbdKmNxq0w=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -112,6 +126,10 @@ stdenv.mkDerivation rec {
     "bindnow"
     "relro"
   ];
+
+  postPatch = ''
+    sed -i 's/-Wno-c++11-narrowing/-Wno-narrowing/' configure.ac src/Makefile
+  '';
 
   # compat with icu61+
   # https://github.com/unicode-org/icu/blob/release-64-2/icu4c/readme.html#L554

--- a/pkgs/applications/video/aegisub/update-ffms2.patch
+++ b/pkgs/applications/video/aegisub/update-ffms2.patch
@@ -1,0 +1,105 @@
+commit 89c4e8d34ab77c3322f097b91fd9de22cbea7a37
+Author: Thomas Goyne <plorkyeran@aegisub.org>
+Date:   Wed Nov 21 16:41:05 2018 -0800
+
+    Update ffmpeg and ffms2
+
+diff --git a/src/video_provider_ffmpegsource.cpp b/src/video_provider_ffmpegsource.cpp
+index 8bd68fbbf..f4ed6a2f2 100644
+--- a/src/video_provider_ffmpegsource.cpp
++++ b/src/video_provider_ffmpegsource.cpp
+@@ -44,6 +44,23 @@
+ #include <libaegisub/make_unique.h>
+ 
+ namespace {
++typedef enum AGI_ColorSpaces {
++	AGI_CS_RGB = 0,
++	AGI_CS_BT709 = 1,
++	AGI_CS_UNSPECIFIED = 2,
++	AGI_CS_FCC = 4,
++	AGI_CS_BT470BG = 5,
++	AGI_CS_SMPTE170M = 6,
++	AGI_CS_SMPTE240M = 7,
++	AGI_CS_YCOCG = 8,
++	AGI_CS_BT2020_NCL = 9,
++	AGI_CS_BT2020_CL = 10,
++	AGI_CS_SMPTE2085 = 11,
++	AGI_CS_CHROMATICITY_DERIVED_NCL = 12,
++	AGI_CS_CHROMATICITY_DERIVED_CL = 13,
++	AGI_CS_ICTCP = 14
++} AGI_ColorSpaces;
++
+ /// @class FFmpegSourceVideoProvider
+ /// @brief Implements video loading through the FFMS library.
+ class FFmpegSourceVideoProvider final : public VideoProvider, FFmpegSourceProvider {
+@@ -78,7 +95,7 @@ public:
+ 		if (matrix == RealColorSpace)
+ 			FFMS_SetInputFormatV(VideoSource, CS, CR, FFMS_GetPixFmt(""), nullptr);
+ 		else if (matrix == "TV.601")
+-			FFMS_SetInputFormatV(VideoSource, FFMS_CS_BT470BG, CR, FFMS_GetPixFmt(""), nullptr);
++			FFMS_SetInputFormatV(VideoSource, AGI_CS_BT470BG, CR, FFMS_GetPixFmt(""), nullptr);
+ 		else
+ 			return;
+ 		ColorSpace = matrix;
+@@ -103,16 +120,16 @@ std::string colormatrix_description(int cs, int cr) {
+ 	std::string str = cr == FFMS_CR_JPEG ? "PC" : "TV";
+ 
+ 	switch (cs) {
+-		case FFMS_CS_RGB:
++		case AGI_CS_RGB:
+ 			return "None";
+-		case FFMS_CS_BT709:
++		case AGI_CS_BT709:
+ 			return str + ".709";
+-		case FFMS_CS_FCC:
++		case AGI_CS_FCC:
+ 			return str + ".FCC";
+-		case FFMS_CS_BT470BG:
+-		case FFMS_CS_SMPTE170M:
++		case AGI_CS_BT470BG:
++		case AGI_CS_SMPTE170M:
+ 			return str + ".601";
+-		case FFMS_CS_SMPTE240M:
++		case AGI_CS_SMPTE240M:
+ 			return str + ".240M";
+ 		default:
+ 			throw VideoOpenError("Unknown video color space");
+@@ -206,8 +223,10 @@ void FFmpegSourceVideoProvider::LoadVideo(agi::fs::path const& filename, std::st
+ 
+ 	// set thread count
+ 	int Threads = OPT_GET("Provider/Video/FFmpegSource/Decoding Threads")->GetInt();
++#if FFMS_VERSION < ((2 << 24) | (30 << 16) | (0 << 8) | 0)
+ 	if (FFMS_GetVersion() < ((2 << 24) | (17 << 16) | (2 << 8) | 1) && FFMS_GetSourceType(Index) == FFMS_SOURCE_LAVF)
+ 		Threads = 1;
++#endif
+ 
+ 	// set seekmode
+ 	// TODO: give this its own option?
+@@ -235,18 +254,22 @@ void FFmpegSourceVideoProvider::LoadVideo(agi::fs::path const& filename, std::st
+ 	else
+ 		DAR = double(Width) / Height;
+ 
+-	CS = TempFrame->ColorSpace;
++	int VideoCS = CS = TempFrame->ColorSpace;
+ 	CR = TempFrame->ColorRange;
+ 
+-	if (CS == FFMS_CS_UNSPECIFIED)
+-		CS = Width > 1024 || Height >= 600 ? FFMS_CS_BT709 : FFMS_CS_BT470BG;
++	if (CS == AGI_CS_UNSPECIFIED)
++		CS = Width > 1024 || Height >= 600 ? AGI_CS_BT709 : AGI_CS_BT470BG;
+ 	RealColorSpace = ColorSpace = colormatrix_description(CS, CR);
+ 
+ #if FFMS_VERSION >= ((2 << 24) | (17 << 16) | (1 << 8) | 0)
+-	if (CS != FFMS_CS_RGB && CS != FFMS_CS_BT470BG && ColorSpace != colormatrix && (colormatrix == "TV.601" || OPT_GET("Video/Force BT.601")->GetBool())) {
+-		if (FFMS_SetInputFormatV(VideoSource, FFMS_CS_BT470BG, CR, FFMS_GetPixFmt(""), &ErrInfo))
++	if (CS != AGI_CS_RGB && CS != AGI_CS_BT470BG && ColorSpace != colormatrix && (colormatrix == "TV.601" || OPT_GET("Video/Force BT.601")->GetBool())) {
++		CS = AGI_CS_BT470BG;
++		ColorSpace = colormatrix_description(AGI_CS_BT470BG, CR);
++	}
++
++	if (CS != VideoCS) {
++		if (FFMS_SetInputFormatV(VideoSource, CS, CR, FFMS_GetPixFmt(""), &ErrInfo))
+ 			throw VideoOpenError(std::string("Failed to set input format: ") + ErrInfo.Buffer);
+-		ColorSpace = colormatrix_description(FFMS_CS_BT470BG, CR);
+ 	}
+ #endif


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042

This fixes the Linux build for Aegisu. The main repository is clearly not active so I considered switching to the 3.3.2 update through wangqr's [fork](https://github.com/wangqr/Aegisub/releases/tag/v3.3.2), however, I wasn't too sure that was the right call (correct me if I'm wrong).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
