### PR TITLE
tcl: add Tcl packaging support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -302,6 +302,12 @@
     githubId = 4296804;
     name = "Alex Franchuk";
   };
+  agbrooks = {
+    email = "andrewgrantbrooks@gmail.com";
+    github = "agbrooks";
+    githubId = 19290901;
+    name = "Andrew Brooks";
+  };
   aherrmann = {
     email = "andreash87@gmx.ch";
     github = "aherrmann";

--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optional guiSupport makeWrapper;
 
   buildInputs = [ boehmgc readline ]
-  ++ lib.optionals guiSupport [tk tcl.tclPackageHook tcllib]
+  ++ lib.optionals guiSupport [ tk tcl.tclPackageHook tcllib ]
   ++ lib.optional miSupport json_c
   ++ lib.optional nbdSupport libnbd
   ++ lib.optional textStylingSupport gettext

--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optional guiSupport makeWrapper;
 
   buildInputs = [ boehmgc readline ]
-  ++ lib.optional guiSupport tk
+  ++ lib.optionals guiSupport [tk tcl.tclPackageHook tcllib]
   ++ lib.optional miSupport json_c
   ++ lib.optional nbdSupport libnbd
   ++ lib.optional textStylingSupport gettext
@@ -56,11 +56,6 @@ in stdenv.mkDerivation rec {
 
   doCheck = !isCross;
   checkInputs = lib.optionals (!isCross) [ dejagnu ];
-
-  postFixup = lib.optionalString guiSupport ''
-    wrapProgram "$out/bin/poke-gui" \
-      --prefix TCLLIBPATH ' ' ${tcllib}/lib/tcllib${tcllib.version}
-  '';
 
   meta = with lib; {
     description = "Interactive, extensible editor for binary data";

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-uNDJIBlt2K4pFS+nRI5ROh+nxYiHG3heP7/Ae0KgX7k=";
   };
 
-  nativeBuildInputs = [ installShellFiles tcl ];
+  nativeBuildInputs = [ installShellFiles tcl tcllib ];
 
   buildInputs = [ zlib openssl readline sqlite which ed ]
     ++ lib.optional stdenv.isDarwin libiconv;
@@ -35,10 +35,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-internal-sqlite" ]
     ++ lib.optional withJson "--json";
-
-  preCheck = ''
-    export TCLLIBPATH="${tcllib}/lib/tcllib${tcllib.version}"
-  '';
 
   preBuild = ''
     export USER=nonexistent-but-specified-user

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -1,55 +1,69 @@
-{ lib, stdenv
+{ lib, stdenv, callPackage, makeSetupHook, makeWrapper
 
 # Version specific stuff
 , release, version, src
 , ...
 }:
 
-stdenv.mkDerivation {
-  pname = "tcl";
-  inherit version;
+let
+  baseInterp =
+    stdenv.mkDerivation {
+      pname = "tcl";
+      inherit version;
 
-  inherit src;
+      inherit src;
 
-  outputs = [ "out" "man" ];
+      outputs = [ "out" "man" ];
 
-  setOutputFlags = false;
+      setOutputFlags = false;
 
-  preConfigure = ''
-    cd unix
-  '';
+      preConfigure = ''
+        cd unix
+      '';
 
-  configureFlags = [
-    "--enable-threads"
-    # Note: using $out instead of $man to prevent a runtime dependency on $man.
-    "--mandir=${placeholder "out"}/share/man"
-    "--enable-man-symlinks"
-    # Don't install tzdata because NixOS already has a more up-to-date copy.
-    "--with-tzdata=no"
-    "tcl_cv_strtod_unbroken=ok"
-  ] ++ lib.optional stdenv.is64bit "--enable-64bit";
+      configureFlags = [
+        "--enable-threads"
+        # Note: using $out instead of $man to prevent a runtime dependency on $man.
+        "--mandir=${placeholder "out"}/share/man"
+        "--enable-man-symlinks"
+        # Don't install tzdata because NixOS already has a more up-to-date copy.
+        "--with-tzdata=no"
+        "tcl_cv_strtod_unbroken=ok"
+      ] ++ lib.optional stdenv.is64bit "--enable-64bit";
 
-  enableParallelBuilding = true;
+      enableParallelBuilding = true;
 
-  postInstall = let
-    dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
-  in ''
-    make install-private-headers
-    ln -s $out/bin/tclsh${release} $out/bin/tclsh
-    ln -s $out/lib/libtcl${release}${dllExtension} $out/lib/libtcl${dllExtension}
-  '';
+      postInstall = let
+        dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
+      in ''
+        make install-private-headers
+        ln -s $out/bin/tclsh${release} $out/bin/tclsh
+        ln -s $out/lib/libtcl${release}${dllExtension} $out/lib/libtcl${dllExtension}
+      '';
 
-  meta = with lib; {
-    description = "The Tcl scripting language";
-    homepage = "https://www.tcl.tk/";
-    license = licenses.tcltk;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ vrthra ];
-  };
+      meta = with lib; {
+        description = "The Tcl scripting language";
+        homepage = "https://www.tcl.tk/";
+        license = licenses.tcltk;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ vrthra ];
+      };
 
-  passthru = rec {
-    inherit release version;
-    libPrefix = "tcl${release}";
-    libdir = "lib/${libPrefix}";
-  };
-}
+      passthru = rec {
+        inherit release version;
+        libPrefix = "tcl${release}";
+        libdir = "lib/${libPrefix}";
+        tclPackageHook = callPackage ({}: makeSetupHook {
+          name = "tcl-package-hook";
+          deps = [ makeWrapper ];
+        } ./tcl-package-hook.sh) {};
+      };
+    };
+
+  mkTclDerivation = callPackage ./mk-tcl-derivation.nix { tcl = baseInterp; };
+
+in baseInterp.overrideAttrs (self: {
+     passthru = self.passthru // {
+       inherit mkTclDerivation;
+     };
+})

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -44,7 +44,7 @@ let
         homepage = "https://www.tcl.tk/";
         license = licenses.tcltk;
         platforms = platforms.all;
