### PR TITLE
minio: 2021-05-11T23-27-41Z -> 2021-05-16T05-32-34Z

### DIFF
--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -15,16 +15,16 @@ let
 in
 buildGoModule rec {
   pname = "minio";
-  version = "2021-05-11T23-27-41Z";
+  version = "2021-05-16T05-32-34Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "0yljq4lm9maz73ha9m38ljv977999p57rfkzybgzbjjrijgszm2b";
+    sha256 = "sha256-+zanqJMYNg/1c20cMm+bqVsW8VquucxEK5NiFAqOmS0=";
   };
 
-  vendorSha256 = "1dm8nbg86zvxakc7h4dafqb035sc5x6viz8p409l22l695qrp6bi";
+  vendorSha256 = "sha256-5aDD68nugFyWsySLEj7LXAdtFXFKWnqfz+5zF5wC2qw=";
 
   doCheck = false;
 

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -30,25 +30,18 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  postPatch = ''
-    sed -i "s/Version.*/Version = \"${versionToTimestamp version}\"/g" cmd/build-constants.go
-    sed -i "s/ReleaseTag.*/ReleaseTag = \"RELEASE.${version}\"/g" cmd/build-constants.go
-    sed -i "s/CommitID.*/CommitID = \"${src.rev}\"/g" cmd/build-constants.go
-  '';
-
-  postConfigure = ''
-    export CGO_ENABLED=0
-  '';
-
-  buildFlagsArray = [
-    "-tags=kqueue"
-  ];
+  preBuild = let t = "github.com/minio/minio/cmd"; in
+    ''
+      export CGO_ENABLED=0
+      buildFlagsArray+=("-tags" "kqueue" "-ldflags" "-s -w -X ${t}.Version=${versionToTimestamp version} -X ${t}.ReleaseTag=RELEASE.${version} -X ${t}.CommitID=${src.rev}")
+    '';
 
   passthru.tests.minio = nixosTests.minio;
 
   meta = with lib; {
     homepage = "https://www.minio.io/";
     description = "An S3-compatible object storage server";
+    changelog = "https://github.com/minio/minio/releases/tag/RELEASE.${version}";
     maintainers = with maintainers; [ eelco bachp ];
     platforms = platforms.unix;
     license = licenses.agpl3Plus;

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -51,6 +51,6 @@ buildGoModule rec {
     description = "An S3-compatible object storage server";
     maintainers = with maintainers; [ eelco bachp ];
     platforms = platforms.unix;
-    license = licenses.asl20;
+    license = licenses.agpl3Plus;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- fix license change
- set version variables with ldflags
- Bump minio to `2021-05-16T05-32-34Z`

Build and NixOS test passed


```
λ ./result/bin/minio -v
minio version RELEASE.2021-05-16T05-32-34Z
λ ./result/bin/minio --help
NAME:
  minio - High Performance Object Storage

DESCRIPTION:
  Build high performance data infrastructure for machine learning, analytics and application data workloads with MinIO

USAGE:
  minio [FLAGS] COMMAND [ARGS...]

COMMANDS:
  server   start object storage server
  gateway  start object storage gateway

FLAGS:
  --certs-dir value, -S value  path to certs directory (default: "/home/jk/.minio/certs")
  --quiet                      disable startup information
  --anonymous                  hide sensitive information from logging
  --json                       output server logs and startup information in json format
  --help, -h                   show help
  --version, -v                print the version

VERSION:
  RELEASE.2021-05-16T05-32-34Z
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
