### PR TITLE
lxqt-build-tools: fix darwin detection

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , mkDerivation
 , fetchFromGitHub
 , cmake
@@ -20,6 +21,13 @@ mkDerivation rec {
     rev = version;
     sha256 = "0zhcv6cbdn9fr5lpglz26gzssbxkpi824sgc0g7w3hh1z6nqqf8l";
   };
+
+  # Nix clang on darwin identifies as 'Clang', not 'AppleClang'
+  # Without this, dependants fail to link.
+  postPatch = ''
+    substituteInPlace cmake/modules/LXQtCompilerSettings.cmake \
+      --replace AppleClang Clang
+  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

This package detects Darwin via the 'AppleClang' identifier that only applies to Xcode; Nix clang identifies as 'Clang'. This causes dependants to fail linking, for example: https://hydra.nixos.org/build/142959638/nixlog/1

This patch is a stop-gap solution, I think. i don't think it's appropriate to upstream, but I also don't know what the correct solution is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
