### PR TITLE
fancy-motd: init at unstable-2021-05-15

### DIFF
--- a/pkgs/tools/system/fancy-motd/default.nix
+++ b/pkgs/tools/system/fancy-motd/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchFromGitHub, bc, curl, figlet, fortune, gawk, iproute2, procps }:
+
+stdenv.mkDerivation rec {
+  pname = "fancy-motd";
+  version = "unstable-2021-05-15";
+
+  src = fetchFromGitHub {
+    owner = "bcyran";
+    repo = pname;
+    rev = "b25c1e7d76927d7f947a048d844dad4400de3598";
+    sha256 = "05jazmijk3im1wl4nprkwmrq6bxhb3ah8syyqym109blajy72841";
+  };
+
+  buildInputs = [ bc curl figlet fortune gawk iproute2 ];
+
+  postPatch = ''
+    substituteInPlace motd.sh \
+      --replace 'BASE_DIR="$(dirname "$(readlink -f "$0")")"' "BASE_DIR=\"$out/lib\""
+
+    substituteInPlace modules/20-uptime \
+      --replace "uptime -p" "${procps}/bin/uptime -p"
+
+    # does not work on nixos
+    rm modules/41-updates
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D motd.sh $out/bin/motd
+
+    install -D framework.sh $out/lib/framework.sh
+    install -D config.sh.example $out/lib/config.sh
+    find modules -type f -exec install -D {} $out/lib/{} \;
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fancy, colorful MOTD written in bash. Server status at a glance.";
+    homepage = "https://github.com/bcyran/fancy-motd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rhoriguchi ];
+    platforms = platforms.linux;
+    mainProgram = "motd";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4388,6 +4388,8 @@ in
 
   fakechroot = callPackage ../tools/system/fakechroot { };
 
+  fancy-motd = callPackage ../tools/system/fancy-motd { };
+
   fastpbkdf2 = callPackage ../development/libraries/fastpbkdf2 { };
 
   fanficfare = callPackage ../tools/text/fanficfare { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
