### PR TITLE
Ansible 2.11

### DIFF
--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -1,0 +1,83 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, installShellFiles
+, ansible-collections
+, cryptography
+, jinja2
+, junit-xml
+, lxml
+, ncclient
+, packaging
+, paramiko
+, pexpect
+, psutil
+, pycrypto
+, pyyaml
+, requests
+, resolvelib
+, scp
+, windowsSupport ? false, pywinrm
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "ansible-core";
+  version = "2.11.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1if9cybdicjhrfzi6nndqakb4sh3mw1fijhvbzbsq7ki22vwww4l";
+  };
+
+  # ansible_connection is already wrapped, so don't pass it through
+  # the python interpreter again, as it would break execution of
+  # connection plugins.
+  postPatch = ''
+    substituteInPlace lib/ansible/executor/task_executor.py \
+      --replace "[python," "["
+
+    substituteInPlace requirements.txt \
+      --replace "resolvelib >= 0.5.3, < 0.6.0" "resolvelib"
+  '';
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  propagatedBuildInputs = [
+    # depend on ansible-collections instead of the other way around
+    ansible-collections
+    # from requirements.txt
+    cryptography
+    jinja2
+    packaging
+    pyyaml
+    resolvelib
+    # optional dependencies
+    junit-xml
+    lxml
+    ncclient
+    paramiko
+    pexpect
+    psutil
+    pycrypto
+    requests
+    scp
+    xmltodict
+  ] ++ lib.optional windowsSupport pywinrm;
+
+  postInstall = ''
+    installManPage docs/man/man1/*.1
+  '';
+
+  # internal import errors, missing dependencies
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Radically simple IT automation";
+    homepage = "https://www.ansible.com";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/commentjson/default.nix
+++ b/pkgs/development/python-modules/commentjson/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub, six, lark-parser, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "commentjson";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "vaidik";
+    repo = "commentjson";
+    rev = "v${version}";
+    sha256 = "sha256-dPnIcv7TIeyG7rU938w7FrDklmaGuPpXz34uw/JjOgY=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "lark-parser>=0.7.1,<0.8.0" "lark-parser"
+
+    # NixOS is missing test.test_json module
+    rm -r commentjson/tests/test_json
+  '';
+
+  propagatedBuildInputs = [ lark-parser six ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "commentjson" ];
+
+  meta = with lib; {
+    description = "Add JavaScript or Python style comments in JSON";
+    homepage = "https://github.com/vaidik/commentjson/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/resolvelib/default.nix
+++ b/pkgs/development/python-modules/resolvelib/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, commentjson
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "resolvelib";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "sarugaku";
+    repo = "resolvelib";
+    rev = version;
+    sha256 = "0r7cxwrfvpqz4kd7pdf8fsynzlmi6c754jd5hzd6vssc1zlyvvhx";
+  };
+
+  checkInputs = [
+    commentjson
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Resolve abstract dependencies into concrete ones";
+    homepage = "https://github.com/sarugaku/resolvelib";
+    license = licenses.isc;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/ttp/default.nix
+++ b/pkgs/development/python-modules/ttp/default.nix
@@ -19,14 +19,14 @@ let
 in
 buildPythonPackage rec {
   pname = "ttp";
-  version = "0.6.0";
+  version = "0.7.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "dmulyalin";
     repo = pname;
     rev = version;
-    sha256 = "08pglwmnhdrsj9rgys1zclhq1h597izb0jq7waahpdabfg25v2sw";
+    sha256 = "0gv1hykbxx3wy195xynqi21rxzlh4701qw01s6pmf3x54w63fz42";
   };
 
   propagatedBuildInputs = [
@@ -76,6 +76,9 @@ buildPythonPackage rec {
     "test_include_attribute_with_yaml_loader"
     # TypeError: string indices must be integers
     "test_lookup_include_yaml"
+    # Missing .xslx files *shrug*
+    "test_excel_formatter_update"
+    "test_excel_formatter_update_using_result_kwargs"
     # missing package n2g
     "test_n2g_formatter"
   ];

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -1,7 +1,9 @@
 { python3Packages, fetchurl, fetchFromGitHub }:
 
 rec {
-  ansible = ansible_2_10;
+  ansible = ansible_2_11;
+
+  ansible_2_11 = python3Packages.toPythonApplication python3Packages.ansible-core;
 
   ansible_2_10 = python3Packages.toPythonApplication python3Packages.ansible-base;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12586,7 +12586,8 @@ in
     ansible
     ansible_2_8
     ansible_2_9
-    ansible_2_10;
+    ansible_2_10
+    ansible_2_11;
 
   ansible-lint = with python3.pkgs; toPythonApplication ansible-lint;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -417,6 +417,8 @@ in {
 
   ansible-collections = callPackage ../development/python-modules/ansible/collections.nix { };
 
+  ansible-core = callPackage ../development/python-modules/ansible/core.nix { };
+
   ansible-kernel = callPackage ../development/python-modules/ansible-kernel { };
 
   ansible-lint = callPackage ../development/python-modules/ansible-lint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1519,6 +1519,8 @@ in {
 
   commandparse = callPackage ../development/python-modules/commandparse { };
 
+  commentjson = callPackage ../development/python-modules/commentjson { };
+
   commoncode = callPackage ../development/python-modules/commoncode { };
 
   CommonMark = callPackage ../development/python-modules/commonmark { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7206,6 +7206,8 @@ in {
 
   resampy = callPackage ../development/python-modules/resampy { };
 
+  resolvelib = callPackage ../development/python-modules/resolvelib { };
+
   responses = callPackage ../development/python-modules/responses { };
 
   respx = callPackage ../development/python-modules/respx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://docs.ansible.com/ansible-core/devel/roadmap/ROADMAP_2_11.html

And as announced in #122670 the 2.11 release is `ansible-core`. :shrug: 

I'm so close to just install Ansible via direnv/pip...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
