### PR TITLE
waypoint: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/applications/networking/cluster/waypoint/default.nix
+++ b/pkgs/applications/networking/cluster/waypoint/default.nix
@@ -1,20 +1,20 @@
-{ lib, buildGoModule, fetchFromGitHub, go-bindata }:
+{ lib, buildGoModule, fetchFromGitHub, go-bindata, installShellFiles }:
 
 buildGoModule rec {
   pname = "waypoint";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-WzKUVfc7oGMh0TamL5b6gsm/BAfSCZ6EB3Hg4Tg/3Hw=";
+    sha256 = "sha256-57DHImPYVFK+MXWGeArvc5fwHmqa3zodLytfDoAxglo=";
   };
 
   deleteVendor = true;
-  vendorSha256 = "sha256-VxKUYD92DssoSjWxR+1gZLq34vCVM/4U2ju5felLWzI=";
+  vendorSha256 = "sha256-HxrY35SqfUbT6VCCXkLUjAsxgtMzpOeoicAGLwD2OyA=";
 
-  nativeBuildInputs = [ go-bindata ];
+  nativeBuildInputs = [ go-bindata installShellFiles ];
 
   # GIT_{COMMIT,DIRTY} filled in blank to prevent trying to run git and ending up blank anyway
   buildPhase = ''
@@ -23,9 +23,29 @@ buildGoModule rec {
     runHook postBuild
   '';
 
+  doCheck = false;
+
   installPhase = ''
     runHook preInstall
+
+    local INSTALL="$out/bin/waypoint"
     install -D waypoint $out/bin/waypoint
+
+    # Write to a file as it doesn't like EOF within <()
+    cat > waypoint.fish <<EOF
+    function __complete_waypoint
+      set -lx COMP_LINE (commandline -cp)
+      test -z (commandline -ct)
+      and set COMP_LINE "$COMP_LINE "
+      $INSTALL
+    end
+    complete -f -c waypoint -a "(__complete_waypoint)"
+    EOF
+    installShellCompletion --cmd waypoint \
+      --bash <(echo "complete -C $INSTALL waypoint") \
+      --fish <(cat waypoint.fish) \
+      --zsh <(echo "complete -o nospace -C $INSTALL waypoint")
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump waypoint to `0.3.2`

Disable check phase to avoid an error message

Added shell completions based on the values *injected* into shell config files by `-autocomplete-install`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
