### PR TITLE
[staging-next] llvmPackages_{10,11,12}.compiler-rt: install resource txts to $out/share

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 35a48c6af29c..e4300f256091 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/11/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/11/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 7c127a93dfa7..6a95a65b70a7 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  

--- a/pkgs/development/compilers/llvm/12/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/gnu-install-dirs.patch
@@ -19,7 +19,7 @@ index 361538a58e47..f0d8d9ab80f1 100644
    # Install in Clang resource directory.
    install(FILES ${file_name}
 -    DESTINATION ${COMPILER_RT_INSTALL_PATH}/share
-+    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
++    DESTINATION ${COMPILER_RT_INSTALL_PATH}/${CMAKE_INSTALL_FULL_DATADIR}
      COMPONENT ${component})
    add_dependencies(${component} ${target_name})
  


### PR DESCRIPTION
This is a scaled back version of #123103 which doesn't cause a stdenv rebuild on darwin according to my testing,
I'm hoping ofborg will confirm that.

---

7869d1654517c028aa76fc1dedc9b5ac301a867a changed how resource files are
installed. Likely by accident, now some of the resource files are
installed to $dev/include instead of $out/share. This causes the cc
wrapper's resource-root to miss those files from compiler-rt as they are
in a different place than expected.

This commit fixes all instances of this incorrect installation for
llvmPackages_10, 11 and 12 which are the only llvm package sets which
link ${targetLlvmLibraries.compiler-rt.out}/share to the resource-root.

For the other llvm package set this will likely also need to be fixed,
but it doesn't have to have immediate urgency and doing it in two steps
allows us to (hopefully) fix the chromium build without causing a darwin
stdenv rebuild.

The full fix can be found in #123103 and should probably be included in
the next staging-next rotation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
