### PR TITLE
darwin packages: Get ready for cross

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/CarbonHeaders/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/CarbonHeaders/default.nix
@@ -1,6 +1,6 @@
-{ lib, appleDerivation }:
+{ lib, appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   dontBuild = true;
 
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/CommonCrypto/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/CommonCrypto/default.nix
@@ -1,6 +1,6 @@
-{ lib, appleDerivation }:
+{ lib, appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir -p $out/include/CommonCrypto
     cp include/* $out/include/CommonCrypto

--- a/pkgs/os-specific/darwin/apple-source-releases/Csu/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Csu/default.nix
@@ -1,13 +1,14 @@
-{ lib, appleDerivation }:
+{ lib, appleDerivation', stdenv }:
 
-appleDerivation {
+appleDerivation' stdenv {
+
   prePatch = ''
     substituteInPlace Makefile \
       --replace /usr/lib /lib \
       --replace /usr/local/lib /lib \
       --replace /usr/bin "" \
       --replace /bin/ "" \
-      --replace "CC = " "CC = cc #" \
+      --replace "CC = " "#" \
       --replace "SDK_DIR = " "SDK_DIR = . #" \
 
     # Mac OS didn't support rpaths back before 10.5, but we don't care about it.

--- a/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
@@ -1,7 +1,7 @@
-{ lib, appleDerivation, IOKitSrcs, xnu, darwin-stubs }:
+{ lib, appleDerivation', stdenv, IOKitSrcs, xnu, darwin-stubs }:
 
 # Someday it'll make sense to split these out into their own packages, but today is not that day.
-appleDerivation {
+appleDerivation' stdenv {
   srcs = lib.attrValues IOKitSrcs;
   sourceRoot = ".";
 

--- a/pkgs/os-specific/darwin/apple-source-releases/Libc/825_40_1.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libc/825_40_1.nix
@@ -1,6 +1,6 @@
-{ appleDerivation, ed, unifdef }:
+{ appleDerivation', stdenvNoCC, ed, unifdef }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   nativeBuildInputs = [ ed unifdef ];
 
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/Libc/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libc/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation, ed, unifdef, Libc_old, Libc_10-9 }:
+{ appleDerivation', stdenvNoCC, ed, unifdef, Libc_old, Libc_10-9 }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   nativeBuildInputs = [ ed unifdef ];
 
   # TODO: asl.h actually comes from syslog project now

--- a/pkgs/os-specific/darwin/apple-source-releases/Libinfo/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libinfo/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     substituteInPlace xcodescripts/install_files.sh \
       --replace "/usr/local/" "/" \

--- a/pkgs/os-specific/darwin/apple-source-releases/Libm/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libm/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir -p $out/include
 

--- a/pkgs/os-specific/darwin/apple-source-releases/Libnotify/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libnotify/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir -p $out/include
     cp notify.h      $out/include

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -1,9 +1,13 @@
-{ lib, appleDerivation, cpio, xnu, Libc, Libm, libdispatch, cctools, Libinfo
+{ lib, stdenv, buildPackages
+, appleDerivation', cpio, xnu, Libc, Libm, libdispatch, Libinfo
 , dyld, Csu, architecture, libclosure, CarbonHeaders, ncurses, CommonCrypto
-, copyfile, removefile, libresolv, Libnotify, libplatform, libpthread
-, mDNSResponder, launchd, libutil, hfs, darling, darwin-stubs }:
+, copyfile, removefile, libresolvHeaders, libresolv, Libnotify, libplatform, libpthread
+, mDNSResponder, launchd, libutilHeaders, hfsHeaders, darling, darwin-stubs
+, headersOnly ? false
+, withLibresolv ? !headersOnly
+}:
 
-appleDerivation {
+appleDerivation' stdenv {
   dontBuild = true;
   dontFixup = true;
 
@@ -21,13 +25,13 @@ appleDerivation {
 
     for dep in ${Libc} ${Libm} ${Libinfo} ${dyld} ${architecture} \
                ${libclosure} ${CarbonHeaders} ${libdispatch} ${ncurses.dev} \
-               ${CommonCrypto} ${copyfile} ${removefile} ${libresolv} \
+               ${CommonCrypto} ${copyfile} ${removefile} ${libresolvHeaders} \
                ${Libnotify} ${libplatform} ${mDNSResponder} ${launchd} \
-               ${libutil} ${libpthread} ${hfs}; do
+               ${libutilHeaders} ${libpthread} ${hfsHeaders}; do
       (cd $dep/include && find . -name '*.h' | cpio -pdm $out/include)
     done
 
-    (cd ${cctools.dev}/include/mach-o && find . -name '*.h' | cpio -pdm $out/include/mach-o)
+    (cd ${buildPackages.darwin.cctools.dev}/include/mach-o && find . -name '*.h' | cpio -pdm $out/include/mach-o)
 
     mkdir -p $out/include/os
 
@@ -84,6 +88,7 @@ appleDerivation {
     #define TARGET_RT_64_BIT        1
     #endif  /* __TARGETCONDITIONALS__ */
     EOF
+  '' + lib.optionalString (!headersOnly) ''
 
     # The startup object files
     cp ${Csu}/lib/* $out/lib
@@ -101,14 +106,15 @@ appleDerivation {
     for name in c dbm dl info m mx poll proc pthread rpcsvc util gcc_s.10.4 gcc_s.10.5; do
       ln -s libSystem.tbd $out/lib/lib$name.tbd
     done
+  '' + lib.optionalString withLibresolv ''
 
     # This probably doesn't belong here, but we want to stay similar to glibc, which includes resolv internally...
     cp ${libresolv}/lib/libresolv.9.dylib $out/lib/libresolv.9.dylib
-    resolv_libSystem=$(otool -L "$out/lib/libresolv.9.dylib" | tail -n +3 | grep -o "$NIX_STORE.*-\S*") || true
+    resolv_libSystem=$(${stdenv.cc.bintools.targetPrefix}otool -L "$out/lib/libresolv.9.dylib" | tail -n +3 | grep -o "$NIX_STORE.*-\S*") || true
     echo $libs
 
     chmod +w $out/lib/libresolv.9.dylib
-    install_name_tool \
+    ${stdenv.cc.bintools.targetPrefix}install_name_tool \
       -id $out/lib/libresolv.9.dylib \
       -change "$resolv_libSystem" /usr/lib/libSystem.dylib \
       $out/lib/libresolv.9.dylib

--- a/pkgs/os-specific/darwin/apple-source-releases/Security/boot.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Security/boot.nix
@@ -1,6 +1,6 @@
-{ appleDerivation, darwin-stubs }:
+{ appleDerivation', stdenv, darwin-stubs }:
 
-appleDerivation {
+appleDerivation' stdenv {
   phases = [ "unpackPhase" "installPhase" ];
 
   __propagatedImpureHostDeps = [

--- a/pkgs/os-specific/darwin/apple-source-releases/architecture/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/architecture/default.nix
@@ -1,6 +1,6 @@
-{ lib, appleDerivation }:
+{ lib, appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   dontBuild = true;
 
   postPatch = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, appleDerivation, bison, flex }:
+{ lib, appleDerivation, stdenv, bison, flex }:
+
+let
+
+  # Hard to get CC to pull this off without infinite recursion
+  targetTargetPrefix = lib.optionalString
+    (with stdenv; hostPlatform != targetPlatform)
+    (stdenv.targetPlatform.config + "-");
+
+in
 
 appleDerivation {
   nativeBuildInputs = [ bison flex ];
@@ -12,7 +21,7 @@ appleDerivation {
     yacc -d parser.y
     flex --header-file=lexxer.yy.h -o lexxer.yy.c lexxer.l
 
-    cc -std=gnu99 -Os -dead_strip -DMIG_VERSION=\"$pname-$version\" -I. -o migcom *.c
+    $CC -std=gnu99 -Os -dead_strip -DMIG_VERSION=\"$pname-$version\" -I. -o migcom *.c
   '';
 
   installPhase = ''
@@ -29,6 +38,6 @@ appleDerivation {
       --replace 'arch=`/usr/bin/arch`' 'arch=${stdenv.targetPlatform.darwinArch}' \
       --replace '/usr/bin/' "" \
       --replace '/bin/rmdir' "rmdir" \
-      --replace 'C=''${MIGCC}' "C=cc"
+      --replace 'C=''${MIGCC}' "C=${targetTargetPrefix}cc"
   '';
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/configd/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, appleDerivation, launchd, bootstrap_cmds, xnu, ppp, IOKit, eap8021x, Security }:
+{ stdenv, appleDerivation', launchd, bootstrap_cmds, xnu, ppp, IOKit, eap8021x, Security }:
 
-appleDerivation {
+appleDerivation' stdenv {
   meta.broken = stdenv.cc.nativeLibc;
 
   nativeBuildInputs = [ bootstrap_cmds ];
@@ -127,78 +127,78 @@ appleDerivation {
     mig -arch x86_64 -header derived/helper.h          -user derived/helperUser.c          -sheader /dev/null -server /dev/null helper/helper.defs
     mig -arch x86_64 -header derived/pppcontroller.h   -user derived/pppcontrollerUser.c   -sheader /dev/null -server /dev/null pppcontroller.defs
 
-    cc -I. -Ihelper -Iderived -F. -c SCSchemaDefinitions.c -o SCSchemaDefinitions.o
-    cc -I. -Ihelper -Iderived -F. -c SCD.c -o SCD.o
-    cc -I. -Ihelper -Iderived -F. -c SCDKeys.c -o SCDKeys.o
-    cc -I. -Ihelper -Iderived -F. -c SCDPrivate.c -o SCDPrivate.o
-    cc -I. -Ihelper -Iderived -F. -c SCDPlugin.c -o SCDPlugin.o
-    cc -I. -Ihelper -Iderived -F. -c CaptiveNetwork.c -o CaptiveNetwork.o
-    cc -I. -Ihelper -Iderived -F. -c SCDOpen.c -o SCDOpen.o
-    cc -I. -Ihelper -Iderived -F. -c SCDList.c -o SCDList.o
-    cc -I. -Ihelper -Iderived -F. -c SCDAdd.c -o SCDAdd.o
-    cc -I. -Ihelper -Iderived -F. -c SCDGet.c -o SCDGet.o
-    cc -I. -Ihelper -Iderived -F. -c SCDSet.c -o SCDSet.o
-    cc -I. -Ihelper -Iderived -F. -c SCDRemove.c -o SCDRemove.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotify.c -o SCDNotify.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierSetKeys.c -o SCDNotifierSetKeys.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierAdd.c -o SCDNotifierAdd.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierRemove.c -o SCDNotifierRemove.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierGetChanges.c -o SCDNotifierGetChanges.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierWait.c -o SCDNotifierWait.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierInformViaCallback.c -o SCDNotifierInformViaCallback.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierInformViaFD.c -o SCDNotifierInformViaFD.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierInformViaSignal.c -o SCDNotifierInformViaSignal.o
-    cc -I. -Ihelper -Iderived -F. -c SCDNotifierCancel.c -o SCDNotifierCancel.o
-    cc -I. -Ihelper -Iderived -F. -c SCDSnapshot.c -o SCDSnapshot.o
-    cc -I. -Ihelper -Iderived -F. -c SCP.c -o SCP.o
-    cc -I. -Ihelper -Iderived -F. -c SCPOpen.c -o SCPOpen.o
-    cc -I. -Ihelper -Iderived -F. -c SCPLock.c -o SCPLock.o
-    cc -I. -Ihelper -Iderived -F. -c SCPUnlock.c -o SCPUnlock.o
-    cc -I. -Ihelper -Iderived -F. -c SCPList.c -o SCPList.o
-    cc -I. -Ihelper -Iderived -F. -c SCPGet.c -o SCPGet.o
-    cc -I. -Ihelper -Iderived -F. -c SCPAdd.c -o SCPAdd.o
-    cc -I. -Ihelper -Iderived -F. -c SCPSet.c -o SCPSet.o
-    cc -I. -Ihelper -Iderived -F. -c SCPRemove.c -o SCPRemove.o
-    cc -I. -Ihelper -Iderived -F. -c SCPCommit.c -o SCPCommit.o
-    cc -I. -Ihelper -Iderived -F. -c SCPApply.c -o SCPApply.o
-    cc -I. -Ihelper -Iderived -F. -c SCPPath.c -o SCPPath.o
-    cc -I. -Ihelper -Iderived -F. -c SCDConsoleUser.c -o SCDConsoleUser.o
-    cc -I. -Ihelper -Iderived -F. -c SCDHostName.c -o SCDHostName.o
-    cc -I. -Ihelper -Iderived -F. -c SCLocation.c -o SCLocation.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetwork.c -o SCNetwork.o
-    cc -I. -Ihelper -Iderived -F. -c derived/pppcontrollerUser.c -o pppcontrollerUser.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkConnection.c -o SCNetworkConnection.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkConnectionPrivate.c -o SCNetworkConnectionPrivate.o
-    cc -I. -Ihelper -Iderived -I../dnsinfo -F. -c SCNetworkReachability.c -o SCNetworkReachability.o
-    cc -I. -Ihelper -Iderived -F. -c SCProxies.c -o SCProxies.o
-    cc -I. -Ihelper -Iderived -F. -c DHCP.c -o DHCP.o
-    cc -I. -Ihelper -Iderived -F. -c moh.c -o moh.o
-    cc -I. -Ihelper -Iderived -F. -c DeviceOnHold.c -o DeviceOnHold.o
-    cc -I. -Ihelper -Iderived -I $HACK -F. -c LinkConfiguration.c -o LinkConfiguration.o
-    cc -I. -Ihelper -Iderived -F. -c dy_framework.c -o dy_framework.o
-    cc -I. -Ihelper -Iderived -I $HACK -F. -c VLANConfiguration.c -o VLANConfiguration.o
-    cc -I. -Ihelper -Iderived -F. -c derived/configUser.c -o configUser.o
-    cc -I. -Ihelper -Iderived -F. -c SCPreferencesPathKey.c -o SCPreferencesPathKey.o
-    cc -I. -Ihelper -Iderived -I../dnsinfo -F. -c derived/shared_dns_infoUser.c -o shared_dns_infoUser.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkConfigurationInternal.c -o SCNetworkConfigurationInternal.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkInterface.c -o SCNetworkInterface.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkProtocol.c -o SCNetworkProtocol.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkService.c -o SCNetworkService.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkSet.c -o SCNetworkSet.o
-    cc -I. -Ihelper -Iderived -I $HACK -F. -c BondConfiguration.c -o BondConfiguration.o
-    cc -I. -Ihelper -Iderived -I $HACK -F. -c BridgeConfiguration.c -o BridgeConfiguration.o
-    cc -I. -Ihelper -Iderived -F. -c helper/SCHelper_client.c -o SCHelper_client.o
-    cc -I. -Ihelper -Iderived -F. -c SCPreferencesKeychainPrivate.c -o SCPreferencesKeychainPrivate.o
-    cc -I. -Ihelper -Iderived -F. -c SCNetworkSignature.c -o SCNetworkSignature.o
-    cc -I. -Ihelper -Iderived -F. -c VPNPrivate.c -o VPNPrivate.o
-    cc -I. -Ihelper -Iderived -F. -c VPNConfiguration.c -o VPNConfiguration.o
-    cc -I. -Ihelper -Iderived -F. -c VPNTunnel.c -o VPNTunnel.o
-    cc -I. -Ihelper -Iderived -F. -c derived/helperUser.c -o helperUser.o
-    cc -I. -Ihelper -Iderived -F. -c reachability/SCNetworkReachabilityServer_client.c -o SCNetworkReachabilityServer_client.o
-    cc -I. -Ihelper -Iderived -F. -c reachability/rb.c -o rb.o
-    cc -I. -Ihelper -Iderived -F. -c derived/SystemConfiguration_vers.c -o SystemConfiguration_vers.o
+    $CC -I. -Ihelper -Iderived -F. -c SCSchemaDefinitions.c -o SCSchemaDefinitions.o
+    $CC -I. -Ihelper -Iderived -F. -c SCD.c -o SCD.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDKeys.c -o SCDKeys.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDPrivate.c -o SCDPrivate.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDPlugin.c -o SCDPlugin.o
+    $CC -I. -Ihelper -Iderived -F. -c CaptiveNetwork.c -o CaptiveNetwork.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDOpen.c -o SCDOpen.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDList.c -o SCDList.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDAdd.c -o SCDAdd.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDGet.c -o SCDGet.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDSet.c -o SCDSet.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDRemove.c -o SCDRemove.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotify.c -o SCDNotify.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierSetKeys.c -o SCDNotifierSetKeys.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierAdd.c -o SCDNotifierAdd.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierRemove.c -o SCDNotifierRemove.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierGetChanges.c -o SCDNotifierGetChanges.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierWait.c -o SCDNotifierWait.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierInformViaCallback.c -o SCDNotifierInformViaCallback.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierInformViaFD.c -o SCDNotifierInformViaFD.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierInformViaSignal.c -o SCDNotifierInformViaSignal.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDNotifierCancel.c -o SCDNotifierCancel.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDSnapshot.c -o SCDSnapshot.o
+    $CC -I. -Ihelper -Iderived -F. -c SCP.c -o SCP.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPOpen.c -o SCPOpen.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPLock.c -o SCPLock.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPUnlock.c -o SCPUnlock.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPList.c -o SCPList.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPGet.c -o SCPGet.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPAdd.c -o SCPAdd.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPSet.c -o SCPSet.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPRemove.c -o SCPRemove.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPCommit.c -o SCPCommit.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPApply.c -o SCPApply.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPPath.c -o SCPPath.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDConsoleUser.c -o SCDConsoleUser.o
+    $CC -I. -Ihelper -Iderived -F. -c SCDHostName.c -o SCDHostName.o
+    $CC -I. -Ihelper -Iderived -F. -c SCLocation.c -o SCLocation.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetwork.c -o SCNetwork.o
+    $CC -I. -Ihelper -Iderived -F. -c derived/pppcontrollerUser.c -o pppcontrollerUser.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkConnection.c -o SCNetworkConnection.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkConnectionPrivate.c -o SCNetworkConnectionPrivate.o
+    $CC -I. -Ihelper -Iderived -I../dnsinfo -F. -c SCNetworkReachability.c -o SCNetworkReachability.o
+    $CC -I. -Ihelper -Iderived -F. -c SCProxies.c -o SCProxies.o
+    $CC -I. -Ihelper -Iderived -F. -c DHCP.c -o DHCP.o
+    $CC -I. -Ihelper -Iderived -F. -c moh.c -o moh.o
+    $CC -I. -Ihelper -Iderived -F. -c DeviceOnHold.c -o DeviceOnHold.o
+    $CC -I. -Ihelper -Iderived -I $HACK -F. -c LinkConfiguration.c -o LinkConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c dy_framework.c -o dy_framework.o
+    $CC -I. -Ihelper -Iderived -I $HACK -F. -c VLANConfiguration.c -o VLANConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c derived/configUser.c -o configUser.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPreferencesPathKey.c -o SCPreferencesPathKey.o
+    $CC -I. -Ihelper -Iderived -I../dnsinfo -F. -c derived/shared_dns_infoUser.c -o shared_dns_infoUser.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkConfigurationInternal.c -o SCNetworkConfigurationInternal.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkInterface.c -o SCNetworkInterface.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkProtocol.c -o SCNetworkProtocol.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkService.c -o SCNetworkService.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkSet.c -o SCNetworkSet.o
+    $CC -I. -Ihelper -Iderived -I $HACK -F. -c BondConfiguration.c -o BondConfiguration.o
+    $CC -I. -Ihelper -Iderived -I $HACK -F. -c BridgeConfiguration.c -o BridgeConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c helper/SCHelper_client.c -o SCHelper_client.o
+    $CC -I. -Ihelper -Iderived -F. -c SCPreferencesKeychainPrivate.c -o SCPreferencesKeychainPrivate.o
+    $CC -I. -Ihelper -Iderived -F. -c SCNetworkSignature.c -o SCNetworkSignature.o
+    $CC -I. -Ihelper -Iderived -F. -c VPNPrivate.c -o VPNPrivate.o
+    $CC -I. -Ihelper -Iderived -F. -c VPNConfiguration.c -o VPNConfiguration.o
+    $CC -I. -Ihelper -Iderived -F. -c VPNTunnel.c -o VPNTunnel.o
+    $CC -I. -Ihelper -Iderived -F. -c derived/helperUser.c -o helperUser.o
+    $CC -I. -Ihelper -Iderived -F. -c reachability/SCNetworkReachabilityServer_client.c -o SCNetworkReachabilityServer_client.o
+    $CC -I. -Ihelper -Iderived -F. -c reachability/rb.c -o rb.o
+    $CC -I. -Ihelper -Iderived -F. -c derived/SystemConfiguration_vers.c -o SystemConfiguration_vers.o
 
-    cc -dynamiclib *.o -install_name $out/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration -dead_strip -framework CoreFoundation -single_module -o SystemConfiguration.framework/SystemConfiguration
+    $CC -dynamiclib *.o -install_name $out/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration -dead_strip -framework CoreFoundation -single_module -o SystemConfiguration.framework/SystemConfiguration
 
     popd >/dev/null
   '';

--- a/pkgs/os-specific/darwin/apple-source-releases/copyfile/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/copyfile/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   dontBuild = true;
   installPhase = ''
     mkdir -p $out/include/

--- a/pkgs/os-specific/darwin/apple-source-releases/dyld/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/dyld/default.nix
@@ -1,6 +1,6 @@
-{ lib, appleDerivation }:
+{ lib, appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir -p $out/lib $out/include
     ln -s /usr/lib/dyld $out/lib/dyld

--- a/pkgs/os-specific/darwin/apple-source-releases/eap8021x/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/eap8021x/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenv }:
 
-appleDerivation {
+appleDerivation' stdenv {
   dontBuild = true;
   installPhase = ''
     mkdir -p $out/Library/Frameworks/EAP8021X.framework/Headers

--- a/pkgs/os-specific/darwin/apple-source-releases/hfs/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/hfs/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation, lib, headersOnly ? true }:
+{ appleDerivation', stdenv, stdenvNoCC, lib, headersOnly ? true }:
 
-appleDerivation {
+appleDerivation' (if headersOnly then stdenvNoCC else stdenv) {
   installPhase = lib.optionalString headersOnly ''
     mkdir -p $out/include/hfs
     cp core/*.h $out/include/hfs

--- a/pkgs/os-specific/darwin/apple-source-releases/launchd/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/launchd/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   # No clue why the same file has two different names. Ask Apple!
   installPhase = ''
     mkdir -p $out/include/ $out/include/servers

--- a/pkgs/os-specific/darwin/apple-source-releases/libclosure/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libclosure/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir -p $out/include
     cp *.h $out/include/

--- a/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   dontConfigure = true;
   dontBuild = true;
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/libplatform/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libplatform/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir $out
     cp -r include $out/include

--- a/pkgs/os-specific/darwin/apple-source-releases/libpthread/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libpthread/default.nix
@@ -1,6 +1,6 @@
-{ lib, appleDerivation, libdispatch, xnu }:
+{ lib, appleDerivation', stdenvNoCC, libdispatch, xnu }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   propagatedBuildInputs = [ libdispatch xnu ];
 
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/libresolv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libresolv/default.nix
@@ -1,37 +1,39 @@
-{ appleDerivation, Libinfo, configd, mDNSResponder }:
+{ lib, appleDerivation', stdenv, stdenvNoCC, Libinfo, configd, mDNSResponder
+, headersOnly ? false
+}:
 
-appleDerivation {
-  buildInputs = [ Libinfo configd mDNSResponder ];
+appleDerivation' (if headersOnly then stdenvNoCC else stdenv) {
+  buildInputs = lib.optionals (!headersOnly) [ Libinfo configd mDNSResponder ];
 
-  buildPhase = ''
-    cc -I. -c dns_util.c
-    cc -I. -c dns.c
-    cc -I. -c dns_async.c
-    cc -I. -c base64.c
-    cc -I. -c dst_api.c
-    cc -I. -c dst_hmac_link.c
-    cc -I. -c dst_support.c
-    cc -I. -c ns_date.c
-    cc -I. -c ns_name.c
-    cc -I. -c ns_netint.c
-    cc -I. -c ns_parse.c
-    cc -I. -c ns_print.c
-    cc -I. -c ns_samedomain.c
-    cc -I. -c ns_sign.c
-    cc -I. -c ns_ttl.c
-    cc -I. -c ns_verify.c
-    cc -I. -c res_comp.c
-    cc -I. -c res_data.c
-    cc -I. -c res_debug.c
-    cc -I. -c res_findzonecut.c
-    cc -I. -c res_init.c
-    cc -I. -c res_mkquery.c
-    cc -I. -c res_mkupdate.c
-    cc -I. -c res_query.c
-    cc -I. -c res_send.c
-    cc -I. -c res_sendsigned.c
-    cc -I. -c res_update.c
-    cc -dynamiclib -install_name $out/lib/libresolv.9.dylib -current_version 1.0.0 -compatibility_version 1.0.0 -o libresolv.9.dylib *.o
+  buildPhase = lib.optionalString (!headersOnly) ''
+    $CC -I. -c dns_util.c
+    $CC -I. -c dns.c
+    $CC -I. -c dns_async.c
+    $CC -I. -c base64.c
+    $CC -I. -c dst_api.c
+    $CC -I. -c dst_hmac_link.c
+    $CC -I. -c dst_support.c
+    $CC -I. -c ns_date.c
+    $CC -I. -c ns_name.c
+    $CC -I. -c ns_netint.c
+    $CC -I. -c ns_parse.c
+    $CC -I. -c ns_print.c
+    $CC -I. -c ns_samedomain.c
+    $CC -I. -c ns_sign.c
+    $CC -I. -c ns_ttl.c
+    $CC -I. -c ns_verify.c
+    $CC -I. -c res_comp.c
+    $CC -I. -c res_data.c
+    $CC -I. -c res_debug.c
+    $CC -I. -c res_findzonecut.c
+    $CC -I. -c res_init.c
+    $CC -I. -c res_mkquery.c
+    $CC -I. -c res_mkupdate.c
+    $CC -I. -c res_query.c
+    $CC -I. -c res_send.c
+    $CC -I. -c res_sendsigned.c
+    $CC -I. -c res_update.c
+    $CC -dynamiclib -install_name $out/lib/libresolv.9.dylib -current_version 1.0.0 -compatibility_version 1.0.0 -o libresolv.9.dylib *.o
   '';
 
   installPhase = ''
@@ -42,6 +44,7 @@ appleDerivation {
     cp nameser.h       $out/include
     ln -s ../nameser.h $out/include/arpa
     cp resolv.h        $out/include
+  '' + lib.optionalString (!headersOnly) ''
 
     cp libresolv.9.dylib $out/lib
     ln -s libresolv.9.dylib $out/lib/libresolv.dylib

--- a/pkgs/os-specific/darwin/apple-source-releases/libutil/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libutil/default.nix
@@ -1,9 +1,9 @@
-{ lib, appleDerivation, xcbuildHook
+{ lib, stdenv, stdenvNoCC, appleDerivation', xcbuildHook
 
 # headersOnly is true when building for libSystem
 , headersOnly ? false }:
 
-appleDerivation {
+appleDerivation' (if headersOnly then stdenvNoCC else stdenv) {
   nativeBuildInputs = lib.optional (!headersOnly) xcbuildHook;
 
   prePatch = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/mDNSResponder/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mDNSResponder/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   phases = [ "unpackPhase" "installPhase" ];
 
   installPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/ppp/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ppp/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenv }:
 
-appleDerivation {
+appleDerivation' stdenv {
   dontBuild = true;
   installPhase = ''
     mkdir -p $out/include/ppp

--- a/pkgs/os-specific/darwin/apple-source-releases/removefile/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/removefile/default.nix
@@ -1,6 +1,6 @@
-{ appleDerivation }:
+{ appleDerivation', stdenvNoCC }:
 
-appleDerivation {
+appleDerivation' stdenvNoCC {
   installPhase = ''
     mkdir -p $out/include/
     cp removefile.h checkint.h $out/include/

--- a/pkgs/os-specific/darwin/apple-source-releases/xnu/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/xnu/default.nix
@@ -1,8 +1,12 @@
-{ appleDerivation, lib, bootstrap_cmds, bison, flex
+{ appleDerivation', lib, stdenv, stdenvNoCC, buildPackages
+, bootstrap_cmds, bison, flex
 , gnum4, unifdef, perl, python3
-, headersOnly ? true }:
+, headersOnly ? true
+}:
 
-appleDerivation ({
+appleDerivation' (if headersOnly then stdenvNoCC else stdenv) ({
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   nativeBuildInputs = [ bootstrap_cmds bison flex gnum4 unifdef perl python3 ];
 
   patches = [ ./python3.patch ];
@@ -44,16 +48,16 @@ appleDerivation ({
 
   PLATFORM = "MacOSX";
   SDKVERSION = "10.11";
-  CC = "cc";
-  CXX = "c++";
+  CC = "${stdenv.cc.targetPrefix or ""}cc";
+  CXX = "${stdenv.cc.targetPrefix or ""}c++";
   MIG = "mig";
   MIGCOM = "migcom";
-  STRIP = "strip";
-  NM = "nm";
+  STRIP = "${stdenv.cc.bintools.targetPrefix or ""}strip";
+  NM = "${stdenv.cc.bintools.targetPrefix or ""}nm";
   UNIFDEF = "unifdef";
   DSYMUTIL = "dsymutil";
   HOST_OS_VERSION = "10.10";
-  HOST_CC = "cc";
+  HOST_CC = "${buildPackages.stdenv.cc.targetPrefix or ""}cc";
   HOST_FLEX = "flex";
   HOST_BISON = "bison";
   HOST_GM4 = "m4";

--- a/pkgs/os-specific/darwin/darwin-stubs/default.nix
+++ b/pkgs/os-specific/darwin/darwin-stubs/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl }:
+{ stdenvNoCC, fetchurl }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "darwin-stubs";
   version = "10.12";
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -201,7 +201,7 @@ in rec {
           '';
         };
 
-        darwin-stubs = superDarwin.darwin-stubs.override { inherit (self) stdenv fetchurl; };
+        darwin-stubs = superDarwin.darwin-stubs.override { inherit (self) stdenvNoCC fetchurl; };
 
         dyld = {
           name = "bootstrap-stage0-dyld";


### PR DESCRIPTION
###### Motivation for this change

If things build fine with `stdenvNoCC`, let them use that. If tools
might be prefixed, prepare for that.

This is a mass rebuild, but I don't think the final stdenv should be any different in contents, so I think it's safe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
