### PR TITLE
nixos/sway: set default wallpaper

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -105,6 +105,22 @@ in {
       '';
     };
 
+    defaultWallpaper = mkOption {
+      type = with types; nullOr path;
+      default = pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom.gnomeFilePath;
+
+      defaultText = literalExample ''
+        pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom.gnomeFilePath;
+      '';
+
+      example = literalExample ''
+        null;
+      '';
+
+      description = ''
+        Default wallpaper. Set to `null` to not install a default wallpaper.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -126,6 +142,12 @@ in {
           # user environments (e.g. required for screen sharing and Pinentry prompts):
           exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK
         '';
+      } // lib.optionalAttrs (cfg.defaultWallpaper != null) {
+        "sway/config.d/wallpaper.conf".source = pkgs.writeText "wallpaper.conf" ''
+          # Set the default wallpaper
+          output '*' background "/etc/sway/wallpaper" fill
+        '';
+        "sway/wallpaper".source = cfg.defaultWallpaper;
       };
     };
     security.pam.services.swaylock = {};


### PR DESCRIPTION
###### Motivation for this change

cc @primeos

See also: https://github.com/Synthetica9/nixpkgs/pull/new/sway-default-wallpaper

The wallpaper shows up in the test, but I don't know if this is what you had in mind.

![sway_exit](https://user-images.githubusercontent.com/7075751/118279518-87860480-b4cb-11eb-9bf8-3e8f23169295.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
