### PR TITLE
python3Packages.flufl_lock: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/flufl/lock.nix
+++ b/pkgs/development/python-modules/flufl/lock.nix
@@ -14,6 +14,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ atpublic psutil ];
   checkInputs = [ pytestCheckHook pytestcov sybil ];
 
+  # disable code coverage checks for all OS. Upstream does not enforce these
+  # checks on Darwin, and code coverage cannot be improved downstream nor is it
+  # relevant to the user.
+  pytestFlagsArray = [ "--no-cov" ];
+
   meta = with lib; {
     homepage = "https://flufllock.readthedocs.io/";
     description = "NFS-safe file locking with timeouts for POSIX and Windows";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Darwin builds were failing: https://hydra.nixos.org/build/142007699

This package is a dependency of cartopy (which is a key package for me).

ZHF: #122042

@jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
