### PR TITLE
docker: 20.10.2 -> 20.10.6

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -10,7 +10,7 @@ rec {
       , containerdRev, containerdSha256
       , tiniRev, tiniSha256, buildxSupport ? false
       # package dependencies
-      , stdenv, fetchFromGitHub, fetchpatch, buildGoPackage
+      , stdenv, fetchFromGitHub, buildGoPackage
       , makeWrapper, installShellFiles, pkg-config
       , go-md2man, go, containerd, runc, docker-proxy, tini, libtool
       , sqlite, iproute2, lvm2, systemd, docker-buildx
@@ -123,7 +123,7 @@ rec {
    }) // rec {
     inherit version rev;
 
-    name = "docker-${version}";
+    pname = "docker";
 
     src = fetchFromGitHub {
       owner = "docker";

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -228,8 +228,8 @@ rec {
       rev = "v${version}";
       sha256 = "1l4ra9bsvydaxd2fy7dgxp7ynpp0mrlwvcdhxiafw596559ab6qk";
     };
-    runcRev = "2c7861bc5e1b3e756392236553ec14a78a09f8bf"; # v1.0.0-rc94
-    runcSha256 = "0f11zr2d3bnycd6rmb1cynhy9zh169yj6kcn5s22wz2j6grghwz7";
+    runcRev = "b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7"; # v1.0.0-rc95
+    runcSha256 = "18sbvmlvb6kird4w3rqsfrjdj7n25firabvdxsl0rxjfy9r1g2xb";
     containerdRev = "12dca9790f4cb6b18a6a7a027ce420145cb98ee7"; # v1.5.1
     containerdSha256 = "16q34yiv5q98b9d5vgy1lmmppg8agrmnfd1kzpakkf4czkws0p4d";
     tiniRev = "de40ad007797e0dcd8b7126f27bb87401d224240"; # v0.19.0

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -228,11 +228,11 @@ rec {
       rev = "v${version}";
       sha256 = "1l4ra9bsvydaxd2fy7dgxp7ynpp0mrlwvcdhxiafw596559ab6qk";
     };
-    runcRev = "v1.0.0-rc94";
+    runcRev = "2c7861bc5e1b3e756392236553ec14a78a09f8bf"; # v1.0.0-rc94
     runcSha256 = "0f11zr2d3bnycd6rmb1cynhy9zh169yj6kcn5s22wz2j6grghwz7";
-    containerdRev = "v1.5.1";
-    containerdSha256 = "1jwz53cpi9sxjsd1qr3sji1jai9wh3kfwspsgxnijhjs0bz8gvyn";
-    tiniRev = "v0.19.0";
+    containerdRev = "12dca9790f4cb6b18a6a7a027ce420145cb98ee7"; # v1.5.1
+    containerdSha256 = "16q34yiv5q98b9d5vgy1lmmppg8agrmnfd1kzpakkf4czkws0p4d";
+    tiniRev = "de40ad007797e0dcd8b7126f27bb87401d224240"; # v0.19.0
     tiniSha256 = "1h20i3wwlbd8x4jr2gz68hgklh0lb0jj7y5xk1wvr8y58fip1rdn";
   };
 }

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -162,8 +162,6 @@ rec {
     postPatch = ''
       patchShebangs .
       substituteInPlace ./scripts/build/.variables --replace "set -eu" ""
-      substituteInPlace ./scripts/docs/generate-man.sh --replace "-v md2man" "-v go-md2man"
-      substituteInPlace ./man/md2man-all.sh            --replace md2man go-md2man
     '' + optionalString buildxSupport ''
       substituteInPlace ./cli-plugins/manager/manager_unix.go --replace /usr/libexec/docker/cli-plugins \
           ${lib.strings.makeSearchPathOutput "bin" "libexec/docker/cli-plugins" [docker-buildx]}
@@ -221,20 +219,20 @@ rec {
   # Get revisions from
   # https://github.com/moby/moby/tree/${version}/hack/dockerfile/install/*
   docker_20_10 = callPackage dockerGen rec {
-    version = "20.10.2";
+    version = "20.10.6";
     rev = "v${version}";
-    sha256 = "0z0hpm5hrqh7p8my8lmiwpym2shs48my6p0zv2cc34wym0hcly51";
+    sha256 = "15kknb26vyzjgqmn8r81a1sy1i5br6bvngqd5xljihppnxvp2gvl";
     moby-src = fetchFromGitHub {
       owner = "moby";
       repo = "moby";
       rev = "v${version}";
-      sha256 = "0c2zycpnwj4kh8m8xckv1raj3fx07q9bfaj46rr85jihm4p2dp5w";
+      sha256 = "1l4ra9bsvydaxd2fy7dgxp7ynpp0mrlwvcdhxiafw596559ab6qk";
     };
-    runcRev = "ff819c7e9184c13b7c2607fe6c30ae19403a7aff"; # v1.0.0-rc92
-    runcSha256 = "0r4zbxbs03xr639r7848282j1ybhibfdhnxyap9p76j5w8ixms94";
-    containerdRev = "269548fa27e0089a8b8278fc4fc781d7f65a939b"; # v1.4.3
-    containerdSha256 = "09xvhjg5f8h90w1y94kqqnqzhbhd62dcdd9wb9sdqakisjk6zrl0";
-    tiniRev = "de40ad007797e0dcd8b7126f27bb87401d224240"; # v0.19.0
+    runcRev = "v1.0.0-rc94";
+    runcSha256 = "0f11zr2d3bnycd6rmb1cynhy9zh169yj6kcn5s22wz2j6grghwz7";
+    containerdRev = "v1.5.1";
+    containerdSha256 = "1jwz53cpi9sxjsd1qr3sji1jai9wh3kfwspsgxnijhjs0bz8gvyn";
+    tiniRev = "v0.19.0";
     tiniSha256 = "1h20i3wwlbd8x4jr2gz68hgklh0lb0jj7y5xk1wvr8y58fip1rdn";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Minor update for Docker

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
