### PR TITLE
cargo-bisect-rustc: init at 0.6.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-bisect-rustc/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/cargo-bisect-rustc/0001-dynamically-patchelf-binaries.patch
@@ -1,0 +1,56 @@
+diff --git a/src/toolchains.rs b/src/toolchains.rs
+index 4d85e7c..b1353c6 100644
+--- a/src/toolchains.rs
++++ b/src/toolchains.rs
+@@ -259,6 +259,8 @@ impl Toolchain {
+             .map_err(InstallError::Download)?;
+         }
+
++        nix_patchelf(tmpdir.path().to_path_buf())
++            .expect("failed to patch toolchain for NixOS");
+         fs::rename(tmpdir.into_path(), dest).map_err(InstallError::Move)?;
+
+         Ok(())
+@@ -557,3 +559,42 @@ pub(crate) fn download_tarball(
+     }
+     download_tar_gz(client, name, &format!("{}.gz", url,), strip_prefix, dest)
+ }
++
++fn nix_patchelf(mut toolchain_path: PathBuf) -> Result<(), Error> {
++    toolchain_path.push("bin");
++
++    for entry in toolchain_path.read_dir()? {
++        let entry = entry?;
++        if !entry.file_type()?.is_file() {
++            continue;
++        }
++
++        eprintln!("info: you seem to be running NixOS. Attempting to patch {}",
++                  entry.path().to_str().unwrap());
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-interpreter")
++            .arg("@dynamicLinker@")
++            .arg(entry.path())
++            .output();
++    }
++
++    toolchain_path.pop();
++    toolchain_path.push("lib");
++
++    for entry in toolchain_path.read_dir()? {
++        let entry = entry?;
++        if !entry.file_type()?.is_file() {
++            continue;
++        }
++
++        eprintln!("info: you seem to be running NixOS. Attempting to patch {}",
++                  entry.path().to_str().unwrap());
++        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++            .arg("--set-rpath")
++            .arg("@libPath@")
++            .arg(entry.path())
++            .output();
++    }
++
++    Ok(())
++}

--- a/pkgs/development/tools/rust/cargo-bisect-rustc/default.nix
+++ b/pkgs/development/tools/rust/cargo-bisect-rustc/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, openssl
+, runCommand
+, patchelf
+, zlib
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-bisect-rustc";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "rust-lang";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-LEmILWVU6hbh2FmdnQVV1Ob2MQvj+/lCr1hdRoTIOkI=";
+  };
+
+  patches =
+    let
+      patchelfPatch = runCommand "0001-dynamically-patchelf-binaries.patch" {
+        CC = stdenv.cc;
+        patchelf = patchelf;
+        libPath = "$ORIGIN/../lib:${lib.makeLibraryPath [ zlib ]}";
+      }
+      ''
+        export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
+        substitute ${./0001-dynamically-patchelf-binaries.patch} $out \
+          --subst-var patchelf \
+          --subst-var dynamicLinker \
+          --subst-var libPath
+      '';
+    in
+    lib.optionals stdenv.isLinux [ patchelfPatch ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  cargoSha256 = "Ls51DQ0yScRhpkuEInCfR45+/WeaUoG935w4BJvwSRk=";
+
+  meta = with lib; {
+    description = "Bisects rustc, either nightlies or CI artifacts";
+    homepage = "https://github.com/rust-lang/${pname}";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11469,6 +11469,9 @@ in
   cargo-audit = callPackage ../tools/package-management/cargo-audit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-bisect-rustc = callPackage ../development/tools/rust/cargo-bisect-rustc {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-c = callPackage ../development/tools/rust/cargo-c {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };


### PR DESCRIPTION
###### Motivation for this change
Add package for `cargo-bisect-rustc`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
