### PR TITLE
python3Packages.pwntools: Patch check for `gdb-multiarch`

### DIFF
--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -23,6 +23,9 @@
 , fetchpatch
 }:
 
+let
+  debuggerName = lib.strings.getName debugger;
+in
 buildPythonPackage rec {
   version = "4.3.1";
   pname = "pwntools";
@@ -32,11 +35,15 @@ buildPythonPackage rec {
     sha256 = "12ja913kz8wl4afrmpzxh9fx6j7rcwc2vqzkvfr1fxn42gkqhqf4";
   };
 
-  # Upstream has set an upper bound on unicorn because of https://github.com/Gallopsled/pwntools/issues/1538,
-  # but since that is a niche use case and it requires extra work to get unicorn 1.0.2rc3 to work we relax
-  # the bound here. Check if this is still necessary when updating!
   postPatch = ''
+    # Upstream has set an upper bound on unicorn because of https://github.com/Gallopsled/pwntools/issues/1538,
+    # but since that is a niche use case and it requires extra work to get unicorn 1.0.2rc3 to work we relax
+    # the bound here. Check if this is still necessary when updating!
     sed -i 's/unicorn>=1.0.2rc1,<1.0.2rc4/unicorn>=1.0.2rc1/' setup.py
+
+    # Upstream hardcoded the check for the command `gdb-multiarch`;
+    # Forcefully use the provided debugger, as `gdb` (hence `pwndbg`) is built with multiarch in `nixpkgs`.
+    sed -i 's/gdb-multiarch/${debuggerName}/' pwnlib/gdb.py
   '';
 
   propagatedBuildInputs = [
@@ -62,7 +69,7 @@ buildPythonPackage rec {
 
   postFixup = ''
     mkdir -p "$out/bin"
-    makeWrapper "${debugger}/bin/${lib.strings.getName debugger}" "$out/bin/pwntools-gdb"
+    makeWrapper "${debugger}/bin/${debuggerName}" "$out/bin/pwntools-gdb"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Make `pwntools` and `gdb` work to debug non native binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
