### PR TITLE
nixos/containerd: minor cleanup

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -7,12 +7,12 @@ let
 
   defaultContainerdConfigFile = pkgs.writeText "containerd.toml" ''
     version = 2
-    root = "/var/lib/containerd/daemon"
-    state = "/var/run/containerd/daemon"
+    root = "/var/lib/containerd"
+    state = "/run/containerd"
     oom_score = 0
 
     [grpc]
-      address = "/var/run/containerd/containerd.sock"
+      address = "/run/containerd/containerd.sock"
 
     [plugins."io.containerd.grpc.v1.cri"]
       sandbox_image = "pause:latest"

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -134,7 +134,7 @@ in
     containerRuntimeEndpoint = mkOption {
       description = "Endpoint at which to find the container runtime api interface/socket";
       type = str;
-      default = "unix:///var/run/containerd/containerd.sock";
+      default = "unix:///run/containerd/containerd.sock";
     };
 
     enable = mkEnableOption "Kubernetes kubelet.";

--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -44,9 +44,7 @@ in
         KillMode = "process";
         Type = "notify";
         Restart = "always";
-        RestartSec = "5";
-        StartLimitBurst = "8";
-        StartLimitIntervalSec = "120s";
+        RestartSec = "10";
 
         # "limits" defined below are adopted from upstream: https://github.com/containerd/containerd/blob/master/containerd.service
         LimitNPROC = "infinity";
@@ -57,6 +55,10 @@ in
 
         StateDirectory = "containerd";
         RuntimeDirectory = "containerd";
+      };
+      unitConfig = {
+        StartLimitBurst = "16";
+        StartLimitIntervalSec = "120s";
       };
     };
   };

--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -54,6 +54,9 @@ in
         LimitNOFILE = "infinity";
         TasksMax = "infinity";
         OOMScoreAdjust = "-999";
+
+        StateDirectory = "containerd";
+        RuntimeDirectory = "containerd";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Turns out that I initially misunderstood the containerd directory configurations. `root` is where containerd wants "persistent data" and `state` is where "runtime state" (ephemeral) lives. See: https://github.com/containerd/containerd/blob/master/docs/ops.md#base-configuration
I've changed directories to comply with systemd/nixos standards, i.e. `/var/lib/containerd` and `/run/containerd` respectively.

Also, systemd StartLimits must be in the `[unit]`-section, otherwise they are ignored. While moving them to `unitConfig`, I had to raise the limits to get reasonable startup times, now that start-limits are actually enforced. Feel free to raise opinions on restart-interval and start-limit _values_, because I chose the current ones rather arbitrarily, tbh.

NixOS tests run green locally with Kubernetes 1.20.5.

I'd like this to be part of release 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
