### PR TITLE
 inspircd: 3.9.0 -> 3.10.0 

### DIFF
--- a/pkgs/servers/irc/inspircd/default.nix
+++ b/pkgs/servers/irc/inspircd/default.nix
@@ -160,6 +160,8 @@ stdenv.mkDerivation rec {
   buildInputs = extraInputs;
 
   configurePhase = ''
+    runHook preConfigure
+
     patchShebangs configure make/*.pl
 
     # configure is executed twice, once to set the extras
@@ -183,6 +185,8 @@ stdenv.mkDerivation rec {
       --module-dir  ${placeholder "lib"}/lib/inspircd \
       --runtime-dir /var/run \
       --script-dir  ${placeholder "bin"}/share/inspircd \
+
+    runHook postConfigure
   '';
 
   postInstall = ''

--- a/pkgs/servers/irc/inspircd/default.nix
+++ b/pkgs/servers/irc/inspircd/default.nix
@@ -142,13 +142,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "inspircd";
-  version = "3.9.0";
+  version = "3.10.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0x3paasf4ynx4ddky2nq613vyirbhfnxzkjq148k7154pz3q426s";
+    sha256 = "1817gmxk4v7k5398d2fb6qkwadg0fd980gqmr80wdnppx450ikn7";
   };
 
   outputs = [ "bin" "lib" "man" "doc" "out" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
