### PR TITLE
ejabberd: 20.12 -> 21.04

### DIFF
--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -24,12 +24,12 @@ let
   ctlpath = lib.makeBinPath [ bash gnused gnugrep coreutils util-linux procps ];
 
 in stdenv.mkDerivation rec {
-  version = "20.12";
+  version = "21.04";
   pname = "ejabberd";
 
   src = fetchurl {
     url = "https://www.process-one.net/downloads/downloads-action.php?file=/${version}/${pname}-${version}.tgz";
-    sha256 = "sha256-nZxdYXRyv4UejPLHNT/p6CrvW22Koo7rZSi96KRjqFQ=";
+    sha256 = "09s8mj0dkvp9mxazsqxqqmnl5n2xyi8avx0rzgvqrbl3byanzfzr";
   };
 
   nativeBuildInputs = [ fakegit makeWrapper ];
@@ -76,7 +76,7 @@ in stdenv.mkDerivation rec {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-0/hBgA+9rsDOBcvbROSpc5Xnw4JkYpuLCl2V+lJnieY=";
+    outputHash = "1mvixgb46ss35abjwz3lw38c69bii1xyj557a92bvrxc1gc6gx31";
   };
 
   configureFlags =

--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -7,7 +7,6 @@
 , withPam ? false, pam
 , withZlib ? true, zlib
 , withRiak ? false
-, withElixir ? false, elixir
 , withIconv ? true
 , withTools ? false
 , withRedis ? false
@@ -38,11 +37,7 @@ in stdenv.mkDerivation rec {
     ++ lib.optional withSqlite sqlite
     ++ lib.optional withPam pam
     ++ lib.optional withZlib zlib
-    ++ lib.optional withElixir elixir
-    ;
-
-  # Apparently needed for Elixir
-  LANG = "en_US.UTF-8";
+  ;
 
   deps = stdenv.mkDerivation {
     pname = "ejabberd-deps";
@@ -52,7 +47,7 @@ in stdenv.mkDerivation rec {
 
     configureFlags = [ "--enable-all" "--with-sqlite3=${sqlite.dev}" ];
 
-    nativeBuildInputs = [ git erlang openssl expat libyaml sqlite pam zlib elixir ];
+    nativeBuildInputs = [ git erlang openssl expat libyaml sqlite pam zlib ];
 
     GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
@@ -86,7 +81,6 @@ in stdenv.mkDerivation rec {
       (lib.enableFeature withPam "pam")
       (lib.enableFeature withZlib "zlib")
       (lib.enableFeature withRiak "riak")
-      (lib.enableFeature withElixir "elixir")
       (lib.enableFeature withIconv "iconv")
       (lib.enableFeature withTools "tools")
       (lib.enableFeature withRedis "redis")
@@ -97,7 +91,7 @@ in stdenv.mkDerivation rec {
   preBuild = ''
     cp -r $deps deps
     chmod -R +w deps
-    patchShebangs deps
+    patchShebangs .
   '';
 
   postInstall = ''
@@ -108,6 +102,7 @@ in stdenv.mkDerivation rec {
       -e 's,\(^ *CONNLOCKDIR=\).*,\1/var/lock/ejabberdctl,' \
       $out/sbin/ejabberdctl
     wrapProgram $out/lib/eimp-*/priv/bin/eimp --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libpng libjpeg libwebp ]}"
+    rm $out/bin/{mix,iex,elixir}
   '';
 
   meta = with lib; {
@@ -116,6 +111,5 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.ejabberd.im";
     platforms = platforms.linux;
     maintainers = with maintainers; [ sander abbradar ];
-    broken = withElixir;
   };
 }

--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -6,7 +6,6 @@
 , withSqlite ? false, sqlite
 , withPam ? false, pam
 , withZlib ? true, zlib
-, withRiak ? false
 , withIconv ? true
 , withTools ? false
 , withRedis ? false
@@ -80,7 +79,6 @@ in stdenv.mkDerivation rec {
       (lib.enableFeature withSqlite "sqlite")
       (lib.enableFeature withPam "pam")
       (lib.enableFeature withZlib "zlib")
-      (lib.enableFeature withRiak "riak")
       (lib.enableFeature withIconv "iconv")
       (lib.enableFeature withTools "tools")
       (lib.enableFeature withRedis "redis")


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
