### PR TITLE
haskellPackages: mark linux-only packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -345,6 +345,19 @@ unsupported-platforms:
   xmobar:                                       [ x86_64-darwin ]
   xmonad-extras:                                [ x86_64-darwin ]
   xmonad-volume:                                [ x86_64-darwin ]
+  # No specific Darwin support.
+  honk:                                         [ x86_64-darwin ]
+  Unixutils-shadow:                             [ x86_64-darwin ]
+  # Linux-only by design.
+  follow-file:                                  [ x86_64-darwin ]
+  hinotify-bytestring:                          [ x86_64-darwin ]
+  linux-evdev:                                  [ x86_64-darwin ]
+  linux-file-extents:                           [ x86_64-darwin ]
+  linux-inotify:                                [ x86_64-darwin ]
+  linux-mount:                                  [ x86_64-darwin ]
+  linux-namespaces:                             [ x86_64-darwin ]
+  netlink:                                      [ x86_64-darwin ]
+  parport:                                      [ x86_64-darwin ]
 
 dont-distribute-packages:
   # Depends on shine, which is a ghcjs project.


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers, @NixOS/haskell

A small subset of Haskell packages that are currently failing on Darwin are simply not supported on Darwin by design, but not marked as such. This PR adds a helper and starts a list of these packages. I also included `cpuid` and `hsignal` under this helper umbrella, because they do a similar thing, but for x86-only.

Haskell in Nix has the `unsupported-platforms` list, but it's flexibility is limited, only allowing to eliminate specific platforms. For example, marking a package as not supported on Darwin would've worked for a while with `x86_64-darwin`,  but then we got `aarch64-darwin`. Similarly, marking a package as Linux-only is impossible: there is no opposite `supported-platforms`, plus we're continuously adding Linux platforms like `riscv64-linux`.

I think fixing this properly is outside the scope of ZHF and the upcoming release, and hopefully this stop-gap solution is okay for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
