### PR TITLE
mbtileserver: 0.6.1 → 0.7.0

### DIFF
--- a/pkgs/servers/mbtileserver/default.nix
+++ b/pkgs/servers/mbtileserver/default.nix
@@ -2,20 +2,21 @@
 
 buildGoModule rec {
   pname = "mbtileserver";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "consbio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0b0982rn5jsv8zxfkrcmhys764nim6136hafc8ccj0mwdyvwafxd";
+    sha256 = "sha256-QdirExVv7p7Mnhp8EGdTVRlmEiYpzoXVQbtO8aS9Kas=";
   };
 
-  vendorSha256 = null;
+  vendorSha256 = "sha256-mUUxUZn8out6WNvKJKHoz+R44RDB0oWJb+57w72+E5w=";
 
   meta = with lib; {
     description = "A simple Go-based server for map tiles stored in mbtiles format";
     homepage = "https://github.com/consbio/mbtileserver";
+    changelog = "https://github.com/consbio/mbtileserver/blob/v${version}/CHANGELOG.md";
     license = licenses.isc;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/consbio/mbtileserver/releases/tag/v0.7.0)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
