### PR TITLE
llvmPackages_12.lld: make sure llvm libunwind is passed

### DIFF
--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -96,6 +96,7 @@ let
 
     lld = callPackage ./lld {
       inherit llvm_meta;
+      inherit (libraries) libunwind;
     };
 
     lldb = callPackage ./lldb {


### PR DESCRIPTION
lld needs LLVM's libunwind for its headers. That libunwind is not part
of the tools scope in pkgs/development/compilers/llvm/12/default.nix,
which means that lld previously received libunwind from top-level pkgs
which of course doesn't have the required headers.

To resolve this pass libunwind from the libraries scope — platform
concerns don't really mattern as only libunwind.src is used.

libunwind was initially passed correctly, but that was removed in
e830db4320ac3b38c648d492b3d04c71a0860a54. This regression was likely
introduced accidentally, pinging @Ericson2314 for comment.

Targeting staging because the offending commit is not yet in `master` nor `staging-next`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
