### PR TITLE
mdbtools: 0.8.2 -> 0.9.3

### DIFF
--- a/pkgs/tools/misc/mdbtools/default.nix
+++ b/pkgs/tools/misc/mdbtools/default.nix
@@ -1,32 +1,26 @@
 { stdenv, lib, fetchFromGitHub, glib, readline
 , bison, flex, pkg-config, autoreconfHook, libxslt, makeWrapper
 , txt2man, which
-# withUi currently doesn't work. It compiles but fails to run.
-, withUi ? false, gtk2, gnome2
 }:
 
-let
-  uiDeps = [ gtk2 ] ++ (with gnome2; [ GConf libglade libgnomeui gnome-doc-utils ]);
-
-in
 stdenv.mkDerivation rec {
   pname = "mdbtools";
-  version = "0.8.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
-    owner = "cyberemissary";
+    owner = "mdbtools";
     repo = "mdbtools";
-    rev = version;
-    sha256 = "12rhf6rgnws6br5dn1l2j7i77q9p4l6ryga10jpax01vvzhr26qc";
+    rev = "v${version}";
+    sha256 = "11cv7hh8j8akpgm1a6pp7im6iacpgx6wzcg9n9rmb41j0fgxamdf";
   };
 
   configureFlags = [ "--disable-scrollkeeper" ];
 
   nativeBuildInputs = [
     pkg-config bison flex autoreconfHook txt2man which
-  ] ++ lib.optional withUi libxslt;
+  ];
 
-  buildInputs = [ glib readline ] ++ lib.optionals withUi uiDeps;
+  buildInputs = [ glib readline ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Updated to version 0.9.3.  This addresses numerous issues, including an
mdb-schema problem where debugging comments were included in the output.

Updated github repository owner to reflect new upstream for mdbtools.

Updated packaging to remove support for gmdb2.  Upstream split out
support for this largely unmaintained component to another repo:
https://github.com/mdbtools/gmdb2.  For more information, see:
https://github.com/mdbtools/mdbtools/blob/dev/NEWS

Note: Version tags in the repository are prefixed with a "v" starting
with the 0.9.0 series.  Also, the previous 0.8.2 tag does not exist in
the new upstream mdbtools repository.  The commit it pointed to is
still present as:

  commit b753ff36a0f1d88ae8a300ed6712f4aa2ddb7d08
  Author: Cyber Emissary <admin@cyberemissary.com>
  Date:   Fri Dec 28 08:03:02 2018 -0500

      Bumped version to 0.8.2 and updated change log

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest release and update repository source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@peterhoeg 