### PR TITLE
curlftpfs: fix sandboxed builds on darwin

### DIFF
--- a/pkgs/tools/filesystems/curlftpfs/default.nix
+++ b/pkgs/tools/filesystems/curlftpfs/default.nix
@@ -1,11 +1,21 @@
 { lib, stdenv, fetchurl, autoreconfHook, fuse, curl, pkg-config, glib, zlib }:
 
-stdenv.mkDerivation {
-  name = "curlftpfs-0.9.2";
+stdenv.mkDerivation rec {
+  pname = "curlftpfs";
+  version = "0.9.2";
+
   src = fetchurl {
-    url = "mirror://sourceforge/curlftpfs/curlftpfs-0.9.2.tar.gz";
+    url = "mirror://sourceforge/curlftpfs/curlftpfs-${version}.tar.gz";
     sha256 = "0n397hmv21jsr1j7zx3m21i7ryscdhkdsyqpvvns12q7qwwlgd2f";
   };
+
+  patches = [
+    # This removes AC_FUNC_MALLOC and AC_FUNC_REALLOC from configure.ac because
+    # it is known to cause problems. Search online for "rpl_malloc" and
+    # "rpl_realloc" to find out more.
+    ./fix-rpl_malloc.patch
+  ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ fuse curl glib zlib ];
 
@@ -24,7 +34,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Filesystem for accessing FTP hosts based on FUSE and libcurl";
     homepage = "http://curlftpfs.sourceforge.net";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/curlftpfs/fix-rpl_malloc.patch
+++ b/pkgs/tools/filesystems/curlftpfs/fix-rpl_malloc.patch
@@ -1,0 +1,13 @@
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2008-04-23 20:37:42.000000000 +0900
++++ b/configure.ac	2021-05-16 01:28:24.000000000 +0900
+@@ -46,9 +46,7 @@
+ 
+ # Checks for library functions.
+ AC_FUNC_CHOWN
+-AC_FUNC_MALLOC
+ AC_FUNC_MKTIME
+-AC_FUNC_REALLOC
+ AC_FUNC_SELECT_ARGTYPES
+ AC_FUNC_STRFTIME
+ AC_FUNC_UTIME_NULL


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This fixes sandboxed builds on Darwin.

ZHF: #122042

ping @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
