### PR TITLE
audit: Fix python bindings

### DIFF
--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -3,7 +3,7 @@
   runCommand,
   autoreconfHook,
   autoconf, automake, libtool,
-  enablePython ? true, python, swig,
+  enablePython ? true, python3, swig,
   linuxHeaders ? stdenv.cc.libc.linuxHeaders
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = lib.optionals enablePython [ python swig ];
+  buildInputs = lib.optionals enablePython [ python3 swig ];
 
   configureFlags = [
     # z/OS plugin is not useful on Linux,

--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -3,10 +3,9 @@
   runCommand,
   autoreconfHook,
   autoconf, automake, libtool,
-  enablePython ? false, python ? null,
+  enablePython ? true, python, swig,
+  linuxHeaders ? stdenv.cc.libc.linuxHeaders
 }:
-
-assert enablePython -> python != null;
 
 stdenv.mkDerivation rec {
   pname = "audit";
@@ -21,7 +20,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = lib.optional enablePython python;
+  buildInputs = lib.optionals enablePython [ python swig ];
 
   configureFlags = [
     # z/OS plugin is not useful on Linux,
@@ -69,8 +68,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  prePatch = ''
+  postPatch = ''
     sed -i 's,#include <sys/poll.h>,#include <poll.h>\n#include <limits.h>,' audisp/audispd.c
+    substituteInPlace bindings/swig/src/auditswig.i \
+      --replace "/usr/include/linux/audit.h" \
+                "${linuxHeaders}/include/linux/audit.h"
   ''
   # According to https://stackoverflow.com/questions/13089166
   # --whole-archive linker flag is required to be sure that linker


### PR DESCRIPTION
###### Motivation for this change

Fixes the python bindings for libaudit, which currently don't build to a missing dependency on swig, and a hardcoded path in upstream source to /usr/include/linux/audit.h.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
