### PR TITLE
eukleides: specify texlive dependencies instead of buildInputs

### DIFF
--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo, readline, texlive }:
+{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo, getopt, readline, texlive }:
 
 lib.fix (eukleides: stdenv.mkDerivation rec {
   pname = "eukleides";
@@ -14,7 +14,7 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ bison flex texinfo makeWrapper ];
 
-  buildInputs = [ readline ];
+  buildInputs = [ getopt readline ];
 
   preConfigure = ''
     substituteInPlace Makefile \
@@ -30,6 +30,11 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
 
   preInstall = ''
     mkdir -p $out/bin
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/euktoeps \
+      --prefix PATH : ${lib.makeBinPath [ getopt ]}
   '';
 
   outputs = [ "out" "doc" "tex" ];

--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo, getopt, readline, texlive }:
+{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo4, getopt, readline, texlive }:
 
 lib.fix (eukleides: stdenv.mkDerivation rec {
   pname = "eukleides";
@@ -16,7 +16,7 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
     ./gs-allowpstransparency.patch
   ];
 
-  nativeBuildInputs = [ bison flex texinfo makeWrapper ];
+  nativeBuildInputs = [ bison flex texinfo4 makeWrapper ];
 
   buildInputs = [ getopt readline ];
 

--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo, readline, texLive }:
+{ lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo, readline, texlive }:
 
 lib.fix (eukleides: stdenv.mkDerivation rec {
   pname = "eukleides";
@@ -14,7 +14,7 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ bison flex texinfo makeWrapper ];
 
-  buildInputs = [ readline texLive ];
+  buildInputs = [ readline ];
 
   preConfigure = ''
     substituteInPlace Makefile \
@@ -32,21 +32,12 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
     mkdir -p $out/bin
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/euktoeps \
-      --set-default TEXINPUTS : \
-      --prefix TEXINPUTS : "$tex/tex/latex/eukleides" \
-      --prefix PATH : "${texLive}/bin"
-    wrapProgram $out/bin/euktopdf \
-      --set-default TEXINPUTS : \
-      --prefix TEXINPUTS : "$tex/tex/latex/eukleides" \
-      --prefix PATH : "${texLive}/bin"
-  '';
-
   outputs = [ "out" "doc" "tex" ];
 
   passthru.tlType = "run";
-  passthru.pkgs = [ eukleides.tex ];
+  passthru.pkgs = [ eukleides.tex ]
+    # packages needed by euktoeps, euktopdf and eukleides.sty
+    ++ (with texlive; collection-pstricks.pkgs ++ epstopdf.pkgs ++ iftex.pkgs ++ moreverb.pkgs);
 
   meta = {
     description = "Geometry Drawing Language";

--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -9,8 +9,12 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
     sha256 = "0s8cyh75hdj89v6kpm3z24i48yzpkr8qf0cwxbs9ijxj1i38ki0q";
   };
 
-  # use $CC instead of hardcoded gcc
-  patches = [ ./use-CC.patch ];
+  patches = [
+    # use $CC instead of hardcoded gcc
+    ./use-CC.patch
+    # allow PostScript transparency in epstopdf call
+    ./gs-allowpstransparency.patch
+  ];
 
   nativeBuildInputs = [ bison flex texinfo makeWrapper ];
 

--- a/pkgs/applications/science/math/eukleides/gs-allowpstransparency.patch
+++ b/pkgs/applications/science/math/eukleides/gs-allowpstransparency.patch
@@ -1,0 +1,10 @@
+--- a/bash/euktopdf
++++ b/bash/euktopdf
+@@ -55,6 +55,6 @@ do
+     exit 1
+   fi
+   dvips -q -E -o $base.eps $base.dvi &&
+-  epstopdf $base.eps &&
++  epstopdf --gsopt=-dALLOWPSTRANSPARENCY $base.eps &&
+   rm -f $base.{tex,log,dvi,eps}
+ done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29828,7 +29828,6 @@ in
   ecm = callPackage ../applications/science/math/ecm { };
 
   eukleides = callPackage ../applications/science/math/eukleides {
-    texLive = texlive.combine { inherit (texlive) scheme-small; };
     texinfo = texinfo4;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29827,9 +29827,7 @@ in
 
   ecm = callPackage ../applications/science/math/ecm { };
 
-  eukleides = callPackage ../applications/science/math/eukleides {
-    texinfo = texinfo4;
-  };
+  eukleides = callPackage ../applications/science/math/eukleides { };
 
   form = callPackage ../applications/science/math/form { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The use of `texLive` as build input was suspicious, and it turns out it is not right. If the user is calling e.g. `euktopdf`, it is always in the context of the user compiling a tex file, so `euktopdf` should call the user's version, not its own copy. Also the default value of `texLive` did not include the necessary dependencies, so it would not work anyway.

~`eukleides` is still partly broken, for instance `epstopdf` must be called with an extra option after recent changes in TeX Live. It would be a good idea to report this upstream.~

Edit: the PR includes a few bug fixes, one of which to be reported upstream.

@SFrijters I am submitting this as a draft, do you think you can improve it, and maybe do some testing? I don't use this myself. You may have a better idea of how the package should be used.

Cc @peti 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
