### PR TITLE
python3Packages.aioasuswrt: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/python-modules/aioasuswrt/default.nix
+++ b/pkgs/development/python-modules/aioasuswrt/default.nix
@@ -9,18 +9,16 @@
 
 buildPythonPackage rec {
   pname = "aioasuswrt";
-  version = "1.3.3";
+  version = "1.3.4";
 
   src = fetchFromGitHub {
     owner = "kennedyshead";
     repo = pname;
-    rev = "V${version}";
-    sha256 = "1h1qwc7szgrcwiz4q6x4mlf26is20lj1ds5rcb9i611j26656v6d";
+    rev = version;
+    sha256 = "101d76zarvilzfmcy8n3bjqzyars8hsjzr0zc80d4rngv4vhrki1";
   };
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "cryptography==3.3.2" "cryptography"
     substituteInPlace setup.cfg \
       --replace "--cov-report html" "" \
       --replace "--cov-report term-missing" ""


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.3.4

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50414
- Target Home Assistant release: current, only dependency update no changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
