### PR TITLE
hackage2nix: Add @Gabriel439 as maintainer

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -237,6 +237,48 @@ package-maintainers:
     - taffybar
     - arbtt
     - lentil
+  Gabriel439:
+    - annah
+    - bench
+    - break
+    - dhall-bash
+    - dhall-docs
+    - dhall-json
+    - dhall-lsp-server
+    - dhall-nix
+    - dhall-nixpkgs
+    - dhall-openapi
+    - dhall-text
+    - dhall-yaml
+    - dhall
+    - dirstream
+    - errors
+    - foldl
+    - index-core
+    - lens-tutorial
+    - list-transformer
+    - managed
+    - mmorph
+    - morte
+    - mvc-updates
+    - mvc
+    - nix-derivation
+    - nix-diff
+    - optional-args
+    - optparse-generic
+    - pipes-bytestring
+    - pipes-concurrency
+    - pipes-csv
+    - pipes-extras
+    - pipes-group
+    - pipes-http
+    - pipes-parse
+    - pipes-safe
+    - pipes
+    - server-generic
+    - total
+    - turtle
+    - typed-spreadsheet
 
 unsupported-platforms:
   Allure:                                       [ x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

This was suggested by @sternenseemann in https://github.com/NixOS/nixpkgs/pull/123094#issuecomment-841645008

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
