### PR TITLE
freeorion: 0.4.9 -> 0.4.10.1

### DIFF
--- a/pkgs/games/freeorion/fix-paths.sh
+++ b/pkgs/games/freeorion/fix-paths.sh
@@ -1,6 +1,6 @@
 #!@shell@
 
 if [ -e ~/.config/freeorion/config.xml ]; then
-  @libxsltBin@/bin/xsltproc -o ~/.config/freeorion/config.xml @out@/fixpaths/fix-paths.xslt ~/.config/freeorion/config.xml
+  @libxsltBin@/bin/xsltproc -o ~/.config/freeorion/config.xml @out@/share/freeorion/fix-paths.xslt ~/.config/freeorion/config.xml
 fi
 exit 0


### PR DESCRIPTION
###### Motivation for this change

Most importantly this allows us to move from py2 -> py3.

The path fix script also moves away from $out/fixpaths as it will otherwise pollute the global environment unnecessarily if installed globally.

Cc: @tex 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
