### PR TITLE
coqPackages.mathcomp-zify: init at 1.0.0+1.12+8.13

### DIFF
--- a/pkgs/development/coq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-zify/default.nix
@@ -1,0 +1,22 @@
+{ lib, mkCoqDerivation, coq, mathcomp-algebra, version ? null }:
+
+with lib; mkCoqDerivation rec {
+  pname = "mathcomp-zify";
+  repo = "mczify";
+  owner = "math-comp";
+  inherit version;
+
+  defaultVersion = with versions;
+     switch [ coq.coq-version mathcomp-algebra.version ] [
+       { cases = [ (isEq "8.13") (isEq "1.12") ]; out = "1.0.0+1.12+8.13"; }
+     ] null;
+
+  release."1.0.0+1.12+8.13".sha256 = "1j533vx6lacr89bj1bf15l1a0s7rvrx4l00wyjv99aczkfbz6h6k";
+
+  propagatedBuildInputs = [ mathcomp-algebra ];
+
+  meta = {
+    description = "Micromega tactics for Mathematical Components";
+    maintainers = with maintainers; [ cohencyril ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -58,6 +58,7 @@ let
       mathcomp-finmap = callPackage ../development/coq-modules/mathcomp-finmap {};
       mathcomp-bigenough = callPackage ../development/coq-modules/mathcomp-bigenough {};
       mathcomp-real-closed = callPackage ../development/coq-modules/mathcomp-real-closed {};
+      mathcomp-zify = callPackage ../development/coq-modules/mathcomp-zify {};
       metalib = callPackage ../development/coq-modules/metalib { };
       multinomials = callPackage ../development/coq-modules/multinomials {};
       odd-order = callPackage ../development/coq-modules/odd-order { };


### PR DESCRIPTION
###### Motivation for this change

Add new Coq package mathcomp-zify

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).