### PR TITLE
python3Packages.pysonos: 0.0.45 -> 0.0.46

### DIFF
--- a/pkgs/development/python-modules/pysonos/default.nix
+++ b/pkgs/development/python-modules/pysonos/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pysonos";
-  version = "0.0.45";
+  version = "0.0.46";
 
   disabled = !isPy3k;
 
@@ -23,10 +23,14 @@ buildPythonPackage rec {
     owner = "amelchio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0wzmrd9ja5makvsgf0ckil99wr8vw91dml8fi9miiq4la0100q0n";
+    sha256 = "sha256-5vQBSKDgzwdWkyGduq2cWa7Eq5l01gbs236H2Syc/Dc=";
   };
 
-  propagatedBuildInputs = [ ifaddr requests xmltodict ];
+  propagatedBuildInputs = [
+    ifaddr
+    requests
+    xmltodict
+  ];
 
   checkInputs = [
     pytestCheckHook
@@ -38,10 +42,10 @@ buildPythonPackage rec {
     "test_desc_from_uri" # test requires network access
   ];
 
-  meta = {
-    homepage = "https://github.com/amelchio/pysonos";
+  meta = with lib; {
     description = "A SoCo fork with fixes for Home Assistant";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ juaningan ];
+    homepage = "https://github.com/amelchio/pysonos";
+    license = licenses.mit;
+    maintainers = with maintainers; [ juaningan ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.46

Change log: https://github.com/amelchio/pysonos/releases/tag/v0.0.46

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50544
- Target Home Assistant release: current, only dependency update no changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
