### PR TITLE
numworks-epsilon: 15.3.2 -> 15.5.0

### DIFF
--- a/pkgs/applications/science/math/numworks-epsilon/0001-ion-linux-makerules.patch
+++ b/pkgs/applications/science/math/numworks-epsilon/0001-ion-linux-makerules.patch
@@ -1,0 +1,12 @@
+diff --git a/ion/src/simulator/linux/Makefile b/ion/src/simulator/linux/Makefile
+index ca7da03fa..b05bba115 100644
+--- a/ion/src/simulator/linux/Makefile
++++ b/ion/src/simulator/linux/Makefile
+@@ -28,7 +28,6 @@ ion_src += $(addprefix ion/src/simulator/shared/, \
+   collect_registers.cpp \
+   haptics.cpp \
+   journal.cpp \
+-  platform_action_modifier_ctrl.cpp \
+   state_file.cpp \
+ )
+ 

--- a/pkgs/applications/science/math/numworks-epsilon/default.nix
+++ b/pkgs/applications/science/math/numworks-epsilon/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Emulator for Epsilon, a High-performance graphing calculator operating system";
+    description = "Simulator for Epsilon, a High-performance graphing calculator operating system";
     homepage = "https://numworks.com/";
     license = licenses.cc-by-nc-sa-40;
     maintainers = with maintainers; [ erikbackman ];

--- a/pkgs/applications/science/math/numworks-epsilon/default.nix
+++ b/pkgs/applications/science/math/numworks-epsilon/default.nix
@@ -2,6 +2,8 @@
 , lib
 , fetchFromGitHub
 , libpng
+, libjpeg
+, freetype
 , xorg
 , python3
 , imagemagick
@@ -11,18 +13,20 @@
 
 stdenv.mkDerivation rec {
   pname = "numworks-epsilon";
-  version = "15.3.2";
+  version = "15.5.0";
 
   src = fetchFromGitHub {
     owner = "numworks";
     repo = "epsilon";
     rev = version;
-    sha256 = "1q34dilyypiggjs16486jm122yf20wcigqxvspc77ig9albaxgh5";
+    sha256 = "fPBO3FzZ4k5OxG+Ifc6R/au4Te974HNKAEdHz+aFdSg=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libpng
+    libjpeg
+    freetype
     xorg.libXext
     python3
     imagemagick
@@ -31,6 +35,12 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PLATFORM=simulator"
+  ];
+
+  patches = [
+    # Remove make rule Introduced in cba596dde7
+    # which causes it to not build with nix
+    ./0001-ion-linux-makerules.patch
   ];
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
