### PR TITLE
organicmaps: init at 2021-05-15

### DIFF
--- a/pkgs/applications/misc/organicmaps/default.nix
+++ b/pkgs/applications/misc/organicmaps/default.nix
@@ -18,13 +18,13 @@
 
 mkDerivation rec {
   pname = "organicmaps";
-  version = "2021.08.19-11-android";
+  version = "2021.09.14-4-android";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     rev = version;
-    sha256 = "sha256-LNW6YBBr+QoTygZ1ITt5ug8z7iVKrZvUK+noOVxQiUE=";
+    sha256 = "sha256-sKZKsxbP9BF4J9Ab/jDJUL5FxExbx0v7kBuxoDvfZ0M=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/organicmaps/default.nix
+++ b/pkgs/applications/misc/organicmaps/default.nix
@@ -17,13 +17,13 @@
 
 mkDerivation rec {
   pname = "organicmaps";
-  version = "2021-06-07";
+  version = "2021.07.08-3";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     rev = version;
-    sha256 = "sha256-K/jR7wd0zgN3BHFRvAT8TfNtYi8Ph7yHArRL23ksACM=";
+    sha256 = "sha256-R53q+g7WZ//Wk5EGVZn1pyCU+C/DunhDKOIo8k37gdE=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/organicmaps/default.nix
+++ b/pkgs/applications/misc/organicmaps/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, mkDerivation
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, ninja
+, pkg-config
+, which
+, python3
+, makeWrapper
+, qtbase
+, qtsvg
+, libGLU
+, zlib
+}:
+
+mkDerivation rec {
+  pname = "organicmaps";
+  version = "2021-06-07";
+
+  src = fetchFromGitHub {
+    owner = "organicmaps";
+    repo = "organicmaps";
+    rev = version;
+    sha256 = "sha256-K/jR7wd0zgN3BHFRvAT8TfNtYi8Ph7yHArRL23ksACM=";
+    fetchSubmodules = true;
+  };
+
+  # Disable certificate check. It's dependent on time
+  postPatch = ''
+    echo "exit 0" > tools/unix/check_cert.sh
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    which
+    python3
+    makeWrapper
+  ];
+
+  # Most dependencies are vendored
+  buildInputs = [
+    qtbase
+    qtsvg
+    libGLU
+    zlib
+  ];
+
+  # Yes, this is PRE configure. The configure phase uses cmake
+  preConfigure = ''
+    bash ./configure.sh
+  '';
+
+  postInstall = ''
+    install -Dm755 OMaps $out/bin/OMaps
+    # Tell the program that the read-only and the read-write data locations
+    # are different, and create the read-write one.
+    wrapProgram $out/bin/OMaps \
+      --add-flags "-resources_path $out/share/organicmaps/data" \
+      --add-flags '-data_path "''${XDG_DATA_HOME:-''${HOME}/.local/share}/OMaps"' \
+      --run 'mkdir -p "''${XDG_DATA_HOME:-''${HOME}/.local/share}/OMaps"'
+
+    mkdir $out/share/organicmaps
+    cp -r ../data $out/share/organicmaps/data
+    install -Dm644 ../qt/res/logo.png $out/share/icons/hicolor/96x96/apps/organicmaps.png
+    install -Dm644 ../qt/res/OrganicMaps.desktop $out/share/applications/OrganicMaps.desktop
+
+    # Part of the vendored expat package. OMaps only needs the library, so we
+    # delete this to avoid conflicts with the system's expat.
+    rm $out/bin/xmlwf
+  '';
+
+  meta = with lib; {
+    homepage = "https://organicmaps.app/";
+    description = "Detailed Offline Maps for Travellers, Tourists, Hikers and Cyclists";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+    mainProgram = "OMaps";
+    broken = stdenv.isDarwin; # "invalid application of 'sizeof' to a function type"
+  };
+}

--- a/pkgs/applications/misc/organicmaps/default.nix
+++ b/pkgs/applications/misc/organicmaps/default.nix
@@ -20,13 +20,13 @@
 
 mkDerivation rec {
   pname = "organicmaps";
-  version = "2022.02.19-1-android";
+  version = "2022.03.23-4-android";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     rev = version;
-    sha256 = "sha256-ABjj0AQanev1ekALDwjbFWC5LIc8Km7PGtvn7DpmcWk=";
+    sha256 = "sha256-4VBsHq8z/odD7Nrk9e0sYMEBBLeTAHsWsdgPIN1KVZo=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/organicmaps/default.nix
+++ b/pkgs/applications/misc/organicmaps/default.nix
@@ -18,13 +18,13 @@
 
 mkDerivation rec {
   pname = "organicmaps";
-  version = "2021.09.14-4-android";
+  version = "2021.12.01-4-android";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     rev = version;
-    sha256 = "sha256-sKZKsxbP9BF4J9Ab/jDJUL5FxExbx0v7kBuxoDvfZ0M=";
+    sha256 = "sha256-1PS9vQ8KPi68MYv3TyeKE430KZb+sxuffeeltKePTQg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/organicmaps/default.nix
+++ b/pkgs/applications/misc/organicmaps/default.nix
@@ -12,18 +12,19 @@
 , qtbase
 , qtsvg
 , libGLU
+, libGL
 , zlib
 }:
 
 mkDerivation rec {
   pname = "organicmaps";
-  version = "2021.07.08-3";
+  version = "2021.08.19-11-android";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     rev = version;
-    sha256 = "sha256-R53q+g7WZ//Wk5EGVZn1pyCU+C/DunhDKOIo8k37gdE=";
+    sha256 = "sha256-LNW6YBBr+QoTygZ1ITt5ug8z7iVKrZvUK+noOVxQiUE=";
     fetchSubmodules = true;
   };
 
@@ -46,6 +47,7 @@ mkDerivation rec {
     qtbase
     qtsvg
     libGLU
+    libGL
     zlib
   ];
 
@@ -53,6 +55,8 @@ mkDerivation rec {
   preConfigure = ''
     bash ./configure.sh
   '';
+
+  NIX_LDFLAGS = "-lGL";
 
   postInstall = ''
     install -Dm755 OMaps $out/bin/OMaps

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28271,6 +28271,8 @@ with pkgs;
 
   orca-c = callPackage ../applications/audio/orca-c {};
 
+  organicmaps = libsForQt5.callPackage ../applications/misc/organicmaps { };
+
   osm2xmap = callPackage ../applications/misc/osm2xmap {
     libyamlcpp = libyamlcpp_0_3;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A good offline map app

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upstream feedback about the patches has been provided: https://github.com/organicmaps/organicmaps/issues/395#issuecomment-841842498