### PR TITLE
Set resolveconf to localhost only when the user does not specify any …

### DIFF
--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -25,7 +25,7 @@ let
     '' + optionalString (length resolvconfOptions > 0) ''
       # Options as described in resolv.conf(5)
       resolv_conf_options='${concatStringsSep " " resolvconfOptions}'
-    '' + optionalString cfg.useLocalResolver ''
+    '' + optionalString (config.networking.nameservers == [] && cfg.useLocalResolver) ''
       # This hosts runs a full-blown DNS resolver.
       name_servers='127.0.0.1'
     '' + cfg.extraConfig;

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -209,8 +209,7 @@ in
 
   config = mkIf cfg.enable {
 
-    # Set resolver to default to local when the user does not specify nameservers.
-    networking.resolvconf.useLocalResolver = mkDefault config.networking.nameservers == [];
+    networking.resolvconf.useLocalResolver = true;
 
     users.users.${bindUser} =
       {

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -209,7 +209,7 @@ in
 
   config = mkIf cfg.enable {
 
-    networking.resolvconf.useLocalResolver = true;
+    networking.resolvconf.useLocalResolver = mkDefault true;
 
     users.users.${bindUser} =
       {

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -209,7 +209,8 @@ in
 
   config = mkIf cfg.enable {
 
-    networking.resolvconf.useLocalResolver = mkDefault true;
+    # Set resolver to default to local when the user does not specify nameservers.
+    networking.resolvconf.useLocalResolver = mkDefault config.networking.nameservers == [];
 
     users.users.${bindUser} =
       {


### PR DESCRIPTION
…nameservers.

The problem was that when the user defines `networking.nameservers` and then enables `services.bind`
the user's name servers are ignored. This violates the principle of least surprise.

This change sets the default only when the user does not specify any name servers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] NixOps
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
