### PR TITLE
kbdd: unstable-2017-01-30 -> unstable-2021-04-26

### DIFF
--- a/pkgs/applications/window-managers/kbdd/default.nix
+++ b/pkgs/applications/window-managers/kbdd/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Simple daemon and library to make per window layout using XKB";
     homepage = "https://github.com/qnikst/kbdd";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.wedens ];
   };

--- a/pkgs/applications/window-managers/kbdd/default.nix
+++ b/pkgs/applications/window-managers/kbdd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "kbdd";
-  version = "unstable-2017-01-29";
+  version = "unstable-2021-04-26";
 
   src = fetchFromGitHub {
     owner = "qnikst";
     repo = "kbdd";
-    rev = "0e1056f066ab6e3c74fd0db0c9710a9a2b2538c3";
-    sha256 = "068iqkqxh7928xlmz2pvnykszn9bcq2qgkkiwf37k1vm8fdmgzlj";
+    rev = "3145099e1fbbe65b27678be72465aaa5b5872874";
+    sha256 = "1gzcjnflgdqnjgphiqpzwbcx60hm0h2cprncm7i8xca3ln5q6ba1";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Simple daemon and library to make per window layout using XKB";
     homepage = "https://github.com/qnikst/kbdd";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.wedens ];
   };


### PR DESCRIPTION
###### Motivation for this change
There was a bug in previous version, which was fixed in yearly 2021.
The bug was in EWMH compatability check in case of no active window at the time of kbdd initialization.

Also, previous update included commit which changed licence from GPL3 to GPL2, but licence in nix file wasn't updated.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
