### PR TITLE
nixos/sway: Extend the default configuration for NixOS

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -31,6 +31,7 @@ let
     extraOptions = cfg.extraOptions;
     withBaseWrapper = cfg.wrapperFeatures.base;
     withGtkWrapper = cfg.wrapperFeatures.gtk;
+    isNixOS = true;
   };
 in {
   options.programs.sway = {
@@ -120,8 +121,11 @@ in {
       systemPackages = [ swayPackage ] ++ cfg.extraPackages;
       etc = {
         "sway/config".source = mkOptionDefault "${swayPackage}/etc/sway/config";
-        #"sway/security.d".source = mkOptionDefault "${swayPackage}/etc/sway/security.d/";
-        #"sway/config.d".source = mkOptionDefault "${swayPackage}/etc/sway/config.d/";
+        "sway/config.d/nixos.conf".source = pkgs.writeText "nixos.conf" ''
+          # Import the most important environment variables into the D-Bus and systemd
+          # user environments (e.g. required for screen sharing and Pinentry prompts):
+          exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK
+        '';
       };
     };
     security.pam.services.swaylock = {};

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -4,6 +4,8 @@
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
 , wlroots, wayland-protocols, libdrm
 , nixosTests
+# Used by the NixOS module:
+, isNixOS ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -26,6 +28,10 @@ stdenv.mkDerivation rec {
       inherit swaybg;
     })
   ];
+
+  postPatch = lib.optionalString isNixOS ''
+    echo -e '\ninclude /etc/sway/config.d/*' >> config.in
+  '';
 
   nativeBuildInputs = [
     meson ninja pkg-config wayland scdoc

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -4,6 +4,8 @@
 , withBaseWrapper ? true, extraSessionCommands ? "", dbus
 , withGtkWrapper ? false, wrapGAppsHook, gdk-pixbuf, glib, gtk3
 , extraOptions ? [] # E.g.: [ "--verbose" ]
+# Used by the NixOS module:
+, isNixOS ? false
 }:
 
 assert extraSessionCommands != "" -> withBaseWrapper;
@@ -11,6 +13,7 @@ assert extraSessionCommands != "" -> withBaseWrapper;
 with lib;
 
 let
+  sway = sway-unwrapped.override { inherit isNixOS; };
   baseWrapper = writeShellScriptBin "sway" ''
      set -o errexit
      if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then
@@ -19,16 +22,16 @@ let
      fi
      if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
        export DBUS_SESSION_BUS_ADDRESS
-       exec ${sway-unwrapped}/bin/sway "$@"
+       exec ${sway}/bin/sway "$@"
      else
-       exec ${dbus}/bin/dbus-run-session ${sway-unwrapped}/bin/sway "$@"
+       exec ${dbus}/bin/dbus-run-session ${sway}/bin/sway "$@"
      fi
    '';
 in symlinkJoin {
-  name = "sway-${sway-unwrapped.version}";
+  name = "sway-${sway.version}";
 
   paths = (optional withBaseWrapper baseWrapper)
-    ++ [ sway-unwrapped ];
+    ++ [ sway ];
 
   nativeBuildInputs = [ makeWrapper ]
     ++ (optional withGtkWrapper wrapGAppsHook);
@@ -48,5 +51,5 @@ in symlinkJoin {
 
   passthru.providedSessions = [ "sway" ];
 
-  inherit (sway-unwrapped) meta;
+  inherit (sway) meta;
 }


### PR DESCRIPTION
The default config.in template contains
"include @sysconfdir@/sway/config.d/*" but we've dropped it to better
support non-NixOS (which seems like a mistake in retrospect).
This restores that behaviour and extends the default configuration via
nixos.conf to fix #119445.

Note: The security configurations (security.d) where dropped entirely
(but maybe they'll return).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note: This is currently just an idea/draft and I haven't tested it yet. Unfortunately it's somewhat hacky so an alternative would be to drop our support to easily use our Sway package outside of NixOS (we could ask around if anyone uses that and if it even works as expected).

TODOs: Extend the NixOS VM test for Sway to test pinentry (maybe an optional test/extension if this causes too many rebuilds when testing changes to core packages).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
