### PR TITLE
mapnik: fix missing proj and libxml2 support

### DIFF
--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -23,17 +23,41 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ boost cairo freetype gdal harfbuzz icu libjpeg libpng libtiff
-      libwebp libxml2 proj python sqlite zlib
+      libwebp proj python sqlite zlib
 
       # optional inputs
       postgresql
     ];
+
+  propagatedBuildInputs = [ libxml2 ];
 
   prefixKey = "PREFIX=";
 
   preConfigure = ''
     patchShebangs ./configure
   '';
+
+  # NOTE: 2021-05-06:
+  # Add -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1 for backwards compatibility
+  # with major versions 6 and 7 of proj which are otherwise not compatible
+  # with mapnik 3.1.0. Note that:
+  #
+  # 1. Starting with proj version 8, this workaround will no longer be
+  #    supported by the upstream proj project.
+  #
+  # 2. Without the workaround, mapnik configures itself without proj support.
+  #
+  # 3. The master branch of mapnik (after 3.1.0) appears to add native support
+  #    for the proj 6 api, so this workaround is not likely to be needed in
+  #    subsequent mapnik releases. At that point, this block comment and the
+  #    NIX_CFLAGS_COMPILE expression can be removed.
+
+  NIX_CFLAGS_COMPILE =
+    if version != "3.1.0" && lib.versionAtLeast version "3.1.0"
+    then throw "The mapnik compatibility workaround for proj 6 may no longer be required. Remove workaround after checking."
+    else if lib.versionAtLeast (lib.getVersion proj) "8"
+    then throw ("mapnik currently requires a version of proj less than 8, but proj version is: " + (lib.getVersion proj))
+    else "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1";
 
   configureFlags = [
     "BOOST_INCLUDES=${boost.dev}/include"
@@ -51,16 +75,19 @@ stdenv.mkDerivation rec {
     "JPEG_LIBS=${libjpeg.out}/lib"
     "PNG_INCLUDES=${libpng.dev}/include"
     "PNG_LIBS=${libpng.out}/lib"
-    "PROJ_INCLUDES=${proj}/include"
-    "PROJ_LIBS=${proj}/lib"
+    "PROJ_INCLUDES=${proj.dev}/include"
+    "PROJ_LIBS=${proj.out}/lib"
     "SQLITE_INCLUDES=${sqlite.dev}/include"
     "SQLITE_LIBS=${sqlite.out}/lib"
     "TIFF_INCLUDES=${libtiff.dev}/include"
     "TIFF_LIBS=${libtiff.out}/lib"
     "WEBP_INCLUDES=${libwebp}/include"
     "WEBP_LIBS=${libwebp}/lib"
-    "XML2_INCLUDES=${libxml2.dev}/include"
-    "XML2_LIBS=${libxml2.out}/lib"
+    "XMLPARSER=libxml2"
+  ];
+
+  buildFlags = [
+    "JOBS=$(NIX_BUILD_CORES)"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
This commit provides three minor improvements:

1. Fix missing proj support. Fixes #91889.
2. Fix missing libxml2 support.
3. Improve build time with parallel build.

Fix missing proj support:
-------------------------
The 2019-07-09 update to proj version 6.1.1 in nixpkgs
commit d55cba68ff3 caused two problems for mapnik:

1. The separation of the dev output was not reflected in the mapnik
   expression. Since proj support is optional in the mapnik build,
   the build succeeded but no longer included proj support.

   See build log for: https://hydra.nixos.org/build/96274475.

2. Even if the mapnik expression was updated to use the separate
   dev output, it would still have dropped proj support because mapnik
   has not been updated for the proj 6 API.

This commit fixes the PROJ_INCLUDES to use the correct dev output and
also makes the PROJ_LIBS output explicit. In addition, it defines
ACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1 since mapnik still does not have
a tagged release that supports the proj 6 api.

Looking to the future, it appears that the mapnik master branch includes
proj 6 support, so some checks were included to help insure that this
workaround gets removed once it is no longer required.

Fix missing libxml2 support:
----------------------------
Configure with "XMLPARSER=libxml2" to get libxml2 support. This has been
needed since mapnik 3.0.2. Remove XML2_INCLUDES and XML2_LIBS which
trigger a bug in the supplied SConstruct script (when used with
"XMLPARSER=libxml2.

In addition, libxml2 needs to be a propagatedBuildInput to avoid
errors building apacheHttpdPackages.mod_tile, python-mapnik, and
possibly other packages.

Enable parallel build:
----------------------
Setting enableParallelBuild does not result in a parallel build
with mapnik. However, setting JOBS=$(NIX_BUILD_CORES) in buildFlags
works and significantly reduces the build time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Other Tests
Verify that "bin/mapnik-config --dep-libs" output includes -lproj and -lxml2

@hrdinka
