### PR TITLE
pythonPackages.pyfirmata: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/pyfirmata/default.nix
+++ b/pkgs/development/python-modules/pyfirmata/default.nix
@@ -1,0 +1,21 @@
+{ lib, pyserial, buildPythonPackage, fetchPypi  }:
+
+buildPythonPackage rec {
+  pname = "pyfirmata";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "pyFirmata";
+    sha256 = "cc180d1b30c85a2bbca62c15fef1b871db048cdcfa80959968356d97bd3ff08e";
+  };
+
+  propagatedBuildInputs = [ pyserial ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tino/pyFirmata";
+    description = "A Python interface for the Firmata protocol";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5611,6 +5611,8 @@ in {
 
   pyfiglet = callPackage ../development/python-modules/pyfiglet { };
 
+  pyfirmata = callPackage ../development/python-modules/pyfirmata { };
+
   pyfnip = callPackage ../development/python-modules/pyfnip { };
 
   pyflakes = callPackage ../development/python-modules/pyflakes { };


### PR DESCRIPTION
pyFirmata is a python library for Firmata, a microcontroller protocol.

Firmata can be used to drive arduino boards with python, using standard
firmata firmware.

Signed-off-by: William Casarin <jb55@jb55.com>
Reviewed-by: Matthias Beyer <mail@beyermatthias.de>
Link: https://lists.sr.ht/~andir/nixpkgs-dev/%3C20210515152500.31824-1-jb55@jb55.com%3E

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
