### PR TITLE
nixos/jupyter: set isSystemUser

### DIFF
--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -197,6 +197,7 @@ in {
         home = "/var/lib/jupyter";
         createHome = true;
         useDefaultShell = true; # needed so that the user can start a terminal.
+        isSystemUser = true;
       };
     })
   ];


### PR DESCRIPTION
###### Motivation for this change
This fixes the following error on evaluation:
Exactly one of users.users.jupyter.isSystemUser and users.users.jupyter.isNormalUser must be set.


###### Things done

- [x] Rebuilt my NixOS system and used jupyter
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
