### PR TITLE
sway: Install the wallpapers by default and use them on NixOS

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -119,6 +119,8 @@ in {
     ];
     environment = {
       systemPackages = [ swayPackage ] ++ cfg.extraPackages;
+      # Needed for the default wallpaper:
+      pathsToLink = [ "/share/backgrounds/sway" ];
       etc = {
         "sway/config".source = mkOptionDefault "${swayPackage}/etc/sway/config";
         "sway/config.d/nixos.conf".source = pkgs.writeText "nixos.conf" ''

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -20,18 +20,21 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    ./sway-config-no-nix-store-references.patch
     ./load-configuration-from-etc.patch
 
     (substituteAll {
       src = ./fix-paths.patch;
       inherit swaybg;
     })
+  ] ++ lib.optionals (!isNixOS) [
+    # References to /nix/store/... will get GC'ed which causes problems when
+    # copying the default configuration:
+    ./sway-config-no-nix-store-references.patch
+  ] ++ lib.optionals isNixOS [
+    # Use /run/current-system/sw/share and /etc instead of /nix/store
+    # references:
+    ./sway-config-nixos-paths.patch
   ];
-
-  postPatch = lib.optionalString isNixOS ''
-    echo -e '\ninclude /etc/sway/config.d/*' >> config.in
-  '';
 
   nativeBuildInputs = [
     meson ninja pkg-config wayland scdoc
@@ -44,7 +47,6 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Ddefault-wallpaper=false"
     "-Dsd-bus-provider=libsystemd"
   ];
 

--- a/pkgs/applications/window-managers/sway/sway-config-nixos-paths.patch
+++ b/pkgs/applications/window-managers/sway/sway-config-nixos-paths.patch
@@ -1,0 +1,21 @@
+diff --git a/config.in b/config.in
+index 08703bef..f3872730 100644
+--- a/config.in
++++ b/config.in
+@@ -22,8 +22,8 @@ set $menu dmenu_path | dmenu | xargs swaymsg exec --
+ 
+ ### Output configuration
+ #
+-# Default wallpaper (more resolutions are available in @datadir@/backgrounds/sway/)
+-output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
++# Default wallpaper (more resolutions are available in /run/current-system/sw/share/backgrounds/sway/)
++output * bg /run/current-system/sw/share/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
+ #
+ # Example configuration:
+ #
+@@ -214,4 +214,4 @@ bar {
+     }
+ }
+ 
+-include @sysconfdir@/sway/config.d/*
++include /etc/sway/config.d/*


### PR DESCRIPTION
Size impact:
$ du -sh $(nix-build -A sway-unwrapped)
5.9M    /nix/store/d07zcpybgpdj8xhn9n4qb04lgm453ia1-sway-unwrapped-1.6
nix@sessel:/var/tmp/michael/nixpkgs$ du -sh $(nix-build -A sway-unwrapped)/share/backgrounds
4.9M    /nix/store/d07zcpybgpdj8xhn9n4qb04lgm453ia1-sway-unwrapped-1.6/share/backgrounds

Screenshot:
![sway_exit](https://user-images.githubusercontent.com/7537109/118288836-0a5f8d00-b4d5-11eb-9483-0cd0f39b662a.png)


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
