### PR TITLE
octant: 0.19.0 -> 0.20.0, octant-desktop: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "octant";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src =
     let
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
       };
     in
     fetchsrc version {
-      x86_64-linux = "sha256-TKvUBof4TLcHr9hg6AOLjVd1NcAX9HHVuuABdFKRNQA=";
-      aarch64-linux = "sha256-BJb7h6kJZ3QhdlEqNHkiFp91uYLXzYHvKftxEAhjY38=";
-      x86_64-darwin = "sha256-Ig98IqLmlN9D4iXrP9SXYwTrQOvbtQ/tQW+uEmntm+I=";
+      x86_64-linux = "sha256-VFlZP5d6/YhzVIhveqMc4HfapBt0K/XjtqjCQNc514A=";
+      aarch64-linux = "sha256-RfdMfimmoHG4ixBtUVJ/V+mDhQ9aD+yeohkeUMUP8Zg=";
+      x86_64-darwin = "sha256-2Qgl3RdA4mMRTqR7o3Q86Zip5wtgvFp1vZn689FUtSI=";
     };
 
   dontConfigure = true;

--- a/pkgs/applications/networking/cluster/octant/desktop.nix
+++ b/pkgs/applications/networking/cluster/octant/desktop.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "octant-desktop";
-  version = "0.19.0";
+  version = "0.20.0";
   name = "${pname}-${version}";
 
   inherit (stdenv.hostPlatform) system;
@@ -15,8 +15,8 @@ let
   src = fetchurl {
     url = "https://github.com/vmware-tanzu/octant/releases/download/v${version}/Octant-${version}.${suffix}";
     sha256 = {
-      x86_64-linux = "sha256-1XFb0zuyOy8XEUd9hoexItjq4assuWlWIzqw7pZxHx0=";
-      x86_64-darwin = "sha256-e3v5BFX7wnx4sAQrOq+dBIDVPJYzQZKKvKjSX+dis2U=";
+      x86_64-linux = "sha256-mPD5qa/IYsakjcoPnWVpkmhgkhnRK0qTGQ6hanzDt/Y=";
+      x86_64-darwin = "sha256-nxpwBRUeLSPqNEFjF8hKzRhA2ahqh/KyAitnSxYdyJ8=";
     }.${system};
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump octant and octant-desktop to `0.20.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
