### PR TITLE
fetchurl: add testpypi mirror

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -417,6 +417,11 @@
     "https://pypi.io/packages/source/"
   ];
 
+  # Python Test-PyPI mirror
+  testpypi = [
+    "https://test.pypi.io/packages/source/"
+  ];
+
   # Mozilla projects.
   mozilla = [
     "http://download.cdn.mozilla.net/pub/mozilla.org/"


### PR DESCRIPTION
This should make it easier to run nixpkgs-based tests from versions that
are still only on test-pypi, and should not cost anything significant.

### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 21.05, sandbox = "true"
**packages declared changed:** {"fetchurl"}
**manual tests declared performed:**
 * ✔ built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions
 * building rss2email v3.13.1 from test-pypi
 * running nixosTests.rss2email from that version

**complies with contributing.md:** ✔ yes
**package fetchurl:** 😢 still does not build