### PR TITLE
pythonnet: 2.4.0 -> 2.5.2

### DIFF
--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -2,8 +2,7 @@
 , fetchPypi
 , fetchNuGet
 , buildPythonPackage
-, python
-, pytest
+, pytestCheckHook
 , pycparser
 , psutil
 , pkg-config
@@ -15,29 +14,36 @@
 
 let
 
-  UnmanagedExports127 = fetchNuGet {
-    baseName = "UnmanagedExports";
-    version = "1.2.7";
-    sha256 = "0bfrhpmq556p0swd9ssapw4f2aafmgp930jgf00sy89hzg2bfijf";
-    outputFiles = [ "*" ];
-  };
-
-  NUnit371 = fetchNuGet {
-    baseName = "NUnit";
-    version = "3.7.1";
-    sha256 = "1yc6dwaam4w2ss1193v735nnl79id78yswmpvmjr1w4bgcbdza4l";
-    outputFiles = [ "*" ];
-  };
+  dotnetPkgs = [
+    (fetchNuGet {
+      baseName = "UnmanagedExports";
+      version = "1.2.7";
+      sha256 = "0bfrhpmq556p0swd9ssapw4f2aafmgp930jgf00sy89hzg2bfijf";
+      outputFiles = [ "*" ];
+    })
+    (fetchNuGet {
+      baseName = "NUnit";
+      version = "3.12.0";
+      sha256 = "1880j2xwavi8f28vxan3hyvdnph4nlh5sbmh285s4lc9l0b7bdk2";
+      outputFiles = [ "*" ];
+    })
+    (fetchNuGet {
+      baseName = "System.ValueTuple";
+      version = "4.5.0";
+      sha256 = "00k8ja51d0f9wrq4vv5z2jhq8hy31kac2rg0rv06prylcybzl8cy";
+      outputFiles = [ "*" ];
+    })
+  ];
 
 in
 
 buildPythonPackage rec {
   pname = "pythonnet";
-  version = "2.4.0";
+  version = "2.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ach9jic7a9rd3vmc4bphkr9fq01a0qk81f8a7gr9npwzmkqx8x3";
+    sha256 = "1qzdc6jd7i9j7p6bcihnr98y005gv1358xqdr1plpbpnl6078a5p";
   };
 
   postPatch = ''
@@ -50,7 +56,6 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    pytest
     pycparser
 
     pkg-config
@@ -59,13 +64,15 @@ buildPythonPackage rec {
 
     mono
 
-    NUnit371
-    UnmanagedExports127
-  ];
+  ] ++ dotnetPkgs;
 
   buildInputs = [
     glib
     mono
+  ];
+
+  checkInputs = [
+    pytestCheckHook
     psutil # needed for memory leak tests
   ];
 
@@ -73,22 +80,21 @@ buildPythonPackage rec {
     rm -rf packages
     mkdir packages
 
-    ln -s ${NUnit371}/lib/dotnet/NUnit/ packages/NUnit.3.7.1
-    ln -s ${UnmanagedExports127}/lib/dotnet/NUnit/ packages/UnmanagedExports.1.2.7
+    ${builtins.concatStringsSep "\n" (
+        builtins.map (
+            x: ''ln -s ${x}/lib/dotnet/${x.baseName} ./packages/${x.baseName}.${x.version}''
+          ) dotnetPkgs)}
 
     # Setting TERM=xterm fixes an issue with terminfo in mono: System.Exception: Magic number is wrong: 542
     export TERM=xterm
-  '';
-
-  checkPhase = ''
-    ${python.interpreter} -m pytest
   '';
 
   meta = with lib; {
     description = ".Net and Mono integration for Python";
     homepage = "https://pythonnet.github.io";
     license = licenses.mit;
+    # <https://github.com/pythonnet/pythonnet/issues/898>
+    badPlatforms = [ "aarch64-linux" ];
     maintainers = with maintainers; [ jraygauthier ];
-    broken = true;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6642,8 +6642,8 @@ in {
 
   pythonnet = callPackage
     ../development/python-modules/pythonnet {
-      # `mono >= 4.6` required to prevent crashes encountered with earlier versions.
-      mono = pkgs.mono4;
+      # Using `mono > 5`, tests are failing..
+      mono = pkgs.mono5;
     };
 
   python-nmap = callPackage ../development/python-modules/python-nmap { };


### PR DESCRIPTION
 -  No longer broken.
 -  Updated mono dependency to mono5.
 -  Fix / improve packaging.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/122759#pullrequestreview-659043536

Noticed package was marked broken as that it was using really old mono.

Also as part of:

https://github.com/NixOS/nixpkgs/issues/122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


 -  Upstream package tests now passing.
 -  Tested basic usage from ipython via `nix-shell -I nixpkgs=. -p 'python3.withPackages (pp: with pp; [pythonnet ipython])'`. Seems to work fine, can use dotnet types from python.
