### PR TITLE
caprice32: Add <string> include

### DIFF
--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -5,6 +5,9 @@ stdenv.mkDerivation rec {
 
   pname = "caprice32";
   version = "4.6.0";
+  # NOTE: When bumping version beyond 4.6.0, you likely need to remove
+  #       string.patch below. The fix of this patch has already been
+  #       done upstream but is not yet part of a release
 
   src = fetchFromGitHub {
     repo = "caprice32";
@@ -15,6 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ desktop-file-utils pkg-config ];
   buildInputs = [ libpng SDL freetype zlib ];
+
+  patches = [ ./string.patch ];
 
   makeFlags = [
     "APP_PATH=${placeholder "out"}/share/caprice32"

--- a/pkgs/misc/emulators/caprice32/string.patch
+++ b/pkgs/misc/emulators/caprice32/string.patch
@@ -1,0 +1,12 @@
+diff --git a/src/configuration.h b/src/configuration.h
+index 34fd690..97fb0e5 100644
+--- a/src/configuration.h
++++ b/src/configuration.h
+@@ -2,6 +2,7 @@
+ #define CONFIGURATION_H
+ 
+ #include <map>
++#include <string>
+ 
+ namespace config
+ {


### PR DESCRIPTION
###### Motivation for this change

Build log showed errors for missing `std::string`. Adding `<string>` include to that header fixed it. This has already been patched upstream but is not yet part of a release. I added a note that this patch likely needs to be removed when bumping the version next time.

https://github.com/ColinPitrat/caprice32/commit/6b250ead2a8b66ed2b676124368191e7adc11768

ZHF: #122042

@jonringer

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
