### PR TITLE
vapoursynth: improve plugin dependency resolution

### DIFF
--- a/pkgs/development/libraries/vapoursynth/plugin-interface.nix
+++ b/pkgs/development/libraries/vapoursynth/plugin-interface.nix
@@ -8,10 +8,11 @@ plugins: let
 
   getRecursivePropagatedBuildInputs = pkgs: lib.flatten
     (map
-      (pkg: pkg.propagatedBuildInputs ++ (getRecursivePropagatedBuildInputs pkg.propagatedBuildInputs))
+      (pkg: let cleanPropagatedBuildInputs = lib.filter lib.isDerivation pkg.propagatedBuildInputs;
+        in cleanPropagatedBuildInputs ++ (getRecursivePropagatedBuildInputs cleanPropagatedBuildInputs))
       pkgs);
 
-  deepPlugins = plugins ++ (getRecursivePropagatedBuildInputs plugins);
+  deepPlugins = lib.unique (plugins ++ (getRecursivePropagatedBuildInputs plugins));
 
   pluginsEnv = buildEnv {
     name = "vapoursynth-plugins-env";


### PR DESCRIPTION
Some python packages (e.g. functools32) are conditionally disabled for
certain interpreter versions by having them return null instead of a
derivation. `getRecursivePropagatedBuildInputs` fails if such a package
is part of the dependency tree. This PR makes it only recurse into
derivations and ignore everything else.

This also deduplicates the final plugin list to improve startup time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
