### PR TITLE
blobfuse: 1.0.2 -> 1.3.7, separately build cpplite

### DIFF
--- a/pkgs/tools/filesystems/blobfuse/default.nix
+++ b/pkgs/tools/filesystems/blobfuse/default.nix
@@ -1,19 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, curl, gnutls, libgcrypt, libuuid, fuse }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, curl, gnutls, libgcrypt, libuuid, fuse, boost }:
 
-stdenv.mkDerivation rec {
-  pname = "blobfuse";
-  version = "1.0.2";
-
+let
+  version = "1.3.7";
   src = fetchFromGitHub {
     owner  = "Azure";
     repo   = "azure-storage-fuse";
-    rev    = "v${version}";
-    sha256 = "1qh04z1fsj1l6l12sz9yl2sy9hwlrnzac54hwrr7wvsgv90n9gbp";
+    rev    = "blobfuse-${version}-Linux";
+    sha256 = "sha256-yihIuS4AG489U7eBi/p7H6S7Cg54kkQeNVCexxQZ60A=";
   };
+  cpplite = stdenv.mkDerivation rec {
+    pname = "cpplite";
+    inherit version src;
+
+    sourceRoot = "source/cpplite";
+    patches = [ ./install-adls.patch ];
+
+    cmakeFlags = [ "-DBUILD_ADLS=ON" "-DUSE_OPENSSL=OFF" ];
+
+    buildInputs = [ curl libuuid gnutls ];
+    nativeBuildInputs = [ cmake pkg-config ];
+  };
+in stdenv.mkDerivation rec {
+  pname = "blobfuse";
+  inherit version src;
 
   NIX_CFLAGS_COMPILE = "-Wno-error=catch-value";
 
-  buildInputs = [ curl gnutls libgcrypt libuuid fuse ];
+  buildInputs = [ curl gnutls libgcrypt libuuid fuse boost cpplite ];
   nativeBuildInputs = [ cmake pkg-config ];
 
   meta = with lib; {

--- a/pkgs/tools/filesystems/blobfuse/install-adls.patch
+++ b/pkgs/tools/filesystems/blobfuse/install-adls.patch
@@ -1,0 +1,14 @@
+diff --git a/adls/CMakeLists.txt b/adls/CMakeLists.txt
+index 1fb7146..22e663a 100644
+--- a/adls/CMakeLists.txt
++++ b/adls/CMakeLists.txt
+@@ -50,3 +50,9 @@ if(BUILD_TESTS)
+   string(REGEX REPLACE "([^;]+)" "${CMAKE_CURRENT_SOURCE_DIR}/\\1" AZURE_STORAGE_ADLS_TEST_SOURCES "${AZURE_STORAGE_ADLS_TEST_SOURCES}")
+   set(AZURE_STORAGE_ADLS_TEST_SOURCES ${AZURE_STORAGE_ADLS_TEST_SOURCES} PARENT_SCOPE)
+ endif()
++
++install(TARGETS azure-storage-adls
++        ARCHIVE DESTINATION lib
++        LIBRARY DESTINATION lib
++        RUNTIME DESTINATION bin)
++


### PR DESCRIPTION
###### Motivation for this change

* Build was broken due to missing `<stdexcept>` include, fix available in newer upstream release
* Bumped version from 1.0.2 -> 1.3.7
* Build scripts have changed, `cpplite` (azure-storage-lite) is now built in a separate CMake run
* Upstream uses `build.sh` to manually copy resulting static libraries from `cpplite` build for `blobfuse` build, I put `cpplite` in a separate derivation and have the main `blobfuse` derivation depend on it
* Upstream build would not install `libazure-storage-adls.a` during `cpplite` build, instead relying on manual copying in `build.sh` script
* Added a patch to install `libazure-storage-adls.a` during `cpplite` build, so it is properly picked up during `blobfuse` build

The resulting binary works, but since I am not an Azure user, I could not test for actual functionality.

ZHF: #122042

@jonringer 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
