### PR TITLE
python3Packages.gios: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/gios/default.nix
+++ b/pkgs/development/python-modules/gios/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-error-for-skips
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "gios";
+  version = "1.0.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bieniu";
+    repo = pname;
+    rev = version;
+    sha256 = "031z5j1j961pcw8s4ajj5z2xn2jxb2hyfn3x3bxbaagwl9a5qkvn";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    aioresponses
+    pytest-asyncio
+    pytest-error-for-skips
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov --cov-report term-missing " ""
+    substituteInPlace setup.py \
+      --replace "pytest-runner" ""
+  '';
+
+  disabledTests = [
+    # Test requires network access
+    "test_invalid_station_id"
+  ];
+
+  pythonImportsCheck = [ "gios" ];
+
+  meta = with lib; {
+    description = "Python client for getting air quality data from GIOS";
+    homepage = "https://github.com/bieniu/gios";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -303,7 +303,7 @@
     "geofency" = ps: with ps; [ aiohttp-cors ];
     "geonetnz_quakes" = ps: with ps; [ ]; # missing inputs: aio_geojson_geonetnz_quakes
     "geonetnz_volcano" = ps: with ps; [ ]; # missing inputs: aio_geojson_geonetnz_volcano
-    "gios" = ps: with ps; [ ]; # missing inputs: gios
+    "gios" = ps: with ps; [ gios ];
     "github" = ps: with ps; [ PyGithub ];
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [ ]; # missing inputs: gitterpy

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -359,6 +359,7 @@ in with py.pkgs; buildPythonApplication rec {
     "geo_location"
     "geofency"
     "glances"
+    "gios"
     "google"
     "google_assistant"
     "google_domains"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2752,6 +2752,8 @@ in {
 
   gin-config = callPackage ../development/python-modules/gin-config { };
 
+  gios = callPackage ../development/python-modules/gios { };
+
   gipc = callPackage ../development/python-modules/gipc { };
 
   git-annex-adapter =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for getting air quality data from GIOS

https://github.com/bieniu/gios

This is a Home Assistant dependency.

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50145
- Target Home Assistant release: 2021.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
