### PR TITLE
cmake-language-server: disable test timeouts

### DIFF
--- a/pkgs/development/tools/cmake-language-server/default.nix
+++ b/pkgs/development/tools/cmake-language-server/default.nix
@@ -16,11 +16,15 @@ buildPythonApplication rec {
     sha256 = "0vz7bjxkk0phjhz3h9kj6yr7wnk3g7lqmkqraa0kw12mzcfck837";
   };
 
-  # can be removed after v0.1.2
-  patches = lib.optional stdenv.isDarwin (fetchpatch {
-    url = "https://github.com/regen100/cmake-language-server/commit/0ec120f39127f25898ab110b43819e3e9becb8a3.patch";
-    sha256 = "1xbmarvsvzd61fnlap4qscnijli2rw2iqr7cyyvar2jd87z6sfp0";
-  });
+  patches = [
+    ./disable-test-timeouts.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    # can be removed after v0.1.2
+    (fetchpatch {
+      url = "https://github.com/regen100/cmake-language-server/commit/0ec120f39127f25898ab110b43819e3e9becb8a3.patch";
+      sha256 = "1xbmarvsvzd61fnlap4qscnijli2rw2iqr7cyyvar2jd87z6sfp0";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/tools/cmake-language-server/disable-test-timeouts.patch
+++ b/pkgs/development/tools/cmake-language-server/disable-test-timeouts.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_server.py b/tests/test_server.py
+index c0777f5..1184fb3 100644
+--- a/tests/test_server.py
++++ b/tests/test_server.py
+@@ -11,7 +11,7 @@ from pygls.types import (CompletionContext, CompletionParams,
+                          InitializeParams, Position, TextDocumentIdentifier,
+                          TextDocumentItem, TextDocumentPositionParams)
+ 
+-CALL_TIMEOUT = 2
++CALL_TIMEOUT = None
+ 
+ 
+ def _init(client: LanguageServer, root: Path):


### PR DESCRIPTION
###### Motivation for this change
ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142774909/nixlog/3

Disable test timeouts to prevent intermittent test failures.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).