### PR TITLE
lua-5.4: fix build on darwin

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.4.darwin.patch
+++ b/pkgs/development/interpreters/lua-5/5.4.darwin.patch
@@ -1,0 +1,48 @@
+--- a/Makefile	2021-05-14 22:39:14.407200562 +0300
++++ b/Makefile	2021-05-14 22:36:23.828513407 +0300
+@@ -41,7 +41,7 @@
+ # What to install.
+ TO_BIN= lua luac
+ TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
+-TO_LIB= liblua.a
++TO_LIB= liblua.${version}.dylib
+ TO_MAN= lua.1 luac.1
+ 
+ # Lua version and release.
+@@ -60,6 +60,8 @@
+ 	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
+ 	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
+ 	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
++	ln -s -f liblua.${version}.dylib $(INSTALL_LIB)/liblua.${luaversion}.dylib
++	ln -s -f liblua.${luaversion}.dylib $(INSTALL_LIB)/liblua.dylib
+ 
+ uninstall:
+ 	cd src && cd $(INSTALL_BIN) && $(RM) $(TO_BIN)
+--- a/src/Makefile	2021-05-14 22:35:38.575051882 +0300
++++ b/src/Makefile	2021-05-14 22:35:33.584631206 +0300
+@@ -32,7 +32,7 @@
+ 
+ PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+ 
+-LUA_A=	liblua.a
++LUA_A=	liblua.${version}.dylib
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+@@ -57,11 +57,13 @@
+ a:	$(ALL_A)
+ 
+ $(LUA_A): $(BASE_O)
+-	$(AR) $@ $(BASE_O)
+-	$(RANLIB) $@
++	$(CC) -dynamiclib -install_name $(out)/lib/liblua.${version}.dylib \
++		-compatibility_version ${version} -current_version ${version} \
++		-o liblua.${version}.dylib $^
+ 
+ $(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++	$(CC) -fno-common $(MYLDFLAGS) \
++		-o $@ $(LUA_O) $(LUA_A) -L. -llua.${version} $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)

--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -17,7 +17,7 @@ in rec {
   lua5_4 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "4"; patch = "2"; };
     hash = "0ksj5zpj74n0jkamy3di1p6l10v4gjnd2zjnb453qc6px6bhsmqi";
-    patches = [
+    patches = if stdenv.isDarwin then [ ./5.4.darwin.patch ] else [
       # build lua as a shared library as well, MIT-licensed from
       # https://github.com/archlinux/svntogit-packages/tree/packages/lua/trunk
       ./liblua.so.patch


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nix-cache.s3.amazonaws.com/log/45w5cj3nbsyzcsrfj6i2dvqyvc8g13fx-lua-5.4.2.drv
ZHF: #122042
The 5.4.darwin.patch was just copied from 5.2.darwin.patch with line adjustments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
