### PR TITLE
eukleides: use $CC instead of hardcoded gcc, build on more platforms

### DIFF
--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -9,6 +9,9 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
     sha256 = "0s8cyh75hdj89v6kpm3z24i48yzpkr8qf0cwxbs9ijxj1i38ki0q";
   };
 
+  # use $CC instead of hardcoded gcc
+  patches = [ ./use-CC.patch ];
+
   nativeBuildInputs = [ bison flex texinfo makeWrapper ];
 
   buildInputs = [ readline texLive ];
@@ -59,7 +62,7 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
       circles and conics.
     '';
 
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.peti ];
   };
 })

--- a/pkgs/applications/science/math/eukleides/use-CC.patch
+++ b/pkgs/applications/science/math/eukleides/use-CC.patch
@@ -1,0 +1,11 @@
+--- a/build/Makefile
++++ b/build/Makefile
+@@ -11,7 +11,7 @@ LEX = flex
+ LFLAGS = -8
+ YACC = bison
+ YFLAGS = -d
+-CC = gcc
++CC ?= gcc
+ IFLAGS = -I$(COMMON_DIR) -I$(MAIN_DIR) -I$(BUILD_DIR) 
+ ifneq ($(strip $(LOCALES)),)
+ MOFLAGS = -DMO_DIR=\"$(MO_DIR)\" 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The package hardcodes `gcc`, but it builds just as well with `clang`. With the PR, the package builds with whatever `$CC` is available. It should work on all Unix platforms.

Question: should I use `lib.platforms.all`?

Cc @SFrijters

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
