### PR TITLE
treewide: remove nand0p as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7019,12 +7019,6 @@
     githubId = 1222539;
     name = "Roman Naumann";
   };
-  nand0p = {
-    email = "nando@hex7.com";
-    github = "nand0p";
-    githubId = 1916245;
-    name = "Fernando Jose Pando";
-  };
   nasirhm = {
     email = "nasirhussainm14@gmail.com";
     github = "nasirhm";

--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -283,5 +283,5 @@ in {
     '')
   ];
 
-  meta.maintainers = with lib.maintainers; [ nand0p mic92 lopsided98 ];
+  meta.maintainers = with lib.maintainers; [ mic92 lopsided98 ];
 }

--- a/nixos/modules/services/continuous-integration/buildbot/worker.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/worker.nix
@@ -191,6 +191,6 @@ in {
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ nand0p ];
+  meta.maintainers = with lib.maintainers; [ ];
 
 }

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -54,5 +54,5 @@ in {
 
   };
 
-  meta.maintainers = with lib.maintainers; [ nand0p ];
+  meta.maintainers = with lib.maintainers; [ ];
 }

--- a/nixos/tests/buildbot.nix
+++ b/nixos/tests/buildbot.nix
@@ -109,5 +109,5 @@ import ./make-test-python.nix {
         bbworker.fail("nc -z bbmaster 8011")
   '';
 
-  meta.maintainers = with pkgs.lib.maintainers; [ nand0p ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ];
 } {}

--- a/pkgs/development/libraries/ethash/default.nix
+++ b/pkgs/development/libraries/ethash/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "PoW algorithm for Ethereum 1.0 based on Dagger-Hashimoto";
     homepage = "https://github.com/ethereum/ethash";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     inherit version;
     homepage = "https://github.com/open-source-parsers/jsoncpp";
     description = "A C++ library for interacting with JSON";
-    maintainers = with maintainers; [ ttuegel cpages nand0p ];
+    maintainers = with maintainers; [ ttuegel cpages ];
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/development/python-modules/astroid/1.6.nix
+++ b/pkgs/development/python-modules/astroid/1.6.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PyCQA/astroid";
     license = licenses.lgpl2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PyCQA/astroid";
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -73,6 +73,6 @@ buildPythonPackage rec {
     description = "WebSocket and WAMP in Python for Twisted and asyncio";
     homepage = "https://crossbar.io/autobahn";
     license = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -101,7 +101,7 @@ let
     meta = with lib; {
       homepage = "https://buildbot.net/";
       description = "An open-source continuous integration framework for automating software build, test, and release processes";
-      maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
+      maintainers = with maintainers; [ ryansydnor lopsided98 ];
       license = licenses.gpl2;
     };
   };

--- a/pkgs/development/python-modules/buildbot/pkg.nix
+++ b/pkgs/development/python-modules/buildbot/pkg.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://buildbot.net/";
     description = "Buildbot Packaging Helper";
-    maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
+    maintainers = with maintainers; [ ryansydnor lopsided98 ];
     license = licenses.gpl2;
   };
 }

--- a/pkgs/development/python-modules/buildbot/plugins.nix
+++ b/pkgs/development/python-modules/buildbot/plugins.nix
@@ -23,7 +23,7 @@
     meta = with lib; {
       homepage = "https://buildbot.net/";
       description = "Buildbot UI";
-      maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
+      maintainers = with maintainers; [ ryansydnor lopsided98 ];
       license = licenses.gpl2;
     };
   };
@@ -45,7 +45,7 @@
     meta = with lib; {
       homepage = "https://buildbot.net/";
       description = "Buildbot Console View Plugin";
-      maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
+      maintainers = with maintainers; [ ryansydnor lopsided98 ];
       license = licenses.gpl2;
     };
   };
@@ -67,7 +67,7 @@
     meta = with lib; {
       homepage = "https://buildbot.net/";
       description = "Buildbot Waterfall View Plugin";
-      maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
+      maintainers = with maintainers; [ ryansydnor lopsided98 ];
       license = licenses.gpl2;
     };
   };
@@ -89,7 +89,7 @@
     meta = with lib; {
       homepage = "https://buildbot.net/";
       description = "Buildbot Grid View Plugin";
-      maintainers = with maintainers; [ nand0p lopsided98 ];
+      maintainers = with maintainers; [ lopsided98 ];
       license = licenses.gpl2;
     };
   };

