### PR TITLE
mfcj430w-cupswrapper: init at 3.0.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17226,12 +17226,6 @@
     githubId = 144952;
     name = "Suvash Thapaliya";
   };
-  svavs = {
-    name = "Silvano Sallese";
-    email = "silvano.sallese+nixpkgs@gmail.com";
-    github = "svavs";
-    githubId = 1369198;
-  };
   sveitser = {
     email = "sveitser@gmail.com";
     github = "sveitser";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17226,6 +17226,12 @@
     githubId = 144952;
     name = "Suvash Thapaliya";
   };
+  svavs = {
+    name = "Silvano Sallese";
+    email = "silvano.sallese+nixpkgs@gmail.com";
+    github = "svavs";
+    githubId = 1369198;
+  };
   sveitser = {
     email = "sveitser@gmail.com";
     github = "sveitser";

--- a/pkgs/misc/cups/drivers/mfcj430wcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj430wcupswrapper/default.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, fetchurl, makeWrapper, cups, perl, coreutils, gnused, gnugrep, pkgs, mfcj430wlpr }:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj430w-cupswrapper";
+  version = "3.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006803/mfcj430wcupswrapper-src-${version}.tar.gz";
+    sha256 = "1gryrjx5cbfzrzf6qvbbqnprs3zrkmzvrrbggjy09f8apa2c5dlb";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups perl coreutils gnused gnugrep mfcj430wlpr ];
+
+  patchPhase = ''
+    WRAPPER=cupswrapper/cupswrappermfcj430w
+
+    substituteInPlace $WRAPPER \
+    --replace /opt "${mfcj430wlpr}/opt" \
+    --replace /usr "${mfcj430wlpr}/usr" \
+    --replace /etc "$out/etc"
+
+    substituteInPlace $WRAPPER \
+    --replace "\`cp " "\`cp -p " \
+    --replace "\`mv " "\`cp -p "
+  '';
+
+  buildPhase = ''
+    cd brcupsconfig
+    make all
+    cd ..
+  '';
+
+  installPhase = ''
+    TARGETFOLDER=$out/opt/brother/Printers/mfcj430w/cupswrapper/
+    CUPSPPD_DIR=$out/share/cups/model
+    CUPSFILTER_DIR=$out/lib/cups/filter
+
+    mkdir -p $TARGETFOLDER
+
+    cp brcupsconfig/brcupsconfpt1 $TARGETFOLDER
+    cp cupswrapper/cupswrappermfcj430w $TARGETFOLDER/
+    cp ppd/brother_mfcj430w_printer_en.ppd $TARGETFOLDER/
+
+    mkdir -p $CUPSPPD_DIR
+    ln -s $TARGETFOLDER/brother_mfcj430w_printer_en.ppd $CUPSPPD_DIR
+  '';
+
+  cleanPhase = ''
+    cd brcupsconfig
+    make clean
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.brother.com/";
+    description = "Brother MFC-J430W CUPS wrapper driver";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj430w_all&os=128&autolayerclose=1";
+    maintainers = with maintainers; [ svavs ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcj430wlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj430wlpr/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchurl, cups, dpkg, ghostscript, a2ps, coreutils, gnused, gawk, file, makeWrapper, glibc }:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj430w-cupswrapper";
+  version = "3.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006570/mfcj430wlpr-${version}.i386.deb";
+    sha256 = "0an3xq9gmml2dxwba6jk6m2aypaa8jii7lzqgk7y46acf5ar09da";
+  };
+
+  nativeBuildInputs = [ makeWrapper dpkg ];
+  buildInputs = [ cups ghostscript a2ps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    substituteInPlace $out/opt/brother/Printers/mfcj430w/lpd/filtermfcj430w \
+      --replace /opt "$out/opt" \
+
+    sed -i '/GHOST_SCRIPT=/c\GHOST_SCRIPT=gs' $out/opt/brother/Printers/mfcj430w/lpd/psconvertij2
+
+    patchelf --set-interpreter ${lib.getLib glibc}/lib/ld-linux.so.2 $out/opt/brother/Printers/mfcj430w/lpd/brmfcj430wfilter
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/mfcj430w/lpd/filtermfcj430w $out/lib/cups/filter/brother_lpdwrapper_mfcj430w
+
+    wrapProgram $out/opt/brother/Printers/mfcj430w/lpd/psconvertij2 \
+      --prefix PATH ":" ${lib.makeBinPath [ gnused coreutils gawk ] }
+
+    wrapProgram $out/opt/brother/Printers/mfcj430w/lpd/filtermfcj430w \
+      --prefix PATH ":" ${lib.makeBinPath [ ghostscript a2ps file gnused coreutils ] }
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.brother.com/";
+    description = "Brother MFC-J430W LPR driver";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj430w_all&os=128&autolayerclose=1";
+    maintainers = with maintainers; [ svavs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41069,6 +41069,10 @@ with pkgs;
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 
+  # Brother MFC-J430W
+  mfcj430w-cupswrapper = callPackage ../misc/cups/drivers/mfcj430wcupswrapper { };
+  mfcj430wlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj430wlpr { };
+
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
 The printer Brother MFC-J430W is not recognized by default (gutenprint, brgenml1cupswrapper, brgenml1lpr). Requires official drivers.

###### Things done
This change allows to install the official Brother driver and CUPS wrapper through services.printing.drivers.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
