### PR TITLE
postgresqlPackages.pipelinedb: fix darwin build

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
+++ b/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, postgresql, zeromq, openssl }:
+{ lib, stdenv, fetchFromGitHub, postgresql, zeromq, openssl, libsodium, libkrb5 }:
 
 stdenv.mkDerivation rec {
   pname = "pipelinedb";
@@ -11,9 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1mnqpvx6g1r2n4kjrrx01vbdx7kvndfsbmm7zbzizjnjlyixz75f";
   };
 
-  buildInputs = [ postgresql openssl zeromq ];
+  buildInputs = [ postgresql openssl zeromq libsodium libkrb5 ];
 
   makeFlags = [ "USE_PGXS=1" ];
+
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lsodium";
 
   preConfigure = ''
     substituteInPlace Makefile \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042

https://nix-cache.s3.amazonaws.com/log/d9p1jxf8pdmlpsbnr8sx0n1p17gjwimi-pipelinedb-1.0.0-13.drv

ping @NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
