### PR TITLE
[20.09] squid: 4.14 -> 4.15

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "squid";
-  version = "4.14";
+  version = "4.15";
 
   src = fetchurl {
     url = "http://www.squid-cache.org/Versions/v4/${pname}-${version}.tar.xz";
-    sha256 = "sha256-8Ql9qmQ0iXwVm8EAl4tRNHwDOQQWEIRdCvoSgVFyn/w=";
+    sha256 = "sha256-tpOk5asoEaioVPYN4KYq+786lSux0EeVLJrgEyH4SiU=";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A caching proxy for the Web supporting HTTP, HTTPS, FTP, and more";
     homepage = "http://www.squid-cache.org";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz raskin ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-28116, CVE-2021-31806, CVE-2021-31807, CVE-2021-31808,
CVE-2021-28652, CVE-2021-28662 and CVE-2021-28651.

https://github.com/squid-cache/squid/security/advisories/GHSA-pxwq-f3qr-w2xf
https://github.com/squid-cache/squid/security/advisories/GHSA-m47m-9hvw-7447
https://github.com/squid-cache/squid/security/advisories/GHSA-jjq6-mh2h-g39h
https://github.com/squid-cache/squid/security/advisories/GHSA-572g-rvwr-6c7f
https://github.com/squid-cache/squid/security/advisories/GHSA-ch36-9jhx-phm4
(cherry picked from commit 4b66107509daee791f7675d7866322d770a1aca9)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
