### PR TITLE
influxdb2: 2.0.2 -> 2.0.6 [ZHF]

### DIFF
--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -13,15 +13,15 @@
 # dependencies nix expression.
 
 let
-  version = "2.0.2";
-  shorthash = "84496e507a"; # git rev-parse HEAD with 2.0.2 checked out
-  libflux_version = "0.95.0";
+  version = "2.0.6";
+  shorthash = "4db98b4c9a"; # git rev-parse HEAD with 2.0.6 checked out
+  libflux_version = "0.115.0";
 
   src = fetchFromGitHub {
     owner = "influxdata";
     repo = "influxdb";
     rev = "v${version}";
-    sha256 = "05s09crqgbyfdck33zwax5l47jpc4wh04yd8zsm658iksdgzpmnn";
+    sha256 = "1x74p87csx4m4cgijk57xs75nikv3bnh7skgnzk30ab1ar13iirw";
   };
 
   ui = mkYarnPackage {
@@ -31,7 +31,7 @@ let
     yarnNix = ./influx-ui-yarndeps.nix;
     configurePhase = ''
       cp -r $node_modules ui/node_modules
-      rsync -r $node_modules/../deps/chronograf-ui/node_modules/ ui/node_modules
+      rsync -r $node_modules/../deps/influxdb-ui/node_modules/ ui/node_modules
     '';
     INFLUXDB_SHA = shorthash;
     buildPhase = ''
@@ -52,10 +52,10 @@ let
       owner = "influxdata";
       repo = "flux";
       rev = "v${libflux_version}";
-      sha256 = "07jz2nw3zswg9f4p5sb5r4hpg3n4qibjcgs9sk9csns70h5rp9j3";
+      sha256 = "0zplwsk9xidv8l9sqbxqivy6q20ryd31fhrzspn1mjn4i45kkwz1";
     };
     sourceRoot = "source/libflux";
-    cargoSha256 = "0y5xjkqpaxp9qq1qj39zw3mnvkbbb9g4fa5cli77nhfwz288xx6h";
+    cargoSha256 = "06gh466q7qkid0vs5scic0qqlz3h81yb00nwn8nwq8ppr5z2ijyq";
     nativeBuildInputs = [ llvmPackages.libclang ];
     LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
     pkgcfg = ''
@@ -80,7 +80,7 @@ in buildGoModule {
 
   nativeBuildInputs = [ go-bindata pkg-config ];
 
-  vendorSha256 = "0lviz7l5zbghyfkp0lvlv8ykpak5hhkfal8d7xwvpsm8q3sghc8a";
+  vendorSha256 = "03pabm0h9q0v5dfdq9by2l2n32bz9imwalz0aw897vsrfhci0ldf";
   subPackages = [ "cmd/influxd" "cmd/influx" ];
 
   PKG_CONFIG_PATH = "${flux}/pkgconfig";

--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -7,6 +7,8 @@
 , mkYarnPackage
 , pkg-config
 , rustPlatform
+, stdenv
+, libiconv
 }:
 
 # Note for maintainers: use ./update-influxdb2.sh to update the Yarn
@@ -57,6 +59,7 @@ let
     sourceRoot = "source/libflux";
     cargoSha256 = "06gh466q7qkid0vs5scic0qqlz3h81yb00nwn8nwq8ppr5z2ijyq";
     nativeBuildInputs = [ llvmPackages.libclang ];
+    buildInputs = lib.optional stdenv.isDarwin libiconv;
     LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
     pkgcfg = ''
       Name: flux
@@ -71,6 +74,8 @@ let
       cp -r $NIX_BUILD_TOP/source/libflux/include/influxdata $out/include
       substitute $pkgcfgPath $out/pkgconfig/flux.pc \
         --replace /out $out
+    '' + lib.optionalString stdenv.isDarwin ''
+      install_name_tool -id $out/lib/libflux.dylib $out/lib/libflux.dylib
     '';
   };
 in buildGoModule {

--- a/pkgs/servers/nosql/influxdb2/influx-ui-package.json
+++ b/pkgs/servers/nosql/influxdb2/influx-ui-package.json
@@ -1,12 +1,12 @@
 {
-  "name": "chronograf-ui",
-  "version": "2.0.2",
+  "name": "influxdb-ui",
+  "version": "2.0.5",
   "private": false,
-  "license": "AGPL-3.0",
+  "license": "MIT",
   "description": "",
   "repository": {
     "type": "git",
-    "url": "github:influxdata/chronograf"
+    "url": "github:influxdata/ui"
   },
   "engines": {
     "node": ">=10.5.0",
@@ -40,6 +40,7 @@
     "eslint:circleci": "eslint",
     "eslint:fix": "eslint --fix '{src,cypress}/**/*.{ts,tsx}'",
     "prettier": "prettier --config .prettierrc.json --check '{src,cypress}/**/*.{ts,tsx}'",
+    "prettier:circleci": "prettier --config .prettierrc.json --check",
     "prettier:fix": "prettier --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:cypress": "tsc -p ./cypress/tsconfig.json --noEmit --pretty --skipLibCheck",
@@ -134,7 +135,7 @@
   "dependencies": {
     "@influxdata/clockface": "2.3.4",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.23",
+    "@influxdata/flux-lsp-browser": "^0.5.41",
     "@influxdata/giraffe": "0.29.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/pkgs/servers/nosql/influxdb2/influx-ui-yarndeps.nix
+++ b/pkgs/servers/nosql/influxdb2/influx-ui-yarndeps.nix
@@ -666,11 +666,11 @@
       };
     }
     {
-      name = "_influxdata_flux_lsp_browser___flux_lsp_browser_0.5.23.tgz";
+      name = "_influxdata_flux_lsp_browser___flux_lsp_browser_0.5.41.tgz";
       path = fetchurl {
-        name = "_influxdata_flux_lsp_browser___flux_lsp_browser_0.5.23.tgz";
-        url  = "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.23.tgz";
-        sha1 = "b3d1579e26ff21a11771003cbcaebe5fef82d73c";
+        name = "_influxdata_flux_lsp_browser___flux_lsp_browser_0.5.41.tgz";
+        url  = "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.41.tgz";
+        sha1 = "abf6c5ad253317f34a9217ecfd250d78fe625a83";
       };
     }
     {


### PR DESCRIPTION
###### Motivation for this change

The build of influxdb2 was failing while building libflux because of some Rust changes:

```
commit 6f73a8570ca0cb6d567e8eaebc59293f12bb7483
Author: Arthur Gautier <baloo@superbaloo.net>
Date:   Thu Mar 25 18:03:40 2021 +0000

    rust: 1.50.0 -> 1.51.0
```

```
error: panic message is not a string literal
  --> src/core/ast/flatbuffers/tests.rs:89:28
   |
89 |             assert!(false, e);
   |                            ^
   |
note: the lint level is defined here
  --> src/core/lib.rs:1:38
   |
1  | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
   |                                      ^^^^^^^^
= note: `#[deny(non_fmt_panic)]` implied by `#[deny(warnings)]`
= note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
   |
89 |             assert!(false, "{}", e);
   |                            ^^^^^
```

Upstream fixed this in libflux with commit https://github.com/influxdata/flux/commit/3a89cfc6980d31cf5d9b5a998c2d7a1f2eb1920b

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
