### PR TITLE
mono: 5 -> 6

### DIFF
--- a/pkgs/applications/science/robotics/mission-planner/default.nix
+++ b/pkgs/applications/science/robotics/mission-planner/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper, unzip, mono6 }:
+{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper, unzip, mono }:
 
 let
   pname = "mission-planner";
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1cgpmsmmnbzw1lwsdafp8yklk1rwc61yf12vc1ahcc6bl7q2385x";
   };
 
-  nativeBuildInputs = [ makeWrapper mono6 unzip ];
+  nativeBuildInputs = [ makeWrapper mono unzip ];
   sourceRoot = ".";
 
   AOT_FILES = [ "MissionPlanner.exe" "MissionPlanner.*.dll" ];
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
     install -m 444 -D mpdesktop150.png $out/share/icons/mission-planner.png
     cp -r ${desktopItem}/share/applications $out/share/
     mv * $out/opt/mission-planner
-    makeWrapper ${mono6}/bin/mono $out/bin/mission-planner \
+    makeWrapper ${mono}/bin/mono $out/bin/mission-planner \
       --add-flags $out/opt/mission-planner/MissionPlanner.exe
     runHook postInstall
   '';

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv
 , fetchurl
-, mono6
+, mono
 , msbuild
 , dotnet-sdk
 , makeWrapper
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     chmod -R u+w $out/src
     mv $out/src/.msbuild/Current/{bin,Bin}
 
