### PR TITLE
nixos-install-tools: init

### DIFF
--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -84,12 +84,12 @@ nixpkgs https://nixos.org/channels/nixpkgs-unstable</screen>
    </para>
    <para>
     You'll need <literal>nixos-generate-config</literal> and
-    <literal>nixos-install</literal> and we'll throw in some man pages and
-    <literal>nixos-enter</literal> just in case you want to chroot into your
-    NixOS partition. They are installed by default on NixOS, but you don't have
+    <literal>nixos-install</literal>, but this also makes some man pages
+    and <literal>nixos-enter</literal> available, just in case you want to chroot into your
+    NixOS partition. NixOS installs these by default, but you don't have
     NixOS yet..
    </para>
-<screen><prompt>$ </prompt>nix-env -f '&lt;nixpkgs/nixos&gt;' --arg configuration {} -iA config.system.build.{nixos-generate-config,nixos-install,nixos-enter,manual.manpages}</screen>
+   <screen><prompt>$ </prompt>nix-env -f '&lt;nixpkgs>' -iA nixos-install-tools</screen>
   </listitem>
   <listitem>
    <note>

--- a/pkgs/tools/nix/nixos-install-tools/default.nix
+++ b/pkgs/tools/nix/nixos-install-tools/default.nix
@@ -1,0 +1,67 @@
+{
+  buildEnv,
+  lib,
+  man,
+  nixos,
+  # TODO: replace indirect self-reference by proper self-reference
+  #       https://github.com/NixOS/nixpkgs/pull/119942
+  nixos-install-tools,
+  runCommand,
+}:
+let
+  inherit (nixos {}) config;
+  version = config.system.nixos.version;
+in
+(buildEnv {
+  name = "nixos-install-tools-${version}";
+  paths = lib.attrValues {
+    # See nixos/modules/installer/tools/tools.nix
+    inherit (config.system.build)
+      nixos-install nixos-generate-config nixos-enter;
+
+    # Required for --help.
+    inherit (config.system.build.manual) manpages;
+  };
+
+  extraOutputsToInstall = ["man"];
+
+  meta = {
+    description = "The essential commands from the NixOS installer as a package";
+    longDescription = ''
+      With this package, you get the commands like nixos-generate-config and
+      nixos-install that you would otherwise only find on a NixOS system, such
+      as an installer image.
+
+      This way, you can install NixOS using a machine that only has Nix.
+    '';
+    license = lib.licenses.mit;
+    homepage = "https://nixos.org";
+    platforms = lib.platforms.linux;
+  };
+
+  passthru.tests = {
+    nixos-install-help = runCommand "test-nixos-install-help" {
+      nativeBuildInputs = [
+        man
+        nixos-install-tools
+      ];
+      meta.description = ''
+        Make sure that --help works. It's somewhat non-trivial because it
+        requires man.
+      '';
+    } ''
+      nixos-install --help | grep -F 'NixOS Reference Pages'
+      nixos-install --help | grep -F 'configuration.nix'
+      nixos-generate-config --help | grep -F 'NixOS Reference Pages'
+      nixos-generate-config --help | grep -F 'hardware-configuration.nix'
+
+      # FIXME: Tries to call unshare, which it must not do for --help
+      # nixos-enter --help | grep -F 'NixOS Reference Pages'
+
+      touch $out
+    '';
+  };
+}).overrideAttrs (o: {
+  inherit version;
+  pname = "nixos-install-tools";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30271,6 +30271,8 @@ in
     (import ../../nixos/lib/make-options-doc/default.nix)
     ({ inherit pkgs lib; } // attrs);
 
+  nixos-install-tools = callPackage ../tools/nix/nixos-install-tools { };
+
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
   nixdoc = callPackage ../tools/nix/nixdoc {};


### PR DESCRIPTION
###### Motivation for this change

**Allow NixOS to be installed from a nix-shell.**
Doing so wasn't feasible before. Now it's just `nix-shell -p nixos-in[TAB]`.
Users can find it by themselves now and this change simplifies the manual as well.

Commit message:
The essential commands from the NixOS installer as a package

With this package, you get the commands like nixos-generate-config and
nixos-install that you would otherwise only find on a NixOS system, such
as an installer image.

This way, you can install NixOS using a machine that only has Nix.

It also includes the manpages, which are important because the commands
rely on those for providing --help.

###### Things done

I've tested this package by installing NixOS on a Hetzner machine via their rescue image.
Installing nix was needlessly complicated, but that's another topic. The first three lines shouldn't be necessary.

```shell
mkdir -m 0755 /nix && chown root /nix
groupadd nixbld
for i in `seq 1 32`; do useradd nixbld$i -G nixbld; done
curl -L https://nixos.org/nix/install | sh
. /root/.nix-profile/etc/profile.d/nix.sh
nix-shell -I nixpkgs=https://github.com/hercules-ci/nixpkgs/archive/nixpkgs-init-nixos-install-tools.tar.gz -p nixos-install-tools
```

Testing this installation method via a NixOS test is not quite feasible, because as far as I'm aware, we can't produce an image without these tools already baked in by NixOS.
I did include a simple test to make sure `--help` and therefore the manpages work.

-----

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
