### PR TITLE
webssh: init at 1.5.3

### DIFF
--- a/pkgs/development/python-modules/webssh/default.nix
+++ b/pkgs/development/python-modules/webssh/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, tornado, paramiko }:
+
+buildPythonPackage rec {
+  pname = "webssh";
+  version = "1.5.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Au6PE8jYm8LkEp0B1ymW//ZkrkcV0BauwufQmrHLEU4=";
+  };
+
+  propagatedBuildInputs = [ tornado paramiko ];
+
+  pythonImportsCheck = [ "webssh" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/huashengdun/webssh/";
+    description = "Web based ssh client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26936,6 +26936,8 @@ in
 
   webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
 
+  webssh = with python3Packages; toPythonApplication webssh;
+
   webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};
 
   wrapWeechat = callPackage ../applications/networking/irc/weechat/wrapper.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8647,6 +8647,8 @@ in {
 
   websockify = callPackage ../development/python-modules/websockify { };
 
+  webssh = disabledIf (!isPy3k) (callPackage ../development/python-modules/webssh { });
+
   webtest = callPackage ../development/python-modules/webtest { };
 
   webthing = callPackage ../development/python-modules/webthing { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8647,7 +8647,7 @@ in {
 
   websockify = callPackage ../development/python-modules/websockify { };
 
-  webssh = disabledIf (!isPy3k) (callPackage ../development/python-modules/webssh { });
+  webssh = callPackage ../development/python-modules/webssh { };
 
   webtest = callPackage ../development/python-modules/webtest { };
 


### PR DESCRIPTION
###### Motivation for this change
Add package for `webssh`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
