### PR TITLE
Common Lisp packages updated

### DIFF
--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -24,8 +24,8 @@ let lispPackages = rec {
       quicklispdist = pkgs.fetchurl {
         # Will usually be replaced with a fresh version anyway, but needs to be
         # a valid distinfo.txt
-        url = "https://beta.quicklisp.org/dist/quicklisp/2021-02-28/distinfo.txt";
-        sha256 = "sha256:1apc0s07fmm386rj866dbrhrkq3lrbgbd79kwcyp91ix7sza8z3z";
+        url = "https://beta.quicklisp.org/dist/quicklisp/2021-04-11/distinfo.txt";
+        sha256 = "sha256:1z7a7m9cm7iv4m9ajvyqphsw30s3qwb0l8g8ayfmkvmvhlj79g86";
       };
       buildPhase = "true; ";
       postInstall = ''
@@ -124,7 +124,7 @@ let lispPackages = rec {
   };
   nyxt = pkgs.lispPackages.buildLispPackage rec {
     baseName = "nyxt";
-    version = "2021-03-27";
+    version = "2021-05-06";
 
 
     description = "Browser";
@@ -132,6 +132,14 @@ let lispPackages = rec {
     overrides = x: {
       postInstall = ''
         echo "Building nyxt binary"
+        (
+          source "$out/lib/common-lisp-settings"/*-shell-config.sh
+          cd "$out/lib/common-lisp"/*/
+          makeFlags="''${makeFlags:-}"
+          make LISP=common-lisp.sh NYXT_INTERNAL_QUICKLISP=false PREFIX="$out" $makeFlags all
+          make LISP=common-lisp.sh NYXT_INTERNAL_QUICKLISP=false PREFIX="$out" $makeFlags install
+          cp nyxt "$out/bin/nyxt"
+        )
         NIX_LISP_PRELAUNCH_HOOK='
           nix_lisp_build_system nyxt/gtk-application \
            "(asdf/system:component-entry-point (asdf:find-system :nyxt/gtk-application))" \
@@ -181,13 +189,15 @@ let lispPackages = rec {
             fset
             cl-cffi-gtk
             cl-webkit2
+            cl-gobject-introspection
     ];
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nyxt";
-      rev = "8ef171fd1eb62d168defe4a2d7115393230314d1";
-      sha256 = "sha256:1dz55mdmj68kmllih7ab70nmp0mwzqp9lh3im7kcjfmc1r64irdv";
-      # date = 2021-03-27T09:10:00+00:00;
+      rev = "940a5f9a19770771cf29f8fa7505e99c3a242b67";
+      sha256 = "sha256:0d5mawka26gwi9nb45x1n33vgskwyn46jrvfz7nzmm2jfaq4ipn6";
+      # Version 2 pre-release 7
+      # date = "2021-05-06T11:30:27Z";
     };
 
     packageName = "nyxt";

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd-ext-code-blocks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd-ext-code-blocks.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "_3bmd-ext-code-blocks";
-  version = "3bmd-20201220-git";
+  version = "3bmd-20210411-git";
 
   description = "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize, pygments, or chroma";
 
   deps = [ args."_3bmd" args."alexandria" args."colorize" args."esrap" args."html-encode" args."split-sequence" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz";
-    sha256 = "0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71";
+    url = "http://beta.quicklisp.org/archive/3bmd/2021-04-11/3bmd-20210411-git.tgz";
+    sha256 = "1gwl3r8cffr8yldi0x7zdzbmngqhli2d19wsky5cf8h80m30k4vp";
   };
 
   packageName = "3bmd-ext-code-blocks";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM 3bmd-ext-code-blocks DESCRIPTION
     extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize, pygments, or chroma
-    SHA256 0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71 URL
-    http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz MD5
-    67b6e5fa51d18817e7110e4fef6517ac NAME 3bmd-ext-code-blocks FILENAME
+    SHA256 1gwl3r8cffr8yldi0x7zdzbmngqhli2d19wsky5cf8h80m30k4vp URL
+    http://beta.quicklisp.org/archive/3bmd/2021-04-11/3bmd-20210411-git.tgz MD5
+    09f9290aa1708aeb469fb5154ab1a397 NAME 3bmd-ext-code-blocks FILENAME
     _3bmd-ext-code-blocks DEPS
     ((NAME 3bmd FILENAME _3bmd) (NAME alexandria FILENAME alexandria)
      (NAME colorize FILENAME colorize) (NAME esrap FILENAME esrap)
@@ -33,7 +33,7 @@ rec {
     DEPENDENCIES
     (3bmd alexandria colorize esrap html-encode split-sequence
      trivial-with-current-source-form)
-    VERSION 3bmd-20201220-git SIBLINGS
+    VERSION 3bmd-20210411-git SIBLINGS
     (3bmd-ext-definition-lists 3bmd-ext-math 3bmd-ext-tables
      3bmd-ext-wiki-links 3bmd-youtube-tests 3bmd-youtube 3bmd)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "_3bmd";
-  version = "20201220-git";
+  version = "20210411-git";
 
   description = "markdown processor in CL using esrap parser.";
 
   deps = [ args."alexandria" args."esrap" args."split-sequence" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz";
-    sha256 = "0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71";
+    url = "http://beta.quicklisp.org/archive/3bmd/2021-04-11/3bmd-20210411-git.tgz";
+    sha256 = "1gwl3r8cffr8yldi0x7zdzbmngqhli2d19wsky5cf8h80m30k4vp";
   };
 
   packageName = "3bmd";
@@ -19,16 +19,16 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM 3bmd DESCRIPTION markdown processor in CL using esrap parser. SHA256
-    0hcx8p8la3fmwhj8ddqik7bwrn9rvf5mcv6m77glimwckh51na71 URL
-    http://beta.quicklisp.org/archive/3bmd/2020-12-20/3bmd-20201220-git.tgz MD5
-    67b6e5fa51d18817e7110e4fef6517ac NAME 3bmd FILENAME _3bmd DEPS
+    1gwl3r8cffr8yldi0x7zdzbmngqhli2d19wsky5cf8h80m30k4vp URL
+    http://beta.quicklisp.org/archive/3bmd/2021-04-11/3bmd-20210411-git.tgz MD5
+    09f9290aa1708aeb469fb5154ab1a397 NAME 3bmd FILENAME _3bmd DEPS
     ((NAME alexandria FILENAME alexandria) (NAME esrap FILENAME esrap)
      (NAME split-sequence FILENAME split-sequence)
      (NAME trivial-with-current-source-form FILENAME
       trivial-with-current-source-form))
     DEPENDENCIES
     (alexandria esrap split-sequence trivial-with-current-source-form) VERSION
-    20201220-git SIBLINGS
+    20210411-git SIBLINGS
     (3bmd-ext-code-blocks 3bmd-ext-definition-lists 3bmd-ext-math
      3bmd-ext-tables 3bmd-ext-wiki-links 3bmd-youtube-tests 3bmd-youtube)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "alexandria";
-  version = "20200925-git";
+  version = "20210411-git";
 
   description = "Alexandria is a collection of portable public domain utilities.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/alexandria/2020-09-25/alexandria-20200925-git.tgz";
-    sha256 = "1cpvnzfs807ah07hrk8kplim6ryzqs4r35ym03cpky5xdl8c89fl";
+    url = "http://beta.quicklisp.org/archive/alexandria/2021-04-11/alexandria-20210411-git.tgz";
+    sha256 = "0bd4axr1z1q6khvpyf5xvgybdajs1dc7my6g0rdzhhxbibfcf3yh";
   };
 
   packageName = "alexandria";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM alexandria DESCRIPTION
     Alexandria is a collection of portable public domain utilities. SHA256
-    1cpvnzfs807ah07hrk8kplim6ryzqs4r35ym03cpky5xdl8c89fl URL
-    http://beta.quicklisp.org/archive/alexandria/2020-09-25/alexandria-20200925-git.tgz
-    MD5 59c8237a854de6f4f93328cd5747cd14 NAME alexandria FILENAME alexandria
-    DEPS NIL DEPENDENCIES NIL VERSION 20200925-git SIBLINGS (alexandria-tests)
+    0bd4axr1z1q6khvpyf5xvgybdajs1dc7my6g0rdzhhxbibfcf3yh URL
+    http://beta.quicklisp.org/archive/alexandria/2021-04-11/alexandria-20210411-git.tgz
+    MD5 415c43451862b490577b20ee4fb8e8d7 NAME alexandria FILENAME alexandria
+    DEPS NIL DEPENDENCIES NIL VERSION 20210411-git SIBLINGS (alexandria-tests)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-grovel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-grovel.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cffi-grovel";
-  version = "cffi_0.23.0";
+  version = "cffi_0.24.1";
 
   description = "The CFFI Groveller";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-toolchain" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
-    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
+    url = "http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz";
+    sha256 = "1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh";
   };
 
   packageName = "cffi-grovel";
@@ -19,13 +19,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cffi-grovel DESCRIPTION The CFFI Groveller SHA256
-    1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck URL
-    http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz MD5
-    a43e3c440fc4f20494e6d2347887c963 NAME cffi-grovel FILENAME cffi-grovel DEPS
+    1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh URL
+    http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz MD5
+    c3df5c460e00e5af8b8bd2cd03a4b5cc NAME cffi-grovel FILENAME cffi-grovel DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME cffi-toolchain FILENAME cffi-toolchain)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES (alexandria babel cffi cffi-toolchain trivial-features)
-    VERSION cffi_0.23.0 SIBLINGS
+    VERSION cffi_0.24.1 SIBLINGS
     (cffi-examples cffi-libffi cffi-tests cffi-toolchain cffi-uffi-compat cffi)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-toolchain.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-toolchain.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cffi-toolchain";
-  version = "cffi_0.23.0";
+  version = "cffi_0.24.1";
 
   description = "The CFFI toolchain";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
-    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
+    url = "http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz";
+    sha256 = "1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh";
   };
 
   packageName = "cffi-toolchain";
@@ -19,14 +19,14 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cffi-toolchain DESCRIPTION The CFFI toolchain SHA256
-    1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck URL
-    http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz MD5
-    a43e3c440fc4f20494e6d2347887c963 NAME cffi-toolchain FILENAME
+    1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh URL
+    http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz MD5
+    c3df5c460e00e5af8b8bd2cd03a4b5cc NAME cffi-toolchain FILENAME
     cffi-toolchain DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi)
      (NAME trivial-features FILENAME trivial-features))
