### PR TITLE
GNOME 40: more updates

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-calendar/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-calendar/default.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calendar";
-  version = "40.0";
+  version = "40.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "0d74hng9jdmwdcjgj4xfrcink2gwkbp1k1mad4wanaf7q31c6f38";
+    sha256 = "2M30n57uHDo8aZHDL4VjxKfE2w23ymPOUcyRjkM7M6U=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/apps/gnome-connections/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-connections/default.nix
@@ -1,46 +1,45 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
-, gnome
 , meson
 , ninja
-, vala
 , pkg-config
+, vala
+, gettext
+, itstool
+, python3
+, appstream-glib
+, desktop-file-utils
+, wrapGAppsHook
 , glib
 , gtk3
-, python3
 , libxml2
 , gtk-vnc
-, gettext
-, desktop-file-utils
-, appstream-glib
-, gobject-introspection
-, freerdp
-, wrapGAppsHook
+, gtk-frdp
+, gnome
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-connections";
-  version = "3.38.1";
+  version = "40.0.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/connections/${lib.versions.majorMinor version}/connections-${version}.tar.xz";
-    hash = "sha256-5c7uBFkh9Vsw6bWWUDjNTMDrrFqI5JEgYlsWpfyuTpA=";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    hash = "sha256-vpvLoHzz+vWs4M5UzSL4YJtNx3ZuJe5f2cGAw5WbTRE=";
   };
 
   nativeBuildInputs = [
-    desktop-file-utils
-    gettext
-    glib # glib-compile-resources
     meson
-    appstream-glib
     ninja
     pkg-config
-    python3
     vala
+    gettext
+    itstool
+    python3
+    appstream-glib
+    desktop-file-utils
+    glib # glib-compile-resources
     wrapGAppsHook
-
-    # for gtk-frdp subproject
-    gobject-introspection
   ];
 
   buildInputs = [
@@ -48,9 +47,7 @@ stdenv.mkDerivation rec {
     gtk-vnc
     gtk3
     libxml2
-
-    # for gtk-frdp subproject
-    freerdp
+    gtk-frdp
   ];
 
   postPatch = ''
@@ -60,8 +57,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = "connections";
-      attrPath = "gnome-connections";
+      packageName = pname;
     };
   };
 

--- a/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
@@ -12,17 +12,20 @@
 , libvncserver
 , libsecret
 , libnotify
+, libxkbcommon
 , gdk-pixbuf
 , freerdp
+, fuse3
+, gnome
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "0.1.9";
+  version = "40.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-8iZtp4tBRT7NNRKuzwop3rcMvq16RG/I2sAlEIsJ0M8=";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    hash = "sha256-mvpuUlVwo3IJP5cwM4JwkDiU87H5+KnfX1eDbqHSnek=";
   };
 
   nativeBuildInputs = [
@@ -36,11 +39,13 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cairo
     freerdp
+    fuse3
     gdk-pixbuf # For libnotify
     glib
     libnotify
     libsecret
     libvncserver
+    libxkbcommon
     pipewire
     systemd
   ];
@@ -53,6 +58,13 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dsystemd_user_unit_dir=${placeholder "out"}/lib/systemd/user"
   ];
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = pname;
+      attrPath = "gnome.${pname}";
+    };
+  };
 
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Projects/Mutter/RemoteDesktop";

--- a/pkgs/desktops/gnome/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell-extensions/default.nix
@@ -1,20 +1,23 @@
-{ lib, stdenv, fetchurl, fetchpatch, meson, ninja, gettext, pkg-config, spidermonkey_68, glib
-, gnome, gnome-menus, substituteAll }:
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, gettext
+, pkg-config
+, glib
+, gnome
+, gnome-menus
+, substituteAll
+}:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extensions";
-  version = "40.0";
+  version = "40.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "15hak4prx2nx1svfii39clxy1lll8crdf7p91if85jcsh6r8ab8p";
-  };
-
-  passthru = {
-    updateScript = gnome.updateScript {
-      packageName = pname;
-      attrPath = "gnome.${pname}";
-    };
+    sha256 = "T7/OCtQ1e+5zrn3Bjqoe9MqnOF5PlPavuN/HJR/RqL8=";
   };
 
   patches = [
@@ -22,24 +25,19 @@ stdenv.mkDerivation rec {
       src = ./fix_gmenu.patch;
       gmenu_path = "${gnome-menus}/lib/girepository-1.0";
     })
