### PR TITLE
acl2: fix darwin build

### DIFF
--- a/pkgs/development/interpreters/acl2/libipasirglucose4/default.nix
+++ b/pkgs/development/interpreters/acl2/libipasirglucose4/default.nix
@@ -1,6 +1,11 @@
 { lib, stdenv, fetchurl, zlib, unzip }:
 
-stdenv.mkDerivation rec {
+let
+
+  cxx = "${stdenv.cc.targetPrefix}c++";
+  libName = "libipasirglucose4" + stdenv.targetPlatform.extensions.sharedLibrary;
+
+in stdenv.mkDerivation rec {
   pname = "libipasirglucose4";
   # This library has no version number AFAICT (beyond generally being based on
   # Glucose 4.x), but it was submitted to the 2017 SAT competition so let's use
@@ -18,13 +23,16 @@ stdenv.mkDerivation rec {
   sourceRoot = "sat/glucose4";
   patches = [ ./0001-Support-shared-library-build.patch ];
 
+  makeFlags = [ "CXX=${cxx}" ];
+
   postBuild = ''
-    g++ -shared -Wl,-soname,libipasirglucose4.so -o libipasirglucose4.so \
+    ${cxx} -shared -o ${libName} \
+        ${if stdenv.cc.isClang then "" else "-Wl,-soname,${libName}"} \
         ipasirglucoseglue.o libipasirglucose4.a
   '';
 
   installPhase = ''
-    install -D libipasirglucose4.so $out/lib/libipasirglucose4.so
+    install -D ${libName} $out/lib/${libName}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142046572/nixlog/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
