### PR TITLE
cargo-flash: fix build

### DIFF
--- a/pkgs/development/tools/rust/cargo-flash/default.nix
+++ b/pkgs/development/tools/rust/cargo-flash/default.nix
@@ -3,6 +3,7 @@
 , rustPlatform
 , fetchFromGitHub
 , libusb1
+, openssl
 , pkg-config
 , rustfmt
 , Security
@@ -22,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-P7xyg9I1MhmiKlyAI9cvABcYKNxB6TSvTgMsMk5KxAQ=";
 
   nativeBuildInputs = [ pkg-config rustfmt ];
-  buildInputs = [ libusb1 ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ libusb1 openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   meta = with lib; {
     description = "A cargo extension for working with microcontrollers";


### PR DESCRIPTION
Since v0.10.0 cargo-flash uses sentry for logging, which requires openssl.

ZHF: #122042

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
