### PR TITLE
webex: init at 41.5.0.18815

### DIFF
--- a/pkgs/applications/networking/instant-messengers/webex/default.nix
+++ b/pkgs/applications/networking/instant-messengers/webex/default.nix
@@ -1,0 +1,114 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, makeWrapper
+, autoPatchelfHook
+, libGL
+, libX11
+, libXdamage
+, libXfixes
+, libXcomposite
+, libXrandr
+, cups
+, libxkbcommon
+, libsecret
+, libxcb
+, xcbutilwm
+, xcbutilrenderutil
+, xcbutilimage
+, xcbutilkeysyms
+, libdrm
+, libxshmfence
+, fontconfig
+, mesa
+, nss
+, wayland
+, udev
+, dbus
+, glib
+, libpulseaudio
+, alsaLib
+, at-spi2-core
+, at-spi2-atk
+, harfbuzz
+}:
+stdenv.mkDerivation {
+  pname = "webex";
+  version = "41.5.0.18815";
+
+  src = fetchurl {
+    # Official link: https://binaries.webex.com/WebexDesktop-Ubuntu-Official-Package/Webex.deb
+    # New versions get uploaded to same link, so lock url for this version in archive.org
+    url = "https://web.archive.org/web/20210529010325/https://binaries.webex.com/WebexDesktop-Ubuntu-Official-Package/Webex.deb";
+    sha256 = "sha256-U/m2pO+H1GqXyJ6k0Df0h1iynD13y3PPy/HPlHAXx2k=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    mesa.dev # for libgbm
+    libGL
+    libX11
+    libXdamage
+    libXfixes
+    libXcomposite
+    libXrandr
+    cups
+    libxkbcommon
+    libsecret
+    libxcb
+    xcbutilwm
+    xcbutilrenderutil
+    xcbutilimage
+    xcbutilkeysyms
+    libdrm
+    libxshmfence
+    fontconfig
+    nss
+    wayland
+    udev
+    dbus
+    glib
+    libpulseaudio
+    alsaLib
+    at-spi2-core
+    at-spi2-atk
+    harfbuzz
+  ];
+
+  dontBuild = true;
+
+  unpackPhase = ''
+    dpkg-deb -R $src .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/applications
+    cp -r opt $out/
+
+    wrapProgram $out/opt/Webex/bin/CiscoCollabHost \
+      --prefix LD_LIBRARY_PATH : $out/opt/Webex/lib
+    ln -s $out/opt/Webex/bin/CiscoCollabHost $out/bin/webex
+
+    substitute $out/opt/Webex/bin/webex.desktop $out/share/applications/webex.desktop \
+      --replace /opt/Webex/bin/ $out/opt/Webex/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    license = licenses.unfree;
+    homepage = "https://www.webex.com";
+    downloadPage = "https://www.webex.com/downloads.html";
+    maintainers = with maintainers; [ pacman99 ];
+    description = "Webex for Linux";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26971,6 +26971,8 @@ in
 
   webcamoid = libsForQt5.callPackage ../applications/video/webcamoid { };
 
+  webex = callPackage ../applications/networking/instant-messengers/webex { };
+
   webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
 
   webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};


### PR DESCRIPTION
###### Motivation for this change
closes #122744

I got it to install. And it even runs, but nothing actually shows up. There is no noticeable error either in the logs. It just starts with no GUI pop up and then exits without error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
