### PR TITLE
libvncserver: fix darwin build

### DIFF
--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchzip, fetchpatch, cmake
 , libjpeg, openssl, zlib, libgcrypt, libpng
-, systemd
+, systemd, Carbon
 }:
 
 let
@@ -19,10 +19,11 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [
-    libjpeg openssl libgcrypt libpng
-  ] ++ lib.optional stdenv.isLinux systemd;
+  buildInputs = [ libjpeg openssl libgcrypt libpng ]
+    ++ lib.optional stdenv.isLinux systemd
+    ++ lib.optional stdenv.isDarwin Carbon;
   propagatedBuildInputs = [ zlib ];
+
   meta = {
     inherit (s) version;
     description = "VNC server library";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16583,7 +16583,9 @@ in
 
   libvmaf = callPackage ../development/libraries/libvmaf { };
 
-  libvncserver = callPackage ../development/libraries/libvncserver {};
+  libvncserver = callPackage ../development/libraries/libvncserver {
+    inherit (darwin.apple_sdk.frameworks) Carbon;
+  };
 
   libviper = callPackage ../development/libraries/libviper { };
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142938719/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
