### PR TITLE
include-what-you-use: 0.14 -> 0.16

### DIFF
--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -3,15 +3,15 @@
 stdenv.mkDerivation rec {
   pname = "include-what-you-use";
   # Also bump llvmPackages in all-packages.nix to the supported version!
-  version = "0.14";
+  version = "0.16";
 
   src = fetchurl {
-    sha256 = "1vq0c8jqspvlss8hbazml44fi0mbslgnp2i9wcr0qrjpvfbl6623";
+    sha256 = "sha256-jW/JslU0O8Hl7EWeOVEt8dUcYOA1YpheAHYDYRn/Whw=";
     url = "${meta.homepage}/downloads/${pname}-${version}.src.tar.gz";
   };
 
-  nativeBuildInputs = with llvmPackages; [ cmake llvm.dev llvm clang-unwrapped python3];
-  buildInputs = [ llvmPackages.libclang ];
+  nativeBuildInputs = with llvmPackages; [ cmake llvm.dev llvm python3];
+  buildInputs = with llvmPackages; [ libclang clang-unwrapped ];
 
   cmakeFlags = [ "-DIWYU_LLVM_ROOT_PATH=${llvmPackages.clang-unwrapped}" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13365,7 +13365,7 @@ in
   };
 
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
-    llvmPackages = llvmPackages_10;
+    llvmPackages = llvmPackages_12;
   };
 
   indent = callPackage ../development/tools/misc/indent { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/include-what-you-use/include-what-you-use/releases/tag/0.16

~~I'm trying to update include-what-you-use. Unfortunately the build fails with a linker error both on macOS and on Linux.~~
```
Undefined symbols for architecture x86_64:
  "typeinfo for clang::CommentHandler", referenced from:
      typeinfo for include_what_you_use::IwyuPreprocessorInfo in iwyu_preprocessor.cc.o
  "typeinfo for clang::PPCallbacks", referenced from:
      typeinfo for include_what_you_use::IwyuPreprocessorInfo in iwyu_preprocessor.cc.o
  "typeinfo for clang::ASTConsumer", referenced from:
      typeinfo for include_what_you_use::IwyuAstConsumer in iwyu.cc.o
  "typeinfo for clang::ASTFrontendAction", referenced from:
      typeinfo for include_what_you_use::IwyuAction in iwyu.cc.o
ld: symbol(s) not found for architecture x86_64
```
~~I wasn't able to fix this. If anyone has an idea, that would be really helpful.~~
Version 0.16 seems to have fixed this problem.

@jonringer the change you made to include-what-you-use in #122111 breaks the build on Darwin:
```
-- IWYU: out-of-tree configuration
-- The C compiler identification is Clang 12.0.0
-- The CXX compiler identification is Clang 12.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/nnbm334pybqvznz1mc834ba1n9grgjir-clang-12.0.0/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/nnbm334pybqvznz1mc834ba1n9grgjir-clang-12.0.0/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /nix/store/8f4wp5sdl08wrnj3ajsqrjbv7fw5lgv7-zlib-1.2.11/lib/libz.dylib (found version "1.2.11") 
-- Could NOT find LibXml2 (missing: LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR) 
-- Could NOT find LibXml2 (missing: LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR) 
-- Linker detection: ld64
-- Performing Test LLVM_LIBSTDCXX_MIN
-- Performing Test LLVM_LIBSTDCXX_MIN - Failed
CMake Error at /nix/store/hg7haq03l7diw7ii8va6f3idmw9zhb03-llvm-12.0.0-dev/lib/cmake/llvm/CheckCompilerVersion.cmake:97 (message):
  libstdc++ version must be at least 5.1.
Call Stack (most recent call first):
  /nix/store/hg7haq03l7diw7ii8va6f3idmw9zhb03-llvm-12.0.0-dev/lib/cmake/llvm/HandleLLVMOptions.cmake:9 (include)
  CMakeLists.txt:24 (include)
```
If I move `clang-unwrapped` from `nativeBuildInputs` to `buildInputs` it works again. Does this break anything? Is there a better solution?

Note that I didn't thoroughly test include-what-you-use on a real project because I get errors such as
```
In file included from glfw/init.c:30:
In file included from glfw/internal.h:30:
glfw/../kitty/monotonic.h:11:10: fatal error: 'stdint.h' file not found
#include <stdint.h>
         ^~~~~~~~~~
```
But that may just be me not knowing how to properly use include-what-you-use as I get the same errors with version 0.14.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).