### PR TITLE
librealsense2: 2.43.0 -> 2.45.0

### DIFF
--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -7,7 +7,7 @@ assert enablePython -> pythonPackages != null;
 
 stdenv.mkDerivation rec {
   pname = "librealsense";
-  version = "2.43.0";
+  version = "2.45.0";
 
   outputs = [ "out" "dev" ];
 
@@ -15,17 +15,18 @@ stdenv.mkDerivation rec {
     owner = "IntelRealSense";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-N7EvpcJjtK3INHK7PgoiEVIMq9zGcHKMeI+/dwZ3bNs=";
+    sha256 = "0aqf48zl7825v7x8c3x5w4d17m4qq377f1mn6xyqzf9b0dnk4i1j";
   };
 
   buildInputs = [
     libusb1
     gcc.cc.lib
   ] ++ lib.optional cudaSupport cudatoolkit
-    ++ lib.optional enablePython pythonPackages.python;
+    ++ lib.optionals enablePython (with pythonPackages; [python pybind11 ]);
 
   patches = lib.optionals enablePython [
     ./py_sitepackage_dir.patch
+    ./py_pybind11_no_external_download.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/librealsense/py_pybind11_no_external_download.patch
+++ b/pkgs/development/libraries/librealsense/py_pybind11_no_external_download.patch
@@ -1,0 +1,39 @@
+From 01e51b9c90ba51b2d0ca797dde676812cf3db415 Mon Sep 17 00:00:00 2001
+From: "Robert T. McGibbon" <rmcgibbo@gmail.com>
+Date: Mon, 10 May 2021 17:26:04 -0400
+Subject: [PATCH 1/1] V1
+
+---
+ wrappers/python/CMakeLists.txt | 15 +--------------
+ 1 file changed, 1 insertion(+), 14 deletions(-)
+
+diff --git a/wrappers/python/CMakeLists.txt b/wrappers/python/CMakeLists.txt
+index aa83e4c77..4ec92ccfa 100644
+--- a/wrappers/python/CMakeLists.txt
++++ b/wrappers/python/CMakeLists.txt
+@@ -8,21 +8,8 @@ if (NOT BUILD_PYTHON_BINDINGS)
+ endif()
+ 
+ set(DEPENDENCIES realsense2)
+-# In order for the external project clone to occur during cmake configure step(rather than during compilation, as would normally happen),
+-# we copy the external project declaration to the build folder and then execute it
+-configure_file(${CMAKE_SOURCE_DIR}/third-party/pybind11/CMakeLists.txt ${CMAKE_BINARY_DIR}/external-projects/pybind11/CMakeLists.txt)
+-execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external-projects/pybind11"
+-)
+-execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external-projects/pybind11"
+-)
+ 
+-# Add pybind11 makefile
+-add_subdirectory("${CMAKE_BINARY_DIR}/third-party/pybind11"
+-                 "${CMAKE_BINARY_DIR}/third-party/pybind11"
+-                 EXCLUDE_FROM_ALL
+-)
++find_package(pybind11 REQUIRED)
+ 
+ set(PYBIND11_CPP_STANDARD -std=c++11)
+ # Force Pybind11 not to share pyrealsense2 resources with other pybind modules.
+-- 
+2.29.3
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/v4igkd416hb85p52n2ic6d390rxhir6n-librealsense-2.43.0.drv
ZHF: #122042

Tries to fix `python3Packages.pyrealsense2` by adding a patch to get pybind11 from the nix store rather than via a a git download during the build. I'm not an expert with cmake, so another pair of eyes would be appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
