### PR TITLE
.github/workflows/merge-staging.yml: Include branch in comment

### DIFF
--- a/.github/workflows/merge-staging.yml
+++ b/.github/workflows/merge-staging.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Merge master into staging-next
+        id: staging_next
         uses: devmasx/merge-branch@v1.3.1
         with:
           type: now
@@ -22,6 +23,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge staging-next into staging
+        id: staging
         uses: devmasx/merge-branch@v1.3.1
         with:
           type: now
@@ -35,5 +37,5 @@ jobs:
         with:
           issue-number: 105153
           body: |
-            An automatic merge [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
+            An automatic merge${{ (steps.staging_next.outcome == 'failure' && ' from master to staging-next') || ((steps.staging.outcome == 'failure' && ' from staging-next to staging') || '') }} [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

If I receive the mail notification that staging(-next) merge failed, I either need to check `git log staging-next` or click the action run link to find out where should I resolve the conflict.

To save time, let’s include the information about which step failed right in the comment.

###### Things done

Tested in: https://github.com/jtojnar/repro/issues/2