### PR TITLE
python3Packages.jupytext: fix tests

### DIFF
--- a/pkgs/development/python-modules/jupytext/default.nix
+++ b/pkgs/development/python-modules/jupytext/default.nix
@@ -44,7 +44,9 @@ buildPythonPackage rec {
     jupyter_client
     notebook
   ];
-  # pre-commit tests require a Git repository.
+  # Tests that use a Jupyter notebook require $HOME to be writable.
+  HOME = "$TMPDIR";
+  # Pre-commit tests expect the source directory to be a Git repository.
   pytestFlagsArray = [ "--ignore-glob='tests/test_pre_commit_*.py'" ];
   pythonImportsCheck = [ "jupytext" "jupytext.cli" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Due to improper sandboxing, I didn't notice the failed tests while upgrading jupytext in #121648.  The errors come from `jupyter_core` so the same fix is used here as there: set `$HOME` to a writable directory.

@bhipple @rmcgibbo this should fully build now, I'd appreciate if you could double-check it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
