### PR TITLE
atinout: fix darwin build

### DIFF
--- a/pkgs/tools/networking/atinout/default.nix
+++ b/pkgs/tools/networking/atinout/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   name = "atinout-${version}";
   version = "0.9.2-alpha";
 
-  NIX_CFLAGS_COMPILE = "-Werror=implicit-fallthrough=0";
-  LANG = "C.UTF-8";
+  NIX_CFLAGS_COMPILE = lib.optionalString (!stdenv.cc.isClang) "-Werror=implicit-fallthrough=0";
+  LANG = if stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8";
   nativeBuildInputs = [ ronn mount ];
 
   src = fetchgit {
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     rev = "4976a6cb5237373b7e23cd02d7cd5517f306e3f6";
     sha256 = "0bninv2bklz7ly140cxx8iyaqjlq809jjx6xqpimn34ghwsaxbpv";
   };
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     make PREFIX=$out install


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142057951/log

Would like a Linux review on this, to verify changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