-    makeWrapper ${mono6}/bin/mono $out/bin/omnisharp \
+    makeWrapper ${mono}/bin/mono $out/bin/omnisharp \
     --add-flags "$out/src/OmniSharp.exe"
   '';
 

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
@@ -134,6 +134,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   meta = with lib; {
     description = "C# for Visual Studio Code (powered by OmniSharp)";
+    homepage = "https://github.com/OmniSharp/omnisharp-vscode";
     license = licenses.mit;
     maintainers = [ maintainers.jraygauthier ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
@@ -7,14 +7,12 @@
 , icu
 , stdenv
 , openssl
-, mono6
+, mono
 }:
 
 let
   # Get as close as possible as the `package.json` required version.
   # This is what drives omnisharp.
-  mono = mono6;
-
   rtDepsSrcsFromJson = builtins.fromJSON (builtins.readFile ./rt-deps-bin-srcs.json);
 
   rtDepsBinSrcs = builtins.mapAttrs (k: v:
@@ -114,7 +112,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     declare omnisharp_dir="$PWD/${omnisharp.installPath}"
     unzip_to "${omnisharp.bin-src}" "$omnisharp_dir"
     rm "$omnisharp_dir/bin/mono"
-    ln -s -T "${mono6}/bin/mono" "$omnisharp_dir/bin/mono"
+    ln -s -T "${mono}/bin/mono" "$omnisharp_dir/bin/mono"
     chmod a+x "$omnisharp_dir/run"
     touch "$omnisharp_dir/install.Lock"
 

--- a/pkgs/tools/graphics/snapdragon-profiler/default.nix
+++ b/pkgs/tools/graphics/snapdragon-profiler/default.nix
@@ -4,7 +4,7 @@
 , makeDesktopItem
 , copyDesktopItems
 , icoutils
-, mono6
+, mono
 , jre
 , androidenv
 , gtk-sharp-2_0
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    mono6
+    mono
     gtk-sharp-2_0
     gtk2
     libcxx
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
     mv *.so $out/lib
     cp -r * $out/lib/snapdragon-profiler
-    makeWrapper "${mono6}/bin/mono" $out/bin/snapdragon-profiler \
+    makeWrapper "${mono}/bin/mono" $out/bin/snapdragon-profiler \
       --add-flags "$out/lib/snapdragon-profiler/SnapdragonProfiler.exe" \
       --suffix PATH : ${lib.makeBinPath [ jre androidenv.androidPkgs_9_0.platform-tools coreutils ]} \
       --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10820,7 +10820,7 @@ in
 
   fsharp = callPackage ../development/compilers/fsharp { };
 
-  fsharp41 = callPackage ../development/compilers/fsharp41 { mono = mono6; };
+  fsharp41 = callPackage ../development/compilers/fsharp41 { };
 
   fstar = callPackage ../development/compilers/fstar {
     ocamlPackages = ocaml-ng.ocamlPackages_4_07;
@@ -11273,7 +11273,7 @@ in
 
   mlton = mlton20180207;
 
-  mono = mono5;
+  mono = mono6;
 
   mono4 = lowPrio (callPackage ../development/compilers/mono/4.nix {
     inherit (darwin) libobjc;
@@ -11292,9 +11292,9 @@ in
 
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
-  roslyn = callPackage ../development/compilers/roslyn { mono = mono6; };
+  roslyn = callPackage ../development/compilers/roslyn { };
 
-  msbuild = callPackage ../development/tools/build-managers/msbuild { mono = mono6; };
+  msbuild = callPackage ../development/tools/build-managers/msbuild { };
 
   mosml = callPackage ../development/compilers/mosml { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
6 packages marked as broken and skipped:
dotnetPackages.ExtCore gdata-sharp monodevelop python38Packages.pythonnet python39Packages.pythonnet ue4

20 packages failed to build:
appindicator-sharp bless dotnetPackages.FSharpAutoComplete dotnetPackages.MonoAddins dotnetPackages.Projekt gio-sharp gnome-sharp gtk-sharp-2_0 gtk-sharp-3_0 gtk-sharp-beans hyena mono-addins notify-sharp pdfmod pinta snapdragon-profiler sparkleshare supertux-editor tomboy webkit2-sharp

135 packages built:
avrdudess boogie bottles btcpayserver ckan convchain dafny dbus-sharp-1_0 dbus-sharp-glib-1_0 dbus-sharp-glib-2_0 dotnetPackages.Autofac dotnetPackages.Deedle dotnetPackages.ExcelDna dotnetPackages.ExcelDnaRegistration dotnetPackages.FSharpCompilerCodeDom dotnetPackages.FSharpCompilerService dotnetPackages.FSharpCompilerTools dotnetPackages.FSharpCore302 dotnetPackages.FSharpCore3125 dotnetPackages.FSharpCore4001 dotnetPackages.FSharpCore4117 dotnetPackages.FSharpData dotnetPackages.FSharpData225 dotnetPackages.FSharpDataSQLProvider dotnetPackages.FSharpFormatting dotnetPackages.Fake dotnetPackages.Fantomas dotnetPackages.FsCheck dotnetPackages.FsCheck262 dotnetPackages.FsCheckNunit dotnetPackages.FsLexYacc dotnetPackages.FsLexYacc706 dotnetPackages.FsLexYaccRuntime dotnetPackages.FsPickler dotnetPackages.FsUnit dotnetPackages.FuzzyLogicLibrary dotnetPackages.GitVersionTree dotnetPackages.MathNetNumerics dotnetPackages.MaxMindDb dotnetPackages.MaxMindGeoIP2 dotnetPackages.MicrosoftDiaSymReader dotnetPackages.MicrosoftDiaSymReaderPortablePdb dotnetPackages.MonoNat dotnetPackages.NDeskOptions dotnetPackages.NUnit dotnetPackages.NUnit3 dotnetPackages.NUnit350 dotnetPackages.NUnitConsole dotnetPackages.NUnitRunners dotnetPackages.NewtonsoftJson dotnetPackages.Nuget dotnetPackages.OpenNAT dotnetPackages.Paket dotnetPackages.RestSharp dotnetPackages.SharpFont dotnetPackages.SharpZipLib dotnetPackages.SmartIrc4net dotnetPackages.StyleCopMSBuild dotnetPackages.StyleCopPlusMSBuild dotnetPackages.Suave dotnetPackages.SystemCollectionsImmutable dotnetPackages.SystemCollectionsImmutable131 dotnetPackages.SystemReflectionMetadata dotnetPackages.SystemValueTuple dotnetPackages.UnionArgParser dotnetbuildhelpers duplicati eventstore foundationdb foundationdb51 foundationdb52 foundationdb60 fsharp fsharp41 github-runner haxePackages.hxcs jackett juniper keepass keepass-keeagent keepass-keefox keepass-keepasshttp keepass-otpkeyprov kodiPackages.steam-launcher lidarr lutris midisheetmusic mono mono5 msbuild nbxplorer omnisharp-roslyn openra openraPackages.engines.bleed openraPackages.engines.playtest openraPackages.mods.ca openraPackages.mods.d2 openraPackages.mods.dr openraPackages.mods.gen openraPackages.mods.kknd openraPackages.mods.mw openraPackages.mods.ra2 openraPackages.mods.raclassic openraPackages.mods.rv openraPackages.mods.sp openraPackages.mods.ss openraPackages.mods.ura openraPackages.mods.yr opentabletdriver osu-lazer pash playonlinux protontricks python-language-server python38Packages.foundationdb51 python38Packages.foundationdb52 python38Packages.foundationdb60 python38Packages.foundationdb61 python39Packages.foundationdb51 python39Packages.foundationdb52 python39Packages.foundationdb60 python39Packages.foundationdb61 radarr ryujinx sonarr steam steam-run steam-run-native steam-tui steamcmd syntex taglib-sharp vscode-extensions.ms-vscode.cpptools wasabibackend wavefunctioncollapse
```

I guess we should make `gtk-sharp-2_0` use `mono5`. Do all depending packages also have to use `mono5` then?