### PR TITLE
clpm: fix darwin build

### DIFF
--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     runHook preBuild
 
-    ln -s ${openssl.out}/lib/libcrypto.so.* .
-    ln -s ${openssl.out}/lib/libssl.so.* .
+    ln -s ${openssl.out}/lib/libcrypto*${stdenv.hostPlatform.extensions.sharedLibrary}* .
+    ln -s ${openssl.out}/lib/libssl*${stdenv.hostPlatform.extensions.sharedLibrary}* .
     common-lisp.sh --script scripts/build.lisp
 
     runHook postBuild


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142037968/nixlog/2

Would appreciate a Linux review, just to be sure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
