### PR TITLE
gnomeExtensions.topicons-plus: enable GNOME 40 compatibility

### DIFF
--- a/pkgs/desktops/gnome/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome/extensions/topicons-plus/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Brings all icons back to the top panel, so that it's easier to keep track of apps running in the backround";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ eperuffo ];
+    maintainers = with maintainers; [ eduardosm ];
     homepage = "https://github.com/phocean/TopIcons-plus";
   };
 }

--- a/pkgs/desktops/gnome/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome/extensions/topicons-plus/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, glib, gettext }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, glib, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-topicons-plus";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1p3jlvs4zgnrvy8am7myivv4rnnshjp49kg87rd22qqyvcz51ykr";
   };
+
+  patches = [
+    # GNOME 40 compatibility (from https://github.com/phocean/TopIcons-plus/pull/156)
+    (fetchpatch {
+      url = "https://github.com/phocean/TopIcons-plus/commit/98cd17aa324a031e2ee3d344582dfdafd1e4642f.diff";
+      sha256 = "1c2j0yy7zbn6jzpqkla150gxlhgfz85y2rscx9vz7cgyzdl0q112";
+    })
+  ];
 
   buildInputs = [ glib ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
