### PR TITLE
rtl_433: 20.11 -> 21.05

### DIFF
--- a/pkgs/applications/radio/rtl_433/default.nix
+++ b/pkgs/applications/radio/rtl_433/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "20.11";
+  version = "21.05";
   pname = "rtl_433";
 
   src = fetchFromGitHub {
     owner = "merbanan";
     repo = "rtl_433";
     rev = version;
-    sha256 = "093bxjxkg7yf78wqj5gpijbfa2p05ny09qqsj84kzi1svnzsa369";
+    sha256 = "sha256-01mXOwLv16yTR65BboN+TFm2aE2EMfW1D5teDdW2wLg=";
   };
 
   nativeBuildInputs = [ pkg-config cmake ];

--- a/pkgs/applications/radio/rtl_433/default.nix
+++ b/pkgs/applications/radio/rtl_433/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Decode traffic from devices that broadcast on 433.9 MHz, 868 MHz, 315 MHz, 345 MHz and 915 MHz";
     homepage = "https://github.com/merbanan/rtl_433";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ earldouglas ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

Upstream release: https://github.com/merbanan/rtl_433/releases/tag/21.05

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
