### PR TITLE
cntk: fix build

### DIFF
--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -33,6 +33,9 @@ in stdenv.mkDerivation rec {
   # Force OpenMPI to use g++ in PATH.
   OMPI_CXX = "g++";
 
+  # Uses some deprecated tensorflow functions
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
   buildInputs = [ openblas opencv3 libzip boost protobuf mpi ]
              ++ lib.optional cudaSupport cudatoolkit
              ++ lib.optional cudnnSupport cudnn;
@@ -40,7 +43,7 @@ in stdenv.mkDerivation rec {
   configureFlags = [
     "--with-opencv=${opencv3}"
     "--with-libzip=${libzip.dev}"
-    "--with-openblas=${openblas}"
+    "--with-openblas=${openblas.dev}"
     "--with-boost=${boost.dev}"
     "--with-protobuf=${protobuf}"
     "--with-mpi=${mpi}"


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042

@NixOS/nixos-release-managers 

I'm pretty weak with C++ and I haven't used this library, so this is my best guess at fixing this. It does build and run in general, but I haven't tested it aside from just running the binary.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).