### PR TITLE
yafetch: init at unstable-2021-05-13

### DIFF
--- a/pkgs/tools/misc/yafetch/default.nix
+++ b/pkgs/tools/misc/yafetch/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitLab }:
+
+stdenv.mkDerivation rec {
+  pname = "yafetch";
+  version = "unstable-2021-05-13";
+
+  src = fetchFromGitLab {
+    owner = "cyberkitty";
+    repo = pname;
+    rev = "627465e6bf0192a9bc10f9c9385cde544766486f";
+    sha256 = "1r8jnzfyjs5ardq697crwysclfm3k8aiqvfbsyhsl251a08yls5c";
+  };
+
+  # Use the provided NixOS logo automatically
+  prePatch = ''
+    echo "#include \"ascii/nixos.h\"" > config.h
+  '';
+
+  # Fixes installation path
+  DESTDIR = placeholder "out";
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/cyberkitty/yafetch";
+    description = "Yet another fetch clone written in C++";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -818,6 +818,10 @@ in
     wine = wineWowPackages.staging;
   };
 
+  yafetch = callPackage ../tools/misc/yafetch {
+    stdenv = clangStdenv;
+  };
+
   ### APPLICATIONS/TERMINAL-EMULATORS
 
   alacritty = callPackage ../applications/terminal-emulators/alacritty {


### PR DESCRIPTION

###### Motivation for this change
A minimal, and fast fetch clone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
