### PR TITLE
dduper: init at v0.04

### DIFF
--- a/pkgs/tools/filesystems/dduper/default.nix
+++ b/pkgs/tools/filesystems/dduper/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchpatch, fetchFromGitHub, btrfs-progs, python3 }:
+
+let
+  btrfsProgsPatched = btrfs-progs.overrideAttrs (oldAttrs: {
+    patches = [
+      (fetchpatch {
+        name = "0001-Print-csum-for-a-given-file-on-stdout.patch";
+        url = "https://raw.githubusercontent.com/Lakshmipathi/dduper/8fab08e0f1901bf54411d25f1767b48c978074cb/patch/btrfs-progs-v5.9/0001-Print-csum-for-a-given-file-on-stdout.patch";
+        sha256 = "1li9lslrap70ibad8sij3bgpxn5lqs0j10l60bmy3c36y866q3g1";
+      })
+    ];
+  });
+  py3 = python3.withPackages (ps: with ps; [
+    prettytable
+    numpy
+  ]);
+in
+stdenv.mkDerivation rec {
+  pname = "dduper";
+  version = "0.04";
+
+  src = fetchFromGitHub {
+    owner = "lakshmipathi";
+    repo = "dduper";
+    rev = "v${version}";
+    sha256 = "09ncdawxkffldadqhfblqlkdl05q2qmywxyg6p61fv3dr2f2v5wm";
+  };
+
+  buildInputs = [
+    btrfsProgsPatched
+    py3
+  ];
+
+  patchPhase = ''
+    substituteInPlace ./dduper --replace "/usr/sbin/btrfs.static" "${btrfsProgsPatched}/bin/btrfs"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 ./dduper $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Fast block-level out-of-band BTRFS deduplication tool.";
+    homepage = "https://github.com/Lakshmipathi/dduper";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ thesola10 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2288,6 +2288,8 @@ in
 
   ddate = callPackage ../tools/misc/ddate { };
 
+  dduper = callPackage ../tools/filesystems/dduper { };
+
   dedup = callPackage ../tools/backup/dedup { };
 
   dehydrated = callPackage ../tools/admin/dehydrated { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add a lightweight deduplication tool for Btrfs filesystems, which relies on a specific, patched version of `btrfs-progs`. This derivation facilitates things by building it from the official `btrfs-progs` derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
