### PR TITLE
nixos/tests/signal-desktop: test if the SQLite DB is (un)encrypted

### DIFF
--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 {
   name = "signal-desktop";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ flokli ];
+    maintainers = [ flokli primeos ];
   };
 
   machine = { ... }:
@@ -16,7 +16,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
     services.xserver.enable = true;
     test-support.displayManager.auto.user = "alice";
-    environment.systemPackages = [ pkgs.signal-desktop ];
+    environment.systemPackages = with pkgs; [ signal-desktop file ];
     virtualisation.memorySize = 1024;
   };
 
@@ -39,5 +39,17 @@ import ./make-test-python.nix ({ pkgs, ...} :
     machine.wait_for_text("Signal")
     machine.wait_for_text("File Edit View Window Help")
     machine.screenshot("signal_desktop")
+
+    # Test if the database is encrypted to prevent these issues:
+    # - https://github.com/NixOS/nixpkgs/issues/108772
+    # - https://github.com/NixOS/nixpkgs/pull/117555
+    print(machine.succeed("su - alice -c 'file ~/.config/Signal/sql/db.sqlite'"))
+    # TODO: The DB should be encrypted and the following should be machine.fail
+    # instead of machine.succeed but the DB is currently unencrypted and we
+    # want to notice if this isn't the case anymore as the transition to a
+    # encrypted DB can cause data loss!:
+    machine.succeed(
+        "su - alice -c 'file ~/.config/Signal/sql/db.sqlite' | grep -i sqlite"
+    )
   '';
 })


### PR DESCRIPTION
    Well, this should test if the database is encrypted but currently it is
    still unencrypted and we need to notice if this behaviour changes in the
    future (as it will cause data loss, see e.g. #108772).
    Anyway, this doesn't really matter for security reasons but we need this
    test to prevent data loss (unfortunately Signal-Desktop and SQLCipher
    handle this badly... :o).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Important to prevent data loss for users.
~~An important test to prevent this from ever regressing but this is expected to fail until we merge #117555.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
