### PR TITLE
nixos/modules: Nicer nice level handling

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -270,6 +270,8 @@ rec {
         s32 = sign 32 4294967296;
       };
 
+    niceness = types.ints.between (-20) 19;
+
     # Alias of u16 for a port number
     port = ints.u16;
 

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -756,6 +756,13 @@
           this up.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The option <literal>services.freenet.nice</literal> has been
+          renamed to
+          <link xlink:href="options.html#opt-services.freenet.daemonNiceLevel">services.freenet.daemonNiceLevel</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -763,6 +763,13 @@
           <link xlink:href="options.html#opt-services.freenet.daemonNiceLevel">services.freenet.daemonNiceLevel</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The option <literal>services.icecream.nice</literal> has been
+          renamed to
+          <link xlink:href="options.html#opt-services.icecream.daemonNiceLevel">services.icecream.daemonNiceLevel</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -758,6 +758,13 @@
       </listitem>
       <listitem>
         <para>
+          The option <literal>services.btrbk.nice</literal> has been
+          renamed to
+          <link xlink:href="options.html#opt-services.btrbk.daemonNiceLevel">services.btrbk.daemonNiceLevel</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The option <literal>services.freenet.nice</literal> has been
           renamed to
           <link xlink:href="options.html#opt-services.freenet.daemonNiceLevel">services.freenet.daemonNiceLevel</link>.

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -196,3 +196,5 @@ pt-services.clipcat.enable).
 - The [services.syncoid.enable](options.html#opt-services.syncoid.enable) module now properly drops ZFS permissions after usage. Before it delegated permissions to whole pools instead of datasets and didn't clean up after execution. You can manually look this up for your pools by running `zfs allow your-pool-name` and use `zfs unallow syncoid your-pool-name` to clean this up.
 
 - The option `services.freenet.nice` has been renamed to [services.freenet.daemonNiceLevel](options.html#opt-services.freenet.daemonNiceLevel).
+
+- The option `services.icecream.nice` has been renamed to [services.icecream.daemonNiceLevel](options.html#opt-services.icecream.daemonNiceLevel).

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -194,3 +194,5 @@ pt-services.clipcat.enable).
 - The [networking.wireless.iwd](options.html#opt-networking.wireless.iwd.enable) module has a new [networking.wireless.iwd.settings](options.html#opt-networking.wireless.iwd.settings) option.
 
 - The [services.syncoid.enable](options.html#opt-services.syncoid.enable) module now properly drops ZFS permissions after usage. Before it delegated permissions to whole pools instead of datasets and didn't clean up after execution. You can manually look this up for your pools by running `zfs allow your-pool-name` and use `zfs unallow syncoid your-pool-name` to clean this up.
+
+- The option `services.freenet.nice` has been renamed to [services.freenet.daemonNiceLevel](options.html#opt-services.freenet.daemonNiceLevel).

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -195,6 +195,8 @@ pt-services.clipcat.enable).
 
 - The [services.syncoid.enable](options.html#opt-services.syncoid.enable) module now properly drops ZFS permissions after usage. Before it delegated permissions to whole pools instead of datasets and didn't clean up after execution. You can manually look this up for your pools by running `zfs allow your-pool-name` and use `zfs unallow syncoid your-pool-name` to clean this up.
 
+- The option `services.btrbk.nice` has been renamed to [services.btrbk.daemonNiceLevel](options.html#opt-services.btrbk.daemonNiceLevel).
+
 - The option `services.freenet.nice` has been renamed to [services.freenet.daemonNiceLevel](options.html#opt-services.freenet.daemonNiceLevel).
 
 - The option `services.icecream.nice` has been renamed to [services.icecream.daemonNiceLevel](options.html#opt-services.icecream.daemonNiceLevel).

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -1,18 +1,21 @@
 { config, pkgs, lib, ... }:
+
+with lib;
+
 let
   cfg = config.services.btrbk;
   sshEnabled = cfg.sshAccess != [ ];
   serviceEnabled = cfg.instances != { };
   attr2Lines = attr:
     let
-      pairs = lib.attrsets.mapAttrsToList (name: value: { inherit name value; }) attr;
+      pairs = attrsets.mapAttrsToList (name: value: { inherit name value; }) attr;
       isSubsection = value:
         if builtins.isAttrs value then true
         else if builtins.isString value then false
         else throw "invalid type in btrbk config ${builtins.typeOf value}";
-      sortedPairs = lib.lists.partition (x: isSubsection x.value) pairs;
+      sortedPairs = lists.partition (x: isSubsection x.value) pairs;
     in
-    lib.flatten (
+    flatten (
       # non subsections go first
       (
         map (pair: [ "${pair.name} ${pair.value}" ]) sortedPairs.wrong
@@ -22,7 +25,7 @@ let
         map
           (
             pair:
-            lib.mapAttrsToList
+            mapAttrsToList
               (
                 childname: value:
                   [ "${pair.name} ${childname}" ] ++ (map (x: " " + x) (attr2Lines value))
@@ -34,7 +37,7 @@ let
     )
   ;
   addDefaults = settings: { backend = "btrfs-progs-sudo"; } // settings;
-  mkConfigFile = settings: lib.concatStringsSep "\n" (attr2Lines (addDefaults settings));
+  mkConfigFile = settings: concatStringsSep "\n" (attr2Lines (addDefaults settings));
   mkTestedConfigFile = name: settings:
     let
       configFile = pkgs.writeText "btrbk-${name}.conf" (mkConfigFile settings);
@@ -53,35 +56,35 @@ in
 {
   options = {
     services.btrbk = {
-      extraPackages = lib.mkOption {
+      extraPackages = mkOption {
         description = "Extra packages for btrbk, like compression utilities for <literal>stream_compress</literal>";
-        type = lib.types.listOf lib.types.package;
+        type = types.listOf types.package;
         default = [ ];
-        example = lib.literalExample "[ pkgs.xz ]";
+        example = literalExample "[ pkgs.xz ]";
       };
-      niceness = lib.mkOption {
+      niceness = mkOption {
         description = "Niceness for local instances of btrbk. Also applies to remote ones connecting via ssh when positive.";
-        type = lib.types.ints.between (-20) 19;
+        type = types.ints.between (-20) 19;
         default = 10;
       };
-      ioSchedulingClass = lib.mkOption {
+      ioSchedulingClass = mkOption {
         description = "IO scheduling class for btrbk (see ionice(1) for a quick description). Applies to local instances, and remote ones connecting by ssh if set to idle.";
-        type = lib.types.enum [ "idle" "best-effort" "realtime" ];
+        type = types.enum [ "idle" "best-effort" "realtime" ];
         default = "best-effort";
       };
-      instances = lib.mkOption {
+      instances = mkOption {
         description = "Set of btrbk instances. The instance named <literal>btrbk</literal> is the default one.";
-        type = with lib.types;
+        type = with types;
           attrsOf (
             submodule {
               options = {
-                onCalendar = lib.mkOption {
-                  type = lib.types.str;
+                onCalendar = mkOption {
+                  type = types.str;
                   default = "daily";
                   description = "How often this btrbk instance is started. See systemd.time(7) for more information about the format.";
                 };
-                settings = lib.mkOption {
-                  type = let t = lib.types.attrsOf (lib.types.either lib.types.str (t // { description = "instances of this type recursively"; })); in t;
+                settings = mkOption {
+                  type = let t = types.attrsOf (types.either types.str (t // { description = "instances of this type recursively"; })); in t;
                   default = { };
                   example = {
                     snapshot_preserve_min = "2d";
@@ -103,16 +106,16 @@ in
           );
         default = { };
       };
-      sshAccess = lib.mkOption {
+      sshAccess = mkOption {
         description = "SSH keys that should be able to make or push snapshots on this system remotely with btrbk";
-        type = with lib.types; listOf (
+        type = with types; listOf (
           submodule {
             options = {
-              key = lib.mkOption {
+              key = mkOption {
                 type = str;
                 description = "SSH public key allowed to login as user <literal>btrbk</literal> to run remote backups.";
               };
-              roles = lib.mkOption {
+              roles = mkOption {
                 type = listOf (enum [ "info" "source" "target" "delete" "snapshot" "send" "receive" ]);
                 example = [ "source" "info" "send" ];
                 description = "What actions can be performed with this SSH key. See ssh_filter_btrbk(1) for details";
@@ -125,7 +128,7 @@ in
     };
 
   };
-  config = lib.mkIf (sshEnabled || serviceEnabled) {
+  config = mkIf (sshEnabled || serviceEnabled) {
     environment.systemPackages = [ pkgs.btrbk ] ++ cfg.extraPackages;
     security.sudo.extraRules = [
       {
@@ -152,14 +155,14 @@ in
         (
           v:
           let
-            options = lib.concatMapStringsSep " " (x: "--" + x) v.roles;
+            options = concatMapStringsSep " " (x: "--" + x) v.roles;
             ioniceClass = {
               "idle" = 3;
               "best-effort" = 2;
               "realtime" = 1;
             }.${cfg.ioSchedulingClass};
           in
-          ''command="${pkgs.util-linux}/bin/ionice -t -c ${toString ioniceClass} ${lib.optionalString (cfg.niceness >= 1) "${pkgs.coreutils}/bin/nice -n ${toString cfg.niceness}"} ${pkgs.btrbk}/share/btrbk/scripts/ssh_filter_btrbk.sh --sudo ${options}" ${v.key}''
+          ''command="${pkgs.util-linux}/bin/ionice -t -c ${toString ioniceClass} ${optionalString (cfg.niceness >= 1) "${pkgs.coreutils}/bin/nice -n ${toString cfg.niceness}"} ${pkgs.btrbk}/share/btrbk/scripts/ssh_filter_btrbk.sh --sudo ${options}" ${v.key}''
         )
         cfg.sshAccess;
     };
@@ -169,7 +172,7 @@ in
       "d /var/lib/btrbk/.ssh 0700 btrbk btrbk"
       "f /var/lib/btrbk/.ssh/config 0700 btrbk btrbk - StrictHostKeyChecking=accept-new"
     ];
-    environment.etc = lib.mapAttrs'
+    environment.etc = mapAttrs'
       (
         name: instance: {
           name = "btrbk/${name}.conf";
@@ -177,7 +180,7 @@ in
         }
       )
       cfg.instances;
-    systemd.services = lib.mapAttrs'
+    systemd.services = mapAttrs'
       (
         name: _: {
           name = "btrbk-${name}";
@@ -199,7 +202,7 @@ in
       )
       cfg.instances;
 
-    systemd.timers = lib.mapAttrs'
+    systemd.timers = mapAttrs'
       (
         name: instance: {
           name = "btrbk-${name}";

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -68,7 +68,7 @@ in
       };
       daemonNiceLevel = mkOption {
         description = "Niceness for local instances of btrbk. Also applies to remote ones connecting via ssh when positive.";
-        type = types.ints.between (-20) 19;
+        type = types.niceness;
         default = 10;
       };
       ioSchedulingClass = mkOption {

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -54,6 +54,10 @@ let
     '';
 in
 {
+  imports = [
+    (mkRenamedOptionModule [ "services" "btrbk" "niceness" ] [ "services" "btrbk" "daemonNiceLevel" ])
+  ];
+
   options = {
     services.btrbk = {
       extraPackages = mkOption {
@@ -62,7 +66,7 @@ in
         default = [ ];
         example = literalExample "[ pkgs.xz ]";
       };
-      niceness = mkOption {
+      daemonNiceLevel = mkOption {
         description = "Niceness for local instances of btrbk. Also applies to remote ones connecting via ssh when positive.";
         type = types.ints.between (-20) 19;
         default = 10;
@@ -193,7 +197,7 @@ in
               Group = "btrbk";
               Type = "oneshot";
               ExecStart = "${pkgs.btrbk}/bin/btrbk -c /etc/btrbk/${name}.conf run";
-              Nice = cfg.niceness;
+              Nice = cfg.daemonNiceLevel;
               IOSchedulingClass = cfg.ioSchedulingClass;
               StateDirectory = "btrbk";
             };

--- a/nixos/modules/services/computing/foldingathome/client.nix
+++ b/nixos/modules/services/computing/foldingathome/client.nix
@@ -50,7 +50,7 @@ in
     };
 
     daemonNiceLevel = mkOption {
-      type = types.ints.between (-20) 19;
+      type = types.niceness;
       default = 0;
       description = ''
         Daemon process priority for FAHClient.

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -176,7 +176,7 @@ in
       };
 
       daemonNiceLevel = mkOption {
-        type = types.int;
+        type = types.niceness;
         default = 0;
         description = ''
           Nix daemon process priority. This priority propagates to build processes.

--- a/nixos/modules/services/networking/bee.nix
+++ b/nixos/modules/services/networking/bee.nix
@@ -35,7 +35,7 @@ in {
       };
 
       daemonNiceLevel = mkOption {
-        type = types.int;
+        type = types.niceness;
         default = 0;
         description = ''
           Daemon process priority for bee.

--- a/nixos/modules/services/networking/freenet.nix
+++ b/nixos/modules/services/networking/freenet.nix
@@ -12,6 +12,9 @@ let
 in
 
 {
+  imports = [
+    (mkRenamedOptionModule [ "services" "freenet" "nice" ] [ "services" "freenet" "daemonNiceLevel" ])
+  ];
 
   ### configuration
 
@@ -25,7 +28,7 @@ in
         description = "Enable the Freenet daemon";
       };
 
-      nice = mkOption {
+      daemonNiceLevel = mkOption {
         type = types.int;
         default = 10;
         description = "Set the nice level for the Freenet daemon";
@@ -47,7 +50,7 @@ in
       serviceConfig.User = "freenet";
       serviceConfig.UMask = "0007";
       serviceConfig.WorkingDirectory = varDir;
-      serviceConfig.Nice = cfg.nice;
+      serviceConfig.Nice = cfg.daemonNiceLevel;
     };
 
     users.users.freenet = {

--- a/nixos/modules/services/networking/freenet.nix
+++ b/nixos/modules/services/networking/freenet.nix
@@ -29,7 +29,7 @@ in
       };
 
       daemonNiceLevel = mkOption {
-        type = types.int;
+        type = types.niceness;
         default = 10;
         description = "Set the nice level for the Freenet daemon";
       };

--- a/nixos/modules/services/networking/icecream/daemon.nix
+++ b/nixos/modules/services/networking/icecream/daemon.nix
@@ -5,6 +5,9 @@ with lib;
 let
   cfg = config.services.icecream.daemon;
 in {
+  imports = [
+    (mkRenamedOptionModule [ "services" "icecream" "daemon" "nice" ] [ "services" "icecream" "daemon" "daemonNiceLevel" ])
+  ];
 
   ###### interface
 
@@ -72,7 +75,7 @@ in {
         '';
       };
 
-      nice = mkOption {
+      daemonNiceLevel = mkOption {
         type = types.int;
         default = 5;
         description = ''
@@ -131,7 +134,7 @@ in {
           "${getBin cfg.package}/bin/iceccd"
           "-b" "$STATE_DIRECTORY"
           "-u" "icecc"
-          (toString cfg.nice)
+          (toString cfg.daemonNiceLevel)
         ]
         ++ optionals (cfg.schedulerHost != null) ["-s" cfg.schedulerHost]
         ++ optionals (cfg.netName != null) [ "-n" cfg.netName ]

--- a/nixos/modules/services/networking/icecream/daemon.nix
+++ b/nixos/modules/services/networking/icecream/daemon.nix
@@ -76,7 +76,7 @@ in {
       };
 
       daemonNiceLevel = mkOption {
-        type = types.int;
+        type = types.niceness;
         default = 5;
         description = ''
           The level of niceness to use.


### PR DESCRIPTION
Signed-off-by: Pamplemousse <xav.maso@gmail.com><!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bring some consistency, and make better use of type safety.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
