### PR TITLE
gnucap: broken on darwin

### DIFF
--- a/pkgs/applications/science/electronics/gnucap/default.nix
+++ b/pkgs/applications/science/electronics/gnucap/default.nix
@@ -21,6 +21,7 @@ It performs nonlinear dc and transient analyses, fourier analysis, and ac analys
     changelog = "https://git.savannah.gnu.org/cgit/gnucap.git/plain/NEWS?h=v${version}";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
+    broken = stdenv.isDarwin; # Relies on LD_LIBRARY_PATH
     maintainers = [ maintainers.raboof ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142043222/log

I was trying to fix this, and this contains a partial fix of the build. However, the build relies on `LD_LIBRARY_PATH`, and I noticed the code does too. So my guess is this is not supported on Darwin.

I'm not sure how to indicate `platforms.unix - platforms.darwin`, because that'd be ideal, I think.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
