### PR TITLE
gerbera: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/servers/gerbera/default.nix
+++ b/pkgs/servers/gerbera/default.nix
@@ -1,66 +1,102 @@
-{ lib, stdenv, fetchFromGitHub
-, cmake, pkg-config
-# required
-, libupnp, libuuid, pugixml, libiconv, sqlite, zlib, spdlog, fmt
-# options
-, enableDuktape ? true, duktape
-, enableCurl ? true, curl
-, enableTaglib ? true, taglib
-, enableLibmagic ? true, file
-, enableLibmatroska ? true, libmatroska, libebml
-, enableAvcodec ? false, ffmpeg
-, enableLibexif ? true, libexif
-, enableExiv2 ? false, exiv2
-, enableFFmpegThumbnailer ? false, ffmpegthumbnailer
-, enableInotifyTools ? true, inotify-tools
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+  # required
+, fmt
+, libiconv
+, libupnp
+, libuuid
+, pugixml
+, spdlog
+, sqlite
+, zlib
+  # options
+, enableMysql ? false
+, libmysqlclient
+, enableDuktape ? true
+, duktape
+, enableCurl ? true
+, curl
+, enableTaglib ? true
+, taglib
+, enableLibmagic ? true
+, file
+, enableLibmatroska ? true
+, libmatroska
+, libebml
+, enableAvcodec ? false
+, ffmpeg
+, enableLibexif ? true
+, libexif
+, enableExiv2 ? false
+, exiv2
+, enableFFmpegThumbnailer ? false
+, ffmpegthumbnailer
+, enableInotifyTools ? true
+, inotify-tools
 }:
 
-with lib;
 let
-  optionOnOff = option: if option then "on" else "off";
-in stdenv.mkDerivation rec {
+  libupnp' = libupnp.overrideAttrs (super: rec {
+    cmakeFlags = super.cmakeFlags or [ ] ++ [
+      "-Dblocking_tcp_connections=OFF"
+      "-Dreuseaddr=ON"
+    ];
+  });
+
+  options = [
+    { name = "AVCODEC"; enable = enableAvcodec; packages = [ ffmpeg ]; }
+    { name = "CURL"; enable = enableCurl; packages = [ curl ]; }
+    { name = "EXIF"; enable = enableLibexif; packages = [ libexif ]; }
+    { name = "EXIV2"; enable = enableExiv2; packages = [ exiv2 ]; }
+    { name = "FFMPEGTHUMBNAILER"; enable = enableFFmpegThumbnailer; packages = [ ffmpegthumbnailer ]; }
+    { name = "INOTIFY"; enable = enableInotifyTools; packages = [ inotify-tools ]; }
+    { name = "JS"; enable = enableDuktape; packages = [ duktape ]; }
+    { name = "MAGIC"; enable = enableLibmagic; packages = [ file ]; }
+    { name = "MATROSKA"; enable = enableLibmatroska; packages = [ libmatroska libebml ]; }
+    { name = "MYSQL"; enable = enableMysql; packages = [ libmysqlclient ]; }
+    { name = "TAGLIB"; enable = enableTaglib; packages = [ taglib ]; }
+  ];
+
+  inherit (lib) flatten optionals;
+
+in
+stdenv.mkDerivation rec {
   pname = "gerbera";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     repo = "gerbera";
     owner = "gerbera";
     rev = "v${version}";
-    sha256 = "sha256-i33pAgSOjVOoj0qGBnb8hpRMqgTCBTQmKTuZ9AkvoPg=";
+    sha256 = "sha256-bJIT/qQOKTy2l0wsumlGNvaGqzb2mK0hHKG0S6mEG3o=";
   };
 
+  postPatch = lib.optionalString enableMysql ''
+    substituteInPlace cmake/FindMySQL.cmake \
+      --replace /usr/include/mysql ${lib.getDev libmysqlclient}/include/mariadb \
+      --replace /usr/lib/mysql     ${lib.getLib libmysqlclient}/lib/mariadb
+  '';
+
   cmakeFlags = [
-    "-DWITH_JS=${optionOnOff enableDuktape}"
-    "-DWITH_CURL=${optionOnOff enableCurl}"
-    "-DWITH_TAGLIB=${optionOnOff enableTaglib}"
-    "-DWITH_MAGIC=${optionOnOff enableLibmagic}"
-    "-DWITH_MATROSKA=${optionOnOff enableLibmatroska}"
-    "-DWITH_AVCODEC=${optionOnOff enableAvcodec}"
-    "-DWITH_EXIF=${optionOnOff enableLibexif}"
-    "-DWITH_EXIV2=${optionOnOff enableExiv2}"
-    "-DWITH_FFMPEGTHUMBNAILER=${optionOnOff enableFFmpegThumbnailer}"
-    "-DWITH_INOTIFY=${optionOnOff enableInotifyTools}"
     # systemd service will be generated alongside the service
     "-DWITH_SYSTEMD=OFF"
-  ];
+  ] ++ map (e: "-DWITH_${e.name}=${if e.enable then "ON" else "OFF"}") options;
 
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [
-    libupnp libuuid pugixml libiconv sqlite zlib fmt.dev
+    fmt
+    libiconv
+    libupnp'
+    libuuid
+    pugixml
     spdlog
-  ]
-  ++ optionals enableDuktape [ duktape ]
-  ++ optionals enableCurl [ curl ]
-  ++ optionals enableTaglib [ taglib ]
-  ++ optionals enableLibmagic [ file ]
-  ++ optionals enableLibmatroska [ libmatroska libebml ]
-  ++ optionals enableAvcodec [ ffmpeg.dev ]
-  ++ optionals enableLibexif [ libexif ]
-  ++ optionals enableExiv2 [ exiv2 ]
-  ++ optionals enableInotifyTools [ inotify-tools ]
-  ++ optionals enableFFmpegThumbnailer [ ffmpegthumbnailer ];
-
+    sqlite
+    zlib
+  ] ++ flatten (builtins.catAttrs "packages" (builtins.filter (e: e.enable) options));
 
   meta = with lib; {
     homepage = "https://docs.gerbera.io/";
@@ -70,8 +106,8 @@ in stdenv.mkDerivation rec {
       It allows to stream your digital media through your home network and consume it on all kinds
       of UPnP supporting devices.
     '';
-    license = licenses.gpl2;
-    maintainers = [ maintainers.ardumont ];
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ ardumont ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I had a locally packaged version from before it made it into nixpkgs.

In addition to the version bump, there are few other things going on:

1. add mysql support (which our nixos module doesn't support, but that's for another time)
2. unify handling of buildInputs and cmakeFlags so we don't have to change things in multiple places
3. don't pull in all of lib
4. override libupnp to get a variant with the flags recommended by gerbera
   
There are no changes to the defaults.

Cc: @ardumont

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
