### PR TITLE
treewide: use fetchFromGitHub when possible

### DIFF
--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -4,9 +4,11 @@ let
   template-bootstrap3 = pkgs.stdenv.mkDerivation {
     name = "bootstrap3";
     # Download the theme from the dokuwiki site
-    src = pkgs.fetchurl {
-      url = "https://github.com/giterlizzi/dokuwiki-template-bootstrap3/archive/v2019-05-22.zip";
-      sha256 = "4de5ff31d54dd61bbccaf092c9e74c1af3a4c53e07aa59f60457a8f00cfb23a6";
+    src = pkgs.fetchFromGitHub {
+      owner = "giterlizzi";
+      repo = "dokuwiki-template-bootstrap3";
+      rev = "v2019-05-22";
+      sha256 = "WOaWTZ+vHcg72d1AQ6yxsO5Am5MapuaBNYjy8N1pV9M=";
     };
     # We need unzip to build this package
     nativeBuildInputs = [ pkgs.unzip ];

--- a/nixos/tests/redmine.nix
+++ b/nixos/tests/redmine.nix
@@ -15,9 +15,11 @@ let
         package = pkgs.redmine;
         database.type = type;
         plugins = {
-          redmine_env_auth = pkgs.fetchurl {
-            url = "https://github.com/Intera/redmine_env_auth/archive/0.7.zip";
-            sha256 = "1xb8lyarc7mpi86yflnlgyllh9hfwb9z304f19dx409gqpia99sc";
+          redmine_env_auth = pkgs.fetchFromGitHub {
+            owner = "Intera";
+            repo = "redmine_env_auth";
+            rev = "0.7";
+            sha256 = "ptiXR2MUmf+9d4lUW2LmToP4brhdONB4cNi+rY86CCQ=";
           };
         };
         themes = {

--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, fetchFromGitHub }:
 
 with lib;
 
@@ -26,9 +26,11 @@ stdenv.mkDerivation {
   pname = "stockfish";
   inherit version;
 
-  src = fetchurl {
-    url = "https://github.com/official-stockfish/Stockfish/archive/sf_${version}.tar.gz";
-    sha256 = "16980aicm5i6i9252239q4f9bcxg1gnqkv6nphrmpz4drg8i3v6i";
+  src = fetchFromGitHub {
+    owner = "official-stockfish";
+    repo = "Stockfish";
+    rev = "sf_${version}";
+    sha256 = "YlBg3cC2hnZOhnWXoNpkrcQZhAakq3EvCcHZcvmqnm0=";
   };
 
   # This addresses a linker issue with Darwin

--- a/pkgs/servers/matterbridge/default.nix
+++ b/pkgs/servers/matterbridge/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchurl }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "matterbridge";
@@ -8,9 +8,11 @@ buildGoModule rec {
 
   doCheck = false;
 
-  src = fetchurl {
-    url = "https://github.com/42wim/matterbridge/archive/v${version}.tar.gz";
-    sha256 = "sha256-yV805OWFNOxKIGd6t2kRcUzdB8xYWYHFK+W2u/QPTXg=";
+  src = fetchFromGitHub {
+    owner = "42wim";
+    repo = "matterbridge";
+    rev = "v${version}";
+    sha256 = "QPi4eCxverfBwYeE1fvx2FkQucOFCQkzoq/XhV2s2Gg=";
   };
 
   meta = with lib; {

--- a/pkgs/tools/misc/txt2man/default.nix
+++ b/pkgs/tools/misc/txt2man/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, coreutils, gawk }:
+{ lib, stdenv, fetchFromGitHub, coreutils, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "txt2man";
   version = "1.7.1";
 
-  src = fetchurl {
-    url = "https://github.com/mvertes/txt2man/archive/${pname}-${version}.tar.gz";
-    sha256 = "0ka3krmblsprv0v6h6wnm8lv08w30z0ynfnbwns6alks5gx1p6sd";
+  src = fetchFromGitHub {
+    owner = "mvertes";
+    repo = "txt2man";
+    rev = "${pname}-${version}";
+    sha256 = "Aqi5PNNaaM/tr9A/7vKeafYKYIs/kHbwHzE7+R/9r9s=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is just 7 out of possibly hundreds that ripgrep found, I may need to find a way to automate this since it's quite time consuming. Found these via

```ShellSession
$ rg -l -U -P 'fetchurl[^]]*\n*[^]]*?\bgithub'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
