### PR TITLE
gnome-inform7: init at unstable-2021-04-06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3351,6 +3351,12 @@
     githubId = 10799507;
     name = "Karl Fischer";
   };
+  fitzgibbon = {
+    name = "Niall FitzGibbon";
+    email = "fitzgibbon.niall@gmail.com";
+    github = "fitzgibbon";
+    githubId = 617048;
+  };
   Flakebi = {
     email = "flakebi@t-online.de";
     github = "Flakebi";

--- a/pkgs/applications/editors/gnome-inform7/default.nix
+++ b/pkgs/applications/editors/gnome-inform7/default.nix
@@ -1,0 +1,117 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, python3, perl, bison
+, texinfo, desktop-file-utils, wrapGAppsHook, docbook2x, docbook-xsl-nons
+, inform7, gettext, libossp_uuid, gtk3, gobject-introspection, vala, gtk-doc
+, webkitgtk, gtksourceview3, gspell, libxml2, goocanvas2, libplist, glib
+, gst_all_1 }:
+
+# Neither gnome-inform7 nor its dependencies ratify and chimara have tagged releases in the GTK3 branch yet.
+
+let
+  ratify = (stdenv.mkDerivation {
+    pname = "ratify";
+    version = "unstable-2021-02-21";
+    src = fetchFromGitHub {
+      owner = "ptomato";
+      repo = "ratify";
+      rev = "f4d2d60ec73d5588e953650b3879e69a727f30ca";
+      sha256 = "eRh/9pYvdfbdbdJQ7pYMLq5p91I+rtyb/AqEGfakjKs=";
+    };
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      docbook2x
+      docbook-xsl-nons
+    ];
+    buildInputs = [
+      gtk3
+      gobject-introspection
+      vala gtk-doc
+      wrapGAppsHook
+    ];
+  });
+
+  chimara = (stdenv.mkDerivation {
+    pname = "chimara";
+    version = "unstable-2021-04-06";
+    src = fetchFromGitHub {
+      owner = "chimara";
+      repo = "Chimara";
+      rev = "9934b142af508c75c0f1eed597990f39495b1af4";
+      sha256 = "aRz1XX8XaSLTBIrMIIMS3QNMm6Msi+slrZ6+KYlyRMo=";
+    };
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      perl
+      bison
+      texinfo
+      python3
+      glib
+      wrapGAppsHook
+    ];
+    buildInputs = [
+      gtk3
+      gobject-introspection
+      vala
+      gtk-doc
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+      glib
+    ];
+    preConfigure = ''
+      patchShebangs build-aux/meson_post_install.py
+    '';
+  });
+
+in stdenv.mkDerivation {
+  pname = "gnome-inform7";
+  version = "unstable-2021-04-06";
+  src = fetchFromGitHub {
+    owner = "ptomato";
+    repo = "gnome-inform7";
+    # build from revision in the GTK3 branch as mainline requires webkit-1.0
+    rev = "c37e045c159692aae2e4e79b917e5f96cfefa66a";
+    sha256 = "Q4xoITs3AYXhvpWaABRAvJaUWTtUl8lYQ1k9zX7FrNw=";
+  };
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    inform7
+    python3
+    desktop-file-utils
+    wrapGAppsHook
+  ];
+  buildInputs = [
+    gettext
+    libossp_uuid
+    gtk3
+    gtksourceview3
+    gspell
+    webkitgtk
+    libxml2
+    goocanvas2
+    libplist
+    ratify
+    chimara
+  ];
+  preConfigure = ''
+    cp ${inform7}/libexec/ni ./src/ni
+    patchShebangs build-aux/* src/generate-resource-xml.{py,sh}
+  '';
+
+  meta = with lib; {
+    description = "Inform 7 for the Gnome platform";
+    longDescription = ''
+      This version of Inform 7 for the Gnome platform was created by Philip Chimento, based on a design by Graham Nelson and Andrew Hunter.
+    '';
+    homepage = "https://github.com/ptomato/gnome-inform7";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.fitzgibbon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13045,6 +13045,8 @@ in
 
   gnome-usage = callPackage ../applications/misc/gnome-usage {};
 
+  gnome-inform7 = callPackage ../applications/editors/gnome-inform7/default.nix { };
+
   gnome-latex = callPackage ../applications/editors/gnome-latex/default.nix { };
 
   gnome-network-displays = callPackage ../applications/networking/gnome-network-displays { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
