### PR TITLE
python3Packages.locationsharinglib: init at 4.1.6

### DIFF
--- a/pkgs/development/python-modules/locationsharinglib/default.nix
+++ b/pkgs/development/python-modules/locationsharinglib/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, betamax
+, buildPythonPackage
+, cachetools
+, coloredlogs
+, emoji
+, fetchPypi
+, nose
+, python
+, pythonOlder
+, pytz
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "locationsharinglib";
+  version = "4.1.6";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "092j8z01nwjqh5zr7aj8mxl1zjd3j2irhrs39dhn47bd6db2a6ij";
+  };
+
+  propagatedBuildInputs = [
+    coloredlogs
+    requests
+    cachetools
+    pytz
+  ];
+
+  checkInputs = [
+    betamax
+    emoji
+    nose
+  ];
+
+  postPatch = ''
+    # Tests requirements want to pull in multiple modules which we don't need
+    substituteInPlace setup.py \
+      --replace "tests_require=test_requirements" "tests_require=[]"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    # Only coverage no real unit tests
+    ${python.interpreter} setup.py nosetests
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "locationsharinglib" ];
+
+  meta = with lib; {
+    description = "Python package to retrieve coordinates from a Google account";
+    homepage = "https://locationsharinglib.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -316,7 +316,7 @@
     "google_assistant" = ps: with ps; [ aiohttp-cors ];
     "google_cloud" = ps: with ps; [ google-cloud-texttospeech ];
     "google_domains" = ps: with ps; [ ];
-    "google_maps" = ps: with ps; [ ]; # missing inputs: locationsharinglib
+    "google_maps" = ps: with ps; [ locationsharinglib ];
     "google_pubsub" = ps: with ps; [ google-cloud-pubsub ];
     "google_translate" = ps: with ps; [ gtts ];
     "google_travel_time" = ps: with ps; [ googlemaps ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3955,6 +3955,8 @@ in {
 
   localzone = callPackage ../development/python-modules/localzone { };
 
+  locationsharinglib = callPackage ../development/python-modules/locationsharinglib { };
+
   locket = callPackage ../development/python-modules/locket { };
 
   lockfile = callPackage ../development/python-modules/lockfile { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python package to retrieve coordinates from a Google account.

https://locationsharinglib.readthedocs.io/

This is a Home Assistant dependency. The `google_maps` integration doesn't have tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
