### PR TITLE
brscan5: init at 1.2.6-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6238,6 +6238,12 @@
     githubId = 11810057;
     name = "Matt Snider";
   };
+  mattchrist = {
+    email = "nixpkgs-matt@christ.systems";
+    github = "mattchrist";
+    githubId = 952712;
+    name = "Matt Christ";
+  };
   matthewbauer = {
     email = "mjbauer95@gmail.com";
     github = "matthewbauer";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -398,6 +398,7 @@
   ./services/hardware/ratbagd.nix
   ./services/hardware/sane.nix
   ./services/hardware/sane_extra_backends/brscan4.nix
+  ./services/hardware/sane_extra_backends/brscan5.nix
   ./services/hardware/sane_extra_backends/dsseries.nix
   ./services/hardware/spacenavd.nix
   ./services/hardware/tcsd.nix

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan5.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan5.nix
@@ -68,12 +68,7 @@ in
   options = {
 
     hardware.sane.brscan5.enable =
-      mkEnableOption "Brother's brscan5 scan backend" // {
-      description = ''
-        When enabled, will automatically register the "brscan5" sane
-        backend and bring configuration files to their expected location.
-      '';
-    };
+      mkEnableOption "the Brother brscan5 sane backend";
 
     hardware.sane.brscan5.netDevices = mkOption {
       default = {};

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan5.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan5.nix
@@ -29,7 +29,7 @@ let
           The model of the network device.
         '';
 
-        example = literalExample "MFC-7860DW";
+        example = literalExample "ADS-1200";
       };
 
       ip = mkOption {

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan5.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan5.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.sane.brscan5;
+
+  netDeviceList = attrValues cfg.netDevices;
+
+  etcFiles = pkgs.callPackage ./brscan5_etc_files.nix { netDevices = netDeviceList; };
+
+  netDeviceOpts = { name, ... }: {
+
+    options = {
+
+      name = mkOption {
+        type = types.str;
+        description = ''
+          The friendly name you give to the network device. If undefined,
+          the name of attribute will be used.
+        '';
+
+        example = literalExample "office1";
+      };
+
+      model = mkOption {
+        type = types.str;
+        description = ''
+          The model of the network device.
+        '';
+
+        example = literalExample "MFC-7860DW";
+      };
+
+      ip = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          The ip address of the device. If undefined, you will have to
+          provide a nodename.
+        '';
+
+        example = literalExample "192.168.1.2";
+      };
+
+      nodename = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          The node name of the device. If undefined, you will have to
+          provide an ip.
+        '';
+
+        example = literalExample "BRW0080927AFBCE";
+      };
+
+    };
+
+
+    config =
+      { name = mkDefault name;
+      };
+  };
+
+in
+
+{
+  options = {
+
+    hardware.sane.brscan5.enable =
+      mkEnableOption "Brother's brscan5 scan backend" // {
+      description = ''
+        When enabled, will automatically register the "brscan5" sane
+        backend and bring configuration files to their expected location.
+      '';
+    };
+
+    hardware.sane.brscan5.netDevices = mkOption {
+      default = {};
+      example =
+        { office1 = { model = "MFC-7860DW"; ip = "192.168.1.2"; };
+          office2 = { model = "MFC-7860DW"; nodename = "BRW0080927AFBCE"; };
+        };
+      type = with types; attrsOf (submodule netDeviceOpts);
+      description = ''
+        The list of network devices that will be registered against the brscan5
+        sane backend.
+      '';
+    };
+  };
+
+  config = mkIf (config.hardware.sane.enable && cfg.enable) {
+
+    hardware.sane.extraBackends = [
+      pkgs.brscan5
+    ];
+
+    environment.etc."opt/brother/scanner/brscan5" =
+      { source = "${etcFiles}/etc/opt/brother/scanner/brscan5"; };
+    environment.etc."opt/brother/scanner/models" =
+      { source = "${etcFiles}/etc/opt/brother/scanner/brscan5/models"; };
+    environment.etc."sane.d/dll.d/brother5.conf".source = "${pkgs.brscan5}/etc/sane.d/dll.d/brother.conf";
+
+    assertions = [
+      { assertion = all (x: !(null != x.ip && null != x.nodename)) netDeviceList;
+        message = ''
+          When describing a network device as part of the attribute list
+          `hardware.sane.brscan5.netDevices`, only one of its `ip` or `nodename`
+          attribute should be specified, not both!
+        '';
+      }
+    ];
+
+  };
+}

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix
@@ -21,8 +21,8 @@ nix-build -E 'let pkgs = import ./. {};
                   brscan5-etc-files = pkgs.callPackage (import ./nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix) {};
               in brscan5-etc-files.override {
                    netDevices = [
-                     {name="a"; model="MFC-7860DW"; nodename="BRW0080927AFBCE";}
-                     {name="b"; model="MFC-7860DW"; ip="192.168.1.2";}
+                     {name="a"; model="ADS-1200"; nodename="BRW0080927AFBCE";}
+                     {name="b"; model="ADS-1200"; ip="192.168.1.2";}
                    ];
               }'
 ~~~
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
     cp -rp "./brscan5.ini" "$TARGET_DIR"
     cp -rp "./brsanenetdevice.cfg" "$TARGET_DIR"
 
