### PR TITLE
Introduce Arcan

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -104,6 +104,12 @@
     githubId = 12578560;
     name = "Quinn Bohner";
   };
+  a12l = {
+    name = "Albin Otterhäll";
+    email = "dev@a12l.xyx";
+    github = "a12l";
+    githubId = 38804798;
+  };
   a1russell = {
     email = "adamlr6+pub@gmail.com";
     github = "a1russell";

--- a/pkgs/applications/window-managers/pipeworld/default.nix
+++ b/pkgs/applications/window-managers/pipeworld/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, runtimeShell
+, bash
+, arcan
+, makeWrapper
+, withXarcan ? true
+, xarcan
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pipeworld";
+  version = "0.0.0+unstable=2021-05-27";
+
+  src = fetchFromGitHub {
+    owner = "letoram";
+    repo = pname;
+    rev = "c26df9ca0225ce2fd4f89e7ec59d4ab1f94a4c2e";
+    sha256 = "sha256-RkDAbM1q4o61RGPLPLXHLvbvClp+bfjodlWgUGoODzA=";
+  };
+
+  buildInputs = [
+    arcan
+    makeWrapper
+  ] ++ lib.optionals withXarcan [
+    xarcan
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    desktopName = "Pipeworld";
+    exec = pname;
+    comment = "Zooming-Tiling window manager for Arcan";
+    type = "Application";
+    terminal = "false";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parents $out/bin $out/share/${pname}
+
+    # Copy appl's source
+    cp --recursive ./pipeworld/* $out/share/${pname}/
+
+    # Add command
+    echo "#!${runtimeShell}
+
+    exec arcan $out/share/${pname}" > $out/bin/${pname}
+    chmod +x $out/bin/${pname}
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/${pname} --prefix PATH : ${lib.makeBinPath [ arcan ]}
+  '';
+
+  meta = with lib; {
+    description = "A dataflow programming and desktop environment";
+    homepage = "https://github.com/letoram/pipeworld";
+    changelog = "https://github.com/letoram/pipeworld/releases/tag/${version}";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ a12l ];
+  };
+}

--- a/pkgs/desktops/durden/default.nix
+++ b/pkgs/desktops/durden/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, runtimeShell
+, bash
+, arcan
+, makeWrapper
+, withXarcan ? true
+, xarcan
+}:
+
+stdenv.mkDerivation rec {
+  pname = "durden";
+  version = "0.6.1+unstable=2021-06-25";
+
+  src = fetchFromGitHub {
+    owner = "letoram";
+    repo = pname;
+    rev = "fb618fccc57a68b6ce933b4df5822acd1965d591";
+    sha256 = "sha256-PovI837Xca4wV0g0s4tYUMFGVUDf+f8HcdvM1+0aDxk=";
+  };
+
+  buildInputs = [
+    arcan
+    makeWrapper
+  ] ++ lib.optionals withXarcan [
+    xarcan
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    desktopName = "Durden";
+    exec = pname;
+    comment = "Desktop environment for Arcan";
+    type = "Application";
+    terminal = "false";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parents $out/bin $out/share/${pname}
+
+    # Copy appl's source
+    cp --recursive ./durden/* $out/share/${pname}/
+
+    # Add command
+    echo "#!${runtimeShell}
+
+    exec arcan $out/share/${pname}" > $out/bin/${pname}
+    chmod +x $out/bin/${pname}
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/${pname} --prefix PATH : ${lib.makeBinPath [ arcan ]}
+  '';
+
+  meta = with lib; {
+    description = "A desktop environment for the Arcan Display Server";
+    homepage = "https://github.com/letoram/durden";
+    changelog = "https://github.com/letoram/durden/releases/tag/${version}";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ a12l ];
+  };
+}

--- a/pkgs/development/libraries/arcan/default.nix
+++ b/pkgs/development/libraries/arcan/default.nix
@@ -1,0 +1,164 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, xz
+, libuvc
+, libffi
+, libX11
+, libxcb
+, libXcomposite
+, libXfixes
+, xcbutil
+, xcbutilwm
+, libXau
+, libXdmcp
+, openal
+, freetype
+, sqlite
+, libGL
+, libdrm
+, libxkbcommon
+, mesa
+, valgrind
+, luajit
+, libusb1
+, harfbuzzFull
+, SDL2
+, withVLC ? true
+, libvlc
+, withFFmpeg ? true
+, ffmpeg-full
+, withWayland ? true
+, wayland
+, wayland-protocols
+, withEspeak ? true
+, espeak-classic
+, withLibmagic ? true
+, file
+, withTesseract ? true
+, tesseract
+, withLeptonica ? true
+, leptonica
+, withVNC ? true
+, libvncserver
+, debugging ? false
+}:
+
+let
+  srcs = {
+    arcan = fetchFromGitHub {
+      owner = "letoram";
+      repo = "arcan";
+      rev = "f3341ab94b32d02f3d15c3b91a512b2614e950a5";
+      sha256 = "sha256-YBtRA5uCk4tjX3Bsu5vMkaNaCLRlM6HVQ53sna3gDsY=";
+    };
+
+    openal = fetchFromGitHub {
+      owner = "letoram";
+      repo = "openal";
+      rev = "1c7302c580964fee9ee9e1d89ff56d24f934bdef";
+      sha256 = "sha256-InqU59J0zvwJ20a7KU54xTM7d76VoOlFbtj7KbFlnTU=";
+    };
+  };
+in stdenv.mkDerivation rec {
+  pname = "arcan";
+  version = "0.6.1pre1+unstable=2021-07-08";
+
+  src = srcs.arcan;
+
+  postUnpack = ''
+    mkdir --parents $sourceRoot/external/git/openal
+    pushd $sourceRoot/external/git/
+    cp --recursive ${srcs.openal}/* openal/
+    chmod --recursive 777 openal/
+    popd
+  '';
+
+  postPatch = ''
+    substituteInPlace ./src/platform/posix/paths.c \
+      --replace "/usr/bin" "$out/bin" \
+      --replace "/usr/share" "$out/share"
+
+    substituteInPlace ./src/CMakeLists.txt \
+      --replace "SETUID" ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    openal
+    freetype
+    sqlite
+    libuvc
+    libGL
+    SDL2
+    libdrm
+    libxkbcommon
+    mesa
+    valgrind
+    luajit
+    libusb1
+    libvlc
+    xz
+    libffi
+    libX11
+    libxcb
+    libXcomposite
+    libXfixes
+    xcbutil
+    xcbutilwm
+    libXau
+    libXdmcp
+    harfbuzzFull
+  ] ++ lib.optionals withFFmpeg [
+    ffmpeg-full
+  ] ++ lib.optionals withWayland [
+    wayland
+    wayland-protocols
+  ] ++ lib.optionals withEspeak [
+    espeak-classic
+  ] ++ lib.optionals withLibmagic [
+    file
+  ] ++ lib.optionals withTesseract [
+    tesseract
+  ] ++ lib.optionals withLeptonica [
+    leptonica
+  ] ++ lib.optionals withVNC [
+    libvncserver
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_PRESET=everything"
+    "-DISTR_TAG=Nixpkgs"
+    "-DENGINE_BUILDTAG=${version}+Nixpkgs"
+    "../src"
+  ] ++ lib.optionals debugging [
+    "-DCMAKE_BUILD_TYPE=Debug"
+  ];
+
+  hardeningDisable = [
+    "format"
+  ] ++ lib.optionals debugging [
+    "fortify"
+  ];
+
+  meta = with lib; {
+    description = "Scriptable Multimedia Engine";
+    longDescription = ''
+      Arcan  is a portable and fast self-sufficient multimedia engine for
+      advanced visualization and analysis work in a wide range of applications
+      e.g. game development, real-time streaming video,  monitoring  and
+      surveillance, up to and including desktop compositors and window managers.
+    '';
+    homepage = "https://github.com/letoram/arcan";
+    changelog = "https://github.com/letoram/arcan/releases/tag/${version}";
+    license = with licenses; [ gpl2Plus lgpl2Plus bsd3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ a12l ];
+  };
+}

--- a/pkgs/servers/x11/xarcan/default.nix
+++ b/pkgs/servers/x11/xarcan/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, pkg-config
+, xorgproto
+, xtrans
+, libxshmfence
+, pixman
+, xkbcomp
+, libxkbfile
+, libXfont2
+, dbus
+, systemd
+, fontutil
+, mesa
+, epoxy
+, libmd
+, nettle
+, libgcrypt
+, openssl
+, libXdmcp
+, libdrm
+, libselinux
+, audit
+, libGL
+, libtirpc
+, libXau
+, arcan
+, libxcb
+, ninja
+, libX11
+, xcbutil
+, xcbutilwm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xarcan";
+  version = "0.6.0+unstable=2021-06-14";
+
+  src = fetchFromGitHub {
+    owner = "letoram";
+    repo = pname;
+    rev = "98d28a5f2c6860bb191fbc1c9e577c18e4c9a9b7";
+    sha256 = "sha256-UTIVDKnYD/q0K6G7NJUKh1tHcqnsuiJ/cQxWuPMJ2G4=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+  ];
+
+  buildInputs = [
+    xorgproto
+    xtrans
+    libxshmfence
+    pixman
+    xkbcomp
+    libxkbfile
+    libXfont2
+    dbus
+    systemd
+    fontutil
+    mesa
+    epoxy
+    libmd
+    nettle
+    libgcrypt
+    openssl
+    libXdmcp
+    libdrm
+    libselinux
+    audit
+    libGL
+    libtirpc
+    libXau
+    arcan
+    libxcb
+    ninja
+    libX11
+    xcbutil
+    xcbutilwm
+  ];
+
+  meta = with lib; {
+    description = "Patched Xserver that bridges connections to Arcan";
+    homepage = "https://github.com/letoram/letoram";
+    changelog = "https://github.com/letoram/letoram/releases/tag/${version}";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ a12l ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28671,6 +28671,8 @@ in
 
   duckmarines = callPackage ../games/duckmarines { love = love_0_10; };
 
+  durden = callPackage ../desktops/durden { };
+
   dwarf-fortress-packages = recurseIntoAttrs (callPackage ../games/dwarf-fortress { });
 
   dwarf-fortress = dwarf-fortress-packages.dwarf-fortress;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20270,6 +20270,8 @@ in
     inherit (darwin.apple_sdk.libs) Xplugin;
   };
 
+  xarcan = callPackage ../servers/x11/xarcan { };
+
   # Use `lib.callPackageWith __splicedPackages` rather than plain `callPackage`
   # so as not to have the newly bound xorg items already in scope,  which would
   # have created a cycle.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7935,6 +7935,8 @@ in
 
   pirate-get = callPackage ../tools/networking/pirate-get { };
 
+  pipeworld = callPackage ../applications/window-managers/pipeworld { };
+
   pipr = callPackage ../applications/misc/pipr { };
 
   pipreqs = callPackage ../tools/misc/pipreqs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -184,6 +184,8 @@ in
 
   antsimulator = callPackage ../games/antsimulator { };
 
+  arcan = callPackage ../development/libraries/arcan { };
+
   atuin = callPackage ../tools/misc/atuin {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

From arcan(1):

> Arcan is a portable and fast self-sufficient multimedia engine for advanced visualization and analysis work in a wide range of applications e.g. game development, real-time streaming video, monitoring and surveillance, up to and including desktop compositors and window managers.

This is a work in progress, expect force pushes to my repository.

###### Things written

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built with all relevant dependencies
  - [x] Arcan
  - [x] Xarcan
- [x] Written expressions for selected appls
  - [x] Durden
  - [x] Pipeworld
- [ ] Create security wrapper for Arcan
- [ ] Write documentation describing Arcan's optional dependencies.

###### How Things is built

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
