### PR TITLE
python3Packages.ha-philipsjs: init at 2.7.4

### DIFF
--- a/pkgs/development/python-modules/ha-philipsjs/default.nix
+++ b/pkgs/development/python-modules/ha-philipsjs/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, httpx
+, pytest-aiohttp
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, respx
+}:
+
+buildPythonPackage rec {
+  pname = "ha-philipsjs";
+  version = "2.7.4";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "danielperna84";
+    repo = pname;
+    rev = version;
+    sha256 = "08fjdb1q02dwxq8s15ddd00gps64xplblkn8dx5yivldskiy8i1n";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    httpx
+  ];
+
+  checkInputs = [
+    pytest-aiohttp
+    pytest-mock
+    pytestCheckHook
+    respx
+  ];
+
+  pythonImportsCheck = [ "haphilipsjs" ];
+
+  meta = with lib; {
+    description = "Python library to interact with Philips TVs with jointSPACE API";
+    homepage = "https://github.com/danielperna84/ha-philipsjs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -626,7 +626,7 @@
     "pencom" = ps: with ps; [ ]; # missing inputs: pencompy
     "persistent_notification" = ps: with ps; [ ];
     "person" = ps: with ps; [ aiohttp-cors pillow ];
-    "philips_js" = ps: with ps; [ ]; # missing inputs: ha-philipsjs
+    "philips_js" = ps: with ps; [ ha-philipsjs ];
     "pi4ioe5v9xxxx" = ps: with ps; [ ]; # missing inputs: pi4ioe5v9xxxx
     "pi_hole" = ps: with ps; [ hole ];
     "picnic" = ps: with ps; [ python-picnic-api ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -333,6 +333,7 @@ in with py.pkgs; buildPythonApplication rec {
     "panel_iframe"
     "persistent_notification"
     "person"
+    "philips_js"
     "plaato"
     "plugwise"
     "prometheus"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3015,6 +3015,8 @@ in {
 
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
 
+  ha-philipsjs = callPackage ../development/python-modules/ha-philipsjs{ };
+
   halo = callPackage ../development/python-modules/halo { };
 
   handout = callPackage ../development/python-modules/handout { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to interact with Philips TVs with jointSPACE API

https://github.com/danielperna84/ha-philipsjs

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
