### PR TITLE
ell: 0.38 -> 0.40, iwd: 1.12 -> 1.14, ofono: 1.31 -> 1.32

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.38";
+  version = "0.40";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/${pname}/${pname}.git";
     rev = version;
-    sha256 = "sha256-UR6NHIO/L/QbuVerXe32RNT33wwrDvIZpV6nlYaImI8=";
+    sha256 = "sha256-Yr08Kb8YU7xqBnhhS8rn+GFXAV68Hgj4aY26eptb9/8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "1.12";
+  version = "1.14";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     rev = version;
-    sha256 = "sha256-o3Vc5p/AFZwbkEWJZzO6wWAJ/BmSh0eKxdnjm5B9BFU=";
+    sha256 = "sha256-uGe4TO1/bs8k2z3wOJqaZgT6u6yX/7wx4HMSS2hN4XE=";
   };
 
   outputs = [ "out" "man" ]
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
   ];
 
   postUnpack = ''
+    mkdir -p iwd/ell
+    ln -s ${ell.src}/ell/useful.h iwd/ell/useful.h
     patchShebangs .
   '';
 

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ofono";
-  version = "1.31";
+  version = "1.32";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/ofono/ofono.git";
     rev = version;
-    sha256 = "033y3vggjxn1c7mw75j452idp7arrdv51axs727f7l3c5lnxqdjy";
+    sha256 = "sha256-bJ7Qgau5soPiptrhcMZ8rWxfprRCTeR7OjQ5HZQ9hbc=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ell, https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=0.40
```
ver 0.40:
	Fix issue with handling failure from missing CA certificates.
	Fix issue with handling DBus.Introspectable queries.

ver 0.39:
	Add support for serialized test execution framework.
```

iwd, https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog?h=1.14
```
ver 1.14:
	Fix issue with scanning property and quick scan cancellation.
	Fix issue with handling authentication timeouts from SAE.
	Fix issue with handling association timeouts and retries.
	Fix issue with handling roaming frequencies after roaming.
	Fix issue with requesting neighbor report after roaming.
	Add support for handling PSK offload connections.

ver 1.13:
	Fix issue with EAPoL protocol version 2010 handling.
	Fix issue with authenticator method logic handling.
	Fix issue with getting scan results from firmware.
	Add support for handling SAE offload connections.
	Add support for roaming with FullMAC devices.
```

iwd needs to have `ell/useful.h` to build now. I've opted for symlinking it in (not sure if that's the best/most nix way to do it?), the alternative is just using release tarballs - but they do not contain the `doc` directory. I went for the option that changed the fewest things, though it feels more correct to use the release tarballs for both ell/iwd to me.

EDIT: Added a bump for ofono as it failed to build otherwise.

ofono, https://git.kernel.org/pub/scm/network/ofono/ofono.git/tree/ChangeLog?h=1.32
```
ver 1.32:
	Fix issue with handling of IMS private identity validation.
	Fix issue with handling of SIM EF structure bit processing.
	Fix issue with handling removal of Huawai modems.
	Add support for USSD indication with QMI modems.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
