### PR TITLE
gdcm: 3.0.8 -> 3.0.9

### DIFF
--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -1,40 +1,46 @@
-{ lib, stdenv, fetchurl, cmake, vtk_7, darwin
-, enablePython ? false, python ? null,  swig ? null}:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, enableVTK ? true
+, vtk
+, ApplicationServices
+, Cocoa
+, enablePython ? false
+, python
+, swig
+}:
 
 stdenv.mkDerivation rec {
-  version = "3.0.8";
   pname = "gdcm";
+  version = "3.0.9";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/gdcm/${pname}-${version}.tar.bz2";
-    sha256 = "1q9p0r7wszn51yak9wdp61fd9i0wj3f8ja2frmhk7d1gxic7j1rk";
+  src = fetchFromGitHub {
+    owner = "malaterre";
+    repo = "GDCM";
+    rev = "v${version}";
+    sha256 = "sha256-wqrM8lxJM8VL+1QEdu6Gr1XWT1j9pT6gGd3yn1yokIY=";
   };
-
-  dontUseCmakeBuildDir = true;
 
   cmakeFlags = [
     "-DGDCM_BUILD_APPLICATIONS=ON"
     "-DGDCM_BUILD_SHARED_LIBS=ON"
+  ] ++ lib.optionals enableVTK [
     "-DGDCM_USE_VTK=ON"
-  ]
-  ++ lib.optional enablePython [
+  ] ++ lib.optionals enablePython [
     "-DGDCM_WRAP_PYTHON:BOOL=ON"
     "-DGDCM_INSTALL_PYTHONMODULE_DIR=${placeholder "out"}/${python.sitePackages}"
   ];
 
-  preConfigure = ''
-    cmakeDir=$PWD
-    mkdir ../build
-    cd ../build
-  '';
-
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ vtk_7 ]
-    ++ lib.optional stdenv.isDarwin [
-      darwin.apple_sdk.frameworks.ApplicationServices
-      darwin.apple_sdk.frameworks.Cocoa
-    ] ++ lib.optional enablePython [ swig python ];
-  propagatedBuildInputs = [ ];
+
+  buildInputs = lib.optional enableVTK [
+    vtk
+  ]
+  ++ lib.optional stdenv.isDarwin [
+    ApplicationServices
+    Cocoa
+  ] ++ lib.optionals enablePython [ swig python ];
 
   meta = with lib; {
     description = "The grassroots cross-platform DICOM implementation";
@@ -44,6 +50,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://gdcm.sourceforge.net/";
     license = with licenses; [ bsd3 asl20 ];
-    platforms = platforms.all;
+    maintainers = with maintainers; [ tfmoraes ];
   };
 }

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -36,8 +36,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optional enableVTK [
     vtk
-  ]
-  ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optional stdenv.isDarwin [
     ApplicationServices
     Cocoa
   ] ++ lib.optionals enablePython [ swig python ];

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = lib.optional enableVTK [
+  buildInputs = lib.optionals enableVTK [
     vtk
-  ] ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     ApplicationServices
     Cocoa
   ] ++ lib.optionals enablePython [ swig python ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14636,7 +14636,9 @@ in
 
   gdal_2 = callPackage ../development/libraries/gdal/2.4.nix { };
 
-  gdcm = callPackage ../development/libraries/gdcm { };
+  gdcm = callPackage ../development/libraries/gdcm {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Cocoa;
+  };
 
   ggz_base_libs = callPackage ../development/libraries/ggz_base_libs {};
 


### PR DESCRIPTION
gdcm: 3.0.8 -> 3.0.9

- make use of VTK optional (enabled by default)
- use vtk instead of vtk_7
- fetching source code from GitHub (sourceforge doesn't have the last  version).
- nixpkgs-fmt

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update GDCM

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
