### PR TITLE
pythonPackages.ansible-lint: 5.0.2 -> 5.0.8

### DIFF
--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -14,6 +14,8 @@
 , enrich
 , python
 , tenacity
+, flaky
+, yamllint
 }:
 
 buildPythonPackage rec {
@@ -34,7 +36,7 @@ buildPythonPackage rec {
 
   buildInputs = [ python ];
 
-  propagatedBuildInputs = [ ansible enrich pyyaml rich ruamel-yaml wcmatch tenacity ];
+  propagatedBuildInputs = [ ansible enrich pyyaml rich ruamel-yaml wcmatch tenacity flaky yamllint ];
 
   checkInputs = [ pytestCheckHook pytest-xdist git ];
 
@@ -54,19 +56,13 @@ buildPythonPackage rec {
     "test_prerun_reqs_v1"
     "test_prerun_reqs_v2"
     # Assertion error with negative numbers; maybe requieres an ansible update?
-    "test_negative"
-    "test_example"
-    "test_playbook"
     "test_included_tasks"
-    "test_long_line"
 
     "test_get_yaml_files_umlaut"
     "test_run_inside_role_dir"
-    "test_role_handler_positive"
+    "test_custom_kinds"
+    "test_rule_no_handler"
   ];
-
-  # fails to run tests due to issues with temporary directory
-  doCheck = !stdenv.isDarwin;
 
   makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ ansible ]}" ];
 

--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -29,11 +29,6 @@ buildPythonPackage rec {
     sha256 = "sha256-tnuWKEB66bwVuwu3H3mHG99ZP+/msGhMDMRL5fyQgD8=";
   };
 
-  postPatch = ''
-    substituteInPlace src/ansiblelint/file_utils.py \
-      --replace 'raise RuntimeError("Unable to determine file type for %s" % pathex)' 'return "playbook"'
-  '';
-
   buildInputs = [ python ];
 
   propagatedBuildInputs = [ ansible enrich pyyaml rich ruamel-yaml wcmatch tenacity flaky yamllint ];

--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -13,17 +13,18 @@
 , wcmatch
 , enrich
 , python
+, tenacity
 }:
 
 buildPythonPackage rec {
   pname = "ansible-lint";
-  version = "5.0.2";
+  version = "5.0.8";
   disabled = isPy27;
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-vgt/KqNozTPaON/I19SybBZuo7bbl3Duq5dTBTMlj44=";
+    sha256 = "sha256-tnuWKEB66bwVuwu3H3mHG99ZP+/msGhMDMRL5fyQgD8=";
   };
 
   postPatch = ''
@@ -33,7 +34,7 @@ buildPythonPackage rec {
 
   buildInputs = [ python ];
 
-  propagatedBuildInputs = [ ansible enrich pyyaml rich ruamel-yaml wcmatch ];
+  propagatedBuildInputs = [ ansible enrich pyyaml rich ruamel-yaml wcmatch tenacity ];
 
   checkInputs = [ pytestCheckHook pytest-xdist git ];
 

--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -51,6 +51,9 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
+    # Both patches are addressed in https://github.com/ansible-community/ansible-lint/pull/1549
+    # and should be removed once merged upstream
+
     # fixes test_get_yaml_files_umlaut and test_run_inside_role_dir
     substituteInPlace src/ansiblelint/file_utils.py \
       --replace 'os.path.join(root, name)' 'os.path.normpath(os.path.join(root, name))'


### PR DESCRIPTION
###### Motivation for this change

Various bug fixes and minor changes, see https://github.com/ansible-community/ansible-lint/releases/tag/v5.0.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
