### PR TITLE
superTuxKart: Build on Darwin

### DIFF
--- a/pkgs/development/interpreters/angelscript/default.nix
+++ b/pkgs/development/interpreters/angelscript/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, unzip}:
+{ lib, stdenv, fetchurl, unzip, cmake }:
 let
   s = # Generated upstream information
   rec {
@@ -12,25 +12,32 @@ let
 in
 stdenv.mkDerivation {
   inherit (s) name version;
-  nativeBuildInputs = [ unzip ];
+
   src = fetchurl {
     inherit (s) url sha256;
   };
+
+  nativeBuildInputs = [ unzip cmake ];
+
   preConfigure = ''
-    cd angelscript/projects/gnuc
-    export makeFlags="$makeFlags PREFIX=$out"
+    export ROOT=$PWD
+    cd angelscript/projects/cmake
   '';
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
   postInstall = ''
     mkdir -p "$out/share/docs/angelscript"
-    cp -r ../../../docs/* "$out/share/docs/angelscript"
+    cp -r $ROOT/docs/* "$out/share/docs/angelscript"
   '';
-  meta = {
+
+  meta = with lib; {
     inherit (s) version;
     description = "Light-weight scripting library";
-    license = lib.licenses.zlib ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
-    downloadPage = "http://www.angelcode.com/angelscript/downloads.html";
-    homepage="http://www.angelcode.com/angelscript/";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.all;
+    downloadPage = "https://www.angelcode.com/angelscript/downloads.html";
+    homepage = "https://www.angelcode.com/angelscript/";
   };
 }

--- a/pkgs/development/libraries/wiiuse/default.nix
+++ b/pkgs/development/libraries/wiiuse/default.nix
@@ -2,8 +2,10 @@
 , stdenv
 , fetchFromGitHub
 , cmake
-, pkg-config
 , bluez
+, libobjc
+, Foundation
+, IOBluetooth
 }:
 stdenv.mkDerivation rec {
 
@@ -19,15 +21,18 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ (lib.getDev bluez) ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ bluez ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ libobjc Foundation IOBluetooth ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLE_SDL=NO" ];
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ bluez ];
+
+  cmakeFlags = [ "-DBUILD_EXAMPLE_SDL=OFF" ];
 
   meta = with lib; {
     description = "Feature complete cross-platform Wii Remote access library";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     homepage = "https://github.com/wiiuse/wiiuse";
     maintainers = with maintainers; [ shamilton ];
-    platforms = with platforms; linux;
+    platforms = with platforms; unix;
   };
 }

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -9,18 +9,19 @@
 , SDL2
 , glew
 , openal
+, OpenAL
 , libvorbis
 , libogg
 , curl
 , freetype
-, bluez
 , libjpeg
 , libpng
-, enet
 , harfbuzz
 , mcpp
 , wiiuse
 , angelscript
+, Cocoa
+, IOKit
 }:
 let
   dir = "stk-code";
@@ -82,10 +83,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  # Deletes all bundled libs in stk-code/lib except those
-  # That couldn't be replaced with system packages
   postPatch = ''
+    # Deletes all bundled libs in stk-code/lib except those
+    # That couldn't be replaced with system packages
     find lib -maxdepth 1 -type d | egrep -v "^lib$|${(lib.concatStringsSep "|" bundledLibraries)}" | xargs -n1 -L1 -r -I{} rm -rf {}
+
+    # Allow building with system-installed wiiuse on Darwin
+    substituteInPlace CMakeLists.txt \
+      --replace 'NOT (APPLE OR HAIKU)) AND USE_SYSTEM_WIIUSE' 'NOT (HAIKU)) AND USE_SYSTEM_WIIUSE'
   '';
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];
@@ -93,20 +98,19 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL2
     glew
-    openal
     libvorbis
     libogg
     freetype
     curl
-    bluez
     libjpeg
     libpng
-    enet
     harfbuzz
     mcpp
     wiiuse
   ]
-  ++ lib.optional (!stdenv.hostPlatform.isAarch64) angelscript;
+  ++ lib.optional (!stdenv.hostPlatform.isAarch64) angelscript
+  ++ lib.optional stdenv.hostPlatform.isLinux openal
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ OpenAL IOKit Cocoa ];
 
   cmakeFlags = [
     "-DBUILD_RECORDER=OFF" # libopenglrecorder is not in nixpkgs
@@ -117,9 +121,18 @@ stdenv.mkDerivation rec {
     "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 
+  # Extract binary from built app bundle
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir $out/bin
+    mv $out/{supertuxkart.app/Contents/MacOS,bin}/supertuxkart
+    rm -rf $out/supertuxkart.app
+  '';
+
   # Obtain the assets directly from the fetched store path, to avoid duplicating assets across multiple engine builds
   preFixup = ''
-    wrapProgram $out/bin/supertuxkart --set-default SUPERTUXKART_ASSETS_DIR "${assets}"
+    wrapProgram $out/bin/supertuxkart \
+      --set-default SUPERTUXKART_ASSETS_DIR "${assets}" \
+      --set-default SUPERTUXKART_DATADIR "$out/share/supertuxkart" \
   '';
 
   meta = with lib; {
@@ -132,7 +145,7 @@ stdenv.mkDerivation rec {
     homepage = "https://supertuxkart.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ pyrolagus peterhoeg ];
-    platforms = with platforms; linux;
+    platforms = with platforms; unix;
     changelog = "https://github.com/supertuxkart/stk-code/blob/${version}/CHANGELOG.md";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28502,7 +28502,9 @@ in
 
   superTux = callPackage ../games/supertux { };
 
-  superTuxKart = callPackage ../games/super-tux-kart { };
+  superTuxKart = callPackage ../games/super-tux-kart {
+    inherit (darwin.apple_sdk.frameworks) Cocoa IOKit OpenAL;
+  };
 
   synthv1 = libsForQt5.callPackage ../applications/audio/synthv1 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9680,7 +9680,10 @@ in
 
   whsniff = callPackage ../applications/networking/sniffers/whsniff { };
 
-  wiiuse = callPackage ../development/libraries/wiiuse { };
+  wiiuse = callPackage ../development/libraries/wiiuse {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) Foundation IOBluetooth;
+  };
 
   woeusb = callPackage ../tools/misc/woeusb { };
 


### PR DESCRIPTION
###### Motivation for this change
Make STK build on Darwin. I can't test functionality but I'm getting the same GL-related error with this package that I get with the official download, so I assume it works.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
