### PR TITLE
writeDirectReferencesToFile and maintenance

### DIFF
--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -51,6 +51,32 @@ Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `
 
 This can be used to put many derivations into the same directory structure. It works by creating a new derivation and adding symlinks to each of the paths listed. It expects two arguments, `name`, and `paths`. `name` is the name used in the Nix store path for the created derivation. `paths` is a list of paths that will be symlinked. These paths can be to Nix store derivations or any other subdirectory contained within.
 
+## `writeReferencesToFile` {#trivial-builder-writeReferencesToFile}
+
+Writes the closure of transitive dependencies to a file.
+
+This produces the equivalent of `nix-store -q --requisites`.
+
+For example,
+
+```nix
+writeReferencesToFile (writeScriptBin "hi" ''${hello}/bin/hello'')
+```
+
+produces an output path `/nix/store/<hash>-runtime-deps` containing
+
+```nix
+/nix/store/<hash>-hello-2.10
+/nix/store/<hash>-hi
+/nix/store/<hash>-libidn2-2.3.0
+/nix/store/<hash>-libunistring-0.9.10
+/nix/store/<hash>-glibc-2.32-40
+```
+
+You can see that this includes `hi`, the original input path,
+`hello`, which is a direct reference, but also
+the other paths that are indirectly required to run `hello`.
+
 ## `writeDirectReferencesToFile` {#trivial-builder-writeDirectReferencesToFile}
 
 Writes the set of references to the output file, that is, their immediate dependencies.

--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -50,3 +50,24 @@ Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `
 ## `symlinkJoin` {#trivial-builder-symlinkJoin}
 
 This can be used to put many derivations into the same directory structure. It works by creating a new derivation and adding symlinks to each of the paths listed. It expects two arguments, `name`, and `paths`. `name` is the name used in the Nix store path for the created derivation. `paths` is a list of paths that will be symlinked. These paths can be to Nix store derivations or any other subdirectory contained within.
+
+## `writeDirectReferencesToFile` {#trivial-builder-writeDirectReferencesToFile}
+
+Writes the set of references to the output file, that is, their immediate dependencies.
+
+This produces the equivalent of `nix-store -q --references`.
+
+For example,
+
+```nix
+writeDirectReferencesToFile (writeScriptBin "hi" ''${hello}/bin/hello'')
+```
+
+produces an output path `/nix/store/<hash>-runtime-references` containing
+
+```nix
+/nix/store/<hash>-hello-2.10
+```
+
+but none of `hello`'s dependencies, because those are not referenced directly
+by `hi`'s output.

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -438,6 +438,35 @@ rec {
       done < graph
     '';
 
+  /*
+    Write the set of references to a file, that is, their immediate dependencies.
+
+    This produces the equivalent of `nix-store -q --references`.
+   */
+  writeDirectReferencesToFile = path: runCommand "runtime-references"
+    {
+      exportReferencesGraph = ["graph" path];
+      inherit path;
+    }
+    ''
+      touch ./references
+      while read p; do
+        read dummy
+        read nrRefs
+        if [[ $p == $path ]]; then
+          for ((i = 0; i < nrRefs; i++)); do
+            read ref;
+            echo $ref >>./references
+          done
+        else
+          for ((i = 0; i < nrRefs; i++)); do
+            read ref;
+          done
+        fi
+      done < graph
+      sort ./references >$out
+    '';
+
 
   /* Print an error message if the file with the specified name and
    * hash doesn't exist in the Nix store. This function should only

--- a/pkgs/build-support/trivial-builders/test.nix
+++ b/pkgs/build-support/trivial-builders/test.nix
@@ -1,0 +1,20 @@
+{ lib, nixosTest, path, writeText, hello, figlet, stdenvNoCC }:
+
+nixosTest {
+  name = "nixpkgs-trivial-builders";
+  nodes.machine = { ... }: {
+    virtualisation.writableStore = true;
+
+    # Test runs without network, so we don't substitute and prepare our deps
+    nix.binaryCaches = lib.mkForce [];
+    environment.etc."pre-built-paths".source = writeText "pre-built-paths" (
+      builtins.toJSON [hello figlet stdenvNoCC]
+    );
+  };
+  testScript = ''
+    machine.succeed("""
+      cd ${lib.cleanSource path}
+      ./pkgs/build-support/trivial-builders/test.sh 2>/dev/console
+    """)
+  '';
+}

--- a/pkgs/build-support/trivial-builders/test.sh
+++ b/pkgs/build-support/trivial-builders/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# -------------------------------------------------------------------------- #
+#
+#                         trivial-builders test
+#
+# -------------------------------------------------------------------------- #
+#
+#  This file can be run independently (quick):
+#
+#      $ pkgs/build-support/trivial-builders/test.sh
+#
+#  or in the build sandbox with a ~20s VM overhead
+#
+#      $ nix-build -A tests.trivial-builders
+#
+# -------------------------------------------------------------------------- #
+
+# strict bash
+set -euo pipefail
+
+# debug
+# set -x
+# PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+cd "$(dirname ${BASH_SOURCE[0]})"  # nixpkgs root
+
+testDirectReferences() {
+  expr="$1"
+  diff -U3 \
+    <(sort <$(nix-build --no-out-link --expr "with import ../../.. {}; writeDirectReferencesToFile ($expr)")) \
+    <(nix-store -q --references $(nix-build --no-out-link --expr "with import ../../.. {}; ($expr)") | sort)
+}
+
+testDirectReferences 'hello'
+testDirectReferences 'figlet'
+testDirectReferences 'writeText "hi" "hello"'
+testDirectReferences 'writeText "hi" "hello ${hello}"'
+testDirectReferences 'writeText "hi" "hello ${hello} ${figlet}"'
+
+echo 'OK!'

--- a/pkgs/build-support/trivial-builders/test.sh
+++ b/pkgs/build-support/trivial-builders/test.sh
@@ -38,4 +38,20 @@ testDirectReferences 'writeText "hi" "hello"'
 testDirectReferences 'writeText "hi" "hello ${hello}"'
 testDirectReferences 'writeText "hi" "hello ${hello} ${figlet}"'
 
+
+
+testClosure() {
+  expr="$1"
+  diff -U3 \
+    <(sort <$(nix-build --no-out-link --expr "with import ../../.. {}; writeReferencesToFile ($expr)")) \
+    <(nix-store -q --requisites $(nix-build --no-out-link --expr "with import ../../.. {}; ($expr)") | sort)
+}
+
+testClosure 'hello'
+testClosure 'figlet'
+testClosure 'writeText "hi" "hello"'
+testClosure 'writeText "hi" "hello ${hello}"'
+testClosure 'writeText "hi" "hello ${hello} ${figlet}"'
+
+
 echo 'OK!'

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -50,5 +50,7 @@ with pkgs;
 
   cuda = callPackage ./cuda { };
 
+  trivial = callPackage ../build-support/trivial-builders/test.nix {};
+
   writers = callPackage ../build-support/writers/test.nix {};
 }


### PR DESCRIPTION

###### Motivation for this change

1. Test and document `writeReferencesToFile`.
2. Add its little brother `writeDirectReferencesToFile` and test and document it as well.

The latter function is of course similar to `writeReferencesToFile`, but its output
 - does not contain the input path unless it is self-referencing
 - only contains direct dependencies instead of the whole transitive closure

If you want to copy the closure of a string rather than of a derivation, you can use this function after `writeText` to get the string context, all from within Nix. This is more efficient in some use cases, such as the `hercules-ci-effects` ssh helper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] **N/A** Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] **N/A** Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
