### PR TITLE
rtorrent-jesec: 0.9.8-r10 -> 0.9.8-r13

### DIFF
--- a/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "rtorrent-jesec";
-  version = "0.9.8-r10";
+  version = "0.9.8-r13";
 
   src = fetchFromGitHub {
     owner = "jesec";
     repo = "rtorrent";
     rev = "v${version}";
-    sha256 = "sha256-Ge5W1rLaneUA7LxnBuMO/jQlqLOUKFf3gaAAlRr/qeM=";
+    sha256 = "1srn1ms7dvsn994zvb8i4m6gc144ygc7wc2a23bma79cqpl7drlw";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
Update rtorrent-jesec to latest: https://github.com/jesec/rtorrent/releases/tag/v0.9.8-r13

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
