### PR TITLE
ldgallery: fix darwin build

### DIFF
--- a/pkgs/tools/graphics/ldgallery/default.nix
+++ b/pkgs/tools/graphics/ldgallery/default.nix
@@ -1,10 +1,10 @@
-{ lib, pkgs, makeWrapper, haskellPackages, haskell, pandoc, imagemagick }:
+{ lib, pkgs, makeWrapper, haskellPackages, haskell, pandoc, imagemagick, CoreServices }:
 
 with lib;
 with haskell.lib;
 
 let
-  ldgallery-viewer = pkgs.callPackage ./viewer { };
+  ldgallery-viewer = pkgs.callPackage ./viewer { inherit CoreServices; };
   inherit (haskellPackages) ldgallery-compiler;
 
 in

--- a/pkgs/tools/graphics/ldgallery/viewer/default.nix
+++ b/pkgs/tools/graphics/ldgallery/viewer/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkgs, nodejs-12_x, pandoc }:
+{ lib, stdenv, fetchFromGitHub, pkgs, nodejs-12_x, pandoc, CoreServices }:
 
 with lib;
 
@@ -24,6 +24,7 @@ let
   nodePkg = nodePackages.package.override {
     src = "${sourcePkg}/viewer";
     postInstall = "npm run build";
+    buildInputs = optionals stdenv.isDarwin [ CoreServices ];
   };
 
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6032,7 +6032,9 @@ in
 
   ldc = callPackage ../development/compilers/ldc { };
 
-  ldgallery = callPackage ../tools/graphics/ldgallery { };
+  ldgallery = callPackage ../tools/graphics/ldgallery {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
 
   lbreakout2 = callPackage ../games/lbreakout2 { };
 


### PR DESCRIPTION
###### Motivation for this change

This adds a missing build dependency for building on Darwin.

GitHub: fixes #122681


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
