### PR TITLE
netlify-cli: fix build

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nodejs, stdenv }:
+{ pkgs, nodejs, stdenv, fetchFromGitHub }:
 
 let
   since = (version: pkgs.lib.versionAtLeast nodejs.version version);
@@ -207,6 +207,26 @@ let
         ]}
       '';
     };
+
+    netlify-cli =
+      let
+        esbuild = pkgs.esbuild.overrideAttrs (old: rec {
+          version = "0.11.14";
+
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${version}";
+            sha256 = "sha256-N7WNam0zF1t++nLVhuxXSDGV/JaFtlFhufp+etinvmM=";
+          };
+
+        });
+      in
+      super.netlify-cli.override {
+        preRebuild = ''
+          export ESBUILD_BINARY_PATH="${esbuild}/bin/esbuild"
+        '';
+      };
 
     ssb-server = super.ssb-server.override {
       buildInputs = [ pkgs.automake pkgs.autoconf self.node-gyp-build ];


### PR DESCRIPTION
###### Motivation for this change

This commit uses the `ESBUILD_BINARY_PATH` environment variable of `esbuild` to supply a Nix managed `esbuild` binary. Otherwise the `postInstall` script would try to make a network request, which would fail in the Nix build sandbox.

We need a specific `esbuild` version, which is why I'm overriding certain attributes on the package.

I tested this by creating a little Netlify project and instructing Netlify to use `esbuild`:

```
[functions]
  node_bundler = "esbuild"
```

I then ran a few commands like `/nix/store/.../netlify-cli build` and `dev`. So far things seem to work. The app works, the bundle looks alright and has dependencies included.
 
I also tried running the CLI with `strace` to see if it correctly calls `esbuild` and here I see

```
access("/nix/store/khchdaxfvad0mv7gb49p8rdqgmvbrah6-node_netlify-cli-3.21.9/lib/node_modules/netlify-cli/node_modules/esbuild/esbuild", F_OK) = -1 ENOENT (No such file or directory)
```

which doesn't look right? But I know nothing about `strace` or why Netlify succeeds at bundling my code even though it at some point looks for `esbuild` in the wrong place.

The binary lands in the right place:

```
~/netlify_test
$ /nix/store/khchdaxfvad0mv7gb49p8rdqgmvbrah6-node_netlify-cli-3.21.9/lib/node_modules/netlify-cli/node_modules/esbuild/bin/esbuild --version
0.11.14
```

See below links for more info:

https://github.com/evanw/esbuild/pull/597/files
https://docs.netlify.com/configure-builds/file-based-configuration/#functions

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
