### PR TITLE
copper: 4.4 -> 4.5

### DIFF
--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -4,15 +4,17 @@
 }:
 stdenv.mkDerivation rec {
   pname = "copper";
-  version = "4.4";
+  version = "4.5";
+
   src = fetchurl {
     url = "https://tibleiz.net/download/copper-${version}-src.tar.gz";
-    sha256 = "1nf0bw143rjhd019yms3k6k531rahl8anidwh6bif0gm7cngfwfw";
+    sha256 = "133xavmpi8si9pybx57knpx7wvx59bpr7gvr8gwilcn9gs5g7yhj";
   };
   buildInputs = [
     libffi
   ];
   postPatch = ''
+    substituteInPlace Makefile --replace "CC=gcc" "CC?=gcc"
     substituteInPlace Makefile --replace "-s scripts/" "scripts/"
     patchShebangs .
   '';
@@ -27,6 +29,7 @@ stdenv.mkDerivation rec {
     description = "Simple imperative language, statically typed with type inference and genericity";
     homepage = "https://tibleiz.net/copper/";
     license = licenses.bsd2;
+    broken = stdenv.isDarwin;
     platforms = platforms.x86_64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://nix-cache.s3.amazonaws.com/log/qhk2m29qwx0pwwv4gydpkyq7ldciwjq0-copper-4.4.drv
Once you fix the obvious error of looking for gcc in the makefile, it fails on darwin like this: https://gist.github.com/rmcgibbo/592646f3637232a57ae016d198e6006b
So I marked it as broken on darwin
ZHF: #122042


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
