### PR TITLE
Mix2nix support

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -1,0 +1,98 @@
+{ stdenv, writeText, elixir, erlang, hex, lib }:
+
+{ name
+, version
+, src
+, setupHook ? null
+, buildInputs ? [ ]
+, beamDeps ? [ ]
+, postPatch ? ""
+, compilePorts ? false
+, installPhase ? null
+, buildPhase ? null
+, configurePhase ? null
+, meta ? { }
+, enableDebugInfo ? false
+, ...
+}@attrs:
+
+with lib;
+
+let
+
+  debugInfoFlag = lib.optionalString (enableDebugInfo || elixir.debugInfo) "--debug-info";
+
+  shell = drv: stdenv.mkDerivation {
+    name = "interactive-shell-${drv.name}";
+    buildInputs = [ drv ];
+  };
+
+  bootstrapper = ./mix-bootstrap;
+
+  pkg = self: stdenv.mkDerivation (attrs // {
+    name = "${name}-${version}";
+    inherit version;
+
+    dontStrip = true;
+
+    inherit src;
+
+    setupHook =
+      if setupHook == null
+      then
+        writeText "setupHook.sh" ''
+          addToSearchPath ERL_LIBS "$1/lib/erlang/lib"
+        ''
+      else setupHook;
+
+    inherit buildInputs;
+    propagatedBuildInputs = [ hex elixir ] ++ beamDeps;
+
+    configurePhase =
+      if configurePhase == null
+      then ''
+        runHook preConfigure
+        ${erlang}/bin/escript ${bootstrapper}
+        runHook postConfigure
+      ''
+      else configurePhase;
+
+
+    buildPhase =
+      if buildPhase == null
+      then ''
+        runHook preBuild
+        export HEX_OFFLINE=1
+        export HEX_HOME=`pwd`
+        mix compile ${debugInfoFlag} --no-deps-check
+        runHook postBuild
+      ''
+      else buildPhase;
+
+    installPhase =
+      if installPhase == null
+      then ''
+        runHook preInstall
+        MIXENV=prod
+        if [ -d "_build/shared" ]; then
+          MIXENV=shared
+        fi
+        mkdir -p "$out/lib/erlang/lib/${name}-${version}"
+        for reldir in src ebin priv include; do
+          fd="_build/$MIXENV/lib/${name}/$reldir"
+          [ -d "$fd" ] || continue
+          cp -Hrt "$out/lib/erlang/lib/${name}-${version}" "$fd"
+          success=1
+        done
+        runHook postInstall
+      ''
+      else installPhase;
+
+    passthru = {
+      packageName = name;
+      env = shell self;
+      inherit beamDeps;
+    };
+  });
+in
+fix pkg

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -1,30 +1,41 @@
-{ stdenv, writeText, erlang, rebar3, openssl, libyaml,
-  pc, lib }:
+{ stdenv
+, writeText
+, erlang
+, rebar3
+, openssl
+, libyaml
+, pc
+, lib
+}:
 
-{ name, version
+{ name
+, version
 , src
 , setupHook ? null
-, buildInputs ? [], beamDeps ? [], buildPlugins ? []
+, buildInputs ? [ ]
+, beamDeps ? [ ]
+, buildPlugins ? [ ]
 , postPatch ? ""
 , compilePorts ? false
 , installPhase ? null
 , buildPhase ? null
 , configurePhase ? null
-, meta ? {}
+, meta ? { }
 , enableDebugInfo ? false
-, ... }@attrs:
+, ...
+}@attrs:
 
 with lib;
 
 let
   debugInfoFlag = lib.optionalString (enableDebugInfo || erlang.debugInfo) "debug-info";
 
-  ownPlugins = buildPlugins ++ (if compilePorts then [pc] else []);
+  ownPlugins = buildPlugins ++ (if compilePorts then [ pc ] else [ ]);
 
   shell = drv: stdenv.mkDerivation {
-          name = "interactive-shell-${drv.name}";
-          buildInputs = [ drv ];
-    };
+    name = "interactive-shell-${drv.name}";
+    buildInputs = [ drv ];
+  };
 
   customPhases = filterAttrs
     (_: v: v != null)
@@ -46,7 +57,7 @@ let
     inherit src;
 
     setupHook = writeText "setupHook.sh" ''
-       addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
+      addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
     '';
 
     postPatch = ''
@@ -91,4 +102,4 @@ let
     };
   } // customPhases);
 in
-  fix pkg
+fix pkg

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -33,6 +33,7 @@ let
       buildHex = callPackage ./build-hex.nix { };
       buildErlangMk = callPackage ./build-erlang-mk.nix { };
       fetchMixDeps = callPackage ./fetch-mix-deps.nix { };
+      buildMix = callPackage ./build-mix.nix { };
       mixRelease = callPackage ./mix-release.nix { };
 
       # BEAM-based languages.

