### PR TITLE
python3Packages.torchvision-bin: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/torchvision/bin.nix
+++ b/pkgs/development/python-modules/torchvision/bin.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchurl
+, isPy37
+, isPy38
+, isPy39
+, patchelf
+, pillow
+, python
+, pytorch-bin
+}:
+
+let
+  pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+  srcs = import ./binary-hashes.nix version;
+  unsupported = throw "Unsupported system";
+  version = "0.9.1";
+in buildPythonPackage {
+  inherit version;
+
+  pname = "torchvision";
+
+  format = "wheel";
+
+  src = fetchurl srcs."${stdenv.system}-${pyVerNoDot}" or unsupported;
+
+  disabled = !(isPy37 || isPy38 || isPy39);
+
+  nativeBuildInputs = [
+    patchelf
+  ];
+
+  propagatedBuildInputs = [
+    pillow
+    pytorch-bin
+  ];
+
+  pythonImportsCheck = [ "torchvision" ];
+
+  postFixup = let
+    rpath = lib.makeLibraryPath [ stdenv.cc.cc.lib ];
+  in ''
+    # Note: after patchelf'ing, libcudart can still not be found. However, this should
+    #       not be an issue, because PyTorch is loaded before torchvision and brings
+    #       in the necessary symbols.
+    patchelf --set-rpath "${rpath}:${pytorch-bin}/${python.sitePackages}/torch/lib:" \
+      "$out/${python.sitePackages}/torchvision/_C.so"
+  '';
+
+  meta = with lib; {
+    description = "PyTorch vision library";
+    homepage = "https://pytorch.org/";
+    changelog = "https://github.com/pytorch/vision/releases/tag/v${version}";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/python-modules/torchvision/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchvision/binary-hashes.nix
@@ -1,0 +1,22 @@
+# Warning: use the same CUDA version as pytorch-bin.
+#
+# Precompiled wheels can be found at:
+# https://download.pytorch.org/whl/torch_stable.html
+
+version: {
+  x86_64-linux-37 = {
+    name = "torchvision-${version}-cp37-cp37m-linux_x86_64.whl";
+    url = "https://download.pytorch.org/whl/cu111/torchvision-${version}%2Bcu111-cp37-cp37m-linux_x86_64.whl";
+    hash = "sha256-7EMVB8KZg2I3P4RqnIVk/7OOAPA1OWOipns58cSCUrw=";
+  };
+  x86_64-linux-38 = {
+    name = "torchvision-${version}-cp38-cp38-linux_x86_64.whl";
+    url = "https://download.pytorch.org/whl/cu111/torchvision-${version}%2Bcu111-cp38-cp38-linux_x86_64.whl";
+    hash = "sha256-VjsCBW9Lusr4aDQLqaFh5dpV/5ZJ5PDs7nY4CbCHDTA=";
+  };
+  x86_64-linux-39 = {
+    name = "torchvision-${version}-cp39-cp39-linux_x86_64.whl";
+    url = "https://download.pytorch.org/whl/cu111/torchvision-${version}%2Bcu111-cp39-cp39-linux_x86_64.whl";
+    hash = "sha256-pzR7TBE+WcAmozskoeOVBuMkGJf9tvsaXsUkTcu86N8=";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8211,6 +8211,8 @@ in {
 
   torchvision = callPackage ../development/python-modules/torchvision { };
 
+  torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix { };
+
   tornado = callPackage ../development/python-modules/tornado { };
 
   # Used by circus and grab-site, 2020-08-29


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This derivation can be used in conjunction with pytorch-bin to avoid
the long build time of PyTorch/TorchVision CUDA builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
