### PR TITLE
vimPlugins.vim-easyescape: init at 2020-11-22 and vimPlugins.edge: init at 2021-05-08

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -5942,6 +5942,18 @@ final: prev:
     meta.homepage = "https://github.com/junegunn/vim-easy-align/";
   };
 
+  vim-easyescape = buildVimPluginFrom2Nix {
+    pname = "vim-easyescape";
+    version = "2020-11-22";
+    src = fetchFromGitHub {
+      owner = "zhou13";
+      repo = "vim-easyescape";
+      rev = "fd7875f1657fd54fae85088acf289b9723d8a790";
+      sha256 = "0h8kmhliicbdqhximp3d961crp6qkjjs4yciksl037ds47kzrkif";
+    };
+    meta.homepage = "https://github.com/zhou13/vim-easyescape/";
+  };
+
   vim-easygit = buildVimPluginFrom2Nix {
     pname = "vim-easygit";
     version = "2018-07-08";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -1290,6 +1290,18 @@ final: prev:
     meta.homepage = "https://github.com/Shougo/echodoc.vim/";
   };
 
+  edge = buildVimPluginFrom2Nix {
+    pname = "edge";
+    version = "2021-05-08";
+    src = fetchFromGitHub {
+      owner = "sainnhe";
+      repo = "edge";
+      rev = "8f4cc117b703168f6c5d03ef65b36b095bb3f981";
+      sha256 = "0rq256pwfrxpgy9w2wx4fk9jddmb0xrifhnjkdjf3cmir8xdl7mp";
+    };
+    meta.homepage = "https://github.com/sainnhe/edge/";
+  };
+
   editorconfig-vim = buildVimPluginFrom2Nix {
     pname = "editorconfig-vim";
     version = "2021-04-04";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -556,6 +556,7 @@ rstacruz/vim-closer
 rust-lang/rust.vim
 ryanoasis/vim-devicons
 ryvnf/readline.vim
+sainnhe/edge
 sainnhe/sonokai
 sakhnik/nvim-gdb
 saltstack/salt-vim

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -779,4 +779,5 @@ yssl/QFEnter
 yuki-yano/ncm2-dictionary
 yunlingz/ci_dark
 zah/nim.vim
+zhou13/vim-easyescape
 ziglang/zig.vim


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds vim-easyescape and the edge colorscheme plugins

###### Things done
Tested that both plugins build correctly using `nix-build -A vimPlugins.vim-easyescape` and `nix-build -A vimPlugins.edge`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
