### PR TITLE
kak-ansi: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/overrides.nix
+++ b/pkgs/applications/editors/kakoune/plugins/overrides.nix
@@ -34,13 +34,13 @@ self: super: {
 
   kak-ansi = stdenv.mkDerivation rec {
     pname = "kak-ansi";
-    version = "0.2.3";
+    version = "0.2.4";
 
     src = fetchFromGitHub {
       owner = "eraserhd";
       repo = "kak-ansi";
       rev = "v${version}";
-      sha256 = "pO7M3MjKMJQew9O20KALEvsXLuCKPYGGTtuN/q/kj8Q=";
+      sha256 = "kFjTYFy0KF5WWEHU4hHFAnD/03/d3ptjqMMbTSaGImE=";
     };
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).