--- a/pkgs/development/python-modules/buildbot/worker.nix
+++ b/pkgs/development/python-modules/buildbot/worker.nix
@@ -26,7 +26,7 @@ buildPythonPackage (rec {
   meta = with lib; {
     homepage = "https://buildbot.net/";
     description = "Buildbot Worker Daemon";
-    maintainers = with maintainers; [ nand0p ryansydnor lopsided98 ];
+    maintainers = with maintainers; [ ryansydnor lopsided98 ];
     license = licenses.gpl2;
   };
 })

--- a/pkgs/development/python-modules/distro/default.nix
+++ b/pkgs/development/python-modules/distro/default.nix
@@ -18,6 +18,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/nir0s/distro";
     description = "Linux Distribution - a Linux OS platform information API.";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     description = "Distributed Python deployment and communication";
     license = licenses.mit;
     homepage = "https://execnet.readthedocs.io/";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/incremental/default.nix
+++ b/pkgs/development/python-modules/incremental/default.nix
@@ -13,6 +13,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/twisted/treq";
     description = "Incremental is a small library that versions your Python projects";
     license = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/isort/4.nix
+++ b/pkgs/development/python-modules/isort/4.nix
@@ -38,6 +38,6 @@ in buildPythonPackage rec {
     description = "A Python utility / library to sort Python imports";
     homepage = "https://github.com/timothycrosley/isort";
     license = licenses.mit;
-    maintainers = with maintainers; [ couchemar nand0p ];
+    maintainers = with maintainers; [ couchemar ];
   };
 }

--- a/pkgs/development/python-modules/isort/default.nix
+++ b/pkgs/development/python-modules/isort/default.nix
@@ -72,6 +72,6 @@ in buildPythonPackage rec {
     description = "A Python utility / library to sort Python imports";
     homepage = "https://github.com/PyCQA/isort";
     license = licenses.mit;
-    maintainers = with maintainers; [ couchemar nand0p ];
+    maintainers = with maintainers; [ couchemar ];
   };
 }

--- a/pkgs/development/python-modules/jsonref/default.nix
+++ b/pkgs/development/python-modules/jsonref/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     description = "An implementation of JSON Reference for Python";
     homepage    = "https://github.com/gazpachoking/jsonref";
     license     = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/pylint/1.9.nix
+++ b/pkgs/development/python-modules/pylint/1.9.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     description = "A bug and style checker for Python";
     platforms = platforms.all;
     license = licenses.gpl1Plus;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -67,6 +67,6 @@ buildPythonPackage rec {
     homepage = "https://pylint.pycqa.org/";
     description = "A bug and style checker for Python";
     license = licenses.gpl1Plus;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-mock/2.nix
+++ b/pkgs/development/python-modules/pytest-mock/2.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Thin-wrapper around the mock package for easier use with py.test.";
     homepage    = "https://github.com/pytest-dev/pytest-mock";
     license     = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     description = "Thin-wrapper around the mock package for easier use with pytest";
     homepage = "https://github.com/pytest-dev/pytest-mock";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-server-fixtures/default.nix
+++ b/pkgs/development/python-modules/pytest-server-fixtures/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Extensible server fixures for py.test";
     homepage  = "https://github.com/manahl/pytest-plugins";
     license = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/ramlfications/default.nix
+++ b/pkgs/development/python-modules/ramlfications/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     description = "A Python RAML parser.";
     homepage    = "https://ramlfications.readthedocs.org";
     license     = licenses.asl20;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     platforms   = platforms.all;
   };
 

--- a/pkgs/development/python-modules/setuptoolstrial/default.nix
+++ b/pkgs/development/python-modules/setuptoolstrial/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     description = "Setuptools plugin that makes unit tests execute with trial instead of pyunit.";
     homepage = "https://github.com/rutsky/setuptools-trial";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ ryansydnor nand0p ];
+    maintainers = with maintainers; [ ryansydnor ];
   };
 
 }

--- a/pkgs/development/python-modules/sphinx-jinja/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Sphinx extension to include jinja templates in documentation";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/sphinx/2.nix
+++ b/pkgs/development/python-modules/sphinx/2.nix
@@ -77,6 +77,6 @@ buildPythonPackage rec {
     description = "A tool that makes it easy to create intelligent and beautiful documentation for Python projects";
     homepage = "http://sphinx.pocoo.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ nand0p ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -84,6 +84,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://www.sphinx-doc.org";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/sphinxcontrib-blockdiag/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-blockdiag/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Sphinx blockdiag extension";
     homepage = "https://github.com/blockdiag/sphinxcontrib-blockdiag";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.bsd2;
   };
 