-    DEPENDENCIES (alexandria babel cffi trivial-features) VERSION cffi_0.23.0
+    DEPENDENCIES (alexandria babel cffi trivial-features) VERSION cffi_0.24.1
     SIBLINGS
     (cffi-examples cffi-grovel cffi-libffi cffi-tests cffi-uffi-compat cffi)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-uffi-compat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi-uffi-compat.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cffi-uffi-compat";
-  version = "cffi_0.23.0";
+  version = "cffi_0.24.1";
 
   description = "UFFI Compatibility Layer for CFFI";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
-    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
+    url = "http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz";
+    sha256 = "1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh";
   };
 
   packageName = "cffi-uffi-compat";
@@ -19,14 +19,14 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cffi-uffi-compat DESCRIPTION UFFI Compatibility Layer for CFFI
-    SHA256 1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck URL
-    http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz MD5
-    a43e3c440fc4f20494e6d2347887c963 NAME cffi-uffi-compat FILENAME
+    SHA256 1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh URL
+    http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz MD5
+    c3df5c460e00e5af8b8bd2cd03a4b5cc NAME cffi-uffi-compat FILENAME
     cffi-uffi-compat DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi)
      (NAME trivial-features FILENAME trivial-features))
-    DEPENDENCIES (alexandria babel cffi trivial-features) VERSION cffi_0.23.0
+    DEPENDENCIES (alexandria babel cffi trivial-features) VERSION cffi_0.24.1
     SIBLINGS
     (cffi-examples cffi-grovel cffi-libffi cffi-tests cffi-toolchain cffi)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cffi.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cffi";
-  version = "cffi_0.23.0";
+  version = "cffi_0.24.1";
 
   parasites = [ "cffi/c2ffi" "cffi/c2ffi-generator" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."cl-json" args."cl-ppcre" args."trivial-features" args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz";
-    sha256 = "1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck";
+    url = "http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz";
+    sha256 = "1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh";
   };
 
   packageName = "cffi";
@@ -21,15 +21,15 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cffi DESCRIPTION The Common Foreign Function Interface SHA256
-    1szpbg5m5fjq7bpkblflpnwmgz3ncsvp1y43g3jzwlk7yfxrwxck URL
-    http://beta.quicklisp.org/archive/cffi/2020-07-15/cffi_0.23.0.tgz MD5
-    a43e3c440fc4f20494e6d2347887c963 NAME cffi FILENAME cffi DEPS
+    1ir8a4rrnilj9f8rv1hh6fhkg2wp8z8zcf9hiijcix50pabxq8qh URL
+    http://beta.quicklisp.org/archive/cffi/2021-04-11/cffi_0.24.1.tgz MD5
+    c3df5c460e00e5af8b8bd2cd03a4b5cc NAME cffi FILENAME cffi DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cl-json FILENAME cl-json) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME trivial-features FILENAME trivial-features)
      (NAME uiop FILENAME uiop))
     DEPENDENCIES (alexandria babel cl-json cl-ppcre trivial-features uiop)
-    VERSION cffi_0.23.0 SIBLINGS
+    VERSION cffi_0.24.1 SIBLINGS
     (cffi-examples cffi-grovel cffi-libffi cffi-tests cffi-toolchain
      cffi-uffi-compat)
     PARASITES (cffi/c2ffi cffi/c2ffi-generator)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/chanl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/chanl.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "chanl";
-  version = "20210124-git";
+  version = "20210411-git";
 
   parasites = [ "chanl/examples" "chanl/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/chanl/2021-01-24/chanl-20210124-git.tgz";
-    sha256 = "1lb0k5nh51f8hskpm1pma5ds4lk1zpbk9czpw9bk8hdykr178mzc";
+    url = "http://beta.quicklisp.org/archive/chanl/2021-04-11/chanl-20210411-git.tgz";
+    sha256 = "1c1yiw616q5hv6vzyg1y4kg68v94p37s5jrq387rwadfnnf46rgi";
   };
 
   packageName = "chanl";
