### PR TITLE
gcc*: force building a cross compiler if host and target platform differ

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -196,7 +196,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform langJava langGo;
+    inherit version targetPlatform hostPlatform langJava langGo;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -209,7 +209,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform langJava langGo;
+    inherit version targetPlatform hostPlatform langJava langGo;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -232,7 +232,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform gnatboot langJava langAda langGo;
+    inherit version targetPlatform hostPlatform gnatboot langJava langAda langGo;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -197,7 +197,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform langGo;
+    inherit version targetPlatform hostPlatform langGo;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -183,7 +183,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform langGo;
+    inherit version targetPlatform hostPlatform langGo;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -200,7 +200,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version hostPlatform gnatboot langAda langGo langJit;
+    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -1,4 +1,4 @@
-{ lib, version, hostPlatform
+{ lib, version, hostPlatform, targetPlatform
 , gnatboot ? null
 , langAda ? false
 , langJava ? false
@@ -57,4 +57,11 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # table entries that can't be stripped".
 + lib.optionalString (hostPlatform.isDarwin && langJit) ''
   export STRIP='strip -x'
+''
+
+# HACK: if host and target config are the same, but the platforms are
+# actually different we need to convince the configure script that it
+# is in fact building a cross compiler although it doesn't believe it.
++ lib.optionalString (targetPlatform.config == hostPlatform.config && targetPlatform != hostPlatform) ''
+  substituteInPlace configure --replace is_cross_compiler=no is_cross_compiler=yes
 ''


### PR DESCRIPTION
gcc's configure system has the nasty habit (for us) of judging for
itself if it is building a cross compiler (or cross compiling), but on
the limited information of the build, host and target platforms' config
which only contains a subset of the information we encode in
`stdenv.*Platform`. The practical consequence was that prior to this
change building `pkgsLLVM.buildPackages.gcc` actually fails because it
refuses to use `--with-headers` with something it believes to not be a
cross compiler.

As a workaround we force the appropriate variable in the configure
script to always be `yes` regardless of its own conditional check.

At some point we probably should report this issue in some capacity, so
future gcc versions don't force us into workarounds like this and
acdc783418538f23cdfb671bc8fd4b1c076979bd.

Now the following works which failed pretty early previously (on staging):

```
nix-build -A pkgsLLVM.buildPackages.gcc
/nix/store/v3rrxn542209lqzwb4yhyj6zwi1shskb-x86_64-unknown-linux-gnu-stage-final-gcc-wrapper-10.3.0
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
