### PR TITLE
nixos/tor: fixes for settings.HidServAuth

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -726,6 +726,12 @@ in
                 };
               })
             ]);
+            example = [
+              {
+                onion = "xxxxxxxxxxxxxxxx.onion";
+                auth = "xxxxxxxxxxxxxxxxxxxxxx";
+              }
+            ];
           };
           options.HiddenServiceNonAnonymousMode = optionBool "HiddenServiceNonAnonymousMode";
           options.HiddenServiceStatistics = optionBool "HiddenServiceStatistics";

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -170,7 +170,7 @@ let
     else if k == "ServerTransportPlugin" then
       optionalString (v.transports != []) "${concatStringsSep "," v.transports} exec ${v.exec}"
     else if k == "HidServAuth" then
-      concatMapStringsSep "\n${k} " (settings: settings.onion + " " settings.auth) v
+      v.onion + " " + v.auth
     else generators.mkValueStringDefault {} v;
   genTorrc = settings:
     generators.toKeyValue {

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -715,7 +715,7 @@ in
               (submodule {
                 options = {
                   onion = mkOption {
-                    type = strMatching "[a-z2-7]{16}(\\.onion)?";
+                    type = strMatching "[a-z2-7]{16}\\.onion";
                     description = "Onion address.";
                     example = "xxxxxxxxxxxxxxxx.onion";
                   };


### PR DESCRIPTION
###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/122429

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
