### PR TITLE
nixos/davfs2: wrap {,u}mount.davfs with setuid=true

### DIFF
--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -70,6 +70,24 @@ in
       };
     };
 
+    security.wrappers."mount.davfs" = {
+      program = "mount.davfs";
+      source = "${pkgs.davfs2}/bin/mount.davfs";
+      owner = "root";
+      group = cfg.davGroup;
+      setuid = true;
+      permissions = "u+rx,g+x";
+    };
+
+    security.wrappers."umount.davfs" = {
+      program = "umount.davfs";
+      source = "${pkgs.davfs2}/bin/umount.davfs";
+      owner = "root";
+      group = cfg.davGroup;
+      setuid = true;
+      permissions = "u+rx,g+x";
+    };
+
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
Enabling `davfs2` and setting a `davfs` mount point in `/etc/fstab`:
```
services.davfs2.enable = true;
fileSystems."/home/julm/mnt/example/julm" = {
  device = "https://nextcloud.example.org/remote.php/dav/files/julm/";
  fsType = "davfs";
  options =
    let conf = pkgs.writeText "davfs2.conf" ''
      backup_dir /home/julm/.backup/davfs2/example/julm
      cache_dir /home/julm/.cache/davfs2/example/julm
    ''; in
    [ "conf=${conf}" "user" "noexec" "nosuid" "noauto" ];
};
```
Currently leads to:
```
$ mount ~/mnt/example/julm
/run/current-system/sw/bin/mount.davfs: program is not setuid root
```
This PR makes `mount.davfs` and `umount.davfs` setuid root to make it work.
Note also that https://github.com/NixOS/nixpkgs/commit/fba4c99f4f211f041f66c7e584ed3362aac2555f (mentioned in https://github.com/NixOS/nixpkgs/issues/103683) is required for `umount` to also work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
