### PR TITLE
virt-manager-qt: 0.71.95 -> 0.72.97

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/qt.nix
+++ b/pkgs/applications/virtualization/virt-manager/qt.nix
@@ -6,13 +6,13 @@
 
 mkDerivation rec {
   pname = "virt-manager-qt";
-  version = "0.71.95";
+  version = "0.72.97";
 
   src = fetchFromGitHub {
     owner  = "F1ash";
     repo   = "qt-virt-manager";
     rev    = version;
-    sha256 = "1s8753bzsjyixpv1c2l9d1xjcn8i47k45qj7pr50prc64ldf5f47";
+    sha256 = "0b2bx7ah35glcsiv186sc9cqdrkhg1vs9jz036k9byk61np0cb1i";
   };
 
   cmakeFlags = [
@@ -22,10 +22,9 @@ mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      # Maintainer note: Check whether this patch is still needed when a new version is released
-      name = "krdc-variable-name-changes.patch";
-      url = "https://github.com/fadenb/qt-virt-manager/commit/4640f5f64534ed7c8a1ecc6851f1c7503988de6d.patch";
-      sha256 = "1chl58nra1mj96n8jmnjbsyr6vlwkhn38afhwqsbr0bgyg23781v";
+      # drop with next update
+      url = "https://github.com/F1ash/qt-virt-manager/commit/0d338b037ef58c376d468c1cd4521a34ea181edd.patch";
+      sha256 = "1wjqyc5wsnxfwwjzgqjr9hcqhd867amwhjd712qyvpvz8x7p2s24";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
#122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
