### PR TITLE
pari: 2.11.4 -> 2.13.1, update sage test expectations

### DIFF
--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -12,13 +12,22 @@ assert withThread -> libpthreadstubs != null;
 
 stdenv.mkDerivation rec {
   pname = "pari";
-  version = "2.11.4";
+  version = "2.13.1";
 
   src = fetchurl {
-    # Versions with current majorMinor values are at http://pari.math.u-bordeaux.fr/pub/pari/unix/${pname}-${version}.tar.gz
-    url = "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-v8iPxPc1L0hA5uNSxy8DacvqikVAOxg0piafNwmXCxw=";
+    urls = [
+      "https://pari.math.u-bordeaux.fr/pub/pari/unix/${pname}-${version}.tar.gz"
+      # old versions are at the url below
+      "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor version}/${pname}-${version}.tar.gz"
+    ];
+    sha256 = "sha256-gez31wzNquIwFlz/Ynyc4uwpe48i+fQHQiedhfht/LE=";
   };
+
+  patches = [
+    # rebased version of 3edb98db78, see
+    # https://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=2284
+    ./rnfdisc.patch
+  ];
 
   buildInputs = [
     gmp

--- a/pkgs/applications/science/math/pari/rnfdisc.patch
+++ b/pkgs/applications/science/math/pari/rnfdisc.patch
@@ -1,0 +1,51 @@
+commit 0d8a3ac970291c62b56104172418b3f2ca30927c
+Author: Bill Allombert <Bill.Allombert@math.u-bordeaux.fr>
+Date:   Sun Mar 28 13:27:24 2021 +0200
+
+    rnfdisc_factored: remove spurious Q_primpart [#2284]
+
+diff --git a/src/basemath/base2.c b/src/basemath/base2.c
+index 7e7d0db9d..c461826f4 100644
+--- a/src/basemath/base2.c
++++ b/src/basemath/base2.c
+@@ -3582,7 +3582,7 @@ rnfdisc_factored(GEN nf, GEN pol, GEN *pd)
+ 
+   nf = checknf(nf);
+   pol = rnfdisc_get_T(nf, pol, &lim);
+-  disc = nf_to_scalar_or_basis(nf, nfX_disc(nf, Q_primpart(pol)));
++  disc = nf_to_scalar_or_basis(nf, nfX_disc(nf, pol));
+   pol = nfX_to_monic(nf, pol, NULL);
+   fa = idealfactor_partial(nf, disc, lim);
+   P = gel(fa,1); l = lg(P);
+diff --git a/src/test/32/rnf b/src/test/32/rnf
+index 1e743f415..c016dce00 100644
+--- a/src/test/32/rnf
++++ b/src/test/32/rnf
+@@ -853,9 +853,10 @@ error("inconsistent dimensions in idealtwoelt.")
+ 0
+ 0
+ 1
+-[[7361, 3786, 318, 5823; 0, 1, 0, 0; 0, 0, 1, 0; 0, 0, 0, 1], [-3, 6, -2, 0]
+-~]
+-[2, -1]
++[[433, 322, 318, 1318/17; 0, 1, 0, 12/17; 0, 0, 1, 5/17; 0, 0, 0, 1/17], [25
++/17, -12/17, 12/17, 16/17]~]
++[1, -1]
++[[12, 0, 0, 0; 0, 12, 4, 0; 0, 0, 4, 0; 0, 0, 0, 4], [6, 5, -1, 2]~]
+   ***   at top-level: rnfdedekind(nf,P,pr2,1)
+   ***                 ^-----------------------
+   *** rnfdedekind: sorry, Dedekind in the difficult case is not yet implemented.
+diff --git a/src/test/in/rnf b/src/test/in/rnf
+index 7851ae291..318d5349e 100644
+--- a/src/test/in/rnf
++++ b/src/test/in/rnf
+@@ -212,6 +212,9 @@ k = nfinit(y^4 + 10*y^2 + 17);
+ rnfdisc(k, x^2 - x + 1/Mod(y,k.pol))
+ rnfdisc(k, x^2 - x + 1/2)
+ 
++k = nfinit(y^4 - 10*y^2 + 1);
++rnfdisc(k,x^2-(y^3/2+y^2-5*y/2+1))
++
+ \\ ERRORS, keep at end of file
+ rnfdedekind(nf, P, pr2, 1)
+ rnfdedekind(nf, P)

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -78,6 +78,18 @@ stdenv.mkDerivation rec {
 
     # ignore a deprecation warning for usage of `cmp` in the attrs library in the doctests
     ./patches/ignore-cmp-deprecation.patch
+
+    # https://trac.sagemath.org/ticket/30801. this patch has
+    # positive_review but has not been merged upstream yet, so we
+    # don't use fetchSageDiff because it returns a file that contains
+    # each commit as a separate patch instead of a single diff, and
+    # some commits from the pari update branch are already in 9.3.rc5
+    # (auto-resolvable merge conflicts).
+    (fetchpatch {
+      name = "pari-2.13.1.patch";
+      url = "https://github.com/sagemath/sagetrac-mirror/compare/d6c5cd9be78cc448ee4c54bac93385b1244a234c...10a4531721d2700fd717e2b3a1364508ffd971c3.diff";
+      sha256 = "sha256-zMjRMEReoiTvmt+vvV0Ij1jtyLSLwSXBEVXqgvmq1D4=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
###### Motivation for this change

Fixes #102699 without breaking Sage. We will wait until the Sage patch is upstreamed, though (see https://github.com/NixOS/nixpkgs/pull/122592#pullrequestreview-657112637).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
