### PR TITLE
jiq: init at 0.7.1

### DIFF
--- a/pkgs/development/tools/misc/jiq/default.nix
+++ b/pkgs/development/tools/misc/jiq/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub, jq, makeWrapper }:
+
+buildGoModule rec {
+  pname = "jiq";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "fiatjaf";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-EPhnfgmn0AufuxwcwRrEEQk+RD97akFJSzngkTl4LmY=";
+  };
+
+  vendorSha256 = "sha256-ZUmOhPGy+24AuxdeRVF0Vnu8zDGFrHoUlYiDdfIV5lc=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  checkInputs = [ jq ];
+
+  postInstall = ''
+    wrapProgram $out/bin/jiq \
+      --prefix PATH : ${lib.makeBinPath [ jq ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/fiatjaf/jiq";
+    license = licenses.mit;
+    description = "jid on jq - interactive JSON query tool using jq expressions";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5853,6 +5853,8 @@ in
 
   jq = callPackage ../development/tools/jq { };
 
+  jiq = callPackage ../development/tools/misc/jiq { };
+
   jql = callPackage ../development/tools/jql { };
 
   jo = callPackage ../development/tools/jo { };


### PR DESCRIPTION


###### Motivation for this change

[`jiq`](https://github.com/fiatjaf/jiq) is a tool which can be used to interactively develop `jq` expressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
