### PR TITLE
llvmPackages_{7-12}.compiler-rt: install resource files to DATADIR

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 35a48c6af29c..e4300f256091 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/11/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/11/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 7c127a93dfa7..6a95a65b70a7 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/12/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 361538a58e47..f0d8d9ab80f1 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/7/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/7/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index cd4c704fc824..5abcd1260381 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -26,6 +26,7 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/8/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/8/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 81b110203c27..df7598a11caf 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -26,6 +26,7 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/9/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/9/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index f7ee932f214f..ef94a97c4be9 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -26,6 +26,7 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
     '';
 
   in {


### PR DESCRIPTION
This is in an effort to fix the following build failure shown by
chromium:

    clang++: error: no such file or directory: '/nix/store/fhd89wrmkx6nflzjk0d6waz70bk3zc4i-clang-wrapper-12.0.0/resource-root/share/cfi_blacklist.txt'

As it turns out a change introduced via the gnu-install-dirs.patch
caused `add_compiler_rt_resource_file` to install resource files to
$dev/include (FULL_INCLUDEDIR) instead of $out/share (FULL_DATADIR)
which in turn meant that the clang wrappers we had didn't link those
files to its resource root at all.

Alternative fix to this would have been to link
compiler-rt.dev/include/*.txt to the wrappers resource-root/share as
well, but since this was handled inconsistently across the patch anyways
(the dfsan list is installed correctly), opt to handle this
consistently within the patch.

llvmPackages_{5,6} install the resource files to a completely different
location and need separate investigation.

```
lr $(nix-build -A llvmPackages_12.stdenv.cc)/resource-root/share/
/nix/store/5i59ga5gfw08mg1cxyya5dspw2m63gai-clang-wrapper-12.0.0/resource-root/share/
/nix/store/5i59ga5gfw08mg1cxyya5dspw2m63gai-clang-wrapper-12.0.0/resource-root/share/asan_blacklist.txt
/nix/store/5i59ga5gfw08mg1cxyya5dspw2m63gai-clang-wrapper-12.0.0/resource-root/share/cfi_blacklist.txt
/nix/store/5i59ga5gfw08mg1cxyya5dspw2m63gai-clang-wrapper-12.0.0/resource-root/share/dfsan_abilist.txt
/nix/store/5i59ga5gfw08mg1cxyya5dspw2m63gai-clang-wrapper-12.0.0/resource-root/share/hwasan_blacklist.txt
/nix/store/5i59ga5gfw08mg1cxyya5dspw2m63gai-clang-wrapper-12.0.0/resource-root/share/msan_blacklist.txt
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
