### PR TITLE
dcs: use yuicompressor instead of slimit and CSSMinifier

### DIFF
--- a/pkgs/tools/text/dcs/default.nix
+++ b/pkgs/tools/text/dcs/default.nix
@@ -1,8 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, python3Packages
-, perl
+, yuicompressor
 , zopfli
 , stdenv
 }:
@@ -23,8 +22,7 @@ buildGoModule {
   doCheck = false;
 
   nativeBuildInputs = [
-    python3Packages.slimit
-    (perl.withPackages (p: [ p.CSSMinifier ]))
+    yuicompressor
     zopfli
   ];
 


### PR DESCRIPTION
slimit appears to be unmaintained (and broken on Python 3.9), but we have
yuicompressor packaged which supercedes both slimit and CSSMinifier. Let's use
that instead.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/122354#issuecomment-835834098

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
