### PR TITLE
Tinydns: test more requests

### DIFF
--- a/nixos/tests/tinydns.nix
+++ b/nixos/tests/tinydns.nix
@@ -21,6 +21,7 @@ import ./make-test-python.nix ({ lib, ...} : {
   testScript = ''
     nameserver.start()
     nameserver.wait_for_unit("tinydns.service")
-    nameserver.succeed("host bla.foo.bar 192.168.1.1 | grep '1\.2\.3\.4'")
+    for loop in range(100):
+        nameserver.succeed("host bla.foo.bar 192.168.1.1 | grep '1\.2\.3\.4'")
   '';
 })

--- a/pkgs/tools/networking/djbdns/default.nix
+++ b/pkgs/tools/networking/djbdns/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, glibc, dns-root-data } :
+{ lib, stdenv, fetchurl, glibc, dns-root-data, nixosTests } :
 
 let
   version = "1.05";
@@ -40,6 +40,10 @@ stdenv.mkDerivation {
     done;
     rm -rv djbdns-man;
   '';
+
+  passthru.tests = {
+    tinydns = nixosTests.tinydns;
+  };
 
   meta = with lib; {
     description = "A collection of Domain Name System tools";


### PR DESCRIPTION
###### Motivation for this change

Related to #119066.
This does NOT fix the issue and the test currently does NOT pass.
This adds a test to ensure that the case will be tested and a fix will not regress.

Let me know what you think: the loop should be done in python or in bash? Is testing 100 times OK? It fails currently on my machine after 9 successful requests but since this is memory-related it's not trivial to design a good test.

I also added a link between the package and the test,  like #118442.

cc @jerith666 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
