### PR TITLE
exim: fix enableMySQL (use libmysqlclient.dev)

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
         s:^# \(LOOKUP_MYSQL_PC=libmysqlclient\)$:\1:
         s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -ldl -lm -lpthread -lz:
         s:^# \(LOOKUP_LIBS\)=.*:\1=-lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -ldl -lm -lpthread -lz:
-        s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${libmysqlclient}/include/mysql/:
+        s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${libmysqlclient.dev}/include/mysql/:
       ''}
       ${lib.optionalString enableAuthDovecot ''
         s:^# \(AUTH_DOVECOT\)=.*:\1=yes:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
When setting `enableMySQL=true` for exim via an overlay the build fails, because the `mysql.h` file cannot be found. That file exists in the dev-output of `libmysqlclient`.

For testing i ran `nix-build -E 'with (import ./default.nix {}); exim.override { enableMySQL = true; }'`.

before:

```sh
make[2]: Entering directory '/build/exim-4.94.2/build-Linux-x86_64/lookups'
cc dbmdb.c
cc dnsdb.c
cc dsearch.c
cc lsearch.c
cc mysql.c
mysql.c:16:10: fatal error: mysql.h: No such file or directory
   16 | #include <mysql.h>       /* The system header */
      |          ^~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:25: mysql.o] Error 1
make[2]: Leaving directory '/build/exim-4.94.2/build-Linux-x86_64/lookups'
make[1]: *** [Makefile:1012: buildlookups] Error 2
make[1]: Leaving directory '/build/exim-4.94.2/build-Linux-x86_64'
make: *** [Makefile:35: all] Error 2
```

after:

```sh
❯ ./result/bin/exim -bV | grep mysql
[...]
Lookups (built-in): [...] mysql
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
