### PR TITLE
[20.09] nixos/modules: add "sdhci_pci" to availableKernelModules

### DIFF
--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -35,6 +35,9 @@
       # drives.
       "uas"
 
+      # SD cards.
+      "sdhci_pci"
+
       # Firewire support.  Not tested.
       "ohci1394" "sbp2"
 


### PR DESCRIPTION
###### Motivation for this change
backport #110435

Encountered issues booting the live image on an Acer R11 Chromebook (CYAN). Got help from @samueldr on Freenode, and adding this module fixed it. Likely useful for other platforms/situations where booting from SD is necessary.

(cherry picked from commit c2a901798e85c2f5108df679fba9b9f7702fac96)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
