### PR TITLE
python3Packages.agate-excel: fix build

### DIFF
--- a/pkgs/development/python-modules/agate-excel/default.nix
+++ b/pkgs/development/python-modules/agate-excel/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchPypi, buildPythonPackage
-, agate, openpyxl, xlrd, nose
+, agate, openpyxl, xlrd, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -13,11 +13,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ agate openpyxl xlrd ];
 
-  checkInputs = [ nose ];
+  checkInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    nosetests
-  '';
+  disabledTests = [
+    # See https://github.com/wireservice/agate-excel/issues/45
+    "test_ambiguous_date"
+  ];
 
   meta = with lib; {
     description = "Adds read support for excel files to agate";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/gj2vn41aa7ccl3frmkcvssn4na8z3ngm-python3.8-agate-excel-0.2.3.drv
ZHF: #122042

I git bisected the failure, and pinpointed it to a [bugfix in a dependency bump](https://foss.heptapod.net/openpyxl/openpyxl/-/merge_requests/395/). I filed a ticket with upstream. Based on my read of the openpxyl issue, I determined that this failing test was probably erroneous, so I disabled it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
