### PR TITLE
pythonPackages.requests: patch in CA bundles

### DIFF
--- a/pkgs/development/python-modules/requests/0001-Prefer-NixOS-Nix-default-CA-bundles-over-certifi.patch
+++ b/pkgs/development/python-modules/requests/0001-Prefer-NixOS-Nix-default-CA-bundles-over-certifi.patch
@@ -1,0 +1,60 @@
+From b36083efafec5a3c1c5864cd0b62367ddf3856ae Mon Sep 17 00:00:00 2001
+From: Keshav Kini <keshav.kini@gmail.com>
+Date: Sun, 16 May 2021 20:35:24 -0700
+Subject: [PATCH] Prefer NixOS/Nix default CA bundles over certifi
+
+Normally, requests gets its default CA bundle from the certifi
+package.  On NixOS and when using Nix on non-NixOS platforms, we would
+rather default to using our own certificate bundles controlled by the
+Nix/NixOS user.
+
+This commit overrides requests.certs.where(), which previously was
+just aliased to certifi.where(), so that now it does the following:
+
+- When run by Nix on non-NixOS, the environment variable
+  $NIX_SSL_CERT_FILE will point to the CA bundle we're using, so we
+  use that.
+
+- When running on NixOS, the CA bundle we're using has the static path
+  /etc/ssl/certs/ca-certificates.crt , so we use that.
+
+- Otherwise, we fall back to the original behavior of using certifi's
+  CA bundle.  Higher in the call stack, users of requests can also
+  explicitly specify a CA bundle to use, which overrides all this
+  logic.
+---
+ requests/certs.py | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/requests/certs.py b/requests/certs.py
+index d1a378d7..faf462b7 100644
+--- a/requests/certs.py
++++ b/requests/certs.py
+@@ -12,7 +12,23 @@ If you are packaging Requests, e.g., for a Linux distribution or a managed
+ environment, you can change the definition of where() to return a separately
+ packaged CA bundle.
+ """
+-from certifi import where
++
++import os
++
++import certifi
++
++
++def where():
++    nix_ssl_cert_file = os.getenv("NIX_SSL_CERT_FILE")
++    if nix_ssl_cert_file and os.path.exists(nix_ssl_cert_file):
++        return nix_ssl_cert_file
++
++    nixos_ca_bundle = "/etc/ssl/certs/ca-certificates.crt"
++    if os.path.exists(nixos_ca_bundle):
++        return nixos_ca_bundle
++
++    return certifi.where()
++
+ 
+ if __name__ == '__main__':
+     print(where())
+-- 
+2.31.1
+

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
     sha256 = "sha256-J5c91KkEpPE7JjoZyGbBO5KjntHJZGVfAl8/jT11uAQ=";
   };
 
+  patches = [ ./0001-Prefer-NixOS-Nix-default-CA-bundles-over-certifi.patch ];
+
   postPatch = ''
     # Use latest idna
     substituteInPlace setup.py --replace ",<3" ""


### PR DESCRIPTION
This is an attempt to do what #94024 was trying to do, but at a deeper level in the code. In fact [the file I edit here](https://github.com/psf/requests/blob/f6d43b03fbb9a1e75ed63a9aa15738a8fce99b50/requests/certs.py#L11-L13) has a docstring in it saying the following:

```
 If you are packaging Requests, e.g., for a Linux distribution or a managed
 environment, you can change the definition of where() to return a separately
 packaged CA bundle.
```

So I guess this is the "right" way to do this (?).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The requests library defaults to using the certificates from the
certifi library when not otherwise specified.  If I understand the
discussion at #8247 correctly, we should instead patch it so that it
follows the following priority order:

1. the path pointed to by the environment variable $NIX_SSL_CERT_FILE

2. /etc/ssl/certs/ca-certificates.crt

3. whatever it was doing before (in this case, using certifi)

This commit implements that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
