### PR TITLE
(nixos/systemd): Add Persistent for services.

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -371,6 +371,21 @@ in rec {
       apply = v: if isList v then v else [ v ];
     };
 
+    persistent = mkOption {
+      type = types.bool;
+      default = false;
+      example = "true";
+      description = ''
+        When the timer is activated, trigger immediately if the timer would have
+        triggered at least once while the timer was inactive. Can be useful to
+        trigger missed runs of a service while the system was powered down. See
+        <citerefentry><refentrytitle>systemd.timer</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry>. This is equivalent to adding a
+        corresponding timer unit with <option>Persistent</option> set to the
+        value given here.
+      '';
+    };
+
   };
 
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1134,6 +1134,7 @@ in
       mapAttrs (name: service:
         { wantedBy = [ "timers.target" ];
           timerConfig.OnCalendar = service.startAt;
+          timerConfig.Persistent = service.persistent;
         })
         (filterAttrs (name: service: service.enable && service.startAt != []) cfg.services);
 
@@ -1142,6 +1143,7 @@ in
       mapAttrs (name: service:
         { wantedBy = [ "timers.target" ];
           timerConfig.OnCalendar = service.startAt;
+          timerConfig.Persistent = service.persistent;
         })
         (filterAttrs (name: service: service.startAt != []) cfg.user.services);
 


### PR DESCRIPTION
Persistent will check on startup if a timer trigger was missed while the
timer was inactive and trigger the timer once if it was.  This is useful
for computers to catch up on missed automated tasks from while they were
shut down.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This will enable us to provide the persistent option for system.autoUpgrade or services.borgbackup.jobs. That way, if you have a daily update or backup that is sometimes missed because your personal computer is off, it will catch up the next time you turn the computer on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS (n/a, nixos change)
   - [ ] other Linux distributions (n/a)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`). (I manually checked that the timer would work correctly for a service)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date (I added docs for the new options, not sure if that is everything).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
