### PR TITLE
python3Packages.pytaglib: 1.4.5 -> 1.4.6

### DIFF
--- a/pkgs/development/python-modules/pytaglib/default.nix
+++ b/pkgs/development/python-modules/pytaglib/default.nix
@@ -3,56 +3,35 @@
 , fetchFromGitHub
 , taglib
 , cython
-, pytest
-, glibcLocales
-, fetchpatch
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
-  pname   = "pytaglib";
-  version = "1.4.5";
+  pname = "pytaglib";
+  version = "1.4.6";
 
   src = fetchFromGitHub {
     owner = "supermihi";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1gvvadlgk8ny8bg76gwvvfcwp1nfgrjphi60h5f9ha7h5ff1g2wb";
+    sha256 = "sha256-UAWXR1MCxEB48n7oQE+L545F+emlU3HErzLX6YTRteg=";
   };
 
-  patches = [
-    # fix tests on python 2.7
-    (fetchpatch {
-      url = "https://github.com/supermihi/pytaglib/commit/0c4ae750fcd5b18d2553975c7e3e183e9dca5bf1.patch";
-      sha256 = "1kv3c68vimx5dc8aacvzphiaq916avmprxddi38wji8p2ql6vngj";
-    })
-
-    # properly install pyprinttags
-    (fetchpatch {
-      url = "https://github.com/supermihi/pytaglib/commit/ba7a1406ddf35ddc41ed57f1c8d1f2bc2ed2c93a.patch";
-      sha256 = "0pi0dcq7db5fd3jnbwnfsfsgxvlhnm07z5yhpp93shk0s7ci2bwp";
-    })
-    (fetchpatch {
-      url = "https://github.com/supermihi/pytaglib/commit/28772f6f94d37f05728071381a0fa04c6a14783a.patch";
-      sha256 = "0h259vzj1l0gpibdf322yclyd10x5rh1anzhsjj2ghm6rj6q0r0m";
-    })
+  buildInputs = [
+    cython
+    taglib
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "'pytest-runner', " ""
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  buildInputs = [ taglib cython ];
+  pythonImportsCheck = [ "taglib" ];
 
-  checkInputs = [ pytest glibcLocales ];
-
-  checkPhase = ''
-    LC_ALL=en_US.utf-8 pytest .
-  '';
-
-  meta = {
+  meta = with lib; {
+    description = "Python bindings for the Taglib audio metadata library";
     homepage = "https://github.com/supermihi/pytaglib";
-    description = "Python 2.x/3.x bindings for the Taglib audio metadata library";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.mrkkrp ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mrkkrp ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4.6

Change log: https://github.com/supermihi/pytaglib/releases/tag/v1.4.6

ZHF: #122042
Ref: https://hydra.nixos.org/build/141960295

CC @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
