### PR TITLE
vimPlugins.barbar-nvim: upgrade to fix issue

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -269,12 +269,12 @@ let
 
   barbar-nvim = buildVimPluginFrom2Nix {
     pname = "barbar-nvim";
-    version = "2021-05-11";
+    version = "2021-05-13";
     src = fetchFromGitHub {
       owner = "romgrk";
       repo = "barbar.nvim";
-      rev = "78ab34de8c77e2e230502945bd4d156af5d54ab8";
-      sha256 = "0smbf73i0ingvagxyjk6lb6g2axr6mgqk74c8w27504bnvay7y0w";
+      rev = "fa07efc01700896f1b52d11a237e16aacebac443";
+      sha256 = "sha256-JTnk0KKlL5Zmo042oNhQmoHABfjQJgx6jSGsCt7zIPQ=";
     };
     meta.homepage = "https://github.com/romgrk/barbar.nvim/";
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes build.

Failing hydra build: https://hydra.nixos.org/build/142933317/nixlog/1
Commit which fixes issue: https://github.com/romgrk/barbar.nvim/commit/439abe601107b6e346be2c90ad54bb876d907156

Upgrading this so we have the upstream fix

ZHF: #122042 

CC @NixOS/nixos-release-managers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
