### PR TITLE
vsftpd: fix build with gcc9

### DIFF
--- a/pkgs/servers/ftp/vsftpd/default.nix
+++ b/pkgs/servers/ftp/vsftpd/default.nix
@@ -24,7 +24,11 @@ stdenv.mkDerivation rec {
   '';
 
   NIX_LDFLAGS = "-lcrypt -lssl -lcrypto -lpam -lcap";
-  NIX_CFLAGS_COMPILE = "-Wno-error=enum-conversion";
+
+  # On gcc9, this would produce
+  #   error: '-Werror=enum-conversion': no option -Wenum-conversion
+  NIX_CFLAGS_COMPILE = lib.optionalString (lib.versionAtLeast stdenv.cc.version "10")
+    "-Wno-error=enum-conversion";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We still use that version on aarch64.
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/nixos-release-managers 