### PR TITLE
telfhash: add support for new TLSH hash format, which has been the default since TLSH 4.0.0. Deprecate support for the old format.

### DIFF
--- a/pkgs/development/python-modules/telfhash/default.nix
+++ b/pkgs/development/python-modules/telfhash/default.nix
@@ -17,6 +17,8 @@ buildPythonPackage {
     sha256 = "jNu6qm8Q/UyJVaCqwFOPX02xAR5DwvCK3PaH6Fvmakk=";
   };
 
+  patches = [ ./telfhash-new-tlsh-hash.patch ];
+
   # The tlsh library's name is just "tlsh"
   postPatch = ''
     substituteInPlace requirements.txt --replace "python-tlsh" "tlsh"

--- a/pkgs/development/python-modules/telfhash/telfhash-new-tlsh-hash.patch
+++ b/pkgs/development/python-modules/telfhash/telfhash-new-tlsh-hash.patch
@@ -1,0 +1,30 @@
+diff --git a/telfhash/grouping.py b/telfhash/grouping.py
+index c62f8d9..4ee9f0b 100644
+--- a/telfhash/grouping.py
++++ b/telfhash/grouping.py
+@@ -32,10 +32,10 @@ import tlsh
+ def get_combination(telfhash_data):
+ 
+     #
+-    # TLSH hash is 70 characters long. if the telfhash is not 70
++    # The new TLSH hash is 72 characters long. if the telfhash is not 72
+     # characters in length, exclude from the list
+     #
+-    files_list = [x for x in list(telfhash_data.keys()) if telfhash_data[x]["telfhash"] is not None and len(telfhash_data[x]["telfhash"]) == 70]
++    files_list = [x for x in list(telfhash_data.keys()) if telfhash_data[x]["telfhash"] is not None and len(telfhash_data[x]["telfhash"]) == 72]
+ 
+     #
+     # get the combination of all the possible pairs of filenames
+diff --git a/telfhash/telfhash.py b/telfhash/telfhash.py
+index f2bbd25..c6e346c 100755
+--- a/telfhash/telfhash.py
++++ b/telfhash/telfhash.py
+@@ -132,7 +132,7 @@ def get_hash(symbols_list):
+     symbol_string = ",".join(symbols_list)
+     encoded_symbol_string = symbol_string.encode("ascii")
+ 
+-    return tlsh.forcehash(encoded_symbol_string).lower()
++    return tlsh.forcehash(encoded_symbol_string)
+ 
+ 
+ def elf_get_imagebase(elf):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

telfhash has a bug so it doesn't support the new TLSH format, which has been the default since TLSH 4.0.0. The attached patch works around this issue, but removes support for older TLSH hashes, which I think is a reasonable trade off to make.

Also see: https://github.com/trendmicro/telfhash/issues/4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
