### PR TITLE
python3Packages.growattserver: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/growattserver/default.nix
+++ b/pkgs/development/python-modules/growattserver/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "growattserver";
+  version = "1.0.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "indykoning";
+    repo = "PyPi_GrowattServer";
+    rev = version;
+    sha256 = "1vgb92axlz1kkszmamjbsqgi74afnbr2mc1np3pmbn3bx5rmk1d9";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  postPatch = ''
+    # https://github.com/indykoning/PyPi_GrowattServer/issues/2
+    substituteInPlace setup.py \
+      --replace "tag = os.environ['LATEST_TAG']" "" \
+      --replace "version=tag," 'version="${version}",'
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "growattServer" ];
+
+  meta = with lib; {
+    description = "Python package to retrieve information from Growatt units";
+    homepage = "https://github.com/indykoning/PyPi_GrowattServer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -329,7 +329,7 @@
     "greeneye_monitor" = ps: with ps; [ ]; # missing inputs: greeneye_monitor
     "greenwave" = ps: with ps; [ ]; # missing inputs: greenwavereality
     "group" = ps: with ps; [ ];
-    "growatt_server" = ps: with ps; [ ]; # missing inputs: growattServer
+    "growatt_server" = ps: with ps; [ growattserver ];
     "gstreamer" = ps: with ps; [ ]; # missing inputs: gstreamer-player
     "gtfs" = ps: with ps; [ ]; # missing inputs: pygtfs
     "guardian" = ps: with ps; [ aioguardian ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -259,6 +259,7 @@ in with py.pkgs; buildPythonApplication rec {
     "geo_json_events"
     "geo_location"
     "group"
+    "growatt_server"
     "hddtemp"
     "history"
     "history_stats"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2934,6 +2934,8 @@ in {
 
   gremlinpython = callPackage ../development/python-modules/gremlinpython { };
 
+  growattserver = callPackage ../development/python-modules/growattserver { };
+
   grip = callPackage ../development/python-modules/grip { };
 
   grpc_google_iam_v1 = callPackage ../development/python-modules/grpc_google_iam_v1 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package to retrieve information from Growatt units

https://github.com/indykoning/PyPi_GrowattServer

This is a Home Assistant dependency.

- Related Home Assistant change: https://github.com/home-assistant/core/pull/41303
- Target Home Assistant release: 2021.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
