### PR TITLE
zprint: init at 1.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9481,6 +9481,12 @@
     githubId = 1699155;
     name = "Steve Elliott";
   };
+  stelcodes = {
+    email = "stel@stel.codes";
+    github = "stelcodes";
+    githubId = 22163194;
+    name = "Stel Abrego";
+  };
   stephank = {
     email = "nix@stephank.nl";
     github = "stephank";

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, fetchurl, graalvm11-ce, glibcLocales }:
+
+stdenv.mkDerivation rec {
+  pname = "zprint";
+  version = "1.1.2";
+
+  src = fetchurl {
+    url =
+      "https://github.com/kkinnear/${pname}/releases/download/${version}/${pname}-filter-${version}";
+    sha256 = "1wh8jyj7alfa6h0cycfwffki83wqb5d5x0p7kvgdkhl7jx7isrwj";
+  };
+
+  dontUnpack = true;
+
+  LC_ALL = "en_US.UTF-8";
+  nativeBuildInputs = [ graalvm11-ce glibcLocales ];
+
+  buildPhase = ''
+    native-image \
+    --no-server \
+    -J-Xmx7G \
+    -J-Xms4G \
+    -jar ${src} \
+    -H:Name=${pname} \
+    -H:EnableURLProtocols=https,http \
+    -H:+ReportExceptionStackTraces \
+    --report-unsupported-elements-at-runtime \
+    --initialize-at-build-time \
+    --no-fallback
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install ${pname} $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Clojure/EDN source code formatter and pretty printer";
+    longDescription = ''
+      Library and command line tool providing a variety of pretty printing capabilities
+      for both Clojure code and Clojure/EDN structures. It can meet almost anyone's needs.
+      As such, it supports a number of major source code formatting approaches
+    '';
+    homepage = "https://github.com/kkinnear/zprint";
+    license = licenses.mit;
+    platforms = graalvm11-ce.meta.platforms;
+    maintainers = with maintainers; [ stelcodes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9868,6 +9868,8 @@ in
 
   yj = callPackage ../development/tools/yj { };
 
+  zprint = callPackage ../development/tools/zprint { };
+
   yle-dl = callPackage ../tools/misc/yle-dl {};
 
   you-get = python3Packages.callPackage ../tools/misc/you-get { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding zprint to nixpkgs, a clojure pretty printer and source code formatter.

###### Things done
Added myself to the maintainer list, added derivation for zprint

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
