### PR TITLE
trilium: 0.47.2 -> 0.47.3

### DIFF
--- a/nixos/modules/services/web-apps/trilium.nix
+++ b/nixos/modules/services/web-apps/trilium.nix
@@ -9,6 +9,7 @@ let
 
     # Disable automatically generating desktop icon
     noDesktopIcon=true
+    noBackup=${cfg.noBackup}
 
     [Network]
     # host setting is relevant only for web deployments - set the host on which the server will listen
@@ -37,6 +38,14 @@ in
       default = "Trilium";
       description = ''
         Instance name used to distinguish between different instances
+      '';
+    };
+
+    noBackup = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Disable periodic database backups.
       '';
     };
 

--- a/nixos/modules/services/web-apps/trilium.nix
+++ b/nixos/modules/services/web-apps/trilium.nix
@@ -28,7 +28,7 @@ in
       type = types.str;
       default = "/var/lib/trilium";
       description = ''
-        The directory storing the nodes database and the configuration.
+        The directory storing the notes database and the configuration.
       '';
     };
 
@@ -85,7 +85,7 @@ in
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
   {
-    meta.maintainers = with lib.maintainers; [ ];
+    meta.maintainers = with lib.maintainers; [ fliegendewurst ];
 
     users.groups.trilium = {};
     users.users.trilium = {

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -19,16 +19,16 @@ let
     maintainers = with maintainers; [ fliegendewurst ];
   };
 
-  version = "0.47.2";
+  version = "0.47.3";
 
   desktopSource = {
     url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-    sha256 = "04fyi0gbih6iw61b6d8lprf9qhxb6zb1pgckmi016wgv8x5ck02p";
+    sha256 = "05l8yiqbqh2yr4cfbivpmj5q3jyzqz86wni36wcjlcg3rccms0hc";
   };
 
   serverSource = {
     url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-server-${version}.tar.xz";
-    sha256 = "1f8csjgqq4yw1qcnlrfy5ysarazmvj2fnmnxj4sr1xjbfa78y2rr";
+    sha256 = "03nsvalaa0rch9i1kh6p5ynnsdmidm5zrw42klj70bamviklzsnh";
   };
 
 in {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/zadam/trilium/compare/v0.47.2...v0.47.3

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).