### PR TITLE
php80Extensions.apcu_bc: mark as broken

### DIFF
--- a/pkgs/development/php-packages/apcu_bc/default.nix
+++ b/pkgs/development/php-packages/apcu_bc/default.nix
@@ -15,4 +15,5 @@ buildPecl {
   '';
 
   meta.maintainers = lib.teams.php.members;
+  meta.broken = lib.versionAtLeast php.version "8";
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF #122042
Failing Hydra build: https://hydra.nixos.org/build/142591498

`apcu_bc`[1] is a PHP extension which provides support for the older APC
caching-interface (i.e. `apc_fetch`, `apc_store` etc.) on newer PHP
versions. As the codebase wasn't touched since 2019 it's not really
surprising that it doesn't compile for PHP 8. Also, if people have
already managed to get their codebases running on PHP8, they're most
likely also using the newer APCu[2] interface.

I think it's okay to keep this as long as we support PHP 7.4 and drop
the package after that.

[1] https://pecl.php.net/package/apcu_bc
[2] https://www.php.net/manual/en/book.apcu.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
