### PR TITLE
xvfb-run: mark as linux-only

### DIFF
--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

I came across this via a failing build of `flent` on Darwin: https://hydra.nixos.org/build/142500397/nixlog/1

It looks like the xvfb-run script uses mcookie, which is part of util-linux. For laughs, I tried building util-linux on Darwin, but it has dependencies that are also marked broken on Darwin, so not sure following that path is much use.

I think the proper solution here is to somehow package mcookie separately, as a small build of util-linux? NetBSD appears to be doing this as well: https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/x11/mcookie/index.html

Quick resolution is to mark this as linux-only for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
