### PR TITLE
godot: 3.2.2 -> 3.3.2

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, scons, pkg-config, libX11, libXcursor
-, libXinerama, libXrandr, libXrender, libpulseaudio ? null
+{ stdenv, lib, fetchFromGitHub, scons, pkg-config, libudev ? null, libX11
+, libXcursor , libXinerama, libXrandr, libXrender, libpulseaudio ? null
 , libXi ? null, libXext, libXfixes, freetype, openssl
 , alsaLib, libGLU, zlib, yasm ? null }:
 
@@ -7,7 +7,7 @@ let
   options = {
     touch = libXi != null;
     pulseaudio = false;
-    udev = false;
+    udev = libudev != null;
   };
 in stdenv.mkDerivation rec {
   pname = "godot";
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    scons libX11 libXcursor libXinerama libXrandr libXrender
+    scons libudev libX11 libXcursor libXinerama libXrandr libXrender
     libXi libXext libXfixes freetype openssl alsaLib libpulseaudio
     libGLU zlib yasm
   ];

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -7,16 +7,17 @@ let
   options = {
     touch = libXi != null;
     pulseaudio = false;
+    udev = false;
   };
 in stdenv.mkDerivation rec {
   pname = "godot";
-  version = "3.2.3";
+  version = "3.3";
 
   src = fetchFromGitHub {
     owner  = "godotengine";
     repo   = "godot";
     rev    = "${version}-stable";
-    sha256 = "19vrp5lhyvxbm6wjxzn28sn3i0s8j08ca7nani8l1nrhvlc8wi0v";
+    sha256 = "0lclrx0y7w1dah40053sjlppb6c5p32icq7x5pvdfgyd3i63mnbb";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -13,13 +13,13 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "godot";
-  version = "3.3";
+  version = "3.3.2";
 
   src = fetchFromGitHub {
     owner  = "godotengine";
     repo   = "godot";
     rev    = "${version}-stable";
-    sha256 = "0lclrx0y7w1dah40053sjlppb6c5p32icq7x5pvdfgyd3i63mnbb";
+    sha256 = "0rfm6sbbwzvsn76a8aqagd7cqdzmk8qxphgl89k7y982l9a5sz50";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, scons, pkg-config, libudev ? null, libX11
-, libXcursor , libXinerama, libXrandr, libXrender, libpulseaudio ? null
-, libXi ? null, libXext, libXfixes, freetype, openssl
-, alsaLib, libGLU, zlib, yasm ? null }:
+{ stdenv, lib, fetchFromGitHub, scons, pkg-config, libudev, libX11
+, libXcursor , libXinerama, libXrandr, libXrender, libpulseaudio
+, libXi, libXext, libXfixes, freetype, openssl
+, alsaLib, libGLU, zlib, yasm
+, withUdev ? true
+}:
 
 let
   options = {
     touch = libXi != null;
     pulseaudio = false;
-    udev = libudev != null;
+    udev = withUdev;
   };
 in stdenv.mkDerivation rec {
   pname = "godot";

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    scons libudev libX11 libXcursor libXinerama libXrandr libXrender
+    scons udev libX11 libXcursor libXinerama libXrandr libXrender
     libXi libXext libXfixes freetype openssl alsaLib libpulseaudio
     libGLU zlib yasm
   ];

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, scons, pkg-config, libudev, libX11
+{ stdenv, lib, fetchFromGitHub, scons, pkg-config, udev, libX11
 , libXcursor , libXinerama, libXrandr, libXrender, libpulseaudio
 , libXi, libXext, libXfixes, freetype, openssl
 , alsaLib, libGLU, zlib, yasm

--- a/pkgs/development/tools/godot/dont_clobber_environment.patch
+++ b/pkgs/development/tools/godot/dont_clobber_environment.patch
@@ -1,18 +1,19 @@
 diff --git a/SConstruct b/SConstruct
-index b3d033dc90..04b8dcc832 100644
+index d138c7b250..c925bf908e 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -62,10 +62,9 @@ elif platform_arg == "javascript":
-     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
- 
+@@ -65,10 +65,10 @@ elif platform_arg == "javascript":
+ # want to have to pull in manually.
+ # Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
  env_base = Environment(tools=custom_tools)
--if "TERM" in os.environ:
+-env_base.PrependENVPath("PATH", os.getenv("PATH"))
+-env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
+-if "TERM" in os.environ:  # Used for colored output.
 -    env_base["ENV"]["TERM"] = os.environ["TERM"]
--env_base.AppendENVPath("PATH", os.getenv("PATH"))
--env_base.AppendENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
 +for k in ("TERM", "PATH", "PKG_CONFIG_PATH"):
 +    if (k in os.environ):
 +        env_base["ENV"][k] = os.environ[k]
++
+
  env_base.disabled_modules = []
  env_base.use_ptrcall = False
- env_base.module_version_string = ""

--- a/pkgs/development/tools/godot/pkg_config_additions.patch
+++ b/pkgs/development/tools/godot/pkg_config_additions.patch
@@ -1,5 +1,5 @@
 diff --git a/platform/x11/detect.py b/platform/x11/detect.py
-index 91652aad55..e1cff3a4f2 100644
+index 91652aad55..d12389f9f2 100644
 --- a/platform/x11/detect.py
 +++ b/platform/x11/detect.py
 @@ -218,6 +218,11 @@ def configure(env):
@@ -21,3 +21,12 @@ index 91652aad55..e1cff3a4f2 100644
 +        env.ParseConfig("pkg-config alsa --cflags --libs")
      else:
          print("ALSA libraries not found, disabling driver")
+
+@@ -340,6 +346,7 @@ def configure(env):
+             if os.system("pkg-config --exists libudev") == 0:  # 0 means found
+                 print("Enabling udev support")
+                 env.Append(CPPDEFINES=["UDEV_ENABLED"])
++                env.ParseConfig("pkg-config libudev --cflags --libs")
+             else:
+                 print("libudev development libraries not found, disabling udev support")
+     else:

--- a/pkgs/development/tools/godot/pkg_config_additions.patch
+++ b/pkgs/development/tools/godot/pkg_config_additions.patch
@@ -1,11 +1,11 @@
 diff --git a/platform/x11/detect.py b/platform/x11/detect.py
-index 5674e78350..7051d8e73c 100644
+index 91652aad55..e1cff3a4f2 100644
 --- a/platform/x11/detect.py
 +++ b/platform/x11/detect.py
-@@ -201,6 +201,11 @@ def configure(env):
+@@ -218,6 +218,11 @@ def configure(env):
      env.ParseConfig("pkg-config xrender --cflags --libs")
      env.ParseConfig("pkg-config xi --cflags --libs")
- 
+
 +    env.ParseConfig("pkg-config xext --cflags --libs")
 +    env.ParseConfig("pkg-config xfixes --cflags --libs")
 +    env.ParseConfig("pkg-config glu --cflags --libs")
@@ -13,13 +13,11 @@ index 5674e78350..7051d8e73c 100644
 +
      if env["touch"]:
          env.Append(CPPDEFINES=["TOUCH_ENABLED"])
- 
-@@ -299,7 +304,7 @@ def configure(env):
+
+@@ -323,6 +328,7 @@ def configure(env):
          print("Enabling ALSA")
+         env["alsa"] = True
          env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
-         # Don't parse --cflags, we don't need to add /usr/include/alsa to include path
--        env.ParseConfig("pkg-config alsa --libs")
 +        env.ParseConfig("pkg-config alsa --cflags --libs")
      else:
          print("ALSA libraries not found, disabling driver")
- 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the most recent version of Godot 3.x.

###### Additional Notes

I'm not quite sure why the patch files are necessary (or if they still are), but I've updated them to cleanly apply to the updated Godot codebase.

Additionally, I had to add an extra build option (`udev = false;`) to get it to build. If I read [Godot's build docs](https://docs.godotengine.org/en/stable/development/compiling/compiling_for_x11.html#doc-compiling-for-x11) correctly, the default is supposed to be `false`, but without explicitly adding the flag, it tries to build with `libudev`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
