### PR TITLE
hdhomerun-config-gui: install path correction and warning about libhdhomerun version added

### DIFF
--- a/pkgs/applications/video/hdhomerun-config-gui/default.nix
+++ b/pkgs/applications/video/hdhomerun-config-gui/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
   makeFlags = [ "SUBDIRS=src" ];
 
   installPhase = ''
-    install -vDm 755 src/hdhomerun_config_gui $out/usr/bin/hdhomerun_config_gui
+    runHook preInstall
+    install -vDm 755 src/hdhomerun_config_gui $out/bin/hdhomerun_config_gui
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package failed to build correctly due to wrong install path.
Also same version of libhdhomerun is needed hence warning added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
