### PR TITLE
python3Packages.connexion: 2.4.0 -> 2.7.0

### DIFF
--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -1,89 +1,60 @@
-{ buildPythonPackage
-, fetchFromGitHub
-, isPy3k
-, glibcLocales
-, lib
-, pythonOlder
-
+{ lib
 , aiohttp
-, aiohttp-swagger
 , aiohttp-jinja2
+, aiohttp-remotes
+, aiohttp-swagger
+, buildPythonPackage
 , clickclick
 , decorator
-, flake8
+, fetchFromGitHub
 , flask
-, gevent
 , inflection
 , jsonschema
-, mock
 , openapi-spec-validator
-, pathlib
-, pytest
 , pytest-aiohttp
-, pytestcov
+, pytestCheckHook
+, pythonOlder
 , pyyaml
 , requests
-, six
 , swagger-ui-bundle
 , testfixtures
-, typing ? null
-, ujson
 }:
 
 buildPythonPackage rec {
   pname = "connexion";
-  version = "2.4.0";
+  version = "2.7.0";
+  disabled = pythonOlder "3.6";
 
-  # we're fetching from GitHub because tests weren't distributed on PyPi
   src = fetchFromGitHub {
     owner = "zalando";
     repo = pname;
     rev = version;
-    sha256 = "1b9q027wrks0afl7l3a1wxymz3aick26b9fq2m07pc5wb9np0vvg";
+    sha256 = "15iflq5403diwda6n6qrpq67wkdcvl3vs0gsg0fapxqnq3a2m7jj";
   };
 
-  checkInputs = [
-    decorator
-    mock
-    pytest
-    pytestcov
-    testfixtures
-    flask
-    swagger-ui-bundle
-  ]
-  ++ lib.optionals isPy3k [ aiohttp aiohttp-jinja2 aiohttp-swagger ujson pytest-aiohttp ]
-  ++ lib.optional (pythonOlder "3.7") glibcLocales
-  ;
   propagatedBuildInputs = [
+    aiohttp
+    aiohttp-jinja2
+    aiohttp-swagger
     clickclick
+    flask
+    inflection
     jsonschema
+    openapi-spec-validator
     pyyaml
     requests
-    six
-    inflection
-    openapi-spec-validator
     swagger-ui-bundle
-    flask
-  ]
-  ++ lib.optional (pythonOlder "3.4") pathlib
-  ++ lib.optional (pythonOlder "3.6") typing
-  ++ lib.optionals isPy3k [ aiohttp aiohttp-jinja2 aiohttp-swagger ujson ]
-  ;
+  ];
 
-  preConfigure = lib.optional (pythonOlder "3.7") ''
-    export LANG=en_US.UTF-8
-  '';
+  checkInputs = [
+    aiohttp-remotes
+    decorator
+    pytest-aiohttp
+    pytestCheckHook
+    testfixtures
+  ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "'aiohttp>=2.3.10,<3.5.2'" "'aiohttp>=2.3.10'"
-  '';
-
-  checkPhase = if isPy3k then ''
-    pytest -k "not test_app_get_root_path and \
-               not test_verify_oauth_scopes_remote and \
-               not test_verify_oauth_scopes_local and \
-               not test_run_with_aiohttp_not_installed"''
-  else "pytest --ignore=tests/aiohttp";
+  pythonImportsCheck = [ "connexion" ];
 
   meta = with lib; {
     description = "Swagger/OpenAPI First framework on top of Flask";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream 2.7.0

Change log: https://github.com/zalando/connexion/releases/tag/2.7.0

Ref: https://hydra.nixos.org/build/142738018#tabs-summary
ZHF: #122042 

CC @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
