### PR TITLE
Libwebsockets: add and use 4.2.0 as default

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -20,6 +20,8 @@ let
       "-DLWS_WITH_PLUGINS=ON"
       "-DLWS_WITH_IPV6=ON"
       "-DLWS_WITH_SOCKS5=ON"
+      # Required since v4.2.0
+      "-DLWS_BUILD_HASH=no_hash"
     ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON";
 
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-error=unused-but-set-variable";
@@ -60,5 +62,10 @@ rec {
   libwebsockets_4_1 = generic {
     version = "4.1.6";
     sha256 = "0x56v4hsx92vm1zibfmnqb5g3v23kzciffn3fjlsc3sly2pknhsg";
+  };
+
+  libwebsockets_4_2 = generic {
+    version = "4.2.0";
+    sha256 = "glnLGXniero/5CW/1TBPZngdOM6gww8DnT5wiX66sW0=";
   };
 }

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -54,16 +54,6 @@ rec {
     sha256 = "0m1kn4p167jv63zvwhsvmdn8azx3q7fkk8qc0fclwyps2scz6dna";
   };
 
-  libwebsockets_4_0 = generic {
-    version = "4.0.21";
-    sha256 = "01k05x4711ngin598jr9dag4ml3m7hi6pkgr4dsb02ryh1kc6146";
-  };
-
-  libwebsockets_4_1 = generic {
-    version = "4.1.6";
-    sha256 = "0x56v4hsx92vm1zibfmnqb5g3v23kzciffn3fjlsc3sly2pknhsg";
-  };
-
   libwebsockets_4_2 = generic {
     version = "4.2.0";
     sha256 = "glnLGXniero/5CW/1TBPZngdOM6gww8DnT5wiX66sW0=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6502,7 +6502,8 @@ in
     libwebsockets_3_1
     libwebsockets_3_2
     libwebsockets_4_0
-    libwebsockets_4_1;
+    libwebsockets_4_1
+    libwebsockets_4_2;
   libwebsockets = libwebsockets_3_2;
 
   licensee = callPackage ../tools/package-management/licensee { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6504,7 +6504,7 @@ in
     libwebsockets_4_0
     libwebsockets_4_1
     libwebsockets_4_2;
-  libwebsockets = libwebsockets_3_2;
+  libwebsockets = libwebsockets_4_2;
 
   licensee = callPackage ../tools/package-management/licensee { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6501,8 +6501,6 @@ in
   inherit (callPackages ../development/libraries/libwebsockets { })
     libwebsockets_3_1
     libwebsockets_3_2
-    libwebsockets_4_0
-    libwebsockets_4_1
     libwebsockets_4_2;
   libwebsockets = libwebsockets_4_2;
 


### PR DESCRIPTION
###### Motivation for this change

Add a libwebsockets version 4.2.0 and make it default. I think it's most logical to track the latest version, and I got everything to build.

Depends on https://github.com/NixOS/nixpkgs/pull/123135 for a successful ttyd build.

Please also look at the commit messages, I'm not sure if they're fully conforming the standards.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
    - [ ] ardour: already broken on hydra
    - [x] ttyd: bumping version makes it compile (https://github.com/NixOS/nixpkgs/pull/123135)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
