### PR TITLE
rustup-toolchain-install-master: init at 1.7.3

### DIFF
--- a/pkgs/development/tools/rust/rustup-toolchain-install-master/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup-toolchain-install-master/0001-dynamically-patchelf-binaries.patch
@@ -1,0 +1,61 @@
+diff --git a/src/main.rs b/src/main.rs
+index 3cb6896..7f070e0 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -275,7 +275,9 @@ fn install_single_toolchain(
+
+     // install
+     if maybe_dry_client.is_some() {
+-        rename(&toolchain.dest, toolchain_path)?;
++        rename(&toolchain.dest, toolchain_path.clone())?;
++        nix_patchelf(toolchain_path)
++            .expect("failed to patch toolchain for NixOS");
+         eprintln!(
+             "toolchain `{}` is successfully installed!",
+             toolchain.dest.display()
+@@ -291,6 +293,45 @@ fn install_single_toolchain(
+     Ok(())
+ }
+
++fn nix_patchelf(mut toolchain_path: PathBuf) -> Result<(), Error> {
++    toolchain_path.push("bin");
++
++    for entry in toolchain_path.read_dir()? {
++        let entry = entry?;
++        if !entry.file_type()?.is_file() {
++            continue;
++        }
++
++        eprintln!("info: you seem to be running NixOS. Attempting to patch {}",
++                  entry.path().to_str().unwrap());
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-interpreter")
++            .arg("@dynamicLinker@")
++            .arg(entry.path())
++            .output();
++    }
++
++    toolchain_path.pop();
++    toolchain_path.push("lib");
++
++    for entry in toolchain_path.read_dir()? {
++        let entry = entry?;
++        if !entry.file_type()?.is_file() {
++            continue;
++        }
++
++        eprintln!("info: you seem to be running NixOS. Attempting to patch {}",
++                  entry.path().to_str().unwrap());
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-rpath")
++            .arg("@libPath@")
++            .arg(entry.path())
++            .output();
++    }
++
++    Ok(())
++}
++
+ fn fetch_master_commit(client: &Client, github_token: Option<&str>) -> Result<String, Error> {
+     eprintln!("fetching master commit hash... ");
+     fetch_master_commit_via_git()

--- a/pkgs/development/tools/rust/rustup-toolchain-install-master/default.nix
+++ b/pkgs/development/tools/rust/rustup-toolchain-install-master/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, openssl
+, runCommand
+, patchelf
+, zlib
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustup-toolchain-install-master";
+  version = "1.7.3";
+
+  src = fetchFromGitHub {
+    owner = "kennytm";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-J25ER/g8Kylw/oTIEl4Gl8i1xmhR+4JM5M5EHpl1ras=";
+  };
+
+  patches =
+    let
+      patchelfPatch = runCommand "0001-dynamically-patchelf-binaries.patch" {
+        CC = stdenv.cc;
+        patchelf = patchelf;
+        libPath = "$ORIGIN/../lib:${lib.makeLibraryPath [ zlib ]}";
+      }
+      ''
+        export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
+        substitute ${./0001-dynamically-patchelf-binaries.patch} $out \
+          --subst-var patchelf \
+          --subst-var dynamicLinker \
+          --subst-var libPath
+      '';
+    in
+    lib.optionals stdenv.isLinux [ patchelfPatch ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  cargoSha256 = "n7t8Ap9hdhrjmtKjfdyozf26J7yhu57pedm19CunLF4=";
+
+  meta = with lib; {
+    description = "Install a rustc master toolchain usable from rustup";
+    homepage = "https://github.com/kennytm/rustup-toolchain-install-master";
+    license = licenses.mit;
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11585,6 +11585,9 @@ in
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
+  rustup-toolchain-install-master = callPackage ../development/tools/rust/rustup-toolchain-install-master {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   sagittarius-scheme = callPackage ../development/compilers/sagittarius-scheme {};
 


### PR DESCRIPTION
###### Motivation for this change
Add package for `rustup-toolchain-install-master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
