### PR TITLE
nixos/install-grub: add classes to NixOS entry

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -487,7 +487,7 @@ sub addEntry {
 # Add default entries.
 $conf .= "$extraEntries\n" if $extraEntriesBeforeNixOS;
 
-addEntry("NixOS - Default", $defaultConfig, "--unrestricted");
+addEntry("NixOS - Default", $defaultConfig, "--class nixos --class gnu-linux --class gnu --class os --unrestricted");
 
 $conf .= "$extraEntries\n" unless $extraEntriesBeforeNixOS;
 


### PR DESCRIPTION
###### Motivation for this change
This is needed for theming the NixOS menuentry icon.

###### Things done
Succeeds on a `nixos-rebuild` no idea how it affects GRUB1, but works fine for GRUB2.