### PR TITLE
swiProlog: fix darwin

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
 
   # Add the packInstall path to the swipl pack search path
   postPatch = ''
-    echo "user:file_search_path(pack, '$out/lib/swipl/pack')." >> /build/$sourceRoot/boot/init.pl
+    echo "user:file_search_path(pack, '$out/lib/swipl/pack')." >> boot/init.pl
   '';
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/p81m1hl9j60vp27rc6yj3n97nica6rdi-swi-prolog-8.3.9.drv
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
