### PR TITLE
python3Packages.hickle: mark as broken

### DIFF
--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "hickle" ];
 
   meta = {
+    # incompatible with h5py>=3.0, see https://github.com/telegraphic/hickle/issues/143
+    broken = true;
     description = "Serialize Python data to HDF5";
     homepage = "https://github.com/telegraphic/hickle";
     license = lib.licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
Looks like this will be broken until https://github.com/telegraphic/hickle/issues/143 is addressed. Marking as broken now will prevent any more ZHF #122042 pursuers falling down this rabbit hole.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
