### PR TITLE
python3Packages.fastapi: fix build

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -17,19 +17,19 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.63.0";
+  version = "0.65.0";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "fastapi";
     rev = version;
-    sha256 = "0l3imrcs42pqf9d6k8c1q15k5sqcnapl5zk71xl52mrxhz49lgpi";
+    sha256 = "sha256-DPfijCGORF3ThZblqaYTKN0H8+wlhtdIS8lfKfJl/bY=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "starlette ==0.13.6" "starlette"
+      --replace "starlette ==" "starlette >="
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/json-logging/default.nix
+++ b/pkgs/development/python-modules/json-logging/default.nix
@@ -30,10 +30,8 @@ buildPythonPackage rec {
   ];
 
   # - Quart is not packaged for Nixpkgs.
-  # - FastAPI is broken, see #112701 and tiangolo/fastapi#2335.
-  checkInputs = [ wheel flask /*quart*/ sanic /*fastapi*/ uvicorn requests pytestCheckHook ];
-  disabledTests = [ "quart" "fastapi" ];
-  disabledTestPaths = [ "tests/test_fastapi.py" ];
+  checkInputs = [ wheel flask /*quart*/ sanic fastapi uvicorn requests pytestCheckHook ];
+  disabledTests = [ "quart" ];
   # Tests spawn servers and try to connect to them.
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/tiangolo/fastapi/pull/2335 was merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
