### PR TITLE
awscli2: 2.2.1 -> 2.2.4

### DIFF
--- a/pkgs/development/python-modules/awscrt/default.nix
+++ b/pkgs/development/python-modules/awscrt/default.nix
@@ -5,7 +5,7 @@ buildPythonPackage rec {
   version = "0.11.13";
 
   buildInputs = lib.optionals stdenv.isDarwin
-    (with darwin.apple_sdk.frameworks; [ Security ]);
+    (with darwin.apple_sdk.frameworks; [ CoreFoundation Security ]);
 
   # Required to suppress -Werror
   # https://github.com/NixOS/nixpkgs/issues/39687

--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -3,12 +3,12 @@ let
   py = python3.override {
     packageOverrides = self: super: {
       botocore = super.botocore.overridePythonAttrs (oldAttrs: rec {
-        version = "2.0.0dev109";
+        version = "2.0.0dev112";
         src = fetchFromGitHub {
           owner = "boto";
           repo = "botocore";
-          rev = "b006ff741d12608a9187b873e276abd1fd8eb707";
-          sha256 = "sha256-uU3XVQiwtbBt7cdSwAeHkv6NUbL8kK2Ro44h1GYyA1A=";
+          rev = "221c0aa5dbad42f096e00fed45d2e2071561b1da";
+          sha256 = "sha256-uJCP3bUK/xACQVG4kMBDIIP+zPjre+uWbqWEC/gBTD4=";
         };
       });
       prompt_toolkit = super.prompt_toolkit.overridePythonAttrs (oldAttrs: rec {
@@ -31,13 +31,13 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.2.1"; # N.B: if you change this, change botocore to a matching version too
+  version = "2.2.4"; # N.B: if you change this, change botocore to a matching version too
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     rev = version;
-    sha256 = "sha256-TafYBkRlPCqewGBMgTfcX8kLtDhSCdiUYK1xXofKrLk=";
+    sha256 = "sha256-MctW31X012DXY16qS6AP6nLiaAt/cuA8iMwGm0oXi6M=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- api changes
- fix https://github.com/NixOS/nixpkgs/issues/122736


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
