### PR TITLE
taglib: 1.11.1 -> 1.12

### DIFF
--- a/pkgs/applications/audio/strawberry/default.nix
+++ b/pkgs/applications/audio/strawberry/default.nix
@@ -82,10 +82,6 @@ mkDerivation rec {
     util-linux
   ];
 
-  cmakeFlags = [
-    "-DUSE_SYSTEM_TAGLIB=ON"
-  ];
-
   postInstall = ''
     qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';

--- a/pkgs/development/libraries/taglib/default.nix
+++ b/pkgs/development/libraries/taglib/default.nix
@@ -1,38 +1,20 @@
-{ lib, stdenv, fetchurl, cmake, fetchpatch
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "taglib";
-  version = "1.11.1";
+  version = "1.12";
 
-  src = fetchurl {
-    url = "http://taglib.org/releases/${pname}-${version}.tar.gz";
-    sha256 = "0ssjcdjv4qf9liph5ry1kngam1y7zp8fzr9xv4wzzrma22kabldn";
+  src = fetchFromGitHub {
+    owner = "taglib";
+    repo = "taglib";
+    rev = "v${version}";
+    sha256 = "sha256-omErajnYgxbflsbe6pS2KsexZcXisso0WGYnmIud7WA=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/taglib/taglib/issues/829
-      name = "CVE-2017-12678.patch";
-      url = "https://github.com/taglib/taglib/commit/eb9ded1206f18.patch";
-      sha256 = "1bvpxsvmlpi3by7myzss9kkpdkv405612n8ff68mw1ambj8h1m90";
-    })
-
-    (fetchpatch {
-      # https://github.com/taglib/taglib/pull/869
-      name = "CVE-2018-11439.patch";
-      url = "https://github.com/taglib/taglib/commit/272648ccfcccae30e002ccf34a22e075dd477278.patch";
-      sha256 = "0p397qq4anvcm0p8xs68mxa8hg6dl07chg260lc6k2929m34xv72";
-    })
-
-    (fetchpatch {
-      # many consumers of taglib have started vendoring taglib due to this bug
-      name = "fix_ogg_corruption.patch";
-      url = "https://github.com/taglib/taglib/commit/9336c82da3a04552168f208cd7a5fa4646701ea4.patch";
-      sha256 = "01wlwk4gmfxdg5hjj9jmrain7kia89z0zsdaf5gn3nibmy5bq70r";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -51,7 +33,6 @@ stdenv.mkDerivation rec {
       Speex, WavPack, TrueAudio, WAV, AIFF, MP4 and ASF files.
     '';
     license = with licenses; [ lgpl3 mpl11 ];
-    inherit (cmake.meta) platforms;
     maintainers = with maintainers; [ ttuegel ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Several packages consuming taglib complain and/or vendor a patched taglib due to a high-profile corruption issue in 1.11.1 (which we patch in nixpkgs) but finally we have an upstream release with the fix.

This means we can drop our workarounds (strawberry is included here).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
