### PR TITLE
cask: Fix shebang of cask executable

### DIFF
--- a/pkgs/development/tools/cask/default.nix
+++ b/pkgs/development/tools/cask/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, python3, emacs }:
+{ lib, stdenv, python3, emacs, bash }:
 
 stdenv.mkDerivation rec {
   pname = "cask";
@@ -13,15 +13,19 @@ stdenv.mkDerivation rec {
     noflet ert-async shell-split-string git package-build
   ] ++ [
     python3
+    bash
   ];
 
   strictDeps = true;
 
   buildPhase = ''
+    runHook preBuild
     emacs --batch -L . -f batch-byte-compile cask.el cask-cli.el
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     mkdir -p $out/templates
     mkdir -p $out/share/emacs/site-lisp/cask/bin
@@ -30,6 +34,7 @@ stdenv.mkDerivation rec {
     install -Dm644 templates/* $out/templates/
     touch $out/.no-upgrade
     ln -s $out/share/emacs/site-lisp/cask/bin/cask $out/bin/cask
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Hi, the cask executable was broken. To fix the issue the shebang was set correctly.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