@@ -22,11 +22,11 @@ rec {
 }
 /* (SYSTEM chanl DESCRIPTION
     Communicating Sequential Process support for Common Lisp SHA256
-    1lb0k5nh51f8hskpm1pma5ds4lk1zpbk9czpw9bk8hdykr178mzc URL
-    http://beta.quicklisp.org/archive/chanl/2021-01-24/chanl-20210124-git.tgz
-    MD5 2f9e2d16caa2febff4f5beb6226b7ccf NAME chanl FILENAME chanl DEPS
+    1c1yiw616q5hv6vzyg1y4kg68v94p37s5jrq387rwadfnnf46rgi URL
+    http://beta.quicklisp.org/archive/chanl/2021-04-11/chanl-20210411-git.tgz
+    MD5 efaa5705b5feaa718290d25a95e2a684 NAME chanl FILENAME chanl DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME fiveam FILENAME fiveam))
-    DEPENDENCIES (alexandria bordeaux-threads fiveam) VERSION 20210124-git
+    DEPENDENCIES (alexandria bordeaux-threads fiveam) VERSION 20210411-git
     SIBLINGS NIL PARASITES (chanl/examples chanl/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-change-case.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-change-case.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-change-case";
-  version = "20210228-git";
+  version = "20210411-git";
 
   parasites = [ "cl-change-case/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."fiveam" args."flexi-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-change-case/2021-02-28/cl-change-case-20210228-git.tgz";
-    sha256 = "15x8zxwa3pxs02fh0qxmbvz6vi59x6ha09p5hs4rgd6axs0k4pmi";
+    url = "http://beta.quicklisp.org/archive/cl-change-case/2021-04-11/cl-change-case-20210411-git.tgz";
+    sha256 = "14s26b907h1nsnwdqbj6j4c9bvc4rc2l8ry2q1j7ibjfzqvhp4mj";
   };
 
   packageName = "cl-change-case";
@@ -22,13 +22,13 @@ rec {
 }
 /* (SYSTEM cl-change-case DESCRIPTION
     Convert strings between camelCase, param-case, PascalCase and more SHA256
-    15x8zxwa3pxs02fh0qxmbvz6vi59x6ha09p5hs4rgd6axs0k4pmi URL
-    http://beta.quicklisp.org/archive/cl-change-case/2021-02-28/cl-change-case-20210228-git.tgz
-    MD5 8fec07f0634a739134dc4fcec807fe16 NAME cl-change-case FILENAME
+    14s26b907h1nsnwdqbj6j4c9bvc4rc2l8ry2q1j7ibjfzqvhp4mj URL
+    http://beta.quicklisp.org/archive/cl-change-case/2021-04-11/cl-change-case-20210411-git.tgz
+    MD5 df72a3d71a6c65e149704688aec859b9 NAME cl-change-case FILENAME
     cl-change-case DEPS
     ((NAME cl-ppcre FILENAME cl-ppcre)
      (NAME cl-ppcre-unicode FILENAME cl-ppcre-unicode)
      (NAME cl-unicode FILENAME cl-unicode) (NAME fiveam FILENAME fiveam)
      (NAME flexi-streams FILENAME flexi-streams))
     DEPENDENCIES (cl-ppcre cl-ppcre-unicode cl-unicode fiveam flexi-streams)
-    VERSION 20210228-git SIBLINGS NIL PARASITES (cl-change-case/test)) */
+    VERSION 20210411-git SIBLINGS NIL PARASITES (cl-change-case/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors2.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-colors2";
-  version = "20200218-git";
+  version = "20210411-git";
 
   parasites = [ "cl-colors2/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."cl-ppcre" args."clunit2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-colors2/2020-02-18/cl-colors2-20200218-git.tgz";
-    sha256 = "0rpf8j232qv254zhkvkz3ja20al1kswvcqhvvv0r2ag6dks56j29";
+    url = "http://beta.quicklisp.org/archive/cl-colors2/2021-04-11/cl-colors2-20210411-git.tgz";
+    sha256 = "14kdi214x8rxil27wfbx0csgi7g8dg5wsifpsrdrqph0p7ps8snk";
   };
 
   packageName = "cl-colors2";
@@ -21,11 +21,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-colors2 DESCRIPTION Simple color library for Common Lisp SHA256
-    0rpf8j232qv254zhkvkz3ja20al1kswvcqhvvv0r2ag6dks56j29 URL
-    http://beta.quicklisp.org/archive/cl-colors2/2020-02-18/cl-colors2-20200218-git.tgz
-    MD5 054283564f17af46a09e259ff509b656 NAME cl-colors2 FILENAME cl-colors2
+    14kdi214x8rxil27wfbx0csgi7g8dg5wsifpsrdrqph0p7ps8snk URL
+    http://beta.quicklisp.org/archive/cl-colors2/2021-04-11/cl-colors2-20210411-git.tgz
+    MD5 e6b54e76e7d1cfcff45955dbd4752f1d NAME cl-colors2 FILENAME cl-colors2
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME clunit2 FILENAME clunit2))
-    DEPENDENCIES (alexandria cl-ppcre clunit2) VERSION 20200218-git SIBLINGS
+    DEPENDENCIES (alexandria cl-ppcre clunit2) VERSION 20210411-git SIBLINGS
     NIL PARASITES (cl-colors2/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-gobject-introspection.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-gobject-introspection.nix
@@ -1,0 +1,32 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cl-gobject-introspection";
+  version = "20210124-git";
+
+  description = "Binding to GObjectIntrospection";
+
+  deps = [ args."alexandria" args."babel" args."cffi" args."iterate" args."trivial-features" args."trivial-garbage" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-gobject-introspection/2021-01-24/cl-gobject-introspection-20210124-git.tgz";
+    sha256 = "1hrc451d9xdp3pfmwalw32r3iqfvw6ccy665kl5560lihwmk59w0";
+  };
+
+  packageName = "cl-gobject-introspection";
+
+  asdFilesToKeep = ["cl-gobject-introspection.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-gobject-introspection DESCRIPTION Binding to GObjectIntrospection
+    SHA256 1hrc451d9xdp3pfmwalw32r3iqfvw6ccy665kl5560lihwmk59w0 URL
+    http://beta.quicklisp.org/archive/cl-gobject-introspection/2021-01-24/cl-gobject-introspection-20210124-git.tgz
+    MD5 ad760b820c86142c0a1309af29541680 NAME cl-gobject-introspection FILENAME
+    cl-gobject-introspection DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi) (NAME iterate FILENAME iterate)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage))
+    DEPENDENCIES
+    (alexandria babel cffi iterate trivial-features trivial-garbage) VERSION
+    20210124-git SIBLINGS (cl-gobject-introspection-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-postgres";
-  version = "postmodern-20210124-git";
+  version = "postmodern-20210411-git";
 
   parasites = [ "cl-postgres/simple-date-tests" "cl-postgres/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-ppcre" args."fiveam" args."ironclad" args."md5" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
-    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz";
+    sha256 = "0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw";
   };
 
   packageName = "cl-postgres";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-postgres DESCRIPTION Low-level client library for PostgreSQL
-    SHA256 1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc URL
-    http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz
-    MD5 05c2c5f4d2354a5fa69a32b7b96f8ff8 NAME cl-postgres FILENAME cl-postgres
+    SHA256 0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw URL
+    http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz
+    MD5 8a75a05ba9e371f672f2620d40724cb2 NAME cl-postgres FILENAME cl-postgres
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -36,5 +36,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-ppcre fiveam ironclad md5
      simple-date simple-date/postgres-glue split-sequence uax-15 usocket)
-    VERSION postmodern-20210124-git SIBLINGS (postmodern s-sql simple-date)
+    VERSION postmodern-20210411-git SIBLINGS (postmodern s-sql simple-date)
     PARASITES (cl-postgres/simple-date-tests cl-postgres/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-typesetting.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-typesetting.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-typesetting";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "Common Lisp Typesetting system";
 
   deps = [ args."cl-pdf" args."iterate" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-typesetting/2021-02-28/cl-typesetting-20210228-git.tgz";
-    sha256 = "13rmzyzp0glq35jq3qdlmrsdssa6csqp5g455li4wi7kq8clrwnp";
+    url = "http://beta.quicklisp.org/archive/cl-typesetting/2021-04-11/cl-typesetting-20210411-git.tgz";
+    sha256 = "1102n049hhg0kqnfvdfcisjq5l9yfvbw090nq0q8vd2bc688ng41";
   };
 
   packageName = "cl-typesetting";
@@ -19,11 +19,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-typesetting DESCRIPTION Common Lisp Typesetting system SHA256
-    13rmzyzp0glq35jq3qdlmrsdssa6csqp5g455li4wi7kq8clrwnp URL
-    http://beta.quicklisp.org/archive/cl-typesetting/2021-02-28/cl-typesetting-20210228-git.tgz
-    MD5 949e7de37838d63f4c6b6e7dd88befeb NAME cl-typesetting FILENAME
+    1102n049hhg0kqnfvdfcisjq5l9yfvbw090nq0q8vd2bc688ng41 URL
+    http://beta.quicklisp.org/archive/cl-typesetting/2021-04-11/cl-typesetting-20210411-git.tgz
+    MD5 f3fc7a47efb99cf849cb5eeede96dbaf NAME cl-typesetting FILENAME
     cl-typesetting DEPS
     ((NAME cl-pdf FILENAME cl-pdf) (NAME iterate FILENAME iterate)
      (NAME zpb-ttf FILENAME zpb-ttf))
-    DEPENDENCIES (cl-pdf iterate zpb-ttf) VERSION 20210228-git SIBLINGS
+    DEPENDENCIES (cl-pdf iterate zpb-ttf) VERSION 20210411-git SIBLINGS
     (xml-render cl-pdf-doc) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-webkit2";
-  version = "cl-webkit-20210228-git";
+  version = "cl-webkit-20210411-git";
 
   description = "An FFI binding to WebKit2GTK+";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-02-28/cl-webkit-20210228-git.tgz";
-    sha256 = "1r6i64g37palar4hij6c5m240xbn2dwzwaashv015nhjwmra1ms1";
+    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-04-11/cl-webkit-20210411-git.tgz";
+    sha256 = "10cky5v67s9mx2j96k0z01qbqfyc8w6a8byaamm7al5qkw997brh";
   };
 
   packageName = "cl-webkit2";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-webkit2 DESCRIPTION An FFI binding to WebKit2GTK+ SHA256
-    1r6i64g37palar4hij6c5m240xbn2dwzwaashv015nhjwmra1ms1 URL
-    http://beta.quicklisp.org/archive/cl-webkit/2021-02-28/cl-webkit-20210228-git.tgz
-    MD5 49f38c18ac292122628356762270e5ff NAME cl-webkit2 FILENAME cl-webkit2
+    10cky5v67s9mx2j96k0z01qbqfyc8w6a8byaamm7al5qkw997brh URL
+    http://beta.quicklisp.org/archive/cl-webkit/2021-04-11/cl-webkit-20210411-git.tgz
+    MD5 01b52f031fd8742ac9d422e4fcd2a225 NAME cl-webkit2 FILENAME cl-webkit2
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -41,4 +41,4 @@ rec {
      cl-cffi-gtk-gdk cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
      cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
      trivial-garbage)
