### PR TITLE
communi: fix darwin build

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -1,4 +1,4 @@
-{ fetchgit, libcommuni, qtbase, qmake, lib, stdenv }:
+{ fetchgit, libcommuni, qtbase, qmake, lib, stdenv, wrapQtAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "communi";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake ]
+    ++ lib.optional stdenv.isDarwin wrapQtAppsHook;
 
   buildInputs = [ libcommuni qtbase ];
 
@@ -25,14 +26,23 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [
     "COMMUNI_INSTALL_PREFIX=${placeholder "out"}"
-    "COMMUNI_INSTALL_BINS=${placeholder "out"}/bin"
     "COMMUNI_INSTALL_PLUGINS=${placeholder "out"}/lib/communi/plugins"
     "COMMUNI_INSTALL_ICONS=${placeholder "out"}/share/icons/hicolor"
     "COMMUNI_INSTALL_DESKTOP=${placeholder "out"}/share/applications"
     "COMMUNI_INSTALL_THEMES=${placeholder "out"}/share/communi/themes"
+    (if stdenv.isDarwin
+      then [ "COMMUNI_INSTALL_BINS=${placeholder "out"}/Applications" ]
+      else [ "COMMUNI_INSTALL_BINS=${placeholder "out"}/bin" ])
   ];
 
-  postInstall = lib.optionalString stdenv.isLinux ''
+  postInstall = if stdenv.isDarwin then ''
+    # Nix qmake does not add the bundle rpath by default.
+    install_name_tool \
+      -add_rpath @executable_path/../Frameworks \
+      $out/Applications/Communi.app/Contents/MacOS/Communi
+
+    wrapQtApp $out/Applications/Communi.app/Contents/MacOS/Communi
+  '' else ''
     substituteInPlace "$out/share/applications/communi.desktop" \
       --replace "/usr/bin" "$out/bin"
   '';

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   dontUseQmakeConfigure = true;
-  configureFlags = [ "-config" "release" ];
+  configureFlags = [ "-config" "release" ]
+    # Build mixes up dylibs/frameworks if one is not explicitely specified.
+    ++ lib.optionals stdenv.isDarwin [ "-config" "qt_framework" ];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
@NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142599722/nixlog/1

Note that this does **NOT** yet result in a working Communi.app, but is what I could fix in reasonable time. So the libcommuni fix should be good here, but the communi fix is partial.

The app now launches, shows in the dock, but is 'not responding' and goes into what appears to be a tight rendering loop with nothing on screen. One CPU is pegged at 100%, and interrupting with lldb only shows AppKit / Qt stuff in the backtrace.

The wrapQtAppsHook stuff is also my best guess for a fix here. Without it, the app exits immediately with `qt.qpa.plugin: Could not find the Qt platform plugin "cocoa" in ""`. But I don't know enough about Qt to understand why this would not be a problem on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
