### PR TITLE
psi-plus: 1.4.1473 -> 1.5.1520

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,18 +1,19 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake
+{ lib, mkDerivation, fetchFromGitHub, cmake
 , qtbase, qtmultimedia, qtx11extras, qttools, qtwebengine
-, libidn, qca-qt5, libsecret, libXScrnSaver, hunspell
-, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
+, libidn, qca-qt5, libXScrnSaver, hunspell
+, libsecret, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
+, usrsctp
 }:
 
 mkDerivation rec {
   pname = "psi-plus";
-  version = "1.4.1473";
+  version = "1.5.1520";
 
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
     rev = version;
-    sha256 = "03f28zwbjn6fnsm0fqg8lmc11rpfdfvzjf7k7xydc3lzy8pxbds5";
+    sha256 = "0cj811qv0n8xck2qrnps2ybzrpvyjqz7nxkyccpaivq6zxj6mc12";
   };
 
   cmakeFlags = [
@@ -23,12 +24,13 @@ mkDerivation rec {
 
   buildInputs = [
     qtbase qtmultimedia qtx11extras qtwebengine
-    libidn qca-qt5 libsecret libXScrnSaver hunspell
-    libgcrypt libotr html-tidy libgpgerror libsignal-protocol-c
+    libidn qca-qt5 libXScrnSaver hunspell
+    libsecret libgcrypt libotr html-tidy libgpgerror libsignal-protocol-c
+    usrsctp
   ];
 
   meta = with lib; {
-    homepage = "https://sourceforge.net/projects/psiplus/";
+    homepage = "https://psi-plus.com";
     description = "XMPP (Jabber) client";
     maintainers = with maintainers; [ orivej misuzu ];
     license = licenses.gpl2;

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
     homepage = "https://psi-plus.com";
     description = "XMPP (Jabber) client";
     maintainers = with maintainers; [ orivej misuzu ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/usrsctp/default.nix
+++ b/pkgs/development/libraries/usrsctp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "usrsctp";
+  version = "0.9.5.0";
+
+  src = fetchFromGitHub {
+    owner = "sctplab";
+    repo = "usrsctp";
+    rev = version;
+    sha256 = "10ndzkip8blgkw572n3dicl6mgjaa7kygwn3vls80liq92vf1sa9";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://github.com/sctplab/usrsctp";
+    description = "A portable SCTP userland stack";
+    maintainers = with maintainers; [ misuzu ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18004,6 +18004,8 @@ in
 
   ustr = callPackage ../development/libraries/ustr { };
 
+  usrsctp = callPackage ../development/libraries/usrsctp { };
+
   usbredir = callPackage ../development/libraries/usbredir { };
 
   uthash = callPackage ../development/libraries/uthash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/psi-plus/psi-plus-snapshots/releases/tag/1.5.1520

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
