### PR TITLE
gnomeExtensions.clipboard-indicator: 37 -> 38

### DIFF
--- a/pkgs/desktops/gnome/extensions/clipboard-indicator/default.nix
+++ b/pkgs/desktops/gnome/extensions/clipboard-indicator/default.nix
@@ -1,24 +1,26 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, gettext, glib }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-clipboard-indicator";
-  version = "37";
+  version = "38";
 
   src = fetchFromGitHub {
     owner = "Tudmotu";
     repo = "gnome-shell-extension-clipboard-indicator";
     rev = "v${version}";
-    sha256 = "0npxhaam2ra2b9zh2gk2q0n5snlhx6glz86m3jf8hz037w920k41";
+    sha256 = "FNrh3b6la2BuWCsriYP5gG0/KNbkFPuq/YTXTj0aJAI=";
   };
 
   uuid = "clipboard-indicator@tudmotu.com";
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/gnome-shell/extensions/${uuid}
-    cp -r * $out/share/gnome-shell/extensions/${uuid}
-    runHook postInstall
-  '';
+  nativeBuildInputs = [
+    gettext
+    glib
+  ];
+
+  makeFlags = [
+    "INSTALLPATH=${placeholder "out"}/share/gnome-shell/extensions/${uuid}/"
+  ];
 
   meta = with lib; {
     description = "Adds a clipboard indicator to the top panel and saves clipboard history";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

clipboard-indicator has a new release. The previous version does not work on gnome 40, the new one does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
