### PR TITLE
python3Packages.croniter: 1.0.9 -> 1.0.13

### DIFF
--- a/pkgs/development/python-modules/croniter/default.nix
+++ b/pkgs/development/python-modules/croniter/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "croniter";
-  version = "1.0.9";
+  version = "1.0.13";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "708532f70584207e23ef2989ca40f367e6238bfe050133a1aff43e1e0e6f6092";
+    sha256 = "sha256-V/Nt9PWhwxu/ULv/o1UWEsGfYVarHoji5CNCzLufm5o=";
   };
 
   propagatedBuildInputs = [
@@ -27,6 +27,8 @@ buildPythonPackage rec {
     pytz
     tzlocal
   ];
+
+  pythonImportsCheck = [ "croniter" ];
 
   meta = with lib; {
     description = "croniter provides iteration for datetime object with cron like format";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.13

Change log: https://github.com/taichino/croniter/blob/master/docs/CHANGES.rst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
