### PR TITLE
keeweb: 1.17.0 → 1.18.6

### DIFF
--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -1,26 +1,24 @@
 { lib, stdenv, fetchurl, appimageTools, undmg, libsecret, libxshmfence }:
 let
-  inherit (stdenv.hostPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
-
   pname = "keeweb";
-  version = "1.17.0";
+  version = "1.18.6";
   name = "${pname}-${version}";
 
-  suffix = {
-    x86_64-linux = "linux.AppImage";
-    x86_64-darwin = "mac.x64.dmg";
-    aarch64-darwin = "mac.arm64.dmg";
-  }.${system} or throwSystem;
-
-  src = fetchurl {
-    url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.${suffix}";
-    sha256 = {
-      x86_64-linux = "1c7zvwnd46d3lrlcdigv341flz44jl6mnvr6zqny5mfz221ynbj7";
-      x86_64-darwin = "1n4haxychm5jjhjnpncavjh0wr4dagqi78qfsx5gwlv86hzryzwy";
-      aarch64-darwin = "1j7z63cbfms02f2lhl949wy3lc376jw8kqmjfn9j949s0l5fanpb";
-    }.${system} or throwSystem;
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.linux.AppImage";
+      sha256 = "sha256-hxXs8Dfh5YQy1zaFb20KDWNl8eqFjuN5QY7tsO6+E/U=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.mac.x64.dmg";
+      sha256 = "sha256-8+7NzaHVcLinKb57SAcJmF2Foy9RfxFhcTxzvL0JSJQ=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.mac.arm64.dmg";
+      sha256 = "sha256-1BNY6kRS0F+AUI+80ZGFi/ek28NMP1uexo1UORz5D6g=";
+    };
   };
+  src = srcs.${stdenv.hostPlatform.system};
 
   appimageContents = appimageTools.extract {
     inherit name src;
@@ -32,7 +30,7 @@ let
     changelog = "https://github.com/keeweb/keeweb/blob/v${version}/release-notes.md";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = builtins.attrNames srcs;
   };
 
   linux = appimageTools.wrapType2 rec {


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/keeweb/keeweb/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