-    VERSION cl-webkit-20210228-git SIBLINGS NIL PARASITES NIL) */
+    VERSION cl-webkit-20210411-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl_plus_ssl";
-  version = "cl+ssl-20210228-git";
+  version = "cl+ssl-20210411-git";
 
   description = "Common Lisp interface to OpenSSL.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-02-28/cl+ssl-20210228-git.tgz";
-    sha256 = "1njppcg5fm8l0lhf7nf8nfyaz9vsr922y0vfxqdp9hp7qfid8yll";
+    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-04-11/cl+ssl-20210411-git.tgz";
+    sha256 = "1rc13lc5wwzlkn7yhl3bwl6cmxxldmbfnz52nz5b83v4wlw2zbcw";
   };
 
   packageName = "cl+ssl";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl+ssl DESCRIPTION Common Lisp interface to OpenSSL. SHA256
-    1njppcg5fm8l0lhf7nf8nfyaz9vsr922y0vfxqdp9hp7qfid8yll URL
-    http://beta.quicklisp.org/archive/cl+ssl/2021-02-28/cl+ssl-20210228-git.tgz
-    MD5 01b61fd8ee6ad8d3c1c695ba56d510b6 NAME cl+ssl FILENAME cl_plus_ssl DEPS
+    1rc13lc5wwzlkn7yhl3bwl6cmxxldmbfnz52nz5b83v4wlw2zbcw URL
+    http://beta.quicklisp.org/archive/cl+ssl/2021-04-11/cl+ssl-20210411-git.tgz
+    MD5 9ef5b60ac4c8ad4f435a3ef6234897d0 NAME cl+ssl FILENAME cl_plus_ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME flexi-streams FILENAME flexi-streams)
@@ -33,4 +33,4 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi flexi-streams split-sequence
      trivial-features trivial-garbage trivial-gray-streams uiop usocket)
-    VERSION cl+ssl-20210228-git SIBLINGS (cl+ssl.test) PARASITES NIL) */
+    VERSION cl+ssl-20210411-git SIBLINGS (cl+ssl.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack-handler-hunchentoot";
-  version = "clack-20191007-git";
+  version = "clack-20210411-git";
 
   description = "Clack handler for Hunchentoot.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."clack-socket" args."flexi-streams" args."hunchentoot" args."md5" args."rfc2388" args."split-sequence" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
-    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
+    url = "http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz";
+    sha256 = "0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf";
   };
 
   packageName = "clack-handler-hunchentoot";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-handler-hunchentoot DESCRIPTION Clack handler for Hunchentoot.
-    SHA256 004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
-    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
-    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-handler-hunchentoot
+    SHA256 0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf URL
+    http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz
+    MD5 c47deb6287b72fc9033055914787f3a5 NAME clack-handler-hunchentoot
     FILENAME clack-handler-hunchentoot DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -43,7 +43,7 @@ rec {
      cl-ppcre clack-socket flexi-streams hunchentoot md5 rfc2388 split-sequence
      trivial-backtrace trivial-features trivial-garbage trivial-gray-streams
      usocket)
-    VERSION clack-20191007-git SIBLINGS
+    VERSION clack-20210411-git SIBLINGS
     (clack-handler-fcgi clack-handler-toot clack-handler-wookie clack-socket
      clack-test clack-v1-compat clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-socket.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack-socket";
-  version = "clack-20191007-git";
+  version = "clack-20210411-git";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
-    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
+    url = "http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz";
+    sha256 = "0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf";
   };
 
   packageName = "clack-socket";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-socket DESCRIPTION System lacks description SHA256
-    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
-    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
-    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-socket FILENAME
-    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20191007-git SIBLINGS
+    0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf URL
+    http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz
+    MD5 c47deb6287b72fc9033055914787f3a5 NAME clack-socket FILENAME
+    clack-socket DEPS NIL DEPENDENCIES NIL VERSION clack-20210411-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-test clack-v1-compat clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack-test";
-  version = "clack-20191007-git";
+  version = "clack-20210411-git";
 
   description = "Testing Clack Applications.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."md5" args."named-readtables" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
-    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
+    url = "http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz";
+    sha256 = "0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf";
   };
 
   packageName = "clack-test";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-test DESCRIPTION Testing Clack Applications. SHA256
-    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
-    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
-    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-test FILENAME clack-test
+    0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf URL
+    http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz
+    MD5 c47deb6287b72fc9033055914787f3a5 NAME clack-test FILENAME clack-test
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -68,7 +68,7 @@ rec {
      proc-parse quri rfc2388 rove smart-buffer split-sequence static-vectors
      trivial-backtrace trivial-features trivial-garbage trivial-gray-streams
      trivial-mimes trivial-types usocket xsubseq)
-    VERSION clack-20191007-git SIBLINGS
+    VERSION clack-20210411-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-v1-compat clack
      t-clack-handler-fcgi t-clack-handler-hunchentoot t-clack-handler-toot

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-v1-compat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-v1-compat.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack-v1-compat";
-  version = "clack-20191007-git";
+  version = "clack-20210411-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."circular-streams" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."clack-test" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."marshal" args."md5" args."named-readtables" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."uiop" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
-    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
+    url = "http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz";
+    sha256 = "0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf";
   };
 
   packageName = "clack-v1-compat";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack-v1-compat DESCRIPTION System lacks description SHA256
-    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
-    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
-    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack-v1-compat FILENAME
+    0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf URL
+    http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz
+    MD5 c47deb6287b72fc9033055914787f3a5 NAME clack-v1-compat FILENAME
     clack-v1-compat DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -73,7 +73,7 @@ rec {
      split-sequence static-vectors trivial-backtrace trivial-features
      trivial-garbage trivial-gray-streams trivial-mimes trivial-types uiop
      usocket xsubseq)
-    VERSION clack-20191007-git SIBLINGS
+    VERSION clack-20210411-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-test clack t-clack-handler-fcgi
      t-clack-handler-hunchentoot t-clack-handler-toot t-clack-handler-wookie

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clack";
-  version = "20191007-git";
+  version = "20210411-git";
 
   description = "Web application environment for Common Lisp";
 
-  deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."uiop" ];
+  deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."split-sequence" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz";
-    sha256 = "004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w";
+    url = "http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz";
+    sha256 = "0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf";
   };
 
   packageName = "clack";
@@ -19,19 +19,21 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clack DESCRIPTION Web application environment for Common Lisp SHA256
-    004drm82mhxmcsa00lbmq2l89g4fzwn6j2drfwdazrpi27z0ry5w URL
-    http://beta.quicklisp.org/archive/clack/2019-10-07/clack-20191007-git.tgz
-    MD5 25741855fa1e989d373ac06ddfabf351 NAME clack FILENAME clack DEPS
+    0yai9cx1gha684ljr8k1s5n4mi6mpj2wmvv6b9iw7pw1vhw5m8mf URL
+    http://beta.quicklisp.org/archive/clack/2021-04-11/clack-20210411-git.tgz
+    MD5 c47deb6287b72fc9033055914787f3a5 NAME clack FILENAME clack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad) (NAME lack FILENAME lack)
      (NAME lack-component FILENAME lack-component)
      (NAME lack-middleware-backtrace FILENAME lack-middleware-backtrace)
-     (NAME lack-util FILENAME lack-util) (NAME uiop FILENAME uiop))
+     (NAME lack-util FILENAME lack-util)
+     (NAME split-sequence FILENAME split-sequence) (NAME uiop FILENAME uiop)
+     (NAME usocket FILENAME usocket))
     DEPENDENCIES
     (alexandria bordeaux-threads ironclad lack lack-component
-     lack-middleware-backtrace lack-util uiop)
-    VERSION 20191007-git SIBLINGS
+     lack-middleware-backtrace lack-util split-sequence uiop usocket)
+    VERSION 20210411-git SIBLINGS
     (clack-handler-fcgi clack-handler-hunchentoot clack-handler-toot
      clack-handler-wookie clack-socket clack-test clack-v1-compat
      t-clack-handler-fcgi t-clack-handler-hunchentoot t-clack-handler-toot

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "closer-mop";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/closer-mop/2021-02-28/closer-mop-20210228-git.tgz";
-    sha256 = "0x3rp2v84zzw5mhcxrgbq2kcb9gs4jn1l9rh4ylsnih89l9lqc6i";
+    url = "http://beta.quicklisp.org/archive/closer-mop/2021-04-11/closer-mop-20210411-git.tgz";
+    sha256 = "0pynql962m2z7wqnmd51a2xm3wsqvgfxcq9maw2br0zs0icys236";
   };
 
   packageName = "closer-mop";
