### PR TITLE
cd-hit: fix darwin build

### DIFF
--- a/pkgs/applications/science/biology/cd-hit/default.nix
+++ b/pkgs/applications/science/biology/cd-hit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, zlib, perl, perlPackages }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, zlib, perl, perlPackages, openmp }:
 
 stdenv.mkDerivation rec {
   version = "4.8.1";
@@ -14,8 +14,12 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ perl perlPackages.TextNSP perlPackages.PerlMagick ];
 
   nativeBuildInputs = [ zlib makeWrapper ];
+  buildInputs = lib.optional stdenv.cc.isClang openmp;
 
-  makeFlags = [ "PREFIX=$(out)/bin" ];
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}c++"
+    "PREFIX=$(out)/bin"
+  ];
 
   preInstall = "mkdir -p $out/bin";
 

--- a/pkgs/applications/science/biology/cd-hit/default.nix
+++ b/pkgs/applications/science/biology/cd-hit/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional stdenv.cc.isClang openmp;
 
   makeFlags = [
-    "CC=${stdenv.cc.targetPrefix}c++"
+    "CC=${stdenv.cc.targetPrefix}c++" # remove once https://github.com/weizhongli/cdhit/pull/114 is merged
     "PREFIX=$(out)/bin"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28941,7 +28941,9 @@ in
 
   bppsuite = callPackage ../applications/science/biology/bppsuite { };
 
-  cd-hit = callPackage ../applications/science/biology/cd-hit { };
+  cd-hit = callPackage ../applications/science/biology/cd-hit {
+    inherit (llvmPackages) openmp;
+  };
 
   cmtk = callPackage ../applications/science/biology/cmtk { };
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142598941/log

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
