### PR TITLE
aegisub: downgrade ffms dependency to fix build

### DIFF
--- a/pkgs/development/libraries/ffms/default.nix
+++ b/pkgs/development/libraries/ffms/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   ];
 
   preAutoreconf = ''
-    mkdir src/config
+    mkdir -p src/config
   '';
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -725,6 +725,7 @@ in
   aefs = callPackage ../tools/filesystems/aefs { };
 
   aegisub = callPackage ../applications/video/aegisub ({
+    ffms = ffms_2_23;
     wxGTK = wxGTK30;
   } // (config.aegisub or {}));
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14433,6 +14433,15 @@ in
   ffmpeg-normalize = python3Packages.callPackage ../applications/video/ffmpeg-normalize { };
 
   ffms = callPackage ../development/libraries/ffms { };
+  ffms_2_23 = ffms.overrideAttrs (oldAttrs: rec {
+    version = "2.23";
+    src = fetchFromGitHub {
+      owner = "FFMS";
+      repo = "ffms2";
+      rev = version;
+      sha256 = "0dkz5b3gxq5p4xz0qqg6l2sigszrlsinz3skyf0ln4wf3zrvf8m5";
+    };
+  });
 
   fftw = callPackage ../development/libraries/fftw { };
   fftwSinglePrec = fftw.override { precision = "single"; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

PR #120846, which upgraded ffms from 2.23 to 2.40, broke aegisub. This PR adds a top-level nixpkgs attribute `ffms_2_23` and passes it to the `aegisub` expression, which fixes the build. Note that the new `ffms_2_23` depends on `ffmpeg` rather than `ffmpeg_3`, so this change should be compatible with issue #120705.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
