### PR TITLE
python3Packages.requests-http-signature: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/requests-http-signature/default.nix
+++ b/pkgs/development/python-modules/requests-http-signature/default.nix
@@ -1,28 +1,40 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, requests
 , cryptography
-, python
+, requests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "requests-http-signature";
-  version = "0.1.0";
+  version = "0.2.0";
 
   # .pem files for tests aren't present on PyPI
   src = fetchFromGitHub {
     owner = "pyauth";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0y96wsbci296m1rcxx0ybx8r44rdvyb59p1jl27p7rgz7isr3kx1";
+    sha256 = "1jsplqrxadjsc86f0kb6dgpblgwplxrpi0ql1a714w8pbbz4z3h7";
   };
 
-  propagatedBuildInputs = [ requests cryptography ];
+  propagatedBuildInputs = [
+    cryptography
+    requests
+  ];
 
-  checkPhase = ''
-    ${python.interpreter} test/test.py
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "test/test.py" ];
+
+  disabledTests = [
+    # Test require network access
+    "test_readme_example"
+  ];
+
+  pythonImportsCheck = [ "requests_http_signature" ];
 
   meta = with lib; {
     description = "A Requests auth module for HTTP Signature";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.0 and fix build.

ZHF: #122042
Ref: https://hydra.nixos.org/build/142027045

CC @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
