### PR TITLE
py-dmidecode: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/py-dmidecode/default.nix
+++ b/pkgs/development/python-modules/py-dmidecode/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, dmidecode }:
+
+buildPythonPackage rec {
+  pname = "py-dmidecode";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bv1vmhj8h520kj6slwpz16xfmgp117yjjkfyihkl5ix6mn5zkpa";
+  };
+
+  propagatedBuildInputs = [ dmidecode ];
+
+  # Project has no tests.
+  doCheck = false;
+  pythonImportsCheck = [ "dmidecode" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/zaibon/py-dmidecode/";
+    description = "Python library that parses the output of dmidecode";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ davidtwco ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5300,6 +5300,8 @@ in {
 
   py-air-control-exporter = callPackage ../development/python-modules/py-air-control-exporter { };
 
+  py-dmidecode = callPackage ../development/python-modules/py-dmidecode { };
+
   py2bit = callPackage ../development/python-modules/py2bit { };
 
   py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });


### PR DESCRIPTION
###### Motivation for this change
Add `py-dmidecode` package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
