### PR TITLE
gnonograms: init at 1.4.5

### DIFF
--- a/pkgs/games/gnonograms/default.nix
+++ b/pkgs/games/gnonograms/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, vala
+, meson
+, ninja
+, pkg-config
+, desktop-file-utils
+, appstream
+, python3
+, shared-mime-info
+, wrapGAppsHook
+, gtk3
+, pantheon
+, libgee
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnonograms";
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "jeremypw";
+    repo = "gnonograms";
+    rev = "v${version}";
+    sha256 = "1ly3inp6dvjrixdysz5hdfwlhbs49ks0lf8062z2iq6gaf8ivkb2";
+  };
+
+  postPatch = ''
+    patchShebangs meson/post_install.py
+  '';
+
+  nativeBuildInputs = [
+    vala
+    meson
+    ninja
+    pkg-config
+    desktop-file-utils
+    appstream
+    python3
+    shared-mime-info
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    pantheon.granite
+    libgee
+  ];
+
+  meta = with lib; {
+    description = "Nonograms puzzle game";
+    longDescription = ''
+      An implementation of the Japanese logic puzzle "Nonograms" written in
+      Vala, allowing the user to:
+      * Draw puzzles
+      * Generate random puzzles of chosen difficulty
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fgaz ];
+    homepage = "https://github.com/jeremypw/gnonograms";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28743,6 +28743,8 @@ in
 
   gmad = callPackage ../games/gmad { };
 
+  gnonograms = callPackage ../games/gnonograms { };
+
   gnubg = callPackage ../games/gnubg { };
 
   gnuchess = callPackage ../games/gnuchess { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
