### PR TITLE
python3Packages.pyvesync: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pyvesync/default.nix
+++ b/pkgs/development/python-modules/pyvesync/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "pyvesync";
-  version = "1.3.1";
+  version = "1.4.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "02fpbyg46mlpc2c1j4zylw9a1h6bacxvigrl3cndsf6fxlhfx15z";
+    sha256 = "sha256-xvHvZx22orJR94cRMyyXey27Ksh2/ULHRvv7xxXv11k=";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -397,6 +397,7 @@ in with py.pkgs; buildPythonApplication rec {
     "uptime"
     "vacuum"
     "verisure"
+    "vesync"
     "weather"
     "webhook"
     "websocket_api"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4.0

Change log: https://github.com/webdjoe/pyvesync/releases/tag/1.4.0

Enable Home Assistant tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