-
-    # Do not show welcome dialog in gnome-classic.
-    # Needed for gnome-shell 40.1.
-    # https://gitlab.gnome.org/GNOME/gnome-shell-extensions/merge_requests/169
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-shell-extensions/commit/3e8bbb07ea7109c44d5ac7998f473779e742d041.patch";
-      sha256 = "jSmPwSBgRBfPPP9mGVjw1mSWumIXQqtA6tSqHr3U+3w=";
-    })
   ];
 
-  doCheck = true;
-  # 60 is required for tests
-  # https://gitlab.gnome.org/GNOME/gnome-shell-extensions/blob/3.34.0/meson.build#L23
-  checkInputs = [ spidermonkey_68 ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    glib
+  ];
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext glib ];
-
-  mesonFlags = [ "-Dextension_set=all" ];
+  mesonFlags = [
+    "-Dextension_set=all"
+  ];
 
   preFixup = ''
     # The meson build doesn't compile the schemas.
@@ -63,11 +61,18 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = pname;
+      attrPath = "gnome.${pname}";
+    };
+  };
+
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Projects/GnomeShell/Extensions";
     description = "Modify and extend GNOME Shell functionality and behavior";
     maintainers = teams.gnome.members;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -1,6 +1,5 @@
 { fetchurl
 , fetchpatch
-, fetchgit
 , substituteAll
 , lib, stdenv
 , meson
@@ -67,20 +66,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "40.0-unstable-2021-05-01";
+  version = "40.1";
 
   outputs = [ "out" "devdoc" ];
 
-  src = fetchgit {
-    url = "https://gitlab.gnome.org/GNOME/gnome-shell.git";
-    rev = "a8a79c03330427808e776c344f7ebc42782a1b5a";
-    sha256 = "ivHV0SRpnBqsdC7fu1Xhtd/BA55O0UdbUyDLy5KHNYs=";
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-shell/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    sha256 = "sha256-9j4r7Zm9iVjPMT2F9EoBjVn4UqBbqfKap8t0S+xvprc=";
   };
-  # src = fetchurl {
-  #   url = "mirror://gnome/sources/gnome-shell/${lib.versions.major version}/${pname}-${version}.tar.xz";
-  #   sha256 = "sha256-vOcfQC36qcXiab9lv0iiI0PYlubPmiw0ZpOS1/v2hHg=";
-  # };
 
   patches = [
     # Hardcode paths to various dependencies so that they can be found at runtime.

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -1,8 +1,8 @@
 { fetchurl
-, fetchpatch
 , substituteAll
 , runCommand
-, lib, stdenv
+, lib
+, stdenv
 , pkg-config
 , gnome
 , gettext
@@ -45,13 +45,13 @@
 
 let self = stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "40.0";
+  version = "40.1";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-enGzEuWmZ8U3SJUYilBqP2tnF2i8s2K2jv3FYnc9GY4=";
+    sha256 = "sha256-pl8ycpYRM4KWh9QQcmfk4ZKQ5thueAf62H6rCDHB4MA=";
   };
 
   patches = [
@@ -62,13 +62,6 @@ let self = stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit zenity;
-    })
-
-    # Fix non-deterministic build failure:
-    # https://gitlab.gnome.org/GNOME/mutter/-/issues/1682
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/91117bb052ed0d69c8ea4159c1df15c814d90627.patch";
-      sha256 = "ek8hEoPP4S2TGOm6SGGOhUVIp4OT68nz0SQzZrceFUU=";
     })
   ];
 

