### PR TITLE
bionic: use fetchzip for everything

### DIFF
--- a/pkgs/os-specific/linux/bionic-prebuilt/default.nix
+++ b/pkgs/os-specific/linux/bionic-prebuilt/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, fetchurl, fetchzip, pkgs
+{ stdenvNoCC, lib, fetchzip, pkgs
 }:
 let
 
@@ -28,9 +28,10 @@ let
 
   kernelHeaders = pkgs.makeLinuxHeaders {
     version = "android-common-11-5.4";
-    src = fetchurl {
+    src = fetchzip {
       url = "https://android.googlesource.com/kernel/common/+archive/48ffcbf0b9e7f0280bfb8c32c68da0aaf0fdfef6.tar.gz";
-      sha256 = "0ksm1243zm9hsv0a6q9v15jabf2rivsn14kmnm2qw6zk3mjd4jvv";
+      sha256 = "1y7cmlmcr5vdqydd9n785s139yc4aylc3zhqa59xsylmkaf5habk";
+      stripRoot = false;
     };
   };
 
@@ -39,12 +40,11 @@ stdenvNoCC.mkDerivation rec {
   pname = "bionic-prebuilt";
   version = "ndk-release-r23";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://android.googlesource.com/platform/bionic/+archive/00e8ce1142d8823b0d2fc8a98b40119b0f1f02cd.tar.gz";
-    sha256 = "0cfkwdcb2c9nnlmkx0inbsja3cyiha71nj92lm66m5an70zc3b8q";
+    sha256 = "10z5mp4w0acvjvgxv7wlqa7m70hcyarmjdlfxbd9rwzf4mrsr8d1";
+    stripRoot = false;
   };
-
-  sourceRoot = ".";
 
   NIX_DONT_SET_RPATH = true;
 

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -30,8 +30,6 @@ let
 
     hardeningDisable = lib.optional stdenvNoCC.buildPlatform.isDarwin "format";
 
-    sourceRoot = lib.optionalString stdenvNoCC.hostPlatform.isAndroid ".";
-
     makeFlags = [
       "SHELL=bash"
       # Avoid use of runtime build->host compilers for checks. These


### PR DESCRIPTION
Since the hashes of the remaining two archives that used fetchurl broke,
now as good a time as any to switch the remaining fetchurls to fetchzip.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
