### PR TITLE
open-vm-tools: fix build with glib 2.68

### DIFF
--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -1,45 +1,87 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, autoreconfHook,
-  fuse, libmspack, openssl, pam, xercesc, icu, libdnet, procps, libtirpc, rpcsvc-proto,
-  libX11, libXext, libXinerama, libXi, libXrender, libXrandr, libXtst,
-  pkg-config, glib, gdk-pixbuf-xlib, gtk3, gtkmm3, iproute2, dbus, systemd, which,
-  withX ? true }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, autoreconfHook
+, fetchpatch
+, fuse
+, libmspack
+, openssl
+, pam
+, xercesc
+, icu
+, libdnet
+, procps
+, libtirpc
+, rpcsvc-proto
+, libX11
+, libXext
+, libXinerama
+, libXi
+, libXrender
+, libXrandr
+, libXtst
+, pkg-config
+, glib
+, gdk-pixbuf-xlib
+, gtk3
+, gtkmm3
+, iproute2
+, dbus
+, systemd
+, which
+, withX ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "open-vm-tools";
   version = "11.2.5";
 
   src = fetchFromGitHub {
-    owner  = "vmware";
-    repo   = "open-vm-tools";
-    rev    = "stable-${version}";
+    owner = "vmware";
+    repo = "open-vm-tools";
+    rev = "stable-${version}";
     sha256 = "sha256-Jv+NSKw/+l+b4lfVGgCZFlcTScO/WAO/d7DtI0FAEV4=";
   };
+
+  patches = [
+    # Fix build on new glib version.  Can be removed when next version is released.
+    (fetchpatch {
+      name = "open-vm-tools-glib-2.68.patch";
+      url = "https://github.com/vmware/open-vm-tools/commit/82931a1bcb39d5132910c7fb2ddc086c51d06662.patch";
+      sha256 = "sha256-Hr2j0tMSswhy7yNg10FCdqXxgutHcW+rl8ElS6WsWWA=";
+    })
+  ];
+  patchFlags = [
+    "-p2" # needed because of sourceRoot setting below
+    "-F3" # otherwise patch rejects AUTHORS file
+  ];
 
   sourceRoot = "${src.name}/open-vm-tools";
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config ];
-  buildInputs = [ fuse glib icu libdnet libmspack libtirpc openssl pam procps rpcsvc-proto xercesc ]
-      ++ lib.optionals withX [ gdk-pixbuf-xlib gtk3 gtkmm3 libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config rpcsvc-proto ];
+  buildInputs = [ fuse glib icu libdnet libmspack libtirpc openssl pam procps xercesc ]
+    ++ lib.optionals withX [ gdk-pixbuf-xlib gtk3 gtkmm3 libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
 
   postPatch = ''
-     # Build bugfix for 10.1.0, stolen from Arch PKGBUILD
-     mkdir -p common-agent/etc/config
-     sed -i 's|.*common-agent/etc/config/Makefile.*|\\|' configure.ac
+    # Build bugfix for 10.1.0, stolen from Arch PKGBUILD
+    mkdir -p common-agent/etc/config
+    sed -i 's|.*common-agent/etc/config/Makefile.*|\\|' configure.ac
 
-     sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' Makefile.am
-     sed -i 's,^confdir = ,confdir = ''${prefix},' scripts/Makefile.am
-     sed -i 's,usr/bin,''${prefix}/usr/bin,' scripts/Makefile.am
-     sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' services/vmtoolsd/Makefile.am
-     sed -i 's,$(PAM_PREFIX),''${prefix}/$(PAM_PREFIX),' services/vmtoolsd/Makefile.am
-     sed -i 's,$(UDEVRULESDIR),''${prefix}/$(UDEVRULESDIR),' udev/Makefile.am
+    sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' Makefile.am
+    sed -i 's,^confdir = ,confdir = ''${prefix},' scripts/Makefile.am
+    sed -i 's,usr/bin,''${prefix}/usr/bin,' scripts/Makefile.am
+    sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' services/vmtoolsd/Makefile.am
+    sed -i 's,$(PAM_PREFIX),''${prefix}/$(PAM_PREFIX),' services/vmtoolsd/Makefile.am
+    sed -i 's,$(UDEVRULESDIR),''${prefix}/$(UDEVRULESDIR),' udev/Makefile.am
 
-     # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
-     sed 1i'#include <sys/sysmacros.h>' -i lib/wiper/wiperPosix.c
+    # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
+    sed 1i'#include <sys/sysmacros.h>' -i lib/wiper/wiperPosix.c
 
-     # Make reboot work, shutdown is not in /sbin on NixOS
-     sed -i 's,/sbin/shutdown,shutdown,' lib/system/systemLinux.c
+    # Make reboot work, shutdown is not in /sbin on NixOS
+    sed -i 's,/sbin/shutdown,shutdown,' lib/system/systemLinux.c
   '';
 
   configureFlags = [ "--without-kernel-modules" "--without-xmlsecurity" ]
@@ -69,8 +111,8 @@ stdenv.mkDerivation rec {
       A set of services and modules that enable several features in VMware products for
       better management of, and seamless user interactions with, guests.
     '';
-    license = licenses.gpl2;
-    platforms =  [ "x86_64-linux" "i686-linux" ];
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ joamaki ];
   };
 }


### PR DESCRIPTION
Also apply nixpkgs-format.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix failing build, see e.g. https://hydra.nixos.org/build/142620456

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [z] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
