### PR TITLE
python3Packages.pwntools: 4.3.1 -> 4.5.0

### DIFF
--- a/pkgs/development/python-modules/colored-traceback/default.nix
+++ b/pkgs/development/python-modules/colored-traceback/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "colored-traceback";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-bafOKx2oafa7VMkntBW5VyfEu22ahMRhXqd9mHKRGwU=";
+  };
+
+  buildInputs = [ pygments ];
+
+  # No setuptools tests for the package.
+  doCheck = false;
+
+  pythonImportsCheck = [ "colored_traceback" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/staticshock/colored-traceback.py";
+    description = "Automatically color Python's uncaught exception tracebacks";
+    license = licenses.isc;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -10,6 +10,7 @@
 , pygments
 , ROPGadget
 , capstone
+, colored-traceback
 , paramiko
 , pip
 , psutil
@@ -17,6 +18,7 @@
 , pyserial
 , dateutil
 , requests
+, rpyc
 , tox
 , unicorn
 , intervaltree
@@ -24,12 +26,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "4.3.1";
+  version = "4.5.0";
   pname = "pwntools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12ja913kz8wl4afrmpzxh9fx6j7rcwc2vqzkvfr1fxn42gkqhqf4";
+    sha256 = "sha256-IWHMorSASG/po8ib1whS3xPuoUUlD0tbbWI35DI2SIY=";
   };
 
   # Upstream has set an upper bound on unicorn because of https://github.com/Gallopsled/pwntools/issues/1538,
@@ -46,6 +48,7 @@ buildPythonPackage rec {
     pygments
     ROPGadget
     capstone
+    colored-traceback
     paramiko
     pip
     psutil
@@ -53,6 +56,7 @@ buildPythonPackage rec {
     pyserial
     dateutil
     requests
+    rpyc
     tox
     unicorn
     intervaltree

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1464,6 +1464,8 @@ in {
 
   colored = callPackage ../development/python-modules/colored { };
 
+  colored-traceback = callPackage ../development/python-modules/colored-traceback { };
+
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };
 
   colorful = callPackage ../development/python-modules/colorful { };


### PR DESCRIPTION
Signed-off-by: Pamplemousse <xav.maso@gmail.com>

###### Motivation for this change

Be up-to-date!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
