### PR TITLE
stdenv/check-meta: description may not end in period

### DIFF
--- a/pkgs/applications/audio/m4acut/default.nix
+++ b/pkgs/applications/audio/m4acut/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ l-smash ];
 
   meta = with lib; {
-    description = "Losslessly & gaplessly cut m4a (AAC in MP4) files.";
+    description = "Losslessly & gaplessly cut m4a (AAC in MP4) files";
     homepage = "https://github.com/nu774/m4acut";
     license = with licenses; [ bsdOriginal zlib ];
     maintainers = [ maintainers.chkno ];

--- a/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A multiband compressor made from shelving filters.";
+    description = "A multiband compressor made from shelving filters";
     homepage = "https://github.com/magnetophon/shelfMultiBand";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];

--- a/pkgs/applications/audio/mopidy/scrobbler.nix
+++ b/pkgs/applications/audio/mopidy/scrobbler.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://github.com/mopidy/mopidy-scrobbler";
-    description = "Mopidy extension for scrobbling played tracks to Last.fm.";
+    description = "Mopidy extension for scrobbling played tracks to Last.fm";
     license = licenses.asl20;
     maintainers = with maintainers; [ jakeisnt ];
   };

--- a/pkgs/applications/audio/new-session-manager/default.nix
+++ b/pkgs/applications/audio/new-session-manager/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://linuxaudio.github.io/new-session-manager/";
-    description = "A session manager designed for audio applications.";
+    description = "A session manager designed for audio applications";
     maintainers = [ maintainers._6AA4FD ];
     license = licenses.gpl3Plus;
     platforms = ["x86_64-linux"];

--- a/pkgs/applications/audio/spotify-cli-linux/default.nix
+++ b/pkgs/applications/audio/spotify-cli-linux/default.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://pwittchen.github.io/spotify-cli-linux/";
     maintainers = [ maintainers.kmein ];
-    description = "A command line interface to Spotify on Linux.";
+    description = "A command line interface to Spotify on Linux";
     license = licenses.gpl3;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -60,7 +60,7 @@
     postUnpack = "mv $sourceRoot/src/data/emacs-mode/agda-input.el $sourceRoot";
 
     meta = {
-      description = "Standalone package providing the agda-input method without building Agda.";
+      description = "Standalone package providing the agda-input method without building Agda";
       inherit (pkgs.haskellPackages.Agda.meta) homepage license;
     };
   };
@@ -124,7 +124,7 @@
 
     meta = {
       inherit (pkgs.llvmPackages.llvm.meta) homepage license;
-      description = "Major mode for the LLVM assembler language.";
+      description = "Major mode for the LLVM assembler language";
     };
   };
 
@@ -188,7 +188,7 @@
     postUnpack = "mv $sourceRoot/emacs/ott-mode.el $sourceRoot";
 
     meta = {
-      description = "Standalone package providing ott-mode without building ott and with compiled bytecode.";
+      description = "Standalone package providing ott-mode without building ott and with compiled bytecode";
       inherit (pkgs.haskellPackages.Agda.meta) homepage license;
     };
   };

