### PR TITLE
heimdall-gui: fix darwin build

### DIFF
--- a/pkgs/tools/misc/heimdall/default.nix
+++ b/pkgs/tools/misc/heimdall/default.nix
@@ -31,7 +31,11 @@ mkDerivation {
     substituteInPlace libpit/CMakeLists.txt --replace "-std=gnu++11" ""
   '';
 
-  installPhase = ''
+  installPhase = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv bin/heimdall-frontend.app $out/Applications/heimdall-frontend.app
+    wrapQtApp $out/Applications/heimdall-frontend.app/Contents/MacOS/heimdall-frontend
+  '' + ''
     mkdir -p $out/{bin,share/doc/heimdall,lib/udev/rules.d}
     install -m755 -t $out/bin                bin/*
     install -m644 -t $out/lib/udev/rules.d   ../heimdall/60-heimdall.rules


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142504831/nixlog/1

Note that this does **NOT** yet result in a working heimdall-frontend.app, but is what I could fix in reasonable time. The app now launches, shows in the dock, but is 'not responding' and goes into what appears to be a tight rendering loop with nothing on screen. One CPU is pegged at 100%, and interrupting with lldb only shows AppKit / Qt stuff in the backtrace.

We seem to have a general Qt on Darwin issue here, because I had the exact same problem with Communi.app in #122563.

~~I hope the `wrapQtAppsHook` is the correct fix here, and that it is also appropriate for Linux.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
