### PR TITLE
python3Packages.accuweather: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/accuweather/default.nix
+++ b/pkgs/development/python-modules/accuweather/default.nix
@@ -11,20 +11,20 @@
 
 buildPythonPackage rec {
   pname = "accuweather";
-  version = "0.1.1";
+  version = "0.2.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-fjOwa13hxY8/gCM6TCAFWVmEY1oZyqKyc6o3OSsxHpY=";
+    sha256 = "sha256-Swe8vegRcyaeG4n/8aeGFLrXkwcLM/Al53yD6oD/0GA=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace "pytest-runner" ""
-    substituteInPlace pytest.ini \
+    substituteInPlace setup.cfg \
       --replace "--cov --cov-report term-missing" ""
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.0

Change log: https://github.com/bieniu/accuweather/releases/tag/0.2.0

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50573
- Target Home Assistant release: current, only dependency update no changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
