### PR TITLE
plasma-sdk: init at 5.21.4

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -139,6 +139,7 @@ let
       plasma-integration = callPackage ./plasma-integration {};
       plasma-nm = callPackage ./plasma-nm {};
       plasma-pa = callPackage ./plasma-pa.nix { inherit gconf; };
+      plasma-sdk = callPackage ./plasma-sdk.nix {};
       plasma-systemmonitor = callPackage ./plasma-systemmonitor.nix { };
       plasma-thunderbolt = callPackage ./plasma-thunderbolt.nix { };
       plasma-vault = callPackage ./plasma-vault {};

--- a/pkgs/desktops/plasma-5/plasma-sdk.nix
+++ b/pkgs/desktops/plasma-5/plasma-sdk.nix
@@ -1,0 +1,41 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, karchive
+, kcompletion
+, kconfig
+, kconfigwidgets
+, kcoreaddons
+, kdbusaddons
+, kdeclarative
+, ki18n
+, kiconthemes
+, kio
+, plasma-framework
+, kservice
+, ktexteditor
+, kwidgetsaddons
+, kdoctools
+, qtbase
+}:
+
+mkDerivation {
+  name = "plasma-sdk";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    karchive
+    kcompletion
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kdbusaddons
+    kdeclarative
+    ki18n
+    kiconthemes
+    kio
+    plasma-framework
+    kservice
+    ktexteditor
+    kwidgetsaddons
+  ];
+}


### PR DESCRIPTION
###### Motivation for this change
Provide access to tools helpful in KDE Plasma development, such as:
- cuttlefish
- lookandfeelexplorer
- plasmaengineexplorer
- plasmathemeexplorer
- plasmoidviewer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
