### PR TITLE
python3Packages.flask-appbuilder: 3.2.3 -> 3.3.0

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, nose
 , apispec
 , colorama
 , click
@@ -27,15 +26,16 @@
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "3.2.3";
+  version = "3.3.0";
 
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "sha256-+ZYrn2LnVORyYsnZtsH3JX+4XbGgAZZ/Eh6O5gUP+y4=";
+    sha256 = "00dsfv1apl6483wy20aj91f9h5ak2casbx5vcajv2nd3i7c7v8gx";
   };
 
   patches = [
+    # https://github.com/dpgaspar/Flask-AppBuilder/pull/1610
     (fetchpatch {
       name = "flask_jwt_extended-and-pyjwt-patch";
       url = "https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch";
@@ -75,7 +75,7 @@ buildPythonPackage rec {
       --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy >=0.22.0, <0.25.0"
   '';
 
-  # majority of tests require network access or mongo
+  # Majority of tests require network access or mongo
   doCheck = false;
 
   pythonImportsCheck = [ "flask_appbuilder" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.3.0

Change log: https://github.com/dpgaspar/Flask-AppBuilder/releases/tag/v3.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
