### PR TITLE
flint: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -13,10 +13,12 @@ assert withBlas -> openblas != null && blas.implementation == "openblas" && lapa
 stdenv.mkDerivation rec {
   pname = "flint";
   version = "2.7.1";
+
   src = fetchurl {
     url = "http://www.flintlib.org/flint-${version}.tar.gz";
     sha256 = "07j8r96kdzp19cy3a5yvpjxf90mkd6103yr2n42qmpv7mgcjyvhq";
   };
+
   buildInputs = [
     gmp
     mpir
@@ -36,9 +38,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals withBlas [
     "--with-blas=${openblas}"
   ];
-
-  # issues with ntl -- https://github.com/wbhart/flint2/issues/487
-  NIX_CXXSTDLIB_COMPILE = "-std=c++11";
 
   doCheck = true;
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/122593#issuecomment-838786418
the particular flag that was being breaks darwin and is no longer necessary on linux, because the PR that fixed the underlying issue has already been merged into this release of flint, cc @timokau.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
