### PR TITLE
exiv2: fix security issues

### DIFF
--- a/pkgs/development/libraries/exiv2/CVE-2021-29470_2.patch
+++ b/pkgs/development/libraries/exiv2/CVE-2021-29470_2.patch
@@ -1,0 +1,59 @@
+From 4ffde8cb998cb62f4291a264225b9f274feb7002 Mon Sep 17 00:00:00 2001
+From: Kevin Backhouse <kevinbackhouse@github.com>
+Date: Wed, 21 Apr 2021 12:06:04 +0100
+Subject: [PATCH] Add more bounds checks in Jp2Image::encodeJp2Header
+
+---
+ src/jp2image.cpp     |  3 +++
+ src/jp2image.cpp.rej | 18 ++++++++++++++++++
+ 2 files changed, 21 insertions(+)
+ create mode 100644 src/jp2image.cpp.rej
+
+diff --git a/src/jp2image.cpp b/src/jp2image.cpp
+index 0961203e..475439d1 100644
+--- a/src/jp2image.cpp
++++ b/src/jp2image.cpp
+@@ -648,13 +648,16 @@ static void boxes_check(size_t b,size_t m)
+         DataBuf output(boxBuf.size_ + iccProfile_.size_ + 100); // allocate sufficient space
+         int     outlen = sizeof(Jp2BoxHeader) ; // now many bytes have we written to output?
+         int      inlen = sizeof(Jp2BoxHeader) ; // how many bytes have we read from boxBuf?
++        enforce(sizeof(Jp2BoxHeader) <= static_cast<size_t>(output.size_), Exiv2::kerCorruptedMetadata);
+         Jp2BoxHeader* pBox   = (Jp2BoxHeader*) boxBuf.pData_;
+         int32_t       length = getLong((byte*)&pBox->length, bigEndian);
++        enforce(length <= static_cast<size_t>(output.size_), Exiv2::kerCorruptedMetadata);
+         int32_t       count  = sizeof (Jp2BoxHeader);
+         char*         p      = (char*) boxBuf.pData_;
+         bool          bWroteColor = false ;
+ 
+         while ( count < length || !bWroteColor ) {
++            enforce(sizeof(Jp2BoxHeader) <= length - count, Exiv2::kerCorruptedMetadata);
+             Jp2BoxHeader* pSubBox = (Jp2BoxHeader*) (p+count) ;
+ 
+             // copy data.  pointer could be into a memory mapped file which we will decode!
+diff --git a/src/jp2image.cpp.rej b/src/jp2image.cpp.rej
+new file mode 100644
+index 00000000..43699f20
+--- /dev/null
++++ b/src/jp2image.cpp.rej
+@@ -0,0 +1,18 @@
++diff a/src/jp2image.cpp b/src/jp2image.cpp	(rejected hunks)
++@@ -648,13 +648,16 @@ static void boxes_check(size_t b,size_t m)
++         DataBuf output(boxBuf.size_ + iccProfile_.size_ + 100); // allocate sufficient space
++         long    outlen = sizeof(Jp2BoxHeader) ; // now many bytes have we written to output?
++         long    inlen = sizeof(Jp2BoxHeader) ; // how many bytes have we read from boxBuf?
+++        enforce(sizeof(Jp2BoxHeader) <= static_cast<size_t>(output.size_), Exiv2::kerCorruptedMetadata);
++         Jp2BoxHeader* pBox   = (Jp2BoxHeader*) boxBuf.pData_;
++         uint32_t      length = getLong((byte*)&pBox->length, bigEndian);
+++        enforce(length <= static_cast<size_t>(output.size_), Exiv2::kerCorruptedMetadata);
++         uint32_t      count  = sizeof (Jp2BoxHeader);
++         char*         p      = (char*) boxBuf.pData_;
++         bool          bWroteColor = false ;
++ 
++         while ( count < length || !bWroteColor ) {
+++            enforce(sizeof(Jp2BoxHeader) <= length - count, Exiv2::kerCorruptedMetadata);
++             Jp2BoxHeader* pSubBox = (Jp2BoxHeader*) (p+count) ;
++ 
++             // copy data.  pointer could be into a memory mapped file which we will decode!
+-- 
+2.31.1
+

--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -45,6 +45,57 @@ stdenv.mkDerivation rec {
       url = "https://github.com/Exiv2/exiv2/commit/306c8a6fd4ddd70e76043ab255734720829a57e8.patch";
       sha256 = "0D/omxYxBPGUu3uSErlf48dc6Ukwc2cEN9/J3e7a9eU=";
     })
+    # https://github.com/Exiv2/exiv2/pull/1523
+    (fetchpatch {
+      name = "CVE-2021-3482_1.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/22ea582c6b74ada30bec3a6b15de3c3e52f2b4da.patch";
+      sha256 = "0z9hcywjzb2q3yh3kkvjcg70rz3l7vgqjhk1h9wn291ys0jc2yxm";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3482_2.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/cac151ec052d44da3dc779e9e4028e581acb128a.patch";
+      sha256 = "1jyh0almvbg47c7i46hk9vg05v1r6mzc89xc7y6d8zcrvhyra0wk";
+    })
+
+    # https://github.com/Exiv2/exiv2/pull/1534
+    (fetchpatch {
+      name = "CVE-2021-29457.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/13e5a3e02339b746abcaee6408893ca2fd8e289d.patch";
+      sha256 = "19nkdpn7jdm1rp8na68djzrl6rxdl1n5n4974ypazpmqr04x0j79";
+    })
+    # https://github.com/Exiv2/exiv2/pull/1539
+    (fetchpatch {
+      name = "CVE-2021-29458_1.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/0a91b56616404f7b29ca28deb01ce18b767d1871.patch";
+      sha256 = "0ryjp2pzlj5h79q67y7az91yhmdqhdpgdg3mlc2qdamsqdp29m2b";
+    })
+    (fetchpatch {
+      name = "CVE-2021-29458_2.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/c92ac88cb0ebe72a5a17654fe6cecf411ab1e572.patch";
+      sha256 = "1g7xm7mkr01lvd4d0hikswxbdmb5q2ihw4ddxhc0shsg3lkv3zqp";
+    })
+    (fetchpatch {
+      name = "CVE-2021-29458_3.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/9b7a19f957af53304655ed1efe32253a1b11a8d0.patch";
+      sha256 = "0a8xqmh97q7gj727yz4gbrzh5jsmlg2a45fjfl3wychpwbn7dqlc";
+    })
+    (fetchpatch {
+      name = "CVE-2021-29458_4.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/fadb68718eb1bff3bd3222bd26ff3328f5306730.patch";
+      sha256 = "1hx6jf17if4afrz9halky7rlpvmgvysd46bby3zk6hipv8s8bk6h";
+    })
+    (fetchpatch {
+      name = "CVE-2021-29458_5.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/06d2db6e5fd2fcca9c060e95fc97f8a5b5d4c22d.patch";
+      sha256 = "1mh4ww2rj3a2kd0i2510zgv2n72wd0p3j1xd735ndp85fzvw4n3z";
+    })
+    # https://github.com/Exiv2/exiv2/pull/1581
+    (fetchpatch {
+      name = "CVE-2021-29470_1.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/6527e4f5979ced22d509e27d87d51287046f2008.patch";
+      sha256 = "0djh19xvn7p9bn06flznjw3xsjpmn10cdxwqq9xgh5k4f6ic4fz1";
+    })
+    ./CVE-2021-29470_2.patch  # rebased on top of v0.27.3
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes two out of bounds reads, one input validation issue and one heap
buffer overflow.

Fixes: CVE-2021-3482, CVE-2021-29458, CVE-2021-29457, CVE-2021-29470

https://nvd.nist.gov/vuln/detail/CVE-2021-29458
https://nvd.nist.gov/vuln/detail/CVE-2021-29470
https://nvd.nist.gov/vuln/detail/CVE-2021-3482
https://nvd.nist.gov/vuln/detail/CVE-2021-29457

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