--- a/pkgs/development/beam-modules/mix-bootstrap
+++ b/pkgs/development/beam-modules/mix-bootstrap
@@ -1,0 +1,108 @@
+#!/usr/bin/env escript
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%%! -smp enable
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% The purpose of this command is to prepare a mix project so that mix
+%%% understands that the dependencies are all already installed. If you want a
+%%% hygienic build on nix then you must run this command before running mix. I
+%%% suggest that you add a `Makefile` to your project and have the bootstrap
+%%% command be a dependency of the build commands. See the nix documentation for
+%%% more information.
+%%%
+%%% This command designed to have as few dependencies as possible so that it can
+%%% be a dependency of root level packages like mix. To that end it does many
+%%% things in a fairly simplistic way. That is by design.
+%%%
+%%% ### Assumptions
+%%%
+%%% This command makes the following assumptions:
+%%%
+%%% * It is run in a nix-shell or nix-build environment
+%%% * that all dependencies have been added to the ERL_LIBS
+%%%   Environment Variable
+
+-record(data, {version
+              , erl_libs
+              , root
+              , name}).
+-define(LOCAL_HEX_REGISTRY, "registry.ets").
+
+main(Args) ->
+    {ok, RequiredData} = gather_required_data_from_the_environment(Args),
+    ok = bootstrap_libs(RequiredData).
+
+%% @doc
+%% This takes an app name in the standard OTP <name>-<version> format
+%% and returns just the app name. Why? Because rebar doesn't
+%% respect OTP conventions in some cases.
+-spec fixup_app_name(file:name()) -> string().
+fixup_app_name(Path) ->
+    BaseName = filename:basename(Path),
+    case string:split(BaseName, "-") of
+        [Name, _Version] -> Name;
+        Name -> Name
+    end.
+
+
+-spec gather_required_data_from_the_environment([string()]) -> {ok, #data{}}.
+gather_required_data_from_the_environment(_) ->
+    {ok, #data{ version = guard_env("version")
+              , erl_libs = os:getenv("ERL_LIBS", [])
+              , root = code:root_dir()
+              , name = guard_env("name")}}.
+
+-spec guard_env(string()) -> string().
+guard_env(Name) ->
+    case os:getenv(Name) of
+        false ->
+            stderr("Expected Environment variable ~s! Are you sure you are "
+                   "running in a Nix environment? Either a nix-build, "
+                   "nix-shell, etc?~n", [Name]),
+            erlang:halt(1);
+        Variable ->
+            Variable
+    end.
+
+-spec bootstrap_libs(#data{}) -> ok.
+bootstrap_libs(#data{erl_libs = ErlLibs}) ->
+    io:format("Bootstrapping dependent libraries~n"),
+    Target = "_build/prod/lib/",
+    Paths = string:tokens(ErlLibs, ":"),
+    CopiableFiles =
+        lists:foldl(fun(Path, Acc) ->
+                            gather_directory_contents(Path) ++ Acc
+                    end, [], Paths),
+    lists:foreach(fun (Path) ->
+                          ok = link_app(Path, Target)
+                  end, CopiableFiles).
+
+-spec gather_directory_contents(string()) -> [{string(), string()}].
+gather_directory_contents(Path) ->
+    {ok, Names} = file:list_dir(Path),
+    lists:map(fun(AppName) ->
+                 {filename:join(Path, AppName), fixup_app_name(AppName)}
+              end, Names).
+
+%% @doc
+%% Makes a symlink from the directory pointed at by Path to a
+%% directory of the same name in Target. So if we had a Path of
+%% {`foo/bar/baz/bash`, `baz`} and a Target of `faz/foo/foos`, the symlink
+%% would be `faz/foo/foos/baz`.
+-spec link_app({string(), string()}, string()) -> ok.
+link_app({Path, TargetFile}, TargetDir) ->
+    Target = filename:join(TargetDir, TargetFile),
+    ok = make_symlink(Path, Target).
+
+-spec make_symlink(string(), string()) -> ok.
+make_symlink(Path, TargetFile) ->
+    file:delete(TargetFile),
+    ok = filelib:ensure_dir(TargetFile),
+    io:format("Making symlink from ~s to ~s~n", [Path, TargetFile]),
+    ok = file:make_symlink(Path, TargetFile).
+
+%% @doc
+%% Write the result of the format string out to stderr.
+-spec stderr(string(), [term()]) -> ok.
+stderr(FormatStr, Args) ->
+    io:put_chars(standard_error, io_lib:format(FormatStr, Args)).

--- a/pkgs/development/tools/build-managers/rebar3/rebar3-nix-bootstrap
+++ b/pkgs/development/tools/build-managers/rebar3/rebar3-nix-bootstrap
@@ -87,7 +87,7 @@ bootstrap_plugins(#data{plugins = Plugins}) ->
 -spec bootstrap_libs(#data{}) -> ok.
 bootstrap_libs(#data{erl_libs = ErlLibs}) ->
     io:format("Bootstrapping dependent libraries~n"),
-    Target = "_build/default/lib/",
+    Target = "_checkout/default/lib/",
     Paths = string:tokens(ErlLibs, ":"),
     CopiableFiles =
         lists:foldl(fun(Path, Acc) ->


### PR DESCRIPTION
###### Motivation for this change

this is just a support PR for https://github.com/NixOS/nixpkgs/pull/121555
The only reason I'm doing this PR is to make it clearer what files have been changed.

Here is what I did here
- nixpkgs-fmt
- bring back the old build-mix 
- cleaned up a couple of environment variables in build-mix
- Fixed the buildRebar3 not working with cowboy telemetry.
the current rebar3 bootstrap will symlink dependencies to `_build/default/lib`. However during compilation of `cowboy_telemetry`, it tries to compile the `ranch` dependency. Even if it is already compiled and symlinked to the correct location. Looking at the documentationn for `rebar3` it looks like the `_checkouts` directory should be used instead of the `_build` directory
https://rebar3.readme.io/docs/dependencies#checkout-dependencies
I'm not 100% sure that this should be the correct behavior, however it seems to be what the doc says.

What is left after this fix
- correctly symlink dependencies in mix-release. It's probably just a matter of invoking the mix-bootstrap.