### PR TITLE
nixos/opensmtpd: add useACMEHosts option

### DIFF
--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -5,7 +5,32 @@ with lib;
 let
 
   cfg = config.services.opensmtpd;
-  conf = pkgs.writeText "smtpd.conf" cfg.serverConfiguration;
+  certs = config.security.acme.certs;
+
+  # This path is created by systemd but is predictable if you know the service name
+  # See here for discussion: https://github.com/NixOS/nixpkgs/issues/101389#issuecomment-841704851
+  certsDir = "/run/credentials/opensmtpd.service";
+
+  # Add each host listed in useACMEHosts to the config as a pki.
+  # Certs are assumed to be in the working directory so that we can
+  # test the configuration in opensmtp-acme-restart.service
+  certConf = concatStringsSep "\n" (concatMap (host: [
+    "pki ${host} cert \"${certsDir}/${host}.cert.pem\""
+    "pki ${host} key \"${certsDir}/${host}.key.pem\""
+  ]) cfg.useACMEHosts);
+
+  # Prepare systemd LoadCredential list
+  credsConf = concatMap (host: let
+    certDir = certs."${host}".directory;
+  in [
+    "${host}.cert.pem:${certDir}/cert.pem"
+    "${host}.key.pem:${certDir}/key.pem"
+  ]) cfg.useACMEHosts;
+
+  certTargets = map (host: "acme-finished-${host}.target") cfg.useACMEHosts;
+  certServices = map (host: "acme-${host}.service") cfg.useACMEHosts;
+
+  conf = pkgs.writeText "smtpd.conf" (certConf + "\n" + cfg.serverConfiguration);
   args = concatStringsSep " " cfg.extraServerArgs;
 
   sendmail = pkgs.runCommand "opensmtpd-sendmail" { preferLocalBuild = true; } ''
@@ -76,8 +101,20 @@ in {
           that package.
         '';
       };
-    };
 
+      useACMEHosts = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          A list of hosts of existing Let's Encrypt certificates to load on start up.
+          This will add the appropriate "pki $host" lines to the configuration and add
+          systemd service dependencies on the relevant ACME renewal services, but will
+          not configure any "listen" directives to use the certificates.
+          <emphasis>Note that this option does not create any certificates – you will need
+          to create them manually using <option>security.acme.certs</option></emphasis>
+        '';
+      };
+    };
   };
 
 
@@ -124,9 +161,31 @@ in {
       };
     in {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-      serviceConfig.ExecStart = "${cfg.package}/sbin/smtpd -d -f ${conf} ${args}";
+      wants = certTargets;
+      after = [ "network.target" ] ++ certServices;
+      serviceConfig = {
+        ExecStart = "${cfg.package}/sbin/smtpd -d -f ${conf} ${args}";
+        LoadCredential = credsConf;
+      };
       environment.OPENSMTPD_PROC_PATH = "${procEnv}/libexec/opensmtpd";
+    };
+
+    # This service works in a similar fashion to the httpd/nginx-config-reload services.
+    # Its purpose is to collate multiple cert updates into a single service restart.
+    systemd.services.opensmtpd-acme-restart = mkIf (cfg.useACMEHosts != []) {
+      description = "Restart OpenSMTPD when ACME certificates are updated";
+      requisite = [ "opensmtpd.service" ];
+      wantedBy = certServices;
+      before = certTargets;
+      after = [ "opensmtpd.service" ] ++ certServices;
+      # Block reloading if not all certs exist yet.
+      # Happens when config changes add new certs.
+      unitConfig.ConditionPathExists = map (certName: certs.${certName}.directory + "/cert.pem") cfg.useACMEHosts;
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutSec = 60;
+        ExecStart = "/run/current-system/systemd/bin/systemctl restart opensmtpd.service";
+      };
     };
   };
 }

