### PR TITLE
rPackages.RcppArmadillo: fix darwin

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -379,6 +379,7 @@ let
   packagesWithBuildInputs = {
     # sort -t '=' -k 2
     gam = lib.optionals stdenv.isDarwin [ pkgs.libiconv ];
+    RcppArmadillo = lib.optionals stdenv.isDarwin [ pkgs.libiconv ];
     quantreg = lib.optionals stdenv.isDarwin [ pkgs.libiconv ];
     rmutil = lib.optionals stdenv.isDarwin [ pkgs.libiconv ];
     robustbase = lib.optionals stdenv.isDarwin [ pkgs.libiconv ];


### PR DESCRIPTION
###### Motivation for this change

Without this I get

```
/nix/store/47vpv5i10dwfg1cf5wca1k40f982g5fm-clang-wrapper-7.1.0/bin/c++ -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -L/nix/store/3ndhndpas5zaxpa63gldf2xgcd2skd3y-libc++-7.1.0/lib -o RcppArmadillo.so RcppArmadillo.o RcppExports.o fastLm.o -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -lRlapack -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -lRblas -L/nix/store/jgq6753lj37wz7rxh03h8w7s2x7m9f0r-gfortran-9.3.0-lib/lib -L/nix/store/lsbcpdqhhnvxc1xmvyryihfv0wyf4mqi-gfortran-wrapper-9.3.0/bin -L/nix/store/pgs2br6vpd9y0cnq51pxpgxxs6y2x4l9-gfortran-9.3.0/lib/gcc/x86_64-apple-darwin/9.3.0 -L/nix/store/pgs2br6vpd9y0cnq51pxpgxxs6y2x4l9-gfortran-9.3.0/lib -lintl -liconv -lgfortran -lquadmath -lm -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -lR -lintl -Wl,-framework -Wl,CoreFoundation
/nix/store/47vpv5i10dwfg1cf5wca1k40f982g5fm-clang-wrapper-7.1.0/bin/c++ -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -L/nix/store/3ndhndpas5zaxpa63gldf2xgcd2skd3y-libc++-7.1.0/lib -o RcppArmadillo.so RcppArmadillo.o RcppExports.o fastLm.o -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -lRlapack -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -lRblas -L/nix/store/jgq6753lj37wz7rxh03h8w7s2x7m9f0r-gfortran-9.3.0-lib/lib -L/nix/store/lsbcpdqhhnvxc1xmvyryihfv0wyf4mqi-gfortran-wrapper-9.3.0/bin -L/nix/store/pgs2br6vpd9y0cnq51pxpgxxs6y2x4l9-gfortran-9.3.0/lib/gcc/x86_64-apple-darwin/9.3.0 -L/nix/store/pgs2br6vpd9y0cnq51pxpgxxs6y2x4l9-gfortran-9.3.0/lib -lintl -liconv -lgfortran -lquadmath -lm -L/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/lib -lR -lintl -Wl,-framework -Wl,CoreFoundation
ld: library not found for -liconv
ld: library not found for -liconv
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/share/make/shlib.mk:10: RcppArmadillo.so] Error 1
make: *** [/nix/store/k20dhvmbiabz6v91qk324n9b8hpqjg1m-R-4.0.4/lib/R/share/make/shlib.mk:10: RcppArmadillo.so] Error 1
```

on Darwin. I am a complete R beginner and as such took some inspiration from existing overrides.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
