### PR TITLE
tinyproxy: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -1,6 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, perl, withDebug ? false
-, withXTinyProxy ? true, withFilter ? true, withUpstream ? true
-, withTransparent ? true, withReverse ? true, withManpageSupport ? true }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, perl, withDebug ? false }:
 
 with lib;
 stdenv.mkDerivation rec {
@@ -14,18 +12,10 @@ stdenv.mkDerivation rec {
     owner = "tinyproxy";
   };
 
-  nativeBuildInputs = [
-    autoreconfHook
-  ] ++ optionals withManpageSupport [ perl ];
+  # perl is needed for man page generation.
+  nativeBuildInputs = [ autoreconfHook perl ];
 
-  configureFlags =
-    optionals    (withDebug)           [ "--enable-debug" ]             # Enable debugging support code and methods.
-    ++ optionals (!withXTinyProxy)     [ "--disable-xtinyproxy" ]       # Compile in support for the XTinyproxy header, which is sent to any web server in your domain.
-    ++ optionals (!withFilter)         [ "--disable-filter"]            # Allows Tinyproxy to filter out certain domains and URLs.
-    ++ optionals (!withUpstream)       [ "--disable-upstream" ]         # Enable support for proxying connections through another proxy server.
-    ++ optionals (!withTransparent)    [ "--disable-transparent" ]      # Allow Tinyproxy to be used as a transparent proxy daemon.
-    ++ optionals (!withReverse)        [ "--disable-reverse" ]          # Enable reverse proxying.
-    ++ optionals (!withManpageSupport) [ "--disable-manpage_support" ]; # Enable support for building manpages.
+  configureFlags = optionals withDebug [ "--enable-debug" ]; # Enable debugging support code and methods.
 
   meta = {
     homepage = "https://tinyproxy.github.io/";

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://tinyproxy.github.io/";
     description = "A light-weight HTTP/HTTPS proxy daemon for POSIX operating systems";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.all;
     maintainers = [ maintainers.carlosdagos ];
   };

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -1,52 +1,33 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, asciidoc, libxml2,
-  libxslt, docbook_xsl }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, perl, withDebug ? false
+, withXTinyProxy ? true, withFilter ? true, withUpstream ? true
+, withTransparent ? true, withReverse ? true, withManpageSupport ? true }:
 
+with lib;
 stdenv.mkDerivation rec {
   pname = "tinyproxy";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
-    sha256 = "0gzapnllzyc005l3rs6iarjk1p5fc8mf9ysbck1mbzbd8xg6w35s";
+    sha256 = "13fhkmmrwzl657dq04x2wagkpjwdrzhkl141qvzr7y7sli8j0w1n";
     rev = version;
     repo = "tinyproxy";
     owner = "tinyproxy";
   };
 
-  nativeBuildInputs = [ autoreconfHook asciidoc libxml2 libxslt docbook_xsl ];
+  nativeBuildInputs = [
+    autoreconfHook
+  ] ++ optionals withManpageSupport [ perl ];
 
-  # -z flag is not supported in darwin
-  preAutoreconf = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace configure.ac --replace \
-          'LDFLAGS="-Wl,-z,defs $LDFLAGS"' \
-          'LDFLAGS="-Wl, $LDFLAGS"'
-  '';
+  configureFlags =
+    optionals    (withDebug)           [ "--enable-debug" ]             # Enable debugging support code and methods.
+    ++ optionals (!withXTinyProxy)     [ "--disable-xtinyproxy" ]       # Compile in support for the XTinyproxy header, which is sent to any web server in your domain.
+    ++ optionals (!withFilter)         [ "--disable-filter"]            # Allows Tinyproxy to filter out certain domains and URLs.
+    ++ optionals (!withUpstream)       [ "--disable-upstream" ]         # Enable support for proxying connections through another proxy server.
+    ++ optionals (!withTransparent)    [ "--disable-transparent" ]      # Allow Tinyproxy to be used as a transparent proxy daemon.
+    ++ optionals (!withReverse)        [ "--disable-reverse" ]          # Enable reverse proxying.
+    ++ optionals (!withManpageSupport) [ "--disable-manpage_support" ]; # Enable support for building manpages.
 
-  # See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=154624
-  postConfigure = ''
-    substituteInPlace docs/man5/Makefile --replace \
-          "-f manpage" \
-          "--xsltproc-opts=--nonet \\
-           -f manpage \\
-           -L"
-    substituteInPlace docs/man8/Makefile --replace \
-          "-f manpage" \
-          "--xsltproc-opts=--nonet \\
-           -f manpage \\
-           -L"
-  '';
-
-  configureFlags = [
-    "--disable-debug"      # Turn off debugging
-    "--enable-xtinyproxy"  # Compile in support for the XTinyproxy header, which is sent to any web server in your domain.
-    "--enable-filter"      # Allows Tinyproxy to filter out certain domains and URLs.
-    "--enable-upstream"    # Enable support for proxying connections through another proxy server.
-    "--enable-transparent" # Allow Tinyproxy to be used as a transparent proxy daemon.
-    "--enable-reverse"     # Enable reverse proxying.
-  ] ++
-  # See: https://github.com/tinyproxy/tinyproxy/issues/1
-  lib.optional stdenv.isDarwin "--disable-regexcheck";
-
-  meta = with lib; {
+  meta = {
     homepage = "https://tinyproxy.github.io/";
     description = "A light-weight HTTP/HTTPS proxy daemon for POSIX operating systems";
     license = licenses.gpl2;

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   # perl is needed for man page generation.
   nativeBuildInputs = [ autoreconfHook perl ];
 
-  configureFlags = optionals withDebug [ "--enable-debug" ]; # Enable debugging support code and methods.
+  configureFlags = lib.optionals withDebug [ "--enable-debug" ]; # Enable debugging support code and methods.
 
   meta = with lib; {
     homepage = "https://tinyproxy.github.io/";

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, perl, withDebug ? false }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "tinyproxy";
   version = "1.11.0";
@@ -17,7 +16,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = optionals withDebug [ "--enable-debug" ]; # Enable debugging support code and methods.
 
-  meta = {
+  meta = with lib; {
     homepage = "https://tinyproxy.github.io/";
     description = "A light-weight HTTP/HTTPS proxy daemon for POSIX operating systems";
     license = licenses.gpl2Only;


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest version.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
