### PR TITLE
apacheHttpdPackages.mod_python: fix darwin build

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_python/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_python/default.nix
@@ -1,10 +1,11 @@
-{ lib, stdenv, fetchurl, apacheHttpd, python2 }:
+{ lib, stdenv, fetchurl, apacheHttpd, python2, libintl }:
 
 stdenv.mkDerivation rec {
-  name = "mod_python-3.5.0";
+  pname = "mod_python";
+  version = "3.5.0";
 
   src = fetchurl {
-    url = "http://dist.modpython.org/dist/${name}.tgz";
+    url = "http://dist.modpython.org/dist/${pname}-${version}.tgz";
     sha256 = "146apll3yfqk05s8fkf4acmxzqncl08bgn4rv0c1rd4qxmc91w0f";
   };
 
@@ -24,7 +25,8 @@ stdenv.mkDerivation rec {
 
   passthru = { inherit apacheHttpd; };
 
-  buildInputs = [ apacheHttpd python2 ];
+  buildInputs = [ apacheHttpd python2 ]
+    ++ lib.optional stdenv.isDarwin libintl;
 
   meta = {
     homepage = "http://modpython.org/";


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142067272/log

I don't really know how to test this, but the build failure seemed simple enough to fix.

On both Darwin and Linux, `bin/mod_python` does only:

```
Traceback (most recent call last):
  File "/nix/store/2br16hr5v1n3nl90snr16wbvfbzcrr10-mod_python-3.5.0/bin/mod_python", line 30, in <module>
    import mod_python
ImportError: No module named mod_python
```

Maybe you're not supposed to run it directly?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