@@ -20,7 +20,7 @@ rec {
 }
 /* (SYSTEM closer-mop DESCRIPTION
     Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.
-    SHA256 0x3rp2v84zzw5mhcxrgbq2kcb9gs4jn1l9rh4ylsnih89l9lqc6i URL
-    http://beta.quicklisp.org/archive/closer-mop/2021-02-28/closer-mop-20210228-git.tgz
-    MD5 49c0004ff21157bc99f227cecf7b6025 NAME closer-mop FILENAME closer-mop
-    DEPS NIL DEPENDENCIES NIL VERSION 20210228-git SIBLINGS NIL PARASITES NIL) */
+    SHA256 0pynql962m2z7wqnmd51a2xm3wsqvgfxcq9maw2br0zs0icys236 URL
+    http://beta.quicklisp.org/archive/closer-mop/2021-04-11/closer-mop-20210411-git.tgz
+    MD5 05b05d98ad294f8bd6f9779d04cc848a NAME closer-mop FILENAME closer-mop
+    DEPS NIL DEPENDENCIES NIL VERSION 20210411-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dexador.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dexador";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "Yet another HTTP client for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-cookie" args."cl-ppcre" args."cl-reexport" args."cl-utilities" args."fast-http" args."fast-io" args."flexi-streams" args."local-time" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."usocket" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/dexador/2021-02-28/dexador-20210228-git.tgz";
-    sha256 = "0glzvi7nbr58izpwr8xzxvlcc78zmgwqaik374rmcy6w89q5ksw7";
+    url = "http://beta.quicklisp.org/archive/dexador/2021-04-11/dexador-20210411-git.tgz";
+    sha256 = "1px4llzb6x930cq3dmrkzidydqqc8rd2y4s3nlwpsrv4874cxwx1";
   };
 
   packageName = "dexador";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dexador DESCRIPTION Yet another HTTP client for Common Lisp SHA256
-    0glzvi7nbr58izpwr8xzxvlcc78zmgwqaik374rmcy6w89q5ksw7 URL
-    http://beta.quicklisp.org/archive/dexador/2021-02-28/dexador-20210228-git.tgz
-    MD5 e3b69c8ceb78d99351e574c40dfd0e12 NAME dexador FILENAME dexador DEPS
+    1px4llzb6x930cq3dmrkzidydqqc8rd2y4s3nlwpsrv4874cxwx1 URL
+    http://beta.quicklisp.org/archive/dexador/2021-04-11/dexador-20210411-git.tgz
+    MD5 10d59691af3e25e590a2dfff29c91292 NAME dexador FILENAME dexador DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -48,4 +48,4 @@ rec {
      fast-http fast-io flexi-streams local-time proc-parse quri smart-buffer
      split-sequence static-vectors trivial-features trivial-garbage
      trivial-gray-streams trivial-mimes usocket xsubseq)
-    VERSION 20210228-git SIBLINGS (dexador-test) PARASITES NIL) */
+    VERSION 20210411-git SIBLINGS (dexador-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/file-attributes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/file-attributes.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "file-attributes";
-  version = "20200925-git";
+  version = "20210411-git";
 
   description = "Access to file attributes (uid, gid, atime, mtime, mod)";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."documentation-utils" args."trivial-features" args."trivial-indent" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/file-attributes/2020-09-25/file-attributes-20200925-git.tgz";
-    sha256 = "0wq3gs36zwl8dzknj3c794l60vg1zpf0siwhd7ad9pn81v3mdan7";
+    url = "http://beta.quicklisp.org/archive/file-attributes/2021-04-11/file-attributes-20210411-git.tgz";
+    sha256 = "0zsqimyzfivr08d6pdg6xxw6cj7q9pjh2wi9c460nh85z7a51yc9";
   };
 
   packageName = "file-attributes";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM file-attributes DESCRIPTION
     Access to file attributes (uid, gid, atime, mtime, mod) SHA256
-    0wq3gs36zwl8dzknj3c794l60vg1zpf0siwhd7ad9pn81v3mdan7 URL
-    http://beta.quicklisp.org/archive/file-attributes/2020-09-25/file-attributes-20200925-git.tgz
-    MD5 368468453cf57ecc29fa75f2a030a738 NAME file-attributes FILENAME
+    0zsqimyzfivr08d6pdg6xxw6cj7q9pjh2wi9c460nh85z7a51yc9 URL
+    http://beta.quicklisp.org/archive/file-attributes/2021-04-11/file-attributes-20210411-git.tgz
+    MD5 75e0f0e2c280c97fe496545e7105fa01 NAME file-attributes FILENAME
     file-attributes DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi)
@@ -31,4 +31,4 @@ rec {
      (NAME trivial-indent FILENAME trivial-indent))
     DEPENDENCIES
     (alexandria babel cffi documentation-utils trivial-features trivial-indent)
-    VERSION 20200925-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20210411-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "ironclad";
-  version = "v0.54";
+  version = "v0.55";
 
   parasites = [ "ironclad/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/ironclad/2021-01-24/ironclad-v0.54.tgz";
-    sha256 = "01mpsnjx8cgn3wx2n0dkv8v83z93da9zrxncn58ghbpyq3z1i4w2";
+    url = "http://beta.quicklisp.org/archive/ironclad/2021-04-11/ironclad-v0.55.tgz";
+    sha256 = "0vdqaad9i3dkz6z2y1iqmh6m77kc9jy49xh9bysgywl0gfdyhnq6";
   };
 
   packageName = "ironclad";
