### PR TITLE
texlab: 2.2.2 → 3.0.0

### DIFF
--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -8,16 +8,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "texlab";
-  version = "2.2.2";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "06x7j4ppgw24xbsnyj1icaksngqbvq6mk8wfcqikzmvmifjspx9m";
+    hash = "sha256-jOxneMqeyvMQWKPNha59H6qWSFmx+Z71SU2+M5VWMsA=";
   };
 
-  cargoSha256 = "0gzxylpn2hps0kxczd6wwcqhnvm6ir971bfvpgjr6rxi12hs47ky";
+  cargoHash = "sha256-H6czxSTw93RNTaN0OJyv0RfwmGAiFkpDgUtXHCD+jrY=";
+
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -25,7 +27,14 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     installManPage texlab.1
-  '';
+
+    # Remove generated dylib of html2md dependency. TexLab statically
+    # links to the generated rlib and doesn't reference the dylib. I
+    # couldn't find any way to prevent building this by passing cargo flags.
+    # See https://gitlab.com/Kanedias/html2md/-/blob/0.2.10/Cargo.toml#L20
+    rm "$out/lib/libhtml2md.so"
+    rmdir "$out/lib"
+ '';
 
   meta = with lib; {
     description = "An implementation of the Language Server Protocol for LaTeX";


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/latex-lsp/texlab/releases/tag/v3.0.0

Also removes unused dylib build of html2md dependency, fixing #95568.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@doronbehar