### PR TITLE
unpackerr: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7335,6 +7335,12 @@
     githubId = 1839979;
     name = "Niklas Thörne";
   };
+  nullx76 = {
+    email = "nix@xirion.net";
+    github = "NULLx76";
+    githubId = 1809198;
+    name = "Victor Roest";
+  };
   numinit = {
     email = "me@numin.it";
     github = "numinit";

--- a/pkgs/servers/unpackerr/default.nix
+++ b/pkgs/servers/unpackerr/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "unpackerr";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "davidnewhall";
+    repo = "unpackerr";
+    rev = "v${version}";
+    sha256 = "0ss12i8bclz1q9jgr54shvs8zgcs6jrwdm1vj9gvycyd5sx4717s";
+  };
+
+  vendorSha256 = "1j79vmf0mkwkqrg5j6fm2b8y3a23y039kbiqkiwb56724bmd27dd";
+
+  meta = with lib; {
+    description = "Extracts downloads for Radarr, Sonarr, Lidarr - Deletes extracted files after import";
+    homepage = "https://github.com/davidnewhall/unpackerr";
+    maintainers = with maintainers; [ nullx76 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19578,6 +19578,8 @@ in
     unifi6;
   unifi = unifi6;
 
+  unpackerr = callPackage ../servers/unpackerr { };
+
   urserver = callPackage ../servers/urserver { };
 
   victoriametrics = callPackage ../servers/nosql/victoriametrics { };


### PR DESCRIPTION
###### Motivation for this change
This adds [unpackerr](https://github.com/davidnewhall/unpackerr) a program to automaticially extract downloads initiated by Radarr, Sonarr and Lidarr (all of which are already in nixpkgs).

A module for running it as service may follow, I already have something working [here](https://git.xirion.net/0x76/nixos-configs/src/branch/main/common/services/unpackerr.nix).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
