### PR TITLE
Postman: 7.36.1 -> 8.4.0, add libdrm and mesa which were missing (according #111382)

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,16 +2,16 @@
 , atk, at-spi2-atk, at-spi2-core, alsaLib, cairo, cups, dbus, expat, gdk-pixbuf, glib, gtk3
 , freetype, fontconfig, nss, nspr, pango, udev, libuuid, libX11, libxcb, libXi
 , libXcursor, libXdamage, libXrandr, libXcomposite, libXext, libXfixes
-, libXrender, libXtst, libXScrnSaver
+, libXrender, libXtst, libXScrnSaver, libdrm, mesa
 }:
 
 stdenv.mkDerivation rec {
   pname = "postman";
-  version = "7.36.1";
+  version = "8.4.0";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "sha256-6brThKTAQI3cu3SSqvEIT1nwlQ/jPTP+d/Q/m/Ez5nQ=";
+    sha256 = "040l0g6m8lmjrm0wvq8z13xyddasz7v95v54d658w14gv0n713vw";
     name = "${pname}.tar.gz";
   };
 
@@ -43,10 +43,12 @@ stdenv.mkDerivation rec {
     gtk3
     freetype
     fontconfig
+    mesa
     nss
     nspr
     pango
     udev
+    libdrm
     libuuid
     libX11
     libxcb


### PR DESCRIPTION
###### Motivation for this change
Getting latest version of Postman

###### Things done
Updated version and hashes, tested (failed), added missing libraries and tested successful.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [?] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s) -> Enabled by default so assuming yes
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) - About 5 MB diff?
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
