### PR TITLE
vdr: 2.4.6 -> 2.4.7

### DIFF
--- a/pkgs/applications/video/vdr/default.nix
+++ b/pkgs/applications/video/vdr/default.nix
@@ -5,12 +5,12 @@
 }: stdenv.mkDerivation rec {
 
   pname = "vdr";
-  version = "2.4.6";
+  version = "2.4.7";
 
   src = fetchgit {
     url = "git://git.tvdr.de/vdr.git";
-    rev = "V20406";
-    sha256 = "sha256-te9lMmnWpesv+np2gJUDL17pI0WyVxhUnoBsFSRtOco=";
+    rev = version;
+    sha256 = "sha256-hDJ/DemWuLddDvXGqxkSTIqATlWUjolcP7ojjhK2CDk=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/video/vdr/default.nix
+++ b/pkgs/applications/video/vdr/default.nix
@@ -51,6 +51,6 @@
     description = "Video Disc Recorder";
     maintainers = [ maintainers.ck3d ];
     platforms = [ "i686-linux" "x86_64-linux" ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
