### PR TITLE
batman-adv: fix build on linux>=5.12

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, kernel }:
+{ lib, stdenv, fetchurl, fetchpatch, kernel }:
 
 let cfg = import ./version.nix; in
 
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     url = "http://downloads.open-mesh.org/batman/releases/${pname}-${cfg.version}/${pname}-${cfg.version}.tar.gz";
     sha256 = cfg.sha256.${pname};
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix build with Kernel>=5.12, remove for batman-adv>=2021.1
+      url = "https://git.open-mesh.org/batman-adv.git/patch/6d67ca7f530d4620e3d066b02aefbfd8893d6c05?hp=362da918384286a959ad7c3455d9d33d9ff99d7d";
+      sha256 = "039x67yfkwl0b8af8vwx5m58ji2qn8x44rr1rkzi5j43cvmnh2cg";
+    })
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/job/nixpkgs/trunk/linuxPackages_5_12.batman_adv.x86_64-linux
ZHF #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
