### PR TITLE
vscode-extensions.WakaTime.vscode-wakatime: Fix path

### DIFF
--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -13,8 +13,8 @@ in
     };
 
     postPatch = ''
-      mkdir -p wakatime-master
-      cp -rt wakatime-master --no-preserve=all ${wakatime}/lib/python*/site-packages/wakatime
+      mkdir wakatime-cli
+      ln -s ${wakatime}/bin/wakatime ./wakatime-cli/wakatime-cli
     '';
 
     meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

WakaTime vscode extension now tries to find `wakatime-cli` executable which we don't provide, so the extension will download it and then fail.

Log from vscode developer tools:
```
[Extension Host] [WakaTime][DEBUG] Initializing WakaTime v4.0.9
[Extension Host] [WakaTime][DEBUG] Using standalone wakatime-cli.
[Extension Host] [WakaTime][DEBUG] Downloading wakatime-cli standalone...
 ERR EROFS: read-only file system, open '/home/berberman/.vscode/extensions/WakaTime.vscode-wakatime/wakatime-cli.zip': Error: EROFS: read-only file system, open '/home/berberman/.vscode/extensions/WakaTime.vscode-wakatime/wakatime-cli.zip'
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
