### PR TITLE
glibc, libiconv: use pname and version

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -32,7 +32,7 @@
 , python3Minimal
 }:
 
-{ name
+{ pname
 , withLinuxHeaders ? false
 , profilingLibraries ? false
 , withGd ? false
@@ -50,7 +50,7 @@ assert withLinuxHeaders -> linuxHeaders != null;
 assert withGd -> gd != null && libpng != null;
 
 stdenv.mkDerivation ({
-  inherit version;
+  version = version + patchSuffix;
   linuxHeaders = if withLinuxHeaders then linuxHeaders else null;
 
   inherit (stdenv) is64bit;
@@ -186,15 +186,11 @@ stdenv.mkDerivation ({
   # prevent a retained dependency on the bootstrap tools in the stdenv-linux
   # bootstrap.
   BASH_SHELL = "/bin/sh";
-
-  passthru = { inherit version; };
 }
 
 // (removeAttrs args [ "withLinuxHeaders" "withGd" ]) //
 
 {
-  name = name + "-${version}${patchSuffix}";
-
   src = fetchurl {
     url = "mirror://gnu/glibc/glibc-${version}.tar.xz";
     inherit sha256;

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -14,7 +14,7 @@ let
 in
 
 callPackage ./common.nix { inherit stdenv; } {
-    name = "glibc" + lib.optionalString withGd "-gd";
+    pname = "glibc" + lib.optionalString withGd "-gd";
 
     inherit withLinuxHeaders profilingLibraries withGd;
 

--- a/pkgs/development/libraries/glibc/info.nix
+++ b/pkgs/development/libraries/glibc/info.nix
@@ -1,7 +1,7 @@
 { callPackage, texinfo, perl }:
 
 callPackage ./common.nix {} {
-  name = "glibc-info";
+  pname = "glibc-info";
 
   outputs = [ "out" ];
 

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -11,7 +11,7 @@
 }:
 
 callPackage ./common.nix { inherit stdenv; } {
-  name = "glibc-locales";
+  pname = "glibc-locales";
 
   builder = ./locales-builder.sh;
 

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, lib }:
 
 stdenv.mkDerivation {
-  name = "wasilibc-20190712";
+  pname = "wasilibc";
+  version = "20190712";
   src = fetchFromGitHub {
     owner = "CraneStation";
     repo = "wasi-libc";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -159,7 +159,8 @@ in
       # create a dummy Glibc here, which will be used in the stdenv of
       # stage1.
       ${localSystem.libc} = self.stdenv.mkDerivation {
-        name = "bootstrap-stage0-${localSystem.libc}";
+        pname = "bootstrap-stage0-${localSystem.libc}";
+        version = "bootstrap";
         buildCommand = ''
           mkdir -p $out
           ln -s ${bootstrapTools}/lib $out/lib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16001,9 +16001,9 @@ in
     else libiconvReal;
 
   glibcIconv = libc: let
-    inherit (builtins.parseDrvName libc.name) name version;
+    inherit (libc) pname version;
     libcDev = lib.getDev libc;
-  in runCommand "${name}-iconv-${version}" {} ''
+  in runCommand "${pname}-iconv-${version}" {} ''
     mkdir -p $out/include
     ln -sv ${libcDev}/include/iconv.h $out/include
   '';


### PR DESCRIPTION
###### Motivation for this change

I'd It's hardly worth a mass rebuild, but I guess that's why it's been put off until now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
