### PR TITLE
ffmpeg_4: fix build error on darwin

### DIFF
--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -9,4 +9,7 @@ callPackage ./generic.nix (rec {
   branch = "4.4";
   sha256 = "03kxc29y8190k4y8s8qdpsghlbpmchv1m8iqygq2qn0vfm4ka2a2";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
+
+  /* Work around https://trac.ffmpeg.org/ticket/9242 */
+  patches = [ ./v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch ];
 } // args)

--- a/pkgs/development/libraries/ffmpeg/v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch
+++ b/pkgs/development/libraries/ffmpeg/v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch
@@ -1,0 +1,35 @@
+From 5b562aaddbc6e7a94a079c2e88230b205a7f4d73 Mon Sep 17 00:00:00 2001
+From: Zane van Iperen <zane@zanevaniperen.com>
+Date: Sat, 15 May 2021 19:33:52 +1000
+Subject: [PATCH v2] avcodec/videotoolboxenc: #define TARGET_CPU_ARM64 to 0 if
+ not provided by the SDK
+
+Fixes build failure on older SDKs without it.
+
+Fixes #9242
+
+Signed-off-by: Zane van Iperen <zane@zanevaniperen.com>
+---
+ libavcodec/videotoolboxenc.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+NB: This is untested, I do not have a Mac to try it on.
+
+diff --git a/libavcodec/videotoolboxenc.c b/libavcodec/videotoolboxenc.c
+index 58239e0ab9..f063a86e73 100644
+--- a/libavcodec/videotoolboxenc.c
++++ b/libavcodec/videotoolboxenc.c
+@@ -50,6 +50,10 @@ enum { kCVPixelFormatType_420YpCbCr10BiPlanarFullRange = 'xf20' };
+ enum { kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange = 'x420' };
+ #endif
+ 
++#ifndef TARGET_CPU_ARM64
++#   define TARGET_CPU_ARM64 0
++#endif
++
+ typedef OSStatus (*getParameterSetAtIndex)(CMFormatDescriptionRef videoDesc,
+                                            size_t parameterSetIndex,
+                                            const uint8_t **parameterSetPointerOut,
+-- 
+2.29.3
+


### PR DESCRIPTION

###### Motivation for this change

Fix build on Darwin.

* https://hydra.nixos.org/build/142702864
* https://trac.ffmpeg.org/ticket/9242

ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
