### PR TITLE
llvm*Packages: fix output selection (lib.get*)

### DIFF
--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -31,15 +31,15 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     # disabled until recommonmark supports sphinx 3
     #Llvm-manpages = lowPrio (tools.libllvm.override {

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -33,16 +33,15 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
-
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
     # disabled until recommonmark supports sphinx 3
     #Llvm-manpages = lowPrio (tools.libllvm.override {
     #  enableManpages = true;

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -42,15 +42,15 @@ let
       inherit llvm_meta;
     };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src llvm_meta;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     # disabled until recommonmark supports sphinx 3
     #Llvm-manpages = lowPrio (tools.libllvm.override {

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -30,19 +30,19 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libllvm-polly = callPackage ./llvm { enablePolly = true; };
 
-    llvm-polly = tools.libllvm-polly.lib;
+    llvm-polly = tools.libllvm-polly.lib // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     llvm-manpages = lowPrio (tools.libllvm.override {
       enableManpages = true;

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -30,19 +30,19 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libllvm-polly = callPackage ./llvm { enablePolly = true; };
 
-    llvm-polly = tools.libllvm-polly.lib;
+    llvm-polly = tools.libllvm-polly.lib // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     llvm-manpages = lowPrio (tools.libllvm.override {
       enableManpages = true;

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -30,19 +30,19 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libllvm-polly = callPackage ./llvm { enablePolly = true; };
 
-    llvm-polly = tools.libllvm-polly.lib;
+    llvm-polly = tools.libllvm-polly.lib // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     clang-polly-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -30,19 +30,19 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libllvm-polly = callPackage ./llvm { enablePolly = true; };
 
-    llvm-polly = tools.libllvm-polly.lib;
+    llvm-polly = tools.libllvm-polly.lib // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     clang-polly-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -30,19 +30,19 @@ let
 
     libllvm = callPackage ./llvm { };
 
-    # `llvm` historically had the binaries. But this migration
-    # technique also impedes `lib.get*`. Perhaps we will revisit it.
-    llvm = tools.libllvm.out;
+    # `llvm` historically had the binaries.  When choosing an output explicitly,
+    # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
+    llvm = tools.libllvm.out // { outputUnspecified = true; };
 
     libllvm-polly = callPackage ./llvm { enablePolly = true; };
 
-    llvm-polly = tools.libllvm-polly.lib;
+    llvm-polly = tools.libllvm-polly.lib // { outputUnspecified = true; };
 
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src;
     };
 
-    clang-unwrapped = tools.libclang.out;
+    clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
 
     clang-polly-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/120058#issuecomment-836459634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
