### PR TITLE
xfce.mousepad: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad/default.nix
+++ b/pkgs/desktops/xfce/applications/mousepad/default.nix
@@ -1,16 +1,19 @@
-{ mkXfceDerivation, gobject-introspection, vala, gtk3, gtksourceview4, xfconf }:
+{ mkXfceDerivation, gobject-introspection, gtk3, gtksourceview4, gspell }:
 
 mkXfceDerivation {
   category = "apps";
   pname = "mousepad";
-  version = "0.5.4";
+  version = "0.5.5";
   odd-unstable = false;
 
-  sha256 = "0yrmjs6cyzm08jz8wzrx8wdxj7zdbxn6x625109ckfcfxrkp4a2f";
+  sha256 = "1c985xb3395bn1024qhqqdnlkbn02zldsnybxsw49xqh55pa4a2n";
 
-  nativeBuildInputs = [ gobject-introspection vala ];
+  nativeBuildInputs = [ gobject-introspection ];
 
-  buildInputs = [ gtk3 gtksourceview4 xfconf ];
+  buildInputs = [ gtk3 gtksourceview4 gspell ];
+
+  # Use the GSettings keyfile backend rather than DConf
+  configureFlags = [ "--enable-keyfile-settings" ];
 
   meta = {
     description = "Simple text editor for Xfce";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update to version [0.5.5](https://gitlab.xfce.org/apps/mousepad/-/blob/master/NEWS)
- Remove unused dependences: `vala`, `xfconf`
- Add new dependence: gspell (for the new `gspell` plugin)
- Use the GSettings keyfile backend

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