-        maintainers = with maintainers; [ vrthra ];
+        maintainers = with maintainers; [ agbrooks ];
       };
 
       passthru = rec {

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -9,9 +9,7 @@ let
   baseInterp =
     stdenv.mkDerivation {
       pname = "tcl";
-      inherit version;
-
-      inherit src;
+      inherit version src;
 
       outputs = [ "out" "man" ];
 

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -1,0 +1,69 @@
+# Generic builder for tcl packages/applications, generally based on mk-python-derivation.nix
+{ tcl
+, lib
+, makeWrapper
+, runCommand
+, writeScript
+}:
+
+{ buildInputs ? []
+, nativeBuildInputs ? []
+, propagatedBuildInputs ? []
+, checkInputs ? []
+
+# true if we should skip the configuration phase altogether
+, dontConfigure ? false
+
+# Extra flags passed to configure step
+, configureFlags ? []
+
+# Whether or not we should add common Tcl-related configure flags
+, addTclConfigureFlags ? true
+
+, meta ? {}
+, passthru ? {}
+, doCheck ? true
+, ... } @ attrs:
+
+let
+  inherit (tcl) stdenv;
+  inherit (lib) getBin optionalAttrs optionals;
+
+  defaultTclPkgConfigureFlags = [
+    "--with-tcl=${tcl}/lib"
+    "--with-tclinclude=${tcl}/include"
+    "--exec-prefix=\${out}"
+  ];
+
+  self = (stdenv.mkDerivation ((builtins.removeAttrs attrs [
+    "addTclConfigureFlags" "checkPhase" "checkInputs" "doCheck"
+  ]) // {
+
+    buildInputs = buildInputs ++ [ makeWrapper tcl.tclPackageHook ];
+    nativeBuildInputs = nativeBuildInputs ++ [ tcl ];
+    propagatedBuildInputs = propagatedBuildInputs ++ [ tcl ];
+
+    TCLSH = "${getBin tcl}/bin/tclsh";
+
+    # Run tests after install, at which point we've done all TCLLIBPATH setup
+    doCheck = false;
+    doInstallCheck = attrs.doCheck or ((attrs ? doInstallCheck) && attrs.doInstallCheck);
+    installCheckInputs = checkInputs ++ (optionals (attrs ? installCheckInputs) attrs.installCheckInputs);
+
+    # Add typical values expected by TEA for configureFlags
+    configureFlags =
+      if (!dontConfigure && addTclConfigureFlags)
+        then (configureFlags ++ defaultTclPkgConfigureFlags)
+        else configureFlags;
+
+    meta = {
+      platforms = tcl.meta.platforms;
+    } // meta;
+
+
+  } // optionalAttrs (attrs?checkPhase) {
+    installCheckPhase = attrs.checkPhase;
+  }
+  ));
+
+in lib.extendDerivation true passthru self

