### PR TITLE
dasher: Fix build

### DIFF
--- a/pkgs/applications/accessibility/dasher/default.nix
+++ b/pkgs/applications/accessibility/dasher/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv, lib, fetchFromGitHub, fetchpatch
 , autoreconfHook, pkg-config, wrapGAppsHook
 , glib, gtk3, expat, gnome-doc-utils, which
 , at-spi2-core, dbus
@@ -18,6 +18,14 @@ stdenv.mkDerivation {
     rev = "9ab12462e51d17a38c0ddc7f7ffe1cb5fe83b627";
     sha256 = "1r9xn966nx3pv2bidd6i3pxmprvlw6insnsb38zabmac609h9d9s";
   };
+
+  patches = [
+    # https://github.com/dasher-project/dasher/issues/180
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/dasher/commit/5eed251f9bb0bae10e2efe177e1054346c7347d1.patch";
+      sha256 = "sha256-wMmU1AY0ZL3u3k1IfUzg6ZyGdpNd7A8sWf8levf7rqY=";
+    })
+  ];
 
   prePatch = ''
     # tries to invoke git for something, probably fetching the ref


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042

@NixOS/nixos-release-managers

@Profpatsch I don't know anything else about this package, but it looks like the development on https://gitlab.gnome.org/GNOME/dasher/ is more active than on https://github.com/dasher-project/dasher - maybe the sources should be switched?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
