### PR TITLE
xcbuild: 0.1.2-pre -> archived, fix build (x86_64-linux)

### DIFF
--- a/pkgs/development/tools/xcbuild/add-missing-import.patch
+++ b/pkgs/development/tools/xcbuild/add-missing-import.patch
@@ -1,0 +1,10 @@
+--- source_orig/Libraries/plist/Sources/Format/Encoding.cpp	1970-01-01 01:00:01.000000000 +0100
++++ source/Libraries/plist/Sources/Format/Encoding.cpp	2021-05-15 14:39:14.135561458 +0200
+@@ -10,6 +10,7 @@
+ #include <plist/Format/unicode.h>
+ 
+ #include <cassert>
++#include <cstdlib>
+ 
+ #if defined(__linux__)
+ #include <endian.h>

--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -5,8 +5,8 @@ let
   googletest = fetchFromGitHub {
     owner  = "google";
     repo   = "googletest";
-    rev    = "43359642a1c16ad3f4fc575c7edd0cb935810815";
-    sha256 = "0y4xaah62fjr3isaryc3vfz3mn9xflr00vchdimj8785milxga4q";
+    rev    = "a2b8a8e07628e5fd60644b6dd99c1b5e7d7f1f47";
+    sha256 = "1jhxgx8vcf9nfrj82336q773x44hd8vmgkx0l6mcrqymxdwqv00w";
   };
 
   linenoise = fetchFromGitHub {
@@ -18,16 +18,14 @@ let
 in stdenv.mkDerivation {
   pname = "xcbuild";
 
-  # Once a version is released that includes
-  # https://github.com/facebook/xcbuild/commit/183c087a6484ceaae860c6f7300caf50aea0d710,
-  # we can stop doing this -pre thing.
-  version = "0.1.2-pre";
+  # The project has been archived on github, we build the last available revision
+  version = "archived";
 
   src = fetchFromGitHub {
     owner  = "facebook";
     repo   = "xcbuild";
-    rev    = "32b9fbeb69bfa2682bd0351ec2f14548aaedd554";
-    sha256 = "1xxwg2849jizxv0g1hy0b1m3i7iivp9bmc4f5pi76swsn423d41m";
+    rev    = "dbaee552d2f13640773eb1ad3c79c0d2aca7229c";
+    sha256 = "05ypbvrxrda2k1jhhwf4jg69510pglp9qrhp43jz4lwn22wx4szf";
   };
 
   prePatch = ''
@@ -35,6 +33,12 @@ in stdenv.mkDerivation {
     cp -r --no-preserve=all ${googletest} ThirdParty/googletest
     cp -r --no-preserve=all ${linenoise} ThirdParty/linenoise
   '';
+
+  patches = [
+    # add a missing `<cstdlib>` import
+    # Failure: https://hydra.nixos.org/build/142008015/nixlog/2
+    ./add-missing-import.patch
+  ];
 
   postPatch = lib.optionalString (!stdenv.isDarwin) ''
     # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.


### PR DESCRIPTION
Update to the last available version as the project has been archived, also fix the build.

Previous failure:

https://hydra.nixos.org/build/142008015/nixlog/2

```
[...]
FAILED: Libraries/plist/CMakeFiles/plist.dir/Sources/Format/Encoding.cpp.o 
/nix/store/zzvq5qwlm2xikawfqxb0q8gl2bw391a9-gcc-wrapper-10.2.0/bin/g++ -Dplist_EXPORTS -I/nix/store/pj89fimswl2c12dazdfy8cyka7037s6r-libxml2-2.9.10-dev/include/libxml2 -I../Libraries/plist/Headers -I../Libraries/plist/PrivateHeaders -I../Libraries/libutil/Headers -I../Libraries/ext/Headers -std=c++11 -fno-rtti -fno-exceptions -O3 -DNDEBUG -fPIC -Wall -Werror -Wno-multichar -Wno-sign-compare -fdiagnostics-color -MD -MT Libraries/plist/CMakeFiles/plist.dir/Sources/Format/Encoding.cpp.o -MF Libraries/plist/CMakeFiles/plist.dir/Sources/Format/Encoding.cpp.o.d -o Libraries/plist/CMakeFiles/plist.dir/Sources/Format/Encoding.cpp.o -c ../Libraries/plist/Sources/Format/Encoding.cpp
../Libraries/plist/Sources/Format/Encoding.cpp: In static member function 'static std::vector<unsigned char> plist::Format::Encodings::BOM(plist::Format::Encoding)':
../Libraries/plist/Sources/Format/Encoding.cpp:75:5: error: 'abort' was not declared in this scope
   75 |     abort();
      |     ^~~~~
../Libraries/plist/Sources/Format/Encoding.cpp: In function 'Endian EncodingEndian(plist::Format::Encoding)':
../Libraries/plist/Sources/Format/Encoding.cpp:105:5: error: 'abort' was not declared in this scope
  105 |     abort();
      |     ^~~~~
[...]
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042

@jonringer (ping meant for @NixOS/nixos-release-managers)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>xcbuild</li>
    <li>xcbuild6Hook</li>
    <li>xcbuildHook</li>
    <li>xcodebuild6</li>
  </ul>
</details>
