### PR TITLE
nixos/security.pki: handle PEMs w/o a final newline

### DIFF
--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -10,15 +10,10 @@ let
     blacklist = cfg.caCertificateBlacklist;
   };
 
-  caCertificates = pkgs.runCommand "ca-certificates.crt"
-    { files =
-        cfg.certificateFiles ++
-        [ (builtins.toFile "extra.crt" (concatStringsSep "\n" cfg.certificates)) ];
-      preferLocalBuild = true;
-     }
-    ''
-      cat $files > $out
-    '';
+  caCertificates = pkgs.runCommand "ca-certificates.crt" {
+    files = cfg.certificateFiles ++ [ (builtins.toFile "extra.crt" (concatStringsSep "\n" cfg.certificates)) ];
+    preferLocalBuild = true;
+  } "awk 1 $files > $out";  # awk ensures a newline between each pair of consecutive files
 
 in
 


### PR DESCRIPTION
Note: I'm not sure how to thoroughly test this, or which tests in `nixos/tests` are relevant.

I did verify that on my system, with `config.security.pki.certificateFiles` containing some PEMs without final newlines, the resulting `/etc/ssl/certs/ca-certificates.crt` has all the erroneous occurrences of 
```
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
```
replaced with the corrected
```
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
```
, with everything else remaining the same as before, which shows that this PR at least fixes the issue it aims to fix.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

According to the ABNF grammar for PEM files described in [RFC
7468][1], an eol character (i.e. a newline) is not mandatory after the
posteb line (i.e. "-----END CERTIFICATE-----" in the case of
certificates).

This commit makes our CA certificate bundler expression account for
the possibility that files in config.security.pki.certificateFiles
might not have final newlines, by using `awk` instead of `cat` to
concatenate them. (`awk` prints a final newline from each input file
even if the file doesn't end with a newline.)

[1]: https://datatracker.ietf.org/doc/html/rfc7468#section-3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
