### PR TITLE
python-engineio: 3.x on python 3.9 Darwin broken

### DIFF
--- a/pkgs/development/python-modules/python-engineio/3.nix
+++ b/pkgs/development/python-modules/python-engineio/3.nix
@@ -13,6 +13,7 @@
 , websocket_client
 , websockets
 , pytestCheckHook
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
@@ -63,5 +64,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/miguelgrinberg/python-engineio/";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ graham33 ];
+    broken = stdenv.isDarwin && (pythonAtLeast "3.9");  # See https://github.com/miguelgrinberg/python-socketio/issues/567
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The tests are failing, but the package appears to be generally broken for
python 3.9 on Darwin.  See https://github.com/miguelgrinberg/python-socketio/issues/567 for details.

https://hydra.nixos.org/build/142505307

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
