### PR TITLE
nixos/fancontrol: back to running as root

### DIFF
--- a/nixos/modules/services/hardware/fancontrol.nix
+++ b/nixos/modules/services/hardware/fancontrol.nix
@@ -31,16 +31,6 @@ in
 
   config = mkIf cfg.enable {
 
-    users = {
-      groups.lm_sensors = {};
-
-      users.fancontrol = {
-        isSystemUser = true;
-        group = "lm_sensors";
-        description = "fan speed controller";
-      };
-    };
-
     systemd.services.fancontrol = {
       documentation = [ "man:fancontrol(8)" ];
       description = "software fan control";
@@ -49,8 +39,6 @@ in
 
       serviceConfig = {
         ExecStart = "${pkgs.lm_sensors}/sbin/fancontrol ${configFile}";
-        Group = "lm_sensors";
-        User = "fancontrol";
       };
     };
   };


### PR DESCRIPTION
regular users don't have write access to /sys/devices
  which is where the kernel endpoints are to control fan speed

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/122074#issuecomment-841916901

###### Things done

actually confirm it works this time...

checked if there's any sensors exposed in a nixos test VM to be able to test this,
no luck there

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @jonringer 

###### Notes

i've been trying to learn about systemd hardening, i'll revisit this when i'm more knowledgeable