### PR TITLE
wally-cli: remove unnecessary line (zsa/wally-cli/pulls/1 has long been m…

### DIFF
--- a/pkgs/development/tools/wally-cli/default.nix
+++ b/pkgs/development/tools/wally-cli/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "wally-cli";
-  version = "2.0.0";
+  version = "2.0.1";
 
   subPackages = [ "." ];
 
@@ -14,14 +14,11 @@ buildGoModule rec {
     owner = "zsa";
     repo = "wally-cli";
     rev = "${version}-linux";
-    sha256 = "0xz3z18bbnf736ngjj6jhnp3p2j55m5jhnb2xl6l5hybracfyhm7";
+    sha256 = "NuyQHEygy4LNqLtrpdwfCR+fNy3ZUxOClVdRen6AXMc=";
   };
 
-  vendorSha256 = "0jqx38x5qvir6zc5yq9p2adafwqhy4hil1k5g81rr1fvbn06k3a6";
+  vendorSha256 = "AVYG+aLpAXohUOORV/uPw7vro+Kg98+AmSmYGHtOals=";
   runVend = true;
-
-  # Can be removed when https://github.com/zsa/wally-cli/pull/1 is merged.
-  doCheck = false;
 
   meta = with lib; {
     description = "A tool to flash firmware to mechanical keyboards";


### PR DESCRIPTION
###### Motivation for this change
An extra line was in an application `default.nix` waiting for a [PR](https://github.com/zsa/wally-cli/pull/1) to be merged. It was merged ~222 days ago.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [N/A ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

*Note* I didn't know how to build this one package alone without using flakes (I ran `nix build '.#legacyPackages.x86_64-linux.wally-cli'`). If someone could tell me how to test the build of this package with `nix-build` (traditional way) I'd really appreciate it.

Thanks!

@spacekookie @r-burns 