### PR TITLE
[ZHF] perlPackages.TextBibTeX: use lib instead of lib64 on aarch64

### DIFF
--- a/pkgs/development/perl-modules/TextBibTeX-use-lib-on-aarch64.patch
+++ b/pkgs/development/perl-modules/TextBibTeX-use-lib-on-aarch64.patch
@@ -1,0 +1,11 @@
+--- a/Build.PL
++++ b/Build.PL
+@@ -88,7 +88,7 @@ if ( $^O =~ /mswin32/i ) {
+     }
+ }
+ else {
+-    if ( $Config{archname} =~ /^x86_64|^ppc64|^s390x|^aarch64|^riscv64/ ) {
++    if ( $Config{archname} =~ /^x86_64|^ppc64|^s390x|^riscv64/ ) {
+         $libdir =~ s/\bbin\b/lib64/;
+         if ( !-d $libdir ) {
+             my $test = $libdir;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21779,7 +21779,7 @@ let
     };
   };
 
-  TextBibTeX = buildPerlModule {
+  TextBibTeX = buildPerlModule ({
     pname = "Text-BibTeX";
     version = "0.88";
     buildInputs = [ CaptureTiny ConfigAutoConf ExtUtilsLibBuilder ];
@@ -21802,7 +21802,10 @@ let
       description = "Interface to read and parse BibTeX files";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-  };
+  } // lib.optionalAttrs stdenv.isAarch64 {
+    # libbtparse.so: cannot open shared object file (aarch64 only)
+    patches = [ ../development/perl-modules/TextBibTeX-use-lib-on-aarch64.patch ];
+  });
 
   TextBrew = buildPerlPackage {
     pname = "Text-Brew";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21779,7 +21779,7 @@ let
     };
   };
 
-  TextBibTeX = buildPerlModule ({
+  TextBibTeX = buildPerlModule {
     pname = "Text-BibTeX";
     version = "0.88";
     buildInputs = [ CaptureTiny ConfigAutoConf ExtUtilsLibBuilder ];
@@ -21787,6 +21787,8 @@ let
       url = "mirror://cpan/authors/id/A/AM/AMBS/Text-BibTeX-0.88.tar.gz";
       sha256 = "0b7lmjvfmypps1nw6nsdikgaakm0n0g4186glaqazg5xd1p5h55h";
     };
+    # libbtparse.so: cannot open shared object file (aarch64 only)
+    patches = [ ../development/perl-modules/TextBibTeX-use-lib-on-aarch64.patch ];
     perlPreHook = "export LD=$CC";
     perlPostHook = lib.optionalString stdenv.isDarwin ''
       oldPath="$(pwd)/btparse/src/libbtparse.dylib"
@@ -21802,10 +21804,7 @@ let
       description = "Interface to read and parse BibTeX files";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
-  } // lib.optionalAttrs stdenv.isAarch64 {
-    # libbtparse.so: cannot open shared object file (aarch64 only)
-    patches = [ ../development/perl-modules/TextBibTeX-use-lib-on-aarch64.patch ];
-  });
+  };
 
   TextBrew = buildPerlPackage {
     pname = "Text-Brew";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Build failure https://hydra.nixos.org/build/142787205

This is absolutely a shot in the dark, as I don't have anywhere to test this.

Is it ok to let OfBorg build it?

PS:  I suppose that `Text::BibTeX` should actually ask `DynaLoader` what is the standard library folder, or something like that, instead of guessing `lib` vs `lib64`. I will report this upstream if this is indeed the source of the problem.

Cc @veprbl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
