### PR TITLE
cxxopts: fix darwin build

### DIFF
--- a/pkgs/development/libraries/cxxopts/default.nix
+++ b/pkgs/development/libraries/cxxopts/default.nix
@@ -12,10 +12,16 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = lib.optional enableUnicodeHelp [ icu.dev ];
-  cmakeFlags = lib.optional enableUnicodeHelp [ "-DCXXOPTS_USE_UNICODE_HELP=TRUE" ];
+  cmakeFlags = [ "-DCXXOPTS_BUILD_EXAMPLES=OFF" ]
+    ++ lib.optional enableUnicodeHelp "-DCXXOPTS_USE_UNICODE_HELP=TRUE"
+    # Due to -Wsuggest-override, remove when cxxopts is updated
+    ++ lib.optional stdenv.isDarwin "-DCXXOPTS_ENABLE_WARNINGS=OFF";
   nativeBuildInputs = [ cmake ] ++ lib.optional enableUnicodeHelp [ pkg-config ];
 
   doCheck = true;
+
+  # Conflict on case-insensitive filesystems.
+  dontUseCmakeBuildDir = true;
 
   meta = with lib; {
     homepage = "https://github.com/jarro2783/cxxopts";


### PR DESCRIPTION
###### Motivation for this change

Darwin Hydra failure: https://hydra.nixos.org/build/142025157/log

I've been trying to fix the Darwin build, and the change here solves the immediate error from the log above, however it then fails with:

```
building
build flags: -j8 -l8 SHELL=/nix/store/30njb8l701pwnm5ya749fh2cgyc2d70m-bash-4.4-p23/bin/bash
[ 37%] Building CXX object src/CMakeFiles/example.dir/example.cpp.o
error: unknown warning option '-Wsuggest-override'; did you mean '-Wshift-overflow'? [-Werror,-Wunknown-warning-option]
```

This appears to have been fixed upstream, but there is no new release. I'm hesitant to upgrade the unstable version used here, because it is linked to the version of ydotool, which is also Linux only. Cherry picking the change would also be a custom patch in this case. So we're stuck, hence I propose we flag it as Linux-only.

ZHF: #122042
cc @NixOS/nixos-release-managers

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
