### PR TITLE
pharo-cog32: add missing dependency libnsl

### DIFF
--- a/pkgs/development/pharo/vm/build-vm-legacy.nix
+++ b/pkgs/development/pharo/vm/build-vm-legacy.nix
@@ -13,6 +13,7 @@
 , alsaLib
 , cairo
 , libuuid
+, libnsl
 , makeWrapper
 , ... }:
 
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ unzip cmake gcc makeWrapper ];
 
   buildInputs = [ bash glibc openssl libGLU libGL freetype
-                  xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share ];
+                  xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libnsl ];
 
   LD_LIBRARY_PATH = lib.makeLibraryPath
     [ cairo libGLU libGL freetype openssl libuuid alsaLib

--- a/pkgs/development/pharo/vm/vms.nix
+++ b/pkgs/development/pharo/vm/vms.nix
@@ -19,6 +19,7 @@
 , fetchFromGitHub
 , makeWrapper
 , runtimeShell
+, libnsl
 } @args:
 
 let


### PR DESCRIPTION
This change adds the missing dependency libnsl.

See https://hydra.nixos.org/build/142615153

ZHF: #122042

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
