### PR TITLE
solaar: 1.0.2 -> 1.0.5

### DIFF
--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,46 +1,59 @@
 { fetchFromGitHub, lib, gobject-introspection, gtk3, python3Packages }:
-# Although we copy in the udev rules here, you probably just want to use logitech-udev-rules instead of
-# adding this to services.udev.packages on NixOS
+
+# Although we copy in the udev rules here, you probably just want to use
+# logitech-udev-rules instead of adding this to services.udev.packages on NixOS
 python3Packages.buildPythonApplication rec {
   pname = "solaar";
-  version = "1.0.2";
+  version = "1.0.5";
+
   src = fetchFromGitHub {
     owner = "pwr-Solaar";
     repo = "Solaar";
     rev = version;
-    sha256 = "0k5z9dap6rawiafkg1x7zjx51ala7wra6j6lvc2nn0y8r79yp7a9";
+    sha256 = "sha256-k87DqIkvy5CVEsHT82ZArSM2JBi5sYdSCPfP4KjI850=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ gobject-introspection gtk3 pygobject3 pyudev ];
+  propagatedBuildInputs = with python3Packages; [
+    gobject-introspection
+    gtk3
+    psutil
+    pygobject3
+    pyudev
+    pyyaml
+    xlib
+  ];
 
+  makeWrapperArgs = [
+    "--prefix PYTHONPATH : $PYTHONPATH"
+    "--prefix GI_TYPELIB_PATH : $GI_TYPELIB_PATH"
+  ];
+
+  # the -cli symlink is just to maintain compabilility with older versions where
+  # there was a difference between the GUI and CLI versions.
   postInstall = ''
-    wrapProgram "$out/bin/solaar" \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
-    wrapProgram "$out/bin/solaar-cli" \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
+    ln -s $out/bin/solaar $out/bin/solaar-cli
 
-    install -Dm644 -t $out/etc/udev/rules.d rules.d/*.rules
+    install -Dm444 -t $out/etc/udev/rules.d rules.d/*.rules
   '';
 
-  enableParallelBuilding = true;
+  # No tests
+  doCheck = false;
+
   meta = with lib; {
     description = "Linux devices manager for the Logitech Unifying Receiver";
     longDescription = ''
-      Solaar is a Linux device manager for Logitech’s Unifying Receiver
-      peripherals. It is able to pair/unpair devices to the receiver, and for
-      most devices read battery status.
+      Solaar is a Linux manager for many Logitech keyboards, mice, and trackpads that
+      connect wirelessly to a USB Unifying, Lightspeed, or Nano receiver, connect
+      directly via a USB cable, or connect via Bluetooth. Solaar does not work with
+      peripherals from other companies.
 
-      It comes in two flavors, command-line and GUI. Both are able to list the
-      devices paired to a Unifying Receiver, show detailed info for each
-      device, and also pair/unpair supported devices with the receiver.
+      Solaar can be used as a GUI application or via its command-line interface.
 
-      To be able to use it, make sure you have access to /dev/hidraw* files.
+      This tool requires either to be run with root/sudo or alternatively to have the udev rules files installed. On NixOS this can be achieved by setting `hardware.logitech.wireless.enable`.
     '';
-    license = licenses.gpl2;
     homepage = "https://pwr-solaar.github.io/Solaar/";
-    platforms = platforms.linux;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ spinus ysndr ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/logitech-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/logitech-udev-rules/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   inherit (solaar) version;
 
   buildCommand = ''
-    install -Dm644 -t $out/etc/udev/rules.d ${solaar.src}/rules.d/*.rules
+    install -Dm444 -t $out/etc/udev/rules.d ${solaar.src}/rules.d/*.rules
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/ltunify/default.nix
+++ b/pkgs/tools/misc/ltunify/default.nix
@@ -1,23 +1,26 @@
 { lib, stdenv, fetchFromGitHub }:
 
-# Although we copy in the udev rules here, you probably just want to use logitech-udev-rules instead of
-# adding this to services.udev.packages on NixOS
+# Although we copy in the udev rules here, you probably just want to use
+# logitech-udev-rules instead of adding this to services.udev.packages on NixOS
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ltunify";
-  version = "unstable-20180330";
+  version = "0.3";
 
   src = fetchFromGitHub {
-    owner  = "Lekensteyn";
-    repo   = "ltunify";
-    rev    = "f664d1d41d5c4beeac5b81e485c3498f13109db7";
-    sha256 = "07sqhih9jmm7vgiwqsjzihd307cj7l096sxjl25p7nwr1q4180wv";
+    owner = "Lekensteyn";
+    repo = "ltunify";
+    rev = "v${version}";
+    sha256 = "sha256-9avri/2H0zv65tkBsIi9yVxx3eVS9oCkVCCFdjXqSgI=";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "bindir=/bin" ];
 
   meta = with lib; {
     description = "Tool for working with Logitech Unifying receivers and devices";
+    longDescription = ''
+      This tool requires either to be run with root/sudo or alternatively to have the udev rules files installed. On NixOS this can be achieved by setting `hardware.logitech.wireless.enable`.
+    '';
     homepage = "https://lekensteyn.nl/logitech-unifying.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ abbradar ];


### PR DESCRIPTION
###### Motivation for this change

Upstream update.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
