### PR TITLE
lightning-loop: init at version 0.12.2

### DIFF
--- a/pkgs/applications/blockchains/lightning-loop/default.nix
+++ b/pkgs/applications/blockchains/lightning-loop/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "lightning-loop";
+  version = "0.12.2-beta";
+
+  src = fetchFromGitHub {
+    owner = "lightninglabs";
+    repo = "loop";
+    rev = "v${version}";
+    sha256 = "1yyx9j9lxdianm0mxm8zs2yn6xglc1kb7vbcalnxss8j62zn1msm";
+  };
+
+  vendorSha256 = "03z0cmn9qgcmqm8llybfn1hz1m9hx3pn18m11s3fwnay8ib00r89";
+
+  subPackages = [ "cmd/loop" "cmd/loopd" ];
+
+  meta = with lib; {
+    description = "Lightning Loop Client";
+    homepage = "https://github.com/lightninglabs/loop";
+    license = licenses.mit;
+    maintainers = with maintainers; [ proofofkeags ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28129,6 +28129,8 @@ in
 
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };
 
+  lightning-loop = callPackage ../applications/blockchains/lightning-loop { };
+
   lightning-pool = callPackage ../applications/blockchains/lightning-pool { };
 
   litecoin  = libsForQt514.callPackage ../applications/blockchains/litecoin.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the Lightning Loop Client to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
