### PR TITLE
retry: init at 1.04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3657,6 +3657,12 @@
     githubId = 10353047;
     name = "Tobias Happ";
   };
+  gfrascadorio = {
+    email = "gfrascadorio@tutanota.com";
+    github = "gfrascadorio";
+    githubId = 37602871;
+    name = "Galois";
+  };
   ggpeti = {
     email = "ggpeti@gmail.com";
     github = "ggpeti";

--- a/pkgs/tools/system/retry/default.nix
+++ b/pkgs/tools/system/retry/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "Retry a command until the command succeeds";
     platforms = platforms.all;
     license = licenses.asl20;
-    # maintainers = with maintainers; [ gfrascadorio ];
+    maintainers = with maintainers; [ gfrascadorio ];
   };
 }
 

--- a/pkgs/tools/system/retry/default.nix
+++ b/pkgs/tools/system/retry/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, which, txt2man }:
+stdenv.mkDerivation rec {
+  pname = "retry";
+  version = "1.0.4";
+
+  nativeBuildInputs = [ autoreconfHook which txt2man ];
+
+  src = fetchFromGitHub {
+    owner = "minfrin";
+    repo = "retry";
+    rev = "${pname}-${version}";
+    sha256 = "sha256:0jrx4yrwlf4fn3309kxraj7zgwk7gq6rz5ibswq3w3b3jfvxi8qb";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/minfrin/retry";
+    description = "Retry a command until the command succeeds";
+    platforms = platforms.all;
+    license = licenses.asl20;
+    # maintainers = with maintainers; [ gfrascadorio ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13567,6 +13567,8 @@ in
     lua = lua5;
   } // (config.radare or {}));
 
+  retry = callPackage ../tools/system/retry { };
+
   rizin = pkgs.callPackage ../development/tools/analysis/rizin { };
 
   cutter = libsForQt515.callPackage ../development/tools/analysis/rizin/cutter.nix { };


### PR DESCRIPTION
Add package for 'retry' tool that allows a script to repeat a command
until it succeeds or hits a repetition threshold. 'Retry' supports
replaying stdin, emitting the final stdout, and backoff delays.

###### Motivation for this change

I needed a retry for another package that had to wait on a PostgresQL startup. 
Retry was available in Ubuntu, but not nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date (gf - there is a man page and it gets installed too)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
