### PR TITLE
bochs: Fix compilation [ZHF]

### DIFF
--- a/pkgs/applications/virtualization/bochs/bochs_fix_narrowing_conv_warning.patch
+++ b/pkgs/applications/virtualization/bochs/bochs_fix_narrowing_conv_warning.patch
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------
+r13882 | vruppert | 2020-06-09 09:30:01 +0200 (Tue, 09 Jun 2020) | 2 lines
+
+Compilation fix for MSYS2 gcc 10.1.0 (narrowing conversion).
+
+
+Index: iodev/display/voodoo_data.h
+===================================================================
+--- a/iodev/display/voodoo_data.h	(revision 13881)
++++ b/iodev/display/voodoo_data.h	(revision 13882)
+@@ -1837,11 +1837,11 @@
+ 
+ /* fifo content defines */
+ #define FIFO_TYPES  (7 << 29)
+-#define FIFO_WR_REG     (1 << 29)
+-#define FIFO_WR_TEX     (2 << 29)
+-#define FIFO_WR_FBI_32  (3 << 29)
+-#define FIFO_WR_FBI_16L (4 << 29)
+-#define FIFO_WR_FBI_16H (5 << 29)
++#define FIFO_WR_REG     (1U << 29)
++#define FIFO_WR_TEX     (2U << 29)
++#define FIFO_WR_FBI_32  (3U << 29)
++#define FIFO_WR_FBI_16L (4U << 29)
++#define FIFO_WR_FBI_16H (5U << 29)
+ 
+ BX_CPP_INLINE void fifo_reset(fifo_state *f)
+ {
+
+------------------------------------------------------------------------

--- a/pkgs/applications/virtualization/bochs/default.nix
+++ b/pkgs/applications/virtualization/bochs/default.nix
@@ -26,7 +26,11 @@ stdenv.mkDerivation rec {
     sha256 = "0ql8q6y1k356li1g9gbvl21448mlxphxxi6kjb2b3pxvzd0pp2b3";
   };
 
-  patches = [ ./bochs-2.6.11-glibc-2.26.patch ./fix-build-smp.patch ];
+  patches = [
+    ./bochs-2.6.11-glibc-2.26.patch
+    ./fix-build-smp.patch
+    ./bochs_fix_narrowing_conv_warning.patch
+  ];
 
   buildInputs =
   [ pkg-config libtool gtk2 libGLU libGL readline libX11 libXpm docbook_xml_dtd_45 docbook_xsl ]


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
