### PR TITLE
haskell.compiler.ghcHEAD: disable DWARF on non x86

### DIFF
--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -10,7 +10,9 @@
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+  # Libdw.c only supports x86_64, i686 and s390x
+, enableDwarf ? stdenv.targetPlatform.isx86 &&
+                !stdenv.targetPlatform.isDarwin &&
                 !stdenv.targetPlatform.isWindows
 , elfutils # for DWARF support
 
@@ -258,10 +260,7 @@ stdenv.mkDerivation (rec {
     homepage = "http://haskell.org/ghc";
     description = "The Glasgow Haskell Compiler";
     maintainers = with lib.maintainers; [ marcweber andres peti ];
-    inherit (ghc.meta) license;
-    # GHC-HEAD does not appear to compile on aarch64.
-    broken = stdenv.isAarch64;
-    platforms = builtins.filter (p: p != "aarch64-linux") ghc.meta.platforms;
+    inherit (ghc.meta) license platforms;
   };
 
   dontStrip = (targetPlatform.useAndroidPrebuilt || targetPlatform.isWasm);

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -86,7 +86,7 @@ in {
       llvmPackages = pkgs.llvmPackages_10;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
-      bootPkgs = packages.ghc8104; # no binary yet
+      bootPkgs = packages.ghc901; # no binary yet
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_10;
       llvmPackages = pkgs.llvmPackages_10;


### PR DESCRIPTION
The broken build of ghcHEAD on aarch64-linux results from rts/Libdw.c
not supporting that platform. Seemingly this particular file is only
relevant for DWARF support in GHC, so we disable that on unsupported
platforms.

(untested)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
