### PR TITLE
hetzner-kube: fix darwin build

### DIFF
--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -11,6 +11,13 @@ buildGoModule rec {
     sha256 = "1iqgpmljqx6rhmvsir2675waj78amcfiw08knwvlmavjgpxx2ysw";
   };
 
+  patches = [
+    # Use $HOME instead of the OS user database.
+    # Upstream PR: https://github.com/xetys/hetzner-kube/pull/346
+    # Unfortunately, the PR patch does not apply against release.
+    ./fix-home.patch
+  ];
+
   vendorSha256 = "1jh2f66ys6rmrrwrf5zqfprgcvziyq6l4z8bfqwxgf1ysnxx525h";
 
   doCheck = false;
@@ -25,6 +32,8 @@ buildGoModule rec {
   ];
 
   postInstall = ''
+    # Need a writable home, because it fails if unable to write config.
+    export HOME=$TMP
     $out/bin/hetzner-kube completion bash > hetzner-kube
     $out/bin/hetzner-kube completion zsh > _hetzner-kube
     installShellCompletion --zsh _hetzner-kube

--- a/pkgs/applications/networking/cluster/hetzner-kube/fix-home.patch
+++ b/pkgs/applications/networking/cluster/hetzner-kube/fix-home.patch
@@ -1,0 +1,53 @@
+diff --git a/cmd/cluster_kubeconfig.go b/cmd/cluster_kubeconfig.go
+index 54cc0c9..fab288a 100644
+--- a/cmd/cluster_kubeconfig.go
++++ b/cmd/cluster_kubeconfig.go
+@@ -6,7 +6,7 @@ import (
+ 	"io/ioutil"
+ 	"log"
+ 	"os"
+-	"os/user"
++	"path/filepath"
+ 	"strings"
+ 
+ 	"github.com/spf13/cobra"
+@@ -52,9 +52,8 @@ Example 4: hetzner-kube cluster kubeconfig -n my-cluster -p > my-conf.yaml # pri
+ 		} else {
+ 			fmt.Println("create file")
+ 
+-			usr, _ := user.Current()
+-			dir := usr.HomeDir
+-			path := fmt.Sprintf("%s/.kube", dir)
++			dir, _ := os.UserHomeDir()
++			path := filepath.Join(dir, ".kube")
+ 
+ 			if _, err := os.Stat(path); os.IsNotExist(err) {
+ 				os.MkdirAll(path, 0755)
+diff --git a/cmd/config.go b/cmd/config.go
+index ce0f3e5..a03c4ba 100644
+--- a/cmd/config.go
++++ b/cmd/config.go
+@@ -8,7 +8,6 @@ import (
+ 	"io/ioutil"
+ 	"log"
+ 	"os"
+-	"os/user"
+ 	"path/filepath"
+ 
+ 	"github.com/hetznercloud/hcloud-go/hcloud"
+@@ -28,13 +27,8 @@ type AppSSHClient struct {
+ // NewAppConfig creates a new AppConfig struct using the locally saved configuration file. If no local
+ // configuration file is found a new config will be created.
+ func NewAppConfig() AppConfig {
+-	usr, err := user.Current()
+-	if err != nil {
+-		return AppConfig{}
+-	}
+-	if usr.HomeDir != "" {
+-		DefaultConfigPath = filepath.Join(usr.HomeDir, ".hetzner-kube")
+-	}
++	dir, _ := os.UserHomeDir()
++	DefaultConfigPath = filepath.Join(dir, ".hetzner-kube")
+ 
+ 	appConf := AppConfig{
+ 		Context: context.Background(),


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142736383/log

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
