### PR TITLE
Restore version in Qt derivation names

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtcharts.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative }:
 
 qtModule {
-  name = "qtcharts";
+  pname = "qtcharts";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtconnectivity.nix
@@ -1,7 +1,7 @@
 { qtModule, lib, stdenv, qtbase, qtdeclarative, bluez }:
 
 qtModule {
-  name = "qtconnectivity";
+  pname = "qtconnectivity";
   qtInputs = [ qtbase qtdeclarative ];
   buildInputs = lib.optional stdenv.isLinux bluez;
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -3,7 +3,7 @@
 with lib;
 
 qtModule {
-  name = "qtdeclarative";
+  pname = "qtdeclarative";
   qtInputs = [ qtbase qtsvg ];
   nativeBuildInputs = [ python3 ];
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/qt-5/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdoc.nix
@@ -1,7 +1,7 @@
 { qtModule, qtdeclarative }:
 
 qtModule {
-  name = "qtdoc";
+  pname = "qtdoc";
   qtInputs = [ qtdeclarative ];
   outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtgamepad.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtgamepad.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative, pkg-config }:
 
 qtModule {
-  name = "qtgamepad";
+  pname = "qtgamepad";
   qtInputs = [ qtbase qtdeclarative ];
   buildInputs = [ ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/libraries/qt-5/modules/qtgraphicaleffects.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtgraphicaleffects.nix
@@ -1,7 +1,7 @@
 { qtModule, qtdeclarative }:
 
 qtModule {
-  name = "qtgraphicaleffects";
+  pname = "qtgraphicaleffects";
   qtInputs = [ qtdeclarative ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtimageformats.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtimageformats.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, libtiff }:
 
 qtModule {
-  name = "qtimageformats";
+  pname = "qtimageformats";
   qtInputs = [ qtbase ];
   propagatedBuildInputs = [ libtiff ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, qtModule, qtbase, qtmultimedia }:
 
 qtModule {
-  name = "qtlocation";
+  pname = "qtlocation";
   qtInputs = [ qtbase qtmultimedia ];
   outputs = [ "bin" "out" "dev" ];
   qmakeFlags = lib.optional stdenv.isDarwin [

--- a/pkgs/development/libraries/qt-5/modules/qtmacextras.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmacextras.nix
@@ -1,7 +1,7 @@
 { lib, qtModule, qtbase }:
 
 qtModule {
-  name = "qtmacextras";
+  pname = "qtmacextras";
   qtInputs = [ qtbase ];
   meta = with lib; {
     maintainers = with maintainers; [ periklis ];

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -5,7 +5,7 @@
 with lib;
 
 qtModule {
-  name = "qtmultimedia";
+  pname = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gstreamer gst-plugins-base libpulseaudio ]

--- a/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
@@ -1,6 +1,6 @@
 { qtModule, qtbase }:
 
 qtModule {
-  name = "qtnetworkauth";
+  pname = "qtnetworkauth";
   qtInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols.nix
@@ -1,6 +1,6 @@
 { qtModule, qtdeclarative }:
 
 qtModule {
-  name = "qtquickcontrols";
+  pname = "qtquickcontrols";
   qtInputs = [ qtdeclarative ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtquickcontrols2.nix
@@ -1,7 +1,7 @@
 { qtModule, qtdeclarative }:
 
 qtModule {
-  name = "qtquickcontrols2";
+  pname = "qtquickcontrols2";
   qtInputs = [ qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtscript.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtscript.nix
@@ -1,6 +1,6 @@
 { qtModule, qtbase, qttools }:
 
 qtModule {
-  name = "qtscript";
+  pname = "qtscript";
   qtInputs = [ qtbase qttools ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtscxml.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative }:
 
 qtModule {
-  name = "qtscxml";
+  pname = "qtscxml";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtsensors.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsensors.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative }:
 
 qtModule {
-  name = "qtsensors";
+  pname = "qtsensors";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtserialbus.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtserialbus.nix
@@ -1,6 +1,6 @@
 { qtModule, qtbase, qtserialport }:
 
 qtModule {
-  name = "qtserialbus";
+  pname = "qtserialbus";
   qtInputs = [ qtbase qtserialport ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtserialport.nix
@@ -3,7 +3,7 @@
 let inherit (lib) getLib optional; in
 
 qtModule {
-  name = "qtserialport";
+  pname = "qtserialport";
   qtInputs = [ qtbase ];
   NIX_CFLAGS_COMPILE =
     optional stdenv.isLinux

--- a/pkgs/development/libraries/qt-5/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtspeech.nix
@@ -1,7 +1,7 @@
 { qtModule }:
 
 qtModule {
-  name = "qtspeech";
+  pname = "qtspeech";
   qtInputs = [ ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtsvg.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase }:
 
 qtModule {
-  name = "qtsvg";
+  pname = "qtsvg";
   qtInputs = [ qtbase ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -3,7 +3,7 @@
 with lib;
 
 qtModule {
-  name = "qttools";
+  pname = "qttools";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 

--- a/pkgs/development/libraries/qt-5/modules/qttranslations.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttranslations.nix
@@ -1,6 +1,6 @@
 { qtModule, qttools }:
 
 qtModule {
-  name = "qttranslations";
+  pname = "qttranslations";
   qtInputs = [ qttools ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtvirtualkeyboard.nix
@@ -1,6 +1,6 @@
 { qtModule, qtbase, qtdeclarative, qtsvg, hunspell  }:
 
 qtModule {
-  name = "qtvirtualkeyboard";
+  pname = "qtvirtualkeyboard";
   qtInputs = [ qtbase qtdeclarative qtsvg hunspell ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtquickcontrols, wayland, pkg-config }:
 
 qtModule {
-  name = "qtwayland";
+  pname = "qtwayland";
   qtInputs = [ qtbase qtquickcontrols ];
   buildInputs = [ wayland ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative }:
 
 qtModule {
-  name = "qtwebchannel";
+  pname = "qtwebchannel";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -24,7 +24,7 @@
 with lib;
 
 qtModule {
-  name = "qtwebengine";
+  pname = "qtwebengine";
   qtInputs = [ qtdeclarative qtquickcontrols qtlocation qtwebchannel ];
   nativeBuildInputs = [
     bison coreutils flex git gperf ninja pkg-config python2 which gn nodejs

--- a/pkgs/development/libraries/qt-5/modules/qtwebglplugin.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebglplugin.nix
@@ -1,6 +1,6 @@
 { qtModule, qtbase, qtwebsockets }:
 
 qtModule {
-  name = "qtwebglplugin";
+  pname = "qtwebglplugin";
   qtInputs = [ qtbase qtwebsockets ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -22,7 +22,7 @@ let
   usingAnnulenWebkitFork = lib.versionAtLeast qtbase.version "5.11.0";
 in
 qtModule {
-  name = "qtwebkit";
+  pname = "qtwebkit";
   qtInputs = [ qtbase qtdeclarative qtlocation qtsensors ]
     ++ optional (stdenv.isDarwin && lib.versionAtLeast qtbase.version "5.9.0") qtmultimedia
     ++ optional usingAnnulenWebkitFork qtwebchannel;

--- a/pkgs/development/libraries/qt-5/modules/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebsockets.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative }:
 
 qtModule {
-  name = "qtwebsockets";
+  pname = "qtwebsockets";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebview.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebview.nix
@@ -3,7 +3,7 @@
 with lib;
 
 qtModule {
-  name = "qtwebview";
+  pname = "qtwebview";
   qtInputs = [ qtdeclarative qtwebengine ];
   buildInputs = optional (stdenv.isDarwin) [
     darwin.apple_sdk.frameworks.CoreFoundation

--- a/pkgs/development/libraries/qt-5/modules/qtx11extras.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtx11extras.nix
@@ -1,6 +1,6 @@
 { qtModule, qtbase }:
 
 qtModule {
-  name = "qtx11extras";
+  pname = "qtx11extras";
   qtInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtxmlpatterns.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtxmlpatterns.nix
@@ -1,7 +1,7 @@
 { qtModule, qtbase, qtdeclarative }:
 
 qtModule {
-  name = "qtxmlpatterns";
+  pname = "qtxmlpatterns";
   qtInputs = [ qtbase qtdeclarative ];
   devTools = [ "bin/xmlpatterns" "bin/xmlpatternsvalidator" ];
 }

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -7,7 +7,7 @@ let inherit (lib) licenses maintainers platforms; in
 args:
 
 let
-  pname = args.name;
+  inherit (args) pname;
   version = args.version or srcs.${pname}.version;
   src = args.src or srcs.${pname}.src;
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

At some point, the Qt derivation names stopped showing versions.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
