### PR TITLE
nvd: init at 0.1.1

### DIFF
--- a/pkgs/tools/package-management/nvd/default.nix
+++ b/pkgs/tools/package-management/nvd/default.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitLab, installShellFiles, lib, python3, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "nvd";
+  version = "0.1.1";
+
+  src = fetchFromGitLab {
+    owner = "khumba";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0accq0cw6qsxin1fb2bp2ijgjf9akb9qlivkykpfsgnk5qjafv2n";
+  };
+
+  buildInputs = [ python3 ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+    install -m555 -Dt $out/bin src/nvd
+    installManPage src/nvd.1
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Nix/NixOS package version diff tool";
+    homepage = "https://gitlab.com/khumba/nvd";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ khumba ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30481,6 +30481,8 @@ in
 
   nut = callPackage ../applications/misc/nut { };
 
+  nvd = callPackage ../tools/package-management/nvd { };
+
   solfege = python3Packages.callPackage ../misc/solfege { };
 
   disnix = callPackage ../tools/package-management/disnix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[nvd](https://gitlab.com/khumba/nvd) is a tool I've written for inspecting installed versions of Nix packages, and for comparing built system configurations.  It can display packages that are being upgraded or downgraded between two system configs, and can be used to search the list of packages in a system's closure, in a format similar to `emerge -pv`, `apt upgrade -V`, and `apt list -i`.  It works with regular Nix builds that aren't system configs as well.  There is special handling for `environment.systemPackages` (or direct dependencies, for regular packages).

There was [interest](https://discourse.nixos.org/t/nvd-simple-nix-nixos-version-diff-tool/12397) in having it packaged in Nixpkgs, so here we go!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `du` reports 48K for nvd itself, and 98M for its closure (all of which is Python).
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
