### PR TITLE
arcanist: generate & install bash-completion

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -30,7 +30,10 @@ stdenv.mkDerivation {
     rev = "2565cc7b4d1dbce6bc7a5b3c4e72ae94be4712fe";
     sha256 = "0jiv4aj4m5750dqw9r8hizjkwiyxk4cg4grkr63sllsa2dpiibxw";
   };
-  buildInputs = [ bison flex php installShellFiles ];
+
+  buildInputs = [ php ];
+
+  nativeBuildInputs = [ bison flex installShellFiles ];
 
   postPatch = lib.optionalString stdenv.isAarch64 ''
     substituteInPlace support/xhpast/Makefile \
@@ -38,11 +41,14 @@ stdenv.mkDerivation {
   '';
 
   buildPhase = ''
+    runHook preBuild
     make cleanall -C support/xhpast
     make xhpast -C support/xhpast
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin $out/libexec
     make install -C support/xhpast
     make cleanall -C support/xhpast
@@ -54,6 +60,7 @@ stdenv.mkDerivation {
     $out/bin/arc shell-complete --generate --
     installShellCompletion --cmd arc --bash $out/libexec/arcanist/support/shell/rules/bash-rules.sh
     installShellCompletion --cmd phage --bash $out/libexec/arcanist/support/shell/rules/bash-rules.sh
+    runHook postInstall
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -3,6 +3,7 @@
 , flex
 , php
 , lib, stdenv
+, installShellFiles
 }:
 
 # Make a custom wrapper. If `wrapProgram` is used, arcanist thinks .arc-wrapped is being
@@ -29,7 +30,7 @@ stdenv.mkDerivation {
     rev = "2565cc7b4d1dbce6bc7a5b3c4e72ae94be4712fe";
     sha256 = "0jiv4aj4m5750dqw9r8hizjkwiyxk4cg4grkr63sllsa2dpiibxw";
   };
-  buildInputs = [ bison flex php ];
+  buildInputs = [ bison flex php installShellFiles ];
 
   postPatch = lib.optionalString stdenv.isAarch64 ''
     substituteInPlace support/xhpast/Makefile \
@@ -49,6 +50,10 @@ stdenv.mkDerivation {
 
     ${makeArcWrapper "arc"}
     ${makeArcWrapper "phage"}
+
+    $out/bin/arc shell-complete --generate --
+    installShellCompletion --cmd arc --bash $out/libexec/arcanist/support/shell/rules/bash-rules.sh
+    installShellCompletion --cmd phage --bash $out/libexec/arcanist/support/shell/rules/bash-rules.sh
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -42,16 +42,16 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
-    make cleanall -C support/xhpast
-    make xhpast -C support/xhpast
+    make cleanall -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
+    make xhpast   -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin $out/libexec
-    make install -C support/xhpast
-    make cleanall -C support/xhpast
+    make install  -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
+    make cleanall -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
     cp -R . $out/libexec/arcanist
 
     ${makeArcWrapper "arc"}


### PR DESCRIPTION
Arcanist only supports bash for shell-completion as of 20200711, otherwise I would include zsh and/or fish here.

Upstream discussion of zsh non-support: https://secure.phabricator.com/D19700

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
