### PR TITLE
copper: broken on darwin

### DIFF
--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     homepage = "https://tibleiz.net/copper/";
     license = licenses.bsd2;
     platforms = platforms.x86_64;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142620896/nixlog/1

When setting CC to clang:

```
building
file-unix.c
Bootstrapping...
boot/copper-c-unix-64.c:1906:18: error: second parameter of 'main' (argument array) must be of type 'char **'
extern int CDECL main(int zargc, unsigned char **zargv);
                 ^
boot/copper-c-unix-64.c:3332:23: warning: declaration of built-in function 'fopen' requires inclusion of the header <stdio.h> [-Wbuiltin-requires-header]
extern FILE176 *CDECL fopen(unsigned char *, unsigned char *);
                      ^
boot/copper-c-unix-64.c:3334:21: warning: declaration of built-in function 'fread' requires inclusion of the header <stdio.h> [-Wbuiltin-requires-header]
extern size_t CDECL fread(unsigned char *, size_t , size_t , FILE176 *);
                    ^
boot/copper-c-unix-64.c:3335:21: warning: declaration of built-in function 'fwrite' requires inclusion of the header <stdio.h> [-Wbuiltin-requires-header]
extern size_t CDECL fwrite(unsigned char *, size_t , size_t , FILE176 *);
                    ^
boot/copper-c-unix-64.c:3837:11: error: second parameter of 'main' (argument array) must be of type 'char **'
int CDECL main(int zargc, unsigned char **zargv)
          ^
3 warnings and 2 errors generated.
make: *** [Makefile:131: boot] Error 1
```

When adding gcc as build input:

```
Linking...
ld: warning: ignoring file stage2/copper-elf64.o, building for macOS-x86_64 but attempting to link with file built for unknown-unsupported file format ( 0x7F 0x45 0x4C 0x46 0x02 0x01 0x01 0x03 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 )
Undefined symbols for architecture x86_64:
  "_main", referenced from:
     implicit entry/start for main executable
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:147: stage2/copper-elf64] Error 1
```

(Not sure if clang works on other platforms.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