@@ -22,10 +22,10 @@ rec {
 }
 /* (SYSTEM ironclad DESCRIPTION
     A cryptographic toolkit written in pure Common Lisp SHA256
-    01mpsnjx8cgn3wx2n0dkv8v83z93da9zrxncn58ghbpyq3z1i4w2 URL
-    http://beta.quicklisp.org/archive/ironclad/2021-01-24/ironclad-v0.54.tgz
-    MD5 f99610509e4603aac66d9aa03ede2770 NAME ironclad FILENAME ironclad DEPS
+    0vdqaad9i3dkz6z2y1iqmh6m77kc9jy49xh9bysgywl0gfdyhnq6 URL
+    http://beta.quicklisp.org/archive/ironclad/2021-04-11/ironclad-v0.55.tgz
+    MD5 c3c4a88e71ef37c9604662071069afcc NAME ironclad FILENAME ironclad DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads) (NAME rt FILENAME rt))
-    DEPENDENCIES (alexandria bordeaux-threads rt) VERSION v0.54 SIBLINGS
+    DEPENDENCIES (alexandria bordeaux-threads rt) VERSION v0.55 SIBLINGS
     (ironclad-text) PARASITES (ironclad/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "marshal";
-  version = "cl-20201016-git";
+  version = "cl-20210411-git";
 
   description = "marshal: Simple (de)serialization of Lisp datastructures.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-marshal/2020-10-16/cl-marshal-20201016-git.tgz";
-    sha256 = "03j52yhgpc2myypgy07213l20rznxvf6m3sfbzy2wyapcmv7nxnz";
+    url = "http://beta.quicklisp.org/archive/cl-marshal/2021-04-11/cl-marshal-20210411-git.tgz";
+    sha256 = "0wi4csgl5qxgl0si5mcg19xx4qlmw125qn0w1i2f3dvvrzp20qrp";
   };
 
   packageName = "marshal";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM marshal DESCRIPTION
     marshal: Simple (de)serialization of Lisp datastructures. SHA256
-    03j52yhgpc2myypgy07213l20rznxvf6m3sfbzy2wyapcmv7nxnz URL
-    http://beta.quicklisp.org/archive/cl-marshal/2020-10-16/cl-marshal-20201016-git.tgz
-    MD5 243a2c3a5f1243ffb1639bca32a0aff0 NAME marshal FILENAME marshal DEPS NIL
-    DEPENDENCIES NIL VERSION cl-20201016-git SIBLINGS (marshal-tests) PARASITES
+    0wi4csgl5qxgl0si5mcg19xx4qlmw125qn0w1i2f3dvvrzp20qrp URL
+    http://beta.quicklisp.org/archive/cl-marshal/2021-04-11/cl-marshal-20210411-git.tgz
+    MD5 2463314a6bcd1a18bea2690deb6bce55 NAME marshal FILENAME marshal DEPS NIL
+    DEPENDENCIES NIL VERSION cl-20210411-git SIBLINGS (marshal-tests) PARASITES
     NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "mgl-pax";
-  version = "20210228-git";
+  version = "20210411-git";
 
   parasites = [ "mgl-pax/test" ];
 
@@ -12,8 +12,8 @@ rec {
   deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."colorize" args."esrap" args."html-encode" args."ironclad" args."named-readtables" args."pythonic-string-reader" args."split-sequence" args."swank" args."trivial-features" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-02-28/mgl-pax-20210228-git.tgz";
-    sha256 = "1dyhbnd69lb6ih89pvg8nn6pwsg25v5xjsfk1i5l1fdib14612cw";
+    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-04-11/mgl-pax-20210411-git.tgz";
+    sha256 = "0dq5jkb6li0s1gqj6hfhifs6cd4kypavv2kjqg5zgs6zfs82sxh3";
   };
 
   packageName = "mgl-pax";
@@ -23,9 +23,9 @@ rec {
 }
 /* (SYSTEM mgl-pax DESCRIPTION Exploratory programming tool and documentation
   generator.
-    SHA256 1dyhbnd69lb6ih89pvg8nn6pwsg25v5xjsfk1i5l1fdib14612cw URL
-    http://beta.quicklisp.org/archive/mgl-pax/2021-02-28/mgl-pax-20210228-git.tgz
-    MD5 a256ce4ee76d669d233ee09830ef7968 NAME mgl-pax FILENAME mgl-pax DEPS
+    SHA256 0dq5jkb6li0s1gqj6hfhifs6cd4kypavv2kjqg5zgs6zfs82sxh3 URL
+    http://beta.quicklisp.org/archive/mgl-pax/2021-04-11/mgl-pax-20210411-git.tgz
+    MD5 44cf1bd71e6c40c256a43a87efa2c2a1 NAME mgl-pax FILENAME mgl-pax DEPS
     ((NAME 3bmd FILENAME _3bmd)
      (NAME 3bmd-ext-code-blocks FILENAME _3bmd-ext-code-blocks)
      (NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
@@ -44,4 +44,4 @@ rec {
      colorize esrap html-encode ironclad named-readtables
      pythonic-string-reader split-sequence swank trivial-features
      trivial-with-current-source-form)
-    VERSION 20210228-git SIBLINGS NIL PARASITES (mgl-pax/test)) */
+    VERSION 20210411-git SIBLINGS NIL PARASITES (mgl-pax/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/plump.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/plump.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "plump";
-  version = "20210124-git";
+  version = "20210411-git";
 
   description = "An XML / XHTML / HTML parser that aims to be as lenient as possible.";
 
   deps = [ args."array-utils" args."documentation-utils" args."trivial-indent" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/plump/2021-01-24/plump-20210124-git.tgz";
-    sha256 = "0br64xiz4mgmmsvkfmi43k2q16rmc6hbqf976x8cdafs3h266jdm";
+    url = "http://beta.quicklisp.org/archive/plump/2021-04-11/plump-20210411-git.tgz";
+    sha256 = "05zs9blznfhapz5yiy08968hw64rzdgqgvfgc9r9da45b45pl6dp";
   };
 
   packageName = "plump";
@@ -20,11 +20,11 @@ rec {
 }
 /* (SYSTEM plump DESCRIPTION
     An XML / XHTML / HTML parser that aims to be as lenient as possible. SHA256
-    0br64xiz4mgmmsvkfmi43k2q16rmc6hbqf976x8cdafs3h266jdm URL
-    http://beta.quicklisp.org/archive/plump/2021-01-24/plump-20210124-git.tgz
-    MD5 44a5d371dd1c3d4afc6b8801926b059a NAME plump FILENAME plump DEPS
+    05zs9blznfhapz5yiy08968hw64rzdgqgvfgc9r9da45b45pl6dp URL
+    http://beta.quicklisp.org/archive/plump/2021-04-11/plump-20210411-git.tgz
+    MD5 055e30ed07ae793426a48b55c947f9bb NAME plump FILENAME plump DEPS
     ((NAME array-utils FILENAME array-utils)
      (NAME documentation-utils FILENAME documentation-utils)
      (NAME trivial-indent FILENAME trivial-indent))
     DEPENDENCIES (array-utils documentation-utils trivial-indent) VERSION
-    20210124-git SIBLINGS (plump-dom plump-lexer plump-parser) PARASITES NIL) */
+    20210411-git SIBLINGS (plump-dom plump-lexer plump-parser) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "postmodern";
-  version = "20210124-git";
+  version = "20210411-git";
 
   parasites = [ "postmodern/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_plus_local-time" args."cl-postgres_slash_tests" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."fiveam" args."flexi-streams" args."global-vars" args."ironclad" args."local-time" args."md5" args."s-sql" args."s-sql_slash_tests" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
-    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz";
+    sha256 = "0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw";
   };
 
   packageName = "postmodern";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM postmodern DESCRIPTION PostgreSQL programming API SHA256
-    1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc URL
-    http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz
-    MD5 05c2c5f4d2354a5fa69a32b7b96f8ff8 NAME postmodern FILENAME postmodern
+    0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw URL
+    http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz
+    MD5 8a75a05ba9e371f672f2620d40724cb2 NAME postmodern FILENAME postmodern
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -46,5 +46,5 @@ rec {
      cl-postgres/tests cl-ppcre cl-unicode closer-mop fiveam flexi-streams
      global-vars ironclad local-time md5 s-sql s-sql/tests simple-date
      simple-date/postgres-glue split-sequence uax-15 usocket)
-    VERSION 20210124-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
+    VERSION 20210411-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
     (postmodern/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/quri.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/quri.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "quri";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "Yet another URI library for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cl-utilities" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/quri/2021-02-28/quri-20210228-git.tgz";
-    sha256 = "03hq6x715kv37c089b73f6j8b0f4ywhxr37wbw9any2jcgrswx0g";
+    url = "http://beta.quicklisp.org/archive/quri/2021-04-11/quri-20210411-git.tgz";
+    sha256 = "1j4al77bl8awj7755g8zvgvfskdh6gcl3gygbz2fi6lrrk9125d7";
   };
 
   packageName = "quri";
@@ -19,13 +19,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM quri DESCRIPTION Yet another URI library for Common Lisp SHA256
-    03hq6x715kv37c089b73f6j8b0f4ywhxr37wbw9any2jcgrswx0g URL
-    http://beta.quicklisp.org/archive/quri/2021-02-28/quri-20210228-git.tgz MD5
-    67eac028850cc2539c076d31b049f7bd NAME quri FILENAME quri DEPS
+    1j4al77bl8awj7755g8zvgvfskdh6gcl3gygbz2fi6lrrk9125d7 URL
+    http://beta.quicklisp.org/archive/quri/2021-04-11/quri-20210411-git.tgz MD5
+    2727c706f51bef480171c59f6134bba5 NAME quri FILENAME quri DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cl-utilities FILENAME cl-utilities)
      (NAME split-sequence FILENAME split-sequence)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES
     (alexandria babel cl-utilities split-sequence trivial-features) VERSION
-    20210228-git SIBLINGS (quri-test) PARASITES NIL) */
+    20210411-git SIBLINGS (quri-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "s-sql";
-  version = "postmodern-20210124-git";
+  version = "postmodern-20210411-git";
 
   parasites = [ "s-sql/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_slash_tests" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."md5" args."postmodern" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
-    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz";
+    sha256 = "0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw";
   };
 
   packageName = "s-sql";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM s-sql DESCRIPTION Lispy DSL for SQL SHA256
-    1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc URL
-    http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz
-    MD5 05c2c5f4d2354a5fa69a32b7b96f8ff8 NAME s-sql FILENAME s-sql DEPS
+    0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw URL
+    http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz
+    MD5 8a75a05ba9e371f672f2620d40724cb2 NAME s-sql FILENAME s-sql DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-base64 FILENAME cl-base64)
@@ -39,5 +39,5 @@ rec {
     (alexandria bordeaux-threads cl-base64 cl-postgres cl-postgres/tests
      cl-ppcre cl-unicode closer-mop fiveam global-vars ironclad md5 postmodern
      split-sequence uax-15 usocket)
-    VERSION postmodern-20210124-git SIBLINGS
+    VERSION postmodern-20210411-git SIBLINGS
     (cl-postgres postmodern simple-date) PARASITES (s-sql/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "serapeum";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "Utilities beyond Alexandria.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/serapeum/2021-02-28/serapeum-20210228-git.tgz";
-    sha256 = "1dici8bmvrx5h74disrlvwns8f8jl746i4cyzyclswhv208x2m3x";
+    url = "http://beta.quicklisp.org/archive/serapeum/2021-04-11/serapeum-20210411-git.tgz";
+    sha256 = "1zz0sjp2dwy7qg7a3h1asvflkl9z2ajwk9zqfqylm0mhl0mv2c01";
   };
 
   packageName = "serapeum";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM serapeum DESCRIPTION Utilities beyond Alexandria. SHA256
-    1dici8bmvrx5h74disrlvwns8f8jl746i4cyzyclswhv208x2m3x URL
-    http://beta.quicklisp.org/archive/serapeum/2021-02-28/serapeum-20210228-git.tgz
-    MD5 25502093ea13851021422000686a54b7 NAME serapeum FILENAME serapeum DEPS
+    1zz0sjp2dwy7qg7a3h1asvflkl9z2ajwk9zqfqylm0mhl0mv2c01 URL
+    http://beta.quicklisp.org/archive/serapeum/2021-04-11/serapeum-20210411-git.tgz
+    MD5 091a7c572d48164ba8499bb44a37a85f NAME serapeum FILENAME serapeum DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop)
@@ -60,4 +60,4 @@ rec {
      trivia.level2 trivia.quasiquote trivia.trivial trivial-cltl2
      trivial-features trivial-file-size trivial-garbage trivial-macroexpand-all
      type-i uiop)
