### PR TITLE
plantuml-server: 1.2020.14 -> 1.2021.6

### DIFF
--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -1,30 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, maven, jdk }:
+{ lib, stdenv, fetchFromGitHub, maven, jdk8_headless }:
 
 let
-  version = "1.2020.14";
+  version = "1.2021.6";
 
   src = fetchFromGitHub {
     owner = "plantuml";
     repo = "plantuml-server";
     rev = "v${version}";
-    sha256 = "08g6ddpkly5yhjhw7gpsanyspar1752jy9cypwxsqrdzqrv738b8";
+    sha256 = "sha256:1v69vabdq9pv75wzb6n5s198iy5ijfcx6lgjqwxz7n5ns3blf6sz";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
   deps = stdenv.mkDerivation {
     name = "plantuml-server-${version}-deps";
     inherit src;
-    buildInputs = [ jdk maven ];
+    nativeBuildInputs = [ jdk8_headless maven ];
     buildPhase = ''
+      runHook preBuild
+
       while mvn package -Dmaven.repo.local=$out/.m2; [ $? = 1 ]; do
         echo "timeout, restart maven to continue downloading"
       done
+
+      runHook postBuild
     '';
     # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
     installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "1wwgyjalhlj5azggs9vvsrr54pg7gl8p36pgf6pk12rsszzl7a97";
+    outputHash = "sha256:1fvir7yvg4a4dc4kiv2d5q081cygj7s2lmxj90j8zzkggyq7v8zh";
   };
 in
 
@@ -33,25 +37,33 @@ stdenv.mkDerivation rec {
   inherit version;
   inherit src;
 
-  buildInputs = [ jdk maven ];
+  nativeBuildInputs = [ jdk8_headless maven ];
 
   buildPhase = ''
+    runHook preBuild
+
     # 'maven.repo.local' must be writable so copy it out of nix store
     cp -R $src repo
     chmod +w -R repo
     cd repo
     mvn package --offline -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/webapps"
     cp "target/plantuml.war" "$out/webapps/plantuml.war"
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "A web application to generate UML diagrams on-the-fly.";
     homepage = "https://plantuml.com/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ truh ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update PlantUML Server to the current release 1.2021.6.

plantuml-server is currently on the list of failing Hydra packages

ZHF: #122042

@NixOS/nixos-release-managers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)

10593080 -> 24907536

- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
