### PR TITLE
sc-im: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/applications/misc/sc-im/default.nix
+++ b/pkgs/applications/misc/sc-im/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , makeWrapper
 , pkg-config
 , which
@@ -16,28 +15,16 @@
 
 stdenv.mkDerivation rec {
   pname = "sc-im";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "andmarti1424";
     repo = "sc-im";
     rev = "v${version}";
-    sha256 = "sha256-AIYa3d1ml1f5GNLKijeFPX+UabgEqzdXiP60BGvBPsQ=";
+    sha256 = "sha256-H+GQUpouiXc/w6GWdkSVvTXZ/Dtb7sUmBLGcpxG3Mts=";
   };
 
   sourceRoot = "${src.name}/src";
-
-  patches = [
-    # libxls and libxlsxwriter are not found without the patch
-    # https://github.com/andmarti1424/sc-im/pull/542
-    (fetchpatch {
-      name = "use-pkg-config-for-libxls-and-libxlsxwriter.patch";
-      url = "https://github.com/andmarti1424/sc-im/commit/b62dc25eb808e18a8ab7ee7d8eb290e34efeb075.patch";
-      sha256 = "1yn32ps74ngzg3rbkqf8dn0g19jv4xhxrfgx9agnywf0x8gbwjh3";
-    })
-  ];
-
-  patchFlags = [ "-p2" ];
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/andmarti1424/sc-im/releases/tag/v0.8.2


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
