### PR TITLE
kodi: Fix Blu-ray ISO playback

### DIFF
--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -97,6 +97,13 @@ let
     sha256 = "1xxn01mhkdnp10cqdr357wx77vyzfb5glqpqyg8m0skyi75aii59";
   };
 
+  # Necessary so that Blu-ray ISO playback works as expected.
+  libudfread = builtins.fetchTarball {
+    name = "libudfread";
+    url = "https://mirrors.kodi.tv/build-deps/sources/libudfread-1.1.0.tar.gz";
+    sha256 = "1ijlg9lsic5f2nrsqxlwqprhrdcqk0n1abfvsxgm6hyrzfni91zj";
+  };
+
   kodi_platforms = lib.optional gbmSupport "gbm"
     ++ lib.optional waylandSupport "wayland"
     ++ lib.optional x11Support "x11";
@@ -177,6 +184,8 @@ in stdenv.mkDerivation {
       "-Dlibdvdcss_URL=${libdvdcss}"
       "-Dlibdvdnav_URL=${libdvdnav}"
       "-Dlibdvdread_URL=${libdvdread}"
+      "-DENABLE_INTERNAL_UDFREAD=ON"
+      "-DUDFREAD_URL=${libudfread}"
       "-DGIT_VERSION=${kodiReleaseDate}"
       "-DENABLE_EVENTCLIENTS=ON"
       "-DENABLE_INTERNAL_CROSSGUID=OFF"


### PR DESCRIPTION
Originally, attempting to play a Blu-ray ISO resulted in errors like:

```
2021-05-10 22:04:30.045 T:875821 WARNING <general>: CreateLoader - unsupported protocol(udf) in udf://%2fkodi-test-library%2fblu-ray-test.iso/BDMV/index.bdmv
```

and a failure to play the ISO file.

This log message originates from
https://github.com/xbmc/xbmc/blob/a80d1293b0579bbed7dd7d20304ba34a20519f78/xbmc/filesystem/FileFactory.cpp#L177,
which can only be generated when the check at
https://github.com/xbmc/xbmc/blob/a80d1293b0579bbed7dd7d20304ba34a20519f78/xbmc/filesystem/FileFactory.cpp#L139-L142
doesn't exist and hence doesn't recognize the `udf://` protocol at all.

This ensures that the UDF-reading library is built and included
correctly, which allows Blu-ray ISO files to be played back successfully
once again.

I tested this on my local NixOS installation by making the change, then
running:

```
nix-shell -p kodi -I "nixpkgs=${NIXPKGS}" --command kodi
```

locally with success and seeing playback succeed for Blu-ray ISO files
using Kodi launched from within the shell.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix Blu-ray ISO playback in Kodi 19.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
