### PR TITLE
faraday: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8053,6 +8053,12 @@
     githubId = 406946;
     name = "Valentin Lorentz";
   };
+  proofofkeags = {
+    email = "keagan.mcclelland@gmail.com";
+    github = "ProofOfKeags";
+    githubId = 4033651;
+    name = "Keagan McClelland";
+  };
   protoben = {
     email = "protob3n@gmail.com";
     github = "protoben";

--- a/pkgs/applications/blockchains/faraday/default.nix
+++ b/pkgs/applications/blockchains/faraday/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "faraday";
+  version = "0.2.3-alpha";
+
+  src = fetchFromGitHub {
+    owner = "lightninglabs";
+    repo = "faraday";
+    rev = "v${version}";
+    sha256 = "16cqaslsbwda23b5n0sfppybd3ma4ch545100ydxrwac4zhrq4kq";
+  };
+
+  vendorSha256 = "1hh99nfprlmhkc36arg3w1kxby59i2l7n258cp40niv7bjn37hrq";
+
+  subPackages = [ "cmd/frcli" "cmd/faraday" ];
+
+  meta = with lib; {
+    description = "LND Channel Management Tools";
+    homepage = "https://github.com/lightninglabs/faraday";
+    license = licenses.mit;
+    maintainers = with maintainers; [ proofofkeags ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27532,6 +27532,8 @@ in
 
   exodus = callPackage ../applications/blockchains/exodus { };
 
+  faraday = callPackage ../applications/blockchains/faraday { };
+
   go-ethereum = callPackage ../applications/blockchains/go-ethereum.nix {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) IOKit;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the package `faraday` to extend the capabilities of `lnd` to report on Lightning Network channel performance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
