### PR TITLE
arc_unpacker: fix build

### DIFF
--- a/pkgs/tools/archivers/arc_unpacker/add-missing-import.patch
+++ b/pkgs/tools/archivers/arc_unpacker/add-missing-import.patch
@@ -1,0 +1,22 @@
+From 29c0b393283395c69ecdd747e960301e95c93bcf Mon Sep 17 00:00:00 2001
+From: Felix Rath <felixm.rath@gmail.com>
+Date: Sat, 15 May 2021 13:07:38 +0200
+Subject: [PATCH] add missing <stdexcept> import
+
+`std::logic_error` is used in this file, which resides in `<stdexcept>`, but was not imported before. This caused the build to fail, see, e.g., https://hydra.nixos.org/build/141997371/log.
+---
+ src/algo/crypt/lcg.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/algo/crypt/lcg.cc b/src/algo/crypt/lcg.cc
+index 6c2a7945..66630a08 100644
+--- a/src/algo/crypt/lcg.cc
++++ b/src/algo/crypt/lcg.cc
+@@ -17,6 +17,7 @@
+ 
+ #include "algo/crypt/lcg.h"
+ #include <functional>
++#include <stdexcept>
+ 
+ using namespace au;
+ using namespace au::algo::crypt;

--- a/pkgs/tools/archivers/arc_unpacker/default.nix
+++ b/pkgs/tools/archivers/arc_unpacker/default.nix
@@ -30,17 +30,25 @@ stdenv.mkDerivation rec {
   '';
 
   checkPhase = ''
+    runHook preCheck
+
     pushd ..
     ./build/run_tests
     popd
+
+    runHook postCheck
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/doc/arc_unpacker $out/libexec/arc_unpacker
     cp arc_unpacker $out/libexec/arc_unpacker/arc_unpacker
     cp ../GAMELIST.{htm,js} $out/share/doc/arc_unpacker
     cp -r ../etc $out/libexec/arc_unpacker
     makeWrapper $out/libexec/arc_unpacker/arc_unpacker $out/bin/arc_unpacker
+
+    runHook postInstall
   '';
 
   doCheck = true;
@@ -48,7 +56,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A tool to extract files from visual novel archives";
     homepage = "https://github.com/vn-tools/arc_unpacker";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ midchildan ];
   };
 }

--- a/pkgs/tools/archivers/arc_unpacker/default.nix
+++ b/pkgs/tools/archivers/arc_unpacker/default.nix
@@ -18,6 +18,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake makeWrapper catch ];
   buildInputs = [ boost libpng libjpeg zlib openssl libwebp ];
 
+  patches = [
+    # Add a missing `<stdexcept>` import that caused the build to fail.
+    # Failure: https://hydra.nixos.org/build/141997371/log
+    # Also submitted as an upstream PR: https://github.com/vn-tools/arc_unpacker/pull/194
+    ./add-missing-import.patch
+  ];
+
   postPatch = ''
     cp ${catch}/include/catch/catch.hpp tests/test_support/catch.h
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix build of the package, as it was failing before:

https://hydra.nixos.org/build/141997371/log

```console
[...]
build/source/src/algo/crypt/lcg.cc: In constructor 'au::algo::crypt::Lcg::Lcg(au::algo::crypt::LcgKind, au::u32)':
/build/source/src/algo/crypt/lcg.cc:70:24: error: 'logic_error' is not a member of 'std'
   70 |             throw std::logic_error("Unknown LCG kind");
      |                        ^~~~~~~~~~~
make[2]: *** [CMakeFiles/libau.dir/build.make:160: CMakeFiles/libau.dir/src/algo/crypt/lcg.cc.o] Error 1
[...]
```

Also submitted as a PR to the upstream repo: https://github.com/vn-tools/arc_unpacker/pull/194

ZHF: #122042

@jonringer (ping meant for @NixOS/nixos-release-managers)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
