### PR TITLE
mail-parser: Remove invalid requirements.txt patch

### DIFF
--- a/pkgs/development/python-modules/mail-parser/default.nix
+++ b/pkgs/development/python-modules/mail-parser/default.nix
@@ -14,16 +14,6 @@ buildPythonPackage rec {
 
   LC_ALL = "en_US.utf-8";
 
-  # remove version bounds
-  prePatch = ''
-    sed -i -e 's/==.*//g' requirements.txt
-  ''
-  # ipaddress is part of the standard library of Python 3.3+
-  + lib.optionalString (!pythonOlder "3.3") ''
-    substituteInPlace requirements.txt \
-      --replace "ipaddress" ""
-  '';
-
   nativeBuildInputs = [ glibcLocales ];
   propagatedBuildInputs = [ simplejson six ] ++ lib.optional (pythonOlder "3.3") ipaddress;
 


### PR DESCRIPTION
Upstream modified requirements.txt and is no longer pinning
dependencies to exact versions. Instead, it provides version
bounds. Also, the ipaddress dependency is now limited already
in requirements.txt to Python versions < 3.3.

Removed all the patching since it generated an invalid
requirements.txt that caused the build to fail.

###### Motivation for this change

Build fails since updating from 3.12.0 to 3.15.0. Patching from Nix-derivation would create an invalid requirements.txt after upstream changes to that file.

ZHF: #122042

@jonringer 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
