### PR TITLE
cardboard: 0.0.0-unstable=2021-01-21 -> 0.0.0+unstable=2021-05-10

### DIFF
--- a/pkgs/applications/window-managers/cardboard/default.nix
+++ b/pkgs/applications/window-managers/cardboard/default.nix
@@ -15,6 +15,7 @@
 , mesa
 , meson
 , ninja
+, pandoc
 , pixman
 , pkg-config
 , unzip
@@ -56,18 +57,19 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cardboard";
-  version = "0.0.0-unstable=2021-01-21";
+  version = "0.0.0+unstable=2021-05-10";
 
   src = fetchFromGitLab {
     owner = "cardboardwm";
     repo = pname;
-    rev = "f2ef2ff076ddbbd23994553b8eff131f9bd0207f";
-    hash = "sha256-43aqAWk4QoIP0BpRyPRDWFtVh/1UbrBoEeTDEF2gZX4=";
+    rev = "b54758d85164fb19468f5ca52588ebea576cd027";
+    hash = "sha256-Kn5NyQSDyX7/nn2bKZPnsuepkoppi5XIkdu7IDy5r4w=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
+    pandoc
     pkg-config
     unzip
   ];
@@ -101,6 +103,7 @@ stdenv.mkDerivation rec {
 
   # "Inherited" from Nixpkgs expression for wlroots
   mesonFlags = [
+    "-Dman=true"
     "-Dwlroots:logind-provider=systemd"
     "-Dwlroots:libseat=disabled"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