-    VERSION 20210228-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20210411-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "simple-date";
-  version = "postmodern-20210124-git";
+  version = "postmodern-20210411-git";
 
   parasites = [ "simple-date/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz";
-    sha256 = "1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz";
+    sha256 = "0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw";
   };
 
   packageName = "simple-date";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM simple-date DESCRIPTION
     Simple date library that can be used with postmodern SHA256
-    1fl103fga5iq2gf1p15xvbrmmjrcv2bbi3lz1zv32j6smy5aymhc URL
-    http://beta.quicklisp.org/archive/postmodern/2021-01-24/postmodern-20210124-git.tgz
-    MD5 05c2c5f4d2354a5fa69a32b7b96f8ff8 NAME simple-date FILENAME simple-date
+    0q8izkkddmqq5sw55chkx6jrycawgchaknik5i84vynv50zirsbw URL
+    http://beta.quicklisp.org/archive/postmodern/2021-04-11/postmodern-20210411-git.tgz
+    MD5 8a75a05ba9e371f672f2620d40724cb2 NAME simple-date FILENAME simple-date
     DEPS ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION
-    postmodern-20210124-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
+    postmodern-20210411-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
     (simple-date/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "str";
-  version = "cl-20210124-git";
+  version = "cl-20210411-git";
 
   description = "Modern, consistent and terse Common Lisp string manipulation library.";
 
   deps = [ args."cl-change-case" args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."flexi-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-str/2021-01-24/cl-str-20210124-git.tgz";
-    sha256 = "07y24mx8gmhwz6px63llgsz15aqicqa4m8gd5zwxy708xggv73jc";
+    url = "http://beta.quicklisp.org/archive/cl-str/2021-04-11/cl-str-20210411-git.tgz";
+    sha256 = "0xyazb3j4j0wsq443fpavv4hxnizkcvhkgz709lnp7cxygpdnl7m";
   };
 
   packageName = "str";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM str DESCRIPTION
     Modern, consistent and terse Common Lisp string manipulation library.
-    SHA256 07y24mx8gmhwz6px63llgsz15aqicqa4m8gd5zwxy708xggv73jc URL
-    http://beta.quicklisp.org/archive/cl-str/2021-01-24/cl-str-20210124-git.tgz
-    MD5 afd5d3e1078bef872b0507215855397e NAME str FILENAME str DEPS
+    SHA256 0xyazb3j4j0wsq443fpavv4hxnizkcvhkgz709lnp7cxygpdnl7m URL
+    http://beta.quicklisp.org/archive/cl-str/2021-04-11/cl-str-20210411-git.tgz
+    MD5 6c6b4de0886d448155a5cca0dd38a189 NAME str FILENAME str DEPS
     ((NAME cl-change-case FILENAME cl-change-case)
      (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME cl-ppcre-unicode FILENAME cl-ppcre-unicode)
@@ -30,4 +30,4 @@ rec {
      (NAME flexi-streams FILENAME flexi-streams))
     DEPENDENCIES
     (cl-change-case cl-ppcre cl-ppcre-unicode cl-unicode flexi-streams) VERSION
-    cl-20210124-git SIBLINGS (str.test) PARASITES NIL) */
+    cl-20210411-git SIBLINGS (str.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/stumpwm.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "stumpwm";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "A tiling, keyboard driven window manager";
 
   deps = [ args."alexandria" args."cl-ppcre" args."clx" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/stumpwm/2021-02-28/stumpwm-20210228-git.tgz";
-    sha256 = "0vfhn90vfyhlbjkfkzx0i7i6qh79p9q4c4hhsym80niz508xw5v8";
+    url = "http://beta.quicklisp.org/archive/stumpwm/2021-04-11/stumpwm-20210411-git.tgz";
+    sha256 = "0rrhmryfgbjrl04ww107pvm4lzm620xp7a5kwhqbh5d7hpbdk49j";
   };
 
   packageName = "stumpwm";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM stumpwm DESCRIPTION A tiling, keyboard driven window manager SHA256
-    0vfhn90vfyhlbjkfkzx0i7i6qh79p9q4c4hhsym80niz508xw5v8 URL
-    http://beta.quicklisp.org/archive/stumpwm/2021-02-28/stumpwm-20210228-git.tgz
-    MD5 0506bcd0951463ea45cebfdb5ce76511 NAME stumpwm FILENAME stumpwm DEPS
+    0rrhmryfgbjrl04ww107pvm4lzm620xp7a5kwhqbh5d7hpbdk49j URL
+    http://beta.quicklisp.org/archive/stumpwm/2021-04-11/stumpwm-20210411-git.tgz
+    MD5 4497670e2aac3038ed5fb87121ff1b7a NAME stumpwm FILENAME stumpwm DEPS
     ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
      (NAME clx FILENAME clx))
-    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20210228-git SIBLINGS
+    DEPENDENCIES (alexandria cl-ppcre clx) VERSION 20210411-git SIBLINGS
     (stumpwm-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivia DESCRIPTION
     NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase
-    SHA256 0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia FILENAME trivia DEPS
+    SHA256 1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia FILENAME trivia DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
      (NAME introspect-environment FILENAME introspect-environment)
@@ -38,7 +38,7 @@ rec {
     (alexandria closer-mop introspect-environment iterate lisp-namespace
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION 20210228-git SIBLINGS
+    VERSION 20210411-git SIBLINGS
     (trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_balland2006";
-  version = "trivia-20210228-git";
+  version = "trivia-20210411-git";
 
   description = "Optimizer for Trivia based on (Balland 2006)";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia.balland2006";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivia.balland2006 DESCRIPTION
     Optimizer for Trivia based on (Balland 2006) SHA256
-    0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia.balland2006 FILENAME
+    1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia.balland2006 FILENAME
     trivia_dot_balland2006 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -38,7 +38,7 @@ rec {
     (alexandria closer-mop introspect-environment iterate lisp-namespace
      trivia.level0 trivia.level1 trivia.level2 trivia.trivial trivial-cltl2
      type-i)
-    VERSION trivia-20210228-git SIBLINGS
+    VERSION trivia-20210411-git SIBLINGS
     (trivia trivia.benchmark trivia.cffi trivia.level0 trivia.level1
      trivia.level2 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_level0";
-  version = "trivia-20210228-git";
+  version = "trivia-20210411-git";
 
   description = "Bootstrapping Pattern Matching Library for implementing Trivia";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia.level0";
@@ -20,11 +20,11 @@ rec {
 }
 /* (SYSTEM trivia.level0 DESCRIPTION
     Bootstrapping Pattern Matching Library for implementing Trivia SHA256
-    0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia.level0 FILENAME
+    1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia.level0 FILENAME
     trivia_dot_level0 DEPS ((NAME alexandria FILENAME alexandria)) DEPENDENCIES
-    (alexandria) VERSION trivia-20210228-git SIBLINGS
+    (alexandria) VERSION trivia-20210411-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level1
      trivia.level2 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_level1";
-  version = "trivia-20210228-git";
+  version = "trivia-20210411-git";
 
   description = "Core patterns of Trivia";
 
   deps = [ args."alexandria" args."trivia_dot_level0" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia.level1";
@@ -19,13 +19,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM trivia.level1 DESCRIPTION Core patterns of Trivia SHA256
-    0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia.level1 FILENAME
+    1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia.level1 FILENAME
     trivia_dot_level1 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivia.level0 FILENAME trivia_dot_level0))
-    DEPENDENCIES (alexandria trivia.level0) VERSION trivia-20210228-git
+    DEPENDENCIES (alexandria trivia.level0) VERSION trivia-20210411-git
     SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level2 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_level2";
-  version = "trivia-20210228-git";
+  version = "trivia-20210411-git";
 
   description = "NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase";
 
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia.level2";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivia.level2 DESCRIPTION
     NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase
-    SHA256 0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia.level2 FILENAME
+    SHA256 1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia.level2 FILENAME
     trivia_dot_level2 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -33,7 +33,7 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop lisp-namespace trivia.level0 trivia.level1
      trivial-cltl2)
-    VERSION trivia-20210228-git SIBLINGS
+    VERSION trivia-20210411-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.ppcre trivia.quasiquote trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_quasiquote";
-  version = "trivia-20210228-git";
+  version = "trivia-20210411-git";
 
   description = "fare-quasiquote extension for trivia";
 
   deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia.quasiquote";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM trivia.quasiquote DESCRIPTION fare-quasiquote extension for trivia
-    SHA256 0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia.quasiquote FILENAME
+    SHA256 1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia.quasiquote FILENAME
     trivia_dot_quasiquote DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -39,7 +39,7 @@ rec {
     (alexandria closer-mop fare-quasiquote fare-quasiquote-readtable fare-utils
      lisp-namespace named-readtables trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2)
-    VERSION trivia-20210228-git SIBLINGS
+    VERSION trivia-20210411-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.test trivia.trivial)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_trivial";
-  version = "trivia-20210228-git";
+  version = "trivia-20210411-git";
 
   description = "Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz";
-    sha256 = "0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz";
+    sha256 = "1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8";
   };
 
   packageName = "trivia.trivial";
@@ -24,9 +24,9 @@ rec {
     Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
  in order to avoid the circular dependency.
-    SHA256 0qqyspq2mryl87wgrm43sj7d2wqb1pckk7fjvnmmyrf5kz5p4pc6 URL
-    http://beta.quicklisp.org/archive/trivia/2021-02-28/trivia-20210228-git.tgz
-    MD5 b374212a63c1e3b7e5c0e26348516106 NAME trivia.trivial FILENAME
+    SHA256 1dy35yhjhzcqsq5rwsan1f9x2ss8wcw55n2jzzgymj1vqvzp5mn8 URL
+    http://beta.quicklisp.org/archive/trivia/2021-04-11/trivia-20210411-git.tgz
+    MD5 3fde6243390481d089cda082573876f6 NAME trivia.trivial FILENAME
     trivia_dot_trivial DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -38,7 +38,7 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop lisp-namespace trivia.level0 trivia.level1
      trivia.level2 trivial-cltl2)
-    VERSION trivia-20210228-git SIBLINGS
+    VERSION trivia-20210411-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-features";
-  version = "20210228-git";
+  version = "20210411-git";
 
   description = "Ensures consistent *FEATURES* across multiple CLs.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-features/2021-02-28/trivial-features-20210228-git.tgz";
-    sha256 = "1najk88r8nlpbxm8mjfj8b22f9chr9h2hxg9wqz87kkmhg4rfwwj";
+    url = "http://beta.quicklisp.org/archive/trivial-features/2021-04-11/trivial-features-20210411-git.tgz";
+    sha256 = "0z6nzql8z7bz8kzd08mh36h0r54vqx7pwigy8r617jhvb0r0n0n4";
   };
 
   packageName = "trivial-features";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM trivial-features DESCRIPTION
     Ensures consistent *FEATURES* across multiple CLs. SHA256
-    1najk88r8nlpbxm8mjfj8b22f9chr9h2hxg9wqz87kkmhg4rfwwj URL
-    http://beta.quicklisp.org/archive/trivial-features/2021-02-28/trivial-features-20210228-git.tgz
-    MD5 6d628c0c941346773751a684213a52d7 NAME trivial-features FILENAME
-    trivial-features DEPS NIL DEPENDENCIES NIL VERSION 20210228-git SIBLINGS
+    0z6nzql8z7bz8kzd08mh36h0r54vqx7pwigy8r617jhvb0r0n0n4 URL
+    http://beta.quicklisp.org/archive/trivial-features/2021-04-11/trivial-features-20210411-git.tgz
+    MD5 5ec554fff48d38af5023604a1ae42d3a NAME trivial-features FILENAME
+    trivial-features DEPS NIL DEPENDENCIES NIL VERSION 20210411-git SIBLINGS
     (trivial-features-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-items.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-items.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "utilities_dot_print-items";
-  version = "20190813-git";
+  version = "20210411-git";
 
   parasites = [ "utilities.print-items/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/utilities.print-items/2019-08-13/utilities.print-items-20190813-git.tgz";
-    sha256 = "12l4kzz621qfcg8p5qzyxp4n4hh9wdlpiziykwb4c80g32rdwkc2";
+    url = "http://beta.quicklisp.org/archive/utilities.print-items/2021-04-11/utilities.print-items-20210411-git.tgz";
+    sha256 = "0da2m4b993w31wph2ybdmdd6rycadrp44ccjdba5pygpkf3x00gx";
   };
 
   packageName = "utilities.print-items";
@@ -22,10 +22,10 @@ rec {
 }
 /* (SYSTEM utilities.print-items DESCRIPTION
     A protocol for flexible and composable printing. SHA256
-    12l4kzz621qfcg8p5qzyxp4n4hh9wdlpiziykwb4c80g32rdwkc2 URL
-    http://beta.quicklisp.org/archive/utilities.print-items/2019-08-13/utilities.print-items-20190813-git.tgz
-    MD5 0f26580bb5d3587ed1815f70976b2a0a NAME utilities.print-items FILENAME
+    0da2m4b993w31wph2ybdmdd6rycadrp44ccjdba5pygpkf3x00gx URL
+    http://beta.quicklisp.org/archive/utilities.print-items/2021-04-11/utilities.print-items-20210411-git.tgz
+    MD5 35be0e5ee4c957699082fb6ae8f14ef2 NAME utilities.print-items FILENAME
     utilities_dot_print-items DEPS
     ((NAME alexandria FILENAME alexandria) (NAME fiveam FILENAME fiveam))
-    DEPENDENCIES (alexandria fiveam) VERSION 20190813-git SIBLINGS NIL
+    DEPENDENCIES (alexandria fiveam) VERSION 20210411-git SIBLINGS NIL
     PARASITES (utilities.print-items/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -276,4 +276,5 @@ $out/lib/common-lisp/query-fs"
     (extraLispDeps (with quicklisp-to-nix-packages; [cl-syslog]));
   md5 = ifLispNotIn ["sbcl" "ccl" "gcl"]
     (extraLispDeps (with quicklisp-to-nix-packages; [flexi-streams]));
+  cl-gobject-introspection = addNativeLibs (with pkgs; [glib gobject-introspection]);
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -41,6 +41,7 @@ cl-emb
 cl-fad
 cl-fuse
 cl-fuse-meta-fs
+cl-gobject-introspection
 cl-hooks
 cl-html-diff
 cl-html5-parser

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -3520,6 +3520,20 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-gobject-introspection" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-gobject-introspection" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-gobject-introspection.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+       }));
+
+
   "cl-fuse-meta-fs" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-fuse-meta-fs" or (x: {}))
@@ -3879,7 +3893,9 @@ let quicklisp-to-nix-packages = rec {
            "lack-component" = quicklisp-to-nix-packages."lack-component";
            "lack-middleware-backtrace" = quicklisp-to-nix-packages."lack-middleware-backtrace";
            "lack-util" = quicklisp-to-nix-packages."lack-util";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "uiop" = quicklisp-to-nix-packages."uiop";
+           "usocket" = quicklisp-to-nix-packages."usocket";
        }));
 
 

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -11,6 +11,6 @@ self = rec {
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
   ];
   CPATH = "${libfixposix}/include";
-  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk-pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib:${webkitgtk}/lib";
+  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib:${glib.out}/lib:${gdk-pixbuf}/lib:${cairo}/lib:${pango.out}/lib:${gtk3}/lib:${webkitgtk}/lib:${gobject-introspection}/lib";
 };
 in stdenv.mkDerivation self


### PR DESCRIPTION
lispPackages.quicklisp: distinfo 2021-02-28 -> 2021-04-11,
quicklispPackages: regenerate,
lispPackages.nyxt: 2021-03-27 -> 2021-05-06, use upstream Makefile

Will self-merge once tests pass.

Note that a full rebuild of all changed paths is comparable with a single mid-size package

###### Motivation for this change

Quicklisp 2 months out of date. And Nyxt upstream asked to update the package with their code

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