--- a/pkgs/desktops/gnome/extensions/sound-output-device-chooser/default.nix
+++ b/pkgs/desktops/gnome/extensions/sound-output-device-chooser/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-sound-output-device-chooser";
-  version = "35";
+  version = "38";
 
   src = fetchFromGitHub {
     owner = "kgshank";
     repo = "gse-sound-output-device-chooser";
     rev = version;
-    sha256 = "sha256-Yl5ut6kJAkAAdCBiNFpwDgshXCLMmFH3/zhnFGpyKqs=";
+    sha256 = "sha256-LZ+C9iK+j7+DEscYCIObxXc0Bn0Z0xSsEFMZxc8REWA=";
   };
 
   patches = [
@@ -28,11 +28,13 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   uuid = "sound-output-device-chooser@kgshank.net";
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/gnome-shell/extensions
-    cp -r ${uuid} $out/share/gnome-shell/extensions
-    runHook postInstall
+
+  makeFlags = [
+    "INSTALL_DIR=${placeholder "out"}/share/gnome-shell/extensions"
+  ];
+
+  preInstall = ''
+    mkdir -p ${placeholder "out"}/share/gnome-shell/extensions
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
+++ b/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
@@ -1,18 +1,18 @@
-From 2bf6614a6d7516e194e39eb691c05b486860153c Mon Sep 17 00:00:00 2001
+From 57bed86429db9d871f1442c94f14e94e38972ca3 Mon Sep 17 00:00:00 2001
 From: worldofpeace <worldofpeace@protonmail.ch>
 Date: Thu, 16 May 2019 21:15:15 -0400
 Subject: [PATCH] meson: add options for tests installation dirs
 
 ---
  meson_options.txt |  6 ++++++
- tests/meson.build | 19 ++++++++++++++-----
- 2 files changed, 20 insertions(+), 5 deletions(-)
+ tests/meson.build | 23 ++++++++++++++++-------
+ 2 files changed, 22 insertions(+), 7 deletions(-)
 
 diff --git a/meson_options.txt b/meson_options.txt
-index 578bdae..6f5fa23 100644
+index b9a2fb5..4b8629f 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -22,3 +22,9 @@ option('tests', type: 'boolean',
+@@ -23,3 +23,9 @@ option('tests', type: 'boolean',
  option('installed_tests', type: 'boolean',
         value: true,
         description: 'Install tests')
@@ -23,12 +23,12 @@ index 578bdae..6f5fa23 100644
 +       value: '',
 +       description: 'Installation directory for binary files in tests')
 diff --git a/tests/meson.build b/tests/meson.build
-index 1f9bd0e..0253ac3 100644
+index 77281f5..c4c7fac 100644
 --- a/tests/meson.build
 +++ b/tests/meson.build
-@@ -22,8 +22,17 @@ unit_tests = [
- python = python3.find_python()
- gen_installed_test = join_paths(meson.current_source_dir(), 'gen-installed-test.py')
+@@ -21,8 +21,17 @@ unit_tests = [
+ 
+ gen_installed_test = find_program('gen-installed-test.py')
  
 -installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_api_path)
 -installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_api_path)
@@ -46,9 +46,9 @@ index 1f9bd0e..0253ac3 100644
  
  # Make tests conditional on having mutest-1 installed system-wide, or
  # available as a subproject
-@@ -42,13 +51,13 @@ if mutest_dep.found()
+@@ -40,13 +49,13 @@ if mutest_dep.found()
+       output: wrapper,
        command: [
-         python,
          gen_installed_test,
 -        '--testdir=@0@'.format(installed_test_bindir),
 +        '--testdir=@0@'.format(test_bindir),
@@ -62,7 +62,7 @@ index 1f9bd0e..0253ac3 100644
      )
  
      test(unit,
-@@ -57,7 +66,7 @@ if mutest_dep.found()
+@@ -55,7 +64,7 @@ if mutest_dep.found()
          include_directories: graphene_inc,
          c_args: common_cflags,
          install: get_option('installed_tests'),
@@ -71,6 +71,22 @@ index 1f9bd0e..0253ac3 100644
        ),
        env: ['MUTEST_OUTPUT=tap'],
        protocol: 'tap',
+@@ -70,13 +79,13 @@ if build_gir and host_system == 'linux' and not meson.is_cross_build()
+       output: wrapper,
+       command: [
+         gen_installed_test,
+-        '--testdir=@0@'.format(installed_test_bindir),
++        '--testdir=@0@'.format(test_bindir),
+         '--testname=@0@'.format(unit),
+         '--outdir=@OUTDIR@',
+         '--outfile=@0@'.format(wrapper),
+       ],
+       install: get_option('installed_tests'),
+-      install_dir: installed_test_datadir,
++      install_dir: test_datadir,
+     )
+ 
+     test(unit,
 -- 
-2.22.0
+2.31.1
 

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation rec {
   pname = "graphene";
-  version = "1.10.2";
+  version = "1.10.6";
 
   outputs = [ "out" "devdoc" "installedTests" ];
 
@@ -24,17 +24,12 @@ stdenv.mkDerivation rec {
     owner = "ebassi";
     repo = pname;
     rev = version;
-    sha256 = "1ljhhjafi1nlndjswx7mg0d01zci90wz77yvz5w8bd9mm8ssw38s";
+    sha256 = "v6YH3fRMTzhp7wmU8in9ukcavzHmOAW54EK9ZwQyFxc=";
   };
 
   patches = [
+    # Add option for changing installation path of installed tests.
     ./0001-meson-add-options-for-tests-installation-dirs.patch
-  ];
-
-  mesonFlags = [
-    "-Dgtk_doc=true"
-    "-Dinstalled_test_datadir=${placeholder "installedTests"}/share"
-    "-Dinstalled_test_bindir=${placeholder "installedTests"}/libexec"
   ];
 
   nativeBuildInputs = [
@@ -57,7 +52,17 @@ stdenv.mkDerivation rec {
     mutest
   ];
 
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "-Dinstalled_test_datadir=${placeholder "installedTests"}/share"
+    "-Dinstalled_test_bindir=${placeholder "installedTests"}/libexec"
+  ];
+
   doCheck = true;
+
+  postPatch = ''
+    patchShebangs tests/gen-installed-test.py
+  '';
 
   passthru = {
     tests = {

--- a/pkgs/development/libraries/gtk-frdp/default.nix
+++ b/pkgs/development/libraries/gtk-frdp/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, vala
+, gobject-introspection
+, glib
+, gtk3
+, freerdp
+, nix-update-script
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtk-frdp";
+  version = "3.37.1-unstable-2020-10-26";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = "805721e82ca1df6a50da3b5bd3b75d6747016482";
+    sha256 = "q/UFKYj3LUkAzll3KeKd6oec0GJnDtTuFMTTatKFlcs=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    freerdp
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/GNOME/gtk-frdp";
+    description = "RDP viewer widget for GTK";
+    maintainers = teams.gnome.members;
+    license = licenses.lgpl3Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libportal/default.nix
+++ b/pkgs/development/libraries/libportal/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libportal";
-  version = "0.3";
+  version = "0.4";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -20,21 +20,8 @@ stdenv.mkDerivation rec {
     owner = "flatpak";
     repo = pname;
     rev = version;
-    sha256 = "1s3g17zbbmq3m5jfs62fl94p4irln9hfhpybj7jb05z0p1939rk3";
+    sha256 = "fuYZWGkdazq6H0rThqpF6KIcvwgc17o+CiISb1LjBso=";
   };
-
-  patches = [
-    # Fix build and .pc file
-    # https://github.com/flatpak/libportal/pull/20
-    (fetchpatch {
-      url = "https://github.com/flatpak/libportal/commit/7828be4ec8f05f8de7b129a1e35b5039d8baaee3.patch";
-      sha256 = "04nadcxx69mbnzljwjrzm88cgapn14x3mghpkhr8b9yrjn7yj86h";
-    })
-    (fetchpatch {
-      url = "https://github.com/flatpak/libportal/commit/bf5de2f6fefec65f701b4ec8712b48b29a33fb71.patch";
-      sha256 = "1v0b09diq49c01j5gg2bpvn5f5gfw1a5nm1l8grc4qg4z9jck1z8";
-    })
-  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -16,13 +16,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "d-feet";
-  version = "0.3.15";
+  version = "0.3.16";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/d-feet/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1cgxgpj546jgpyns6z9nkm5k48lid8s36mvzj8ydkjqws2d19zqz";
+    sha256 = "hzPOS5qaVOwYWx2Fv02p2dEQUogqiAdg/2D5d5stHMs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5359,6 +5359,8 @@ in
 
   gtkperf = callPackage ../development/tools/misc/gtkperf { };
 
+  gtk-frdp = callPackage ../development/libraries/gtk-frdp {};
+
   gtk-vnc = callPackage ../tools/admin/gtk-vnc {};
 
   gtmess = callPackage ../applications/networking/instant-messengers/gtmess {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- gnome.gnome-shell: 40.0-unstable-2021-05-01 → 40.1
- gnome.mutter: 40.0 → 40.1
- gnome.gnome-shell-extensions: 40.0 → 40.1
- graphene: 1.10.2 → 1.10.6
- gnome.gnome-todo: 3.28.1 → 40.0
- libportal: 0.3 → 0.4
- gnome-connections: 3.38.1 → 40.0.1
- gtk-frdp: init at 3.37.1-unstable-2020-10-26
- gnome.gnome-remote-desktop: 0.1.9 → 40.1
- gnome.gnome-calendar: 40.0 → 40.1
- dfeet: 0.3.15 → 0.3.16

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
