### PR TITLE
python3Packages.pytorch-bin: use CUDA 11 wheels

### DIFF
--- a/pkgs/development/python-modules/pytorch/binary-hashes.nix
+++ b/pkgs/development/python-modules/pytorch/binary-hashes.nix
@@ -1,17 +1,17 @@
 version: {
   x86_64-linux-37 = {
     name = "torch-${version}-cp37-cp37m-linux_x86_64.whl";
-    url = "https://download.pytorch.org/whl/cu102/torch-${version}%2Bcu102-cp37-cp37m-linux_x86_64.whl";
-    hash = "sha256-79JK2gGlV5Lhbim7GgPCjk++brwpUQE7g7vsrBu06eE=";
+    url = "https://download.pytorch.org/whl/cu111/torch-${version}%2Bcu111-cp37-cp37m-linux_x86_64.whl";
+    hash = "sha256-lxj066PiB+S88GqQnXKgd9RCiKkMk3mctx/eBieZjAk=";
   };
   x86_64-linux-38 = {
     name = "torch-${version}-cp38-cp38-linux_x86_64.whl";
-    url = "https://download.pytorch.org/whl/cu102/torch-${version}%2Bcu102-cp38-cp38-linux_x86_64.whl";
-    hash = "sha256-16h90SdxAgFxmPpgUPA3rBGxs9dtFaCeAgeSpKmtnmQ=";
+    url = "https://download.pytorch.org/whl/cu111/torch-${version}%2Bcu111-cp38-cp38-linux_x86_64.whl";
+    hash = "sha256-qvTQMLz4CQPgalzUyYwz6rm+ExyWlIzI+FSMQhxM4eM=";
   };
   x86_64-linux-39 = {
     name = "torch-${version}-cp39-cp39-linux_x86_64.whl";
-    url = "https://download.pytorch.org/whl/cu102/torch-${version}%2Bcu102-cp39-cp39-linux_x86_64.whl";
-    hash = "sha256-E3RLWpGYbRuKsz0pQv7npmC7WTbdvlYFaxXQYBKT2/8=";
+    url = "https://download.pytorch.org/whl/cu111/torch-${version}%2Bcu111-cp39-cp39-linux_x86_64.whl";
+    hash = "sha256-z0pzEiljU+E2x2SuOEAg86dmVY1iFZSDOCfoOAFhLQo=";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

CUDA 11 support newer GPUs.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
