### PR TITLE
python3Packages.aplpy: fix with latest matplotlib

### DIFF
--- a/pkgs/development/python-modules/aplpy/default.nix
+++ b/pkgs/development/python-modules/aplpy/default.nix
@@ -27,12 +27,25 @@ buildPythonPackage rec {
     sha256 = "239f3d83635ca4251536aeb577df7c60df77fc4d658097b92094719739aec3f3";
   };
 
-  patches = [ (fetchpatch {
-      # Can be removed in next release after 2.0.3
+  patches = [
+    # Fixes compatibility with astropy-helpers. This patch has been merged into
+    # the master branch as of May 2020, and should be part of the next
+    # upstream release (v2.0.3 was tagged in Feb. 2019).
+    (fetchpatch {
       url = "https://github.com/aplpy/aplpy/pull/448.patch";
       sha256 = "1pnzh7ykjc8hwahzbzyryrzv5a8fddgd1bmzbhagkrn6lmvhhpvq";
       excludes = [ "tox.ini" "azure-pipelines.yml" ".circleci/config.yml" "MANIFEST.in" ".gitignore"
        "setup.cfg" "appveyor.yml" "readthedocs.yml" "CHANGES.rst" ".gitmodules" ".travis.yml" "astropy_helpers" ];
+    })
+    # Fix for matplotlib >= 3.4 (https://github.com/aplpy/aplpy/pull/466)
+    # Note: because of a security thing, github will refuse to serve this patch from the
+    # "normal" location
+    # (https://github.com/aplpy/aplpy/commit/56c1cc694fdea69e7da8506d3212c4495adb0ca5.patch)
+    # due to the fact that it contains the PDF magic bytes, but it will serve it from
+    # this githubusercontent domain.
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/aplpy/aplpy/pull/466/commit/56c1cc694fdea69e7da8506d3212c4495adb0ca5.patch";
+      sha256 = "0jna2n1cgfzr0a27m5z94wwph7qg25hs7lycrdb2dp3943rb35g4";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This was broken in the latest staging update that bumped matplotlib from 3.3.4 to 3.4.1.
Upstream patch: https://github.com/aplpy/aplpy/pull/466
Noticed here: https://rmcgibbo.github.io/mydra/post/nixpkgs-0b95e8cb/
ZHF: #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
