### PR TITLE
[20.09] palemoon: Remove MOZ_PKG_SPECIAL, add AV1 configure flag

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -142,6 +142,8 @@ stdenv.mkDerivation rec {
     ac_add_options --enable-jemalloc
     ac_add_options --enable-strip
     ac_add_options --enable-devtools
+    # Missing from build instructions, https://forum.palemoon.org/viewtopic.php?f=5&t=25843#p214767
+    ac_add_options --enable-av1
 
     ac_add_options --disable-eme
     ac_add_options --disable-webrtc
@@ -158,8 +160,6 @@ stdenv.mkDerivation rec {
     export MOZILLA_OFFICIAL=1
 
     ac_add_options --x-libraries=${lib.makeLibraryPath [ xorg.libX11 ]}
-
-    export MOZ_PKG_SPECIAL=gtk$_GTK_VERSION
 
     #
     # NixOS-specific adjustments


### PR DESCRIPTION
###### Motivation for this change
MOZ_PKG_SPECIAL: https://forum.palemoon.org/viewtopic.php?f=3&t=26796#p214729
"This is something we use for distinction for our infra. […] yeah just exclude it from your system packaging."

AV1: https://forum.palemoon.org/viewtopic.php?f=5&t=25843#p214767
"[It's] not on Linux and SunOS build instructions, only on Windows. But […] it is enabled for official Pale Moon"

(cherry picked from commit 0f4d3902abeebcc5379b81e4218f32ca5c2478d9)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
