### PR TITLE
python3Packages.pyjwt: revert approach to conditionally disable test in override; home-assistant: fix build

### DIFF
--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -29,11 +29,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals (lib.versionOlder version "2.0") [
-    # ecdsa changed internal behavior, required if one does 1.7.1 overriding
-    "ec_verify_should_return_false_if_signature_invalid"
-  ];
-
   pythonImportsCheck = [ "jwt" ];
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -38,8 +38,17 @@ let
     })
 
     # Pinned due to API changes in pyjwt>=2.0
-    (mkOverride "pyjwt" "1.7.1"
-      "15hflax5qkw1v6nssk1r0wkj83jgghskcmn875m3wgvpzdvajncd")
+    (self: super: {
+      pyjwt = super.pyjwt.overridePythonAttrs (oldAttrs: rec {
+        version = "1.7.1";
+        src = oldAttrs.src.override {
+          sha256 = "15hflax5qkw1v6nssk1r0wkj83jgghskcmn875m3wgvpzdvajncd";
+        };
+        disabledTests = [
+          "test_ec_verify_should_return_false_if_signature_invalid"
+        ];
+      });
+    })
 
     # Pinned due to bug in ring-doorbell 0.7.0
     # https://github.com/tchellomello/python-ring-doorbell/issues/240


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixing up #122380 … BUT it doesn't seem to work. The test does not get enabled when version is overwritten.

```
=========================== short test summary info ============================
FAILED tests/contrib/test_algorithms.py::TestEcdsaAlgorithms::test_ec_verify_should_return_false_if_signature_invalid
====== 1 failed, 178 passed, 8 skipped, 1 xfailed, 140 warnings in 2.01s =======
builder for '/nix/store/q8jhyxiksz54n85sbnrbr05n6ggbxqd1-python3.8-pyjwt-1.7.1.drv' failed with exit code 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
