### PR TITLE
xarchiver: 0.5.4.14 -> 0.5.4.17

### DIFF
--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ib";
     repo = "xarchiver";
-    rev = "${version}";
+    rev = version;
     sha256 = "00adrjpxqlaccrwjf65w3vhxfswdj0as8aj263c6f9b85llypc5v";
   };
 

--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -2,18 +2,18 @@
   coreutils, zip, unzip, p7zip, unrar, gnutar, bzip2, gzip, lhasa, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  version = "0.5.4.14";
+  version = "0.5.4.17";
   pname = "xarchiver";
 
   src = fetchFromGitHub {
     owner = "ib";
     repo = "xarchiver";
-    rev = version;
-    sha256 = "1iklwgykgymrwcc5p1cdbh91v0ih1m58s3w9ndl5kyd44bwlb7px";
+    rev = "${version}";
+    sha256 = "00adrjpxqlaccrwjf65w3vhxfswdj0as8aj263c6f9b85llypc5v";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper wrapGAppsHook ];
-  buildInputs = [ gtk3 intltool libxslt ];
+  nativeBuildInputs = [ intltool pkg-config makeWrapper wrapGAppsHook ];
+  buildInputs = [ gtk3 libxslt ];
 
   postFixup = ''
     wrapProgram $out/bin/xarchiver \
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "GTK frontend to 7z,zip,rar,tar,bzip2, gzip,arj, lha, rpm and deb (open and extract only)";
     homepage = "https://github.com/ib/xarchiver";
     maintainers = [ lib.maintainers.domenkozar ];
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update package, can't reproduce #92630 - tried before and after update starting from dmenu/cli, choosing file and extracting. Using i3wm.

###### Things done
Update version, hash, tested  after install

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
