### PR TITLE
synergy: 1.11.1 -> 1.13.1.41

### DIFF
--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     description = "Share one mouse and keyboard between multiple computers";
     homepage = "https://synergy-project.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ talyz ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -5,41 +5,21 @@
 
 stdenv.mkDerivation rec {
   pname = "synergy";
-  version = "1.11.1";
+  version = "1.13.1.41";
 
   src = fetchFromGitHub {
     owner = "symless";
     repo = "synergy-core";
     rev = "${version}-stable";
-    sha256 = "1jk60xw4h6s5crha89wk4y8rrf1f3bixgh5mzh3cq3xyrkba41gh";
+    fetchSubmodules = true;
+    sha256 = "1phg0szc9g018zxs5wbys4drzq1cdhyzajfg45l6a3fmi6qdi1kw";
   };
 
-  patches = [
-    ./build-tests.patch
-    (fetchpatch {
-      name = "CVE-2020-15117.patch";
-      url = "https://github.com/symless/synergy-core/commit/"
-          + "0a97c2be0da2d0df25cb86dfd642429e7a8bea39.patch";
-      sha256 = "03q8m5n50fms7fjfjgmqrgy9mrxwi9kkz3f3vlrs2x5h21dl6bmj";
-    })
-  ] ++ lib.optional stdenv.isDarwin ./macos_build_fix.patch;
-
-  # Since the included gtest and gmock don't support clang and the
-  # segfault when built with gcc9, we replace it with 1.10.0 for
-  # synergy-1.11.0. This should become unnecessary when upstream
-  # updates these dependencies.
-  googletest = fetchFromGitHub {
-    owner = "google";
-    repo = "googletest";
-    rev = "release-1.10.0";
-    sha256 = "1zbmab9295scgg4z2vclgfgjchfjailjnvzc6f5x9jvlsdi3dpwz";
-  };
+  patches = lib.optional stdenv.isDarwin ./macos_build_fix.patch;
 
   postPatch = ''
-    rm -r ext/*
-    cp -r ${googletest}/googlemock ext/gmock/
-    cp -r ${googletest}/googletest ext/gtest/
-    chmod -R +w ext/
+    substituteInPlace src/gui/src/SslCertificate.cpp \
+      --replace 'kUnixOpenSslCommand[] = "openssl";' 'kUnixOpenSslCommand[] = "${openssl}/bin/openssl";'
   '';
 
   cmakeFlags = lib.optional (!withGUI) "-DSYNERGY_BUILD_LEGACY_GUI=OFF";
@@ -63,7 +43,7 @@ stdenv.mkDerivation rec {
     cp bin/{synergyc,synergys,synergyd,syntool} $out/bin/
   '' + lib.optionalString withGUI ''
     cp bin/synergy $out/bin/
-    wrapQtApp $out/bin/synergy --prefix PATH : ${lib.makeBinPath [ openssl ]}
+    wrapQtApp $out/bin/synergy
   '' + lib.optionalString stdenv.isLinux ''
     mkdir -p $out/share/icons/hicolor/scalable/apps
     cp ../res/synergy.svg $out/share/icons/hicolor/scalable/apps/
@@ -80,7 +60,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Share one mouse and keyboard between multiple computers";
-    homepage = "http://synergy-project.org/";
+    homepage = "https://synergy-project.org/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/synergy/macos_build_fix.patch
+++ b/pkgs/applications/misc/synergy/macos_build_fix.patch
@@ -1,17 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a2297311..25a51f56 100644
+index c1e78d1d..13639ba1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -138,7 +138,7 @@ if (UNIX)
- 
- 
-     if (APPLE)
--        set (CMAKE_CXX_FLAGS "--sysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
-+        set (CMAKE_CXX_FLAGS "--sysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CXX_FLAGS}")
- 
-         find_library (lib_ScreenSaver ScreenSaver)
-         find_library (lib_IOKit IOKit)
-@@ -292,14 +292,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+@@ -328,14 +328,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
          ${OPENSSL_ROOT}/lib/libssl.lib
          ${OPENSSL_ROOT}/lib/libcrypto.lib
      )
@@ -22,8 +13,8 @@ index a2297311..25a51f56 100644
 -        ${OPENSSL_ROOT}/lib/libssl.a
 -        ${OPENSSL_ROOT}/lib/libcrypto.a
 -    )
--elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux|.*BSD|DragonFly")
++elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux|Darwin|.*BSD|DragonFly")
      set (OPENSSL_LIBS ssl crypto)
  else()
      message (FATAL_ERROR "Couldn't find OpenSSL")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update `synergy` to the latest stable release and take over maintainership.

###### Things done

- Set up a session between NixOS and Darwin, both using the new version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
