### PR TITLE
microsoft_gsl: fix darwin build

### DIFF
--- a/pkgs/development/libraries/microsoft_gsl/default.nix
+++ b/pkgs/development/libraries/microsoft_gsl/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
   buildPhase = if nativeBuild then "make" else "true";
 
   # https://github.com/microsoft/GSL/issues/806
-  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-Wno-catch-value" ];
+  cmakeFlags = lib.optionals stdenv.cc.isGNU
+    [ "-DCMAKE_CXX_FLAGS=-Wno-catch-value" ];
 
   installPhase = ''
     mkdir -p $out/include


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142935004/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