--- a/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Sphinx spelling extension";
     homepage = "https://bitbucket.org/dhellmann/sphinxcontrib-spelling";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.bsd2;
   };
 

--- a/pkgs/development/python-modules/treq/default.nix
+++ b/pkgs/development/python-modules/treq/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/twisted/treq";
     description = "A requests-like API built on top of twisted.web's Agent";
     license = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Utilities to support code that runs unmodified on Twisted and asyncio";
     homepage = "https://github.com/crossbario/txaio";
     license = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/txgithub/default.nix
+++ b/pkgs/development/python-modules/txgithub/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     description = "GitHub API client implemented using Twisted.";
     homepage    = "https://github.com/tomprince/txgithub";
     license     = licenses.mit;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/txrequests/default.nix
+++ b/pkgs/development/python-modules/txrequests/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     description = "Asynchronous Python HTTP for Humans.";
     homepage    = "https://github.com/tardyp/txrequests";
     license     = licenses.asl20;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
 checking library.";
     homepage    = "https://bitbucket.org/mchaput/whoosh";
     license     = licenses.bsd2;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/misc/cli11/default.nix
+++ b/pkgs/development/tools/misc/cli11/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Command line parser for C++11";
     homepage = "https://github.com/CLIUtils/CLI11";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.bsd3;
   };
 

--- a/pkgs/games/opendune/default.nix
+++ b/pkgs/games/opendune/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "Dune, Reinvented";
     homepage = "https://github.com/OpenDUNE/OpenDUNE";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/misc/screensavers/electricsheep/default.nix
+++ b/pkgs/misc/screensavers/electricsheep/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Electric Sheep, a distributed screen saver for evolving artificial organisms";
     homepage = "https://electricsheep.org/";
-    maintainers = with maintainers; [ nand0p fpletz ];
+    maintainers = with maintainers; [ fpletz ];
     platforms = platforms.linux;
     license = licenses.gpl1;
   };

--- a/pkgs/tools/graphics/flam3/default.nix
+++ b/pkgs/tools/graphics/flam3/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Cosmic recursive fractal flames";
     homepage = "https://flam3.com/";
-    maintainers = [ maintainers.nand0p ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
   };

--- a/pkgs/tools/graphics/glee/default.nix
+++ b/pkgs/tools/graphics/glee/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "GL Easy Extension Library";
     homepage = "https://sourceforge.net/p/glee/glee/";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     license = licenses.gpl3;
   };

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
     description = "Ethereum miner with OpenCL${lib.optionalString cudaSupport ", CUDA"} and stratum support";
     homepage = "https://github.com/ethereum-mining/ethminer";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ nand0p atemu ];
+    maintainers = with maintainers; [ atemu ];
     license = licenses.gpl3Only;
     broken = cudaSupport;
   };

--- a/pkgs/tools/networking/httperf/default.nix
+++ b/pkgs/tools/networking/httperf/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The httperf HTTP load generator";
     homepage = "https://github.com/httperf/httperf";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.gpl2;
     platforms = platforms.all;
   };

--- a/pkgs/tools/security/hologram/default.nix
+++ b/pkgs/tools/security/hologram/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   meta = with lib; {
     homepage = "https://github.com/AdRoll/hologram/";
     description = "Easy, painless AWS credentials on developer laptops";
-    maintainers = with maintainers; [ nand0p ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While looking at the sphinx package (#122189) I noticed it was heavily
undermaintained, which is when we noticed nand0p has been inactive for
roughly 18 months. It is therefore prudent to assume they will not be
maintaining their packages, modules and tests.

- Their last contribution to nixpkgs was in 2019/12
- On 2021/05/08 I wrote them an email to the address listed in the
  maintainer-list, which they didn't reply to.

E-Mail contents: 
https://gist.github.com/mweinelt/4c2ffbb8214e58a7630b3da68e8c45a0

Open questions:
- How long do we want to wait for them to reply?
- Should we remove the maintainer handle as well?

What was done:
```
find pkgs -iname "*.nix" -exec sed -i 's/nand0p //' {} \\;
find nixos -iname "*.nix" -exec sed -i 's/nand0p //' {} \\;
```

cc @dotlambda @vcunat @nand0p 

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
