### PR TITLE
fakeroot: fix Darwin by applying an additional patch from Brew

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -37,6 +37,18 @@ stdenv.mkDerivation rec {
     sed -i -e "s@getopt@$(type -p getopt)@g" -e "s@sed@$(type -p sed)@g" ${pname}-${version}/scripts/fakeroot.in
   '';
 
+  postConfigure = let
+    # additional patch from brew, but needs to be applied to a generated file
+    patch-wraptmpf = fetchpatch {
+      name = "fakeroot-patch-wraptmpf-h.patch";
+      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=3;bug=766649;filename=fakeroot-patch-wraptmpf-h.patch;msg=20";
+      sha256 = "1jhsi4bv6nnnjb4vmmmbhndqg719ckg860hgw98bli8m05zwbx6a";
+    };
+  in lib.optional stdenv.isDarwin ''
+    make wraptmpf.h
+    patch -p1 < ${patch-wraptmpf}
+  '';
+
   meta = {
     homepage = "https://salsa.debian.org/clint/fakeroot";
     description = "Give a fake root environment through LD_PRELOAD";


### PR DESCRIPTION
I was testing cross-building of Linux Docker images on macOS hosts. It almost works except for a runtime linker error with `libfakeroot`. The reason is that the patchset ported over from Brew is currently incomplete. One additional patch is missing, but it needs to be applied to a generated file, so an intermediate `make` as to run first.

I ported the change from the [`fakeroot` Brew formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/fakeroot.rb#L52-L76). The patch [is explained upstream](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766649#20).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).