### PR TITLE
opentabletdriver: 0.5.1 -> 0.5.3.1

### DIFF
--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -23,18 +23,18 @@
 
 stdenv.mkDerivation rec {
   pname = "OpenTabletDriver";
-  version = "0.5.1";
+  version = "0.5.3.1";
 
   src = fetchFromGitHub {
     owner = "InfinityGhost";
     repo = "OpenTabletDriver";
     rev = "v${version}";
-    sha256 = "1if2mkj193yzf5si9pwaynrm6wkhqy7ihk4k1lklzcryk5675w36";
+    sha256 = "OT8/c+6wNpZyq/q7uMxIqmyJKNAq0B4ynEAqFF0GWyo=";
   };
 
   debPkg = fetchurl {
     url = "https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${version}/OpenTabletDriver.deb";
-    sha256 = "16a1rr0yxra1dhwysbbfgsxpigh2jhjlsl7r28dgp8qcxncck7wg";
+    sha256 = "0nm0v1xhphl6g6rz3li4rbdp7408g6sf9l4nh3mbbif5042xa0qh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/X11/opentabletdriver/deps.nix
+++ b/pkgs/tools/X11/opentabletdriver/deps.nix
@@ -41,8 +41,8 @@
   })
   (fetchNuGet {
     name = "HidSharpCore";
-    version = "1.2.1";
-    sha256 = "0vcw38skr9g691gxbzv3cf6y9rk11vh5pvcyjshdgii2z1z8a4g2";
+    version = "1.2.1.1";
+    sha256 = "1zkndglmz0s8rblfhnqcvv90rkq2i7lf4bc380g7z8h1avf2ikll";
   })
   (fetchNuGet {
     name = "MessagePack.Annotations";
@@ -121,8 +121,8 @@
   })
   (fetchNuGet {
     name = "Octokit";
-    version = "0.48.0";
-    sha256 = "17ria1shx04rb6knbaswpqndmwam6v3r3lsfsd486q584798ccn8";
+    version = "0.50.0";
+    sha256 = "1ignj5i6a1c19qqrw00wlr9fdjmwrxkxz7gdxj0x653w84gbv7qq";
   })
   (fetchNuGet {
     name = "PangoSharp";

--- a/pkgs/tools/X11/opentabletdriver/update.sh
+++ b/pkgs/tools/X11/opentabletdriver/update.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 deps_file="$(realpath "./deps.nix")"
 
-new_version="$(curl -s "https://api.github.com/repos/InfinityGhost/OpenTabletDriver/releases" | jq -r '.[0].tag_name' | sed 's|[^0-9.]||g')"
+new_version="$(curl -s "https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases" | jq -r '.[0].tag_name' | sed 's|[^0-9.]||g')"
 old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
 if [[ "$new_version" == "$old_version" ]]; then
   echo "Up to date"
@@ -15,8 +15,8 @@ if [[ "$new_version" == "$old_version" ]]; then
 fi
 
 # Updating the hash of deb package manually since there seems to be no way to do it automatically
-oldDebPkgUrl="https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${old_version}/OpenTabletDriver.deb";
-newDebPkgUrl="https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${new_version}/OpenTabletDriver.deb";
+oldDebPkgUrl="https://github.com/OpenTabletDriver/OpenTabletDriver/releases/download/v${old_version}/OpenTabletDriver.deb";
+newDebPkgUrl="https://github.com/OpenTabletDriver/OpenTabletDriver/releases/download/v${new_version}/OpenTabletDriver.deb";
 oldDebSha256=$(nix-prefetch-url "$oldDebPkgUrl")
 newDebSha256=$(nix-prefetch-url "$newDebPkgUrl")
 echo "oldDebSha256: $oldDebSha256 newDebSha256: $newDebSha256"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
