### PR TITLE
keepassxc: add readline support, slight refactor

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -23,6 +23,7 @@
 , qtsvg
 , qtx11extras
 , quazip
+, readline
 , wrapQtAppsHook
 , yubikey-personalization
 , zlib
@@ -51,13 +52,13 @@ stdenv.mkDerivation rec {
     sha256 = "02ajfkw818cmalvkl0kqvza85rgdgs59kw2v7b3c4v8kv00c41j3";
   };
 
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang [
+  NIX_CFLAGS_COMPILE = optionalString stdenv.cc.isClang [
     "-Wno-old-style-cast"
     "-Wno-error"
     "-D__BIG_ENDIAN__=${if stdenv.isBigEndian then "1" else "0"}"
   ];
 
-  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 
   patches = [
     ./darwin.patch
@@ -108,12 +109,14 @@ stdenv.mkDerivation rec {
     qtbase
     qtsvg
     qtx11extras
+    readline
     yubikey-personalization
     zlib
   ]
-  ++ lib.optional withKeePassKeeShareSecure quazip
-  ++ lib.optional stdenv.isDarwin qtmacextras
-  ++ lib.optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication;
+  ++ optional withKeePassKeeShareSecure quazip
+  ++ optional stdenv.isDarwin qtmacextras
+  ++ optional (stdenv.isDarwin && withKeePassTouchID)
+    darwin.apple_sdk.frameworks.LocalAuthentication;
 
   preFixup = optionalString stdenv.isDarwin ''
     # Make it work without Qt in PATH.
@@ -123,8 +126,14 @@ stdenv.mkDerivation rec {
   passthru.tests = nixosTests.keepassxc;
 
   meta = {
-    description = "Password manager to store your passwords safely and auto-type them into your everyday websites and applications";
-    longDescription = "A community fork of KeePassX, which is itself a port of KeePass Password Safe. The goal is to extend and improve KeePassX with new features and bugfixes to provide a feature-rich, fully cross-platform and modern open-source password manager. Accessible via native cross-platform GUI, CLI, and browser integration with the KeePassXC Browser Extension (https://github.com/keepassxreboot/keepassxc-browser).";
+    description = "Offline password manager with many features.";
+    longDescription = ''
+      A community fork of KeePassX, which is itself a port of KeePass Password Safe.
+      The goal is to extend and improve KeePassX with new features and bugfixes,
+      to provide a feature-rich, fully cross-platform and modern open-source password manager.
+      Accessible via native cross-platform GUI, CLI, has browser integration
+      using the KeePassXC Browser Extension (https://github.com/keepassxreboot/keepassxc-browser)
+    '';
     homepage = "https://keepassxc.org/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jonafato turion ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`keepassxc-cli` supports readline

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
