### PR TITLE
k3s: 1.20.6+k3s1 -> 1.21.0+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -44,14 +44,16 @@ with lib;
 # Those pieces of software we entirely ignore upstream's handling of, and just
 # make sure they're in the path if desired.
 let
-  k3sVersion = "1.20.6+k3s1";     # k3s git tag
-  traefikChartVersion = "1.81.0"; # taken from ./scripts/download at the above k3s tag
-  k3sRootVersion = "0.8.1";       # taken from ./scripts/download at the above k3s tag
-  k3sCNIVersion = "0.8.6-k3s1";   # taken from ./scripts/version.sh at the above k3s tag
+  k3sVersion = "1.21.0+k3s1";     # k3s git tag
+  k3sCommit = "2705431d9645d128441c578309574cd262285ae6"; # k3s git commit at the above version
+
+  traefikChartVersion = "9.18.2"; # taken from ./scripts/download at TRAEFIK_VERSION
+  k3sRootVersion = "0.8.1";       # taken from ./scripts/download at ROOT_VERSION
+  k3sCNIVersion = "0.8.6-k3s1";   # taken from ./scripts/version.sh at VERSION_CNIPLUGINS
   # bundled into the k3s binary
   traefikChart = fetchurl {
-    url = "https://kubernetes-charts.storage.googleapis.com/traefik-${traefikChartVersion}.tgz";
-    sha256 = "1aqpzgjlvqhil0g3angz94zd4xbl4iq0qmpjcy5aq1xv9qciwdi9";
+    url = "https://helm.traefik.io/traefik/traefik-${traefikChartVersion}.tgz";
+    sha256 = "sha256-9d7p0ngyMN27u4OPgz7yI14Zj9y36t9o/HMX5wyDpUI=";
   };
   # so, k3s is a complicated thing to package
   # This derivation attempts to avoid including any random binaries from the
@@ -95,8 +97,7 @@ let
   k3sRepo = fetchgit {
     url = "https://github.com/k3s-io/k3s";
     rev = "v${k3sVersion}";
-    leaveDotGit = true; # ./scripts/version.sh depends on git
-    sha256 = "sha256-IIZotJKQ/+WNmfcEJU5wFtZBufWjUp4MeVCRk4tSjyQ=";
+    sha256 = "sha256-xsXxf2ZYrkpOHlSFqTsHwWF3kChUjxWRjyDR3Dhg2ho=";
   };
   # Stage 1 of the k3s build:
   # Let's talk about how k3s is structured.
@@ -134,8 +135,12 @@ let
     # those.
     patches = [ ./patches/0002-Add-nixpkgs-patches.patch ];
 
-    nativeBuildInputs = [ git pkg-config ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libseccomp ];
+
+    # Versioning info for build script
+    DRONE_TAG = "v${version}";
+    DRONE_COMMIT = k3sCommit;
 
     buildPhase = ''
       pushd go/src/${goPackagePath}
@@ -175,7 +180,7 @@ let
     # See the above comment in k3sBuildStage1
     patches = [ ./patches/0002-Add-nixpkgs-patches.patch ];
 
-    nativeBuildInputs = [ git pkg-config zstd ];
+    nativeBuildInputs = [ pkg-config zstd ];
     # These dependencies are embedded as compressed files in k3s at runtime.
     # Propagate them to avoid broken runtime references to libraries.
     propagatedBuildInputs = [ k3sPlugins k3sBuildStage1 runc ];
@@ -185,6 +190,9 @@ let
       if stdenv.hostPlatform.system == "x86_64-linux" then ""
       else if stdenv.hostPlatform.system == "aarch64-linux" then "-arm64"
       else throw "k3s isn't being built for ${stdenv.hostPlatform.system} yet.";
+
+    DRONE_TAG = "v${version}";
+    DRONE_COMMIT = k3sCommit;
 
     # In order to build the thick k3s binary (which is what
     # ./scripts/package-cli does), we need to get all the binaries that script


### PR DESCRIPTION
Upgrades k3s from 1.20.6+k3s1 to 1.21.0+k3s1.

Changelog of 1.21.0+k3s1: https://github.com/k3s-io/k3s/releases/tag/v1.21.0%2Bk3s1

This upgrade is relevant because it fixes K3s for FluxCD use:
* https://github.com/fluxcd/kustomize-controller/issues/320
* https://github.com/fluxcd/flux2/issues/1344

I have tested it on aarch64, RockPro64.
