### PR TITLE
libgcc: use glibc major and minor version but not the patch level

### DIFF
--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -129,7 +129,8 @@ stdenvNoLibs.mkDerivation rec {
 
     "--with-system-zlib"
   ] ++ lib.optional (stdenvNoLibs.hostPlatform.libc == "glibc")
-       "--with-glibc-version=${glibc.version}";
+       # libgcc expects a glibc version of the format X.Y while we usually have a version X.Y-Z where Z is our patchlevel.
+       "--with-glibc-version=${builtins.head (builtins.split "-" glibc.version)}";
 
   configurePlatforms = [ "build" "host" ];
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

libgcc requires the version scheme X.Y whilst our glibc version
attribute usually is X.Y-Z where Z is our patchlevel.

This surfaced in https://hydra.nixos.org/build/143083382.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
