### PR TITLE
pyicu: 2.6 -> 2.7.3

### DIFF
--- a/pkgs/development/python-modules/pyicu/default.nix
+++ b/pkgs/development/python-modules/pyicu/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "PyICU";
-  version = "2.6";
+  version = "2.7.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0wb3v421i2fnnxdywam4ay8hqvnxlz0r2nrpx5lqy3rn6dlbz9d9";
+    sha256 = "1jv1pds94agvn3zs33a8p8f0mk7f5pjwmczmg1s05ri5p0kzk4h8";
   };
 
-  nativeBuildInputs = [ icu ]; # for icu-config
+  nativeBuildInputs = [ icu ]; # for icu-config, but should be replaced with pkg-config
   buildInputs = [ icu ];
   checkInputs = [ pytestCheckHook six ];
 

--- a/pkgs/development/python-modules/pyicu/default.nix
+++ b/pkgs/development/python-modules/pyicu/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , pytestCheckHook
 , six
-, icu
+, icu68
 }:
 
 buildPythonPackage rec {
@@ -15,8 +15,8 @@ buildPythonPackage rec {
     sha256 = "1jv1pds94agvn3zs33a8p8f0mk7f5pjwmczmg1s05ri5p0kzk4h8";
   };
 
-  nativeBuildInputs = [ icu ]; # for icu-config, but should be replaced with pkg-config
-  buildInputs = [ icu ];
+  nativeBuildInputs = [ icu68 ]; # for icu-config, but should be replaced with pkg-config
+  buildInputs = [ icu68 ];
   checkInputs = [ pytestCheckHook six ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #122042, ping @NixOS/nixos-release-managers

Looks like it was broken by b8b108166697cd0a5e68a78216c07a26c252e1f7, since 2.6 requires icu68. We could upgrade pyicu or if that doesn't work / breaks more packages we can use the `icu68` derivation in here instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
