### PR TITLE
gnuradio: add Qt5 wrapper for version 3.9+

### DIFF
--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -96,7 +96,7 @@ let
     ]
     ++ lib.optionals (unwrapped.hasFeature "gr-qtgui" unwrapped.features)
       # 3.7 builds with qt4
-      (if unwrapped.versionAttr.major == "3.8" then
+      (if lib.versionAtLeast unwrapped.versionAttr.major "3.8" then
         [
           "--prefix" "QT_PLUGIN_PATH" ":"
           "${


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/122486.

Qt5 wrapper is enabled for Gnuradio 3.8, but not for 3.9. This is breaking GUI Qt5 modules.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
