### PR TITLE
python-mapnik: fix pycairo support

### DIFF
--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -35,10 +35,16 @@ in buildPythonPackage rec {
     export BOOST_PYTHON_LIB="boost_python${pythonVersion}"
     export BOOST_THREAD_LIB="boost_thread"
     export BOOST_SYSTEM_LIB="boost_system"
+    export PYCAIRO=true
   '';
 
   nativeBuildInputs = [
     mapnik # for mapnik_config
+    pkgs.pkgconfig
+  ];
+
+  patches = [
+    ./find-pycairo-with-pkg-config.patch
   ];
 
   buildInputs = [

--- a/pkgs/development/python-modules/python-mapnik/find-pycairo-with-pkg-config.patch
+++ b/pkgs/development/python-modules/python-mapnik/find-pycairo-with-pkg-config.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index 82a31d733..1c876a553 100755
+--- a/setup.py
++++ b/setup.py
+@@ -228,10 +228,9 @@ extra_comp_args = list(filter(lambda arg: arg != "-fvisibility=hidden", extra_co
+ if os.environ.get("PYCAIRO", "false") == "true":
+     try:
+         extra_comp_args.append('-DHAVE_PYCAIRO')
+-        print("-I%s/include/pycairo".format(sys.exec_prefix))
+-        extra_comp_args.append("-I{0}/include/pycairo".format(sys.exec_prefix))
+-        #extra_comp_args.extend(check_output(["pkg-config", '--cflags', 'pycairo']).strip().split(' '))
+-        #linkflags.extend(check_output(["pkg-config", '--libs', 'pycairo']).strip().split(' '))
++        pycairo_name = 'py3cairo' if PYTHON3 else 'pycairo'
++        extra_comp_args.extend(check_output(["pkg-config", '--cflags', pycairo_name]).strip().split(' '))
++        linkflags.extend(check_output(["pkg-config", '--libs', pycairo_name]).strip().split(' '))
+     except:
+         raise Exception("Failed to find compiler options for pycairo")
+ 


### PR DESCRIPTION
Fully enable pycairo support by exporting PYCAIRO=true and using
pkg-config to locate the pycairo library (with included patch).

The patch restores the use of pkg-config to find pycairo. This code was
present upstream, but commented out; it has been re-enabled and
modified to support both pycairo and py3cairo (the python3 version
of pycairo).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Other tests

Verify that the following returns True:

`nix-shell -p python3Packages.python-mapnik --run 'python3 -c "import mapnik; print (mapnik.has_pycairo())"'`

@hrdinka 
