### PR TITLE
haskellPackages.taffybar: fix build

### DIFF
--- a/pkgs/applications/window-managers/taffybar/default.nix
+++ b/pkgs/applications/window-managers/taffybar/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, haskellPackages, makeWrapper, packages ? (x: []) }:
+{ lib, stdenv, ghcWithPackages, taffybar, makeWrapper, packages ? (x: []) }:
 
 let
-  taffybarEnv = haskellPackages.ghc.withPackages (self: [
+  taffybarEnv = ghcWithPackages (self: [
     self.taffybar
   ] ++ packages self);
 in stdenv.mkDerivation {
@@ -15,5 +15,14 @@ in stdenv.mkDerivation {
       --set NIX_GHC "${taffybarEnv}/bin/ghc"
   '';
 
-  inherit (haskellPackages.taffybar) meta;
+  # Trivial derivation
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  # For hacking purposes
+  passthru.env = taffybarEnv;
+  buildInputs = [ taffybarEnv ];
+  shellHook = "eval $(egrep ^export ${taffybarEnv}/bin/ghc)";
+
+  inherit (taffybar) meta;
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1271,6 +1271,20 @@ self: super: {
   # Created upstream PR @ https://github.com/ghcjs/jsaddle/pull/119
   jsaddle-webkit2gtk = appendPatch super.jsaddle-webkit2gtk ./patches/jsaddle-webkit2gtk.patch;
 
+  # 2021-05-12: gi-gdkpixbuf_2_0_26 fix
+  # https://github.com/taffybar/gtk-sni-tray/pull/25
+  gtk-sni-tray = appendPatch super.gtk-sni-tray (pkgs.fetchpatch {
+    url = "https://github.com/taffybar/gtk-sni-tray/pull/25/commits/4afd84654cb3f2bd2bb7d39451706c5914fd3cdf.patch";
+    sha256 = "1xjxlh58vnykqsjq4qw8mliq3gk17mwxi4h9z8dvjyav8zqg05rn";
+  });
+
+  # 2021-05-12: gi-gdkpixbuf_2_0_26 fix
+  # https://github.com/taffybar/taffybar/pull/507
+  taffybar = appendPatch super.taffybar (pkgs.fetchpatch {
+    url = "https://github.com/taffybar/taffybar/pull/507/commits/14a650d0954000cbd2cb1018a2f3bcd40ecb564f.patch";
+    sha256 = "01rm8zida5858j5r0mw7bpmv24b03mb3rw34lbkaw3i7g62bx3a0";
+  });
+
   # Missing -Iinclude parameter to doc-tests (pull has been accepted, so should be resolved when 0.5.3 released)
   # https://github.com/lehins/massiv/pull/104
   massiv = dontCheck super.massiv;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1699,7 +1699,6 @@ broken-packages:
   - gtk2hs-rpn
   - gtk3-mac-integration
   - gtkglext
-  - gtk-sni-tray
   - gtksourceview2
   - gtksourceview3
   - gtk-toy

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -233,6 +233,10 @@ package-maintainers:
     - hinit
   bdesham:
     - pinboard-notes-backup
+  rvl:
+    - taffybar
+    - arbtt
+    - lentil
 
 unsupported-platforms:
   Allure:                                       [ x86_64-darwin ]

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2886,7 +2886,6 @@ dont-distribute-packages:
  - systemstats
  - t3-client
  - ta
- - taffybar
  - tagged-list
  - tagged-th
  - tagsoup-navigate

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26320,7 +26320,9 @@ in
     # customConfig = builtins.readFile ./tabbed.config.h;
   };
 
-  taffybar = callPackage ../applications/window-managers/taffybar {};
+  taffybar = callPackage ../applications/window-managers/taffybar {
+    inherit (haskellPackages) ghcWithPackages taffybar;
+  };
 
   tagainijisho = callPackage ../applications/office/tagainijisho {};
 


### PR DESCRIPTION
###### Motivation for this change

Add patches to allow building with gi-gdkpixbuf_2_0_26

Upstream PRs:
 - https://github.com/taffybar/gtk-sni-tray/pull/25
 - https://github.com/taffybar/taffybar/pull/507

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
