### PR TITLE
kicad: correct handling of share/metainfo and appdata

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -257,9 +257,12 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share
     ln -s ${base}/share/applications $out/share/applications
-    ln -s ${base}/share/metainfo $out/share/metainfo
     ln -s ${base}/share/icons $out/share/icons
     ln -s ${base}/share/mime $out/share/mime
+  '' + optionalString (stable) ''
+    ln -s ${base}/share/appdata $out/share/appdata
+  '' + optionalString (!stable) ''
+    ln -s ${base}/share/metainfo $out/share/metainfo
   '';
 
   # can't run this for each pname

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,14 +27,14 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2021-05-13";
+      version =			"2021-05-16";
       src = {
-        rev =			"8513ca974c28d76d9f74a7dc96601d98e66e87fd";
-        sha256 =		"1xlj6jwzwxsa14djqhj0csziii21mr9czvdj6fxqp6px84cifjsh";
+        rev =			"c33b2cfa8d16072b9d1bce558e443c4afa889d06";
+        sha256 =		"1fvbxjpf880ikjqjhzj8wlxj0845gzrj1yv35rk7akbg4vl9ph72";
       };
     };
     libVersion = {
-      version =			"2021-05-13";
+      version =			"2021-05-16";
       libSources = {
         i18n.rev =		"e89d9a89bec59199c1ade56ee2556591412ab7b0";
         i18n.sha256 =		"04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";


### PR DESCRIPTION
###### Motivation for this change
fixes #123299
(due to https://github.com/NixOS/nixpkgs/issues/82685)

###### Things done
moved the linking through of share/metainfo to an optionalString for the unstable package
and added linking through of the equivalent (share/appdata) for the stable package

bumped kicad-unstable to the latest commit and tested the result

ran `nix run nixpkgs.symlinks -c symlinks -r result | grep dangling` on both `kicad` and `kicad-unstable` as the result

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - '/nix/store/0pl7p5176k287zxqz8m6gdhny4kmspwh-kicad-unstable-8513ca974c	 6949715408'
  - `/nix/store/1zvmficgqj8cf97apxml7qf5g9zf5h9d-kicad-unstable-c33b2cfa8d	 6949738808`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @SuperSandro2000