### PR TITLE
sphinxcontrib-{actdiag,nwdiag,seqdiag}: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-actdiag/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-actdiag/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, sphinx
+, actdiag
+, blockdiag
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-actdiag";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-TtuFZOLkig4MULLndDQlrTTx8RiGw34MsjmXoPladMY=";
+  };
+
+  propagatedBuildInputs = [ sphinx actdiag blockdiag ];
+
+  pythonImportsCheck = [ "sphinxcontrib.actdiag" ];
+
+  meta = with lib; {
+    description = "Sphinx actdiag extension";
+    homepage = "https://github.com/blockdiag/sphinxcontrib-actdiag";
+    maintainers = with maintainers; [ davidtwco ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/sphinxcontrib-nwdiag/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-nwdiag/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, sphinx
+, blockdiag
+, nwdiag
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-nwdiag";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-bula1DutRv6NwfZRhciZfLHRZmXu42p+qvbeExN/+Fk=";
+  };
+
+  propagatedBuildInputs = [ sphinx blockdiag nwdiag ];
+
+  pythonImportsCheck = [ "sphinxcontrib.nwdiag" ];
+
+  meta = with lib; {
+    description = "Sphinx nwdiag extension";
+    homepage = "https://github.com/blockdiag/sphinxcontrib-nwdiag";
+    maintainers = with maintainers; [ davidtwco ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/sphinxcontrib-seqdiag/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-seqdiag/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, sphinx
+, blockdiag
+, seqdiag
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-seqdiag";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-THJ1ra/W2X/lQaDjGbL27VMn0lWPJApwgKMrPhL0JY0=";
+  };
+
+  propagatedBuildInputs = [ sphinx blockdiag seqdiag ];
+
+  pythonImportsCheck = [ "sphinxcontrib.seqdiag" ];
+
+  meta = with lib; {
+    description = "Sphinx seqdiag extension";
+    homepage = "https://github.com/blockdiag/sphinxcontrib-seqdiag";
+    maintainers = with maintainers; [ davidtwco ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7714,6 +7714,8 @@ in {
 
   sphinxcontrib-katex = callPackage ../development/python-modules/sphinxcontrib-katex { };
 
+  sphinxcontrib-nwdiag = callPackage ../development/python-modules/sphinxcontrib-nwdiag { };
+
   sphinxcontrib_newsfeed = callPackage ../development/python-modules/sphinxcontrib_newsfeed { };
 
   sphinxcontrib-openapi = callPackage ../development/python-modules/sphinxcontrib-openapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7728,6 +7728,8 @@ in {
 
   sphinxcontrib-serializinghtml = callPackage ../development/python-modules/sphinxcontrib-serializinghtml { };
 
+  sphinxcontrib-seqdiag = callPackage ../development/python-modules/sphinxcontrib-seqdiag { };
+
   sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
 
   sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7690,6 +7690,8 @@ in {
 
   spinners = callPackage ../development/python-modules/spinners { };
 
+  sphinxcontrib-actdiag = callPackage ../development/python-modules/sphinxcontrib-actdiag { };
+
   sphinxcontrib-applehelp = callPackage ../development/python-modules/sphinxcontrib-applehelp { };
 
   sphinxcontrib-autoapi = callPackage ../development/python-modules/sphinxcontrib-autoapi { };


### PR DESCRIPTION
###### Motivation for this change
Add packages for `sphinxcontrib-actdiag`, `sphinxcontrib-nwdiag`, `sphinxcontrib-seqdiag`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
