### PR TITLE
libfive: fix darwin build

### DIFF
--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -10,6 +10,7 @@
 , libpng
 , boost
 , guile
+, stdenv
 }:
 
 mkDerivation {
@@ -26,8 +27,19 @@ mkDerivation {
   nativeBuildInputs = [ wrapQtAppsHook cmake ninja pkg-config ];
   buildInputs = [ eigen zlib libpng boost guile ];
 
-  # Link "Studio" binary to "libfive-studio" to be more obvious:
-  postFixup = ''
+  postInstall = if stdenv.isDarwin then ''
+    # No rules to install the mac app, so do it manually.
+    mkdir -p $out/Applications
+    cp -r studio/Studio.app $out/Applications/Studio.app
+
+    install_name_tool \
+      -change libfive.dylib $out/lib/libfive.dylib \
+      -change libfive-guile.dylib $out/lib/libfive-guile.dylib \
+      $out/Applications/Studio.app/Contents/MacOS/Studio
+
+    wrapQtApp $out/Applications/Studio.app/Contents/MacOS/Studio
+  '' else ''
+    # Link "Studio" binary to "libfive-studio" to be more obvious:
     ln -s "$out/bin/Studio" "$out/bin/libfive-studio"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
@NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142512032/nixlog/2

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
