### PR TITLE
yaru-remix-theme: init at 40

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4109,6 +4109,12 @@
     githubId = 362833;
     name = "Hongchang Wu";
   };
+  hoppla20 = {
+    email = "privat@vincentcui.de";
+    github = "hoppla20";
+    githubId = 25618740;
+    name = "Vincent Cui";
+  };
   hoverbear = {
     email = "operator+nix@hoverbear.org";
     github = "hoverbear";

--- a/pkgs/data/themes/yaru-remix/default.nix
+++ b/pkgs/data/themes/yaru-remix/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, meson, sassc, pkg-config, glib, ninja, python3, gtk3, gnome }:
+
+stdenv.mkDerivation rec {
+  pname = "yaru-remix";
+  version = "40";
+
+  src = fetchFromGitHub {
+    owner = "Muqtxdir";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xilhw5gbxsyy80ixxgj0nw6w782lz9dsinhi24026li1xny804c";
+  };
+
+  nativeBuildInputs = [ meson sassc pkg-config glib ninja python3 ];
+  buildInputs = [ gtk3 gnome.gnome-themes-extra ];
+
+  dontDropIconThemeCache = true;
+
+  postPatch = "patchShebangs .";
+
+  meta = with lib; {
+    description = "Fork of the Yaru GTK theme";
+    homepage = "https://github.com/Muqtxdir/yaru-remix";
+    license = with licenses; [ cc-by-sa-40 gpl3Plus lgpl21Only lgpl3Only ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hoppla20 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22354,6 +22354,8 @@ in
 
   yaru-theme = callPackage ../data/themes/yaru {};
 
+  yaru-remix-theme = callPackage ../data/themes/yaru-remix {};
+
   zafiro-icons = callPackage ../data/icons/zafiro-icons {
     inherit (plasma5Packages) breeze-icons;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding [yaru-remix gtk theme](https://github.com/Muqtxdir/yaru-remix).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
