### PR TITLE
apparmor: fix profile building on darwin

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -78,7 +78,8 @@ in stdenv.mkDerivation {
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-framework CoreFoundation";
 
   postInstall = ''
-    install -D -m 644 /dev/stdin $apparmor/bin.transmission-daemon <<EOF
+    mkdir $apparmor
+    cat >$apparmor/bin.transmission-daemon <<EOF
     include <tunables/global>
     $out/bin/transmission-daemon {
       include <abstractions/base>

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -38,7 +38,8 @@ in stdenv.mkDerivation rec {
   buildInputs = [ libcap ]
     ++ lib.optional (!stdenv.hostPlatform.isMusl) libidn2;
   postInstall = ''
-    install -D -m 644 /dev/stdin $apparmor/bin.ping <<EOF
+    mkdir $apparmor
+    cat >$apparmor/bin.ping <<EOF
     include <tunables/global>
     $out/bin/ping {
       include <abstractions/base>

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
   installFlags = [ "SUIDMODE=" ];
 
   postInstall = ''
-    install -D -m 644 /dev/stdin $apparmor/bin.ping <<EOF
+    mkdir $apparmor
+    cat >$apparmor/bin.ping <<EOF
     $out/bin/ping {
       include <abstractions/base>
       include <abstractions/consoles>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
See https://github.com/NixOS/nixpkgs/pull/101071#issuecomment-841254305

###### Things done
- [X] Replace ˋinstallˋ by ˋmkdirˋ and ˋcatˋ.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
