### PR TITLE
rust-analyzer: 2021-04-19 -> 2021-05-10

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices, cmake
+{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices, cmake, fetchpatch
 , libiconv
 , useMimalloc ? false
 , doCheck ? true
@@ -6,15 +6,30 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-analyzer-unwrapped";
-  version = "2021-04-19";
-  cargoSha256 = "sha256-CXkI3CQ/v6RBMM2Dpp2u+qnRwba+nqzeaPSJGBiQUoY=";
+  version = "2021-05-10";
+  cargoSha256 = "sha256-PUecBFdYIJFZa5IwwNnuXOkuxtyrzWhxy3C+2jv/hvU=";
 
   src = fetchFromGitHub {
     owner = "rust-analyzer";
     repo = "rust-analyzer";
     rev = version;
-    sha256 = "sha256-W/cUwZEvlUXzqQ/futeNFwDWR/cTL/RLZaW2srIs83Q=";
+    sha256 = "sha256-oz6FqRMEUUTS4X2XhpWjp2JIgl1A6wQv2OU8auwUoVM=";
   };
+
+  patchFlags = [ "-Rp1" ];
+  patches = [
+    # Revert updates which require rust 1.52.0.
+    # We currently have rust 1.51.0 in nixpkgs.
+    # https://github.com/rust-analyzer/rust-analyzer/pull/8718
+    (fetchpatch {
+      url = "https://github.com/rust-analyzer/rust-analyzer/pull/8718/commits/607d8a2f61e56fabb7a3bc5132592917fcdca970.patch";
+      sha256 = "sha256-ekbeTx+q4QMgQ55SsaeWTBh4Gm87/FuaVIfUIZeDHqw=";
+    })
+    (fetchpatch {
+      url = "https://github.com/rust-analyzer/rust-analyzer/pull/8718/commits/6a16ec52aa0d91945577c99cdf421b303b59301e.patch";
+      sha256 = "sha256-W1pBE1qP8pepQWDKxdSWytsc9I2SVutf1YHOPfrLK7E=";
+    })
+  ];
 
   buildAndTestSubdir = "crates/rust-analyzer";
 

--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -16,18 +16,19 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-oz6FqRMEUUTS4X2XhpWjp2JIgl1A6wQv2OU8auwUoVM=";
   };
 
-  patchFlags = [ "-Rp1" ];
   patches = [
     # Revert updates which require rust 1.52.0.
     # We currently have rust 1.51.0 in nixpkgs.
     # https://github.com/rust-analyzer/rust-analyzer/pull/8718
     (fetchpatch {
       url = "https://github.com/rust-analyzer/rust-analyzer/pull/8718/commits/607d8a2f61e56fabb7a3bc5132592917fcdca970.patch";
-      sha256 = "sha256-ekbeTx+q4QMgQ55SsaeWTBh4Gm87/FuaVIfUIZeDHqw=";
+      sha256 = "sha256-g1yyq/XSwGxftnqSW1bR5UeMW4gW28f4JciGvwQ/n08=";
+      revert = true;
     })
     (fetchpatch {
       url = "https://github.com/rust-analyzer/rust-analyzer/pull/8718/commits/6a16ec52aa0d91945577c99cdf421b303b59301e.patch";
-      sha256 = "sha256-W1pBE1qP8pepQWDKxdSWytsc9I2SVutf1YHOPfrLK7E=";
+      sha256 = "sha256-n7Ew/0fG8zPaMFCi8FVLjQZwJSaczI/QoehC6pDLrAk=";
+      revert = true;
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump. Should fix #122386.

Tested through vscode extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  ```
  3 packages updated:
  rust-analyzer (2021-04-19 → 2021-05-10) rust-analyzer-unwrapped (2021-04-19 → 2021-05-10) vscode-extensions.matklad.rust-analyzer (2021-04-19 → 2021-05-10)
  ```
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
