### PR TITLE
libow: fix darwin build

### DIFF
--- a/pkgs/development/libraries/libow/default.nix
+++ b/pkgs/development/libraries/libow/default.nix
@@ -11,7 +11,28 @@ stdenv.mkDerivation rec {
     sha256 = "0dln1ar7bxwhpi36sccmpwapy7iz4j097rbf02mgn42lw5vrcg3s";
   };
 
-  nativeBuildInputs = [ autoconf automake pkg-config ];
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+
+  preConfigure = ''
+    # Tries to use glibtoolize on Darwin, but it shouldn't for Nix.
+    sed -i -e 's/glibtoolize/libtoolize/g' bootstrap
+    ./bootstrap
+  '';
+
+  configureFlags = [
+    "--disable-owtcl"
+    "--disable-owphp"
+    "--disable-owpython"
+    "--disable-zero"
+    "--disable-owshell"
+    "--disable-owhttpd"
+    "--disable-owftpd"
+    "--disable-owserver"
+    "--disable-owperl"
+    "--disable-owtap"
+    "--disable-owmon"
+    "--disable-owexternal"
+  ];
 
   meta = with lib; {
     description = "1-Wire File System full library";
@@ -20,24 +41,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ disserman ];
     platforms = platforms.unix;
   };
-
-  buildInputs = [ libtool ];
-
-  preConfigure = "./bootstrap";
-
-  configureFlags = [
-      "--disable-owtcl"
-      "--disable-owphp"
-      "--disable-owpython"
-      "--disable-zero"
-      "--disable-owshell"
-      "--disable-owhttpd"
-      "--disable-owftpd"
-      "--disable-owserver"
-      "--disable-owperl"
-      "--disable-owtcl"
-      "--disable-owtap"
-      "--disable-owmon"
-      "--disable-owexternal"
-    ];
 }


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142955431/nixlog/1

I moved libtool from `buildInputs` to `nativeBuildInputs`, and also moved the `meta` block down the file. Hope it's okay to have these additional changes in this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
