### PR TITLE
reproxy: init at 0.5.1

### DIFF
--- a/pkgs/servers/reproxy/default.nix
+++ b/pkgs/servers/reproxy/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "reproxy";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "umputun";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-RB3+IU6halnk/2REh2CLDpQN7djn4Y1QuL8y8xppnQw=";
+  };
+
+  postPatch = ''
+    # Requires network access
+    substituteInPlace app/main_test.go \
+      --replace "Test_Main" "Skip_Main"
+  '';
+
+  vendorSha256 = null;
+
+  buildFlagsArray = [
+    "-ldflags=-s -w -X main.revision=${version}"
+  ];
+
+  installPhase = ''
+    install -Dm755 $GOPATH/bin/app $out/bin/reproxy
+  '';
+
+  meta = with lib; {
+    description = "Simple edge server / reverse proxy";
+    homepage = "https://reproxy.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19420,6 +19420,8 @@ in
 
   redstore = callPackage ../servers/http/redstore { };
 
+  reproxy = callPackage ../servers/reproxy { };
+
   restic = callPackage ../tools/backup/restic { };
 
   restic-rest-server = callPackage ../tools/backup/restic/rest-server.nix { };


### PR DESCRIPTION
###### Motivation for this change
[**Reproxy**](https://reproxy.io/) is a simple edge HTTP(s) server / reverse proxy.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
