### PR TITLE
steam-tui: init at 0.1.0

### DIFF
--- a/pkgs/games/steam-tui/default.nix
+++ b/pkgs/games/steam-tui/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, rustPlatform
+, steamcmd
+, fetchFromGitHub
+, steam-run-native
+, runtimeShell
+, withWine ? false
+, wine
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "steam-tui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "dmadisetti";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-UTXYlPecv0MVonr9zZwfwopfC/Fdch/ZSCxqgUsem40=";
+  };
+
+  cargoSha256 = "sha256-VYBzwDLSV4N4qt2dNgIS399T2HIbPTdQ2rDIeheLlfo=";
+
+  buildInputs = [ steamcmd steam-run-native ]
+    ++ lib.optional withWine wine;
+
+  preFixup = ''
+    mv $out/bin/steam-tui $out/bin/.steam-tui-unwrapped
+    cat > $out/bin/steam-tui <<EOF
+    #!${runtimeShell}
+    exec steam-run $out/bin/.steam-tui-unwrapped '$@'
+    EOF
+    chmod +x $out/bin/steam-tui
+  '';
+
+  meta = with lib; {
+    description = "Rust TUI client for steamcmd";
+    homepage = "https://github.com/dmadisetti/steam-tui";
+    license = licenses.mit;
+    maintainers = with maintainers; [ legendofmiracles ];
+    # steam only supports that platform
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28417,6 +28417,8 @@ in
     nativeOnly = true;
   }).run;
 
+  steam-tui = callPackage ../games/steam-tui { };
+
   steamcmd = steamPackages.steamcmd;
 
   protontricks = python3Packages.callPackage ../tools/package-management/protontricks {


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
