### PR TITLE
graphviz: 2.42.2 -> 2.47.2

### DIFF
--- a/pkgs/tools/graphics/graphviz/base.nix
+++ b/pkgs/tools/graphics/graphviz/base.nix
@@ -2,7 +2,7 @@
 
 { lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, cairo, expat, flex
 , fontconfig, gd, gettext, gts, libdevil, libjpeg, libpng, libtool, pango
-, bison, fetchpatch, xorg ? null, ApplicationServices }:
+, bison, fetchpatch, xorg, ApplicationServices, python3 }:
 
 let
   inherit (lib) optional optionals optionalString;
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     inherit sha256 rev;
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config python3 ];
 
   buildInputs = [
     libpng libjpeg expat bison libtool fontconfig gd gts libdevil flex pango

--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -1,5 +1,5 @@
 import ./base.nix rec {
-  rev = "da4c2ec6f24ca1b6d1752c6b5bc4389e55682147"; # use rev as tags have disappeared before
-  version = "2.42.2";
-  sha256 = "0lacl11amyvj04j78m63qifljl4c0nkyy50z4bkg8mg9j4hjdy0x";
+  rev = "a11eb938514725493324d18db1686f9a99c8569f"; # use rev as tags have disappeared before
+  version = "2.47.2";
+  sha256 = "sha256-6JFjM/2xl7KVmGhSr6RWgO23UwLDyAif3ONsBG4t/Wc=";
  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7640,11 +7640,7 @@ in
 
   pk2cmd = callPackage ../tools/misc/pk2cmd { };
 
-  plantuml = callPackage ../tools/misc/plantuml {
-    # Graphviz 2.39 and 2.40 are discouraged by the PlantUML project, see
-    # http://plantuml.com/faq (heading: "Which version of Graphviz should I use ?")
-    graphviz = graphviz_2_32;
-  };
+  plantuml = callPackage ../tools/misc/plantuml { };
 
   plantuml-server = callPackage ../tools/misc/plantuml-server { };
 


### PR DESCRIPTION
###### Motivation for this change

Version bump. I didn't know graphviz was depended on by so many packages, so this might be quite impactful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
    - [x] `dot`: Tested making a simple diagram
    - [ ] Others: not tested
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
