### PR TITLE
python3Packages.garages-amsterdam: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/garages-amsterdam/default.nix
+++ b/pkgs/development/python-modules/garages-amsterdam/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "garages-amsterdam";
+  version = "2.1.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "klaasnicolaas";
+    repo = "garages_amsterdam";
+    rev = version;
+    sha256 = "1lg66g0im6v0m294j82229n2b7bhs6kkrp0d9nh87k2rz7zgllil";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  # The only test requires network access
+  doCheck = false;
+
+  pythonImportsCheck = [ "garages_amsterdam" ];
+
+  meta = with lib; {
+    description = "Python client for getting garage occupancy in Amsterdam";
+    homepage = "https://github.com/klaasnicolaas/garages_amsterdam";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2624,6 +2624,8 @@ in {
 
   gast = callPackage ../development/python-modules/gast { };
 
+  garages-amsterdam = callPackage ../development/python-modules/garages-amsterdam { };
+
   gcovr = callPackage ../development/python-modules/gcovr { };
 
   gcsfs = callPackage ../development/python-modules/gcsfs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for getting garage occupancy in Amsterdam

https://github.com/klaasnicolaas/garages_amsterdam

This is  Home Assistant dependency. Integration will be introduced with 2021.6.0



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
