### PR TITLE
foot: fix evaluation with clang stdenvs

### DIFF
--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -104,7 +104,9 @@ stdenv.mkDerivation rec {
     tllist
     wayland-protocols
     pkg-config
-  ] ++ lib.optional stdenv.cc.isClang stdenv.cc.cc.llvm;
+  ] ++ lib.optionals (compilerName == "clang") [
+    stdenv.cc.cc.libllvm.out
+  ];
 
   buildInputs = [
     fontconfig


### PR DESCRIPTION
To be able to do LTO with clang we need the LTO-capable llvm-ar from
libllvm.out (== llvmPackages.llvm) which contains a superset of the llvm
bintools. This used to be passed through from stdenv.cc.cc as llvm, but
has been renamed to libllvm in 7869d1654517c028aa76fc1dedc9b5ac301a867a.

llvm-ar would be in stdenv.cc.bintools.bintools provided that we are
using a clang stdenv which uses lld as its linker. In the future we could
thus make this inclusion conditional on stdenv.hostPlatform.linker.

Note that the build of foot.tests still fails, pending resolution of #123361.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
