### PR TITLE
taglib-extras: add missing dependency zlib

### DIFF
--- a/pkgs/development/libraries/taglib-extras/default.nix
+++ b/pkgs/development/libraries/taglib-extras/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, cmake, taglib}:
+{lib, stdenv, fetchurl, cmake, taglib, zlib}:
 
 stdenv.mkDerivation rec {
   name = "taglib-extras-1.0.1";
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cln49ws9svvvals5fzxjxlzqm0fzjfymn7yfp4jfcjz655nnm7y";
   };
   buildInputs = [ taglib ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake zlib ];
 
   # Workaround for upstream bug https://bugs.kde.org/show_bug.cgi?id=357181
   preConfigure = ''


### PR DESCRIPTION
This change adds zlib as a dependency to address the error:

```
/nix/store/5xyjd2qiily84lcv2w2grmwsb8r1hqpr-binutils-2.35.1/bin/ld: cannot find -lz
collect2: error: ld returned 1 exit status
make[2]: *** [taglib-extras/CMakeFiles/tag-extras.dir/build.make:208:
taglib-extras/libtag-extras.so.1.0.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:154:
taglib-extras/CMakeFiles/tag-extras.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
builder for
'/nix/store/w1ac3b6v5yfblbnqzyxa6y4738frlmvr-taglib-extras-1.0.1.drv'
failed with exit code 2
```
This allows amarok to build. See https://hydra.nixos.org/build/142979429

ZHF: #122042

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
