### PR TITLE
sqsh: fix build with freetds

### DIFF
--- a/pkgs/development/tools/sqsh/default.nix
+++ b/pkgs/development/tools/sqsh/default.nix
@@ -14,9 +14,6 @@ in stdenv.mkDerivation rec {
 
   preConfigure = ''
     export SYBASE=${freetds}
-
-    substituteInPlace src/cmd_connect.c \
-      --replace CS_TDS_80 CS_TDS_73
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace "libct.so" "libct.dylib"
   '';
@@ -26,6 +23,17 @@ in stdenv.mkDerivation rec {
   buildInputs = [ freetds readline libiconv ];
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  patches = [
+    (fetchurl {
+      # https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/databases/sqsh/patches/patch-src_cmd_connect_c
+      name = "patch-src_cmd_connect_c.patch";
+      url = "https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/databases/sqsh/patches/patch-src_cmd_connect_c?rev=1.2&content-type=text/plain";
+      sha256 = "1dz97knr2h0a0ca1vq2mx6h8s3ns9jb1a0qraa4wkfmcdi3aqw0j";
+    })
+  ];
+
+  patchFlags = [ "-p0" ];
 
   meta = with lib; {
     description = "Command line tool for querying Sybase/MSSQL databases";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042 

> 
> databases/sqsh: disable CS_SEC_NETWORKAUTH code, FreeTDS 1.2 introduces
> this but API seems different than sqsh expects (it wants things like
> CS_MAX_CHAR, CS_SEC_CHANBIND, CS_SEC_CONFIDENTIALITY, CS_SEC_INTEGRITY).
> breakage reported by aja@, thanks!

https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/databases/sqsh/patches/patch-src_cmd_connect_c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
