### PR TITLE
swaglyrics: bump unidecode version constraint

### DIFF
--- a/pkgs/tools/misc/swaglyrics/default.nix
+++ b/pkgs/tools/misc/swaglyrics/default.nix
@@ -19,7 +19,8 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace setup.py \
       --replace 'requests>=2.24.0' 'requests~=2.23' \
       --replace 'beautifulsoup4==4.9.1' 'beautifulsoup4~=4.9' \
-      --replace 'colorama==0.4.3' 'colorama~=0.4'
+      --replace 'colorama==0.4.3' 'colorama~=0.4' \
+      --replace 'unidecode==1.1.1' 'unidecode~=1.2'
   '';
 
   preBuild = "export HOME=$NIX_BUILD_TOP";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
