### PR TITLE
haskellPackages: unbreak bson and mongoDB

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1898,4 +1898,19 @@ EOT
     })
   ];
 
+  bson = overrideCabal super.bson (drv: {
+    # We replace 'network' by 'network-bsd' because cabal2nix cannot correctly that pick up.
+    libraryHaskellDepends = with pkgs.haskellPackages; [
+      base
+      binary
+      bytestring
+      cryptohash-md5
+      data-binary-ieee754
+      mtl
+      network-bsd # network-bsd AND NOT network
+      text
+      time
+    ];
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super


### PR DESCRIPTION
###### Motivation for this change

Unbreaking `bson` and `mongoDB`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


##### Questions:

1. The problem is that the `network`/`network-bsd` dependency flag is not picked up correctly. Is this the correct place to fix it?
2. Is there a nicer way to 'replace' `network` by `network-bsd` than to re-enumerate all the dependencies and omit `network`?