### PR TITLE
spotify-qt: 3.5 -> 3.6

### DIFF
--- a/pkgs/applications/audio/spotify-qt/default.nix
+++ b/pkgs/applications/audio/spotify-qt/default.nix
@@ -9,13 +9,13 @@
 
 mkDerivation rec {
    pname = "spotify-qt";
-   version = "3.5";
+   version = "3.6";
 
    src = fetchFromGitHub {
       owner = "kraxarn";
       repo = pname;
       rev = "v${version}";
-      sha256 = "1bgd0q4sbbww3lbrx2zwgaz0sl7qh195s4kvgsq16gv7ij82bskn";
+      sha256 = "mKHyE6ZffMYYRLMpzMX53chyJyWxhTAaGvtBI3l6wkI=";
    };
 
    buildInputs = [ libxcb qtbase qtsvg ];


### PR DESCRIPTION
###### Motivation for this change

@kraxarn released 3.6 of the very handy `spotify-qt`. This updates to that version. Notably, this plays well with the `systemd.services.spotifyd` module.

Test via `nix run github:hoverbear/nixpkgs/spotify-qt-update-3.6#spotify-qt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
