### PR TITLE
boost-build: fix darwin build

### DIFF
--- a/pkgs/development/tools/boost-build/darwin-default-toolset.patch
+++ b/pkgs/development/tools/boost-build/darwin-default-toolset.patch
@@ -1,0 +1,12 @@
+diff --git a/src/build-system.jam b/src/build-system.jam
+index 60425c54..c6842217 100644
+--- a/src/build-system.jam
++++ b/src/build-system.jam
+@@ -644,7 +644,7 @@ local rule should-clean-project ( project )
+             }
+             else if [ os.name ] = MACOSX
+             {
+-                default-toolset = darwin ;
++                default-toolset = clang-darwin ;
+             }
+         }

--- a/pkgs/development/tools/boost-build/default.nix
+++ b/pkgs/development/tools/boost-build/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "1r4rwlq87ydmsdqrik4ly5iai796qalvw7603mridg2nwcbbnf54";
   };
 
+  patches = [
+    # Upstream defaults to gcc on darwin, but we use clang.
+    ./darwin-default-toolset.patch
+  ];
+
   nativeBuildInputs = [
     bison
   ];


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/141987985/log

Would like a quick Linux review. Example dependant package is luabind.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
