### PR TITLE
steam-tui: adds missing runtime dependencies correctly

### DIFF
--- a/pkgs/games/steam-tui/default.nix
+++ b/pkgs/games/steam-tui/default.nix
@@ -28,7 +28,8 @@ rustPlatform.buildRustPackage rec {
     mv $out/bin/steam-tui $out/bin/.steam-tui-unwrapped
     cat > $out/bin/steam-tui <<EOF
     #!${runtimeShell}
-    exec steam-run $out/bin/.steam-tui-unwrapped '$@'
+    export PATH=${steamcmd}/bin:\$PATH
+    exec ${steam-run-native}/bin/steam-run $out/bin/.steam-tui-unwrapped '\$@'
     EOF
     chmod +x $out/bin/steam-tui
   '';


### PR DESCRIPTION
###### Motivation for this change
I had steam and steam-run installed on my system when I tested this. Now it also without them being installed.
Pinging @SuperSandro2000 as he merged the other pull request and this here should be merged as quickly as possible.
I'm sorry for not having tried this earlier, without the dependencies installed 😬 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
