### PR TITLE
llvm*: patch to fix a test on older CPUs

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, llvm_meta
 , pkgsBuildBuild
 , fetch
+, fetchpatch
 , cmake
 , python3
 , libffi
@@ -57,6 +58,13 @@ in stdenv.mkDerivation (rec {
 
   patches = [
     ./gnu-install-dirs.patch
+    # On older CPUs (e.g. Hydra/wendy) we'd be getting an error in this test.
+    (fetchpatch {
+      name = "uops-CMOV16rm-noreg.diff";
+      url = "https://github.com/llvm/llvm-project/commit/9e9f991ac033.diff";
+      sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, llvm_meta
 , pkgsBuildBuild
 , fetch
+, fetchpatch
 , cmake
 , python3
 , libffi
@@ -57,6 +58,13 @@ in stdenv.mkDerivation (rec {
 
   patches = [
     ./gnu-install-dirs.patch
+    # On older CPUs (e.g. Hydra/wendy) we'd be getting an error in this test.
+    (fetchpatch {
+      name = "uops-CMOV16rm-noreg.diff";
+      url = "https://github.com/llvm/llvm-project/commit/9e9f991ac033.diff";
+      sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, llvm_meta
 , pkgsBuildBuild
 , fetch
+, fetchpatch
 , cmake
 , python3
 , libffi
@@ -56,10 +57,14 @@ in stdenv.mkDerivation (rec {
   propagatedBuildInputs = [ ncurses zlib ];
 
   patches = [
-    # Force a test to evaluate the saved benchmark for a CPU for which LLVM has
-    # an execution model. See NixOS/nixpkgs#119673.
-    ../../exegesis-force-bdver2.patch
     ./gnu-install-dirs.patch
+    # On older CPUs (e.g. Hydra/wendy) we'd be getting an error in this test.
+    (fetchpatch {
+      name = "uops-CMOV16rm-noreg.diff";
+      url = "https://github.com/llvm/llvm-project/commit/9e9f991ac033.diff";
+      sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -57,6 +57,9 @@ in stdenv.mkDerivation (rec {
 
   patches = [
     ./gnu-install-dirs.patch
+    # Force a test to evaluate the saved benchmark for a CPU for which LLVM has
+    # an execution model. See NixOS/nixpkgs#119673.
+    ../../exegesis-force-bdver2.patch
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''


### PR DESCRIPTION
- 10, 11, 12: use the upstream patch
- 9: use Luke's patch as the upstream patch won't apply

###### Motivation for this change
I recalled this when the old machine got back in Hydra :-)  but it won't hurt to fix this in any case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
