### PR TITLE
python3Packages.brother: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/brother/default.nix
+++ b/pkgs/development/python-modules/brother/default.nix
@@ -5,29 +5,29 @@
 , pytest-asyncio
 , pytest-error-for-skips
 , pytest-runner
-, pytest-tornasync
-, pytest-trio
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "brother";
-  version = "1.0.0";
+  version = "1.0.1";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-0NfqPlQiOkNhR+H55E9LE4dGa9R8vcSyPNbbIeiRJV8=";
+    sha256 = "sha256-Cfut6Y4Hln32g4V13xbOo5JdjPv2cH6FCDqvRRyijIA=";
   };
 
+  nativeBuildInputs = [
+    pytest-runner
+  ];
+
   postPatch = ''
-    substituteInPlace pytest.ini \
+    substituteInPlace setup.cfg \
       --replace "--cov --cov-report term-missing " ""
-    substituteInPlace requirements-test.txt \
-      --replace "pytest-cov" ""
   '';
 
   propagatedBuildInputs = [
@@ -37,9 +37,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytest-asyncio
     pytest-error-for-skips
-    pytest-runner
-    pytest-tornasync
-    pytest-trio
     pytestCheckHook
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.1

Change log: https://github.com/bieniu/brother/releases/tag/1.0.1

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50572
- Target Home Assistant release: current, only dependency update no changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
