### PR TITLE
river: build for baseline arch, cleanup

### DIFF
--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -1,7 +1,19 @@
-{ lib, stdenv ,fetchFromGitHub
-, zig, wayland, pkg-config, scdoc
-, xwayland, wayland-protocols, wlroots
-, libxkbcommon, pixman, udev, libevdev, libX11, libGL
+{ lib
+, stdenv
+, fetchFromGitHub
+, zig
+, wayland
+, pkg-config
+, scdoc
+, xwayland
+, wayland-protocols
+, wlroots
+, libxkbcommon
+, pixman
+, udev
+, libevdev
+, libX11
+, libGL
 }:
 
 stdenv.mkDerivation rec {
@@ -16,8 +28,18 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ wayland-protocols wlroots pixman
-    libxkbcommon pixman udev libevdev libX11 libGL
+  nativeBuildInputs = [ zig wayland xwayland scdoc pkg-config ];
+
+  buildInputs = [
+    wayland-protocols
+    wlroots
+    pixman
+    libxkbcommon
+    pixman
+    udev
+    libevdev
+    libX11
+    libGL
   ];
 
   dontConfigure = true;
@@ -25,17 +47,18 @@ stdenv.mkDerivation rec {
   preBuild = ''
     export HOME=$TMPDIR
   '';
+
   installPhase = ''
     runHook preInstall
-    zig build -Drelease-safe -Dxwayland -Dman-pages --prefix $out install
+    zig build -Drelease-safe -Dtarget=${stdenv.hostPlatform.parsed.cpu.name}-native -Dxwayland -Dman-pages --prefix $out install
     runHook postInstall
   '';
 
-  nativeBuildInputs = [ zig wayland xwayland scdoc pkg-config ];
-
-  # Builder patch install dir into river to get default config
-  # When installFlags is removed, river becomes half broken
-  # see https://github.com/ifreund/river/blob/7ffa2f4b9e7abf7d152134f555373c2b63ccfc1d/river/main.zig#L56
+  /*
+    Builder patch install dir into river to get default config
+    When installFlags is removed, river becomes half broken.
+    See https://github.com/ifreund/river/blob/7ffa2f4b9e7abf7d152134f555373c2b63ccfc1d/river/main.zig#L56
+  */
   installFlags = [ "DESTDIR=$(out)" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix: #123187

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
