### PR TITLE
hylafaxplus: fix build

### DIFF
--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -67,6 +67,9 @@ stdenv.mkDerivation {
     url = "mirror://sourceforge/hylafax/hylafax-${version}.tar.gz";
     inherit sha256;
   };
+  patches = [
+    ./libtiff-4.2.patch  # adjust configure check to work with libtiff > 4.1
+  ];
   # Note that `configure` (and maybe `faxsetup`) are looking
   # for a couple of standard binaries in the `PATH` and
   # hardcode their absolute paths in the new package.

--- a/pkgs/servers/hylafaxplus/libtiff-4.2.patch
+++ b/pkgs/servers/hylafaxplus/libtiff-4.2.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 7456dcb..90f0e8d 100755
+--- a/configure
++++ b/configure
+@@ -2583,7 +2583,7 @@ EOF
+ 				echo '#define TIFFSTRIPBYTECOUNTS uint32'
+ 				echo '#define TIFFVERSION TIFF_VERSION'
+ 				echo '#define TIFFHEADER TIFFHeader';;
+-		4.[01])		tiff_runlen_t="uint32"
++		4.[012])	tiff_runlen_t="uint32"
+ 				tiff_offset_t="uint64"
+ 				echo '#define TIFFSTRIPBYTECOUNTS uint64'
+ 				echo '#define TIFFVERSION TIFF_VERSION_CLASSIC'


### PR DESCRIPTION
###### Motivation for this change
#122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
