### PR TITLE
ultrastardx: 2020.4.0 -> 2021-04-03

### DIFF
--- a/pkgs/games/ultrastardx/default.nix
+++ b/pkgs/games/ultrastardx/default.nix
@@ -31,28 +31,41 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "ultrastardx";
-  version = "2020.4.0";
+  version = "2021-04-03";
   src = fetchFromGitHub {
     owner = "UltraStar-Deluxe";
     repo = "USDX";
-    rev = "v${version}";
-    sha256 = "0vmfv8zpyf8ymx3rjydpd7iqis080lni94vb316vfxkgvjmqbhym";
+    rev = "d49e916705092f3d765d85d276b283b9e7e232a6";
+    sha256 = "0sdcz2vc8i2z50nj7zbkdpxx2mvx0m0927lfsj7d7qr0p8vkm0wa";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ fpc libpng ] ++ sharedLibs;
 
-  patches = [
-    (fetchpatch {
-      name = "fpc-3.2-support.patch";
-      url = "https://github.com/UltraStar-Deluxe/USDX/commit/1b8e8714c1523ef49c2fd689a1545d097a3d76d7.patch";
-      sha256 = "02zmjymj9w1mkpf7armdpf067byvml6lprs1ca4lhpkv45abddp4";
-    })
-  ];
-
   postPatch = ''
     substituteInPlace src/config.inc.in \
       --subst-var-by libpcre_LIBNAME libpcre.so.1
+
+    # ultrastardx binds to libffmpeg (and sublibs), specifying a very restrictive
+    # upper bounds on the minor versions of .so files.
+    # We can assume ffmpeg won’t break any major ABI compatibility, since their
+    # patch version seems to always stay at 100,
+    # and their minor version changes quite frequently.
+    sed \
+      -e 's/^  LIBAVCODEC_MAX_VERSION_MINOR.*$/  LIBAVCODEC_MAX_VERSION_MINOR = 1000;/' \
+      -i src/lib/ffmpeg-4.0/avcodec.pas
+    sed \
+      -e 's/^  LIBAVFORMAT_MAX_VERSION_MINOR.*$/  LIBAVFORMAT_MAX_VERSION_MINOR = 1000;/' \
+      -i src/lib/ffmpeg-4.0/avformat.pas
+    sed \
+      -e 's/^  LIBAVUTIL_MAX_VERSION_MINOR.*$/  LIBAVUTIL_MAX_VERSION_MINOR = 1000;/' \
+      -i src/lib/ffmpeg-4.0/avutil.pas
+    sed \
+      -e 's/^  LIBSWRESAMPLE_MAX_VERSION_MINOR.*$/  LIBSWRESAMPLE_MAX_VERSION_MINOR = 1000;/' \
+      -i src/lib/ffmpeg-4.0/swresample.pas
+    sed \
+      -e 's/^  LIBSWSCALE_MAX_VERSION_MINOR.*$/  LIBSWSCALE_MAX_VERSION_MINOR = 1000;/' \
+      -i src/lib/ffmpeg-4.0/swscale.pas
   '';
 
   preBuild = with lib;


### PR DESCRIPTION
Not a lot has changed since last update, a few fixes were pushed to
the master tree.
We take the liberty to update to master for now.

This updates the ffmpeg version from 2.x to 4.x, which seems to be
supported upstream when we bend the minor version restriction a
little.
A simple karaoke song played just fine in my test.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
