### PR TITLE
gir-rs: 2019-10-16 -> 2021-05-05

### DIFF
--- a/pkgs/development/tools/gir/default.nix
+++ b/pkgs/development/tools/gir/default.nix
@@ -2,16 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gir";
-  version = "2019-10-16";
+  version = "unstable-2021-05-05";
 
   src = fetchFromGitHub {
     owner = "gtk-rs";
     repo = "gir";
-    rev = "241d790085a712db7436c5c25b210ccb7d1a08d5";
-    sha256 = "1kn5kgdma9j6dwpmv6jmydak7ajlgdkw9sfkh3q7h8c2a8yikvxr";
+    rev = "c148542ce89b0bf7cbb9f5ef4179c96a45d022df";
+    sha256 = "0vy366ipwnn0cpp14l1v5g3dpnsr3hd8mjp3333lp0946igfqsy5";
+    leaveDotGit = true; # required for build.rs
   };
 
-  cargoSha256 = "048qhlc4f5khxi7dnakgqkhgww44r6h3mlx2fm7y2wqivr3rj8p1";
+  cargoSha256 = "11as1v88zf0f7l2ngllg5zqycvd05nb4vrsyl1dlarjvbq7fhvv8";
 
   meta = with lib; {
     description = "Tool to generate rust bindings and user API for glib-based libraries";


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

(Is anyone actually using this package? Their [documentation](https://gtk-rs.org/docs-src/tutorial/gir_tutorial#generating-the-sys-library) recommends installing gir from source.)

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
