### PR TITLE
libidn: 1.36 -> 1.37

### DIFF
--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     repositories.git = "git://git.savannah.gnu.org/libidn.git";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ lsix ];
   };
 }

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -11,14 +11,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];
 
-  # broken with gcc-7
-  #doCheck = !stdenv.isDarwin && !stdenv.hostPlatform.isMusl;
-
   hardeningDisable = [ "format" ];
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
-
-  doCheck = false; # fails
 
   meta = {
     homepage = "https://www.gnu.org/software/libidn/";

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -1,11 +1,12 @@
 { fetchurl, lib, stdenv, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "libidn-1.36";
+  pname = "libidn";
+  version = "1.37";
 
   src = fetchurl {
-    url = "mirror://gnu/libidn/${name}.tar.gz";
-    sha256 = "0f20n634whpmdwr81c2r0vxxjwchgkvhsr1i8s2bm0ad6h473dhl";
+    url = "mirror://gnu/libidn/${pname}-${version}.tar.gz";
+    sha256 = "1hljls9rkilh04dwiwg388wk8djkac8idijrdysqq2nqbh6rg3iw";
   };
 
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change

See https://lists.gnu.org/archive/html/info-gnu/2021-05/msg00012.html
for release information.

This release is announced as API and ABI compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
