### PR TITLE
openslide: init at 3.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5886,6 +5886,12 @@
     githubId = 10626;
     name = "Andreas Wagner";
   };
+  lromor = {
+    email = "leonardo.romor@gmail.com";
+    github = "lromor";
+    githubId = 1597330;
+    name = "Leonardo Romor";
+  };
   lrworth = {
     email = "luke@worth.id.au";
     name = "Luke Worth";

--- a/pkgs/development/libraries/openslide/default.nix
+++ b/pkgs/development/libraries/openslide/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook
+, pkg-config, cairo, glib, gdk-pixbuf, libjpeg
+, libpng, libtiff, libxml2, openjpeg, sqlite, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openslide";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "openslide";
+    repo = "openslide";
+    rev = "v${version}";
+    sha256 = "1g4hhjr4cbx754cwi9wl84k33bkg232w8ajic7aqhzm8x182hszp";
+  };
+
+  buildInputs = [ cairo glib gdk-pixbuf libjpeg libpng libtiff libxml2 openjpeg sqlite zlib ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  meta = with lib; {
+    homepage = "https://openslide.org";
+    description = "A C library that provides a simple interface to read whole-slide images.";
+    license = licenses.lgpl21;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ lromor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17084,6 +17084,8 @@ in
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Foundation;
   };
 
+  openslide = callPackage ../development/libraries/openslide { };
+
   openslp = callPackage ../development/libraries/openslp {};
 
   openvdb = callPackage ../development/libraries/openvdb {};


### PR DESCRIPTION
OpenSlide is a C library that provides a simple interface to read whole-slide images (also known as virtual slides). 

https://openslide.org

###### Motivation for this change

I want to add this library to add support to openslide images in nix.
A similar package is present for debian: https://packages.debian.org/bullseye/libopenslide0
I'm happy to help the nix community and maintain this package!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