-    export NIX_REDIRECTS="/etc/opt/brother/scanner/brscan5//brsanenetdevice.cfg=$TARGET_DIR/brsanenetdevice.cfg"
+    export NIX_REDIRECTS="/etc/opt/brother/scanner/brscan5/=$TARGET_DIR/"
 
     printf '${addAllNetDev netDevices}\n'
 

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix
@@ -1,0 +1,77 @@
+{ stdenv, lib, brscan5, netDevices ? [] }:
+
+/*
+
+Testing
+-------
+From nixpkgs repo
+
+No net devices:
+
+~~~
+nix-build -E 'let pkgs = import ./. {};
+                  brscan5-etc-files = pkgs.callPackage (import ./nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix) {};
+              in brscan5-etc-files'
+~~~
+
+Two net devices:
+
+~~~
+nix-build -E 'let pkgs = import ./. {};
+                  brscan5-etc-files = pkgs.callPackage (import ./nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix) {};
+              in brscan5-etc-files.override {
+                   netDevices = [
+                     {name="a"; model="MFC-7860DW"; nodename="BRW0080927AFBCE";}
+                     {name="b"; model="MFC-7860DW"; ip="192.168.1.2";}
+                   ];
+              }'
+~~~
+
+*/
+
+let
+
+  addNetDev = nd: ''
+    brsaneconfig5 -a \
+    name="${nd.name}" \
+    model="${nd.model}" \
+    ${if (lib.hasAttr "nodename" nd && nd.nodename != null) then
+      ''nodename="${nd.nodename}"'' else
+      ''ip="${nd.ip}"''}'';
+  addAllNetDev = xs: lib.concatStringsSep "\n" (map addNetDev xs);
+in
+
+stdenv.mkDerivation {
+
+  name = "brscan5-etc-files";
+  version = "1.2.6-0";
+  src = "${brscan5}/opt/brother/scanner/brscan5";
+
+  nativeBuildInputs = [ brscan5 ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    TARGET_DIR="$out/etc/opt/brother/scanner/brscan5"
+    mkdir -p "$TARGET_DIR"
+    cp -rp "./models" "$TARGET_DIR"
+    cp -rp "./brscan5.ini" "$TARGET_DIR"
+    cp -rp "./brsanenetdevice.cfg" "$TARGET_DIR"
+
+    export NIX_REDIRECTS="/etc/opt/brother/scanner/brscan5//brsanenetdevice.cfg=$TARGET_DIR/brsanenetdevice.cfg"
+
+    printf '${addAllNetDev netDevices}\n'
+
+    ${addAllNetDev netDevices}
+  '';
+
+  dontInstall = true;
+
+  meta = with lib; {
+    description = "Brother brscan5 sane backend driver etc files";
+    homepage = "https://www.brother.com";
+    platforms = platforms.linux;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ mattchrist ];
+  };
+}

