### PR TITLE
gnomeExtensions.caffeine: 37 -> 38

### DIFF
--- a/pkgs/desktops/gnome/extensions/caffeine/default.nix
+++ b/pkgs/desktops/gnome/extensions/caffeine/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, glib, gettext, bash, gnome }:
+{ lib, stdenv, fetchFromGitHub, glib, gettext, bash }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-caffeine";
-  version = "37";
+  version = "38";
 
   src = fetchFromGitHub {
     owner = "eonpatapon";
     repo = "gnome-shell-extension-caffeine";
     rev = "v${version}";
-    sha256 = "1mpa0fbpmv3pblb20dxj8iykn4ayvx89qffpcs67bzlq597zsbkb";
+    sha256 = "0dyagnjmk91h96xr98mc177c473bqpxcv86qf6g3kyh3arwa9shs";
   };
 
   uuid = "caffeine@patapon.info";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Fill the cup to inhibit auto suspend and screensaver";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ eperuffo ];
     homepage = "https://github.com/eonpatapon/gnome-shell-extension-caffeine";
   };


### PR DESCRIPTION
###### Motivation for this change

Add GNOME [40](https://github.com/eonpatapon/gnome-shell-extension-caffeine/blob/v38/caffeine%40patapon.info/metadata.json#L4) support. This update will break `3.36` and `3.38` support.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
