### PR TITLE
erlang-ls: add erlang to buildInputs

### DIFF
--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, fetchHex, stdenv, rebar3WithPlugins, lib }:
+{ fetchFromGitHub, fetchHex, stdenv, erlang, rebar3WithPlugins, lib }:
 let
   version = "0.15.0";
   owner = "erlang-ls";
@@ -7,7 +7,7 @@ let
 in stdenv.mkDerivation {
   inherit version;
   pname = "erlang-ls";
-  buildInputs = [ (rebar3WithPlugins { }) ];
+  buildInputs = [ erlang (rebar3WithPlugins { }) ];
   src = fetchFromGitHub {
     inherit owner repo;
     sha256 = "1s6zk8r5plm7ajifz17mvfrnk5mzbhj7alayink9phqbmzrypnfg";


### PR DESCRIPTION
This enables patch-shebangs to find `escript` and patch the interpreter
path correctly, so that `erlang_ls` works without erlang available on PATH

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
