### PR TITLE
bluez: Disable kernel-dependent test test-mesh-crypto

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -48,6 +48,11 @@ in stdenv.mkDerivation rec {
     substituteInPlace tools/hid2hci.rules \
       --replace /sbin/udevadm ${systemd}/bin/udevadm \
       --replace "hid2hci " "$out/lib/udev/hid2hci "
+    # Disable some tests:
+    # - test-mesh-crypto depends on the following kernel settings:
+    #   CONFIG_CRYPTO_[USER|USER_API|USER_API_AEAD|USER_API_HASH|AES|CCM|AEAD|CMAC]
+    if [[ ! -f unit/test-mesh-crypto.c ]]; then echo "unit/test-mesh-crypto.c no longer exists"; false; fi
+    echo 'int main() { return 77; }' > unit/test-mesh-crypto.c
   '';
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

I'm having trouble building bluez on a CentOS 7.9 builder.
Turns out that the test-mesh-crypto test depends on the following Linux
kernel configuration items:
CONFIG_CRYPTO_[USER|USER_API|USER_API_AEAD|USER_API_HASH|AES|CCM|AEAD|CMAC]
and will fail if run wih an incompatible kernel with the following error
message:

    ...
    IVindex              = 12345678
    NetworkNonce         = 00800000011201000012345678
                           00800000011201000012345678 => PASS
    PrivacyRandom        = 000000000012345678b5e5bfdacbaf6c
                           000000000012345678fffd034b50057e => FAIL
    FAIL unit/test-mesh-crypto (exit status: 1)

I found the same bug reported on Gentoo https://bugs.gentoo.org/704190.
Their fix is to only run the test if the kernel options are available,
which we don't want to do for build reproducibility.
Instead we just want to skip the test unconditionally. As it's simpler
to completely override the test instead of patching the build system, we
opt for doing just that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
