### PR TITLE
python2Packages.pymysql: reinit at 0.10.1

### DIFF
--- a/pkgs/development/python-modules/pymysql/0.nix
+++ b/pkgs/development/python-modules/pymysql/0.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "PyMySQL";
+  version = "0.10.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "263040d2779a3b84930f7ac9da5132be0fefcd6f453a885756656103f8ee1fdd";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  # Wants to connect to MySQL
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pure Python MySQL Client";
+    homepage = "https://github.com/PyMySQL/PyMySQL";
+    license = licenses.mit;
+    maintainers = [ maintainers.kalbasit ];
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -443,6 +443,8 @@ with self; with super; {
 
   pylint = callPackage ../development/python-modules/pylint/1.9.nix { };
 
+  pymysql = callPackage ../development/python-modules/pymysql/0.nix { };
+
   pyobjc = if stdenv.isDarwin then
     callPackage ../development/python-modules/pyobjc { }
   else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Reintroduce python2Packages.pymsql, fixes trac, nixosTests.trac.

https://hydra.nixos.org/build/143010147

ZHF #122042.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
