### PR TITLE
[staging-next] python3Packages.pycurl: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -1,11 +1,12 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , isPyPy
 , fetchPypi
 , pythonOlder
 , curl
 , openssl
 , bottle
-, pytest
+, pytestCheckHook
 , nose
 , flaky
 }:
@@ -20,6 +21,11 @@ buildPythonPackage rec {
     sha256 = "8301518689daefa53726b59ded6b48f33751c383cf987b0ccfbbc4ed40281325";
   };
 
+  preConfigure = ''
+    substituteInPlace setup.py --replace '--static-libs' '--libs'
+    export PYCURL_SSL_LIBRARY=openssl
+  '';
+
   buildInputs = [
     curl
     openssl.out
@@ -31,34 +37,48 @@ buildPythonPackage rec {
 
   checkInputs = [
     bottle
-    pytest
+    pytestCheckHook
     nose
     flaky
   ];
 
-  # skip impure or flakey tests
-  # See also:
-  #   * https://github.com/NixOS/nixpkgs/issues/77304
-  checkPhase = ''
-    HOME=$TMPDIR pytest tests -k "not test_ssl_in_static_libs \
-                     and not test_keyfunction \
-                     and not test_keyfunction_bogus_return \
-                     and not test_libcurl_ssl_gnutls \
-                     and not test_libcurl_ssl_nss \
-                     and not test_libcurl_ssl_openssl" \
-                 --ignore=tests/getinfo_test.py \
-                 --ignore=tests/memory_mgmt_test.py \
-                 --ignore=tests/multi_memory_mgmt_test.py \
-                 --ignore=tests/multi_timer_test.py
+  pytestFlagsArray = [
+    # don't pick up the tests directory below examples/
+    "tests"
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
   '';
 
-  preConfigure = ''
-    substituteInPlace setup.py --replace '--static-libs' '--libs'
-    export PYCURL_SSL_LIBRARY=openssl
-  '';
+  disabledTests = [
+    # libcurl stopped passing the reason phrase from the HTTP status line
+    # https://github.com/pycurl/pycurl/issues/679
+    "test_failonerror"
+    "test_failonerror_status_line_invalid_utf8_python3"
+    # bottle>=0.12.17 escapes utf8 properly, so these test don't work anymore
+    # https://github.com/pycurl/pycurl/issues/669
+    "test_getinfo_content_type_invalid_utf8_python3"
+    "test_getinfo_cookie_invalid_utf8_python3"
+    "test_getinfo_raw_content_type_invalid_utf8"
+    "test_getinfo_raw_cookie_invalid_utf8"
+    # tests that require network access
+    "test_keyfunction"
+    "test_keyfunction_bogus_return"
+    # OSError: tests/fake-curl/libcurl/with_openssl.so: cannot open shared object file: No such file or directory
+    "test_libcurl_ssl_openssl"
+    # OSError: tests/fake-curl/libcurl/with_nss.so: cannot open shared object file: No such file or directory
+    "test_libcurl_ssl_nss"
+    # OSError: tests/fake-curl/libcurl/with_gnutls.so: cannot open shared object file: No such file or directory
+    "test_libcurl_ssl_gnutls"
+    # AssertionError: assert 'crypto' in ['curl']
+    "test_ssl_in_static_libs"
+  ];
 
-  meta = {
+  meta = with lib; {
     homepage = "http://pycurl.sourceforge.net/";
     description = "Python wrapper for libcurl";
+    license = licenses.lgpl2Only;
+    maintainers = with maintainers; [];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/build/142633714
https://hydra.nixos.org/build/142719939

ZHF #122042

staging-next #122068 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
