### PR TITLE
fetchpatch: allow empty hash

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -9,15 +9,18 @@ let
   # 0.3.4 would change hashes: https://github.com/NixOS/nixpkgs/issues/25154
   patchutils = buildPackages.patchutils_0_3_3;
 in
-{ stripLen ? 0, extraPrefix ? null, excludes ? [], includes ? [], revert ? false, ... }@args:
+{ excludes ? []
+, extraPrefix ? null
+, includes ? []
+, revert ? false
+, postFetch ? ""
+, stripLen ? 0
+, ...
+}@args:
 
-let
-  # Make base-64 encoded SRI hash filename-safe using RFC 4648 §5
-  tmpname = lib.replaceStrings [ "+" "/" "=" ] [ "-" "_" "" ] args.sha256;
-in
 fetchurl ({
   postFetch = ''
-    tmpfile="$TMPDIR/${tmpname}"
+    tmpfile="$TMPDIR/patch"
     if [ ! -s "$out" ]; then
       echo "error: Fetched patch file '$out' is empty!" 1>&2
       exit 1
@@ -56,6 +59,6 @@ fetchurl ({
   '' + lib.optionalString revert ''
     ${patchutils}/bin/interdiff "$out" /dev/null > "$tmpfile"
     mv "$tmpfile" "$out"
-  '' + (args.postFetch or "");
+  '' + postFetch;
   meta.broken = excludes != [] && includes != [];
 } // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch"])


### PR DESCRIPTION
###### Motivation for this change
When an empty sha256 is passed to fetchpatch it crashes with an unhelpful error message:
`/build/: Is a directory`
All fetchers I have used so far seem to accept an empty hash for the initial run to find the actual hash, so I'd like to have that capability also in fetchpatch.

The problem seemed to be that the temp file used to store the patch is derived from the hash, which when empty points to the /build directory.

###### Things done

I couldn't see any reason why the temp file name must include the hash, so I changed it to the static name `$TMPDIR/patch`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
