### PR TITLE
mbp2018-bridge-drv: fix source

### DIFF
--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mbp2018-bridge-drv";
-  version = "0.01";
+  version = "2020-01-31";
 
   src = fetchFromGitHub {
     owner = "MCMrARM";
     repo = "mbp2018-bridge-drv";
-    rev = "${version}";
-    sha256 = "0ac2l51ybfrvg8m36x67rsvgjqs1vwp7c89ssvbjkrcq3y4qdb53";
+    rev = "b43fcc069da73e051072fde24af4014c9c487286";
+    sha256 = "sha256-o6yGiR+Y5SnX1johdi7fQWP5ts7HdDMqeju75UOhgik=";
   };
 
   buildPhase = ''
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ lib.maintainers.hlolli ];
+    broken = kernel.kernelOlder "5.4";
   };
 }


### PR DESCRIPTION
the 0.01 tag was deleted

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
