### PR TITLE
getxbook: fix clang build

### DIFF
--- a/pkgs/applications/misc/getxbook/default.nix
+++ b/pkgs/applications/misc/getxbook/default.nix
@@ -9,11 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0ihwrx4gspj8l7fc8vxch6dpjrw1lvv9z3c19f0wxnmnxhv1cjvs";
   };
 
-  NIX_CFLAGS_COMPILE = builtins.toString [
-    "-Wno-error=format-truncation"
-    "-Wno-error=deprecated-declarations"
-    "-Wno-error=stringop-overflow"
-  ];
+  NIX_CFLAGS_COMPILE = builtins.toString (
+    [ "-Wno-error=deprecated-declarations" ]
+      ++ lib.optionals (!stdenv.cc.isClang) [
+        "-Wno-error=format-truncation"
+        "-Wno-error=stringop-overflow"
+      ]
+  );
 
   buildInputs = [ openssl ];
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142030496/nixlog/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
