### PR TITLE
[staging-next] llvmPackages_{7-12} stdenvs: link all resource files from compiler-rt

### DIFF
--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -26,7 +26,9 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
-      ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
+      mkdir -p "$rsrc/share"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share/"* "$rsrc/share/"
+      ln -s "${targetLlvmLibraries.compiler-rt.dev}/include/"*.txt "$rsrc/share/"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -28,7 +28,9 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
-      ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
+      mkdir -p "$rsrc/share"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share/"* "$rsrc/share/"
+      ln -s "${targetLlvmLibraries.compiler-rt.dev}/include/"*.txt "$rsrc/share/"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -35,7 +35,9 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
-      ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
+      mkdir -p "$rsrc/share"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share/"* "$rsrc/share/"
+      ln -s "${targetLlvmLibraries.compiler-rt.dev}/include/"*.txt "$rsrc/share/"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -26,6 +26,9 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      mkdir -p "$rsrc/share"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share/"* "$rsrc/share/"
+      ln -s "${targetLlvmLibraries.compiler-rt.dev}/include/"*.txt "$rsrc/share/"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -26,6 +26,9 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      mkdir -p "$rsrc/share"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share/"* "$rsrc/share/"
+      ln -s "${targetLlvmLibraries.compiler-rt.dev}/include/"*.txt "$rsrc/share/"
     '';
 
   in {

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -26,6 +26,9 @@ let
     '';
     mkExtraBuildCommands = cc: mkExtraBuildCommands0 cc + ''
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      mkdir -p "$rsrc/share"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/share/"* "$rsrc/share/"
+      ln -s "${targetLlvmLibraries.compiler-rt.dev}/include/"*.txt "$rsrc/share/"
     '';
 
   in {


### PR DESCRIPTION
Likely due to an oversight, after 7869d1654517c028aa76fc1dedc9b5ac301a867a
some of the resource files of compiler-rt are installed to $dev/include
instead of $out/share which breaks the assumption of multiple cc
wrappers in llvmPackages. To resolve this without causing a mass rebuild
on darwin, link the files from the wrong location into the correct place
in clang's resource root.

The proper fix for this is #123103 which however causes a darwin stdenv
rebuild and should go through staging first.

---

Not sure if this will work, waiting for the rebuild count from ofborg.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
