### PR TITLE
supertux-editor: mark as broken

### DIFF
--- a/pkgs/applications/editors/supertux-editor/default.nix
+++ b/pkgs/applications/editors/supertux-editor/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     description = "Level editor for SuperTux";
     homepage = "https://github.com/SuperTux/supertux-editor";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ mathnerd314 ];
     platforms = platforms.linux;
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

SuperTux now uses an in-game editor, so there's no point in trying to build this old C# monstrosity.

I don't think it's actually broken yet, see #122759 for the change that breaks it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