--- a/pkgs/development/interpreters/tcl/tcl-package-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-package-hook.sh
@@ -21,7 +21,7 @@ _addToTclLibPath() {
     if [ -z "${TCLLIBPATH-}" ]; then
         export TCLLIBPATH="$tclPkg"
     else
-        if [[ "$TCLLIBPATH" != *"$tclPkg"* ]]; then
+        if [[ "$TCLLIBPATH" != *"$tclPkg "* && "$TCLLIBPATH" != *"$tclPkg" ]]; then
             export TCLLIBPATH="${TCLLIBPATH} $tclPkg"
         fi
     fi
@@ -53,7 +53,7 @@ wrapTclBins() {
     find "$tclBinsDir" -type f -executable -print |
         while read -r someBin; do
             echo "Adding TCLLIBPATH wrapper for $someBin"
-            wrapProgram "$someBin" --set TCLLIBPATH "$TCLLIBPATH"
+            wrapProgram "$someBin" --prefix TCLLIBPATH ' ' "$TCLLIBPATH"
         done
 }
 

--- a/pkgs/development/interpreters/tcl/tcl-package-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-package-hook.sh
@@ -5,11 +5,11 @@
 # Add a directory to TCLLIBPATH, provided that it exists
 _addToTclLibPath() {
     local tclPkg="$1"
-    if [ -z "$tclPkg" ]; then
+    if [[ -z "$tclPkg" ]]; then
         return
     fi
 
-    if [ ! -d "$tclPkg" ]; then
+    if [[ ! -d "$tclPkg" ]]; then
         >&2 echo "can't add $tclPkg to TCLLIBPATH; that directory doesn't exist"
         exit 1
     fi
@@ -18,7 +18,7 @@ _addToTclLibPath() {
         tclPkg="{$tclPkg}"
     fi
 
-    if [ -z "${TCLLIBPATH-}" ]; then
+    if [[ -z "${TCLLIBPATH-}" ]]; then
         export TCLLIBPATH="$tclPkg"
     else
         if [[ "$TCLLIBPATH" != *"$tclPkg "* && "$TCLLIBPATH" != *"$tclPkg" ]]; then
@@ -30,7 +30,7 @@ _addToTclLibPath() {
 # Locate any directory containing an installed pkgIndex file
 findInstalledTclPkgs() {
     local -r newLibDir="${!outputLib}/lib"
-    if [ ! -d "$newLibDir" ]; then
+    if [[ ! -d "$newLibDir" ]]; then
         >&2 echo "Assuming no loadable tcl packages installed ($newLibDir does not exist)"
         return
     fi
@@ -39,13 +39,13 @@ findInstalledTclPkgs() {
 
 # Wrap any freshly-installed binaries and set up their TCLLIBPATH
 wrapTclBins() {
-    if [ -z "${TCLLIBPATH-}" ]; then
+    if [[ -z "${TCLLIBPATH-}" ]]; then
         echo "skipping automatic Tcl binary wrapping (nothing to do)"
         return
     fi
 
     local -r tclBinsDir="${!outputBin}/bin"
-    if [ ! -d "$tclBinsDir" ]; then
+    if [[ ! -d "$tclBinsDir" ]]; then
         echo "No outputBin found, not using any TCLLIBPATH wrapper"
         return
     fi

--- a/pkgs/development/interpreters/tcl/tcl-package-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-package-hook.sh
@@ -4,7 +4,7 @@
 
 # Add a directory to TCLLIBPATH, provided that it exists
 _addToTclLibPath() {
-    local -r tclPkg="$1"
+    local tclPkg="$1"
     if [ -z "$tclPkg" ]; then
         return
     fi

--- a/pkgs/development/interpreters/tcl/tcl-package-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-package-hook.sh
@@ -1,0 +1,74 @@
+# This hook ensures that we do the following in post-fixup:
+# * wrap any installed executables with a wrapper that configures TCLLIBPATH
+# * write a setup hook that extends the TCLLIBPATH of any anti-dependencies
+
+# Add a directory to TCLLIBPATH, provided that it exists
+_addToTclLibPath() {
+    local -r tclPkg="$1"
+    if [ -z "$tclPkg" ]; then
+        return
+    fi
+
+    if [ ! -d "$tclPkg" ]; then
+        >&2 echo "can't add $tclPkg to TCLLIBPATH; that directory doesn't exist"
+        exit 1
+    fi
+
+    if [[ "$tclPkg" == *" "* ]]; then
+        tclPkg="{$tclPkg}"
+    fi
+
+    if [ -z "${TCLLIBPATH-}" ]; then
+        export TCLLIBPATH="$tclPkg"
+    else
+        if [[ "$TCLLIBPATH" != *"$tclPkg"* ]]; then
+            export TCLLIBPATH="${TCLLIBPATH} $tclPkg"
+        fi
+    fi
+}
+
+# Locate any directory containing an installed pkgIndex file
+findInstalledTclPkgs() {
+    local -r newLibDir="${!outputLib}/lib"
+    if [ ! -d "$newLibDir" ]; then
+        >&2 echo "Assuming no loadable tcl packages installed ($newLibDir does not exist)"
+        return
+    fi
+    echo "$(find "$newLibDir" -name pkgIndex.tcl -exec dirname {} \;)"
+}
+
+# Wrap any freshly-installed binaries and set up their TCLLIBPATH
+wrapTclBins() {
+    if [ -z "${TCLLIBPATH-}" ]; then
+        echo "skipping automatic Tcl binary wrapping (nothing to do)"
+        return
+    fi
+
+    local -r tclBinsDir="${!outputBin}/bin"
+    if [ ! -d "$tclBinsDir" ]; then
+        echo "No outputBin found, not using any TCLLIBPATH wrapper"
+        return
+    fi
+
+    find "$tclBinsDir" -type f -executable -print |
+        while read -r someBin; do
+            echo "Adding TCLLIBPATH wrapper for $someBin"
+            wrapProgram "$someBin" --set TCLLIBPATH "$TCLLIBPATH"
+        done
+}
+
+# Generate hook to adjust TCLLIBPATH in anti-dependencies
+writeTclLibPathHook() {
+    local -r hookPath="${!outputLib}/nix-support/setup-hook"
+    mkdir -p "$(dirname "$hookPath")"
+
+    typeset -f _addToTclLibPath >> "$hookPath"
+    local -r tclPkgs=$(findInstalledTclPkgs)
+    while IFS= read -r tclPkg; do
+        echo "_addToTclLibPath \"$tclPkg\"" >> "$hookPath"
+        _addToTclLibPath "$tclPkg" true
+    done <<< "$tclPkgs"
+}
+
+postFixupHooks+=(writeTclLibPathHook)
+postFixupHooks+=(wrapTclBins)

--- a/pkgs/development/interpreters/tclreadline/default.nix
+++ b/pkgs/development/interpreters/tclreadline/default.nix
@@ -8,7 +8,7 @@
 , tk
 }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "tclreadline";
   version = "2.3.8";
 
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     readline
-    tcl
     tk
   ];
 
@@ -35,7 +34,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-tclshrl"
     "--enable-wishrl"
-    "--with-tcl=${tcl}/lib"
     "--with-tk=${tk}/lib"
     "--with-readline-includes=${readline.dev}/include/readline"
     "--with-libtool=${libtool}"

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -1,11 +1,8 @@
 { lib, fetchurl, tcl, tk }:
 
-let
-  version = "1.9.14";
-  libPrefix = "bwidget${version}";
-in tcl.mkTclDerivation {
+tcl.mkTclDerivation rec {
   pname = "bwidget";
-  inherit version;
+  version = "1.9.14";
 
   src = fetchurl {
     url = "mirror://sourceforge/tcllib/bwidget-${version}.tar.gz";

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -1,8 +1,11 @@
-{ lib, stdenv, fetchurl, tcl }:
+{ lib, fetchurl, tcl }:
 
-stdenv.mkDerivation rec {
-  pname = "bwidget";
+let
   version = "1.9.14";
+  libPrefix = "bwidget${version}";
+in tcl.mkTclDerivation {
+  pname = "bwidget";
+  inherit version;
 
   src = fetchurl {
     url = "mirror://sourceforge/tcllib/bwidget-${version}.tar.gz";
@@ -12,15 +15,9 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p "$out/lib/${passthru.libPrefix}"
-    cp -R *.tcl lang images "$out/lib/${passthru.libPrefix}"
+    mkdir -p "$out/lib/${libPrefix}"
+    cp -R *.tcl lang images "$out/lib/${libPrefix}"
   '';
-
-  passthru = {
-    libPrefix = "bwidget${version}";
-  };
-
-  buildInputs = [ tcl ];
 
   meta = {
     homepage = "https://sourceforge.net/projects/tcllib";

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -13,7 +13,7 @@ in tcl.mkTclDerivation {
   };
 
   dontBuild = true;
-  propagatedBuildInputs = [tk];
+  propagatedBuildInputs = [ tk ];
 
   installPhase = ''
     mkdir -p "$out/lib/${libPrefix}"

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -16,8 +16,8 @@ in tcl.mkTclDerivation {
   propagatedBuildInputs = [ tk ];
 
   installPhase = ''
-    mkdir -p "$out/lib/${libPrefix}"
-    cp -R *.tcl lang images "$out/lib/${libPrefix}"
+    mkdir -p "$out/lib/bwidget${version}"
+    cp -R *.tcl lang images "$out/lib/bwidget${version}"
   '';
 
   meta = {

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, tcl }:
+{ lib, fetchurl, tcl, tk }:
 
 let
   version = "1.9.14";
@@ -13,6 +13,7 @@ in tcl.mkTclDerivation {
   };
 
   dontBuild = true;
+  propagatedBuildInputs = [tk];
 
   installPhase = ''
     mkdir -p "$out/lib/${libPrefix}"
@@ -22,6 +23,7 @@ in tcl.mkTclDerivation {
   meta = {
     homepage = "https://sourceforge.net/projects/tcllib";
     description = "High-level widget set for Tcl/Tk";
+    maintainers = with lib.maintainers; [ agbrooks ];
     license = lib.licenses.tcltk;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/development/libraries/incrtcl/default.nix
+++ b/pkgs/development/libraries/incrtcl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, writeText, tcl }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "incrtcl";
   version = "4.2.0";
 
@@ -9,16 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0w28v0zaraxcq1s9pa6cihqqwqvvwfgz275lks7w4gl7hxjxmasw";
   };
 
-  buildInputs = [ tcl ];
-  configureFlags = [ "--with-tcl=${tcl}/lib" ];
   enableParallelBuilding = true;
 
   patchPhase = ''
     substituteInPlace configure --replace "\''${TCL_SRC_DIR}/generic" "${tcl}/include"
-  '';
-
-  preConfigure = ''
-    configureFlags="--exec_prefix=$prefix $configureFlags"
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/itktcl/default.nix
+++ b/pkgs/development/libraries/itktcl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, tcl, tk, incrtcl }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "itk-tcl";
   version = "4.1.0";
 
@@ -9,11 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1iy964jfgsfnc1agk1w6bbm44x18ily8d4wmr7cc9z9f4acn2r6s";
   };
 
-  buildInputs = [ tcl tk incrtcl ];
+  buildInputs = [ tk incrtcl ];
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--with-tcl=${tcl}/lib"
     "--with-tk=${tk}/lib"
     "--with-itcl=${incrtcl}/lib"
     "--with-tkinclude=${tk.dev}/include"

--- a/pkgs/development/libraries/tcllib/default.nix
+++ b/pkgs/development/libraries/tcllib/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, tcl }:
+{ lib, fetchurl, tcl }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "tcllib";
   version = "1.20";
 
@@ -8,12 +8,6 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/tcllib/tcllib-${version}.tar.gz";
     sha256 = "0wax281h6ksz974a5qpfgf9y34lmlpd8i87lkm1w94ybbd3rgc73";
   };
-
-  passthru = {
-    libPrefix = "tcllib${version}";
-  };
-
-  buildInputs = [ tcl ];
 
   meta = {
     homepage = "https://sourceforge.net/projects/tcllib/";

--- a/pkgs/development/libraries/tcltls/default.nix
+++ b/pkgs/development/libraries/tcltls/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, tcl, openssl }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "tcltls";
   version = "1.6.7";
 
@@ -9,21 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "1f53sfcnrridjl5ayrq1xrqkahs8khf8c3d0m2brndbhahzdw6ai";
   };
 
-  buildInputs = [ tcl openssl ];
+  buildInputs = [ openssl ];
 
   configureFlags = [
-    "--with-tcl=${tcl}/lib"
-    "--with-tclinclude=${tcl}/include"
     "--with-ssl-dir=${openssl.dev}"
   ];
-
-  preConfigure = ''
-    configureFlags="--exec_prefix=$prefix $configureFlags"
-  '';
-
-  passthru = {
-    libPrefix = "tls${version}";
-  };
 
   meta = {
     homepage = "http://tls.sourceforge.net/";

--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -11,10 +11,9 @@ tcl.mkTclDerivation rec {
   };
 
   # required in order for tclx to properly detect tclx.tcl at runtime
-  postInstall =
-    let tclXPkg = "tclx${version}";
-        tclXLib = "$prefix/lib/${tclXPkg}";
-     in "ln -s ${tclXLib} ${tclXLib}/${tclXPkg}";
+  postInstall = ''
+    ln -s $prefix/lib/${tclXPkg} $prefix/lib/tclx${version}/tclx${version}
+  '';
 
   meta = {
     homepage = "http://tclx.sourceforge.net/";

--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -12,7 +12,7 @@ tcl.mkTclDerivation rec {
 
   # required in order for tclx to properly detect tclx.tcl at runtime
   postInstall = ''
-    ln -s $prefix/lib/${tclXPkg} $prefix/lib/tclx${version}/tclx${version}
+    ln -s $prefix/lib/tclx${version} $prefix/lib/tclx${version}/tclx${version}
   '';
 
   meta = {

--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, tcl }:
+{ lib, fetchurl, tcl }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   name = "tclx-${version}.${patch}";
   version = "8.4";
   patch = "1";
@@ -10,13 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1v2qwzzidz0is58fd1p7wfdbscxm3ip2wlbqkj5jdhf6drh1zd59";
   };
 
-  passthru = {
-    libPrefix = ""; # Using tclx${version} did not work
-  };
-
-  buildInputs = [ tcl ];
-
-  configureFlags = [ "--with-tcl=${tcl}/lib" "--exec-prefix=\${prefix}" ];
+  # required in order for tclx to properly detect tclx.tcl at runtime
+  postInstall =
+    let tclXPkg = "tclx${version}";
+        tclXLib = "$prefix/lib/${tclXPkg}";
+     in "ln -s ${tclXLib} ${tclXLib}/${tclXPkg}";
 
   meta = {
     homepage = "http://tclx.sourceforge.net/";

--- a/pkgs/development/libraries/tix/default.nix
+++ b/pkgs/development/libraries/tix/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, tcl, tk, fetchpatch } :
 
-stdenv.mkDerivation {
+tcl.mkTclDerivation {
   version = "8.4.3";
   pname = "tix";
   src = fetchurl {
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     sha256 = "1jaz0l22xj7x1k4rb9ia6i1psnbwk4pblgq4gfvya7gg7fbb7r36";
     })
   ;
-  buildInputs = [ tcl tk ];
+  buildInputs = [ tk ];
   # the configure script expects to find the location of the sources of
   # tcl and tk in {tcl,tk}Config.sh
   # In fact, it only needs some private headers. We copy them in
@@ -35,7 +35,6 @@ stdenv.mkDerivation {
     done;
     '';
   configureFlags = [
-    "--with-tclinclude=${tcl}/include"
     "--with-tclconfig=."
     "--with-tkinclude=${tk.dev}/include"
     "--with-tkconfig=."
@@ -52,4 +51,3 @@ stdenv.mkDerivation {
     ];
   };
 }
-

--- a/pkgs/development/libraries/tix/default.nix
+++ b/pkgs/development/libraries/tix/default.nix
@@ -34,6 +34,7 @@ tcl.mkTclDerivation {
       ln -s $i private_headers/generic;
     done;
     '';
+  addTclConfigureFlags = false;
   configureFlags = [
     "--with-tclconfig=."
     "--with-tkinclude=${tk.dev}/include"

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -2,7 +2,7 @@
 , enableAqua ? stdenv.isDarwin, darwin
 , ... }:
 
-stdenv.mkDerivation {
+tcl.mkTclDerivation {
   name = "tk-${tcl.version}";
 
   inherit src patches;
@@ -33,14 +33,13 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "--enable-threads"
-    "--with-tcl=${tcl}/lib"
   ] ++ lib.optional stdenv.is64bit "--enable-64bit"
     ++ lib.optional enableAqua "--enable-aqua";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optional enableAqua (with darwin.apple_sdk.frameworks; [ Cocoa ]);
 
-  propagatedBuildInputs = [ tcl libXft ];
+  propagatedBuildInputs = [ libXft ];
 
   doCheck = false; # fails. can't find itself
 

--- a/pkgs/games/scid-vs-pc/default.nix
+++ b/pkgs/games/scid-vs-pc/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, tcl, tk, libX11, zlib, makeWrapper, makeDesktopItem }:
+{ lib, fetchurl, tcl, tk, libX11, zlib, makeWrapper, makeDesktopItem }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "scid-vs-pc";
   version = "4.21";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ tcl tk libX11 zlib ];
+  buildInputs = [ tk libX11 zlib ];
 
   prePatch = ''
     sed -i -e '/^ *set headerPath *{/a ${tcl}/include ${tk}/include' \
@@ -49,7 +49,6 @@ stdenv.mkDerivation rec {
 
     for cmd in $out/bin/* ; do
       wrapProgram "$cmd" \
-        --set TCLLIBPATH "${tcl}/${tcl.libdir}" \
         --set TK_LIBRARY "${tk}/lib/${tk.libPrefix}"
     done
   '';
@@ -79,4 +78,3 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
   };
 }
-

--- a/pkgs/games/scid/default.nix
+++ b/pkgs/games/scid/default.nix
@@ -51,7 +51,7 @@ tcl.mkTclDerivation {
 
   meta = {
     description = "Chess database with play and training functionality";
-    maintainers = with maintainers; [ agbrooks ];
+    maintainers = with lib.maintainers; [ agbrooks ];
     homepage = "http://scid.sourceforge.net/";
     license = lib.licenses.gpl2;
   };

--- a/pkgs/games/scid/default.nix
+++ b/pkgs/games/scid/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, tcl, tk, libX11, zlib, makeWrapper }:
+{ lib, fetchurl, tcl, tk, libX11, zlib, makeWrapper }:
 
-stdenv.mkDerivation {
+tcl.mkTclDerivation {
   pname = "scid";
   version = "4.3";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ tcl tk libX11 zlib ];
+  buildInputs = [ tk libX11 zlib ];
 
   prePatch = ''
     sed -i -e '/^ *set headerPath *{/a ${tcl}/include ${tk}/include' \
@@ -45,13 +45,13 @@ stdenv.mkDerivation {
     for cmd in $out/bin/*
     do
       wrapProgram "$cmd" \
-        --set TCLLIBPATH "${tcl}/${tcl.libdir}" \
         --set TK_LIBRARY "${tk}/lib/${tk.libPrefix}"
     done
   '';
 
   meta = {
     description = "Chess database with play and training functionality";
+    maintainers = with maintainers; [ agbrooks ];
     homepage = "http://scid.sourceforge.net/";
     license = lib.licenses.gpl2;
   };

--- a/pkgs/games/tcl2048/default.nix
+++ b/pkgs/games/tcl2048/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, tcl, tcllib, runtimeShell }:
 
-stdenv.mkDerivation {
+tcl.mkTclDerivation {
   name = "tcl2048-0.4.0";
 
   src = fetchurl {
@@ -8,20 +8,12 @@ stdenv.mkDerivation {
     sha256 = "53f5503efd7f029b2614b0f9b1e3aac6c0342735a3c9b811d74a5135fee3e89e";
   };
 
-  phases = "installPhase";
+  buildInputs = [ tcllib ];
+  phases = "installPhase fixupPhase";
 
   installPhase = ''
     mkdir -pv $out/bin
-    cp $src $out/2048.tcl
-    cat > $out/bin/2048 << EOF
-    #!${runtimeShell}
-
-    # wrapper for tcl2048
-    export TCLLIBPATH="${tcllib}/lib/tcllib${tcllib.version}"
-    ${tcl}/bin/tclsh $out/2048.tcl
-    EOF
-
-    chmod +x $out/bin/2048
+    install -m 755 $src $out/bin/2048
   '';
 
   meta = {

--- a/pkgs/games/xconq/default.nix
+++ b/pkgs/games/xconq/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ cpio xorgproto libX11 libXmu libXaw libXt tcl tk libXext
-    fontconfig makeWrapper tcl.tclPackageHook ];
+    fontconfig makeWrapper ];
 
   configureFlags = [
     "--enable-alternate-scoresdir=scores"
@@ -37,6 +37,12 @@ stdenv.mkDerivation rec {
 
     # Fix TCL files
     sed -re 's@MediumBlue@LightBlue@g' -i tcltk/tkconq.tcl
+  '';
+
+  postInstall = ''
+    for file in $out/bin/*; do
+      wrapProgram $file --prefix TCLLIBPATH ' ' "${tk}/lib"
+    done
   '';
 
   meta = with lib; {

--- a/pkgs/games/xconq/default.nix
+++ b/pkgs/games/xconq/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ cpio xorgproto libX11 libXmu libXaw libXt tcl tk libXext
-    fontconfig makeWrapper ];
+    fontconfig makeWrapper tcl.tclPackageHook ];
 
   configureFlags = [
     "--enable-alternate-scoresdir=scores"
@@ -37,12 +37,6 @@ stdenv.mkDerivation rec {
 
     # Fix TCL files
     sed -re 's@MediumBlue@LightBlue@g' -i tcltk/tkconq.tcl
-  '';
-
-  postInstall = ''
-    for file in $out/bin/*; do
-      wrapProgram $file --prefix TCLLIBPATH ' ' "${tk}/lib"
-    done
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, buildPackages, fetchurl, tcl, makeWrapper, autoreconfHook, fetchpatch }:
 
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "expect";
   version = "5.45.4";
 
@@ -20,24 +20,14 @@ stdenv.mkDerivation rec {
     sed -i "s,/bin/stty,$(type -p stty),g" configure.in
   '';
 
-  nativeBuildInputs = [ autoreconfHook makeWrapper tcl ];
-  buildInputs = [ tcl ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper ];
 
   strictDeps = true;
   hardeningDisable = [ "format" ];
 
-  configureFlags = [
-    "--with-tcl=${buildPackages.tcl}/lib"
-    "--with-tclinclude=${tcl}/include"
-    "--exec-prefix=${placeholder "out"}"
-  ];
-
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     for i in $out/bin/*; do
-      wrapProgram $i \
-        --prefix PATH : "${tcl}/bin" \
-        --prefix TCLLIBPATH ' ' $out/lib/* \
-        ${lib.optionalString stdenv.isDarwin "--prefix DYLD_LIBRARY_PATH : $out/lib/expect${version}"}
+      wrapProgram $i --prefix DYLD_LIBRARY_PATH : $out/lib/expect${version}
     done
   '';
 

--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -3,20 +3,18 @@
 , fetchurl
 , tk
 , tcllib
-, makeWrapper
+, tcl
 , tkremind ? true
 }:
 
 let
-  inherit (lib) optional optionalString;
-  tclLibraries = lib.optionals tkremind [ tcllib tk ];
-  tclLibPaths = lib.concatStringsSep " "
-    (map (p: "${p}/lib/${p.libPrefix}") tclLibraries);
+  inherit (lib) optional optionals optionalString;
+  tclLibraries = optionals tkremind [ tcllib tk ];
   tkremindPatch = optionalString tkremind ''
     substituteInPlace scripts/tkremind --replace "exec wish" "exec ${tk}/bin/wish"
   '';
 in
-stdenv.mkDerivation rec {
+tcl.mkTclDerivation rec {
   pname = "remind";
   version = "03.03.06";
 
@@ -25,7 +23,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-lpoMAXDJxwODY0/aoo25GRBYWFhE4uf11pR5/ITZX1s=";
   };
 
-  nativeBuildInputs = optional tkremind makeWrapper;
   propagatedBuildInputs = tclLibraries;
 
   postPatch = ''
@@ -35,10 +32,6 @@ stdenv.mkDerivation rec {
       --replace "rkrphgvba(0);" "" \
       --replace "rkrphgvba(1);" ""
     ${tkremindPatch}
-  '';
-
-  postInstall = optionalString tkremind ''
-    wrapProgram $out/bin/tkremind --set TCLLIBPATH "${tclLibPaths}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
##### Motivation for this change

I am a software engineer at FlightAware, and recently received approval to release some of the tooling that our internal overlay adds for packaging Tcl projects. I think this PR has the potential to make Nix a very compelling tool for working with Tcl (particularly because Tcl does not currently have any actively-maintained package manager).

Currently, it's a bit of a hassle to package software in nixpkgs that depends on Tcl packages. In general, packaging a Tcl application requires you to do the following:
* Manually identify all Tcl packages that your program depends on (directly or transitively) and add a wrapper that will set TCLLIBPATH to the appropriate locations in the store
* Add common Tcl-related configuration flags (thankfully, these are generally pretty standard across Tcl packages and are described by the Tcl Extension Architecture)
* Set TCLLIBPATH appropriately in the checkPhase / installCheckPhase to be able to actually find whatever packages were installed in order to run tests
* Explicitly identify wherever any installed Tcl packages were placed in lib/ and expose that in the passthru to aid other packages in setting up their TCLLIBPATH wrappers

This becomes really unwieldy when you're trying to package something where the dependency tree contains a large number of Tcl packages. At FlightAware, many of our internal Tcl packages have this problem, and it's impractically burdensome just to set up the TCLLIBPATH wrappers manually. Furthermore, the dev experience is also fairly poor compared to something like Python (ie, you can't very well just say `nix-shell -p someTclPackage tcl` and expect to be able to `package require whateverPackage` from `tclsh`).


###### Things done
This PR adds some conveniences for Tcl packaging that are loosely styled after those available for Python. Specifically, there are two major components:

1. A `mkTclDerivation` function, exposed in `tcl`'s passthru. This is just a wrapper around `stdenv.mkDerivation` that mostly just adds a few configuration flags, a dependency on Tcl, and the `tclPackageHook` (described below).
2. A `tclPackageHook`, which populates TCLLIBPATH based on the location of any installed `pkgIndex.tcl` files, propagates this to anti-dependencies, and causes any installed binaries to be automatically wrapped with a TCLLIBPATH wrapper.

This lets you do convenient things like
```
$ nix-shell -p tclx tcl --command "tclsh"
% package require Tclx
8.4
```
which currently isn't possible with Tcl packages in nixpkgs.

I've taken the liberty of incorporating the new Tcl packaging code to many of the Tcl packages already present in nixpkgs. This seems to have been pretty successful in simplifying them.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
