### PR TITLE
wayland: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , substituteAll
 , meson
 , pkg-config
@@ -37,6 +38,11 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Picked from upstream 'main' branch for Darwin support.
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/wayland/wayland/-/commit/f452e41264387dee4fd737cbf1af58b34b53941b.patch";
+      sha256 = "00mk32a01vgn31sm3wk4p8mfwvqv3xv02rxvdj1ygnzgb1ac62r7";
+    })
     (substituteAll {
       src = ./0001-add-placeholder-for-nm.patch;
       nm = "${stdenv.cc.targetPrefix}nm";


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/141980180/nixlog/2

There appears to be no direct job in Hydra for wayland on Darwin, and I'm not sure how to fix that. Regardless, this will unblock the build of retroarch, which is several dozen jobs. 🙃

Alternatively, retroarch shouldn't depend on wayland on Darwin, and I'll open a separate PR to make that change.

Upstream merge request: https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/136

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