--- a/nixos/tests/common/resolver.nix
+++ b/nixos/tests/common/resolver.nix
@@ -25,18 +25,19 @@
   };
 
   config = lib.mkIf config.test-support.resolver.enable {
-    networking.firewall.enable = false;
+    networking.firewall.allowedTCPPorts = [ 53 ];
+    networking.firewall.allowedUDPPorts = [ 53 ];
     services.bind.enable = true;
     services.bind.cacheNetworks = lib.mkForce [ "any" ];
     services.bind.forwarders = lib.mkForce [];
     services.bind.zones = lib.singleton {
       name = ".";
+      master = true;
       file = let
         addDot = zone: zone + lib.optionalString (!lib.hasSuffix "." zone) ".";
-        mkNsdZoneNames = zones: map addDot (lib.attrNames zones);
-        mkBindZoneNames = zones: map (zone: addDot zone.name) zones;
-        getZones = cfg: mkNsdZoneNames cfg.services.nsd.zones
-                     ++ mkBindZoneNames cfg.services.bind.zones;
+        mkZoneNames = zones: map addDot (lib.attrNames zones);
+        getZones = cfg: mkZoneNames cfg.services.nsd.zones
+                     ++ mkZoneNames cfg.services.bind.zones;
 
         getZonesForNode = attrs: {
           ip = attrs.config.networking.primaryIPAddress;

--- a/nixos/tests/opensmtpd.nix
+++ b/nixos/tests/opensmtpd.nix
@@ -55,11 +55,70 @@ import ./make-test-python.nix {
       };
     };
 
+    smtp3 = { pkgs, config, lib, nodes, ... }: {
+      imports = [ common/user-account.nix common/acme/client ];
+      networking = {
+        firewall.allowedTCPPorts = [ 25 80 443 ];
+        useDHCP = false;
+        # TODO investigate why primaryIPAddress is wrong by default
+        primaryIPAddress = lib.mkOverride 0 "192.168.1.3";
+        interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
+          { address = "192.168.1.3"; prefixLength = 24; }
+        ];
+        nameservers = [ nodes.acme.config.networking.primaryIPAddress ];
+        # common/resolver.nix parses extraHosts and adds DNS records
+        extraHosts = ''
+          127.0.0.1 example.test
+          ${config.networking.primaryIPAddress} example.test
+        '';
+      };
+      environment.systemPackages = [ pkgs.opensmtpd pkgs.openssl ];
+      services.opensmtpd = {
+        enable = true;
+        useACMEHosts = [ "example.test" ];
+        extraServerArgs = [ "-v" ];
+        serverConfiguration = ''
+          listen on 0.0.0.0 tls pki example.test
+          action do_relay relay
+          # DO NOT DO THIS IN PRODUCTION!
+          # Setting up authentication requires a certificate which is painful in
+          # a test environment, but THIS WOULD BE DANGEROUS OUTSIDE OF A
+          # WELL-CONTROLLED ENVIRONMENT!
+          match from any for any action do_relay
+        '';
+      };
+
+      # Will need a web server to perform cert renewal
+      # First tests configure a basic cert and run a bunch of openssl checks
+      services.nginx.enable = true;
+      services.nginx.virtualHosts."example.test" = {
+        forceSSL = true;
+        enableACME = true;
+        locations."/".root = pkgs.runCommand "docroot" {} ''
+          mkdir -p "$out"
+          echo hello world > "$out/index.html"
+        '';
+      };
+    };
+
+    # The fake ACME server which will respond to client requests
+    acme = { lib, ... }: {
+      imports = [ common/acme/server ];
+      networking = {
+        useDHCP = false;
+        # TODO investigate why primaryIPAddress is wrong by default
+        primaryIPAddress = lib.mkOverride 0 "192.168.1.4";
+        interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+          { address = "192.168.1.4"; prefixLength = 24; }
+        ];
+      };
+    };
+
     client = { pkgs, ... }: {
       networking = {
         useDHCP = false;
         interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
-          { address = "192.168.1.3"; prefixLength = 24; }
+          { address = "192.168.1.5"; prefixLength = 24; }
         ];
       };
       environment.systemPackages = let
@@ -101,19 +160,53 @@ import ./make-test-python.nix {
     };
   };
 
-  testScript = ''
+  testScript = {nodes, ...}:
+  let
+    caDomain = nodes.acme.config.test-support.acme.caDomain;
+  in ''
+    import time
+
+
+    def download_ca_certs(node, retries=5):
+      assert retries >= 0, "Failed to connect to pebble to download root CA certs"
+
+      exit_code, _ = node.execute("curl https://${caDomain}:15000/roots/0 > /tmp/ca.crt")
+      exit_code_2, _ = node.execute(
+          "curl https://${caDomain}:15000/intermediate-keys/0 >> /tmp/ca.crt"
+      )
+
+      if exit_code + exit_code_2 > 0:
+          time.sleep(3)
+          return download_ca_certs(node, retries - 1)
+
+
+    acme.start()
+    acme.wait_for_open_port(443)
+    acme.wait_for_open_port(53)
+    acme.succeed("host example.test 127.0.0.1 | grep 192.168.1.3")
+    acme.succeed("host ${caDomain} 127.0.0.1 | grep 192.168.1.4")
+
     start_all()
 
     client.wait_for_unit("network-online.target")
     smtp1.wait_for_unit("opensmtpd")
     smtp2.wait_for_unit("opensmtpd")
     smtp2.wait_for_unit("dovecot2")
+    smtp3.wait_for_unit("opensmtpd")
 
     # To prevent sporadic failures during daemon startup, make sure
     # services are listening on their ports before sending requests
     smtp1.wait_for_open_port(25)
     smtp2.wait_for_open_port(25)
     smtp2.wait_for_open_port(143)
+    smtp3.wait_for_open_port(25)
+
+    # Test SSL certificate configuration
+    download_ca_certs(smtp3)
+    smtp3.succeed(
+        "echo | openssl s_client -starttls smtp -connect localhost:25 -CAfile /tmp/ca.crt"
+        " -verify 3 -servername example.test 2>&1 | awk '/verify error/ { print $0; exit 1 }'"
+    )
 
     client.succeed("send-a-test-mail")
     smtp1.wait_until_fails("smtpctl show queue | egrep .")


### PR DESCRIPTION
###### Motivation for this change

Closes #101389

This allows the user to configure any number of certificates
to be loaded into opensmtpd on startup. A new service was added
to restart opensmtpd when certificates are updated.

This is the first time we're using LoadCredential. I have not found a way
to support hot reload with this method yet.  It copies the cert files to a
special folder on start, and doesn't repeat the process if the files change
or if the service is reloaded.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
