### PR TITLE
signal-desktop: Fix the database encryption by preloading SQLCipher

### DIFF
--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -44,12 +44,11 @@ import ./make-test-python.nix ({ pkgs, ...} :
     # - https://github.com/NixOS/nixpkgs/issues/108772
     # - https://github.com/NixOS/nixpkgs/pull/117555
     print(machine.succeed("su - alice -c 'file ~/.config/Signal/sql/db.sqlite'"))
-    # TODO: The DB should be encrypted and the following should be machine.fail
-    # instead of machine.succeed but the DB is currently unencrypted and we
-    # want to notice if this isn't the case anymore as the transition to a
-    # encrypted DB can cause data loss!:
     machine.succeed(
-        "su - alice -c 'file ~/.config/Signal/sql/db.sqlite' | grep -i sqlite"
+        "su - alice -c 'file ~/.config/Signal/sql/db.sqlite' | grep 'db.sqlite: data'"
+    )
+    machine.fail(
+        "su - alice -c 'file ~/.config/Signal/sql/db.sqlite' | grep -e SQLite -e database"
     )
   '';
 })

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/db-reencryption-wrapper.py
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/db-reencryption-wrapper.py
@@ -1,0 +1,92 @@
+#!@PYTHON@
+
+import json
+import os
+import re
+import shlex
+import sqlite3
+import subprocess
+import sys
+
+
+DB_PATH = os.path.join(os.environ['HOME'], '.config/Signal/sql/db.sqlite')
+DB_COPY = os.path.join(os.environ['HOME'], '.config/Signal/sql/db.tmp')
+CONFIG_PATH = os.path.join(os.environ['HOME'], '.config/Signal/config.json')
+
+
+def zenity_askyesno(title, text):
+    args = [
+        '@ZENITY@',
+        '--question',
+        '--title',
+        shlex.quote(title),
+        '--text',
+        shlex.quote(text)
+    ]
+    return subprocess.run(args).returncode == 0
+
+
+def start_signal():
+    os.execvp('@SIGNAL-DESKTOP@', ['@SIGNAL-DESKTOP@'] + sys.argv[1:])
+
+
+def copy_pragma(name):
+    result = subprocess.run([
+        '@SQLCIPHER@',
+        DB_PATH,
+        f"PRAGMA {name};"
+    ], check=True, capture_output=True).stdout
+    result = re.search(r'[0-9]+', result.decode()).group(0)
+    subprocess.run([
+        '@SQLCIPHER@',
+        DB_COPY,
+        f"PRAGMA key = \"x'{key}'\"; PRAGMA {name} = {result};"
+    ], check=True, capture_output=True)
+
+
+try:
+    # Test if DB is encrypted:
+    con = sqlite3.connect(f'file:{DB_PATH}?mode=ro', uri=True)
+    cursor = con.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+    con.close()
+except:
+    # DB is encrypted, everything ok:
+    start_signal()
+
+
+# DB is unencrypted!
+answer = zenity_askyesno(
+        "Error: Signal-Desktop database is not encrypted",
+        "Should we try to fix this automatically?"
+        + "You likely want to backup ~/.config/Signal/ first."
+)
+if not answer:
+    answer = zenity_askyesno(
+            "Launch Signal-Desktop",
+            "DB is unencrypted, should we still launch Signal-Desktop?"
+            + "Warning: This could result in data loss!"
+    )
+    if not answer:
+        print('Aborted')
+        sys.exit(0)
+    start_signal()
+
+# Re-encrypt the DB:
+with open(CONFIG_PATH) as json_file:
+    key = json.load(json_file)['key']
+result = subprocess.run([
+    '@SQLCIPHER@',
+    DB_PATH,
+    f" ATTACH DATABASE '{DB_COPY}' AS signal_db KEY \"x'{key}'\";"
+    + " SELECT sqlcipher_export('signal_db');"
+    + " DETACH DATABASE signal_db;"
+]).returncode
+if result != 0:
+    print('DB encryption failed')
+    sys.exit(1)
+# Need to copy user_version and schema_version manually:
+copy_pragma('user_version')
+copy_pragma('schema_version')
+os.rename(DB_COPY, DB_PATH)
+start_signal()

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -117,9 +117,15 @@ in stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  # Required for $SQLCIPHER_LIB which contains "/build/" inside the path:
+  noAuditTmpdir = true;
+
   preFixup = ''
+    export SQLCIPHER_LIB="$out/lib/Signal/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+    test -x "$SQLCIPHER_LIB" # To ensure the location hasn't changed
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ] }"
+      --prefix LD_PRELOAD : "$SQLCIPHER_LIB"
       ${customLanguageWrapperArgs}
     )
 


### PR DESCRIPTION
AFAIK this is the only reliable way for us to ensure SQLCipher will be
loaded instead of SQLite. It feels like a hack/workaround but according
to the SQLCipher developers [0] "this issue can and should be handled
downstream at the application level: 1. While it may feel like a
workaround, using LD_PRELOAD is a legitimate approach here because it
will substitute the system SQLite with SQLCipher which is the intended
usage model;".

This fixes #108772 for NixOS 20.09 users who upgrade to NixOS 21.05 and
replaces #117555.

For nixos-unstable users this will unfortunately break everything again
so we should add a script to ease the transition (in a separate commit
so that we can revert it for NixOS 21.05).

[0]: https://github.com/sqlcipher/sqlcipher/issues/385#issuecomment-802874340

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
