### PR TITLE
_1password: Fix Darwin Builds

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   unpackPhase = lib.optionalString stdenv.isDarwin ''
     xar -xf $src
-    zcat Payload | cpio -i
+    zcat op.pkg/Payload | cpio -i
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The latest update to 1.9.1 broke builds on darwin (noted here: https://github.com/NixOS/nixpkgs/pull/121828), due to some paths
changing in the unpacked darwin package.

This updates the darwin unpackPhase to use the updated path.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
