### PR TITLE
yle-dl: 20210212 → 20210502

### DIFF
--- a/pkgs/tools/misc/yle-dl/default.nix
+++ b/pkgs/tools/misc/yle-dl/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "yle-dl";
-  version = "20210212";
+  version = "20210502";
 
   src = fetchFromGitHub {
     owner = "aajanki";
     repo = "yle-dl";
     rev = version;
-    sha256 = "sha256-0JnigYmslQ/7KsQAFg3AaWPAU/tD1lS7lF6OCcv/ze4=";
+    sha256 = "sha256-HkhyxsiOMOfTHTj+qmY8l2z2sMtO4eMZmJUU/WvV4wY=";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -22,6 +22,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "Downloads videos from Yle (Finnish Broadcasting Company) servers";
     homepage = "https://aajanki.github.io/yle-dl/";
+    changelog = "https://github.com/aajanki/yle-dl/blob/${version}/ChangeLog";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dezgeg SuperSandro2000 ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/aajanki/yle-dl/blob/20210502/ChangeLog)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
