### PR TITLE
gamemode: init at 1.6.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -139,6 +139,7 @@
   ./programs/flexoptix-app.nix
   ./programs/freetds.nix
   ./programs/fuse.nix
+  ./programs/gamemode.nix
   ./programs/geary.nix
   ./programs/gnome-disks.nix
   ./programs/gnome-documents.nix

--- a/nixos/modules/programs/gamemode.nix
+++ b/nixos/modules/programs/gamemode.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.gamemode;
+  settingsFormat = pkgs.formats.ini { };
+  configFile = settingsFormat.generate "gamemode.ini" cfg.settings;
+in
+{
+  options = {
+    programs.gamemode = {
+      enable = mkEnableOption "GameMode to optimise system performance on demand";
+
+      enableRenice = mkEnableOption "CAP_SYS_NICE on gamemoded to support lowering process niceness" // {
+        default = true;
+      };
+
+      settings = mkOption {
+        type = settingsFormat.type;
+        default = {};
+        description = ''
+          System-wide configuration for GameMode (/etc/gamemode.ini).
+          See gamemoded(8) man page for available settings.
+        '';
+        example = literalExample ''
+          {
+            general = {
+              renice = 10;
+            };
+
+            # Warning: GPU optimisations have the potential to damage hardware
+            gpu = {
+              apply_gpu_optimisations = "accept-responsibility";
+              gpu_device = 0;
+              amd_performance_level = "high";
+            };
+
+            custom = {
+              start = "''${pkgs.libnotify}/bin/notify-send 'GameMode started'";
+              end = "''${pkgs.libnotify}/bin/notify-send 'GameMode ended'";
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ pkgs.gamemode ];
+      etc."gamemode.ini".source = configFile;
+    };
+
+    security = {
+      polkit.enable = true;
+      wrappers = mkIf cfg.enableRenice {
+        gamemoded = {
+          source = "${pkgs.gamemode}/bin/gamemoded";
+          capabilities = "cap_sys_nice+ep";
+        };
+      };
+    };
+
+    systemd = {
+      packages = [ pkgs.gamemode ];
+      user.services.gamemoded = {
+        # The upstream service already defines this, but doesn't get applied.
+        # See https://github.com/NixOS/nixpkgs/issues/81138
+        wantedBy = [ "default.target" ];
+
+        # Use pkexec from the security wrappers to allow users to
+        # run libexec/cpugovctl & libexec/gpuclockctl as root with
+        # the the actions defined in share/polkit-1/actions.
+        #
+        # This uses a link farm to make sure other wrapped executables
+        # aren't included in PATH.
+        environment.PATH = mkForce (pkgs.linkFarm "pkexec" [
+          {
+            name = "pkexec";
+            path = "${config.security.wrapperDir}/pkexec";
+          }
+        ]);
+
+        serviceConfig.ExecStart = mkIf cfg.enableRenice [
+          "" # Tell systemd to clear the existing ExecStart list, to prevent appending to it.
+          "${config.security.wrapperDir}/gamemoded"
+        ];
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with maintainers; [ kira-bruneau ];
+  };
+}

--- a/pkgs/tools/games/gamemode/default.nix
+++ b/pkgs/tools/games/gamemode/default.nix
@@ -1,0 +1,105 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, libgamemode32
+, meson
+, ninja
+, pkg-config
+, dbus
+, inih
+, systemd
+, appstream
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gamemode";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "FeralInteractive";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "sha256-P00OnZiPZyxBu9zuG+3JNorXHBhJZy+cKPjX+duZrJ0=";
+  };
+
+  outputs = [ "out" "dev" "lib" "man" "static" ];
+
+  patches = [
+    # Run executables from PATH instead of /usr/bin
+    # See https://github.com/FeralInteractive/gamemode/pull/323
+    (fetchpatch {
+      url = "https://github.com/FeralInteractive/gamemode/commit/be44b7091baa33be6dda60392e4c06c2f398ee72.patch";
+      sha256 = "TlDUETs4+N3pvrVd0FQGlGmC+6ByhJ2E7gKXa7suBtE=";
+    })
+
+    # Fix loading shipped config when using a prefix other than /usr
+    # See https://github.com/FeralInteractive/gamemode/pull/324
+    (fetchpatch {
+      url = "https://github.com/FeralInteractive/gamemode/commit/b29aa903ce5acc9141cfd3960c98ccb047eca872.patch";
+      sha256 = "LwBzBJQ7dfm2mFVSOSPjJP+skgV5N6h77i66L1Sq+ZM=";
+    })
+
+    # Add @libraryPath@ template variable to fix loading the PRELOAD library
+    ./preload-nix-workaround.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace data/gamemoderun \
+      --subst-var-by libraryPath ${lib.makeLibraryPath ([
+        (placeholder "lib")
+      ] ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
+        # Support wrapping 32bit applications on a 64bit linux system
+        libgamemode32
+      ])}
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    inih
+    systemd
+  ];
+
+  mesonFlags = [
+    # libexec is just a way to package binaries without including them
+    # in PATH. It doesn't make sense to install them to $lib
+    # (the default behaviour in the meson hook).
+    "--libexecdir=${placeholder "out"}/libexec"
+
+    "-Dwith-systemd-user-unit-dir=lib/systemd/user"
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    appstream
+  ];
+
+  # Move static libraries to $static so $lib only contains dynamic libraries.
+  postInstall = ''
+    moveToOutput lib/*.a "$static"
+  '';
+
+  # Add $lib/lib to gamemoded & gamemode-simulate-game's rpath since
+  # they use dlopen to load libgamemode. Can't use makeWrapper since
+  # it would break the security wrapper in the NixOS module.
+  postFixup = ''
+    for bin in "$out/bin/gamemoded" "$out/bin/gamemode-simulate-game"; do
+      patchelf --set-rpath "$lib/lib:$(patchelf --print-rpath "$bin")" "$bin"
+    done
+  '';
+
+  meta = with lib; {
+    description = "Optimise Linux system performance on demand";
+    homepage = "https://github.com/FeralInteractive/GameMode";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kira-bruneau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/games/gamemode/default.nix
+++ b/pkgs/tools/games/gamemode/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
     owner = "FeralInteractive";
     repo = pname;
     rev = version;
-    fetchSubmodules = true;
     sha256 = "sha256-P00OnZiPZyxBu9zuG+3JNorXHBhJZy+cKPjX+duZrJ0=";
   };
 

--- a/pkgs/tools/games/gamemode/preload-nix-workaround.patch
+++ b/pkgs/tools/games/gamemode/preload-nix-workaround.patch
@@ -1,0 +1,12 @@
+diff --git a/data/gamemoderun b/data/gamemoderun
+index 573b3e4..6f2799e 100755
+--- a/data/gamemoderun
++++ b/data/gamemoderun
+@@ -5,5 +5,6 @@ GAMEMODEAUTO_NAME="libgamemodeauto.so.0"
+ 
+ # ld will find the right path to load the library, including for 32-bit apps.
+ LD_PRELOAD="${GAMEMODEAUTO_NAME}${LD_PRELOAD:+:$LD_PRELOAD}"
++LD_LIBRARY_PATH="@libraryPath@${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+ 
+-exec env LD_PRELOAD="${LD_PRELOAD}" $GAMEMODERUNEXEC "$@"
++exec env LD_PRELOAD="${LD_PRELOAD}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" $GAMEMODERUNEXEC "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -854,6 +854,10 @@ in
 
   amidst = callPackage ../tools/games/amidst { };
 
+  gamemode = callPackage ../tools/games/gamemode {
+    libgamemode32 = pkgsi686Linux.gamemode.lib;
+  };
+
   gfshare = callPackage ../tools/security/gfshare { };
 
   gobgp = callPackage ../tools/networking/gobgp { };


### PR DESCRIPTION
###### Motivation for this change
Continue the work started in #67779 to port GameMode to Nixpkgs.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Testing Notes
Here are some notes I've made while testing this package:

`gamemoded -t` can be used to verify that everything's working as expected:
```
: Loading config
Loading config file [/nix/store/p8dbmpdak57psrb5c0mz7crsc95nfzs6-gamemode-1.6.1/share/gamemode/gamemode.ini]
Loading config file [/etc/gamemode.ini]
: Running tests

:: Basic client tests
:: Passed

:: Dual client tests
gamemode request succeeded and is active
Quitting by request...
:: Passed

:: Gamemoderun and reaper thread tests
...Waiting for child to quit...
...Waiting for reaper thread (reaper_frequency set to 5 seconds)...
:: Passed

:: Supervisor tests
:: Passed

:: Feature tests
::: Verifying CPU governor setting
::: Passed
::: Verifying Scripts
:::: Running start script [/nix/store/ig8aqj0973jgn6mhnr7smmqb6p7alrz4-libnotify-0.7.9/bin/notify-send 'GameMode started']
:::: Passed
:::: Running end script [/nix/store/ig8aqj0973jgn6mhnr7smmqb6p7alrz4-libnotify-0.7.9/bin/notify-send 'GameMode ended']
:::: Passed
::: Passed
::: Verifying GPU Optimisations
::: Passed
::: Verifying renice
::: Passed
::: Verifying ioprio
::: Passed
:: Passed

: All Tests Passed!
```

Renice & ioprio optimisations sometimes fail. It seems like this is caused by GameMode trying to apply optimisations on processes that exit before the optimisations can be applied. See https://github.com/FeralInteractive/gamemode/issues/167#issuecomment-524277666 (the logs can be accessed with `journalctl --user -u gamemoded.service`).
```
ERROR: Could not inspect tasks for client [329118]! Skipping ioprio optimisation.
ERROR: Refused to renice client [31477,31477]: prio was (-10) but we expected (0)
```

If you don't have an Intel CPU, you will get errors about failing to read the energy levels. This isn't a real problem. It just means that optimizations for integrated graphics cards won't be enabled:
```
ERROR: Failed to open file for read /sys/class/powercap/intel-rapl/intel-rapl:0/intel-rapl:0:0/energy_uj
```

If you don't have a screensaver installed, you will get the following errors:
```
ERROR: Could not call Inhibit on org.freedesktop.ScreenSaver: No route to host
        org.freedesktop.DBus.Error.ServiceUnknown
        The name org.freedesktop.ScreenSaver was not provided by any .service files
```

You can get rid of them by setting:
```
programs.gamemode.settings.general.inhibit_screensaver = 0;
```