### PR TITLE
gojsontoyaml: unstable-2020-06-02 -> unstable-2020-12-16

### DIFF
--- a/pkgs/development/tools/gojsontoyaml/default.nix
+++ b/pkgs/development/tools/gojsontoyaml/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "gojsontoyaml";
-  version = "unstable-2020-06-02";
+  version = "unstable-2020-12-16";
 
   src = fetchFromGitHub {
     owner = "brancz";
     repo = "gojsontoyaml";
-    rev = "3697ded27e8cfea8e547eb082ebfbde36f1b5ee6";
-    sha256 = "07sisadpfnzbylzirs5ski8wl9fl18dm7xhbv8imw6ksxq4v467a";
+    rev = "202f76bf8c1f8fb74941a845b349941064603185";
+    sha256 = "sha256-N49iHQh28nAZBGJnLKG/aZPdn5fwPKQpdrXXtX28yss=";
   };
 
   vendorSha256 = null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the latest commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
