### PR TITLE
python3Packages.pytest-bdd: 4.0.1 -> 4.0.2

### DIFF
--- a/pkgs/development/python-modules/pytest-bdd/default.nix
+++ b/pkgs/development/python-modules/pytest-bdd/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch
 , execnet
 , glob2
 , Mako
@@ -7,29 +7,38 @@
 , parse-type
 , py
 , pytest
+, pytestCheckHook
 , six
 }:
 
 buildPythonPackage rec {
   pname = "pytest-bdd";
-  version = "4.0.1";
+  version = "4.0.2";
 
   # tests are not included in pypi tarball
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = pname;
     rev = version;
-    sha256 = "1yqzz44as4pxffmg4hk9lijvnvlc2chg1maq1fbj5i4k4jpagvjz";
+    sha256 = "0pxx4c8lm68rw0jshbr09fnadg8zz8j73q0qi49yw9s7yw86bg5l";
   };
+
+  patches = [
+    # Fixed compatibility with pytest > 6.1
+    (fetchpatch {
+      url = "https://github.com/pytest-dev/pytest-bdd/commit/e1dc0cad9a1c1ba563ccfbc24f9993d83ac59293.patch";
+      sha256 = "1p3gavh6nir2a8crd5wdf0prfrg0hmgar9slvn8a21ils3k5pm5y";
+    })
+  ];
+
 
   buildInputs = [ pytest ];
 
   propagatedBuildInputs = [ glob2 Mako parse parse-type py six ];
 
-  # Tests require extra dependencies
-  checkInputs = [ execnet mock pytest ];
-  checkPhase = ''
-    PATH=$PATH:$out/bin pytest
+  checkInputs = [ pytestCheckHook execnet mock ];
+  preCheck = ''
+    export PATH=$PATH:$out/bin
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/k0sf499cjgmm5d6dnibjdqlmn3fmjqjg-python3.8-pytest-bdd-4.0.1.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
