### PR TITLE
buildPythonPackage: add output `wheel`

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -53,6 +53,7 @@ with pkgs;
               pytestCheckHook
               pythonCatchConflictsHook
               pythonImportsCheckHook
+              pythonKeepWheelHook
               pythonNamespacesHook
               pythonRecompileBytecodeHook
               pythonRemoveBinBytecodeHook

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -46,6 +46,11 @@ in rec {
       };
     } ./flit-build-hook.sh) {};
 
+  pythonKeepWheelHook = callPackage ({}:
+    makeSetupHook {
+      name = "pythonKeepWheelHook";
+    } ./python-keep-wheel-hook.sh) {};
+
   pipBuildHook = callPackage ({ pip, wheel }:
     makeSetupHook {
       name = "pip-build-hook.sh";

--- a/pkgs/development/interpreters/python/hooks/python-keep-wheel-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-keep-wheel-hook.sh
@@ -1,0 +1,17 @@
+# Setup hook for pip.
+echo "Sourcing pythonKeepWheelHook"
+
+pythonKeepWheelHook() {
+    echo "Executing pythonKeepWheelHook"
+
+    local target
+    target=${wheel:-$out/wheel}
+
+    mkdir -p $target
+    cp dist/*.whl $target/
+
+    echo "Finished executing pythonKeepWheelHook"
+}
+
+echo "Using pythonKeepWheelHook"
+postFixupHooks+=('pythonKeepWheelHook')

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -121,6 +121,7 @@ in {
     pytestCheckHook
     pythonCatchConflictsHook
     pythonImportsCheckHook
+    pythonKeepWheelHook
     pythonNamespacesHook
     pythonRecompileBytecodeHook
     pythonRemoveBinBytecodeHook


### PR DESCRIPTION
###### Motivation for this change
It would be useful if one was able access the wheel files which are built already by buildPythonPackage.
This makes it easier to use different installation methods.
My current personal motivation behind this is to create manylinux compatible wheels with nix at some point

###### Things done
- add output `wheel` if pip install is used.
- set outputsToInstall to `out`, to not install the wheel artifact if it's not needed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
