### PR TITLE
merge some of flake-utils into nixpkgs

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -309,7 +309,7 @@ rec {
    *
    * Type:
    *   mapAttrsJump ::
-   *     [String] -> (String -> AttrSet) -> AttrSet<String, AttrSet>
+   *     [a] -> (a -> AttrSet<b, c>) -> AttrSet<b, AttrSet<a, c>>
    *
    * Example:
    *   mapAttrsJump ["x86_64-linux"] (system: { hello = 42; })

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -79,7 +79,9 @@ let
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
       getLib getDev getMan chooseDevOutputs zipWithNames zip
-      recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets;
+      recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets
+      mapAttrsJump
+      ;
     inherit (self.lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -9,6 +9,20 @@ rec {
   examples = import ./examples.nix { inherit lib; };
   architectures = import ./architectures.nix { inherit lib; };
 
+  # List of all our tier 1 systems
+  tier1 = [
+    "x86_64-linux"
+  ];
+
+  # List of all our tier 2 systems
+  tier2 = [
+    "aarch64-linux"
+    "x86_64-darwin"
+  ];
+
+  # TODO: all the other tiers and systems
+  # See https://github.com/NixOS/rfcs/blob/fd559bdb8276901711e8813cbbf45a1f02578833/rfcs/0046-platform-support-tiers.md
+
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
   # necessary.
   #


### PR DESCRIPTION
###### Motivation for this change

90% of the flakes out there are using flake-utils' eachDefaultSystem.

Since all the flakes that use flake-utils also use nixpkgs as a dependency,
move that functionality here.

Before:

```nix
{
  description = "Flake utils demo";

  inputs.flake-utils.url = "github:numtide/flake-utils";

  outputs = { self, nixpkgs, flake-utils }:
    flake-utils.lib.eachDefaultSystem (system:
      let pkgs = nixpkgs.legacyPackages.${system}; in
      rec {
        packages = {
          hello = pkgs.hello;
        };
        defaultPackage = packages.hello;
      }
    );
}
```

After:


```nix
{
  description = "Flake utils demo";

  outputs = { self, nixpkgs }:
    nixpkgs.lib.mapAttrsJump (nixpkgs.lib.systems.tier1 ++ lib.systems.tier2) (system:
      let pkgs = nixpkgs.legacyPackages.${system}; in
      rec {
        packages = {
          hello = pkgs.hello;
        };
        defaultPackage = packages.hello;
      }
    );
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).