--- a/pkgs/applications/editors/emacs-modes/tramp/default.nix
+++ b/pkgs/applications/editors/emacs-modes/tramp/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   };
   buildInputs = [ emacs texinfo ];
   meta = {
-    description = "Transparently access remote files from Emacs. Newer versions than built-in.";
+    description = "Transparently access remote files from Emacs. Newer versions than built-in";
     homepage = "https://www.gnu.org/software/tramp";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;

--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -10,7 +10,7 @@ mkDerivation {
 
   meta = with lib; {
     homepage = "https://edu.kde.org/rocs/";
-    description = "A graph theory IDE.";
+    description = "A graph theory IDE";
     license = with licenses; [ gpl2 lgpl21 fdl12 ];
     platforms = lib.platforms.linux;
     maintainers = with maintainers; [ knairda ];

--- a/pkgs/applications/misc/elfx86exts/default.nix
+++ b/pkgs/applications/misc/elfx86exts/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "1dfhx40jr5llqa554wifd920mqdbm8s5fns98m6vcqdjxzan4nr2";
 
   meta = with lib; {
-    description = "Decode x86 binaries and print out which instruction set extensions they use.";
+    description = "Decode x86 binaries and print out which instruction set extensions they use";
     longDescription = ''
       Disassemble a binary containing x86 instructions and print out which extensions it uses.
       Despite the utterly misleading name, this tool supports ELF and MachO binaries, and

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -83,7 +83,7 @@ in {
     };
 
     meta = with lib; {
-      description = "Plugin to display the estimated print cost for the loaded model.";
+      description = "Plugin to display the estimated print cost for the loaded model";
       homepage = "https://github.com/malnvenshorn/OctoPrint-CostEstimation";
       license = licenses.agpl3Only;
       maintainers = with maintainers; [ stunkymonkey ];
@@ -311,7 +311,7 @@ in {
     propagatedBuildInputs = with super; [ pillow ];
 
     meta = with lib; {
-      description = "Plugin to send status messages and receive commands via Telegram messenger.";
+      description = "Plugin to send status messages and receive commands via Telegram messenger";
       homepage = "https://github.com/fabianonline/OctoPrint-Telegram";
       license = licenses.agpl3Only;
       maintainers = with maintainers; [ stunkymonkey ];

--- a/pkgs/applications/misc/tabula-java/default.nix
+++ b/pkgs/applications/misc/tabula-java/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A library for extracting tables from PDF files.";
+    description = "A library for extracting tables from PDF files";
     longDescription = ''
       tabula-java is the table extraction engine that powers
       Tabula. You can use tabula-java as a command-line tool to

--- a/pkgs/applications/misc/zktree/default.nix
+++ b/pkgs/applications/misc/zktree/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "1d35jrxvhf7m04s1kh0yrfhy9j9i6qzwbw2mwapgsrcsr5vhxasn";
 
   meta = with lib; {
-    description = "A small tool to display Znodes in Zookeeper in tree structure.";
+    description = "A small tool to display Znodes in Zookeeper in tree structure";
     homepage = "https://github.com/alirezameskin/zktree";
     license = licenses.unlicense;
     maintainers = with lib.maintainers; [ alirezameskin ];

--- a/pkgs/applications/networking/cluster/containerpilot/default.nix
+++ b/pkgs/applications/networking/cluster/containerpilot/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
 
   meta = with lib; {
     homepage = "https://www.joyent.com/containerpilot";
-    description = "An application centric micro-orchestrator.";
+    description = "An application centric micro-orchestrator";
     platforms = platforms.unix;
     license = licenses.mpl20;
     maintainers = with maintainers; [ cpcloud ];

--- a/pkgs/applications/networking/cluster/terraform-providers/ansible/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/ansible/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
   postBuild = "mv go/bin/terraform-provider-ansible{,_v${version}}";
 
   meta = with lib; {
-    description = "A Terraform provider serving as an interop layer for an Ansible dynamic inventory script.";
+    description = "A Terraform provider serving as an interop layer for an Ansible dynamic inventory script";
     homepage = "https://github.com/nbering/terraform-provider-ansible";
     license = licenses.mpl20;
     maintainers = with maintainers; [ uskudnik ];

--- a/pkgs/applications/networking/cluster/terraform-providers/gandi/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/gandi/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
   postBuild = "mv go/bin/terraform-provider-gandi{,_v${version}}";
 
   meta = with lib; {
-    description = "Terraform provider for the Gandi LiveDNS service.";
+    description = "Terraform provider for the Gandi LiveDNS service";
     homepage = "https://github.com/tiramiseb/terraform-provider-gandi";
     license = licenses.mpl20;
     maintainers = with maintainers; [ manveru ];

--- a/pkgs/applications/networking/instant-messengers/matrix-recorder/node-packages.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-recorder/node-packages.nix
@@ -1410,7 +1410,7 @@ let
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A recorder that can record Matrix rooms you are a member of (including E2E-encrypted rooms).";
+      description = "A recorder that can record Matrix rooms you are a member of (including E2E-encrypted rooms)";
       license = "MIT";
     };
     production = true;

--- a/pkgs/applications/networking/instant-messengers/neochat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/neochat/default.nix
@@ -56,7 +56,7 @@ mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A client for matrix, the decentralized communication protocol.";
+    description = "A client for matrix, the decentralized communication protocol";
     homepage = "https://apps.kde.org/en/neochat";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ mjlbach peterhoeg ];

--- a/pkgs/applications/networking/mailreaders/bubblemail/default.nix
+++ b/pkgs/applications/networking/mailreaders/bubblemail/default.nix
@@ -67,7 +67,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "An extensible mail notification service.";
+    description = "An extensible mail notification service";
     homepage = "http://bubblemail.free.fr/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/networking/mailreaders/mailnag/goa-plugin.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/goa-plugin.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Mailnag GNOME Online Accounts plugin.";
+    description = "Mailnag GNOME Online Accounts plugin";
     homepage = "https://github.com/pulb/mailnag-goa-plugin";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -30,7 +30,7 @@ in {
     };
 
     meta = with lib; {
-      description = "Request backlog for IRC channels.";
+      description = "Request backlog for IRC channels";
       homepage = "https://github.com/fruitiex/znc-backlog/";
       license = licenses.asl20;
       maintainers = with maintainers; [ infinisil ];

--- a/pkgs/applications/office/paperless/python-modules/django-filter.nix
+++ b/pkgs/applications/office/paperless/python-modules/django-filter.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   checkPhase = "${python.interpreter} runtests.py";
 
   meta = with lib; {
-    description = "A reusable Django application for allowing users to filter querysets dynamically.";
+    description = "A reusable Django application for allowing users to filter querysets dynamically";
     homepage = "https://github.com/carltongibson/django-filter";
     license = licenses.bsd3;
     maintainers = with maintainers; [ earvstedt ];

--- a/pkgs/applications/version-management/commitizen/node-packages.nix
+++ b/pkgs/applications/version-management/commitizen/node-packages.nix
@@ -9060,7 +9060,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Git commit, but play nice with conventions.";
+      description = "Git commit, but play nice with conventions";
       homepage = https://github.com/commitizen/cz-cli;
       license = "MIT";
     };

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://git.sr.ht/~sircmpwn/git.sr.ht";
-    description = "Shared support code for sr.ht source control services.";
+    description = "Shared support code for sr.ht source control services";
     license = licenses.agpl3;
     maintainers = with maintainers; [ eadwu ];
   };

--- a/pkgs/applications/video/kodi-packages/controllers/default.nix
+++ b/pkgs/applications/video/kodi-packages/controllers/default.nix
@@ -14,7 +14,7 @@ buildKodiAddon rec {
   };
 
   meta = with lib; {
-    description = "Add support for different gaming controllers.";
+    description = "Add support for different gaming controllers";
     platforms = platforms.all;
     license = licenses.odbl;
     maintainers = teams.kodi.members;

--- a/pkgs/applications/video/kodi-packages/joystick/default.nix
+++ b/pkgs/applications/video/kodi-packages/joystick/default.nix
@@ -14,7 +14,7 @@ buildKodiBinaryAddon rec {
   extraBuildInputs = [ tinyxml udev ];
 
   meta = with lib; {
-    description = "Binary addon for raw joystick input.";
+    description = "Binary addon for raw joystick input";
     platforms = platforms.all;
     license = licenses.gpl2Only;
     maintainers = teams.kodi.members;

--- a/pkgs/applications/video/kodi-packages/steam-controller/default.nix
+++ b/pkgs/applications/video/kodi-packages/steam-controller/default.nix
@@ -14,7 +14,7 @@ buildKodiBinaryAddon rec {
   extraBuildInputs = [ libusb1 ];
 
   meta = with lib; {
-    description = "Binary addon for steam controller.";
+    description = "Binary addon for steam controller";
     platforms = platforms.all;
     maintainers = teams.kodi.members;
   };

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -120,7 +120,7 @@ in {
 
     meta = with lib; {
       homepage = "https://projects.vdr-developer.org/projects/plg-markad";
-      description = "Ein Programm zum automatischen Setzen von Schnittmarken bei Werbeeinblendungen während einer Sendung.";
+      description = "Ein Programm zum automatischen Setzen von Schnittmarken bei Werbeeinblendungen während einer Sendung";
       maintainers = [ maintainers.ck3d ];
       license = licenses.gpl2;
       platforms = [ "i686-linux" "x86_64-linux" ];
@@ -195,7 +195,7 @@ in {
 
     meta = with lib; {
       homepage = "https://github.com/FernetMenta/vdr-plugin-vnsiserver";
-      description = "VDR plugin to handle KODI clients.";
+      description = "VDR plugin to handle KODI clients";
       maintainers = [ maintainers.ck3d ];
       license = licenses.gpl2;
       platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/build-support/rust/crates-io.nix
+++ b/pkgs/build-support/rust/crates-io.nix
@@ -9,7 +9,7 @@ rec {
   crates.aho_corasick."0.6.10" = deps: { features?(features_.aho_corasick."0.6.10" deps {}) }: buildRustCrate {
     crateName = "aho-corasick";
     version = "0.6.10";
-    description = "Fast multiple substring searching with finite state machines.";
+    description = "Fast multiple substring searching with finite state machines";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "0bhasxfpmfmz1460chwsx59vdld05axvmk1nbp3sd48xav3d108p";
     libName = "aho_corasick";
@@ -111,7 +111,7 @@ rec {
   crates.arrayvec."0.4.10" = deps: { features?(features_.arrayvec."0.4.10" deps {}) }: buildRustCrate {
     crateName = "arrayvec";
     version = "0.4.10";
-    description = "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString.";
+    description = "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString";
     authors = [ "bluss" ];
     sha256 = "0qbh825i59w5wfdysqdkiwbwkrsy7lgbd4pwbyb8pxx8wc36iny8";
     dependencies = mapFeatures features ([
@@ -558,7 +558,7 @@ rec {
   crates.carnix."0.10.0" = deps: { features?(features_.carnix."0.10.0" deps {}) }: buildRustCrate {
     crateName = "carnix";
     version = "0.10.0";
-    description = "Generate Nix expressions from Cargo.lock files (in order to use Nix as a build system for crates).";
+    description = "Generate Nix expressions from Cargo.lock files (in order to use Nix as a build system for crates)";
     authors = [ "pe@pijul.org <pe@pijul.org>" ];
     sha256 = "0hrp22yvrqnhaanr0ckrwihx9j3irhzd2cmb19sp49ksdi25d8ri";
     crateBin =
@@ -969,7 +969,7 @@ rec {
   crates.cloudabi."0.0.3" = deps: { features?(features_.cloudabi."0.0.3" deps {}) }: buildRustCrate {
     crateName = "cloudabi";
     version = "0.0.3";
-    description = "Low level interface to CloudABI. Contains all syscalls and related types.";
+    description = "Low level interface to CloudABI. Contains all syscalls and related types";
     authors = [ "Nuxi (https://nuxi.nl/) and contributors" ];
     sha256 = "1z9lby5sr6vslfd14d6igk03s7awf91mxpsfmsp3prxbxlk0x7h5";
     libPath = "cloudabi.rs";
@@ -1049,7 +1049,7 @@ rec {
   crates.dirs."1.0.5" = deps: { features?(features_.dirs."1.0.5" deps {}) }: buildRustCrate {
     crateName = "dirs";
     version = "1.0.5";
-    description = "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.";
+    description = "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS";
     authors = [ "Simon Ochsenreither <simon@ochsenreither.de>" ];
     sha256 = "1py68zwwrhlj5vbz9f9ansjmhc8y4gs5bpamw9ycmqz030pprwf3";
     dependencies = (if kernel == "redox" then mapFeatures features ([
@@ -1304,7 +1304,7 @@ rec {
   crates.failure."0.1.5" = deps: { features?(features_.failure."0.1.5" deps {}) }: buildRustCrate {
     crateName = "failure";
     version = "0.1.5";
-    description = "Experimental error handling abstraction.";
+    description = "Experimental error handling abstraction";
     authors = [ "Without Boats <boats@mozilla.com>" ];
     sha256 = "1msaj1c0fg12dzyf4fhxqlx1gfx41lj2smdjmkc9hkrgajk2g3kx";
     dependencies = mapFeatures features ([
@@ -1561,7 +1561,7 @@ rec {
   crates.itertools."0.8.0" = deps: { features?(features_.itertools."0.8.0" deps {}) }: buildRustCrate {
     crateName = "itertools";
     version = "0.8.0";
-    description = "Extra iterator adaptors, iterator methods, free functions, and macros.";
+    description = "Extra iterator adaptors, iterator methods, free functions, and macros";
     authors = [ "bluss" ];
     sha256 = "0xpz59yf03vyj540i7sqypn2aqfid08c4vzyg0l6rqm08da77n7n";
     dependencies = mapFeatures features ([
@@ -1645,7 +1645,7 @@ rec {
   crates.lazy_static."1.3.0" = deps: { features?(features_.lazy_static."1.3.0" deps {}) }: buildRustCrate {
     crateName = "lazy_static";
     version = "1.3.0";
-    description = "A macro for declaring lazily evaluated statics in Rust.";
+    description = "A macro for declaring lazily evaluated statics in Rust";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "1vv47va18ydk7dx5paz88g3jy1d3lwbx6qpxkbj8gyfv770i4b1y";
     dependencies = mapFeatures features ([
@@ -1868,7 +1868,7 @@ rec {
   crates.memchr."2.2.0" = deps: { features?(features_.memchr."2.2.0" deps {}) }: buildRustCrate {
     crateName = "memchr";
     version = "2.2.0";
-    description = "Safe interface to memchr.";
+    description = "Safe interface to memchr";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" "bluss" ];
     sha256 = "11vwg8iig9jyjxq3n1cq15g29ikzw5l7ar87md54k1aisjs0997p";
     dependencies = mapFeatures features ([
@@ -2640,7 +2640,7 @@ rec {
   crates.regex_syntax."0.6.5" = deps: { features?(features_.regex_syntax."0.6.5" deps {}) }: buildRustCrate {
     crateName = "regex-syntax";
     version = "0.6.5";
-    description = "A regular expression parser.";
+    description = "A regular expression parser";
     authors = [ "The Rust Project Developers" ];
     sha256 = "0aaaba1fan2qfyc31wzdmgmbmyirc27zgcbz41ba5wm1lb2d8kli";
     dependencies = mapFeatures features ([
@@ -3615,7 +3615,7 @@ rec {
   crates.utf8_ranges."1.0.2" = deps: { features?(features_.utf8_ranges."1.0.2" deps {}) }: buildRustCrate {
     crateName = "utf8-ranges";
     version = "1.0.2";
-    description = "Convert ranges of Unicode codepoints to UTF-8 byte ranges.";
+    description = "Convert ranges of Unicode codepoints to UTF-8 byte ranges";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1my02laqsgnd8ib4dvjgd4rilprqjad6pb9jj9vi67csi5qs2281";
   };
@@ -3740,7 +3740,7 @@ rec {
   crates.winapi_util."0.1.2" = deps: { features?(features_.winapi_util."0.1.2" deps {}) }: buildRustCrate {
     crateName = "winapi-util";
     version = "0.1.2";
-    description = "A dumping ground for high level safe wrappers over winapi.";
+    description = "A dumping ground for high level safe wrappers over winapi";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "07jj7rg7nndd7bqhjin1xphbv8kb5clvhzpqpxkvm3wl84r3mj1h";
     dependencies = (if kernel == "windows" then mapFeatures features ([
@@ -3815,7 +3815,7 @@ rec {
   crates.aho_corasick."0.7.3" = deps: { features?(features_.aho_corasick."0.7.3" deps {}) }: buildRustCrate {
     crateName = "aho-corasick";
     version = "0.7.3";
-    description = "Fast multiple substring searching.";
+    description = "Fast multiple substring searching";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "0dn42fbdms4brigqphxrvzbjd1s4knyjlzky30kgvpnrcl4sqqdv";
     libName = "aho_corasick";
@@ -3966,7 +3966,7 @@ rec {
   crates.bstr."0.1.2" = deps: { features?(features_.bstr."0.1.2" deps {}) }: buildRustCrate {
     crateName = "bstr";
     version = "0.1.2";
-    description = "A string type that is not required to be valid UTF-8.";
+    description = "A string type that is not required to be valid UTF-8";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1m30sssr8qghgf5fg17vvlrcr5mbbnv8fixzzfvzk3nan4bxyckf";
     dependencies = mapFeatures features ([
@@ -4044,7 +4044,7 @@ rec {
   crates.byteorder."1.3.1" = deps: { features?(features_.byteorder."1.3.1" deps {}) }: buildRustCrate {
     crateName = "byteorder";
     version = "1.3.1";
-    description = "Library for reading/writing numbers in big-endian and little-endian.";
+    description = "Library for reading/writing numbers in big-endian and little-endian";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1dd46l7fvmxfq90kh6ip1ghsxzzcdybac8f0mh2jivsdv9vy8k4w";
     build = "build.rs";
@@ -4916,7 +4916,7 @@ rec {
   crates.docopt."1.1.0" = deps: { features?(features_.docopt."1.1.0" deps {}) }: buildRustCrate {
     crateName = "docopt";
     version = "1.1.0";
-    description = "Command line argument parsing.";
+    description = "Command line argument parsing";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     edition = "2018";
     sha256 = "1xjvfw8398qcxwhdmak1bw2j6zn125ch24dmrmghv50vnlbb997x";
@@ -5125,7 +5125,7 @@ rec {
   crates.fs2."0.4.3" = deps: { features?(features_.fs2."0.4.3" deps {}) }: buildRustCrate {
     crateName = "fs2";
     version = "0.4.3";
-    description = "Cross-platform file locks and file duplication.";
+    description = "Cross-platform file locks and file duplication";
     authors = [ "Dan Burkert <dan@danburkert.com>" ];
     sha256 = "1crj36rhhpk3qby9yj7r77w7sld0mzab2yicmphbdkfymbmp3ldp";
     dependencies = (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
@@ -5376,7 +5376,7 @@ rec {
   crates.hex."0.3.2" = deps: { features?(features_.hex."0.3.2" deps {}) }: buildRustCrate {
     crateName = "hex";
     version = "0.3.2";
-    description = "Encoding and decoding data into/from hexadecimal representation.";
+    description = "Encoding and decoding data into/from hexadecimal representation";
     authors = [ "KokaKiwi <kokakiwi@kokakiwi.net>" ];
     sha256 = "0hs0xfb4x67y4ss9mmbjmibkwakbn3xf23i21m409bw2zqk9b6kz";
     features = mkFeatures (features."hex"."0.3.2" or {});
@@ -5568,7 +5568,7 @@ rec {
   crates.itertools."0.7.11" = deps: { features?(features_.itertools."0.7.11" deps {}) }: buildRustCrate {
     crateName = "itertools";
     version = "0.7.11";
-    description = "Extra iterator adaptors, iterator methods, free functions, and macros.";
+    description = "Extra iterator adaptors, iterator methods, free functions, and macros";
     authors = [ "bluss" ];
     sha256 = "0gavmkvn2c3cwfwk5zl5p7saiqn4ww227am5ykn6pgfm7c6ppz56";
     dependencies = mapFeatures features ([
@@ -5627,7 +5627,7 @@ rec {
   crates.kernel32_sys."0.2.2" = deps: { features?(features_.kernel32_sys."0.2.2" deps {}) }: buildRustCrate {
     crateName = "kernel32-sys";
     version = "0.2.2";
-    description = "Contains function definitions for the Windows API library kernel32. See winapi for types and constants.";
+    description = "Contains function definitions for the Windows API library kernel32. See winapi for types and constants";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1lrw1hbinyvr6cp28g60z97w32w8vsk6pahk64pmrv2fmby8srfj";
     libName = "kernel32";
@@ -5883,7 +5883,7 @@ rec {
   crates.lock_api."0.1.5" = deps: { features?(features_.lock_api."0.1.5" deps {}) }: buildRustCrate {
     crateName = "lock_api";
     version = "0.1.5";
-    description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.";
+    description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "132sidr5hvjfkaqm3l95zpcpi8yk5ddd0g79zf1ad4v65sxirqqm";
     dependencies = mapFeatures features ([
@@ -6069,7 +6069,7 @@ rec {
   crates.ndarray."0.12.1" = deps: { features?(features_.ndarray."0.12.1" deps {}) }: buildRustCrate {
     crateName = "ndarray";
     version = "0.12.1";
-    description = "An n-dimensional array for general elements and for numerics. Lightweight array views and slicing; views support chunking and splitting.";
+    description = "An n-dimensional array for general elements and for numerics. Lightweight array views and slicing; views support chunking and splitting";
     authors = [ "bluss" "Jim Turner" ];
     sha256 = "13708k97kdjfj6g4z1yapjln0v4m7zj0114h8snw44fj79l00346";
     build = "build.rs";
@@ -6193,7 +6193,7 @@ rec {
   crates.num_cpus."1.10.0" = deps: { features?(features_.num_cpus."1.10.0" deps {}) }: buildRustCrate {
     crateName = "num_cpus";
     version = "1.10.0";
-    description = "Get the number of CPUs on a machine.";
+    description = "Get the number of CPUs on a machine";
     authors = [ "Sean McArthur <sean@seanmonstar.com>" ];
     sha256 = "1411jyxy1wd8d59mv7cf6ynkvvar92czmwhb9l2c1brdkxbbiqn7";
     dependencies = mapFeatures features ([
@@ -6214,7 +6214,7 @@ rec {
   crates.once_cell."0.1.8" = deps: { features?(features_.once_cell."0.1.8" deps {}) }: buildRustCrate {
     crateName = "once_cell";
     version = "0.1.8";
-    description = "Single assignment cells and lazy static values without macros.";
+    description = "Single assignment cells and lazy static values without macros";
     authors = [ "Aleksey Kladov <aleksey.kladov@gmail.com>" ];
     sha256 = "1n1da1x3cf3qbq9a925pimy6i0r12gcicwqjxc63nfb2bnzkg074";
     dependencies = mapFeatures features ([
@@ -6242,7 +6242,7 @@ rec {
   crates.opener."0.3.2" = deps: { features?(features_.opener."0.3.2" deps {}) }: buildRustCrate {
     crateName = "opener";
     version = "0.3.2";
-    description = "Open a file or link using the system default program.";
+    description = "Open a file or link using the system default program";
     authors = [ "Brian Bowman <seeker14491@gmail.com>" ];
     sha256 = "1ql2snax07n3xxn4nz9r6d95rhrri66qy5s5zl9jfsdbs193hzcm";
     dependencies = mapFeatures features ([
@@ -6399,7 +6399,7 @@ rec {
   crates.parking_lot."0.7.1" = deps: { features?(features_.parking_lot."0.7.1" deps {}) }: buildRustCrate {
     crateName = "parking_lot";
     version = "0.7.1";
-    description = "More compact and efficient implementations of the standard synchronization primitives.";
+    description = "More compact and efficient implementations of the standard synchronization primitives";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "1qpb49xd176hqqabxdb48f1hvylfbf68rpz8yfrhw0x68ys0lkq1";
     dependencies = mapFeatures features ([
@@ -6450,7 +6450,7 @@ rec {
   crates.parking_lot_core."0.4.0" = deps: { features?(features_.parking_lot_core."0.4.0" deps {}) }: buildRustCrate {
     crateName = "parking_lot_core";
     version = "0.4.0";
-    description = "An advanced API for creating custom synchronization primitives.";
+    description = "An advanced API for creating custom synchronization primitives";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "1mzk5i240ddvhwnz65hhjk4cq61z235g1n8bd7al4mg6vx437c16";
     dependencies = mapFeatures features ([
@@ -6967,7 +6967,7 @@ rec {
   crates.regex_syntax."0.6.6" = deps: { features?(features_.regex_syntax."0.6.6" deps {}) }: buildRustCrate {
     crateName = "regex-syntax";
     version = "0.6.6";
-    description = "A regular expression parser.";
+    description = "A regular expression parser";
     authors = [ "The Rust Project Developers" ];
     sha256 = "1cjrdc3affa3rjfaxkp91xnf9k0fsqn9z4xqc280vv39nvrl8p8b";
     dependencies = mapFeatures features ([
@@ -7589,7 +7589,7 @@ rec {
   crates.typenum."1.10.0" = deps: { features?(features_.typenum."1.10.0" deps {}) }: buildRustCrate {
     crateName = "typenum";
     version = "1.10.0";
-    description = "Typenum is a Rust library for type-level numbers evaluated at compile time. It currently supports bits, unsigned integers, and signed integers. It also provides a type-level array of type-level numbers, but its implementation is incomplete.";
+    description = "Typenum is a Rust library for type-level numbers evaluated at compile time. It currently supports bits, unsigned integers, and signed integers. It also provides a type-level array of type-level numbers, but its implementation is incomplete";
     authors = [ "Paho Lurie-Gregg <paho@paholg.com>" "Andre Bogus <bogusandre@gmail.com>" ];
     sha256 = "1v2cgg0mlzkg5prs7swysckgk2ay6bpda8m83c2sn3z77dcsx3bc";
     build = "build/main.rs";
@@ -7645,7 +7645,7 @@ rec {
   crates.walkdir."2.2.7" = deps: { features?(features_.walkdir."2.2.7" deps {}) }: buildRustCrate {
     crateName = "walkdir";
     version = "2.2.7";
-    description = "Recursively walk a directory.";
+    description = "Recursively walk a directory";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "0wq3v28916kkla29yyi0g0xfc16apwx24py68049kriz3gjlig03";
     dependencies = mapFeatures features ([
@@ -7678,7 +7678,7 @@ rec {
   crates.winapi."0.2.8" = deps: { features?(features_.winapi."0.2.8" deps {}) }: buildRustCrate {
     crateName = "winapi";
     version = "0.2.8";
-    description = "Types and constants for WinAPI bindings. See README for list of crates providing function bindings.";
+    description = "Types and constants for WinAPI bindings. See README for list of crates providing function bindings";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "0a45b58ywf12vb7gvj6h3j264nydynmzyqz8d8rqxsj6icqv82as";
   };
@@ -7693,7 +7693,7 @@ rec {
   crates.winapi."0.3.7" = deps: { features?(features_.winapi."0.3.7" deps {}) }: buildRustCrate {
     crateName = "winapi";
     version = "0.3.7";
-    description = "Raw FFI bindings for all of Windows API.";
+    description = "Raw FFI bindings for all of Windows API";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1k51gfkp0zqw7nj07y443mscs46icmdhld442s2073niap0kkdr8";
     build = "build.rs";
@@ -7727,7 +7727,7 @@ rec {
   crates.winapi_build."0.1.1" = deps: { features?(features_.winapi_build."0.1.1" deps {}) }: buildRustCrate {
     crateName = "winapi-build";
     version = "0.1.1";
-    description = "Common code for build.rs in WinAPI -sys crates.";
+    description = "Common code for build.rs in WinAPI -sys crates";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1lxlpi87rkhxcwp2ykf1ldw3p108hwm24nywf3jfrvmff4rjhqga";
     libName = "build";
@@ -7743,7 +7743,7 @@ rec {
   crates.adler32."1.0.3" = deps: { features?(features_.adler32."1.0.3" deps {}) }: buildRustCrate {
     crateName = "adler32";
     version = "1.0.3";
-    description = "Minimal Adler32 implementation for Rust.";
+    description = "Minimal Adler32 implementation for Rust";
     authors = [ "Remi Rampin <remirampin@gmail.com>" ];
     sha256 = "1z3mvjgw02mbqk98kizzibrca01d5wfkpazsrp3vkkv3i56pn6fb";
   };

--- a/pkgs/data/fonts/et-book/default.nix
+++ b/pkgs/data/fonts/et-book/default.nix
@@ -14,7 +14,7 @@ fetchFromGitHub rec {
   '';
 
   meta = with lib; {
-    description = "The typeface used in Edward Tufte’s books.";
+    description = "The typeface used in Edward Tufte’s books";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ jethro ];

--- a/pkgs/data/fonts/libre-franklin/default.nix
+++ b/pkgs/data/fonts/libre-franklin/default.nix
@@ -16,7 +16,7 @@ fetchFromGitHub rec {
   sha256 = "0aq280m01pbirkzga432340aknf2m5ggalw0yddf40sqz7falykf";
 
   meta = with lib; {
-    description = "A reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic.";
+    description = "A reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic";
     homepage = "https://github.com/impallari/Libre-Franklin";
     license = licenses.ofl;
     maintainers = with maintainers; [ cmfwyp ];

--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -104,7 +104,7 @@ rec {
 
   simple-dark-gray-bootloader = mkNixBackground {
     name = "simple-dark-gray-bootloader-2018-08-28";
-    description = "Simple dark gray background for NixOS, specifically bootloaders.";
+    description = "Simple dark gray background for NixOS, specifically bootloaders";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/9d1f11f652ed5ffe460b6c602fbfe2e7e9a08dff/bootloader/nix-wallpaper-simple-dark-gray_bootloader.png";
       sha256 = "0v26kfydn7alr81f2qpgsqdiq2zk7yrwlgibx2j7k91z9h47dpj9";
@@ -113,7 +113,7 @@ rec {
 
   simple-dark-gray-bottom = mkNixBackground {
     name = "simple-dark-gray-2018-08-28";
-    description = "Simple dark gray background for NixOS, specifically bootloaders and graphical login.";
+    description = "Simple dark gray background for NixOS, specifically bootloaders and graphical login";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/783c38b22de09f6ee33aacc817470a4513392d83/wallpapers/nix-wallpaper-simple-dark-gray_bottom.png";
       sha256 = "13hi4jwp5ga06dpdw5l03b4znwn58fdjlkqjkg824isqsxzv6k15";

--- a/pkgs/data/themes/orchis/default.nix
+++ b/pkgs/data/themes/orchis/default.nix
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A Material Design theme for GNOME/GTK based desktop environments.";
+    description = "A Material Design theme for GNOME/GTK based desktop environments";
     homepage = "https://github.com/vinceliuice/Orchis-theme";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/extensions/timepp/default.nix
+++ b/pkgs/desktops/gnome/extensions/timepp/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarms gnome-shell extension.";
+    description = "A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarms gnome-shell extension";
     homepage = "https://github.com/zagortenay333/timepp__gnome";
     license = licenses.gpl3;
     maintainers = with maintainers; [ svsdep ];

--- a/pkgs/desktops/plasma-5/3rdparty/kwin/scripts/parachute.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/kwin/scripts/parachute.nix
@@ -28,7 +28,7 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Look at your windows and desktops from above.";
+    description = "Look at your windows and desktops from above";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ mjlbach ];
     inherit (src.meta) homepage;

--- a/pkgs/development/compilers/elm/packages/node-packages.nix
+++ b/pkgs/development/compilers/elm/packages/node-packages.nix
@@ -12327,7 +12327,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A tool that allows you analyse your Elm code and identifies deficiencies and best practices.";
+      description = "A tool that allows you analyse your Elm code and identifies deficiencies and best practices";
       license = "MIT";
     };
     production = true;
@@ -12753,7 +12753,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Elm offline documentation previewer with hot reloading.";
+      description = "Elm offline documentation previewer with hot reloading";
       homepage = "https://github.com/dmy/elm-doc-preview#readme";
       license = "BSD-3-Clause";
     };
@@ -12835,7 +12835,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Implementation of an elm language server in node.";
+      description = "Implementation of an elm language server in node";
       homepage = "https://github.com/elm-tooling/elm-language-server#readme";
       license = "MIT";
     };
@@ -13017,7 +13017,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Run elm-test suites.";
+      description = "Run elm-test suites";
       homepage = "https://github.com/rtfeldman/node-test-runner#readme";
       license = "BSD-3-Clause";
     };
@@ -15186,7 +15186,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A second level of optimization for the Javascript that the Elm Compiler produces.";
+      description = "A second level of optimization for the Javascript that the Elm Compiler produces";
       homepage = "https://github.com/mdgriffith/elm-optimize-level-2#readme";
       license = "BSD-3-Clause";
     };

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -11,7 +11,7 @@ openjdk11.overrideAttrs (oldAttrs: rec {
   };
   patches = [];
   meta = with lib; {
-    description = "An OpenJDK fork to better support Jetbrains's products.";
+    description = "An OpenJDK fork to better support Jetbrains's products";
     longDescription = ''
      JetBrains Runtime is a runtime environment for running IntelliJ Platform
      based products on Windows, Mac OS X, and Linux. JetBrains Runtime is

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -24,7 +24,7 @@ with lib; mkCoqDerivation {
 
   meta = {
     homepage = "http://color.inria.fr/";
-    description = "CoLoR is a library of formal mathematical definitions and proofs of theorems on rewriting theory and termination whose correctness has been mechanically checked by the Coq proof assistant.";
+    description = "CoLoR is a library of formal mathematical definitions and proofs of theorems on rewriting theory and termination whose correctness has been mechanically checked by the Coq proof assistant";
     maintainers = with maintainers; [ jpas jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -44,7 +44,7 @@ in mkCoqDerivation {
   extraBuildInputs = [ elpi ];
 
   meta = {
-    description = "Coq plugin embedding ELPI.";
+    description = "Coq plugin embedding ELPI";
     maintainers = [ maintainers.cohencyril ];
     license = licenses.lgpl21;
   };

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -19,7 +19,7 @@ with lib; mkCoqDerivation {
   extraInstallFlags = [ "VFILES=structures.v" ];
 
   meta = {
-    description = "Coq plugin embedding ELPI.";
+    description = "Coq plugin embedding ELPI";
     maintainers = [ maintainers.cohencyril ];
     license = licenses.lgpl21;
   };

--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -11,7 +11,7 @@ with lib; mkCoqDerivation {
 
   meta = {
     homepage = "https://math-classes.github.io";
-    description = "A library of abstract interfaces for mathematical structures in Coq.";
+    description = "A library of abstract interfaces for mathematical structures in Coq";
     maintainers = with maintainers; [ siddharthist jwiegley ];
   };
 }

--- a/pkgs/development/idris-modules/config.nix
+++ b/pkgs/development/idris-modules/config.nix
@@ -20,7 +20,7 @@ build-idris-package  {
   };
 
   meta = {
-    description = "Parsers for various configuration files written in Idris.";
+    description = "Parsers for various configuration files written in Idris";
     homepage = "https://github.com/benclifford/idris-config";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];

--- a/pkgs/development/idris-modules/containers.nix
+++ b/pkgs/development/idris-modules/containers.nix
@@ -18,7 +18,7 @@ build-idris-package  {
   };
 
   meta = {
-    description = "Various data structures for use in the Idris Language.";
+    description = "Various data structures for use in the Idris Language";
     homepage = "https://github.com/jfdm/idris-containers";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];

--- a/pkgs/development/idris-modules/patricia.nix
+++ b/pkgs/development/idris-modules/patricia.nix
@@ -17,7 +17,7 @@ build-idris-package  {
   };
 
   meta = {
-    description = "Immutable map from integer keys to values based on patricia tree. Basically persistent array.";
+    description = "Immutable map from integer keys to values based on patricia tree. Basically persistent array";
     homepage = "https://github.com/ChShersh/idris-patricia";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];

--- a/pkgs/development/idris-modules/posix.nix
+++ b/pkgs/development/idris-modules/posix.nix
@@ -17,7 +17,7 @@ build-idris-package  {
   doCheck = false;
 
   meta = {
-    description = "System POSIX bindings for Idris.";
+    description = "System POSIX bindings for Idris";
     homepage = "https://github.com/idris-hackers/idris-posix";
     maintainers = [ lib.maintainers.brainrape ];
   };

--- a/pkgs/development/libraries/languagemachines/libfolia.nix
+++ b/pkgs/development/libraries/languagemachines/libfolia.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   CXXFLAGS = [ "-DU_USING_ICU_NAMESPACE=1" ];
 
   meta = with lib; {
-    description = "A C++ API for FoLiA documents; an XML-based linguistic annotation format.";
+    description = "A C++ API for FoLiA documents; an XML-based linguistic annotation format";
     homepage    = "https://proycon.github.io/folia/";
     license     = licenses.gpl3;
     platforms   = platforms.all;

--- a/pkgs/development/libraries/languagemachines/ticcutils.nix
+++ b/pkgs/development/libraries/languagemachines/ticcutils.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   preConfigure = "sh bootstrap.sh";
 
   meta = with lib; {
-    description = "This module contains useful functions for general use in the TiCC software stack and beyond.";
+    description = "This module contains useful functions for general use in the TiCC software stack and beyond";
     homepage    = "https://github.com/LanguageMachines/ticcutils";
     license     = licenses.gpl3;
     platforms   = platforms.all;

--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -7,7 +7,7 @@ buildPackage {
   version = "0.1.0.0";
   sha256 = "15rxbwf16wm1la079yr2xn4bccjgd7m8dh6r7bpr6s57cj93i2mq";
 
-  description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions.";
+  description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions";
 
   # TODO: nsss support
   configureFlags = [

--- a/pkgs/development/libraries/uthenticode/default.nix
+++ b/pkgs/development/libraries/uthenticode/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   checkPhase = "test/uthenticode_test";
 
   meta = with lib; {
-    description = "A small cross-platform library for verifying Authenticode digital signatures.";
+    description = "A small cross-platform library for verifying Authenticode digital signatures";
     homepage = "https://github.com/trailofbits/uthenticode";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -85,7 +85,7 @@ let lispPackages = rec {
           buildSystems = [ "clx-truetype" ];
           parasites = [ "clx-truetype-test" ];
 
-          description = "clx-truetype is pure common lisp solution for antialiased TrueType font rendering using CLX and XRender extension.";
+          description = "clx-truetype is pure common lisp solution for antialiased TrueType font rendering using CLX and XRender extension";
           deps = with pkgs.lispPackages; [
                   alexandria bordeaux-threads cl-aa cl-fad cl-paths cl-paths-ttf cl-store
                           cl-vectors clx trivial-features zpb-ttf

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/_3bmd.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "_3bmd";
   version = "20210411-git";
 
-  description = "markdown processor in CL using esrap parser.";
+  description = "markdown processor in CL using esrap parser";
 
   deps = [ args."alexandria" args."esrap" args."split-sequence" args."trivial-with-current-source-form" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/alexandria.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "alexandria";
   version = "20210411-git";
 
-  description = "Alexandria is a collection of portable public domain utilities.";
+  description = "Alexandria is a collection of portable public domain utilities";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/array-utils.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/array-utils.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "array-utils";
   version = "20201220-git";
 
-  description = "A few utilities for working with arrays.";
+  description = "A few utilities for working with arrays";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/asdf-system-connections.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/asdf-system-connections.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "asdf-system-connections";
   version = "20170124-git";
 
-  description = "Allows for ASDF system to be connected so that auto-loading may occur.";
+  description = "Allows for ASDF system to be connected so that auto-loading may occur";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/babel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/babel.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "babel";
   version = "20200925-git";
 
-  description = "Babel, a charset conversion library.";
+  description = "Babel, a charset conversion library";
 
   deps = [ args."alexandria" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/blackbird.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/blackbird.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "blackbird";
   version = "20160531-git";
 
-  description = "A promise implementation for Common Lisp.";
+  description = "A promise implementation for Common Lisp";
 
   deps = [ args."vom" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/bordeaux-threads.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/bordeaux-threads.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "bordeaux-threads/test" ];
 
-  description = "Bordeaux Threads makes writing portable multi-threaded apps simple.";
+  description = "Bordeaux Threads makes writing portable multi-threaded apps simple";
 
   deps = [ args."alexandria" args."fiveam" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode-xhtml.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode-xhtml.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "buildnode-xhtml";
   version = "buildnode-20170403-git";
 
-  description = "Tool for building up an xml dom of an excel spreadsheet nicely.";
+  description = "Tool for building up an xml dom of an excel spreadsheet nicely";
 
   deps = [ args."alexandria" args."babel" args."buildnode" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."cxml" args."flexi-streams" args."iterate" args."named-readtables" args."puri" args."split-sequence" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/buildnode.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "buildnode-test" ];
 
-  description = "Tool for building up an xml dom nicely.";
+  description = "Tool for building up an xml dom nicely";
 
   deps = [ args."alexandria" args."babel" args."buildnode-xhtml" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."closure-common" args."closure-html" args."collectors" args."cxml" args."flexi-streams" args."iterate" args."lisp-unit2" args."named-readtables" args."puri" args."split-sequence" args."swank" args."symbol-munger" args."trivial-features" args."trivial-gray-streams" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/calispel.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/calispel.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "calispel-test" ];
 
-  description = "Thread-safe message-passing channels, in the style of
-the occam programming language.";
+  description = "Thread-safe message-passing channels, in the style of the occam programming language";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."eager-future2" args."jpl-queues" args."jpl-util" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-async-repl";
   version = "cl-async-20210228-git";
 
-  description = "REPL integration for CL-ASYNC.";
+  description = "REPL integration for CL-ASYNC";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-async-ssl";
   version = "cl-async-20210228-git";
 
-  description = "SSL Wrapper around cl-async socket implementation.";
+  description = "SSL Wrapper around cl-async socket implementation";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "cl-async-base" "cl-async-util" ];
 
-  description = "Asynchronous operations for Common Lisp.";
+  description = "Asynchronous operations for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."uiop" args."vom" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-base64.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-base64.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "cl-base64/test" ];
 
-  description = "Base64 encoding and decoding with URI support.";
+  description = "Base64 encoding and decoding with URI support";
 
   deps = [ args."kmrcl" args."ptester" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-difflib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-difflib.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-difflib";
   version = "20130128-git";
 
-  description = "A Lisp library for computing differences between sequences.";
+  description = "A Lisp library for computing differences between sequences";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-hooks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-hooks.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "cl-hooks/test" ];
 
-  description = "This system provides the hooks extension point
-mechanism (as known, e.g., from GNU Emacs).";
+  description = "This system provides the hooks extension point mechanism (as known, e.g., from GNU Emacs)";
 
   deps = [ args."alexandria" args."anaphora" args."closer-mop" args."fiveam" args."let-plus" args."trivial-garbage" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-json.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-json.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "cl-json.test" ];
 
-  description = "JSON in Lisp. JSON (JavaScript Object Notation) is a lightweight data-interchange format.";
+  description = "JSON in Lisp. JSON (JavaScript Object Notation) is a lightweight data-interchange format";
 
   deps = [ args."fiveam" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n-cldr.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-l10n-cldr.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-l10n-cldr";
   version = "20120909-darcs";
 
-  description = "The necessary CLDR files for cl-l10n packaged in a QuickLisp friendly way.";
+  description = "The necessary CLDR files for cl-l10n packaged in a QuickLisp friendly way";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-libuv.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-libuv.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-libuv";
   version = "20200610-git";
 
-  description = "Low-level libuv bindings for Common Lisp.";
+  description = "Low-level libuv bindings for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-template.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ppcre-template.nix
@@ -4,11 +4,7 @@ rec {
   baseName = "cl-ppcre-template";
   version = "cl-unification-20200925-git";
 
-  description = "A system used to conditionally load the CL-PPCRE Template.
-
-This system is not required and it is handled only if CL-PPCRE is
-available.  If it is, then the library provides the
-REGULAR-EXPRESSION-TEMPLATE.";
+  description = "A system used to conditionally load the CL-PPCRE Template";
 
   deps = [ args."cl-ppcre" args."cl-unification" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-qprint.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-qprint.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-qprint";
   version = "20150804-git";
 
-  description = "Encode and decode quoted-printable encoded strings.";
+  description = "Encode and decode quoted-printable encoded strings";
 
   deps = [ args."flexi-streams" args."trivial-gray-streams" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-reexport.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-reexport.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-reexport";
   version = "20210228-git";
 
-  description = "Reexport external symbols in other packages.";
+  description = "Reexport external symbols in other packages";
 
   deps = [ args."alexandria" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-slice.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-slice.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "cl-slice-tests" ];
 
-  description = "DSL for array slices in Common Lisp.";
+  description = "DSL for array slices in Common Lisp";
 
   deps = [ args."alexandria" args."anaphora" args."clunit" args."let-plus" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smtp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smtp.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-smtp";
   version = "20210228-git";
 
-  description = "Common Lisp smtp client.";
+  description = "Common Lisp smtp client";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl_plus_ssl" args."cl-base64" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-speedy-queue.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-speedy-queue.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-speedy-queue";
   version = "20150302-git";
 
-  description = "cl-speedy-queue is a portable, non-consing, optimized queue implementation.";
+  description = "cl-speedy-queue is a portable, non-consing, optimized queue implementation";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syslog.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-syslog.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl-syslog";
   version = "20190202-git";
 
-  description = "Common Lisp syslog interface.";
+  description = "Common Lisp syslog interface";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."global-vars" args."local-time" args."split-sequence" args."trivial-features" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unification.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-unification.nix
@@ -4,9 +4,7 @@ rec {
   baseName = "cl-unification";
   version = "20200925-git";
 
-  description = "The CL-UNIFICATION system.
-
-The system contains the definitions for the 'unification' machinery.";
+  description = "The CL-UNIFICATION system";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "cl_plus_ssl";
   version = "cl+ssl-20210411-git";
 
-  description = "Common Lisp interface to OpenSSL.";
+  description = "Common Lisp interface to OpenSSL";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-handler-hunchentoot.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "clack-handler-hunchentoot";
   version = "clack-20210411-git";
 
-  description = "Clack handler for Hunchentoot.";
+  description = "Clack handler for Hunchentoot";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."clack-socket" args."flexi-streams" args."hunchentoot" args."md5" args."rfc2388" args."split-sequence" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clack-test.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "clack-test";
   version = "clack-20210411-git";
 
-  description = "Testing Clack Applications.";
+  description = "Testing Clack Applications";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chipz" args."chunga" args."cl_plus_ssl" args."cl-annot" args."cl-base64" args."cl-cookie" args."cl-fad" args."cl-ppcre" args."cl-reexport" args."cl-syntax" args."cl-syntax-annot" args."cl-utilities" args."clack" args."clack-handler-hunchentoot" args."clack-socket" args."dexador" args."dissect" args."fast-http" args."fast-io" args."flexi-streams" args."http-body" args."hunchentoot" args."ironclad" args."jonathan" args."lack" args."lack-component" args."lack-middleware-backtrace" args."lack-util" args."local-time" args."md5" args."named-readtables" args."proc-parse" args."quri" args."rfc2388" args."rove" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-mimes" args."trivial-types" args."usocket" args."xsubseq" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "closer-mop";
   version = "20210411-git";
 
-  description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.";
+  description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clss.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clss.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "clss";
   version = "20191130-git";
 
-  description = "A DOM tree searching engine based on CSS selectors.";
+  description = "A DOM tree searching engine based on CSS selectors";
 
   deps = [ args."array-utils" args."documentation-utils" args."plump" args."trivial-indent" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "clunit";
   version = "20171019-git";
 
-  description = "CLUnit is a Common Lisp unit testing framework.";
+  description = "CLUnit is a Common Lisp unit testing framework";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit2.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "clunit2";
   version = "20201016-git";
 
-  description = "CLUnit is a Common Lisp unit testing framework.";
+  description = "CLUnit is a Common Lisp unit testing framework";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "clx/test" ];
 
-  description = "An implementation of the X Window System protocol in Lisp.";
+  description = "An implementation of the X Window System protocol in Lisp";
 
   deps = [ args."fiasco" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "dbd-mysql";
   version = "cl-dbi-20210228-git";
 
-  description = "Database driver for MySQL.";
+  description = "Database driver for MySQL";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-mysql" args."closer-mop" args."dbi" args."split-sequence" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "dbd-postgres";
   version = "cl-dbi-20210228-git";
 
-  description = "Database driver for PostgreSQL.";
+  description = "Database driver for PostgreSQL";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-ppcre" args."closer-mop" args."dbi" args."ironclad" args."md5" args."split-sequence" args."trivial-garbage" args."uax-15" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "dbd-sqlite3";
   version = "cl-dbi-20210228-git";
 
-  description = "Database driver for SQLite3.";
+  description = "Database driver for SQLite3";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."closer-mop" args."dbi" args."iterate" args."split-sequence" args."sqlite" args."trivial-features" args."trivial-garbage" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dissect.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dissect.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "dissect";
   version = "20200427-git";
 
-  description = "A lib for introspecting the call stack and active restarts.";
+  description = "A lib for introspecting the call stack and active restarts";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "djula";
   version = "20210124-git";
 
-  description = "An implementation of Django templates for Common Lisp.";
+  description = "An implementation of Django templates for Common Lisp";
 
   deps = [ args."access" args."alexandria" args."anaphora" args."arnesi" args."babel" args."cl-annot" args."cl-interpol" args."cl-locale" args."cl-ppcre" args."cl-slice" args."cl-syntax" args."cl-syntax-annot" args."cl-unicode" args."closer-mop" args."collectors" args."flexi-streams" args."gettext" args."iterate" args."let-plus" args."local-time" args."named-readtables" args."parser-combinators" args."split-sequence" args."symbol-munger" args."trivial-backtrace" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."yacc" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/documentation-utils.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/documentation-utils.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "documentation-utils";
   version = "20190710-git";
 
-  description = "A few simple tools to help you with documenting your library.";
+  description = "A few simple tools to help you with documenting your library";
 
   deps = [ args."trivial-indent" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "esrap/tests" ];
 
-  description = "A Packrat / Parsing Grammar / TDPL parser for Common Lisp.";
+  description = "A Packrat / Parsing Grammar / TDPL parser for Common Lisp";
 
   deps = [ args."alexandria" args."fiveam" args."trivial-with-current-source-form" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiasco.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fiasco.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "fiasco-self-tests" ];
 
-  description = "A Common Lisp test framework that treasures your failures, logical continuation of Stefil.";
+  description = "A Common Lisp test framework that treasures your failures, logical continuation of Stefil";
 
   deps = [ args."alexandria" args."trivial-gray-streams" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/form-fiddle.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/form-fiddle.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "form-fiddle";
   version = "20190710-git";
 
-  description = "A collection of utilities to destructure lambda forms.";
+  description = "A collection of utilities to destructure lambda forms";
 
   deps = [ args."documentation-utils" args."trivial-indent" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/gettext.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/gettext.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "gettext";
   version = "20171130-git";
 
-  description = "An pure Common Lisp implementation of gettext runtime. gettext is an internationalization and localization (i18n) system commonly used for writing multilingual programs on Unix-like computer operating systems.";
+  description = "An pure Common Lisp implementation of gettext runtime. gettext is an internationalization and localization (i18n) system commonly used for writing multilingual programs on Unix-like computer operating systems";
 
   deps = [ args."flexi-streams" args."split-sequence" args."trivial-gray-streams" args."yacc" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/global-vars.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/global-vars.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "global-vars";
   version = "20141106-git";
 
-  description = "Define efficient global variables.";
+  description = "Define efficient global variables";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/html-encode.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/html-encode.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "html-encode";
   version = "1.2";
 
-  description = "A library for encoding text in various web-savvy encodings.";
+  description = "A library for encoding text in various web-savvy encodings";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_asdf.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "hu_dot_dwim_dot_asdf";
   version = "20200925-darcs";
 
-  description = "Various ASDF extensions such as attached test and documentation system, explicit development support, etc.";
+  description = "Various ASDF extensions such as attached test and documentation system, explicit development support, etc";
 
   deps = [ args."uiop" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_defclass-star.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "hu_dot_dwim_dot_defclass-star";
   version = "stable-git";
 
-  description = "Simplify class like definitions with defclass* and friends.";
+  description = "Simplify class like definitions with defclass* and friends";
 
   deps = [ args."hu_dot_dwim_dot_asdf" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hu_dot_dwim_dot_stefil.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "hu.dwim.stefil/test" ];
 
-  description = "A Simple Test Framework In Lisp.";
+  description = "A Simple Test Framework In Lisp";
 
   deps = [ args."alexandria" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchentoot.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchentoot.nix
@@ -9,7 +9,7 @@ rec {
   description = "Hunchentoot is a HTTP server based on USOCKET and
   BORDEAUX-THREADS.  It supports HTTP 1.1, serves static files, has a
   simple framework for user-defined handlers and can be extended
-  through subclassing.";
+  through subclassing";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."cl-who" args."cxml-stp" args."drakma" args."flexi-streams" args."md5" args."rfc2388" args."split-sequence" args."swank" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."usocket" args."xpath" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/introspect-environment.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/introspect-environment.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "introspect-environment";
   version = "20200715-git";
 
-  description = "Small interface to portable but nonstandard introspection of CL environments.";
+  description = "Small interface to portable but nonstandard introspection of CL environments";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "iolib/multiplex" "iolib/os" "iolib/pathnames" "iolib/sockets" "iolib/streams" "iolib/syscalls" "iolib/trivial-sockets" "iolib/zstreams" ];
 
-  description = "I/O library.";
+  description = "I/O library";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."idna" args."iolib_dot_asdf" args."iolib_dot_base" args."iolib_dot_common-lisp" args."iolib_dot_conf" args."iolib_dot_grovel" args."split-sequence" args."swap-bytes" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_asdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_asdf.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "iolib_dot_asdf";
   version = "iolib-v0.8.3";
 
-  description = "A few ASDF component classes.";
+  description = "A few ASDF component classes";
 
   deps = [ args."alexandria" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_base.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_base.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "iolib_dot_base";
   version = "iolib-v0.8.3";
 
-  description = "Base IOlib package, used instead of CL.";
+  description = "Base IOlib package, used instead of CL";
 
   deps = [ args."alexandria" args."iolib_dot_asdf" args."iolib_dot_common-lisp" args."iolib_dot_conf" args."split-sequence" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_common-lisp.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_common-lisp.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "iolib_dot_common-lisp";
   version = "iolib-v0.8.3";
 
-  description = "Slightly modified Common Lisp.";
+  description = "Slightly modified Common Lisp";
 
   deps = [ args."alexandria" args."iolib_dot_asdf" args."iolib_dot_conf" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_conf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/iolib_dot_conf.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "iolib_dot_conf";
   version = "iolib-v0.8.3";
 
-  description = "Compile-time configuration for IOLib.";
+  description = "Compile-time configuration for IOLib";
 
   deps = [ args."alexandria" args."iolib_dot_asdf" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/jonathan.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/jonathan.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "jonathan";
   version = "20200925-git";
 
-  description = "High performance JSON encoder and decoder. Currently support: SBCL, CCL.";
+  description = "High performance JSON encoder and decoder. Currently support: SBCL, CCL";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-annot" args."cl-ppcre" args."cl-syntax" args."cl-syntax-annot" args."fast-io" args."named-readtables" args."proc-parse" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."trivial-types" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-queues.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-queues.nix
@@ -4,8 +4,7 @@ rec {
   baseName = "jpl-queues";
   version = "0.1";
 
-  description = "A few different kinds of queues, with optional
-multithreading synchronization.";
+  description = "A few different kinds of queues, with optional multithreading synchronization";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."jpl-util" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/jpl-util.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "jpl-util";
   version = "cl-20151031-git";
 
-  description = "Sundry utilities for J.P. Larocque.";
+  description = "Sundry utilities for J.P. Larocque";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/let-plus.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/let-plus.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "let-plus/tests" ];
 
-  description = "Destructuring extension of LET*.";
+  description = "Destructuring extension of LET*";
 
   deps = [ args."alexandria" args."anaphora" args."lift" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-client.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-client.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "lfarm-client";
   version = "lfarm-20150608-git";
 
-  description = "Client component of lfarm, a library for distributing work across machines.";
+  description = "Client component of lfarm, a library for distributing work across machines";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-store" args."flexi-streams" args."lfarm-common" args."lparallel" args."split-sequence" args."trivial-gray-streams" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-common.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-common.nix
@@ -4,8 +4,7 @@ rec {
   baseName = "lfarm-common";
   version = "lfarm-20150608-git";
 
-  description = "(private) Common components of lfarm, a library for distributing
-work across machines.";
+  description = "(private) Common components of lfarm, a library for distributing work across machines";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-store" args."flexi-streams" args."split-sequence" args."trivial-gray-streams" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-server.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lfarm-server.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "lfarm-server";
   version = "lfarm-20150608-git";
 
-  description = "Server component of lfarm, a library for distributing work across machines.";
+  description = "Server component of lfarm, a library for distributing work across machines";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-store" args."flexi-streams" args."lfarm-common" args."split-sequence" args."trivial-gray-streams" args."usocket" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-namespace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-namespace.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "lisp-namespace";
   version = "20171130-git";
 
-  description = "Provides LISP-N --- extensible namespaces in Common Lisp.";
+  description = "Provides LISP-N --- extensible namespaces in Common Lisp";
 
   deps = [ args."alexandria" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-unit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-unit2.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "lisp-unit2-test" ];
 
-  description = "Common Lisp library that supports unit testing.";
+  description = "Common Lisp library that supports unit testing";
 
   deps = [ args."alexandria" args."cl-interpol" args."cl-ppcre" args."cl-unicode" args."flexi-streams" args."iterate" args."named-readtables" args."symbol-munger" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lquery.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lquery.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "lquery";
   version = "20201220-git";
 
-  description = "A library to allow jQuery-like HTML/DOM manipulation.";
+  description = "A library to allow jQuery-like HTML/DOM manipulation";
 
   deps = [ args."array-utils" args."clss" args."documentation-utils" args."form-fiddle" args."plump" args."trivial-indent" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/map-set.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/map-set.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "map-set";
   version = "20190307-hg";
 
-  description = "Set-like data structure.";
+  description = "Set-like data structure";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "marshal";
   version = "cl-20210411-git";
 
-  description = "marshal: Simple (de)serialization of Lisp datastructures.";
+  description = "marshal: Simple (de)serialization of Lisp datastructures";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/metabang-bind.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/metabang-bind.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "metabang-bind";
   version = "20200218-git";
 
-  description = "Bind is a macro that generalizes multiple-value-bind, let, let*, destructuring-bind, structure and slot accessors, and a whole lot more.";
+  description = "Bind is a macro that generalizes multiple-value-bind, let, let*, destructuring-bind, structure and slot accessors, and a whole lot more";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/metatilities-base.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/metatilities-base.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "metatilities-base";
   version = "20191227-git";
 
-  description = "These are metabang.com's Common Lisp basic utilities.";
+  description = "These are metabang.com's Common Lisp basic utilities";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "mgl-pax/test" ];
 
-  description = "Exploratory programming tool and documentation
-  generator.";
+  description = "Exploratory programming tool and documentation generator";
 
   deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."colorize" args."esrap" args."html-encode" args."ironclad" args."named-readtables" args."pythonic-string-reader" args."split-sequence" args."swank" args."trivial-features" args."trivial-with-current-source-form" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/more-conditions.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/more-conditions.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "more-conditions/test" ];
 
-  description = "This system provides some generic condition classes in
-                conjunction with support functions and macros.";
+  description = "This system provides some generic condition classes in conjunction with support functions and macros";
 
   deps = [ args."alexandria" args."closer-mop" args."fiveam" args."let-plus" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/myway.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/myway.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "myway";
   version = "20200325-git";
 
-  description = "Sinatra-compatible routing library.";
+  description = "Sinatra-compatible routing library";
 
   deps = [ args."alexandria" args."babel" args."cl-ppcre" args."cl-utilities" args."map-set" args."quri" args."split-sequence" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/named-readtables.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "named-readtables/test" ];
 
-  description = "Library that creates a namespace for named readtable
-  akin to the namespace of packages.";
+  description = "Library that creates a namespace for named readtable akin to the namespace of packages";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/net_dot_didierverna_dot_asdf-flv.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/net_dot_didierverna_dot_asdf-flv.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "net_dot_didierverna_dot_asdf-flv";
   version = "asdf-flv-version-2.1";
 
-  description = "ASDF extension to provide support for file-local variables.";
+  description = "ASDF extension to provide support for file-local variables";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-declarations-1_dot_0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-declarations-1_dot_0.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "parse-declarations-1_dot_0";
   version = "parse-declarations-20101006-darcs";
 
-  description = "Library to parse and rebuild declarations.";
+  description = "Library to parse and rebuild declarations";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parser_dot_common-rules.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parser_dot_common-rules.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "parser.common-rules/test" ];
 
-  description = "Provides common parsing rules that are useful in many grammars.";
+  description = "Provides common parsing rules that are useful in many grammars";
 
   deps = [ args."alexandria" args."anaphora" args."esrap" args."fiveam" args."let-plus" args."split-sequence" args."trivial-with-current-source-form" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/plump.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/plump.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "plump";
   version = "20210411-git";
 
-  description = "An XML / XHTML / HTML parser that aims to be as lenient as possible.";
+  description = "An XML / XHTML / HTML parser that aims to be as lenient as possible";
 
   deps = [ args."array-utils" args."documentation-utils" args."trivial-indent" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/pythonic-string-reader.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/pythonic-string-reader.nix
@@ -4,8 +4,7 @@ rec {
   baseName = "pythonic-string-reader";
   version = "20180711-git";
 
-  description = "A simple and unintrusive read table modification that allows for
-simple string literal definition that doesn't require escaping characters.";
+  description = "A simple and unintrusive read table modification that allows for simple string literal definition that doesn't require escaping characters";
 
   deps = [ args."named-readtables" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "serapeum";
   version = "20210411-git";
 
-  description = "Utilities beyond Alexandria.";
+  description = "Utilities beyond Alexandria";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-tasks.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-tasks.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "simple-tasks";
   version = "20190710-git";
 
-  description = "A very simple task scheduling framework.";
+  description = "A very simple task scheduling framework";
 
   deps = [ args."alexandria" args."array-utils" args."bordeaux-threads" args."dissect" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/split-sequence.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/split-sequence.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "split-sequence/tests" ];
 
-  description = "Splits a sequence into a list of subsequences
-  delimited by objects satisfying a test.";
+  description = "Splits a sequence into a list of subsequences delimited by objects satisfying a test";
 
   deps = [ args."fiveam" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/sqlite.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/sqlite.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "sqlite";
   version = "cl-20190813-git";
 
-  description = "CL-SQLITE package is an interface to the SQLite embedded relational database engine.";
+  description = "CL-SQLITE package is an interface to the SQLite embedded relational database engine";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."iterate" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-vectors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-vectors.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "static-vectors/test" ];
 
-  description = "Create vectors allocated in static memory.";
+  description = "Create vectors allocated in static memory";
 
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."fiveam" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/str.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "str";
   version = "cl-20210411-git";
 
-  description = "Modern, consistent and terse Common Lisp string manipulation library.";
+  description = "Modern, consistent and terse Common Lisp string manipulation library";
 
   deps = [ args."cl-change-case" args."cl-ppcre" args."cl-ppcre-unicode" args."cl-unicode" args."flexi-streams" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/swap-bytes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/swap-bytes.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "swap-bytes/test" ];
 
-  description = "Optimized byte-swapping primitives.";
+  description = "Optimized byte-swapping primitives";
 
   deps = [ args."fiveam" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
@@ -4,9 +4,7 @@ rec {
   baseName = "trivia_dot_trivial";
   version = "trivia-20210411-git";
 
-  description = "Base level system of Trivia with a trivial optimizer.
- Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
- in order to avoid the circular dependency.";
+  description = "Base level system of Trivia with a trivial optimizer";
 
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivial-cltl2" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-clipboard.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-clipboard.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "trivial-clipboard";
   version = "20210228-git";
 
-  description = "trivial-clipboard let access system clipboard.";
+  description = "trivial-clipboard let access system clipboard";
 
   deps = [ args."uiop" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-features.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "trivial-features";
   version = "20210411-git";
 
-  description = "Ensures consistent *FEATURES* across multiple CLs.";
+  description = "Ensures consistent *FEATURES* across multiple CLs";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-file-size.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-file-size.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "trivial-file-size/tests" ];
 
-  description = "Stat a file's size.";
+  description = "Stat a file's size";
 
   deps = [ args."fiveam" args."uiop" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-garbage.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-garbage.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "trivial-garbage/tests" ];
 
-  description = "Portable finalizers, weak hash-tables and weak pointers.";
+  description = "Portable finalizers, weak hash-tables and weak pointers";
 
   deps = [ args."rt" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-gray-streams.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-gray-streams.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "trivial-gray-streams";
   version = "20210124-git";
 
-  description = "Compatibility layer for Gray Streams (see http://www.cliki.net/Gray%20streams).";
+  description = "Compatibility layer for Gray Streams (see http://www.cliki.net/Gray%20streams)";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-indent.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-indent.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "trivial-indent";
   version = "20191007-git";
 
-  description = "A very simple library to allow indentation hints for SWANK.";
+  description = "A very simple library to allow indentation hints for SWANK";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-main-thread.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-main-thread.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "trivial-main-thread";
   version = "20190710-git";
 
-  description = "Compatibility library to run things in the main thread.";
+  description = "Compatibility library to run things in the main thread";
 
   deps = [ args."alexandria" args."array-utils" args."bordeaux-threads" args."dissect" args."simple-tasks" args."trivial-features" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-mimes.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-mimes.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "trivial-mimes";
   version = "20200715-git";
 
-  description = "Tiny library to detect mime types in files.";
+  description = "Tiny library to detect mime types in files";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-utf-8.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "trivial-utf-8/doc" "trivial-utf-8/tests" ];
 
-  description = "A small library for doing UTF-8-based input and output.";
+  description = "A small library for doing UTF-8-based input and output";
 
   deps = [ args."mgl-pax" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-items.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-items.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "utilities.print-items/test" ];
 
-  description = "A protocol for flexible and composable printing.";
+  description = "A protocol for flexible and composable printing";
 
   deps = [ args."alexandria" args."fiveam" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-tree.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/utilities_dot_print-tree.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "utilities.print-tree/test" ];
 
-  description = "This system provides simple facilities for printing tree structures.";
+  description = "This system provides simple facilities for printing tree structures";
 
   deps = [ args."alexandria" args."fiveam" args."uiop" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/vom.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/vom.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "vom";
   version = "20160825-git";
 
-  description = "A tiny logging utility.";
+  description = "A tiny logging utility";
 
   deps = [ ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/wookie.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/wookie.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "wookie";
   version = "20191130-git";
 
-  description = "An evented webserver for Common Lisp.";
+  description = "An evented webserver for Common Lisp";
 
   deps = [ args."alexandria" args."babel" args."blackbird" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."chunga" args."cl-async" args."cl-async-base" args."cl-async-ssl" args."cl-async-util" args."cl-fad" args."cl-libuv" args."cl-ppcre" args."cl-utilities" args."do-urlencode" args."fast-http" args."fast-io" args."flexi-streams" args."proc-parse" args."quri" args."smart-buffer" args."split-sequence" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" args."xsubseq" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xembed.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xembed.nix
@@ -4,7 +4,7 @@ rec {
   baseName = "xembed";
   version = "clx-20191130-git";
 
-  description = "An implementation of the XEMBED protocol that integrates with CLX.";
+  description = "An implementation of the XEMBED protocol that integrates with CLX";
 
   deps = [ args."clx" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xkeyboard.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xkeyboard.nix
@@ -6,7 +6,7 @@ rec {
 
   parasites = [ "xkeyboard-test" ];
 
-  description = "XKeyboard is X11 extension for clx of the same name.";
+  description = "XKeyboard is X11 extension for clx of the same name";
 
   deps = [ args."clx" ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/xml_dot_location.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/xml_dot_location.nix
@@ -6,8 +6,7 @@ rec {
 
   parasites = [ "xml.location/test" ];
 
-  description = "This system provides a convenient interface for
- manipulating XML data. It is inspired by the xmltio library.";
+  description = "This system provides a convenient interface for manipulating XML data. It is inspired by the xmltio library";
 
   deps = [ args."alexandria" args."anaphora" args."babel" args."cl-ppcre" args."closer-mop" args."closure-common" args."cxml" args."cxml-stp" args."iterate" args."let-plus" args."lift" args."more-conditions" args."parse-number" args."puri" args."split-sequence" args."trivial-features" args."trivial-gray-streams" args."xpath" args."yacc" ];
 

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -41,7 +41,7 @@ ansicolors = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/kikito/ansicolors.lua";
-    description = "Library for color Manipulation.";
+    description = "Library for color Manipulation";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
@@ -140,7 +140,7 @@ busted = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "http://olivinelabs.com/busted/";
-    description = "Elegant Lua unit testing.";
+    description = "Elegant Lua unit testing";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
@@ -241,7 +241,7 @@ cqueues = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "http://25thandclement.com/~william/projects/cqueues.html";
-    description = "Continuation Queues: Embeddable asynchronous networking, threading, and notification framework for Lua on Unix.";
+    description = "Continuation Queues: Embeddable asynchronous networking, threading, and notification framework for Lua on Unix";
     maintainers = with maintainers; [ vcunat ];
     license.fullName = "MIT/X11";
   };
@@ -382,7 +382,7 @@ ldbus = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/daurnimator/ldbus";
-    description = "A Lua library to access dbus.";
+    description = "A Lua library to access dbus";
     license.fullName = "MIT/X11";
   };
 };
@@ -530,7 +530,7 @@ lpty = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "http://www.tset.de/lpty/";
-    description = "A simple facility for lua to control other programs via PTYs.";
+    description = "A simple facility for lua to control other programs via PTYs";
     license.fullName = "MIT";
   };
 };
@@ -547,7 +547,7 @@ lrexlib-gnu = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/rrthomas/lrexlib";
-    description = "Regular expression library binding (GNU flavour).";
+    description = "Regular expression library binding (GNU flavour)";
     license.fullName = "MIT/X11";
   };
 };
@@ -564,7 +564,7 @@ lrexlib-pcre = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/rrthomas/lrexlib";
-    description = "Regular expression library binding (PCRE flavour).";
+    description = "Regular expression library binding (PCRE flavour)";
     maintainers = with maintainers; [ vyp ];
     license.fullName = "MIT/X11";
   };
@@ -582,7 +582,7 @@ lrexlib-posix = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/rrthomas/lrexlib";
-    description = "Regular expression library binding (POSIX flavour).";
+    description = "Regular expression library binding (POSIX flavour)";
     license.fullName = "MIT/X11";
   };
 };
@@ -704,7 +704,7 @@ lua-resty-http = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/ledgetech/lua-resty-http";
-    description = "Lua HTTP client cosocket driver for OpenResty / ngx_lua.";
+    description = "Lua HTTP client cosocket driver for OpenResty / ngx_lua";
     maintainers = with maintainers; [ bbigras ];
     license.fullName = "2-clause BSD";
   };
@@ -722,7 +722,7 @@ lua-resty-jwt = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/cdbattags/lua-resty-jwt";
-    description = "JWT for ngx_lua and LuaJIT.";
+    description = "JWT for ngx_lua and LuaJIT";
     maintainers = with maintainers; [ bbigras ];
     license.fullName = "Apache License Version 2";
   };
@@ -830,7 +830,7 @@ lua-zlib = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/brimworks/lua-zlib";
-    description = "Simple streaming interface to zlib for Lua.";
+    description = "Simple streaming interface to zlib for Lua";
     maintainers = with maintainers; [ koral ];
     license.fullName = "MIT";
   };
@@ -848,7 +848,7 @@ lua_cliargs = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/amireh/lua_cliargs";
-    description = "A command-line argument parser.";
+    description = "A command-line argument parser";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
@@ -1112,7 +1112,7 @@ luaossl = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "http://25thandclement.com/~william/projects/luaossl.html";
-    description = "Most comprehensive OpenSSL module in the Lua universe.";
+    description = "Most comprehensive OpenSSL module in the Lua universe";
     maintainers = with maintainers; [ vcunat ];
     license.fullName = "MIT/X11";
   };
@@ -1171,7 +1171,7 @@ luasec = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/brunoos/luasec/wiki";
-    description = "A binding for OpenSSL library to provide TLS/SSL communication over LuaSocket.";
+    description = "A binding for OpenSSL library to provide TLS/SSL communication over LuaSocket";
     maintainers = with maintainers; [ flosse ];
     license.fullName = "MIT";
   };
@@ -1257,7 +1257,7 @@ luasystem = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "http://olivinelabs.com/luasystem/";
-    description = "Platform independent system calls for Lua.";
+    description = "Platform independent system calls for Lua";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
 };
@@ -1309,7 +1309,7 @@ lua-yajl = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/brimworks/lua-yajl";
-    description = "Integrate the yajl JSON library with Lua.";
+    description = "Integrate the yajl JSON library with Lua";
     maintainers = with maintainers; [ pstn ];
     license.fullName = "MIT/X11";
   };
@@ -1379,7 +1379,7 @@ markdown = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/mpeterv/markdown";
-    description = "Markdown text-to-html markup system.";
+    description = "Markdown text-to-html markup system";
     license.fullName = "MIT/X11";
   };
 };
@@ -1492,7 +1492,7 @@ rapidjson = buildLuarocksPackage {
 
   meta = with lib; {
     homepage = "https://github.com/xpol/lua-rapidjson";
-    description = "Json module based on the very fast RapidJSON.";
+    description = "Json module based on the very fast RapidJSON";
     license.fullName = "MIT";
   };
 };

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -64659,7 +64659,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "The command line interface for Antora.";
+      description = "The command line interface for Antora";
       homepage = "https://antora.org";
       license = "MPL-2.0";
     };
@@ -64975,7 +64975,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "The default site generator pipeline for producing and publishing static documentation sites with Antora.";
+      description = "The default site generator pipeline for producing and publishing static documentation sites with Antora";
       homepage = "https://antora.org";
       license = "MPL-2.0";
     };
@@ -65142,7 +65142,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A secure and free password manager for all of your devices.";
+      description = "A secure and free password manager for all of your devices";
       homepage = "https://bitwarden.com";
       license = "GPL-3.0";
     };
@@ -67279,7 +67279,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Use Azure AD SSO to log into the AWS CLI.";
+      description = "Use Azure AD SSO to log into the AWS CLI";
       homepage = "https://github.com/sportradar/aws-azure-login#readme";
       license = "MIT";
     };
@@ -70352,7 +70352,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Input method extension for coc.nvim on mac.";
+      description = "Input method extension for coc.nvim on mac";
       license = "MIT";
     };
     production = true;
@@ -71664,7 +71664,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Python extension for coc.nvim, forked from vscode-python.";
+      description = "Python extension for coc.nvim, forked from vscode-python";
       homepage = "https://github.com/neoclide/coc-python#readme";
       license = "MIT";
     };
@@ -71705,7 +71705,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Rust language support - code completion, Intellisense, refactoring, reformatting, errors, snippets. A client for the Rust Language Server, built by the RLS team.";
+      description = "Rust language support - code completion, Intellisense, refactoring, reformatting, errors, snippets. A client for the Rust Language Server, built by the RLS team";
       homepage = "https://github.com/neoclide/coc-rls#readme";
       license = "MIT";
     };
@@ -73865,7 +73865,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Create Cycle.js with no build configuration.";
+      description = "Create Cycle.js with no build configuration";
       homepage = "https://github.com/cyclejs-community/create-cycle-app#readme";
       license = "ISC";
     };
@@ -73963,7 +73963,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Create React apps with no build configuration.";
+      description = "Create React apps with no build configuration";
       homepage = "https://github.com/facebook/create-react-app#readme";
       license = "MIT";
     };
@@ -73981,7 +73981,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Create React Native apps with no build configuration.";
+      description = "Create React Native apps with no build configuration";
       homepage = "https://github.com/expo/create-react-native-app";
       license = "BSD-3-Clause";
     };
@@ -74660,7 +74660,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Dat is the package manager for data. Easily share and version control data.";
+      description = "Dat is the package manager for data. Easily share and version control data";
       homepage = "https://datproject.org";
       license = "BSD-3-Clause";
     };
@@ -74816,7 +74816,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A language server for Dockerfiles powered by NodeJS, TypeScript, and VSCode technologies.";
+      description = "A language server for Dockerfiles powered by NodeJS, TypeScript, and VSCode technologies";
       homepage = "https://github.com/rcjsuen/dockerfile-language-server-nodejs#readme";
       license = "MIT";
     };
@@ -75586,7 +75586,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Query for information about values in elm source files.";
+      description = "Query for information about values in elm source files";
       homepage = "https://github.com/ElmCast/elm-oracle#readme";
       license = "BSD-3-Clause";
     };
@@ -75955,7 +75955,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "EmojiOne is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG formats provided for the emoji images.";
+      description = "EmojiOne is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG formats provided for the emoji images";
       homepage = "https://www.emojione.com";
     };
     production = true;
@@ -77635,7 +77635,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "DTV Software in Japan.";
+      description = "DTV Software in Japan";
       homepage = "https://github.com/l3tnun/EPGStation#readme";
       license = "MIT";
     };
@@ -77820,7 +77820,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "An AST-based pattern checker for JavaScript.";
+      description = "An AST-based pattern checker for JavaScript";
       homepage = "https://eslint.org";
       license = "MIT";
     };
@@ -78009,7 +78009,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Package builder for esy.";
+      description = "Package builder for esy";
       license = "MIT";
     };
     production = true;
@@ -82344,7 +82344,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Fabulously kill processes. Cross-platform.";
+      description = "Fabulously kill processes. Cross-platform";
       homepage = "https://github.com/sindresorhus/fkill-cli#readme";
       license = "MIT";
     };
@@ -84348,7 +84348,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A gitmoji client for using emojis on commit messages.";
+      description = "A gitmoji client for using emojis on commit messages";
       homepage = "https://github.com/carloscuesta/gitmoji-cli#readme";
       license = "MIT";
     };
@@ -85710,7 +85710,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "The streaming build system.";
+      description = "The streaming build system";
       homepage = "https://gulpjs.com";
       license = "MIT";
     };
@@ -86097,7 +86097,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A robust HTML entities encoder/decoder with full Unicode support.";
+      description = "A robust HTML entities encoder/decoder with full Unicode support";
       homepage = "https://mths.be/he";
       license = "MIT";
     };
@@ -86128,7 +86128,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Highly configurable, well-tested, JavaScript-based HTML minifier.";
+      description = "Highly configurable, well-tested, JavaScript-based HTML minifier";
       homepage = "https://kangax.github.io/html-minifier/";
       license = "MIT";
     };
@@ -87150,7 +87150,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A tool for creating and developing Ionic Framework mobile apps.";
+      description = "A tool for creating and developing Ionic Framework mobile apps";
       homepage = "https://ionicframework.com";
       license = "MIT";
     };
@@ -88374,7 +88374,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "An API documentation generator for JavaScript.";
+      description = "An API documentation generator for JavaScript";
       homepage = "https://github.com/jsdoc/jsdoc#readme";
       license = "Apache-2.0";
     };
@@ -88532,7 +88532,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Various utilities for JSON References (http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03).";
+      description = "Various utilities for JSON References (http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)";
       homepage = "https://github.com/whitlockjc/json-refs";
       license = "MIT";
     };
@@ -89073,7 +89073,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Fast math typesetting for the web.";
+      description = "Fast math typesetting for the web";
       homepage = "https://katex.org";
       license = "MIT";
     };
@@ -89236,7 +89236,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Spectacular Test Runner for JavaScript.";
+      description = "Spectacular Test Runner for JavaScript";
       homepage = "http://karma-runner.github.io/";
       license = "MIT";
     };
@@ -90617,7 +90617,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A tool for managing JavaScript projects with multiple packages.";
+      description = "A tool for managing JavaScript projects with multiple packages";
       homepage = "https://github.com/lerna/lerna#readme";
       license = "MIT";
     };
@@ -91508,7 +91508,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Live Markdown previews for your favourite editor.";
+      description = "Live Markdown previews for your favourite editor";
       homepage = "https://github.com/shime/livedown";
       license = "MIT";
     };
@@ -93065,7 +93065,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Bot to publish twitter, tumblr or rss posts to an mastodon account.";
+      description = "Bot to publish twitter, tumblr or rss posts to an mastodon account";
       homepage = "https://github.com/yogthos/mastodon-bot";
       license = "MIT";
     };
@@ -93121,7 +93121,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Meeting room kiosk app for displaying meeting room schedules and booking rooms in your organization. Built against Google Apps, but other sources can be defined.";
+      description = "Meeting room kiosk app for displaying meeting room schedules and booking rooms in your organization. Built against Google Apps, but other sources can be defined";
       homepage = "https://bitbucket.org/aahmed/meat";
     };
     production = true;
@@ -93548,7 +93548,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Japanese DTV Tuner Server Service.";
+      description = "Japanese DTV Tuner Server Service";
       homepage = "https://github.com/Chinachu/Mirakurun";
       license = "Apache-2.0";
     };
@@ -97157,7 +97157,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Simple monitor script for use during development of a node.js app.";
+      description = "Simple monitor script for use during development of a node.js app";
       homepage = "https://nodemon.io";
       license = "MIT";
     };
@@ -99584,7 +99584,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A bidirectional runtime wikitext parser. Converts back and forth between wikitext and HTML/XML DOM with RDFa.";
+      description = "A bidirectional runtime wikitext parser. Converts back and forth between wikitext and HTML/XML DOM with RDFa";
       homepage = "https://github.com/wikimedia/parsoid#readme";
       license = "GPL-2.0+";
     };
@@ -100334,7 +100334,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Streaming torrent client for node.js with web ui.";
+      description = "Streaming torrent client for node.js with web ui";
       homepage = "https://github.com/asapach/peerflix-server#readme";
       license = "MIT";
     };
@@ -100562,7 +100562,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Production process manager for Node.JS applications with a built-in load balancer.";
+      description = "Production process manager for Node.JS applications with a built-in load balancer";
       homepage = "http://pm2.keymetrics.io/";
       license = "AGPL-3.0";
     };
@@ -100608,7 +100608,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A T-SQL formatting utility in JS, transpiled from the C# library of the same name.";
+      description = "A T-SQL formatting utility in JS, transpiled from the C# library of the same name";
       homepage = "https://github.com/TaoK/poor-mans-t-sql-formatter-npm-cli#readme";
       license = "AGPL-3.0";
     };
@@ -103251,7 +103251,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A set of complementary tools to React, including the JSX transformer.";
+      description = "A set of complementary tools to React, including the JSX transformer";
       homepage = "https://facebook.github.io/react";
       license = "BSD-3-Clause";
     };
@@ -104554,7 +104554,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A pure JavaScript implementation of Sass.";
+      description = "A pure JavaScript implementation of Sass";
       homepage = "https://github.com/sass/dart-sass";
       license = "MIT";
     };
@@ -104576,7 +104576,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "The semantic version parser used by npm.";
+      description = "The semantic version parser used by npm";
       homepage = "https://github.com/npm/node-semver#readme";
       license = "ISC";
     };
@@ -109293,7 +109293,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A mighty, modern CSS linter.";
+      description = "A mighty, modern CSS linter";
       homepage = "https://stylelint.io";
       license = "MIT";
     };
@@ -110052,7 +110052,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "The Swagger command-line. Provides Swagger utilities and project lifecycle support.";
+      description = "The Swagger command-line. Provides Swagger utilities and project lifecycle support";
       homepage = "https://github.com/swagger-api/swagger-node#readme";
       license = "Apache 2.0";
     };
@@ -110265,7 +110265,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Programmer for TECK keyboards.";
+      description = "Programmer for TECK keyboards";
       homepage = "https://github.com/m-ou-se/teck-programmer";
       license = "GPL-3.0+";
     };
@@ -110541,7 +110541,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "The pluggable linting tool for text and markdown.";
+      description = "The pluggable linting tool for text and markdown";
       homepage = "https://github.com/textlint/textlint/";
       license = "MIT";
     };
@@ -110563,7 +110563,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Latex plugin for [textlint](https://github.com/textlint/textlint &#34;textlint&#34;).";
+      description = "Latex plugin for [textlint](https://github.com/textlint/textlint &#34;textlint&#34;)";
       homepage = "https://github.com/elzup/textlint-plugin-latex";
       license = "MIT";
     };
@@ -110592,7 +110592,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "textlint rule check that abbreviations within parentheses.";
+      description = "textlint rule check that abbreviations within parentheses";
       homepage = "https://github.com/azu/textlint-rule-abbr-within-parentheses";
       license = "MIT";
     };
@@ -111108,7 +111108,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "textlint rule that specify the maximum word count of a sentence.";
+      description = "textlint rule that specify the maximum word count of a sentence";
       homepage = "https://github.com/azu/textlint-rule-en-max-word-count";
       license = "MIT";
     };
@@ -111166,7 +111166,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "textlint rule that limit maxinum comma(,) count of sentence.";
+      description = "textlint rule that limit maxinum comma(,) count of sentence";
       homepage = "https://github.com/azu/textlint-rule-max-comma#readme";
       license = "MIT";
     };
@@ -111205,7 +111205,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "textlint rule that check no start with duplicated conjunction.";
+      description = "textlint rule that check no start with duplicated conjunction";
       homepage = "https://github.com/textlint-rule/textlint-rule-no-start-duplicated-conjunction";
       license = "MIT";
     };
@@ -111254,7 +111254,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "textlint rule that check with or without period in list item.";
+      description = "textlint rule that check with or without period in list item";
       homepage = "https://github.com/textlint-rule/textlint-rule-period-in-list-item";
       license = "MIT";
     };
@@ -111361,7 +111361,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "textlint rule that check unexpanded acronym word.";
+      description = "textlint rule that check unexpanded acronym word";
       homepage = "https://github.com/textlint-rule/textlint-rule-unexpanded-acronym";
       license = "MIT";
     };
@@ -112374,7 +112374,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "undollar strips the dollar sign from the beginning of the terminal command you just copied from StackOverflow when you were searching for what arguments to pass to `tar` (`xzf`? `xvfJ`? Or was it `xvf`? You never seem to remember).";
+      description = "undollar strips the dollar sign from the beginning of the terminal command you just copied from StackOverflow when you were searching for what arguments to pass to `tar` (`xzf`? `xvfJ`? Or was it `xvf`? You never seem to remember)";
       homepage = "https://github.com/ImFeelingDucky/undollar#readme";
       license = "MIT";
     };
@@ -112845,7 +112845,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Command line utilities for server-side Vega.";
+      description = "Command line utilities for server-side Vega";
       homepage = "https://github.com/vega/vega#readme";
       license = "BSD-3-Clause";
     };
@@ -112892,7 +112892,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Vega-Lite is a concise high-level language for interactive visualization.";
+      description = "Vega-Lite is a concise high-level language for interactive visualization";
       homepage = "https://vega.github.io/vega-lite/";
       license = "BSD-3-Clause";
     };
@@ -114359,7 +114359,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A simple CLI for scaffolding Vue.js projects.";
+      description = "A simple CLI for scaffolding Vue.js projects";
       homepage = "https://github.com/vuejs/vue-cli#readme";
       license = "MIT";
     };
@@ -115984,7 +115984,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff.";
+      description = "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff";
       homepage = "https://github.com/webpack/webpack";
       license = "MIT";
     };
@@ -116635,7 +116635,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Serves a webpack app. Updates the browser on changes.";
+      description = "Serves a webpack app. Updates the browser on changes";
       homepage = "https://github.com/webpack/webpack-dev-server#readme";
       license = "MIT";
     };
@@ -117018,7 +117018,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "WebTorrent, the streaming torrent client. For the command line.";
+      description = "WebTorrent, the streaming torrent client. For the command line";
       homepage = "https://webtorrent.io";
       license = "MIT";
     };
@@ -117238,7 +117238,7 @@ in
     };
     buildInputs = globalBuildInputs;
     meta = {
-      description = "📦🐈 Fast, reliable, and secure dependency management.";
+      description = "📦🐈 Fast, reliable, and secure dependency management";
       homepage = "https://github.com/yarnpkg/yarn#readme";
       license = "BSD-2-Clause";
     };

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-everything ${disableIda}" "--with-llvm-config=${llvm}/bin/llvm-config" ];
 
   meta = with lib; {
-    description = "Platform for binary analysis. It is written in OCaml, but can be used from other languages.";
+    description = "Platform for binary analysis. It is written in OCaml, but can be used from other languages";
     homepage = "https://github.com/BinaryAnalysisPlatform/bap/";
     maintainers = [ maintainers.maurer ];
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/flowtype/ocaml-dtoa";
-    description = "Converts OCaml floats into strings (doubles to ascii, \"d to a\"), using the efficient Grisu3 algorithm.";
+    description = "Converts OCaml floats into strings (doubles to ascii, \"d to a\"), using the efficient Grisu3 algorithm";
     license = licenses.mit;
     maintainers = [ maintainers.eqyiel ];
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
@@ -8,7 +8,7 @@ buildOcamlJane {
     [ ppx_core ppx_tools ];
 
   meta = with lib; {
-    description = "ppx_optcomp stands for Optional Compilation. It is a tool used to handle optional compilations of pieces of code depending of the word size, the version of the compiler, etc.";
+    description = "ppx_optcomp stands for Optional Compilation. It is a tool used to handle optional compilations of pieces of code depending of the word size, the version of the compiler, etc";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -50,7 +50,7 @@ buildDunePackage rec {
   checkInputs = [ ounit ];
 
   meta = with lib; {
-    description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02.";
+    description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02";
     maintainers = [ maintainers.maurer ];
     license = licenses.mit;
   };

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/flowtype/ocaml-wtf8";
-    description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";
+    description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates";
     license = licenses.mit;
     maintainers = [ maintainers.eqyiel ];
   };

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -24,7 +24,7 @@ buildPerlPackage rec {
   '';
 
   meta = with lib; {
-    description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks.";
+    description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks";
     homepage = "https://www.percona.com/software/database-tools/percona-toolkit";
     license = with licenses; [ gpl2 ];
     maintainers = with maintainers; [ izorkin ];

--- a/pkgs/development/php-packages/psysh/default.nix
+++ b/pkgs/development/php-packages/psysh/default.nix
@@ -22,7 +22,7 @@ mkDerivation {
   '';
 
   meta = with lib; {
-    description = "PsySH is a runtime developer console, interactive debugger and REPL for PHP.";
+    description = "PsySH is a runtime developer console, interactive debugger and REPL for PHP";
     license = licenses.mit;
     homepage = "https://psysh.org/";
     maintainers = with maintainers; [ caugner ] ++ teams.php.members;

--- a/pkgs/development/python-modules/Markups/default.nix
+++ b/pkgs/development/python-modules/Markups/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ python-markdown-math ];
 
   meta = {
-    description = "A wrapper around various text markup languages.";
+    description = "A wrapper around various text markup languages";
     homepage = "https://github.com/retext-project/pymarkups";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ klntsky ];

--- a/pkgs/development/python-modules/aadict/default.nix
+++ b/pkgs/development/python-modules/aadict/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/metagriffin/aadict";
-    description = "An auto-attribute dict (and a couple of other useful dict functions).";
+    description = "An auto-attribute dict (and a couple of other useful dict functions)";
     maintainers = with maintainers; [ glittershark ];
     license = licenses.gpl3;
   };

--- a/pkgs/development/python-modules/agate-sql/default.nix
+++ b/pkgs/development/python-modules/agate-sql/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "agatesql" ];
 
   meta = with lib; {
-    description = "Adds SQL read/write support to agate.";
+    description = "Adds SQL read/write support to agate";
     homepage = "https://github.com/wireservice/agate-sql";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ vrthra ];

--- a/pkgs/development/python-modules/agent-py/default.nix
+++ b/pkgs/development/python-modules/agent-py/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "A python wrapper around the Agent REST API.";
+    description = "A python wrapper around the Agent REST API";
     homepage = "https://github.com/ispysoftware/agent-py";
     license = licenses.asl20;
     maintainers = with maintainers; [ jamiemagee ];

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Implementation of itertools, builtins, and more for AsyncIO and mixed-type iterables.";
+    description = "Implementation of itertools, builtins, and more for AsyncIO and mixed-type iterables";
     license = licenses.mit;
     homepage = "https://pypi.org/project/aioitertools/";
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "A declarative statistical visualization library for Python.";
+    description = "A declarative statistical visualization library for Python";
     homepage = "https://github.com/altair-viz/altair";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/apptools/default.nix
+++ b/pkgs/development/python-modules/apptools/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Set of packages that Enthought has found useful in creating a number of applications.";
+    description = "Set of packages that Enthought has found useful in creating a number of applications";
     homepage = "https://github.com/enthought/apptools";
     maintainers = with maintainers; [ knedlsepp ];
     license = licenses.bsdOriginal;

--- a/pkgs/development/python-modules/area/default.nix
+++ b/pkgs/development/python-modules/area/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Calculate the area inside of any GeoJSON geometry. This is a port of Mapbox’s geojson-area for Python.";
+    description = "Calculate the area inside of any GeoJSON geometry. This is a port of Mapbox’s geojson-area for Python";
     homepage = "https://github.com/scisco/area";
     license = licenses.bsd2;
   };

--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/lepture/authlib";
-    description = "The ultimate Python library in building OAuth and OpenID Connect servers. JWS,JWE,JWK,JWA,JWT included.";
+    description = "The ultimate Python library in building OAuth and OpenID Connect servers. JWS,JWE,JWK,JWA,JWT included";
     maintainers = with maintainers; [ flokli ];
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "WebSocket and WAMP in Python for Twisted and asyncio.";
+    description = "WebSocket and WAMP in Python for Twisted and asyncio";
     homepage    = "https://crossbar.io/autobahn";
     license     = licenses.mit;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/azure-multiapi-storage/default.nix
+++ b/pkgs/development/python-modules/azure-multiapi-storage/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "azure.common" "azure.multiapi.storage" ];
 
   meta = with lib; {
-    description = "Microsoft Azure Storage Client Library for Python with multi API version support.";
+    description = "Microsoft Azure Storage Client Library for Python with multi API version support";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ jonringer ];

--- a/pkgs/development/python-modules/backports_shutil_get_terminal_size/default.nix
+++ b/pkgs/development/python-modules/backports_shutil_get_terminal_size/default.nix
@@ -27,7 +27,7 @@ if !(pythonOlder "3.3") then null else buildPythonPackage {
   ];
 
   meta = with lib; {
-    description = "A backport of the get_terminal_size function from Python 3.3’s shutil.";
+    description = "A backport of the get_terminal_size function from Python 3.3’s shutil";
     homepage = "https://github.com/chrippa/backports.shutil_get_terminal_size";
     license = with licenses; [ mit ];
     maintainers = teams.sage.members;

--- a/pkgs/development/python-modules/bacpypes/default.nix
+++ b/pkgs/development/python-modules/bacpypes/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/JoelBender/bacpypes";
-    description = "BACpypes provides a BACnet application layer and network layer written in Python for daemons, scripting, and graphical interfaces.";
+    description = "BACpypes provides a BACnet application layer and network layer written in Python for daemons, scripting, and graphical interfaces";
     license = licenses.mit;
     maintainers = with maintainers; [ bachp ];
   };

--- a/pkgs/development/python-modules/bap/default.nix
+++ b/pkgs/development/python-modules/bap/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Platform for binary analysis. It is written in OCaml, but can be used from other languages.";
+    description = "Platform for binary analysis. It is written in OCaml, but can be used from other languages";
     homepage = "https://github.com/BinaryAnalysisPlatform/bap/";
     maintainers = [ maintainers.maurer ];
     license = licenses.mit;

--- a/pkgs/development/python-modules/bespon/default.nix
+++ b/pkgs/development/python-modules/bespon/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "bespon" ];
   meta = with lib; {
-    description = "Encodes and decodes data in the BespON format.";
+    description = "Encodes and decodes data in the BespON format";
     homepage = "https://github.com/gpoore/bespon_py";
     license = licenses.bsd3;
     maintainers = with maintainers; [ synthetica ];

--- a/pkgs/development/python-modules/betacode/default.nix
+++ b/pkgs/development/python-modules/betacode/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pygtrie ];
   meta = {
     homepage = "https://github.com/matgrioni/betacode";
-    description = "A small python package to flexibly convert from betacode to unicode and back.";
+    description = "A small python package to flexibly convert from betacode to unicode and back";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kmein ];
   };

--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/jquast/blessed";
-    description = "A thin, practical wrapper around terminal capabilities in Python.";
+    description = "A thin, practical wrapper around terminal capabilities in Python";
     maintainers = with maintainers; [ eqyiel ];
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Automatic error monitoring for django, flask, etc.";
+    description = "Automatic error monitoring for django, flask, etc";
     homepage = "https://www.bugsnag.com";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/caldav/default.nix
+++ b/pkgs/development/python-modules/caldav/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "caldav" ];
 
   meta = with lib; {
-    description = "This project is a CalDAV (RFC4791) client library for Python.";
+    description = "This project is a CalDAV (RFC4791) client library for Python";
     homepage = "https://github.com/python-caldav/caldav";
     license = licenses.asl20;
     maintainers = with maintainers; [ marenz ];

--- a/pkgs/development/python-modules/canonicaljson/default.nix
+++ b/pkgs/development/python-modules/canonicaljson/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/matrix-org/python-canonicaljson";
-    description = "Encodes objects and arrays as RFC 7159 JSON.";
+    description = "Encodes objects and arrays as RFC 7159 JSON";
     license = licenses.asl20;
   };
 }

--- a/pkgs/development/python-modules/catboost/default.nix
+++ b/pkgs/development/python-modules/catboost/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "catboost" ];
 
   meta = with lib; {
-    description = "High-performance library for gradient boosting on decision trees.";
+    description = "High-performance library for gradient boosting on decision trees";
     longDescription = ''
       A fast, scalable, high performance Gradient Boosting on Decision Trees
       library, used for ranking, classification, regression and other machine

--- a/pkgs/development/python-modules/cement/default.nix
+++ b/pkgs/development/python-modules/cement/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://builtoncement.com/";
-    description = "A CLI Application Framework for Python.";
+    description = "A CLI Application Framework for Python";
     maintainers = with maintainers; [ eqyiel ];
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -105,7 +105,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
+    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits";
     homepage = "https://github.com/quantumlib/cirq";
     changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/class-registry/default.nix
+++ b/pkgs/development/python-modules/class-registry/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "Factory+Registry pattern for Python classes.";
+    description = "Factory+Registry pattern for Python classes";
     homepage = "https://class-registry.readthedocs.io/en/latest/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kevincox ];

--- a/pkgs/development/python-modules/click-datetime/default.nix
+++ b/pkgs/development/python-modules/click-datetime/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "click_datetime" ];
 
   meta = with lib; {
-    description = "Datetime type support for click.";
+    description = "Datetime type support for click";
     homepage = "https://github.com/click-contrib/click-datetime";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/development/python-modules/closure-linter/default.nix
+++ b/pkgs/development/python-modules/closure-linter/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage {
   propagatedBuildInputs = [ gflags ];
 
   meta = with lib; {
-    description = "Checks JavaScript files against Google's style guide.";
+    description = "Checks JavaScript files against Google's style guide";
     homepage = "https://developers.google.com/closure/utilities/";
     license = with licenses; [ asl20 ];
   };

--- a/pkgs/development/python-modules/coapthon3/default.nix
+++ b/pkgs/development/python-modules/coapthon3/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     inherit (src.meta) homepage;
-    description = "Python3 library to the CoAP protocol compliant with the RFC.";
+    description = "Python3 library to the CoAP protocol compliant with the RFC";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];
   };

--- a/pkgs/development/python-modules/colorful/default.nix
+++ b/pkgs/development/python-modules/colorful/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
-    description = "Terminal string styling done right, in Python.";
+    description = "Terminal string styling done right, in Python";
     homepage = "https://github.com/timofurrer/colorful";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/development/python-modules/configparser/4.nix
+++ b/pkgs/development/python-modules/configparser/4.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Updated configparser from Python 3.7 for Python 2.6+.";
+    description = "Updated configparser from Python 3.7 for Python 2.6+";
     license = licenses.mit;
     homepage = "https://github.com/jaraco/configparser";
   };

--- a/pkgs/development/python-modules/configparser/default.nix
+++ b/pkgs/development/python-modules/configparser/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Updated configparser from Python 3.7 for Python 2.6+.";
+    description = "Updated configparser from Python 3.7 for Python 2.6+";
     license = licenses.mit;
     homepage = "https://github.com/jaraco/configparser";
   };

--- a/pkgs/development/python-modules/confuse/default.nix
+++ b/pkgs/development/python-modules/confuse/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pyyaml ] ++ lib.optionals isPy27 [ enum34 pathlib ] ;
 
   meta = with lib; {
-    description = "Confuse is a configuration library for Python that uses YAML.";
+    description = "Confuse is a configuration library for Python that uses YAML";
     homepage = "https://github.com/beetbox/confuse";
     license = licenses.mit;
     maintainers = with maintainers; [ lovesegfault ];

--- a/pkgs/development/python-modules/criticality-score/default.nix
+++ b/pkgs/development/python-modules/criticality-score/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "criticality_score" ];
 
   meta = with lib; {
-    description = "Python tool for computing the Open Source Project Criticality Score.";
+    description = "Python tool for computing the Open Source Project Criticality Score";
     homepage = "https://github.com/ossf/criticality_score";
     license = licenses.asl20;
     maintainers = with maintainers; [ wamserma ];

--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "DEAP is a novel evolutionary computation framework for rapid prototyping and testing of ideas.";
+    description = "DEAP is a novel evolutionary computation framework for rapid prototyping and testing of ideas";
     homepage = "https://github.com/DEAP/deap";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ psyanticy ];

--- a/pkgs/development/python-modules/deepmerge/default.nix
+++ b/pkgs/development/python-modules/deepmerge/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "deepmerge" ];
 
   meta = with lib; {
-    description = "A toolset to deeply merge python dictionaries.";
+    description = "A toolset to deeply merge python dictionaries";
     homepage = "http://deepmerge.readthedocs.io/en/latest/";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "distributed" ];
 
   meta = with lib; {
-    description = "Distributed computation in Python.";
+    description = "Distributed computation in Python";
     homepage = "https://distributed.readthedocs.io/en/latest/";
     license = licenses.bsd3;
     platforms = platforms.x86; # fails on aarch64

--- a/pkgs/development/python-modules/distro/default.nix
+++ b/pkgs/development/python-modules/distro/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/nir0s/distro";
-    description = "Linux Distribution - a Linux OS platform information API.";
+    description = "Linux Distribution - a Linux OS platform information API";
     license = licenses.asl20;
     maintainers = with maintainers; [ nand0p ];
   };

--- a/pkgs/development/python-modules/django-pglocks/default.nix
+++ b/pkgs/development/python-modules/django-pglocks/default.nix
@@ -5,7 +5,7 @@ buildPythonPackage rec {
   version = "1.0.4";
 
   meta = {
-    description = "PostgreSQL locking context managers and functions for Django.";
+    description = "PostgreSQL locking context managers and functions for Django";
     homepage = "https://github.com/Xof/django-pglocks";
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/django-widget-tweaks/default.nix
+++ b/pkgs/development/python-modules/django-widget-tweaks/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ django ];
 
   meta = with lib; {
-      description = "Tweak the form field rendering in templates, not in python-level form definitions.";
+      description = "Tweak the form field rendering in templates, not in python-level form definitions";
       homepage = "https://github.com/jazzband/django-widget-tweaks";
       license = licenses.mit;
       maintainers = with maintainers; [

--- a/pkgs/development/python-modules/docker-pycreds/default.nix
+++ b/pkgs/development/python-modules/docker-pycreds/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ six ];
 
   meta = with lib; {
-    description = "Python bindings for the docker credentials store API.";
+    description = "Python bindings for the docker credentials store API";
     homepage = "https://github.com/shin-/dockerpy-creds";
     license = licenses.asl20;
   };

--- a/pkgs/development/python-modules/email-validator/default.nix
+++ b/pkgs/development/python-modules/email-validator/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   ] ++ (if isPy3k then [ ] else [ ipaddress ]);
 
   meta = with lib; {
-    description = "A robust email syntax and deliverability validation library for Python 2.x/3.x.";
+    description = "A robust email syntax and deliverability validation library for Python 2.x/3.x";
     homepage    = "https://github.com/JoshData/python-email-validator";
     license     = licenses.cc0;
     maintainers = with maintainers; [ siddharthist ];

--- a/pkgs/development/python-modules/eradicate/default.nix
+++ b/pkgs/development/python-modules/eradicate/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "eradicate removes commented-out code from Python files.";
+    description = "eradicate removes commented-out code from Python files";
     homepage = "https://github.com/myint/eradicate";
     license = [ licenses.mit ];
 

--- a/pkgs/development/python-modules/etesync/default.nix
+++ b/pkgs/development/python-modules/etesync/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://www.etesync.com/";
-    description = "A python API to interact with an EteSync server.";
+    description = "A python API to interact with an EteSync server";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ valodim ];
   };

--- a/pkgs/development/python-modules/fastjsonschema/default.nix
+++ b/pkgs/development/python-modules/fastjsonschema/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Fast JSON schema validator for Python.";
+    description = "Fast JSON schema validator for Python";
     homepage = "https://horejsek.github.io/python-fastjsonschema/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ drewrisinger ];

--- a/pkgs/development/python-modules/feedgen/default.nix
+++ b/pkgs/development/python-modules/feedgen/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Python module to generate ATOM feeds, RSS feeds and Podcasts.";
+    description = "Python module to generate ATOM feeds, RSS feeds and Podcasts";
     downloadPage = "https://github.com/lkiesow/python-feedgen/releases";
     homepage = "https://github.com/lkiesow/python-feedgen";
     license = with licenses; [ bsd2 lgpl3 ];

--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "fido2" ];
 
   meta = with lib; {
-    description = "Provides library functionality for FIDO 2.0, including communication with a device over USB.";
+    description = "Provides library functionality for FIDO 2.0, including communication with a device over USB";
     homepage = "https://github.com/Yubico/python-fido2";
     license = licenses.bsd2;
     maintainers = with maintainers; [ prusnak ];

--- a/pkgs/development/python-modules/flask-bootstrap/default.nix
+++ b/pkgs/development/python-modules/flask-bootstrap/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/mbr/flask-bootstrap";
-    description = "Ready-to-use Twitter-bootstrap for use in Flask.";
+    description = "Ready-to-use Twitter-bootstrap for use in Flask";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/flask-mail/default.nix
+++ b/pkgs/development/python-modules/flask-mail/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   version = "0.9.1";
 
   meta = {
-    description = "Flask-Mail is a Flask extension providing simple email sending capabilities.";
+    description = "Flask-Mail is a Flask extension providing simple email sending capabilities";
     homepage = "https://pypi.python.org/pypi/Flask-Mail";
     license = lib.licenses.bsd3;
   };

--- a/pkgs/development/python-modules/flask-testing/default.nix
+++ b/pkgs/development/python-modules/flask-testing/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "flask_testing" ];
 
   meta = with lib; {
-    description = "Flask unittest integration.";
+    description = "Flask unittest integration";
     homepage = "https://pythonhosted.org/Flask-Testing/";
     license = licenses.bsd3;
     maintainers = [ maintainers.mic92 ];

--- a/pkgs/development/python-modules/flask-wtf/default.nix
+++ b/pkgs/development/python-modules/flask-wtf/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   doCheck = false; # requires external service
 
   meta = with lib; {
-    description = "Simple integration of Flask and WTForms.";
+    description = "Simple integration of Flask and WTForms";
     license = licenses.bsd3;
     maintainers = [ maintainers.mic92 ];
     homepage = "https://github.com/lepture/flask-wtf/";

--- a/pkgs/development/python-modules/flexmock/default.nix
+++ b/pkgs/development/python-modules/flexmock/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "flexmock is a testing library for Python that makes it easy to create mocks,stubs and fakes.";
+    description = "flexmock is a testing library for Python that makes it easy to create mocks,stubs and fakes";
     homepage = "https://flexmock.readthedocs.org";
     license = licenses.bsdOriginal;
   };

--- a/pkgs/development/python-modules/fontparts/default.nix
+++ b/pkgs/development/python-modules/fontparts/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   checkInputs = [ pytest ];
 
   meta = with lib; {
-    description = "An API for interacting with the parts of fonts during the font development process.";
+    description = "An API for interacting with the parts of fonts during the font development process";
     homepage = "https://github.com/robotools/fontParts";
     changelog = "https://github.com/robotools/fontParts/releases/tag/v${version}";
     license = licenses.mit;

--- a/pkgs/development/python-modules/gast/default.nix
+++ b/pkgs/development/python-modules/gast/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   };
   checkInputs = [ astunparse ] ;
   meta = with lib; {
-    description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module.";
+    description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jyp ];
   };

--- a/pkgs/development/python-modules/geomet/default.nix
+++ b/pkgs/development/python-modules/geomet/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/geomet/geomet";
     license = licenses.asl20;
-    description = "Convert GeoJSON to WKT/WKB (Well-Known Text/Binary), and vice versa.";
+    description = "Convert GeoJSON to WKT/WKB (Well-Known Text/Binary), and vice versa";
     maintainers = with maintainers; [ turion ris ];
   };
 }

--- a/pkgs/development/python-modules/ghdiff/default.nix
+++ b/pkgs/development/python-modules/ghdiff/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage =  "https://github.com/kilink/ghdiff";
     license = licenses.mit;
-    description = "Generate Github-style HTML for unified diffs.";
+    description = "Generate Github-style HTML for unified diffs";
     maintainers = [ maintainers.mic92 ];
   };
 }

--- a/pkgs/development/python-modules/gin-config/default.nix
+++ b/pkgs/development/python-modules/gin-config/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/google/gin-config";
-    description = "Gin provides a lightweight configuration framework for Python, based on dependency injection.";
+    description = "Gin provides a lightweight configuration framework for Python, based on dependency injection";
     license = licenses.asl20;
     maintainers = with maintainers; [ jethro ];
   };

--- a/pkgs/development/python-modules/globre/default.nix
+++ b/pkgs/development/python-modules/globre/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/metagriffin/globre";
-    description = "A python glob-like regular expression generation library.";
+    description = "A python glob-like regular expression generation library";
     maintainers = with maintainers; [ glittershark ];
     license = licenses.gpl3;
   };

--- a/pkgs/development/python-modules/goocalendar/default.nix
+++ b/pkgs/development/python-modules/goocalendar/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "A calendar widget for GTK using PyGoocanvas.";
+    description = "A calendar widget for GTK using PyGoocanvas";
     homepage = "https://goocalendar.tryton.org/";
     license = licenses.gpl2;
     maintainers = [ maintainers.udono ];

--- a/pkgs/development/python-modules/google-cloud-access-context-manager/default.nix
+++ b/pkgs/development/python-modules/google-cloud-access-context-manager/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Protobufs for Google Access Context Manager.";
+    description = "Protobufs for Google Access Context Manager";
     homepage = "https://github.com/googleapis/python-access-context-manager";
     license = licenses.asl20;
     maintainers = with maintainers; [ austinbutler SuperSandro2000 ];

--- a/pkgs/development/python-modules/google-cloud-org-policy/default.nix
+++ b/pkgs/development/python-modules/google-cloud-org-policy/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "google.cloud.orgpolicy" ];
 
   meta = with lib; {
-    description = "Protobufs for Google Cloud Organization Policy.";
+    description = "Protobufs for Google Cloud Organization Policy";
     homepage = "https://github.com/googleapis/python-org-policy";
     license = licenses.asl20;
     maintainers = with maintainers; [ austinbutler SuperSandro2000 ];

--- a/pkgs/development/python-modules/halo/default.nix
+++ b/pkgs/development/python-modules/halo/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "halo" ];
 
   meta = with lib; {
-    description = "Beautiful Spinners for Terminal, IPython and Jupyter.";
+    description = "Beautiful Spinners for Terminal, IPython and Jupyter";
     homepage = "https://github.com/manrajgrover/halo";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/NabuCasa/hass-nabucasa";
-    description = "Home Assistant cloud integration by Nabu Casa, inc.";
+    description = "Home Assistant cloud integration by Nabu Casa, inc";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ Scriptkiddi ];
   };

--- a/pkgs/development/python-modules/heapdict/default.nix
+++ b/pkgs/development/python-modules/heapdict/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   doCheck = !isPy3k;
 
   meta = with lib; {
-    description = "a heap with decrease-key and increase-key operations.";
+    description = "a heap with decrease-key and increase-key operations";
     homepage = "http://stutzbachenterprises.com";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/hiyapyco/default.nix
+++ b/pkgs/development/python-modules/hiyapyco/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "A simple python lib allowing hierarchical overlay of config files in YAML syntax, offering different merge methods and variable interpolation based on jinja2.";
+    description = "A simple python lib allowing hierarchical overlay of config files in YAML syntax, offering different merge methods and variable interpolation based on jinja2";
     homepage = "https://github.com/zerwes/hiyapyco";
     license = licenses.gpl3;
     maintainers = with maintainers; [ veehaitch ];

--- a/pkgs/development/python-modules/hole/default.nix
+++ b/pkgs/development/python-modules/hole/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "hole" ];
 
   meta = with lib; {
-    description = "Python API for interacting with a Pihole instance.";
+    description = "Python API for interacting with a Pihole instance";
     homepage = "https://github.com/home-assistant-ecosystem/python-hole";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];

--- a/pkgs/development/python-modules/html-sanitizer/default.nix
+++ b/pkgs/development/python-modules/html-sanitizer/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ lxml beautifulsoup4 ];
 
   meta = with lib; {
-    description = "An  allowlist-based and very opinionated HTML sanitizer that can be used both for untrusted and trusted sources.";
+    description = "An  allowlist-based and very opinionated HTML sanitizer that can be used both for untrusted and trusted sources";
     homepage = "https://github.com/matthiask/html-sanitizer";
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/ifconfig-parser/default.nix
+++ b/pkgs/development/python-modules/ifconfig-parser/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Unsophisticated python package for parsing raw output of ifconfig.";
+    description = "Unsophisticated python package for parsing raw output of ifconfig";
     homepage = "https://github.com/KnightWhoSayNi/ifconfig-parser";
     license = licenses.mit;
     maintainers = with maintainers; [ atemu ];

--- a/pkgs/development/python-modules/iocapture/default.nix
+++ b/pkgs/development/python-modules/iocapture/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Capture stdout, stderr easily.";
+    description = "Capture stdout, stderr easily";
     homepage = "https://github.com/oinume/iocapture";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/ipyvue/default.nix
+++ b/pkgs/development/python-modules/ipyvue/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "ipyvue" ];
 
   meta = with lib; {
-    description = "Jupyter widgets base for Vue libraries.";
+    description = "Jupyter widgets base for Vue libraries";
     homepage = "https://github.com/mariobuikhuizen/ipyvuetify";
     license = licenses.mit;
     maintainers = with maintainers; [ drewrisinger ];

--- a/pkgs/development/python-modules/ipyvuetify/default.nix
+++ b/pkgs/development/python-modules/ipyvuetify/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "ipyvuetify" ];
 
   meta = with lib; {
-    description = "Jupyter widgets based on Vuetify UI Components.";
+    description = "Jupyter widgets based on Vuetify UI Components";
     homepage = "https://github.com/mariobuikhuizen/ipyvuetify";
     license = licenses.mit;
     maintainers = with maintainers; [ drewrisinger ];

--- a/pkgs/development/python-modules/isoweek/default.nix
+++ b/pkgs/development/python-modules/isoweek/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "The module provide the class Week. Instances represent specific weeks spanning Monday to Sunday.";
+    description = "The module provide the class Week. Instances represent specific weeks spanning Monday to Sunday";
     homepage = "https://github.com/gisle/isoweek";
     license = licenses.bsd2;
     maintainers = with maintainers; [ mrmebelman ];

--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   disabled = !isPy3k;
 
   meta = with lib; {
-    description = "This library eases the use of the JIRA REST API from Python.";
+    description = "This library eases the use of the JIRA REST API from Python";
     license = licenses.bsd2;
     maintainers = with maintainers; [ globin ];
   };

--- a/pkgs/development/python-modules/jsbeautifier/default.nix
+++ b/pkgs/development/python-modules/jsbeautifier/default.nix
@@ -14,7 +14,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage    = "http://jsbeautifier.org";
-    description = "JavaScript unobfuscator and beautifier.";
+    description = "JavaScript unobfuscator and beautifier";
     license     = licenses.mit;
     maintainers = with maintainers; [ apeyroux ];
   };

--- a/pkgs/development/python-modules/jupyter_server/default.nix
+++ b/pkgs/development/python-modules/jupyter_server/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.";
+    description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications";
     homepage = "https://github.com/jupyter-server/jupyter_server";
     license = licenses.bsdOriginal;
     maintainers = [ maintainers.elohmeier ];

--- a/pkgs/development/python-modules/jupyterhub-tmpauthenticator/default.nix
+++ b/pkgs/development/python-modules/jupyterhub-tmpauthenticator/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "tmpauthenticator" ];
 
   meta = with lib; {
-    description = "Simple Jupyterhub authenticator that allows anyone to log in.";
+    description = "Simple Jupyterhub authenticator that allows anyone to log in";
     license = with licenses; [ bsd3 ];
     homepage = "https://github.com/jupyterhub/tmpauthenticator";
     maintainers = with maintainers; [ chiroptical ];

--- a/pkgs/development/python-modules/jupyterlab-git/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "jupyterlab_git" ];
 
   meta = with lib; {
-    description = "Jupyter lab extension for version control with Git.";
+    description = "Jupyter lab extension for version control with Git";
     license = with licenses; [ bsd3 ];
     homepage = "https://github.com/jupyterlab/jupyterlab-git";
     maintainers = with maintainers; [ chiroptical ];

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "jupyterlab" ];
 
   meta = with lib; {
-    description = "Jupyter lab environment notebook server extension.";
+    description = "Jupyter lab environment notebook server extension";
     license = with licenses; [ bsd3 ];
     homepage = "https://jupyter.org/";
     maintainers = with maintainers; [ zimbatm costrouc ];

--- a/pkgs/development/python-modules/kivy-garden/default.nix
+++ b/pkgs/development/python-modules/kivy-garden/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "The kivy garden installation script, split into its own package for convenient use in buildozer.";
+    description = "The kivy garden installation script, split into its own package for convenient use in buildozer";
     homepage = "https://pypi.python.org/pypi/kivy-garden";
     license = licenses.mit;
     maintainers = with maintainers; [ risson ];

--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "kivy" ];
 
   meta = with lib; {
-    description = "Library for rapid development of hardware-accelerated multitouch applications.";
+    description = "Library for rapid development of hardware-accelerated multitouch applications";
     homepage = "https://pypi.python.org/pypi/kivy";
     license = licenses.mit;
     maintainers = with maintainers; [ risson ];

--- a/pkgs/development/python-modules/korean-lunar-calendar/default.nix
+++ b/pkgs/development/python-modules/korean-lunar-calendar/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "korean_lunar_calendar" ];
 
   meta = with lib; {
-    description = "A library to convert Korean lunar-calendar to Gregorian calendar.";
+    description = "A library to convert Korean lunar-calendar to Gregorian calendar";
     homepage = "https://github.com/usingsky/korean_lunar_calendar_py";
     license = licenses.mit;
     maintainers = [ maintainers.ris ];

--- a/pkgs/development/python-modules/lazy_import/default.nix
+++ b/pkgs/development/python-modules/lazy_import/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "lazy_import provides a set of functions that load modules, and related attributes, in a lazy fashion.";
+    description = "lazy_import provides a set of functions that load modules, and related attributes, in a lazy fashion";
     homepage = https://github.com/mnmelo/lazy_import;
     license = licenses.gpl3;
     maintainers = [ maintainers.marenz ];

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "libcst" ];
 
   meta = with lib; {
-    description = "A Concrete Syntax Tree (CST) parser and serializer library for Python.";
+    description = "A Concrete Syntax Tree (CST) parser and serializer library for Python";
     homepage = "https://github.com/Instagram/libcst";
     license = with licenses; [ mit asl20 psfl ];
     maintainers = with maintainers; [ ruuda SuperSandro2000 ];

--- a/pkgs/development/python-modules/libgpuarray/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/Theano/libgpuarray";
-    description = "Library to manipulate tensors on GPU.";
+    description = "Library to manipulate tensors on GPU";
     license = licenses.free;
     maintainers = with maintainers; [ artuuge ];
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/lima/default.nix
+++ b/pkgs/development/python-modules/lima/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
-    description = "Lightweight Marshalling of Python 3 Objects.";
+    description = "Lightweight Marshalling of Python 3 Objects";
     homepage = "https://github.com/b6d/lima";
     license = licenses.mit;
     maintainers = with maintainers; [ zhaofengli ];

--- a/pkgs/development/python-modules/locket/default.nix
+++ b/pkgs/development/python-modules/locket/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Locket implements a lock that can be used by multiple processes provided they use the same path.";
+    description = "Locket implements a lock that can be used by multiple processes provided they use the same path";
     homepage = "https://github.com/mwilliamson/locket.py";
     license = licenses.bsd2;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/log-symbols/default.nix
+++ b/pkgs/development/python-modules/log-symbols/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "log_symbols" ];
 
   meta = with lib; {
-    description = "Colored Symbols for Various Log Levels.";
+    description = "Colored Symbols for Various Log Levels";
     homepage = "https://github.com/manrajgrover/py-log-symbols";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];

--- a/pkgs/development/python-modules/logfury/default.nix
+++ b/pkgs/development/python-modules/logfury/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "Logfury is for python library maintainers. It allows for responsible, low-boilerplate logging of method calls.";
+    description = "Logfury is for python library maintainers. It allows for responsible, low-boilerplate logging of method calls";
     homepage = "https://github.com/ppolewicz/logfury";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ jwiegley ];

--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/tulir/mautrix-python";
-    description = "A Python 3 asyncio Matrix framework.";
+    description = "A Python 3 asyncio Matrix framework";
     license = licenses.mpl20;
     maintainers = with maintainers; [ nyanloutre ma27 ];
   };

--- a/pkgs/development/python-modules/mediafile/default.nix
+++ b/pkgs/development/python-modules/mediafile/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "MediaFile is a simple interface to the metadata tags for many audio file formats.";
+    description = "MediaFile is a simple interface to the metadata tags for many audio file formats";
     homepage = "https://github.com/beetbox/mediafile";
     license = licenses.mit;
     maintainers = with maintainers; [ lovesegfault ];

--- a/pkgs/development/python-modules/meshio/default.nix
+++ b/pkgs/development/python-modules/meshio/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/nschloe/meshio";
-    description = "I/O for mesh files.";
+    description = "I/O for mesh files";
     license = licenses.mit;
     maintainers = with maintainers; [ wd15 ];
   };

--- a/pkgs/development/python-modules/mistletoe/default.nix
+++ b/pkgs/development/python-modules/mistletoe/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "A fast, extensible Markdown parser in pure Python.";
+    description = "A fast, extensible Markdown parser in pure Python";
     homepage = "https://github.com/miyuchina/mistletoe";
     license = licenses.mit;
     maintainers = with maintainers; [ eadwu ];

--- a/pkgs/development/python-modules/mohawk/default.nix
+++ b/pkgs/development/python-modules/mohawk/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    description = "Python library for Hawk HTTP authorization.";
+    description = "Python library for Hawk HTTP authorization";
     homepage = "https://github.com/kumar303/mohawk";
     license = licenses.mpl20;
     maintainers = [ ];

--- a/pkgs/development/python-modules/mpyq/default.nix
+++ b/pkgs/development/python-modules/mpyq/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = {
-    description = "A Python library for extracting MPQ (MoPaQ) files.";
+    description = "A Python library for extracting MPQ (MoPaQ) files";
     homepage = "https://github.com/eagleflo/mpyq";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ danharaj ];

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "The runtime library 'msrest' for AutoRest generated Python clients.";
+    description = "The runtime library 'msrest' for AutoRest generated Python clients";
     homepage = "https://github.com/Azure/msrest-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ bendlas jonringer maxwilson ];

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   '';
 
   meta = with pkgs.lib; {
-    description = "The runtime library 'msrestazure' for AutoRest generated Python clients.";
+    description = "The runtime library 'msrestazure' for AutoRest generated Python clients";
     homepage = "https://azure.microsoft.com/en-us/develop/python/";
     license = licenses.mit;
     maintainers = with maintainers; [ bendlas jonringer ];

--- a/pkgs/development/python-modules/nbclassic/default.nix
+++ b/pkgs/development/python-modules/nbclassic/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Jupyter lab environment notebook server extension.";
+    description = "Jupyter lab environment notebook server extension";
     license = with licenses; [ bsd3 ];
     homepage = "https://github.com/jupyterlab/nbclassic";
     maintainers = [ maintainers.elohmeier ];

--- a/pkgs/development/python-modules/nbdime/default.nix
+++ b/pkgs/development/python-modules/nbdime/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/jupyter/nbdime";
-    description = "Tools for diffing and merging of Jupyter notebooks.";
+    description = "Tools for diffing and merging of Jupyter notebooks";
     license = licenses.bsd3;
     maintainers = with maintainers; [ tbenst ];
   };

--- a/pkgs/development/python-modules/nose-cov/default.nix
+++ b/pkgs/development/python-modules/nose-cov/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://pypi.org/project/nose-cov/";
     license = licenses.mit;
-    description = "This plugin produces coverage reports. It also supports coverage of subprocesses.";
+    description = "This plugin produces coverage reports. It also supports coverage of subprocesses";
     maintainers = with maintainers; [ ma27 ];
   };
 }

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "notifypy" ];
 
   meta = with lib; {
-    description = " Python Module for sending cross-platform desktop notifications on Windows, macOS, and Linux.";
+    description = " Python Module for sending cross-platform desktop notifications on Windows, macOS, and Linux";
     homepage = "https://github.com/ms7m/notify-py/";
     license = licenses.mit;
     maintainers = with maintainers; [ austinbutler ];

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "oauthenticator" ];
 
   meta = with lib; {
-    description = "Authenticate JupyterHub users with common OAuth providers, including GitHub, Bitbucket, and more.";
+    description = "Authenticate JupyterHub users with common OAuth providers, including GitHub, Bitbucket, and more";
     homepage =  "https://github.com/jupyterhub/oauthenticator";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ixxie ];

--- a/pkgs/development/python-modules/opt-einsum/2.nix
+++ b/pkgs/development/python-modules/opt-einsum/2.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    description = "Optimizing NumPy's einsum function with order optimization and GPU support.";
+    description = "Optimizing NumPy's einsum function with order optimization and GPU support";
     homepage = "https://optimized-einsum.readthedocs.io";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ teh ];

--- a/pkgs/development/python-modules/opt-einsum/default.nix
+++ b/pkgs/development/python-modules/opt-einsum/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Optimizing NumPy's einsum function with order optimization and GPU support.";
+    description = "Optimizing NumPy's einsum function with order optimization and GPU support";
     homepage = "https://github.com/dgasmith/opt_einsum";
     license = licenses.mit;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/ordered-set/default.nix
+++ b/pkgs/development/python-modules/ordered-set/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    description = "A MutableSet that remembers its order, so that every entry has an index.";
+    description = "A MutableSet that remembers its order, so that every entry has an index";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.MostAwesomeDude ];
   };

--- a/pkgs/development/python-modules/orderedmultidict/default.nix
+++ b/pkgs/development/python-modules/orderedmultidict/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     ];
 
   meta = with lib; {
-    description = "Ordered Multivalue Dictionary.";
+    description = "Ordered Multivalue Dictionary";
     homepage = "https://github.com/gruns/orderedmultidict";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ vanzef ];

--- a/pkgs/development/python-modules/oscrypto/default.nix
+++ b/pkgs/development/python-modules/oscrypto/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A compilation-free, always up-to-date encryption library for Python that works on Windows, OS X, Linux and BSD.";
+    description = "A compilation-free, always up-to-date encryption library for Python that works on Windows, OS X, Linux and BSD";
     homepage = "https://www.snowflake.com/";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/osmnx/default.nix
+++ b/pkgs/development/python-modules/osmnx/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "osmnx" ];
 
   meta = with lib; {
-    description = "A package to easily download, construct, project, visualize, and analyze complex street networks from OpenStreetMap with NetworkX.";
+    description = "A package to easily download, construct, project, visualize, and analyze complex street networks from OpenStreetMap with NetworkX";
     homepage = "https://github.com/gboeing/osmnx";
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy ];

--- a/pkgs/development/python-modules/outcome/default.nix
+++ b/pkgs/development/python-modules/outcome/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "Capture the outcome of Python function calls.";
+    description = "Capture the outcome of Python function calls";
     homepage = "https://github.com/python-trio/outcome";
     license = with lib.licenses; [ mit asl20 ];
     maintainers = with lib.maintainers; [ catern ];

--- a/pkgs/development/python-modules/packet-python/default.nix
+++ b/pkgs/development/python-modules/packet-python/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    description = "A Python client for the Packet API.";
+    description = "A Python client for the Packet API";
     homepage    = "https://github.com/packethost/packet-python";
     license     = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ dipinhora ];

--- a/pkgs/development/python-modules/pagelabels/default.nix
+++ b/pkgs/development/python-modules/pagelabels/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Python library to manipulate PDF page labels.";
+    description = "Python library to manipulate PDF page labels";
     homepage = "https://github.com/lovasoa/pagelabels-py";
     maintainers = with maintainers; [ teto ];
     license = licenses.gpl3;

--- a/pkgs/development/python-modules/panel/node/node-packages.nix
+++ b/pkgs/development/python-modules/panel/node/node-packages.nix
@@ -543,7 +543,7 @@ let
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A high level dashboarding library for python visualization libraries.";
+      description = "A high level dashboarding library for python visualization libraries";
       license = "BSD-3-Clause";
     };
     production = true;

--- a/pkgs/development/python-modules/parsley/default.nix
+++ b/pkgs/development/python-modules/parsley/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   meta = with lib; {
     license = licenses.mit;
     homepage = "https://launchpad.net/parsley";
-    description = "A parser generator library based on OMeta, and other useful parsing tools.";
+    description = "A parser generator library based on OMeta, and other useful parsing tools";
     maintainers = with maintainers; [ seppeljordan ];
   };
 }

--- a/pkgs/development/python-modules/parver/default.nix
+++ b/pkgs/development/python-modules/parver/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   checkInputs = [ pytest hypothesis pretend ];
 
   meta = {
-    description = "parver allows parsing and manipulation of PEP 440 version numbers.";
+    description = "parver allows parsing and manipulation of PEP 440 version numbers";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/patch-ng/default.nix
+++ b/pkgs/development/python-modules/patch-ng/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "Library to parse and apply unified diffs.";
+    description = "Library to parse and apply unified diffs";
     homepage = "https://github.com/conan-io/python-patch";
     license = licenses.mit;
     maintainers = with maintainers; [ HaoZeke ];

--- a/pkgs/development/python-modules/pathlib2/default.nix
+++ b/pkgs/development/python-modules/pathlib2/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    description = "This module offers classes representing filesystem paths with semantics appropriate for different operating systems.";
+    description = "This module offers classes representing filesystem paths with semantics appropriate for different operating systems";
     homepage = "https://pypi.python.org/pypi/pathlib2/";
     license = with lib.licenses; [ mit ];
   };

--- a/pkgs/development/python-modules/pdfrw/default.nix
+++ b/pkgs/development/python-modules/pdfrw/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "pdfrw is a pure Python library that reads and writes PDFs.";
+    description = "pdfrw is a pure Python library that reads and writes PDFs";
     homepage = "https://github.com/pmaupin/pdfrw";
     maintainers = with maintainers; [ teto ];
     license =  licenses.mit;

--- a/pkgs/development/python-modules/pdoc3/default.nix
+++ b/pkgs/development/python-modules/pdoc3/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ Mako markdown ];
 
   meta = with lib; {
-    description = "Auto-generate API documentation for Python projects.";
+    description = "Auto-generate API documentation for Python projects";
     homepage = "https://pdoc3.github.io/pdoc/";
     license = with licenses; [ agpl3Plus ];
     maintainers = with maintainers; [ catern ];

--- a/pkgs/development/python-modules/pika-pool/default.nix
+++ b/pkgs/development/python-modules/pika-pool/default.nix
@@ -22,6 +22,6 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/bninja/pika-pool";
     license = licenses.bsdOriginal;
-    description = "Pools for pikas.";
+    description = "Pools for pikas";
   };
 }

--- a/pkgs/development/python-modules/pixelmatch/default.nix
+++ b/pkgs/development/python-modules/pixelmatch/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A pixel-level image comparison library.";
+    description = "A pixel-level image comparison library";
     homepage = "https://github.com/whtsky/pixelmatch-py";
     license = licenses.isc;
     maintainers = with maintainers; [ petabyteboy ];

--- a/pkgs/development/python-modules/podcastparser/default.nix
+++ b/pkgs/development/python-modules/podcastparser/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    description = "podcastparser is a simple, fast and efficient podcast parser written in Python.";
+    description = "podcastparser is a simple, fast and efficient podcast parser written in Python";
     homepage = "http://gpodder.org/podcastparser/";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ mic92 ];

--- a/pkgs/development/python-modules/polyline/default.nix
+++ b/pkgs/development/python-modules/polyline/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/hicsail/polyline";
     license = licenses.mit;
-    description = "Python implementation of Google's Encoded Polyline Algorithm Format.";
+    description = "Python implementation of Google's Encoded Polyline Algorithm Format";
     longDescription = "polyline is a Python implementation of Google's Encoded Polyline Algorithm Format (http://goo.gl/PvXf8Y). It is essentially a port of https://github.com/mapbox/polyline built with Python 2 and 3 support in mind.";
     maintainers = with maintainers; [ ersin ];
   };

--- a/pkgs/development/python-modules/pooch/default.nix
+++ b/pkgs/development/python-modules/pooch/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A friend to fetch your data files.";
+    description = "A friend to fetch your data files";
     homepage = "https://github.com/fatiando/pooch";
     license = licenses.bsd3;
     maintainers = with maintainers; [ GuillaumeDesforges ];

--- a/pkgs/development/python-modules/portpicker/default.nix
+++ b/pkgs/development/python-modules/portpicker/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = {
-    description = "A library to choose unique available network ports.";
+    description = "A library to choose unique available network ports";
     homepage = "https://github.com/google/python_portpicker";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ danharaj ];

--- a/pkgs/development/python-modules/pure-pcapy3/default.nix
+++ b/pkgs/development/python-modules/pure-pcapy3/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "Pure Python reimplementation of pcapy. This package is API compatible and a drop-in replacement.";
+    description = "Pure Python reimplementation of pcapy. This package is API compatible and a drop-in replacement";
     homepage = "https://bitbucket.org/viraptor/pure-pcapy";
     license = licenses.bsd2;
     maintainers = with maintainers; [ etu ];

--- a/pkgs/development/python-modules/py-air-control-exporter/default.nix
+++ b/pkgs/development/python-modules/py-air-control-exporter/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   passthru.tests = { inherit (nixosTests.prometheus-exporters) py-air-control; };
 
   meta = with lib; {
-    description = "Exports Air Quality Metrics to Prometheus.";
+    description = "Exports Air Quality Metrics to Prometheus";
     homepage = "https://github.com/urbas/py-air-control-exporter";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];

--- a/pkgs/development/python-modules/py-air-control/default.nix
+++ b/pkgs/development/python-modules/py-air-control/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     inherit (src.meta) homepage;
-    description = "Command Line App for Controlling Philips Air Purifiers.";
+    description = "Command Line App for Controlling Philips Air Purifiers";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];
   };

--- a/pkgs/development/python-modules/py4j/default.nix
+++ b/pkgs/development/python-modules/py4j/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Py4J enables Python programs running in a Python interpreter to dynamically access Java objects in a Java Virtual Machine. Methods are called as if the Java objects resided in the Python interpreter and Java collections can be accessed through standard Python collection methods. Py4J also enables Java programs to call back Python objects.";
+    description = "Py4J enables Python programs running in a Python interpreter to dynamically access Java objects in a Java Virtual Machine. Methods are called as if the Java objects resided in the Python interpreter and Java collections can be accessed through standard Python collection methods. Py4J also enables Java programs to call back Python objects";
     homepage = "https://www.py4j.org/";
     license = licenses.bsd3;
     maintainers = [ maintainers.shlevy ];

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/inducer/pycuda/";
-    description = "CUDA integration for Python.";
+    description = "CUDA integration for Python";
     license = licenses.mit;
     maintainers = with maintainers; [ artuuge ];
   };

--- a/pkgs/development/python-modules/pydash/default.nix
+++ b/pkgs/development/python-modules/pydash/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/dgilland/pydash";
-    description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way. Based on the Lo-Dash Javascript library.";
+    description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way. Based on the Lo-Dash Javascript library";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];
   };

--- a/pkgs/development/python-modules/pydub/default.nix
+++ b/pkgs/development/python-modules/pydub/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Manipulate audio with a simple and easy high level interface.";
+    description = "Manipulate audio with a simple and easy high level interface";
     homepage    = "http://pydub.com/";
     license     = licenses.mit;
     platforms   = platforms.all;

--- a/pkgs/development/python-modules/pyexcelerator/default.nix
+++ b/pkgs/development/python-modules/pyexcelerator/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "library for generating Excel 97/2000/XP/2003 and OpenOffice Calc compatible spreadsheets.";
+    description = "library for generating Excel 97/2000/XP/2003 and OpenOffice Calc compatible spreadsheets";
     homepage = "https://sourceforge.net/projects/pyexcelerator";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ womfoo ];

--- a/pkgs/development/python-modules/pygments-better-html/default.nix
+++ b/pkgs/development/python-modules/pygments-better-html/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/Kwpolska/pygments_better_html";
-    description = "Improved line numbering for Pygments’ HTML formatter.";
+    description = "Improved line numbering for Pygments’ HTML formatter";
     license = licenses.bsd3;
     maintainers = with maintainers; [ hexa ];
   };

--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pymumble_py3" ];
 
   meta = with lib; {
-    description = "Python 3 version of pymumble, Mumble library used for multiple uses like making mumble bot.";
+    description = "Python 3 version of pymumble, Mumble library used for multiple uses like making mumble bot";
     homepage = "https://github.com/azlux/pymumble";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ thelegy infinisil ];

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Python bindings for MuPDF's rendering library.";
+    description = "Python bindings for MuPDF's rendering library";
     homepage = "https://github.com/pymupdf/PyMuPDF";
     maintainers = with maintainers; [ teto ];
     license =  licenses.agpl3;

--- a/pkgs/development/python-modules/pynamecheap/default.nix
+++ b/pkgs/development/python-modules/pynamecheap/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "Namecheap API client in Python.";
+    description = "Namecheap API client in Python";
     homepage = "https://github.com/Bemmu/PyNamecheap";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/pynamodb/default.nix
+++ b/pkgs/development/python-modules/pynamodb/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   checkInputs = [ requests mock pytest mypy ];
 
   meta = with lib; {
-    description = "A Pythonic interface for Amazon’s DynamoDB that supports Python 2 and 3.";
+    description = "A Pythonic interface for Amazon’s DynamoDB that supports Python 2 and 3";
     longDescription = ''
       DynamoDB is a great NoSQL service provided by Amazon, but the API is
       verbose. PynamoDB presents you with a simple, elegant API.

--- a/pkgs/development/python-modules/pynisher/default.nix
+++ b/pkgs/development/python-modules/pynisher/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "The pynisher is a little module intended to limit a functions resources.";
+    description = "The pynisher is a little module intended to limit a functions resources";
     homepage = "https://github.com/sfalkner/pynisher";
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy ];

--- a/pkgs/development/python-modules/pyro-api/default.nix
+++ b/pkgs/development/python-modules/pyro-api/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "Generic API for dispatch to Pyro backends.";
+    description = "Generic API for dispatch to Pyro backends";
     homepage = "http://pyro.ai";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ georgewhewell ];

--- a/pkgs/development/python-modules/pysc2/default.nix
+++ b/pkgs/development/python-modules/pysc2/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage {
   ];
 
   meta = {
-    description = "Starcraft II environment and library for training agents.";
+    description = "Starcraft II environment and library for training agents";
     homepage = "https://github.com/deepmind/pysc2";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;

--- a/pkgs/development/python-modules/pysmf/default.nix
+++ b/pkgs/development/python-modules/pysmf/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "http://das.nasophon.de/pysmf/";
-    description = "Python extension module for reading and writing Standard MIDI Files, based on libsmf.";
+    description = "Python extension module for reading and writing Standard MIDI Files, based on libsmf";
     license = licenses.bsd2;
     maintainers = [ maintainers.gnidorah ];
   };

--- a/pkgs/development/python-modules/pystemd/default.nix
+++ b/pkgs/development/python-modules/pystemd/default.nix
@@ -16,7 +16,7 @@ python.pkgs.buildPythonPackage rec {
   checkPhase = "pytest tests";
 
   meta = with lib; {
-    description = "A thin Cython-based wrapper on top of libsystemd, focused on exposing the dbus API via sd-bus in an automated and easy to consume way.";
+    description = "A thin Cython-based wrapper on top of libsystemd, focused on exposing the dbus API via sd-bus in an automated and easy to consume way";
     homepage = "https://github.com/facebookincubator/pystemd/";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ flokli ];

--- a/pkgs/development/python-modules/pytest-catchlog/default.nix
+++ b/pkgs/development/python-modules/pytest-catchlog/default.nix
@@ -20,6 +20,6 @@ buildPythonPackage rec {
   meta = with lib; {
     license = licenses.mit;
     homepage = "https://pypi.python.org/pypi/pytest-catchlog/";
-    description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog.";
+    description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog";
   };
 }

--- a/pkgs/development/python-modules/pytest-datafiles/default.nix
+++ b/pkgs/development/python-modules/pytest-datafiles/default.nix
@@ -13,6 +13,6 @@ buildPythonPackage rec {
   meta = with lib; {
     license = licenses.mit;
     homepage = "https://github.com/omarkohl/pytest-datafiles";
-    description = "py.test plugin to create a 'tmpdir' containing predefined files/directories.";
+    description = "py.test plugin to create a 'tmpdir' containing predefined files/directories";
   };
 }

--- a/pkgs/development/python-modules/pytest-fixture-config/default.nix
+++ b/pkgs/development/python-modules/pytest-fixture-config/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Simple configuration objects for Py.test fixtures. Allows you to skip tests when their required config variables aren’t set.";
+    description = "Simple configuration objects for Py.test fixtures. Allows you to skip tests when their required config variables aren’t set";
     homepage = "https://github.com/manahl/pytest-plugins";
     license = licenses.mit;
     maintainers = with maintainers; [ ryansydnor ];

--- a/pkgs/development/python-modules/pytest-mock/2.nix
+++ b/pkgs/development/python-modules/pytest-mock/2.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Thin-wrapper around the mock package for easier use with py.test.";
+    description = "Thin-wrapper around the mock package for easier use with py.test";
     homepage    = "https://github.com/pytest-dev/pytest-mock";
     license     = licenses.mit;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/pytest-tornado/default.nix
+++ b/pkgs/development/python-modules/pytest-tornado/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ tornado ];
 
   meta = with lib; {
-    description = "A py.test plugin providing fixtures and markers to simplify testing of asynchronous tornado applications.";
+    description = "A py.test plugin providing fixtures and markers to simplify testing of asynchronous tornado applications";
     homepage =  "https://github.com/eugeniy/pytest-tornado";
     license = licenses.asl20;
     maintainers = with maintainers; [ ixxie ];

--- a/pkgs/development/python-modules/pytest-virtualenv/default.nix
+++ b/pkgs/development/python-modules/pytest-virtualenv/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pytest ];
 
   meta = with lib; {
-    description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed.";
+    description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed";
     homepage = "https://github.com/manahl/pytest-plugins";
     license = licenses.mit;
     maintainers = with maintainers; [ ryansydnor ];

--- a/pkgs/development/python-modules/python-constraint/default.nix
+++ b/pkgs/development/python-modules/python-constraint/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   dontUseSetuptoolsCheck = true;
 
   meta = with lib; {
-    description = "Constraint Solving Problem resolver for Python.";
+    description = "Constraint Solving Problem resolver for Python";
     homepage = "https://labix.org/doc/constraint/";
     downloadPage = "https://github.com/python-constraint/python-constraint/releases";
     license = licenses.bsd2;

--- a/pkgs/development/python-modules/python-string-utils/default.nix
+++ b/pkgs/development/python-modules/python-string-utils/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "A handy Python library to validate, manipulate and generate strings.";
+    description = "A handy Python library to validate, manipulate and generate strings";
     homepage = "https://github.com/daveoncode/python-string-utils";
     license = licenses.mit;
     maintainers = with maintainers; [ teto ];

--- a/pkgs/development/python-modules/pythonmagick/default.nix
+++ b/pkgs/development/python-modules/pythonmagick/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "http://www.imagemagick.org/script/api.php";
     license = licenses.imagemagick;
-    description = "PythonMagick provides object oriented bindings for the ImageMagick Library.";
+    description = "PythonMagick provides object oriented bindings for the ImageMagick Library";
   };
 }

--- a/pkgs/development/python-modules/pytools/default.nix
+++ b/pkgs/development/python-modules/pytools/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/inducer/pytools/";
-    description = "Miscellaneous Python lifesavers.";
+    description = "Miscellaneous Python lifesavers";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ artuuge ];
   };

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -162,7 +162,7 @@ buildPythonPackage rec {
 
 
   meta = with lib; {
-    description = "Provides the foundations for Qiskit.";
+    description = "Provides the foundations for Qiskit";
     longDescription = ''
       Allows the user to write quantum circuits easily, and takes care of the constraints of real hardware.
     '';

--- a/pkgs/development/python-modules/ramlfications/default.nix
+++ b/pkgs/development/python-modules/ramlfications/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "A Python RAML parser.";
+    description = "A Python RAML parser";
     homepage    = "https://ramlfications.readthedocs.org";
     license     = licenses.asl20;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/requests-aws4auth/default.nix
+++ b/pkgs/development/python-modules/requests-aws4auth/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "requests_aws4auth" ];
 
   meta = {
-    description = "Amazon Web Services version 4 authentication for the Python Requests library.";
+    description = "Amazon Web Services version 4 authentication for the Python Requests library";
     homepage = "https://github.com/sam-washington/requests-aws4auth";
     license = licenses.mit;
     maintainers = [ maintainers.basvandijk ];

--- a/pkgs/development/python-modules/requests-hawk/default.nix
+++ b/pkgs/development/python-modules/requests-hawk/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ mohawk requests ];
 
   meta = with lib; {
-    description = "Hawk authentication strategy for the requests python library.";
+    description = "Hawk authentication strategy for the requests python library";
     homepage = "https://github.com/sam-washington/requests-hawk";
     license = licenses.asl20;
     maintainers = with maintainers; [ austinbutler ];

--- a/pkgs/development/python-modules/requestsexceptions/default.nix
+++ b/pkgs/development/python-modules/requestsexceptions/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Import exceptions from potentially bundled packages in requests.";
+    description = "Import exceptions from potentially bundled packages in requests";
     homepage = "https://pypi.python.org/pypi/requestsexceptions";
     license = licenses.asl20;
     maintainers = with maintainers; [ makefu ];

--- a/pkgs/development/python-modules/retworkx/default.nix
+++ b/pkgs/development/python-modules/retworkx/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   postCheck = "popd";
 
   meta = with lib; {
-    description = "A python graph library implemented in Rust.";
+    description = "A python graph library implemented in Rust";
     homepage = "https://retworkx.readthedocs.io/en/latest/index.html";
     downloadPage = "https://github.com/Qiskit/retworkx/releases";
     changelog = "https://github.com/Qiskit/retworkx/releases/tag/${version}";

--- a/pkgs/development/python-modules/rfc7464/default.nix
+++ b/pkgs/development/python-modules/rfc7464/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/moshez/rfc7464";
-    description = "RFC 7464 is a proposed standard for streaming JSON documents.";
+    description = "RFC 7464 is a proposed standard for streaming JSON documents";
     license = [ licenses.mit ];
     maintainers = with maintainers; [ shlevy ];
   };

--- a/pkgs/development/python-modules/roku/default.nix
+++ b/pkgs/development/python-modules/roku/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "roku" ];
 
   meta = with lib; {
-    description = "Screw remotes. Control your Roku with Python.";
+    description = "Screw remotes. Control your Roku with Python";
     homepage = "https://github.com/jcarbaugh/python-roku";
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/s2clientprotocol/default.nix
+++ b/pkgs/development/python-modules/s2clientprotocol/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   buildInputs = [ protobuf ];
 
   meta = {
-    description = "StarCraft II - client protocol.";
+    description = "StarCraft II - client protocol";
     homepage = "https://github.com/Blizzard/sc2client-proto";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ danharaj ];

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "S3FS builds on boto3 to provide a convenient Python filesystem interface for S3.";
+    description = "S3FS builds on boto3 to provide a convenient Python filesystem interface for S3";
     homepage = "https://github.com/dask/s3fs/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "A module to obtain and visualize band paths in the Brillouin zone of crystal structures.";
+    description = "A module to obtain and visualize band paths in the Brillouin zone of crystal structures";
     homepage = "https://github.com/giovannipizzi/seekpath";
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy ];

--- a/pkgs/development/python-modules/setuptoolstrial/default.nix
+++ b/pkgs/development/python-modules/setuptoolstrial/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Setuptools plugin that makes unit tests execute with trial instead of pyunit.";
+    description = "Setuptools plugin that makes unit tests execute with trial instead of pyunit";
     homepage = "https://github.com/rutsky/setuptools-trial";
     license = licenses.bsd2;
     maintainers = with maintainers; [ ryansydnor nand0p ];

--- a/pkgs/development/python-modules/sigtools/default.nix
+++ b/pkgs/development/python-modules/sigtools/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   patchPhase = ''sed -i s/test_suite="'"sigtools.tests"'"/test_suite="'"unittest2.collector"'"/ setup.py'';
 
   meta = with lib; {
-    description = "Utilities for working with 3.3's inspect.Signature objects.";
+    description = "Utilities for working with 3.3's inspect.Signature objects";
     homepage = "https://pypi.python.org/pypi/sigtools";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/singledispatch/default.nix
+++ b/pkgs/development/python-modules/singledispatch/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3.";
+    description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3";
     homepage = "https://docs.python.org/3/library/functools.html";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ costrouc ];

--- a/pkgs/development/python-modules/softlayer/default.nix
+++ b/pkgs/development/python-modules/softlayer/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "A set of Python libraries that assist in calling the SoftLayer API.";
+    description = "A set of Python libraries that assist in calling the SoftLayer API";
     homepage = "https://github.com/softlayer/softlayer-python";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document.";
+    description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document";
     homepage = "http://sphinx-doc.org/";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "sphinxcontrib-htmlhelp is a sphinx extension which ...";
+    description = "sphinxcontrib-htmlhelp is a sphinx extension which ..";
     homepage = "http://sphinx-doc.org/";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "sphinxcontrib-htmlhelp is a sphinx extension which ..";
+    description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files";
     homepage = "http://sphinx-doc.org/";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/sphinxcontrib-jsmath/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-jsmath/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "sphinxcontrib-jsmath is a sphinx extension which renders display math in HTML via JavaScript.";
+    description = "sphinxcontrib-jsmath is a sphinx extension which renders display math in HTML via JavaScript";
     homepage = "http://sphinx-doc.org/";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document.";
+    description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document";
     homepage = "http://sphinx-doc.org/";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle).";
+    description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)";
     homepage = "http://sphinx-doc.org/";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/spinners/default.nix
+++ b/pkgs/development/python-modules/spinners/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "spinners" ];
 
   meta = with lib; {
-    description = "Spinners for the Terminal.";
+    description = "Spinners for the Terminal";
     homepage = "https://github.com/manrajgrover/py-spinners";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];

--- a/pkgs/development/python-modules/srvlookup/default.nix
+++ b/pkgs/development/python-modules/srvlookup/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/gmr/srvlookup";
     license = [ licenses.bsd3 ];
-    description = "A small wrapper for dnspython to return SRV records for a given host, protocol, and domain name as a list of namedtuples.";
+    description = "A small wrapper for dnspython to return SRV records for a given host, protocol, and domain name as a list of namedtuples";
     maintainers = [ maintainers.mmlb ];
   };
 }

--- a/pkgs/development/python-modules/ssdp/default.nix
+++ b/pkgs/development/python-modules/ssdp/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/codingjoe/ssdp";
-    description = "Python asyncio library for Simple Service Discovery Protocol (SSDP).";
+    description = "Python asyncio library for Simple Service Discovery Protocol (SSDP)";
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/stups-cli-support/default.nix
+++ b/pkgs/development/python-modules/stups-cli-support/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Helper library for all STUPS command line tools.";
+    description = "Helper library for all STUPS command line tools";
     homepage = "https://github.com/zalando-stups/stups-cli-support";
     license = licenses.asl20;
     maintainers = [ maintainers.mschuwalow ];

--- a/pkgs/development/python-modules/stups-fullstop/default.nix
+++ b/pkgs/development/python-modules/stups-fullstop/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Convenience command line tool for fullstop. audit reporting.";
+    description = "Convenience command line tool for fullstop. audit reporting";
     homepage = "https://github.com/zalando-stups/stups-fullstop-cli";
     license = licenses.asl20;
     maintainers = [ maintainers.mschuwalow ];

--- a/pkgs/development/python-modules/stups-tokens/default.nix
+++ b/pkgs/development/python-modules/stups-tokens/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A Python library that keeps OAuth 2.0 service access tokens in memory for your usage.";
+    description = "A Python library that keeps OAuth 2.0 service access tokens in memory for your usage";
     homepage = "https://github.com/zalando-stups/python-tokens";
     license = licenses.asl20;
     maintainers = [ maintainers.mschuwalow ];

--- a/pkgs/development/python-modules/stups-zign/default.nix
+++ b/pkgs/development/python-modules/stups-zign/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "OAuth2 token management command line utility.";
+    description = "OAuth2 token management command line utility";
     homepage = "https://github.com/zalando-stups/zign";
     license = licenses.asl20;
     maintainers = [ maintainers.mschuwalow ];

--- a/pkgs/development/python-modules/tblib/default.nix
+++ b/pkgs/development/python-modules/tblib/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "Traceback fiddling library. Allows you to pickle tracebacks.";
+    description = "Traceback fiddling library. Allows you to pickle tracebacks";
     homepage = "https://github.com/ionelmc/python-tblib";
     license = licenses.bsd2;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/python-modules/tensorboard-plugin-profile/default.nix
+++ b/pkgs/development/python-modules/tensorboard-plugin-profile/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Profile Tensorboard Plugin.";
+    description = "Profile Tensorboard Plugin";
     homepage = http://tensorflow.org;
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];

--- a/pkgs/development/python-modules/tensorboard-plugin-wit/default.nix
+++ b/pkgs/development/python-modules/tensorboard-plugin-wit/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "What-If Tool TensorBoard plugin.";
+    description = "What-If Tool TensorBoard plugin";
     homepage = http://tensorflow.org;
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];

--- a/pkgs/development/python-modules/tensorflow-estimator/default.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ mock numpy absl-py ];
 
   meta = with lib; {
-    description = "TensorFlow Estimator is a high-level API that encapsulates model training, evaluation, prediction, and exporting.";
+    description = "TensorFlow Estimator is a high-level API that encapsulates model training, evaluation, prediction, and exporting";
     homepage = "http://tensorflow.org";
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp ];

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Read and write image data from and to TIFF files.";
+    description = "Read and write image data from and to TIFF files";
     homepage = "https://www.lfd.uci.edu/~gohlke/";
     maintainers = [ maintainers.lebastr ];
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/tlslite-ng/default.nix
+++ b/pkgs/development/python-modules/tlslite-ng/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   buildInputs = [ ecdsa ];
 
   meta = with lib; {
-    description = "Pure python implementation of SSL and TLS.";
+    description = "Pure python implementation of SSL and TLS";
     homepage = "https://pypi.python.org/pypi/tlslite-ng";
     license = licenses.lgpl2;
     maintainers = [ maintainers.erictapen ];

--- a/pkgs/development/python-modules/trimesh/default.nix
+++ b/pkgs/development/python-modules/trimesh/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Python library for loading and using triangular meshes.";
+    description = "Python library for loading and using triangular meshes";
     homepage = "https://trimsh.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ gebner ];

--- a/pkgs/development/python-modules/tvnamer/default.nix
+++ b/pkgs/development/python-modules/tvnamer/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Automatic TV episode file renamer, uses data from thetvdb.com via tvdb_api.";
+    description = "Automatic TV episode file renamer, uses data from thetvdb.com via tvdb_api";
     homepage = "https://github.com/dbr/tvnamer";
     license = licenses.unlicense;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Utilities to support code that runs unmodified on Twisted and asyncio.";
+    description = "Utilities to support code that runs unmodified on Twisted and asyncio";
     homepage    = "https://github.com/crossbario/txaio";
     license     = licenses.mit;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/txgithub/default.nix
+++ b/pkgs/development/python-modules/txgithub/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "GitHub API client implemented using Twisted.";
+    description = "GitHub API client implemented using Twisted";
     homepage    = "https://github.com/tomprince/txgithub";
     license     = licenses.mit;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/txrequests/default.nix
+++ b/pkgs/development/python-modules/txrequests/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Asynchronous Python HTTP for Humans.";
+    description = "Asynchronous Python HTTP for Humans";
     homepage    = "https://github.com/tardyp/txrequests";
     license     = licenses.asl20;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://typer.tiangolo.com/";
-    description = "Typer, build great CLIs. Easy to code. Based on Python type hints.";
+    description = "Typer, build great CLIs. Easy to code. Based on Python type hints";
     license = licenses.mit;
     maintainers = [ maintainers.winpat ];
   };

--- a/pkgs/development/python-modules/vowpalwabbit/default.nix
+++ b/pkgs/development/python-modules/vowpalwabbit/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Vowpal Wabbit is a fast machine learning library for online learning, and this is the python wrapper for the project.";
+    description = "Vowpal Wabbit is a fast machine learning library for online learning, and this is the python wrapper for the project";
     homepage    = "https://github.com/JohnLangford/vowpal_wabbit";
     license     = licenses.bsd3;
     broken      = stdenv.isAarch64;

--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -21,8 +21,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Fast, pure-Python full text indexing, search, and spell
-checking library.";
+    description = "Fast, pure-Python full text indexing, search, and spellchecking library";
     homepage    = "https://bitbucket.org/mchaput/whoosh";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ nand0p ];

--- a/pkgs/development/python-modules/yattag/default.nix
+++ b/pkgs/development/python-modules/yattag/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    description = "Generate HTML or XML in a pythonic way. Pure python alternative to web template engines. Can fill HTML forms with default values and error messages.";
+    description = "Generate HTML or XML in a pythonic way. Pure python alternative to web template engines. Can fill HTML forms with default values and error messages";
     license = [ licenses.lgpl21 ];
     homepage = "https://www.yattag.org/";
   };

--- a/pkgs/development/python-modules/zeroc-ice/default.nix
+++ b/pkgs/development/python-modules/zeroc-ice/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://zeroc.com/";
     license = licenses.gpl2;
-    description = "Comprehensive RPC framework with support for Python, C++, .NET, Java, JavaScript and more.";
+    description = "Comprehensive RPC framework with support for Python, C++, .NET, Java, JavaScript and more";
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/development/python-modules/zict/default.nix
+++ b/pkgs/development/python-modules/zict/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ heapdict ];
 
   meta = with lib; {
-    description = "Mutable mapping tools.";
+    description = "Mutable mapping tools";
     homepage = "https://github.com/dask/zict";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh ];

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "UNIX-like reverse engineering framework and command-line toolset.";
+    description = "UNIX-like reverse engineering framework and command-line toolset";
     homepage = "https://rizin.re/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ raskin makefu mic92 ];

--- a/pkgs/development/tools/poetry2nix/poetry2nix/pkgs/poetry/pyproject.toml
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/pkgs/poetry/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "poetry"
 version = "1.1.5"
-description = "Python dependency management and packaging made easy."
+description = "Python dependency management and packaging made easy"
 authors = [
     "Sébastien Eustace <sebastien@eustace.io>"
 ]

--- a/pkgs/development/tools/rust/cargo-binutils/default.nix
+++ b/pkgs/development/tools/rust/cargo-binutils/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-Zrl269PacPi81TrGTIDzmVndgGY5i5lYyspiOj43rpw=";
 
   meta = with lib; {
-    description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain.";
+    description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain";
     longDescription = ''
       In order for this to work, you either need to run `rustup component add llvm-tools-preview` or install the `llvm-tools-preview` component using your Nix library (e.g. nixpkgs-mozilla, or rust-overlay)
     '';

--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "A Nix build file generator for Rust crates.";
+    description = "A Nix build file generator for Rust crates";
     longDescription = ''
       Crate2nix generates Nix files from Cargo.toml/lock files
       so that you can build every crate individually in a Nix sandbox.

--- a/pkgs/development/tools/rust/probe-run/default.nix
+++ b/pkgs/development/tools/rust/probe-run/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ libusb1 ];
 
   meta = with lib; {
-    description = "Run embedded programs just like native ones.";
+    description = "Run embedded programs just like native ones";
     homepage = "https://github.com/knurling-rs/probe-run";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ hoverbear ];

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description =
-      "SQLx's associated command-line utility for managing databases, migrations, and enabling offline mode with sqlx::query!() and friends.";
+      "SQLx's associated command-line utility for managing databases, migrations, and enabling offline mode with sqlx::query!() and friends";
     homepage = "https://github.com/launchbadge/sqlx";
     license = licenses.asl20;
     maintainers = with maintainers; [ greizgh ];

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -107,7 +107,7 @@ in stdenv.mkDerivation rec {
   desktopItems = [ desktopItem ];
 
   meta = with lib; {
-    description = "A visual, drag'n'drop, layout tool for designing JavaFX application user interfaces.";
+    description = "A visual, drag'n'drop, layout tool for designing JavaFX application user interfaces";
     homepage = "https://gluonhq.com/products/scene-builder/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ wirew0rm ];

--- a/pkgs/development/tools/scenic-view/default.nix
+++ b/pkgs/development/tools/scenic-view/default.nix
@@ -99,7 +99,7 @@ in stdenv.mkDerivation rec {
   desktopItems = [ desktopItem ];
 
   meta = with lib; {
-    description = "JavaFx application to visualize and modify the scenegraph of running JavaFx applications.";
+    description = "JavaFx application to visualize and modify the scenegraph of running JavaFx applications";
     longDescription = ''
       A JavaFX application designed to make it simple to understand the current state of your application scenegraph
       and to also easily manipulate properties of the scenegraph without having to keep editing your code.

--- a/pkgs/development/tools/systemfd/crates-io.nix
+++ b/pkgs/development/tools/systemfd/crates-io.nix
@@ -10,7 +10,7 @@ rec {
   crates.aho_corasick."0.6.4" = deps: { features?(features_.aho_corasick."0.6.4" deps {}) }: buildRustCrate {
     crateName = "aho-corasick";
     version = "0.6.4";
-    description = "Fast multiple substring searching with finite state machines.";
+    description = "Fast multiple substring searching with finite state machines";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "189v919mp6rzzgjp1khpn4zlq8ls81gh43x1lmc8kbkagdlpq888";
     libName = "aho_corasick";
@@ -251,7 +251,7 @@ rec {
   crates.byteorder."1.2.3" = deps: { features?(features_.byteorder."1.2.3" deps {}) }: buildRustCrate {
     crateName = "byteorder";
     version = "1.2.3";
-    description = "Library for reading/writing numbers in big-endian and little-endian.";
+    description = "Library for reading/writing numbers in big-endian and little-endian";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1xghv5f5rydzsam8lnfqhfk090i8a1knb77ikbs0ik44bvrw2ij3";
     features = mkFeatures (features."byteorder"."1.2.3" or {});
@@ -526,7 +526,7 @@ rec {
   crates.failure."0.1.1" = deps: { features?(features_.failure."0.1.1" deps {}) }: buildRustCrate {
     crateName = "failure";
     version = "0.1.1";
-    description = "Experimental error handling abstraction.";
+    description = "Experimental error handling abstraction";
     authors = [ "Without Boats <boats@mozilla.com>" ];
     sha256 = "0gf9cmkm9kc163sszgjksqp5pcgj689lnf2104nn4h4is18nhigk";
     dependencies = mapFeatures features ([
@@ -693,7 +693,7 @@ rec {
   crates.kernel32_sys."0.2.2" = deps: { features?(features_.kernel32_sys."0.2.2" deps {}) }: buildRustCrate {
     crateName = "kernel32-sys";
     version = "0.2.2";
-    description = "Contains function definitions for the Windows API library kernel32. See winapi for types and constants.";
+    description = "Contains function definitions for the Windows API library kernel32. See winapi for types and constants";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1lrw1hbinyvr6cp28g60z97w32w8vsk6pahk64pmrv2fmby8srfj";
     libName = "kernel32";
@@ -722,7 +722,7 @@ rec {
   crates.lazy_static."0.2.11" = deps: { features?(features_.lazy_static."0.2.11" deps {}) }: buildRustCrate {
     crateName = "lazy_static";
     version = "0.2.11";
-    description = "A macro for declaring lazily evaluated statics in Rust.";
+    description = "A macro for declaring lazily evaluated statics in Rust";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "1x6871cvpy5b96yv4c7jvpq316fp5d4609s9py7qk6cd6x9k34vm";
     dependencies = mapFeatures features ([
@@ -754,7 +754,7 @@ rec {
   crates.lazy_static."1.0.0" = deps: { features?(features_.lazy_static."1.0.0" deps {}) }: buildRustCrate {
     crateName = "lazy_static";
     version = "1.0.0";
-    description = "A macro for declaring lazily evaluated statics in Rust.";
+    description = "A macro for declaring lazily evaluated statics in Rust";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "0wfvqyr2nvx2mbsrscg5y7gfa9skhb8p72ayanl8vl49pw24v4fh";
     dependencies = mapFeatures features ([
@@ -808,7 +808,7 @@ rec {
   crates.memchr."2.0.1" = deps: { features?(features_.memchr."2.0.1" deps {}) }: buildRustCrate {
     crateName = "memchr";
     version = "2.0.1";
-    description = "Safe interface to memchr.";
+    description = "Safe interface to memchr";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" "bluss" ];
     sha256 = "0ls2y47rjwapjdax6bp974gdp06ggm1v8d1h69wyydmh1nhgm5gr";
     dependencies = mapFeatures features ([
@@ -883,7 +883,7 @@ rec {
   crates.owning_ref."0.3.3" = deps: { features?(features_.owning_ref."0.3.3" deps {}) }: buildRustCrate {
     crateName = "owning_ref";
     version = "0.3.3";
-    description = "A library for creating references that carry their owner with them.";
+    description = "A library for creating references that carry their owner with them";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "13ivn0ydc0hf957ix0f5si9nnplzzykbr70hni1qz9m19i9kvmrh";
     dependencies = mapFeatures features ([
@@ -904,7 +904,7 @@ rec {
   crates.parking_lot."0.5.5" = deps: { features?(features_.parking_lot."0.5.5" deps {}) }: buildRustCrate {
     crateName = "parking_lot";
     version = "0.5.5";
-    description = "More compact and efficient implementations of the standard synchronization primitives.";
+    description = "More compact and efficient implementations of the standard synchronization primitives";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "0balxl593apy0l70z6dzk6c0r9707hgw2c9yav5asjc87dj6fx7l";
     dependencies = mapFeatures features ([
@@ -945,7 +945,7 @@ rec {
   crates.parking_lot_core."0.2.14" = deps: { features?(features_.parking_lot_core."0.2.14" deps {}) }: buildRustCrate {
     crateName = "parking_lot_core";
     version = "0.2.14";
-    description = "An advanced API for creating custom synchronization primitives.";
+    description = "An advanced API for creating custom synchronization primitives";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "0giypb8ckkpi34p14nfk4b19c7przj4jxs95gs7x2v5ncmi0y286";
     dependencies = mapFeatures features ([
@@ -1192,7 +1192,7 @@ rec {
   crates.regex_syntax."0.5.6" = deps: { features?(features_.regex_syntax."0.5.6" deps {}) }: buildRustCrate {
     crateName = "regex-syntax";
     version = "0.5.6";
-    description = "A regular expression parser.";
+    description = "A regular expression parser";
     authors = [ "The Rust Project Developers" ];
     sha256 = "10vf3r34bgjnbrnqd5aszn35bjvm8insw498l1vjy8zx5yms3427";
     dependencies = mapFeatures features ([
@@ -1213,7 +1213,7 @@ rec {
   crates.regex_syntax."0.6.0" = deps: { features?(features_.regex_syntax."0.6.0" deps {}) }: buildRustCrate {
     crateName = "regex-syntax";
     version = "0.6.0";
-    description = "A regular expression parser.";
+    description = "A regular expression parser";
     authors = [ "The Rust Project Developers" ];
     sha256 = "1zlaq3y1zbiqilxbh0471bizcs4p14b58nqr815w3ssyam169cy6";
     dependencies = mapFeatures features ([
@@ -1447,7 +1447,7 @@ rec {
   crates.systemfd."0.3.0" = deps: { features?(features_.systemfd."0.3.0" deps {}) }: buildRustCrate {
     crateName = "systemfd";
     version = "0.3.0";
-    description = "A convenient helper for passing sockets into another process.  Best to be combined with listenfd and cargo-watch.";
+    description = "A convenient helper for passing sockets into another process.  Best to be combined with listenfd and cargo-watch";
     authors = [ "Armin Ronacher <armin.ronacher@active-4.com>" ];
     sha256 = "0dpckgb0afyzhbv8lccgzmw5yczpfcdsdlqsfncn1vcxvcf0yb5i";
     dependencies = mapFeatures features ([
@@ -1508,7 +1508,7 @@ rec {
   crates.termion."1.5.1" = deps: { features?(features_.termion."1.5.1" deps {}) }: buildRustCrate {
     crateName = "termion";
     version = "1.5.1";
-    description = "A bindless library for manipulating terminals.";
+    description = "A bindless library for manipulating terminals";
     authors = [ "ticki <Ticki@users.noreply.github.com>" "gycos <alexandre.bury@gmail.com>" "IGI-111 <igi-111@protonmail.com>" ];
     sha256 = "02gq4vd8iws1f3gjrgrgpajsk2bk43nds5acbbb4s8dvrdvr8nf1";
     dependencies = (if !(kernel == "redox") then mapFeatures features ([
@@ -1537,7 +1537,7 @@ rec {
   crates.termios."0.2.2" = deps: { features?(features_.termios."0.2.2" deps {}) }: buildRustCrate {
     crateName = "termios";
     version = "0.2.2";
-    description = "Safe bindings for the termios library.";
+    description = "Safe bindings for the termios library";
     authors = [ "David Cuddeback <david.cuddeback@gmail.com>" ];
     sha256 = "0hjy4idvcapx9i6qbhf5536aqnf6rqk2aaj424sfwy7qhv6xmcx3";
     dependencies = mapFeatures features ([
@@ -1650,7 +1650,7 @@ rec {
   crates.unreachable."1.0.0" = deps: { features?(features_.unreachable."1.0.0" deps {}) }: buildRustCrate {
     crateName = "unreachable";
     version = "1.0.0";
-    description = "An unreachable code optimization hint in stable rust.";
+    description = "An unreachable code optimization hint in stable rust";
     authors = [ "Jonathan Reem <jonathan.reem@gmail.com>" ];
     sha256 = "1am8czbk5wwr25gbp2zr007744fxjshhdqjz9liz7wl4pnv3whcf";
     dependencies = mapFeatures features ([
@@ -1671,7 +1671,7 @@ rec {
   crates.utf8_ranges."1.0.0" = deps: { features?(features_.utf8_ranges."1.0.0" deps {}) }: buildRustCrate {
     crateName = "utf8-ranges";
     version = "1.0.0";
-    description = "Convert ranges of Unicode codepoints to UTF-8 byte ranges.";
+    description = "Convert ranges of Unicode codepoints to UTF-8 byte ranges";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "0rzmqprwjv9yp1n0qqgahgm24872x6c0xddfym5pfndy7a36vkn0";
   };
@@ -1779,7 +1779,7 @@ rec {
   crates.void."1.0.2" = deps: { features?(features_.void."1.0.2" deps {}) }: buildRustCrate {
     crateName = "void";
     version = "1.0.2";
-    description = "The uninhabited void type for use in statically impossible cases.";
+    description = "The uninhabited void type for use in statically impossible cases";
     authors = [ "Jonathan Reem <jonathan.reem@gmail.com>" ];
     sha256 = "0h1dm0dx8dhf56a83k68mijyxigqhizpskwxfdrs1drwv2cdclv3";
     features = mkFeatures (features."void"."1.0.2" or {});
@@ -1801,7 +1801,7 @@ rec {
   crates.winapi."0.2.8" = deps: { features?(features_.winapi."0.2.8" deps {}) }: buildRustCrate {
     crateName = "winapi";
     version = "0.2.8";
-    description = "Types and constants for WinAPI bindings. See README for list of crates providing function bindings.";
+    description = "Types and constants for WinAPI bindings. See README for list of crates providing function bindings";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "0a45b58ywf12vb7gvj6h3j264nydynmzyqz8d8rqxsj6icqv82as";
   };
@@ -1816,7 +1816,7 @@ rec {
   crates.winapi."0.3.4" = deps: { features?(features_.winapi."0.3.4" deps {}) }: buildRustCrate {
     crateName = "winapi";
     version = "0.3.4";
-    description = "Raw FFI bindings for all of Windows API.";
+    description = "Raw FFI bindings for all of Windows API";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1qbrf5dcnd8j36cawby5d9r5vx07r0l4ryf672pfncnp8895k9lx";
     build = "build.rs";
@@ -1844,7 +1844,7 @@ rec {
   crates.winapi_build."0.1.1" = deps: { features?(features_.winapi_build."0.1.1" deps {}) }: buildRustCrate {
     crateName = "winapi-build";
     version = "0.1.1";
-    description = "Common code for build.rs in WinAPI -sys crates.";
+    description = "Common code for build.rs in WinAPI -sys crates";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1lxlpi87rkhxcwp2ykf1ldw3p108hwm24nywf3jfrvmff4rjhqga";
     libName = "build";
@@ -1860,7 +1860,7 @@ rec {
   crates.winapi_i686_pc_windows_gnu."0.4.0" = deps: { features?(features_.winapi_i686_pc_windows_gnu."0.4.0" deps {}) }: buildRustCrate {
     crateName = "winapi-i686-pc-windows-gnu";
     version = "0.4.0";
-    description = "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.";
+    description = "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "05ihkij18r4gamjpxj4gra24514can762imjzlmak5wlzidplzrp";
     build = "build.rs";
@@ -1876,7 +1876,7 @@ rec {
   crates.winapi_x86_64_pc_windows_gnu."0.4.0" = deps: { features?(features_.winapi_x86_64_pc_windows_gnu."0.4.0" deps {}) }: buildRustCrate {
     crateName = "winapi-x86_64-pc-windows-gnu";
     version = "0.4.0";
-    description = "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.";
+    description = "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "0n1ylmlsb8yg1v583i4xy0qmqg42275flvbc51hdqjjfjcl9vlbj";
     build = "build.rs";

--- a/pkgs/development/tools/turbogit/default.nix
+++ b/pkgs/development/tools/turbogit/default.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "Keep your git workflow clean without headache.";
+    description = "Keep your git workflow clean without headache";
     longDescription = ''
       turbogit (tug) is a cli tool built to help you deal with your day-to-day git work.
       turbogit enforces convention (e.g. The Conventional Commits) but tries to keep things simple and invisible for you.

--- a/pkgs/development/web/remarkjs/node-packages.nix
+++ b/pkgs/development/web/remarkjs/node-packages.nix
@@ -3620,7 +3620,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "JavaScript test spies, stubs and mocks.";
+      description = "JavaScript test spies, stubs and mocks";
       homepage = "https://sinonjs.org/";
       license = "BSD-3-Clause";
     };

--- a/pkgs/games/black-hole-solver/default.nix
+++ b/pkgs/games/black-hole-solver/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://www.shlomifish.org/open-source/projects/black-hole-solitaire-solver/";
-    description = "A solver for Solitaire variants Golf, Black Hole, and All in a Row.";
+    description = "A solver for Solitaire variants Golf, Black Hole, and All in a Row";
     license = licenses.mit;
   };
 

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -81,7 +81,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A plugin for Dwarf Fortress / DFHack that improves various aspects the game interface.";
+    description = "A plugin for Dwarf Fortress / DFHack that improves various aspects the game interface";
     maintainers = with maintainers; [ Baughn numinit ];
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/games/uchess/default.nix
+++ b/pkgs/games/uchess/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "Play chess against UCI engines in your terminal.";
+    description = "Play chess against UCI engines in your terminal";
     homepage = "https://tmountain.github.io/uchess/";
     maintainers = with maintainers; [ tmountain ];
     license = licenses.mit;

--- a/pkgs/misc/base16-builder/node-packages-generated.nix
+++ b/pkgs/misc/base16-builder/node-packages-generated.nix
@@ -1639,7 +1639,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Base16 Builder is a nimble command-line tool that generates themes for your favourite programs.";
+      description = "Base16 Builder is a nimble command-line tool that generates themes for your favourite programs";
       homepage = "https://github.com/base16-builder/base16-builder#readme";
       license = "MIT";
     };

--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Canon InkJet printer drivers for many Pixma series printers.";
+    description = "Canon InkJet printer drivers for many Pixma series printers";
     longDescription = ''
       Canon InjKet printer drivers for series E200, E300, E3100, E3300, E4200, E450, E470, E480,
       G3000, G3010, G4000, G4010, G5000, G5080, G6000, G6050, G6080, G7000, G7050, G7080, GM2000,

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -774,7 +774,7 @@ in with lib.licenses;
       rev = "8fe07c62a364d0af1e22b7f75e839d42872dae7f";
       sha256 = "0p3fpldw6w4n4l60bv55c17vhqwq4q39fp36h8iqmnj7c32c61kf";
     };
-    description = "Parallel Mupen64plus rewrite for libretro.";
+    description = "Parallel Mupen64plus rewrite for libretro";
     license = gpl2;
     extraBuildInputs = [ libGLU libGL libpng ];
     makefile = "Makefile";

--- a/pkgs/misc/emulators/ruffle/default.nix
+++ b/pkgs/misc/emulators/ruffle/default.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "0pnp5kmij4dwwvmgdv81mqcawcjcgg5gd6cpyf0xalyfjgj8i732";
 
   meta = with lib; {
-    description = "An Adobe Flash Player emulator written in the Rust programming language.";
+    description = "An Adobe Flash Player emulator written in the Rust programming language";
     homepage = "https://ruffle.rs/";
     license = with licenses; [ mit asl20 ];
     maintainers = with maintainers; [ govanify ];

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -357,7 +357,7 @@ let
       file-icons.file-icons = buildVscodeMarketplaceExtension {
         meta = with lib; {
           changelog = "https://marketplace.visualstudio.com/items/file-icons.file-icons/changelog";
-          description = "File-specific icons in VSCode for improved visual grepping.";
+          description = "File-specific icons in VSCode for improved visual grepping";
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=file-icons.file-icons";
           homepage = "https://github.com/file-icons/vscode";
           license = licenses.mit;

--- a/pkgs/misc/vscode-extensions/remote-ssh/default.nix
+++ b/pkgs/misc/vscode-extensions/remote-ssh/default.nix
@@ -46,7 +46,7 @@ in
     '';
 
     meta = with lib; {
-      description ="Use any remote machine with a SSH server as your development environment.";
+      description ="Use any remote machine with a SSH server as your development environment";
       license = licenses.unfree;
       maintainers = with maintainers; [
         tbenst

--- a/pkgs/os-specific/darwin/iproute2mac/default.nix
+++ b/pkgs/os-specific/darwin/iproute2mac/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/brona/iproute2mac";
-    description = "CLI wrapper for basic network utilites on Mac OS X inspired with iproute2 on Linux systems - ip command.";
+    description = "CLI wrapper for basic network utilites on Mac OS X inspired with iproute2 on Linux systems - ip command";
     license = licenses.mit;
     maintainers = with maintainers; [ flokli ];
     platforms = platforms.darwin;

--- a/pkgs/os-specific/darwin/osx-cpu-temp/default.nix
+++ b/pkgs/os-specific/darwin/osx-cpu-temp/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Outputs current CPU temperature for OSX.";
+    description = "Outputs current CPU temperature for OSX";
     homepage = "https://github.com/lavoiesl/osx-cpu-temp";
     license = licenses.gpl2;
     maintainers = with maintainers; [ virusdave ];

--- a/pkgs/os-specific/darwin/trash/default.nix
+++ b/pkgs/os-specific/darwin/trash/default.nix
@@ -26,8 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/ali-rantakari/trash";
-    description = "Small command-line program for OS X that moves files or
-    folders to the trash.";
+    description = "Small command-line program for OS X that moves files or folders to the trash";
     platforms = lib.platforms.darwin;
     license = lib.licenses.mit;
   };

--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Anbox ashmem and binder drivers.";
+    description = "Anbox ashmem and binder drivers";
     homepage = "https://github.com/anbox/anbox-modules";
     license = licenses.gpl2Only;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -20,7 +20,7 @@ buildLinux (args // {
   extraMeta = {
     branch = "5.10/master";
     maintainers = with lib.maintainers; [ atemu andresilva ];
-    description = "Built using the best configuration and kernel sources for desktop, multimedia, and gaming workloads.";
+    description = "Built using the best configuration and kernel sources for desktop, multimedia, and gaming workloads";
   };
 
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A driver for MacBook models 2018 and newer, which makes the keyboard, mouse and audio output work.";
+    description = "A driver for MacBook models 2018 and newer, which makes the keyboard, mouse and audio output work";
     longDescription = ''
       A driver for MacBook models 2018 and newer, implementing the VHCI (required for mouse/keyboard/etc.) and audio functionality.
     '';

--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Aircrack-ng kernel module for Realtek 88XXau network cards\n(8811au, 8812au, 8814au and 8821au chipsets) with monitor mode and injection support.";
+    description = "Aircrack-ng kernel module for Realtek 88XXau network cards\n(8811au, 8812au, 8814au and 8821au chipsets) with monitor mode and injection support";
     homepage = "https://github.com/aircrack-ng/rtl8812au";
     license = licenses.gpl2;
     maintainers = [ maintainers.jethro ];

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs.";
+    description = "Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs";
     homepage = "https://github.com/ocerman/zenpower";
     license = licenses.gpl2;
     maintainers = with maintainers; [ alexbakker ];

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/etesync/server";
-    description = "An Etebase (EteSync 2.0) server so you can run your own.";
+    description = "An Etebase (EteSync 2.0) server so you can run your own";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ felschr ];
     broken = stdenv.isDarwin;

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -93,7 +93,7 @@ in {
     };
     meta = with lib; {
       homepage = "https://github.com/elastic/elasticsearch/tree/master/plugins/discovery-ec2";
-      description = "The EC2 discovery plugin uses the AWS API for unicast discovery.";
+      description = "The EC2 discovery plugin uses the AWS API for unicast discovery";
       license = licenses.asl20;
     };
   };
@@ -127,7 +127,7 @@ in {
     };
     meta = with lib; {
       homepage = "https://github.com/elastic/elasticsearch/tree/master/plugins/repository-s3";
-      description = "The S3 repository plugin adds support for using AWS S3 as a repository for Snapshot/Restore.";
+      description = "The S3 repository plugin adds support for using AWS S3 as a repository for Snapshot/Restore";
       license = licenses.asl20;
     };
   };
@@ -144,7 +144,7 @@ in {
     };
     meta = with lib; {
       homepage = "https://github.com/elastic/elasticsearch/tree/master/plugins/repository-gcs";
-      description = "The GCS repository plugin adds support for using Google Cloud Storage as a repository for Snapshot/Restore.";
+      description = "The GCS repository plugin adds support for using Google Cloud Storage as a repository for Snapshot/Restore";
       license = licenses.asl20;
     };
   };

--- a/pkgs/shells/fish/plugins/forgit.nix
+++ b/pkgs/shells/fish/plugins/forgit.nix
@@ -18,7 +18,7 @@ buildFishPlugin rec {
   };
 
   meta = with lib; {
-    description = "A utility tool powered by fzf for using git interactively.";
+    description = "A utility tool powered by fzf for using git interactively";
     homepage = "https://github.com/wfxr/forgit";
     license = licenses.mit;
     maintainers = with maintainers; [ happysalada ];

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -202,7 +202,7 @@ let
 
   metaTypes = with lib.types; rec {
     # These keys are documented
-    description = str;
+    description = strMatching "|.*[^.]"; # empty or not ending in a period
     mainProgram = str;
     longDescription = str;
     branch = str;

--- a/pkgs/tools/admin/afterburn/default.nix
+++ b/pkgs/tools/admin/afterburn/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/coreos/ignition";
-    description = "This is a small utility, typically used in conjunction with Ignition, which reads metadata from a given cloud-provider and applies it to the system.";
+    description = "This is a small utility, typically used in conjunction with Ignition, which reads metadata from a given cloud-provider and applies it to the system";
     license = licenses.asl20;
     maintainers = [ maintainers.arianvp ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
+++ b/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "To locally test their Lambda function packaged as a container image.";
+    description = "To locally test their Lambda function packaged as a container image";
     homepage = "https://github.com/aws/aws-lambda-runtime-interface-emulator";
     license = licenses.asl20;
     maintainers = with maintainers; [ teto ];

--- a/pkgs/tools/filesystems/rmfuse/default.nix
+++ b/pkgs/tools/filesystems/rmfuse/default.nix
@@ -10,7 +10,7 @@ let
 
         rmfuse = super.rmfuse.overridePythonAttrs(old: {
           meta = old.meta // {
-            description = "RMfuse provides access to your reMarkable Cloud files in the form of a FUSE filesystem.";
+            description = "RMfuse provides access to your reMarkable Cloud files in the form of a FUSE filesystem";
             longDescription = ''
               RMfuse provides access to your reMarkable Cloud files in the form of a FUSE filesystem. These files are exposed either in their original format, or as PDF files that contain your annotations. This lets you manage files in the reMarkable Cloud using the same tools you use on your local system.
             '';

--- a/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
+++ b/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://gitlab.com/interception/linux/plugins/dual-function-keys";
-    description = "Tap for one key, hold for another.";
+    description = "Tap for one key, hold for another";
     license = licenses.mit;
     maintainers = with maintainers; [ svend ];
     platforms = platforms.linux;

--- a/pkgs/tools/inputmethods/remote-touchpad/default.nix
+++ b/pkgs/tools/inputmethods/remote-touchpad/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
   vendorSha256 = "0q1qk5g7kqpcci5fgamvxa8989jglv69kwg5rvkphbnx1bzlivrl";
 
   meta = with lib; {
-    description = "Control mouse and keyboard from the webbrowser of a smartphone.";
+    description = "Control mouse and keyboard from the webbrowser of a smartphone";
     homepage = "https://github.com/unrud/remote-touchpad";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ schnusch ];

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -238,7 +238,7 @@ in {
     };
     meta = {
       homepage = "https://github.com/graylog-labs/graylog-plugin-spaceweather";
-      description = "Correlate proton density to the response time of your app and the ion temperature to your exception rate.";
+      description = "Correlate proton density to the response time of your app and the ion temperature to your exception rate";
     };
   };
   twiliosms = glPlugin rec {

--- a/pkgs/tools/misc/paperlike-go/default.nix
+++ b/pkgs/tools/misc/paperlike-go/default.nix
@@ -19,7 +19,7 @@ buildGoModule {
   vendorSha256 = "00mn0zfivxp2h77s7gmyyjp8p5a1vysn73wwaalgajymvljxxx1r";
 
   meta = {
-    description = "paperlike-go is a Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC.";
+    description = "paperlike-go is a Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC";
     homepage = "https://github.com/leoluk/paperlike-go";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.adisbladis ];

--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A web application to generate UML diagrams on-the-fly.";
+    description = "A web application to generate UML diagrams on-the-fly";
     homepage = "https://plantuml.com/";
     license = licenses.gpl3;
     platforms = platforms.all;

--- a/pkgs/tools/misc/tagref/default.nix
+++ b/pkgs/tools/misc/tagref/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "06ljy213x9lhvqjysz9cjhrrg0ns07qkz27pxd8rih0mk6cck45g";
 
   meta = with lib; {
-    description = "Tagref helps you refer to other locations in your codebase.";
+    description = "Tagref helps you refer to other locations in your codebase";
     homepage = "https://github.com/stepchowfun/tagref";
     license = licenses.mit;
     maintainers = [ maintainers.yusdacra ];

--- a/pkgs/tools/misc/tfk8s/default.nix
+++ b/pkgs/tools/misc/tfk8s/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "An utility to convert Kubernetes YAML manifests to Terraform's HCL format.";
+    description = "An utility to convert Kubernetes YAML manifests to Terraform's HCL format";
     license = licenses.mit;
     longDescription = ''
       tfk8s is a tool that makes it easier to work with the Terraform Kubernetes Provider.

--- a/pkgs/tools/misc/trillian/default.nix
+++ b/pkgs/tools/misc/trillian/default.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://github.com/google/trillian";
-    description = "A transparent, highly scalable and cryptographically verifiable data store.";
+    description = "A transparent, highly scalable and cryptographically verifiable data store";
     license = [ licenses.asl20 ];
     maintainers = [ maintainers.adisbladis ];
   };

--- a/pkgs/tools/networking/airfield/node-packages.nix
+++ b/pkgs/tools/networking/airfield/node-packages.nix
@@ -677,7 +677,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A fast django-like templating engine for node.js and browsers.";
+      description = "A fast django-like templating engine for node.js and browsers";
     };
     production = true;
     bypassCache = true;
@@ -716,7 +716,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A high performance Redis client.";
+      description = "A high performance Redis client";
       homepage = "https://github.com/NodeRedis/node-redis";
       license = "MIT";
     };
@@ -818,7 +818,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "Simplified HTTP request client.";
+      description = "Simplified HTTP request client";
       homepage = "https://github.com/request/request#readme";
       license = "Apache-2.0";
     };

--- a/pkgs/tools/networking/lychee/default.nix
+++ b/pkgs/tools/networking/lychee/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "A fast, async, resource-friendly link checker written in Rust.";
+    description = "A fast, async, resource-friendly link checker written in Rust";
     homepage = "https://github.com/lycheeverse/lychee";
     license = with licenses; [ asl20 mit ];
     maintainers = with maintainers; [ tuxinaut ];

--- a/pkgs/tools/networking/wget2/default.nix
+++ b/pkgs/tools/networking/wget2/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" ];
 
   meta = with lib; {
-    description = "successor of GNU Wget, a file and recursive website downloader.";
+    description = "successor of GNU Wget, a file and recursive website downloader";
     longDescription = ''
       Designed and written from scratch it wraps around libwget, that provides the basic
       functions needed by a web client.

--- a/pkgs/tools/package-management/cargo-download/crates-io.nix
+++ b/pkgs/tools/package-management/cargo-download/crates-io.nix
@@ -10,7 +10,7 @@ rec {
   crates.adler32."1.0.2" = deps: { features?(features_.adler32."1.0.2" deps {}) }: buildRustCrate {
     crateName = "adler32";
     version = "1.0.2";
-    description = "Minimal Adler32 implementation for Rust.";
+    description = "Minimal Adler32 implementation for Rust";
     authors = [ "Remi Rampin <remirampin@gmail.com>" ];
     sha256 = "1974q3nysai026zhz24df506cxwi09jdzqksll4h7ibpb5n9g1d4";
   };
@@ -25,7 +25,7 @@ rec {
   crates.aho_corasick."0.5.3" = deps: { features?(features_.aho_corasick."0.5.3" deps {}) }: buildRustCrate {
     crateName = "aho-corasick";
     version = "0.5.3";
-    description = "Fast multiple substring searching with finite state machines.";
+    description = "Fast multiple substring searching with finite state machines";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1igab46mvgknga3sxkqc917yfff0wsjxjzabdigmh240p5qxqlnn";
     libName = "aho_corasick";
@@ -64,7 +64,7 @@ rec {
   crates.arrayvec."0.4.8" = deps: { features?(features_.arrayvec."0.4.8" deps {}) }: buildRustCrate {
     crateName = "arrayvec";
     version = "0.4.8";
-    description = "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString.";
+    description = "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString";
     authors = [ "bluss" ];
     sha256 = "0zwpjdxgr0a11h9x7mkrif4wyx3c81b90paxjf326i86s13kib1g";
     dependencies = mapFeatures features ([
@@ -207,7 +207,7 @@ rec {
   crates.byteorder."1.1.0" = deps: { features?(features_.byteorder."1.1.0" deps {}) }: buildRustCrate {
     crateName = "byteorder";
     version = "1.1.0";
-    description = "Library for reading/writing numbers in big-endian and little-endian.";
+    description = "Library for reading/writing numbers in big-endian and little-endian";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1i2n0161jm00zvzh4bncgv9zrwa6ydbxdn5j4bx0wwn7rvi9zycp";
     features = mkFeatures (features."byteorder"."1.1.0" or {});
@@ -506,7 +506,7 @@ rec {
   crates.cloudabi."0.0.3" = deps: { features?(features_.cloudabi."0.0.3" deps {}) }: buildRustCrate {
     crateName = "cloudabi";
     version = "0.0.3";
-    description = "Low level interface to CloudABI. Contains all syscalls and related types.";
+    description = "Low level interface to CloudABI. Contains all syscalls and related types";
     authors = [ "Nuxi (https://nuxi.nl/) and contributors" ];
     sha256 = "1z9lby5sr6vslfd14d6igk03s7awf91mxpsfmsp3prxbxlk0x7h5";
     libPath = "cloudabi.rs";
@@ -535,7 +535,7 @@ rec {
   crates.conv."0.3.3" = deps: { features?(features_.conv."0.3.3" deps {}) }: buildRustCrate {
     crateName = "conv";
     version = "0.3.3";
-    description = "This crate provides a number of conversion traits with more specific semantics than those provided by 'as' or 'From'/'Into'.";
+    description = "This crate provides a number of conversion traits with more specific semantics than those provided by 'as' or 'From'/'Into'";
     authors = [ "Daniel Keep <daniel.keep@gmail.com>" ];
     sha256 = "08rl72k1a48xah0ar5l9v1bw19pp8jdw2pdkd3vvj9ijsyyg9yik";
     dependencies = mapFeatures features ([
@@ -766,7 +766,7 @@ rec {
   crates.custom_derive."0.1.7" = deps: { features?(features_.custom_derive."0.1.7" deps {}) }: buildRustCrate {
     crateName = "custom_derive";
     version = "0.1.7";
-    description = "(Note: superseded by `macro-attr`) This crate provides a macro that enables the use of custom derive attributes.";
+    description = "(Note: superseded by `macro-attr`) This crate provides a macro that enables the use of custom derive attributes";
     authors = [ "Daniel Keep <daniel.keep@gmail.com>" ];
     sha256 = "160q3pzri2fgrr6czfdkwy1sbddki2za96r7ivvyii52qp1523zs";
     features = mkFeatures (features."custom_derive"."0.1.7" or {});
@@ -1265,7 +1265,7 @@ rec {
   crates.httparse."1.2.3" = deps: { features?(features_.httparse."1.2.3" deps {}) }: buildRustCrate {
     crateName = "httparse";
     version = "1.2.3";
-    description = "A tiny, safe, speedy, zero-copy HTTP/1.x parser.";
+    description = "A tiny, safe, speedy, zero-copy HTTP/1.x parser";
     authors = [ "Sean McArthur <sean.monstar@gmail.com>" ];
     sha256 = "13x17y9bip0bija06y4vwpgh8jdmdi2gsvjq02kyfy0fbp5cqa93";
     features = mkFeatures (features."httparse"."1.2.3" or {});
@@ -1287,7 +1287,7 @@ rec {
   crates.hyper."0.12.16" = deps: { features?(features_.hyper."0.12.16" deps {}) }: buildRustCrate {
     crateName = "hyper";
     version = "0.12.16";
-    description = "A fast and correct HTTP library.";
+    description = "A fast and correct HTTP library";
     authors = [ "Sean McArthur <sean@seanmonstar.com>" ];
     sha256 = "1h5h9swxh02jcg1m4cvwb5nmkb8z9g4b0p4wfbhfvsd7wf14qr0y";
     dependencies = mapFeatures features ([
@@ -1445,7 +1445,7 @@ rec {
   crates.idna."0.1.4" = deps: { features?(features_.idna."0.1.4" deps {}) }: buildRustCrate {
     crateName = "idna";
     version = "0.1.4";
-    description = "IDNA (Internationalizing Domain Names in Applications) and Punycode.";
+    description = "IDNA (Internationalizing Domain Names in Applications) and Punycode";
     authors = [ "The rust-url developers" ];
     sha256 = "15j44qgjx1skwg9i7f4cm36ni4n99b1ayx23yxx7axxcw8vjf336";
     dependencies = mapFeatures features ([
@@ -1551,7 +1551,7 @@ rec {
   crates.itertools."0.6.5" = deps: { features?(features_.itertools."0.6.5" deps {}) }: buildRustCrate {
     crateName = "itertools";
     version = "0.6.5";
-    description = "Extra iterator adaptors, iterator methods, free functions, and macros.";
+    description = "Extra iterator adaptors, iterator methods, free functions, and macros";
     authors = [ "bluss" ];
     sha256 = "0gbhgn7s8qkxxw10i514fzpqnc3aissn4kcgylm2cvnv9zmg8mw1";
     dependencies = mapFeatures features ([
@@ -1610,7 +1610,7 @@ rec {
   crates.kernel32_sys."0.2.2" = deps: { features?(features_.kernel32_sys."0.2.2" deps {}) }: buildRustCrate {
     crateName = "kernel32-sys";
     version = "0.2.2";
-    description = "Contains function definitions for the Windows API library kernel32. See winapi for types and constants.";
+    description = "Contains function definitions for the Windows API library kernel32. See winapi for types and constants";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1lrw1hbinyvr6cp28g60z97w32w8vsk6pahk64pmrv2fmby8srfj";
     libName = "kernel32";
@@ -1639,7 +1639,7 @@ rec {
   crates.lazy_static."0.2.10" = deps: { features?(features_.lazy_static."0.2.10" deps {}) }: buildRustCrate {
     crateName = "lazy_static";
     version = "0.2.10";
-    description = "A macro for declaring lazily evaluated statics in Rust.";
+    description = "A macro for declaring lazily evaluated statics in Rust";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "0ylwjvppsm56fpv32l4br7zw0pwn81wbfb1abalyyr1d9c94vg8r";
     dependencies = mapFeatures features ([
@@ -1671,7 +1671,7 @@ rec {
   crates.lazy_static."1.2.0" = deps: { features?(features_.lazy_static."1.2.0" deps {}) }: buildRustCrate {
     crateName = "lazy_static";
     version = "1.2.0";
-    description = "A macro for declaring lazily evaluated statics in Rust.";
+    description = "A macro for declaring lazily evaluated statics in Rust";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "07p3b30k2akyr6xw08ggd5qiz5nw3vd3agggj360fcc1njz7d0ss";
     dependencies = mapFeatures features ([
@@ -1783,7 +1783,7 @@ rec {
   crates.lock_api."0.1.5" = deps: { features?(features_.lock_api."0.1.5" deps {}) }: buildRustCrate {
     crateName = "lock_api";
     version = "0.1.5";
-    description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.";
+    description = "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "132sidr5hvjfkaqm3l95zpcpi8yk5ddd0g79zf1ad4v65sxirqqm";
     dependencies = mapFeatures features ([
@@ -1852,7 +1852,7 @@ rec {
   crates.maplit."0.1.6" = deps: { features?(features_.maplit."0.1.6" deps {}) }: buildRustCrate {
     crateName = "maplit";
     version = "0.1.6";
-    description = "Container / collection literal macros for HashMap, HashSet, BTreeMap, BTreeSet.";
+    description = "Container / collection literal macros for HashMap, HashSet, BTreeMap, BTreeSet";
     authors = [ "bluss" ];
     sha256 = "1f8kf5v7xra8ssvh5c10qlacbk4l0z2817pkscflx5s5q6y7925h";
   };
@@ -1867,7 +1867,7 @@ rec {
   crates.matches."0.1.6" = deps: { features?(features_.matches."0.1.6" deps {}) }: buildRustCrate {
     crateName = "matches";
     version = "0.1.6";
-    description = "A macro to evaluate, as a boolean, whether an expression matches a pattern.";
+    description = "A macro to evaluate, as a boolean, whether an expression matches a pattern";
     authors = [ "Simon Sapin <simon.sapin@exyr.org>" ];
     sha256 = "1zlrqlbvzxdil8z8ial2ihvxjwvlvg3g8dr0lcdpsjclkclasjan";
     libPath = "lib.rs";
@@ -1883,7 +1883,7 @@ rec {
   crates.memchr."0.1.11" = deps: { features?(features_.memchr."0.1.11" deps {}) }: buildRustCrate {
     crateName = "memchr";
     version = "0.1.11";
-    description = "Safe interface to memchr.";
+    description = "Safe interface to memchr";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" "bluss" ];
     sha256 = "0x73jghamvxxq5fsw9wb0shk5m6qp3q6fsf0nibn0i6bbqkw91s8";
     dependencies = mapFeatures features ([
@@ -1904,7 +1904,7 @@ rec {
   crates.memoffset."0.2.1" = deps: { features?(features_.memoffset."0.2.1" deps {}) }: buildRustCrate {
     crateName = "memoffset";
     version = "0.2.1";
-    description = "offset_of functionality for Rust structs.";
+    description = "offset_of functionality for Rust structs";
     authors = [ "Gilad Naaman <gilad.naaman@gmail.com>" ];
     sha256 = "00vym01jk9slibq2nsiilgffp7n6k52a4q3n4dqp0xf5kzxvffcf";
   };
@@ -1940,7 +1940,7 @@ rec {
   crates.mime_guess."2.0.0-alpha.6" = deps: { features?(features_.mime_guess."2.0.0-alpha.6" deps {}) }: buildRustCrate {
     crateName = "mime_guess";
     version = "2.0.0-alpha.6";
-    description = "A simple crate for detection of a file's MIME type by its extension.";
+    description = "A simple crate for detection of a file's MIME type by its extension";
     authors = [ "Austin Bonander <austin.bonander@gmail.com>" ];
     sha256 = "1k2mdq43gi2qr63b7m5zs624rfi40ysk33cay49jlhq97jwnk9db";
     dependencies = mapFeatures features ([
@@ -2349,7 +2349,7 @@ rec {
   crates.num_cpus."1.8.0" = deps: { features?(features_.num_cpus."1.8.0" deps {}) }: buildRustCrate {
     crateName = "num_cpus";
     version = "1.8.0";
-    description = "Get the number of CPUs on a machine.";
+    description = "Get the number of CPUs on a machine";
     authors = [ "Sean McArthur <sean@seanmonstar.com>" ];
     sha256 = "1y6qnd9r8ga6y8mvlabdrr73nc8cshjjlzbvnanzyj9b8zzkfwk2";
     dependencies = mapFeatures features ([
@@ -2468,7 +2468,7 @@ rec {
   crates.owning_ref."0.4.0" = deps: { features?(features_.owning_ref."0.4.0" deps {}) }: buildRustCrate {
     crateName = "owning_ref";
     version = "0.4.0";
-    description = "A library for creating references that carry their owner with them.";
+    description = "A library for creating references that carry their owner with them";
     authors = [ "Marvin Löbel <loebel.marvin@gmail.com>" ];
     sha256 = "1m95qpc3hamkw9wlbfzqkzk7h6skyj40zr6sa3ps151slcfnnchm";
     dependencies = mapFeatures features ([
@@ -2489,7 +2489,7 @@ rec {
   crates.parking_lot."0.6.4" = deps: { features?(features_.parking_lot."0.6.4" deps {}) }: buildRustCrate {
     crateName = "parking_lot";
     version = "0.6.4";
-    description = "More compact and efficient implementations of the standard synchronization primitives.";
+    description = "More compact and efficient implementations of the standard synchronization primitives";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "0qwfysx8zfkj72sfcrqvd6pp7lgjmklyixsi3y0g6xjspw876rax";
     dependencies = mapFeatures features ([
@@ -2540,7 +2540,7 @@ rec {
   crates.parking_lot_core."0.3.1" = deps: { features?(features_.parking_lot_core."0.3.1" deps {}) }: buildRustCrate {
     crateName = "parking_lot_core";
     version = "0.3.1";
-    description = "An advanced API for creating custom synchronization primitives.";
+    description = "An advanced API for creating custom synchronization primitives";
     authors = [ "Amanieu d'Antras <amanieu@gmail.com>" ];
     sha256 = "0h5p7dys8cx9y6ii4i57ampf7qdr8zmkpn543kd3h7nkhml8bw72";
     dependencies = mapFeatures features ([
@@ -3332,7 +3332,7 @@ rec {
   crates.regex_syntax."0.3.9" = deps: { features?(features_.regex_syntax."0.3.9" deps {}) }: buildRustCrate {
     crateName = "regex-syntax";
     version = "0.3.9";
-    description = "A regular expression parser.";
+    description = "A regular expression parser";
     authors = [ "The Rust Project Developers" ];
     sha256 = "1mzhphkbwppwd1zam2jkgjk550cqgf6506i87bw2yzrvcsraiw7m";
   };
@@ -3493,7 +3493,7 @@ rec {
   crates.safemem."0.3.0" = deps: { features?(features_.safemem."0.3.0" deps {}) }: buildRustCrate {
     crateName = "safemem";
     version = "0.3.0";
-    description = "Safe wrappers for memory-accessing functions, like `std::ptr::copy()`.";
+    description = "Safe wrappers for memory-accessing functions, like `std::ptr::copy()`";
     authors = [ "Austin Bonander <austin.bonander@gmail.com>" ];
     sha256 = "0pr39b468d05f6m7m4alsngmj5p7an8df21apsxbi57k0lmwrr18";
     features = mkFeatures (features."safemem"."0.3.0" or {});
@@ -4078,7 +4078,7 @@ rec {
   crates.string."0.1.2" = deps: { features?(features_.string."0.1.2" deps {}) }: buildRustCrate {
     crateName = "string";
     version = "0.1.2";
-    description = "A UTF-8 encoded string with configurable byte storage.";
+    description = "A UTF-8 encoded string with configurable byte storage";
     authors = [ "Carl Lerche <me@carllerche.com>" ];
     sha256 = "1120qvf02aydqj0k3kpr8d7zybq0y5arnmgmfsdw75r8qwz75wc6";
   };
@@ -4262,7 +4262,7 @@ rec {
   crates.termion."1.5.1" = deps: { features?(features_.termion."1.5.1" deps {}) }: buildRustCrate {
     crateName = "termion";
     version = "1.5.1";
-    description = "A bindless library for manipulating terminals.";
+    description = "A bindless library for manipulating terminals";
     authors = [ "ticki <Ticki@users.noreply.github.com>" "gycos <alexandre.bury@gmail.com>" "IGI-111 <igi-111@protonmail.com>" ];
     sha256 = "02gq4vd8iws1f3gjrgrgpajsk2bk43nds5acbbb4s8dvrdvr8nf1";
     dependencies = (if !(kernel == "redox") then mapFeatures features ([
@@ -4751,7 +4751,7 @@ rec {
   crates.try_lock."0.2.2" = deps: { features?(features_.try_lock."0.2.2" deps {}) }: buildRustCrate {
     crateName = "try-lock";
     version = "0.2.2";
-    description = "A lightweight atomic lock.";
+    description = "A lightweight atomic lock";
     authors = [ "Sean McArthur <sean@seanmonstar.com>" ];
     sha256 = "1k8xc0jpbrmzp0fwghdh6pwzjb9xx2p8yy0xxnnb8065smc5fsrv";
   };
@@ -4766,7 +4766,7 @@ rec {
   crates.unicase."1.4.2" = deps: { features?(features_.unicase."1.4.2" deps {}) }: buildRustCrate {
     crateName = "unicase";
     version = "1.4.2";
-    description = "A case-insensitive wrapper around strings.";
+    description = "A case-insensitive wrapper around strings";
     authors = [ "Sean McArthur <sean.monstar@gmail.com>" ];
     sha256 = "0rbnhw2mnhcwrij3vczp0sl8zdfmvf2dlh8hly81kj7132kfj0mf";
     build = "build.rs";
@@ -4802,7 +4802,7 @@ rec {
   crates.unicase."2.1.0" = deps: { features?(features_.unicase."2.1.0" deps {}) }: buildRustCrate {
     crateName = "unicase";
     version = "2.1.0";
-    description = "A case-insensitive wrapper around strings.";
+    description = "A case-insensitive wrapper around strings";
     authors = [ "Sean McArthur <sean@seanmonstar.com>" ];
     sha256 = "1zzn16hh8fdx5pnbbnl32q8m2mh4vpd1jm9pdcv969ik83dw4byp";
     build = "build.rs";
@@ -4910,7 +4910,7 @@ rec {
   crates.unreachable."1.0.0" = deps: { features?(features_.unreachable."1.0.0" deps {}) }: buildRustCrate {
     crateName = "unreachable";
     version = "1.0.0";
-    description = "An unreachable code optimization hint in stable rust.";
+    description = "An unreachable code optimization hint in stable rust";
     authors = [ "Jonathan Reem <jonathan.reem@gmail.com>" ];
     sha256 = "1am8czbk5wwr25gbp2zr007744fxjshhdqjz9liz7wl4pnv3whcf";
     dependencies = mapFeatures features ([
@@ -4969,7 +4969,7 @@ rec {
   crates.utf8_ranges."0.1.3" = deps: { features?(features_.utf8_ranges."0.1.3" deps {}) }: buildRustCrate {
     crateName = "utf8-ranges";
     version = "0.1.3";
-    description = "Convert ranges of Unicode codepoints to UTF-8 byte ranges.";
+    description = "Convert ranges of Unicode codepoints to UTF-8 byte ranges";
     authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
     sha256 = "1cj548a91a93j8375p78qikaiam548xh84cb0ck8y119adbmsvbp";
   };
@@ -4984,7 +4984,7 @@ rec {
   crates.uuid."0.7.1" = deps: { features?(features_.uuid."0.7.1" deps {}) }: buildRustCrate {
     crateName = "uuid";
     version = "0.7.1";
-    description = "A library to generate and parse UUIDs.";
+    description = "A library to generate and parse UUIDs";
     authors = [ "Ashley Mannix<ashleymannix@live.com.au>" "Christopher Armstrong" "Dylan DPC<dylan.dpc@gmail.com>" "Hunar Roop Kahlon<hunar.roop@gmail.com>" ];
     sha256 = "1wh5izr7bssf1j8y3cawj4yfr5pz4cfxgsjlk2gs1vccc848qpbj";
     dependencies = mapFeatures features ([
@@ -5079,7 +5079,7 @@ rec {
   crates.version_check."0.1.3" = deps: { features?(features_.version_check."0.1.3" deps {}) }: buildRustCrate {
     crateName = "version_check";
     version = "0.1.3";
-    description = "Tiny crate to check the version of the installed/running rustc.";
+    description = "Tiny crate to check the version of the installed/running rustc";
     authors = [ "Sergio Benitez <sb@sergio.bz>" ];
     sha256 = "0z635wdclv9bvafj11fpgndn7y79ibpsnc364pm61i1m4wwg8msg";
   };
@@ -5094,7 +5094,7 @@ rec {
   crates.void."1.0.2" = deps: { features?(features_.void."1.0.2" deps {}) }: buildRustCrate {
     crateName = "void";
     version = "1.0.2";
-    description = "The uninhabited void type for use in statically impossible cases.";
+    description = "The uninhabited void type for use in statically impossible cases";
     authors = [ "Jonathan Reem <jonathan.reem@gmail.com>" ];
     sha256 = "0h1dm0dx8dhf56a83k68mijyxigqhizpskwxfdrs1drwv2cdclv3";
     features = mkFeatures (features."void"."1.0.2" or {});
@@ -5116,7 +5116,7 @@ rec {
   crates.want."0.0.6" = deps: { features?(features_.want."0.0.6" deps {}) }: buildRustCrate {
     crateName = "want";
     version = "0.0.6";
-    description = "Detect when another Future wants a result.";
+    description = "Detect when another Future wants a result";
     authors = [ "Sean McArthur <sean@seanmonstar.com>" ];
     sha256 = "03cc2lndz531a4kgql1v9kppyb1yz2abcz5l52j1gg2nypmy3lh8";
     dependencies = mapFeatures features ([
@@ -5143,7 +5143,7 @@ rec {
   crates.winapi."0.2.8" = deps: { features?(features_.winapi."0.2.8" deps {}) }: buildRustCrate {
     crateName = "winapi";
     version = "0.2.8";
-    description = "Types and constants for WinAPI bindings. See README for list of crates providing function bindings.";
+    description = "Types and constants for WinAPI bindings. See README for list of crates providing function bindings";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "0a45b58ywf12vb7gvj6h3j264nydynmzyqz8d8rqxsj6icqv82as";
   };
@@ -5158,7 +5158,7 @@ rec {
   crates.winapi."0.3.6" = deps: { features?(features_.winapi."0.3.6" deps {}) }: buildRustCrate {
     crateName = "winapi";
     version = "0.3.6";
-    description = "Raw FFI bindings for all of Windows API.";
+    description = "Raw FFI bindings for all of Windows API";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1d9jfp4cjd82sr1q4dgdlrkvm33zhhav9d7ihr0nivqbncr059m4";
     build = "build.rs";
@@ -5186,7 +5186,7 @@ rec {
   crates.winapi_build."0.1.1" = deps: { features?(features_.winapi_build."0.1.1" deps {}) }: buildRustCrate {
     crateName = "winapi-build";
     version = "0.1.1";
-    description = "Common code for build.rs in WinAPI -sys crates.";
+    description = "Common code for build.rs in WinAPI -sys crates";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1lxlpi87rkhxcwp2ykf1ldw3p108hwm24nywf3jfrvmff4rjhqga";
     libName = "build";
@@ -5202,7 +5202,7 @@ rec {
   crates.winapi_i686_pc_windows_gnu."0.4.0" = deps: { features?(features_.winapi_i686_pc_windows_gnu."0.4.0" deps {}) }: buildRustCrate {
     crateName = "winapi-i686-pc-windows-gnu";
     version = "0.4.0";
-    description = "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.";
+    description = "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "05ihkij18r4gamjpxj4gra24514can762imjzlmak5wlzidplzrp";
     build = "build.rs";
@@ -5218,7 +5218,7 @@ rec {
   crates.winapi_x86_64_pc_windows_gnu."0.4.0" = deps: { features?(features_.winapi_x86_64_pc_windows_gnu."0.4.0" deps {}) }: buildRustCrate {
     crateName = "winapi-x86_64-pc-windows-gnu";
     version = "0.4.0";
-    description = "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.";
+    description = "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "0n1ylmlsb8yg1v583i4xy0qmqg42275flvbc51hdqjjfjcl9vlbj";
     build = "build.rs";
@@ -5234,7 +5234,7 @@ rec {
   crates.ws2_32_sys."0.2.1" = deps: { features?(features_.ws2_32_sys."0.2.1" deps {}) }: buildRustCrate {
     crateName = "ws2_32-sys";
     version = "0.2.1";
-    description = "Contains function definitions for the Windows API library ws2_32. See winapi for types and constants.";
+    description = "Contains function definitions for the Windows API library ws2_32. See winapi for types and constants";
     authors = [ "Peter Atashian <retep998@gmail.com>" ];
     sha256 = "1zpy9d9wk11sj17fczfngcj28w4xxjs3b4n036yzpy38dxp4f7kc";
     libName = "ws2_32";

--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -55,7 +55,7 @@ gcc9Stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "Package management library.";
+    description = "Package management library";
     homepage = "https://github.com/rpm-software-management/libdnf";
     license = licenses.gpl2Plus;
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/tools/security/pass/extensions/audit/default.nix
+++ b/pkgs/tools/security/pass/extensions/audit/default.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Pass extension for auditing your password repository.";
+    description = "Pass extension for auditing your password repository";
     homepage = "https://github.com/roddhjav/pass-audit";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;

--- a/pkgs/tools/security/zsteg/default.nix
+++ b/pkgs/tools/security/zsteg/default.nix
@@ -8,7 +8,7 @@ bundlerApp {
   exes = [ "zsteg" ];
 
   meta = with lib; {
-    description = "Detect stegano-hidden data in PNG & BMP.";
+    description = "Detect stegano-hidden data in PNG & BMP";
     homepage = "http://zed.0xff.me/";
     license = licenses.mit;
     maintainers = with maintainers; [ applePrincess ];

--- a/pkgs/tools/system/gptman/default.nix
+++ b/pkgs/tools/system/gptman/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "1cp8cyrd7ab8r2j28b69c2p3ysix5b9hpsqk07cmzgqwwml0qj12";
 
   meta = with lib; {
-    description = "A CLI tool for Linux to copy a partition from one disk to another and more.";
+    description = "A CLI tool for Linux to copy a partition from one disk to another and more";
     homepage = "https://github.com/cecton/gptman";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ akshgpt7 ];

--- a/pkgs/tools/system/journalwatch/default.nix
+++ b/pkgs/tools/system/journalwatch/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
 
   meta = with lib; {
-    description = "journalwatch is a tool to find error messages in the systemd journal.";
+    description = "journalwatch is a tool to find error messages in the systemd journal";
     homepage = "https://github.com/The-Compiler/journalwatch";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ florianjacob ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22592,7 +22592,7 @@ let
       sha256 = "29e9e2133951046c78f205f1b3e8df62c90e114f0e08fa06b817766a0f808b12";
     };
     meta = {
-      description = "Variable ties made much easier: much, much, much easier.";
+      description = "Variable ties made much easier: much, much, much easier";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -215,7 +215,7 @@ let
     propagatedBuildInputs = [ AlienBuild ];
     buildInputs = [ pkgs.gmp Alienm4 DevelChecklib IOSocketSSL MojoDOM58 NetSSLeay SortVersions Test2Suite URI ];
     meta = {
-      description = "Alien package for the GNU Multiple Precision library.";
+      description = "Alien package for the GNU Multiple Precision library";
       license = with lib.licenses; [ lgpl3Plus ];
     };
   };
@@ -6215,7 +6215,7 @@ let
        sha256 = "1x9jzy3l7gwikj57swzl94qsq03j9na9h1m69azzs7d7ghph58wd";
      };
      meta = {
-       description = "Detect perl's global phase on older perls.";
+       description = "Detect perl's global phase on older perls";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
      };
   };
@@ -8119,7 +8119,7 @@ let
     propagatedBuildInputs = [ PerlIOLayers SubExporterProgressive ];
     buildInputs = [ TestFatal TestWarnings ];
     meta = {
-      description = "Memory mapping made simple and safe.";
+      description = "Memory mapping made simple and safe";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8275,7 +8275,7 @@ let
       sha256 = "fe89cbb427e0e05f1cd97c2dd6d3866ac6b21bc7a85734ede159bdc35479552a";
     };
     meta = {
-      description = "Perl extension for filesystem disk space information.";
+      description = "Perl extension for filesystem disk space information";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8385,7 +8385,7 @@ let
       sha256 = "0hfkaafp6wb0nw19x47wc6wc9mwlw8s2rxiii3ylvzapxxgxjp6k";
     };
     meta = {
-      description = "File::Type uses magic numbers (typically at the start of a file) to determine the MIME type of that file.";
+      description = "File::Type uses magic numbers (typically at the start of a file) to determine the MIME type of that file";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -8443,7 +8443,7 @@ let
        sha256 = "16v61rn0yimpv5kp6b20z2f1c93n5kpsyjvr0gq4w2dc43gfvc8w";
      };
      meta = {
-       description = "Extended globs.";
+       description = "Extended globs";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
      };
   };
@@ -9977,7 +9977,7 @@ let
       sha256 = "0z4mgb8mc6l5nfsm3ihndjqgpk43q39x1kq9hryy6v8hxkwrscrk";
     };
     meta = {
-      description = "WebDAV client library.";
+      description = "WebDAV client library";
     };
     propagatedBuildInputs = [ XMLDOM ];
   };
@@ -11635,7 +11635,7 @@ let
      propagatedBuildInputs = [ ConstFast MooXStrictConstructor MooXTypesMooseLike ParamsValidate namespaceautoclean ];
      buildInputs = [ TestDifferences TestException TestHexDifferences TestNoWarnings ];
      meta = {
-       description = "Locale::MO::File - Write or read gettext MO files.";
+       description = "Locale::MO::File - Write or read gettext MO files";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
      };
   };
@@ -13136,7 +13136,7 @@ let
        sha256 = "1fff81awg9agfawf3wxx0gpf6vgav8w920rmxsbjg30z75943lli";
      };
      meta = {
-       description = "Micro Objects. Mo is less.";
+       description = "Micro Objects. Mo is less";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
        homepage = "https://github.com/ingydotnet/mo-pm";
      };
@@ -14122,7 +14122,7 @@ let
      propagatedBuildInputs = [ Moo strictures ];
      buildInputs = [ TestFatal ];
      meta = {
-       description = "Make your Moo-based object constructors blow up on unknown attributes.";
+       description = "Make your Moo-based object constructors blow up on unknown attributes";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
      };
   };
@@ -14340,7 +14340,7 @@ let
     };
     propagatedBuildInputs = [ EnvSanctify FileHomeDir PerlDestructLevel XMLTwig ];
     meta = {
-      description = "Generate suppressions, analyse and test any command with valgrind.";
+      description = "Generate suppressions, analyse and test any command with valgrind";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
       homepage = "http://search.cpan.org/dist/Test-Valgrind/";
     };
@@ -15162,7 +15162,7 @@ let
     propagatedBuildInputs = [ LWPProtocolHttps Moose ParamsValidate XMLSimple ];
     buildInputs = [ TestException ];
     meta = {
-      description = "Perl interface to the Amazon Elastic Compute Cloud (EC2) environment.";
+      description = "Perl interface to the Amazon Elastic Compute Cloud (EC2) environment";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -15699,7 +15699,7 @@ let
       sed -i 's|$scp = "scp";|$scp = "${pkgs.openssh}/bin/scp";|' SCP.pm
     '';
     meta = {
-      description = "Simple wrappers around ssh and scp commands.";
+      description = "Simple wrappers around ssh and scp commands";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
     buildInputs = [ NetSSH StringShellQuote ];
@@ -15834,7 +15834,7 @@ let
       sed -i 's|$ssh = "ssh";|$ssh = "${pkgs.openssh}/bin/ssh";|' SSH.pm
     '';
     meta = {
-      description = "Simple wrappers around ssh commands.";
+      description = "Simple wrappers around ssh commands";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -17309,7 +17309,7 @@ let
     };
     propagatedBuildInputs = [ PPI Readonly ];
     meta = {
-      description = "Parse Perl string literals and string-literal-like things.";
+      description = "Parse Perl string literals and string-literal-like things";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18426,7 +18426,7 @@ let
       sha256 = "1mz9a2qzkz6fbz76wcwmp48h6ckjxpcazb70q03acklvndy5d4nk";
     };
     meta = with lib; {
-      description = "Linux/POSIX emulation of Win32::SerialPort functions.";
+      description = "Linux/POSIX emulation of Win32::SerialPort functions";
       license = with licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -18557,7 +18557,7 @@ let
        sha256 = "0675v45bbsh7vr7kpf36xs2q79g02iq1kmfw22h20xdk4rzqvkqx";
      };
      meta = {
-       description = "Porters stemming algorithm for norwegian.";
+       description = "Porters stemming algorithm for norwegian";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
      };
   };
@@ -18570,7 +18570,7 @@ let
        sha256 = "0agwc12jk5kmabnpsplw3wf4ii5w1zb159cpin44x3srb0sr5apg";
      };
      meta = {
-       description = "Porters stemming algorithm for swedish.";
+       description = "Porters stemming algorithm for swedish";
        license = with lib.licenses; [ artistic1 gpl1Plus ];
      };
   };
@@ -19111,7 +19111,7 @@ let
     };
     meta = with lib; {
       # https://metacpan.org/pod/String::Interpolate
-      description = "String::Interpolate - Wrapper for builtin the Perl interpolation engine.";
+      description = "String::Interpolate - Wrapper for builtin the Perl interpolation engine";
       license = licenses.gpl1Plus;
     };
     propagatedBuildInputs = [ PadWalker SafeHole ];
@@ -20116,7 +20116,7 @@ let
       sha256 = "f2e491796061205b08688802b287792d7d803b08972339fb1070ba05612af885";
     };
     meta = {
-      description = "Perl extension for displaying a progress indicator on a terminal.";
+      description = "Perl extension for displaying a progress indicator on a terminal";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -22592,7 +22592,7 @@ let
       sha256 = "29e9e2133951046c78f205f1b3e8df62c90e114f0e08fa06b817766a0f808b12";
     };
     meta = {
-      description = "Variable ties made much easier: much, much, much easier..";
+      description = "Variable ties made much easier: much, much, much easier.";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -23467,7 +23467,7 @@ let
     propagatedBuildInputs = [ X11Protocol ];
     buildInputs = [ EncodeHanExtra ModuleUtil ];
     meta = {
-      description = "Miscellaneous helpers for X11::Protocol connections.";
+      description = "Miscellaneous helpers for X11::Protocol connections";
       license = with lib.licenses; [ gpl1Plus gpl3Plus ];
       homepage = "http://user42.tuxfamily.org/x11-protocol-other/index.html";
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
in accordance with https://nixos.org/manual/nixpkgs/unstable/#var-meta-description and https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#submitting-changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The main problem I came across was `hackage-packages.nix`. Maybe we can automatically remove periods (and probably whitespace) from the end of desciptions upon generating it?
cc @NixOS/haskell 
The same goes for the packages in `pkgs/development/lisp-modules/quicklisp-to-nix-output/split-sequence.nix`.
cc @7c6f434c 
... and for poetry2nix
cc @adisbladis 