### PR TITLE
libsForQt5.applet-window-buttons: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/development/libraries/applet-window-buttons/default.nix
+++ b/pkgs/development/libraries/applet-window-buttons/default.nix
@@ -1,7 +1,6 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , extra-cmake-modules
 , kcoreaddons
@@ -12,22 +11,14 @@
 
 mkDerivation rec {
   pname = "applet-window-buttons";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "psifidotos";
     repo = "applet-window-buttons";
     rev = version;
-    sha256 = "0r1h4kbdv6pxj15w4n1w50g8zsl0jrc4808dyfygzwf87mghziyz";
+    sha256 = "sha256-ikgUE8GaiTpNjwrz7SbNQ3+b8KiigDgMREQ7J2b+EEs=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-compilation-error-with-plasma-5.21.patch";
-      url = "https://github.com/psifidotos/applet-window-buttons/commit/dc5ed862fa3cb943f9c0d561c864ff461156a19e.patch";
-      sha256 = "17bdkkmy7k402viynj2bpw281qzsn0f1w8gf98gq65wkm4sf4j6k";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/psifidotos/applet-window-buttons/releases/tag/0.9.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
