### PR TITLE
python3Packages.pyobihai: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/pyobihai/default.nix
+++ b/pkgs/development/python-modules/pyobihai/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pyobihai";
+  version = "1.3.1";
+  disabled = pythonOlder "3.6";
+
+  # GitHub release, https://github.com/dshokouhi/pyobihai/issues/10
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vvf5if57dfd091a7fb5rvx63hvf0isrx28j72nj2aav1as460qp";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyobihai" ];
+
+  meta = with lib; {
+    description = "Python package to interact with Obihai devices";
+    homepage = "https://github.com/dshokouhi/pyobihai";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -582,7 +582,7 @@
     "nx584" = ps: with ps; [ pynx584 ];
     "nzbget" = ps: with ps; [ ]; # missing inputs: pynzbgetapi
     "oasa_telematics" = ps: with ps; [ ]; # missing inputs: oasatelematics
-    "obihai" = ps: with ps; [ ]; # missing inputs: pyobihai
+    "obihai" = ps: with ps; [ pyobihai ];
     "octoprint" = ps: with ps; [ aiohttp-cors netdisco pyroute2 zeroconf ];
     "oem" = ps: with ps; [ ]; # missing inputs: oemthermostat
     "ohmconnect" = ps: with ps; [ defusedxml ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5911,6 +5911,8 @@ in {
 
   pynzb = callPackage ../development/python-modules/pynzb { };
 
+  pyobihai = callPackage ../development/python-modules/pyobihai { };
+
   pyocr = callPackage ../development/python-modules/pyocr {
     tesseract = pkgs.tesseract4;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package to interact with Obihai devices

https://github.com/dshokouhi/pyobihai

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
