### PR TITLE
mplayer: fix build failure with ffmpeg 4.4

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -106,6 +106,8 @@ stdenv.mkDerivation rec {
     rm -rf ffmpeg
   '';
 
+  patches = [ ./svn-r38199-ffmpeg44fix.patch ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config yasm ];
   buildInputs = with lib;

--- a/pkgs/applications/video/mplayer/svn-r38199-ffmpeg44fix.patch
+++ b/pkgs/applications/video/mplayer/svn-r38199-ffmpeg44fix.patch
@@ -1,0 +1,22 @@
+Index: libmpcodecs/ad_spdif.c
+===================================================================
+diff --git a/libmpcodecs/ad_spdif.c b/libmpcodecs/ad_spdif.c
+--- a/libmpcodecs/ad_spdif.c	(revision 38198)
++++ b/libmpcodecs/ad_spdif.c	(revision 38199)
+@@ -298,14 +298,8 @@
+         if (spdif_ctx->header_written)
+             av_write_trailer(lavf_ctx);
+         av_freep(&lavf_ctx->pb);
+-        if (lavf_ctx->streams) {
+-            av_freep(&lavf_ctx->streams[0]->codec);
+-            av_freep(&lavf_ctx->streams[0]->info);
+-            av_freep(&lavf_ctx->streams[0]);
+-        }
+-        av_freep(&lavf_ctx->streams);
+-        av_freep(&lavf_ctx->priv_data);
++        avformat_free_context(lavf_ctx);
++        lavf_ctx = NULL;
+     }
+-    av_freep(&lavf_ctx);
+     av_freep(&spdif_ctx);
+ }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix mplayer build with ffmpeg 4.4.

Backport SVN revision 38199.

See https://hydra.nixos.org/build/142702864

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
