### PR TITLE
fcl: init at 0.6.1

### DIFF
--- a/pkgs/development/libraries/fcl/default.nix
+++ b/pkgs/development/libraries/fcl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, eigen, libccd, octomap }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, eigen, libccd, octomap }:
 
 stdenv.mkDerivation rec {
   pname = "fcl";
@@ -10,6 +10,21 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1i1sd0fsvk5d529aw8aw29bsmymqgcmj3ci35sz58nzp2wjn0l5d";
   };
+
+  patches = [
+    # Disable SSE on Emscripten (required for the next patch to apply cleanly)
+    # https://github.com/flexible-collision-library/fcl/pull/470
+    (fetchpatch {
+      url = "https://github.com/flexible-collision-library/fcl/commit/83a1af61ba4efa81ec0b552b3121100044a8cf46.patch";
+      sha256 = "0bbkv4xpkl3c0i8qdlkghj6qkybrrd491c8rd2cqnxfgspcd40p0";
+    })
+    # Detect SSE support to fix building on ARM
+    # https://github.com/flexible-collision-library/fcl/pull/506
+    (fetchpatch {
+      url = "https://github.com/flexible-collision-library/fcl/commit/cbfe1e9405aa68138ed1a8f33736429b85500dea.patch";
+      sha256 = "18qip8gwhm3fvbz1cvzf625rh5msq8m4669ld1m60fv6z50clr9h";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ eigen libccd octomap ];

--- a/pkgs/development/libraries/fcl/default.nix
+++ b/pkgs/development/libraries/fcl/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, cmake, eigen, libccd, octomap }:
+
+stdenv.mkDerivation rec {
+  pname = "fcl";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "flexible-collision-library";
+    repo = pname;
+    rev = version;
+    sha256 = "1i1sd0fsvk5d529aw8aw29bsmymqgcmj3ci35sz58nzp2wjn0l5d";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ eigen libccd octomap ];
+
+  outputs = [ "out" "dev" ];
+
+  meta = with lib; {
+    description = "Flexible Collision Library";
+    longDescription = ''
+      FCL is a library for performing three types of proximity queries on a
+      pair of geometric models composed of triangles.
+    '';
+    homepage = "https://github.com/flexible-collision-library/fcl";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libccd/default.nix
+++ b/pkgs/development/libraries/libccd/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "libccd";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "danfis";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0sfmn5pd7k5kyhbxnd689xmsa5v843r7sska96dlysqpljd691jc";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Library for collision detection between two convex shapes";
+    homepage = "https://github.com/danfis/libccd";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/octomap/default.nix
+++ b/pkgs/development/libraries/octomap/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "octomap";
+  version = "1.9.6";
+
+  src = fetchFromGitHub {
+    owner = "OctoMap";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03v341dffa0pfzmf2431xb5nq50zq9zlhgl6k2aa3fsza5xmbb70";
+  };
+  sourceRoot = "source/octomap";
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "A probabilistic, flexible, and compact 3D mapping library for robotic systems";
+    homepage = "https://octomap.github.io/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lopsided98 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15522,6 +15522,8 @@ in
 
   libcbor = callPackage ../development/libraries/libcbor { };
 
+  libccd = callPackage ../development/libraries/libccd { };
+
   libcec = callPackage ../development/libraries/libcec {
     libraspberrypi = null;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14442,6 +14442,8 @@ in
 
   fcgi = callPackage ../development/libraries/fcgi { };
 
+  fcl = callPackage ../development/libraries/fcl { };
+
   ffcast = callPackage ../tools/X11/ffcast { };
 
   fflas-ffpack = callPackage ../development/libraries/fflas-ffpack { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20815,6 +20815,8 @@ in
 
   nss_ldap = callPackage ../os-specific/linux/nss_ldap { };
 
+  octomap = callPackage ../development/libraries/octomap { };
+
   odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
 
   odroid-xu3-bootloader = callPackage ../tools/misc/odroid-xu3-bootloader { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the [Flexible Collision Library](https://github.com/flexible-collision-library/fcl) and its dependencies. This package is used by several Robot Operating System (ROS) packages, and would allow them to be included in [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay). On the other hand, fcl is useful outside of ROS, so I thought it should belong in nixpkgs rather than the overlay.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
