### PR TITLE
stage-1: Log to secondary consoles

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -137,6 +137,9 @@ let
         copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
       ''}
 
+      # Copy bootlogd
+      copy_bin_and_libs ${pkgs.bootlogd}/bin/bootlogd
+
       # Copy secrets if needed.
       #
       # TODO: move out to a separate script; see #85000.

--- a/nixos/tests/boot-stage1.nix
+++ b/nixos/tests/boot-stage1.nix
@@ -156,6 +156,12 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     machine.fail("kill -0 $(< /run/canary2.pid)")
     machine.succeed('pgrep -a -f "^@canary3$"')
     machine.succeed('pgrep -a -f "^kcanary$"')
+
+    # Checks the boot log includes the earliest output
+    # First and third lines are empty, the second line is the "banner".
+    machine.succeed('head -n2 /run/log/stage-1-init.log | tail -n1 | grep "<<< NixOS Stage 1 >>>"')
+    # Checks the early boot log is in /dev/kmsg
+    machine.succeed('dmesg | grep "<<< NixOS Stage 1 >>>"')
   '';
 
   meta.maintainers = with pkgs.lib.maintainers; [ aszlig ];

--- a/pkgs/tools/system/bootlogd/default.nix
+++ b/pkgs/tools/system/bootlogd/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "bootlogd";
+  version = "2.95.2";
+
+  src = fetchFromGitHub {
+    owner = "mobile-nixos";
+    repo = "bootlogd";
+    rev = "v${version}";
+    sha256 = "1i8ypigwvqd0scba4r6c1a5pavb5w0jcz73gicm51lyfz5f9rqp9";
+  };
+
+  sourceRoot = "source/src";
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    license = licenses.gpl2Plus;
+    description = "Early logs multiplexer";
+    homepage = "https://github.com/mobile-nixos/bootlogd";
+    maintainers = [ maintainers.samueldr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19751,6 +19751,8 @@ in
 
   bolt = callPackage ../os-specific/linux/bolt { };
 
+  bootlogd = callPackage ../tools/system/bootlogd { };
+
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };
 
   busybox = callPackage ../os-specific/linux/busybox { };


### PR DESCRIPTION
### Motivation for this change

The output from `init` will only be present on the last valid `console=` parameter from the kernel command-line.

This is extremely inconvenient, when not harmful, for generic images. On many ARM platforms the serial console names differ, so there is no absolute truthful console name to use here. Additionally, this prevents logging to be shown on both the connected display, and the serial output at once.

With `bootlogd`, the output is redirected to all `console=` parameters. It also replaces the ad-hoc logging to /run/log and the logging to /dev/kmsg.

This way we should be able to get rid of one of the main annoyance with ARM platforms early boot debugging.

This has been used for a good while in Mobile NixOS.

Ideally we'd somehow do a system test that confirms it logs to multiple serial consoles, but I really don't know how we'd pull that off.

### TODO

 - [ ] Investigate input redirection
 - [ ] Decide how we handle killing bootlogd
 - [ ] Verify operation on an ARM machine

#### Input redirection

While opening this PR, I realized that this probably doesn't cover input during stage-1. Only the last `console=` would be usable as an input in that case. This is important for `boot.debug1*` use cases, and also useful if only to answer `r` to reboot the machine.

We probably can, could, and should merge this even without this being handled, as it would already be a net improvement compared to the current situation.

#### Killing bootlogd

Right now I haven't handled it at all. It gets culled at `Kill any remaining processes`, which means it will be missing all messages up to systemd starting in stage-2.

Should we:

 - Cheat and mark it as a storage daemon by prefixing its argv0 with a `@`?
 - Special case it in the loop?

Then, we can add a late `boot.postBootCommands` which includes `${pkgs.procps}/bin/pkill -x bootlogd` to kill it. Ideally order it to happen last before we `exec` into systemd.

### What even is `bootlogd`??

 - https://github.com/mobile-nixos/bootlogd

It's a minified part of `sysvinit`. The main core hasn't been touched by me. Really the main thing I did was delete the `sysvinit` around it. Then I added features that helps either Mobile NixOS or NixOS in some ways.

### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

* * *

This closes #42255.
