### PR TITLE
vscode-extensions: remote-ssh acquires user's home directory from `$HOME`

### DIFF
--- a/pkgs/misc/vscode-extensions/remote-ssh/default.nix
+++ b/pkgs/misc/vscode-extensions/remote-ssh/default.nix
@@ -2,7 +2,7 @@
 , vscode-utils
 , useLocalExtensions ? false}:
 # Note that useLocalExtensions requires that vscode-server is not running
-# on host. If it is, you'll need to remove ~/.vscode-server,
+# on host. If it is, you'll need to remove $HOME/.vscode-server,
 # and redo the install by running "Connect to host" on client
 
 let
@@ -11,7 +11,7 @@ let
   # patch runs on remote machine hence use of which
   # links to local node if version is 12
   patch = ''
-    f="$(getent passwd $USER | cut -d: -f6)/.vscode-server/bin/$COMMIT_ID/node"
+    f="$HOME/.vscode-server/bin/$COMMIT_ID/node"
     localNodePath=''$(which node)
     if [ -x "''$localNodePath" ]; then
       localNodeVersion=''$(node -v)
@@ -23,10 +23,10 @@ let
     fi
     ${lib.optionalString useLocalExtensions ''
       # Use local extensions
-      if [ -d ~/.vscode/extensions ]; then
-        if ! test -L "~/.vscode-server/extensions"; then
-          mkdir -p ~/.vscode-server
-          ln -s ~/.vscode/extensions ~/.vscode-server/
+      if [ -d $HOME/.vscode/extensions ]; then
+        if ! test -L "$HOME/.vscode-server/extensions"; then
+          mkdir -p $HOME/.vscode-server
+          ln -s $HOME/.vscode/extensions $HOME/.vscode-server/
         fi
       fi
     ''}

--- a/pkgs/misc/vscode-extensions/remote-ssh/default.nix
+++ b/pkgs/misc/vscode-extensions/remote-ssh/default.nix
@@ -11,7 +11,7 @@ let
   # patch runs on remote machine hence use of which
   # links to local node if version is 12
   patch = ''
-    f="/home/''$USER/.vscode-server/bin/''$COMMIT_ID/node"
+    f="$(getent passwd $USER | cut -d: -f6)/.vscode-server/bin/$COMMIT_ID/node"
     localNodePath=''$(which node)
     if [ -x "''$localNodePath" ]; then
       localNodeVersion=''$(node -v)


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`vscode-extensions.ms-vscode-remote.remote-ssh` won't work while I try to login to a NixOS host as a root user. (homed in `/root`). This patch fixes the home mismatch while enabled `userLocalExtensions` in `vscode-extensions.ms-vscode-remote.remote-ssh` via `$HOME`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
