### PR TITLE
gparted: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/gparted/default.nix
+++ b/pkgs/tools/misc/gparted/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv, fetchurl, intltool, gettext, makeWrapper, coreutils, gnused, gnome
+{ lib, stdenv, fetchurl, intltool, gettext, coreutils, gnused, gnome
 , gnugrep, parted, glib, libuuid, pkg-config, gtkmm3, libxml2
 , gpart, hdparm, procps, util-linux, polkit, wrapGAppsHook, substituteAll
 }:
 
 stdenv.mkDerivation rec {
-  name = "gparted-1.2.0";
+  pname = "gparted";
+  version = "1.3.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/gparted/${name}.tar.gz";
-    sha256 = "sha256-bJBxXSVNen7AIIspAHtkFg3Z+330xKp/jsLJ0jEUxxk=";
+    url = "mirror://sourceforge/gparted/${pname}-${version}.tar.gz";
+    sha256 = "sha256-jcGAJF3Z6kXm4vS8aVEvGH4Ivn95nJioJaCwTBYcvSo=";
   };
 
   # Tries to run `pkexec --version` to get version.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Announce: https://gparted.org/news.php?item=238

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).



Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>gparted</li>
  </ul>
</details>