--- a/nixos/tests/brscan5.nix
+++ b/nixos/tests/brscan5.nix
@@ -1,0 +1,34 @@
+# integration tests for brscan5 sane driver
+#
+
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "brscan5";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ mattchrist ];
+  };
+
+  machine = { pkgs, ... }:
+    {
+      nixpkgs.config.allowUnfree = true;
+      hardware.sane = {
+        enable = true;
+        brscan5 = {
+          enable = true;
+          netDevices = {
+            "a" = { model="MFC-7860DW"; nodename="BRW0080927AFBCE"; };
+            "b" = { model="MFC-7860DW"; ip="192.168.1.2"; };
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    # sane loads libsane-brother5.so.1 successfully, and scanimage doesn't die
+    assert 'libsane-brother5.so.1", O_RDONLY|O_CLOEXEC) = 10' in machine.succeed('strace scanimage -L 2>&1')
+
+    # module creates a config
+    cfg = machine.succeed('cat /etc/opt/brother/scanner/brscan5/brsanenetdevice.cfg')
+    assert 'DEVICE=a , "MFC-7860DW" , Unknown , NODENAME=BRW0080927AFBCE' in cfg
+    assert 'DEVICE=b , "MFC-7860DW" , Unknown , IP-ADDRESS=192.168.1.2' in cfg
+  '';
+})

--- a/pkgs/applications/graphics/sane/backends/brscan5/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan5/default.nix
@@ -1,0 +1,98 @@
+{ stdenv, lib, fetchurl, callPackage, patchelf, makeWrapper, coreutils, libusb1, avahi-compat, glib, libredirect }:
+let
+  myPatchElf = file: with lib; ''
+    patchelf --set-interpreter \
+      ${stdenv.glibc}/lib/ld-linux${optionalString stdenv.is64bit "-x86-64"}.so.2 \
+      ${file}
+  '';
+
+in
+stdenv.mkDerivation rec {
+  pname = "brscan5";
+  version = "1.2.6-0";
+  src = {
+    "i686-linux" = fetchurl {
+      url = "https://download.brother.com/welcome/dlf104034/${pname}-${version}.i386.deb";
+      sha256 = "102q745pc0168syggd4gym51qf3m3iqld3a4skfnbkm6yky4w4s8";
+    };
+    "x86_64-linux" = fetchurl {
+      url = "https://download.brother.com/welcome/dlf104033/${pname}-${version}.amd64.deb";
+      sha256 = "1pwbzhpg5nzpw2rw936vf2cr334v8iny16y8fbb1zimgzmv427wx";
+    };
+  }."${stdenv.hostPlatform.system}";
+
+  unpackPhase = ''
+    ar x $src
+    tar xfv data.tar.xz
+  '';
+
+  nativeBuildInputs = [ makeWrapper patchelf coreutils ];
+  buildInputs = [ libusb1 avahi-compat stdenv.cc.cc glib ];
+  dontBuild = true;
+
+  postPatch = ''
+    ${myPatchElf "opt/brother/scanner/brscan5/brsaneconfig5"}
+    ${myPatchElf "opt/brother/scanner/brscan5/brscan_cnetconfig"}
+    ${myPatchElf "opt/brother/scanner/brscan5/brscan_gnetconfig"}
+
+    for a in opt/brother/scanner/brscan5/*.so.* opt/brother/scanner/brscan5/brscan_[cg]netconfig; do
+      if ! test -L $a; then
+        patchelf --set-rpath ${lib.makeLibraryPath buildInputs} $a
+      fi
+    done
+
+    # driver is hardcoded to look in /opt/brother/scanner/brscan5/models for model metadata.
+    # patch it to look in /etc/opt/brother/scanner/models instead, so nixos environment.etc can make it available
+    printf '/etc/opt/brother/scanner/models\x00' | dd of=opt/brother/scanner/brscan5/libsane-brother5.so.1.0.7 bs=1 seek=84632 conv=notrunc
+  '';
+
+  installPhase = with lib; ''
+    runHook preInstall
+    PATH_TO_BRSCAN5="opt/brother/scanner/brscan5"
+    mkdir -p $out/$PATH_TO_BRSCAN5
+    cp -rp $PATH_TO_BRSCAN5/* $out/$PATH_TO_BRSCAN5
+
+
+    pushd $out/$PATH_TO_BRSCAN5
+      ln -s libLxBsDeviceAccs.so.1.0.0 libLxBsDeviceAccs.so.1
+      ln -s libLxBsNetDevAccs.so.1.0.0 libLxBsNetDevAccs.so.1
+      ln -s libLxBsScanCoreApi.so.3.0.0 libLxBsScanCoreApi.so.3
+      ln -s libLxBsUsbDevAccs.so.1.0.0 libLxBsUsbDevAccs.so.1
+      ln -s libsane-brother5.so.1.0.7 libsane-brother5.so.1
+    popd
+
+    mkdir -p $out/lib/sane
+    for file in $out/$PATH_TO_BRSCAN5/*.so.* ; do
+      ln -s $file $out/lib/sane/
+    done
+
+    makeWrapper \
+      "$out/$PATH_TO_BRSCAN5/brsaneconfig5" \
+      "$out/bin/brsaneconfig5" \
+      --suffix-each NIX_REDIRECT ":" "/etc/opt/brother/scanner/brscan5=$out/opt/brother/scanner/brscan5 /opt/brother/scanner/brscan5=$out/opt/brother/scanner/brscan5" \
+      --set LD_PRELOAD ${libredirect}/lib/libredirect.so
+
+    mkdir -p $out/etc/sane.d/dll.d
+    echo "brother5" > $out/etc/sane.d/dll.d/brother5.conf
+
+    mkdir -p $out/etc/udev/rules.d
+    cp -p $PATH_TO_BRSCAN5/udev-rules/NN-brother-mfp-brscan5-1.0.2-2.rules \
+      $out/etc/udev/rules.d/49-brother-mfp-brscan5-1.0.2-2.rules
+
+    ETCDIR=$out/etc/opt/brother/scanner/brscan5
+    mkdir -p $ETCDIR
+    cp -rp $PATH_TO_BRSCAN5/{models,brscan5.ini,brsanenetdevice.cfg} $ETCDIR/
+
+    runHook postInstall
+  '';
+
+  dontPatchELF = true;
+
+  meta = {
+    description = "Brother brscan5 sane backend driver";
+    homepage = "https://www.brother.com";
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ mattchrist ];
+  };
+}

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -9,6 +9,7 @@
 #include <limits.h>
 #include <string.h>
 #include <spawn.h>
+#include <dirent.h>
 
 #define MAX_REDIRECTS 128
 
@@ -189,9 +190,85 @@ int posix_spawnp(pid_t * pid, const char * file,
     return posix_spawnp_real(pid, rewrite(file, buf), file_actions, attrp, argv, envp);
 }
 
-int execv(const char *path, char *const argv[])
+int execv(const char * path, char * const argv[])
 {
-    int (*execv_real) (const char *path, char *const argv[]) = dlsym(RTLD_NEXT, "execv");
+    int (*execv_real) (const char * path, char * const argv[]) = dlsym(RTLD_NEXT, "execv");
     char buf[PATH_MAX];
     return execv_real(rewrite(path, buf), argv);
+}
+
+int execvp(const char * path, char * const argv[])
+{
+    int (*_execvp) (const char *, char * const argv[]) = dlsym(RTLD_NEXT, "execvp");
+    char buf[PATH_MAX];
+    return _execvp(rewrite(path, buf), argv);
+}
+
+int execve(const char * path, char * const argv[], char * const envp[])
+{
+    int (*_execve) (const char *, char * const argv[], char * const envp[]) = dlsym(RTLD_NEXT, "execve");
+    char buf[PATH_MAX];
+    return _execve(rewrite(path, buf), argv, envp);
+}
+
+DIR * opendir(const char * path)
+{
+    char buf[PATH_MAX];
+    DIR * (*_opendir) (const char*) = dlsym(RTLD_NEXT, "opendir");
+
+    return _opendir(rewrite(path, buf));
+}
+
+#define SYSTEM_CMD_MAX 512
+
+char *replace_substring(char * source, char * buf, char * replace_string, char * start_ptr, char * suffix_ptr) {
+    char head[SYSTEM_CMD_MAX] = {0};
+    strncpy(head, source, start_ptr - source);
+
+    char tail[SYSTEM_CMD_MAX] = {0};
+    if(suffix_ptr < source + strlen(source)) {
+       strcpy(tail, suffix_ptr);
+    }
+
+    sprintf(buf, "%s%s%s", head, replace_string, tail);
+    return buf;
+}
+
+char *replace_string(char * buf, char * from, char * to) {
+    int num_matches = 0;
+    char * matches[SYSTEM_CMD_MAX];
+    int from_len = strlen(from);
+    for(int i=0; i<strlen(buf); i++){
+       char *cmp_start = buf + i;
+       if(strncmp(from, cmp_start, from_len) == 0){
+          matches[num_matches] = cmp_start;
+          num_matches++;
+       }
+    }
+    int len_diff = strlen(to) - strlen(from);
+    for(int n = 0; n < num_matches; n++) {
+       char replaced[SYSTEM_CMD_MAX];
+       replace_substring(buf, replaced, to, matches[n], matches[n]+from_len);
+       strcpy(buf, replaced);
+       for(int nn = n+1; nn < num_matches; nn++) {
+          matches[nn] += len_diff;
+       }
+    }
+    return buf;
+}
+
+void rewriteSystemCall(const char * command, char * buf) {
+    strcpy(buf, command);
+    for (int n = 0; n < nrRedirects; ++n) {
+       replace_string(buf, from[n], to[n]);
+    }
+}
+
+int system(const char *command)
+{
+    int (*_system) (const char*) = dlsym(RTLD_NEXT, "system");
+
+    char newCommand[SYSTEM_CMD_MAX];
+    rewriteSystemCall(command, newCommand);
+    return _system(newCommand);
 }

--- a/pkgs/build-support/libredirect/test.c
+++ b/pkgs/build-support/libredirect/test.c
@@ -2,6 +2,7 @@
 #include <fcntl.h>
 #include <spawn.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include <sys/stat.h>
@@ -31,6 +32,10 @@ void test_execv(void) {
     assert(execv(TESTPATH, argv) == 0);
 }
 
+void test_system(void) {
+    assert(system(TESTPATH) == 0);
+}
+
 int main(void)
 {
     FILE *testfp;
@@ -50,6 +55,7 @@ int main(void)
     assert(stat(TESTPATH, &testsb) != -1);
 
     test_spawn();
+    test_system();
     test_execv();
 
     /* If all goes well, this is never reached because test_execv() replaces

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30783,6 +30783,8 @@ in
 
   brscan4 = callPackage ../applications/graphics/sane/backends/brscan4 { };
 
+  brscan5 = callPackage ../applications/graphics/sane/backends/brscan5 { };
+
   dsseries = callPackage ../applications/graphics/sane/backends/dsseries { };
 
   sane-airscan = callPackage ../applications/graphics/sane/backends/airscan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The existing brscan4 and dsseries packages and modules don't work correctly with my Brother DS-640. (with brscan4, scans would 'cut off' after 1/4 of the page.)
This PR creates a brscan5 driver package and NixOS 'hardware.sane.brscan5' module to set it up. 

This works for me with my scanner plugged in via USB, but I don't have a network scanner available to test with. If anyone has a compatible Brother network scanner, please try it out with this driver and report how it works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
