### PR TITLE
gnomeExtensions.dynamic-panel-transparency: 35 -> unstable-2021-03-04

### DIFF
--- a/pkgs/desktops/gnome/extensions/dynamic-panel-transparency/default.nix
+++ b/pkgs/desktops/gnome/extensions/dynamic-panel-transparency/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-dynamic-panel-transparency";
-  version = "35";
+  version = "unstable-2021-03-04";
 
   src = fetchFromGitHub {
     owner = "ewlsh";
     repo = "dynamic-panel-transparency";
-    rev = "0800c0a921bb25f51f6a5ca2e6981b1669a69aec";
-    sha256 = "0200mx861mlsi9lf7h108yam02jfqqw55r521chkgmk4fy6z99pq";
+    rev = "f9e720e98e40c7a2d87928d09a7313c9ef2e832c";
+    sha256 = "0njykxjiwlcmk0q8bsgqaznsryaw43fspfs6rzsjjz5p0xaq04nw";
   };
 
   uuid = "dynamic-panel-transparency@rockon999.github.io";


### PR DESCRIPTION
###### Motivation for this change

This update adds GNOME [40](https://github.com/ewlsh/dynamic-panel-transparency/blob/f9e720e98e40c7a2d87928d09a7313c9ef2e832c/dynamic-panel-transparency%40rockon999.github.io/metadata.json#L5) support.

Please inform me if the chosen version (35-unstable-2021-03-04) is correct.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
