### PR TITLE
modemmanager: 1.14.10 -> 1.14.12

### DIFF
--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "modem-manager";
-  version = "1.14.10";
+  version = "1.14.12";
 
   package = "ModemManager";
   src = fetchurl {
     url = "https://www.freedesktop.org/software/${package}/${package}-${version}.tar.xz";
-    sha256 = "sha256-TqYLN1p2HhfnuwlbyolFee0OjjOyc9xpi1y+A5R/NX8=";
+    sha256 = "sha256-0QqXEZndwl3N8VbFasCOkWEsCVOdVlIueu1G1G5IO7E=";
   };
 
   nativeBuildInputs = [ vala gobject-introspection gettext pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
Version bump
https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/blob/1.14.12/NEWS
```
ModemManager 1.14.12
-------------------------------------------
This is a new bugfix release of ModemManager.

 * MBIM:
   ** Plug memleak in disconnection logic.
   ** Don't fail IPv4v6 connection attempt if only IPv4 succeeds.

 * QMI:
   ** Fix network registration cancellation logic with asserts disabled.
```

1.16.x (1.16.4 specifically) is already available but I haven't had the time/energy to actually look at why its tests are failing right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
