### PR TITLE
siril: fix build with glib-2.68 dependency

### DIFF
--- a/pkgs/applications/science/astronomy/siril/default.nix
+++ b/pkgs/applications/science/astronomy/siril/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitLab, pkg-config, meson, ninja, wrapGAppsHook
+{ lib, stdenv, fetchFromGitLab, fetchpatch, pkg-config, meson, ninja
 , git, criterion, gtk3, libconfig, gnuplot, opencv, json-glib
 , fftwFloat, cfitsio, gsl, exiv2, librtprocess, wcslib, ffmpeg
-, libraw, libtiff, libpng, libjpeg, libheif, ffms
+, libraw, libtiff, libpng, libjpeg, libheif, ffms, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0h3slgpj6zdc0rwmyr9zb0vgf53283hpwb7h26skdswmggsk90i5";
   };
+
+  patches = [
+    # Backport fix for broken build on glib-2.68
+    (fetchpatch {
+      url = "https://gitlab.com/free-astro/siril/-/commit/d319fceca5b00f156e1c5e3512d3ac1f41beb16a.diff";
+      sha256 = "00lq9wq8z48ly3hmkgzfqbdjaxr0hzyl2qwbj45bdnxfwqragh5m";
+    })
+  ];
 
   nativeBuildInputs = [
     meson ninja pkg-config git criterion wrapGAppsHook


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix broken build from glib-2.68 dependency by backporting changes from siril master.
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/nixos-release-managers