### PR TITLE
Prefer `pname` and `version` in `mkDerivation`s instead of `name`

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
@@ -1,10 +1,11 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config, apacheHttpd, apr, avahi }:
 
 stdenv.mkDerivation rec {
-  name = "mod_dnssd-0.6";
+  pname = "mod_dnssd";
+  version = "0.6";
 
   src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/mod_dnssd/${name}.tar.gz";
+    url = "http://0pointer.de/lennart/projects/mod_dnssd/${pname}-${version}.tar.gz";
     sha256 = "2cd171d76eba398f03c1d5bcc468a1756f4801cd8ed5bd065086e4374997c5aa";
   };
 

--- a/pkgs/servers/http/apache-modules/tomcat-connectors/default.nix
+++ b/pkgs/servers/http/apache-modules/tomcat-connectors/default.nix
@@ -1,10 +1,11 @@
 { lib, stdenv, fetchurl, apacheHttpd, jdk }:
 
 stdenv.mkDerivation rec {
-  name = "tomcat-connectors-1.2.48";
+  pname = "tomcat-connectors";
+  version = "1.2.48";
 
   src = fetchurl {
-    url = "mirror://apache/tomcat/tomcat-connectors/jk/${name}-src.tar.gz";
+    url = "mirror://apache/tomcat/tomcat-connectors/jk/${pname}-${version}-src.tar.gz";
     sha256 = "15wfj1mvad15j1fqw67qbpbpwrcz3rb0zdhrq6z2sax1l05kc6yb";
   };
 

--- a/pkgs/servers/http/jboss/default.nix
+++ b/pkgs/servers/http/jboss/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, jdk }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "jboss-as";
   version = "7.1.1.Final";
   src = fetchurl {
-    url = "https://download.jboss.org/jbossas/7.1/jboss-as-7.1.1.Final/jboss-as-7.1.1.Final.tar.gz";
+    url = "https://download.jboss.org/jbossas/${lib.versions.majorMinor version}/jboss-as-${version}/jboss-as-${version}.tar.gz";
     sha256 = "1bdjw0ib9qr498vpfbg8klqw6rl11vbz7vwn6gp1r5gpqkd3zzc8";
   };
 

--- a/pkgs/servers/http/jboss/default.nix
+++ b/pkgs/servers/http/jboss/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchurl, jdk }:
 
 stdenv.mkDerivation {
-  name = "jboss-as-7.1.1.Final";
+  pname = "jboss-as";
+  version = "7.1.1.Final";
   src = fetchurl {
     url = "https://download.jboss.org/jbossas/7.1/jboss-as-7.1.1.Final/jboss-as-7.1.1.Final.tar.gz";
     sha256 = "1bdjw0ib9qr498vpfbg8klqw6rl11vbz7vwn6gp1r5gpqkd3zzc8";

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "1.4.59";
 
   src = fetchurl {
-    url = "https://download.lighttpd.net/lighttpd/releases-1.4.x/${pname}-${version}.tar.xz";
+    url = "https://download.lighttpd.net/lighttpd/releases-${lib.versions.majorMinor version}.x/${pname}-${version}.tar.xz";
     sha256 = "sha256-+5U9snPa7wjttuICVWyuij0H7tYIHJa9mQPblX0QhNU=";
   };
 

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -15,10 +15,11 @@ assert enableWebDAV -> libuuid != null;
 assert enableExtendedAttrs -> attr != null;
 
 stdenv.mkDerivation rec {
-  name = "lighttpd-1.4.59";
+  pname = "lighttpd";
+  version = "1.4.59";
 
   src = fetchurl {
-    url = "https://download.lighttpd.net/lighttpd/releases-1.4.x/${name}.tar.xz";
+    url = "https://download.lighttpd.net/lighttpd/releases-1.4.x/${pname}-${version}.tar.xz";
     sha256 = "sha256-+5U9snPa7wjttuICVWyuij0H7tYIHJa9mQPblX0QhNU=";
   };
 

--- a/pkgs/servers/http/mini-httpd/default.nix
+++ b/pkgs/servers/http/mini-httpd/default.nix
@@ -1,10 +1,11 @@
 { lib, stdenv, fetchurl, boost }:
 
 stdenv.mkDerivation rec {
-  name = "mini-httpd-1.7";
+  pname = "mini-httpd";
+  version = "1.7";
 
   src = fetchurl {
-    url = "https://download-mirror.savannah.gnu.org/releases/mini-httpd/${name}.tar.gz";
+    url = "https://download-mirror.savannah.gnu.org/releases/mini-httpd/${pname}-${version}.tar.gz";
     sha256 = "0jggmlaywjfbdljzv5hyiz49plnxh0har2bnc9dq4xmj1pmjgs49";
   };
 

--- a/pkgs/servers/mail/clamsmtp/default.nix
+++ b/pkgs/servers/mail/clamsmtp/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "clamsmtp-" + version;
+  pname = "clamsmtp";
   version = "1.10";
 
   src = fetchurl {
-    url = "http://thewalter.net/stef/software/clamsmtp/${name}.tar.gz";
+    url = "http://thewalter.net/stef/software/clamsmtp/${pname}-${version}.tar.gz";
     sha256 = "0apr1pxifw6f1rbbsdrrwzs1dnhybg4hda3qqhqcw7p14r5xnbx5";
   };
 

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -1,14 +1,11 @@
 { lib, stdenv, perlPackages, fetchurl }:
 
-let
-  pkg = "dkimproxy";
-  version = "1.4.1";
-in
 stdenv.mkDerivation rec {
-  name = "${pkg}-${version}";
+  pname = "dkimproxy";
+  version = "1.4.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/dkimproxy/${name}.tar.gz";
+    url = "mirror://sourceforge/dkimproxy/${pname}-${version}.tar.gz";
     sha256 = "1gc5c7lg2qrlck7b0lvjfqr824ch6jkrzkpsn0gjvlzg7hfmld75";
   };
 

--- a/pkgs/servers/mail/dspam/default.nix
+++ b/pkgs/servers/mail/dspam/default.nix
@@ -18,10 +18,11 @@ let
   maintenancePath = lib.makeBinPath [ gawk gnused gnugrep coreutils which ];
 
 in stdenv.mkDerivation rec {
-  name = "dspam-3.10.2";
+  pname = "dspam";
+  version = "3.10.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/dspam/dspam/${name}/${name}.tar.gz";
+    url = "mirror://sourceforge/dspam/dspam/${pname}-${version}/${pname}-${version}.tar.gz";
     sha256 = "1acklnxn1wvc7abn31l3qdj8q6k13s51k5gv86vka7q20jb5cxmf";
   };
 

--- a/pkgs/servers/mail/petidomo/default.nix
+++ b/pkgs/servers/mail/petidomo/default.nix
@@ -1,10 +1,11 @@
 { lib, stdenv, fetchurl, flex, bison, sendmailPath ? "/run/wrappers/bin/sendmail" }:
 
 stdenv.mkDerivation rec {
-  name = "petidomo-4.3";
+  pname = "petidomo";
+  version = "4.3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/petidomo/${name}.tar.gz";
+    url = "mirror://sourceforge/petidomo/${pname}-${version}.tar.gz";
     sha256 = "0x4dbxc4fcfg1rw5ywpcypvylnzn3y4rh0m6fz4h4cdnzb8p1lvm";
   };
 

--- a/pkgs/servers/mail/popa3d/default.nix
+++ b/pkgs/servers/mail/popa3d/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl,  openssl }:
 
 stdenv.mkDerivation rec {
-
-  name = "popa3d-1.0.3";
+  pname = "popa3d";
+  version = "1.0.3";
 
   src = fetchurl {
-    url = "http://www.openwall.com/popa3d/${name}.tar.gz";
+    url = "http://www.openwall.com/popa3d/${pname}-${version}.tar.gz";
     sha256 = "1g48cd74sqhl496wmljhq44iyfpghaz363a1ip8nyhpjz7d57f03";
   };
 

--- a/pkgs/servers/mail/system-sendmail/default.nix
+++ b/pkgs/servers/mail/system-sendmail/default.nix
@@ -15,7 +15,8 @@ let script = writeText "script" ''
   fi
 ''; in
 stdenv.mkDerivation {
-  name = "system-sendmail-1.0";
+  pname = "system-sendmail";
+  version = "1.0";
 
   src = script;
 

--- a/pkgs/servers/nosql/riak/2.2.0.nix
+++ b/pkgs/servers/nosql/riak/2.2.0.nix
@@ -26,7 +26,8 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "riak-2.2.0";
+  pname = "riak";
+  version = "2.2.0";
 
   nativeBuildInputs = [ unzip ];
   buildInputs = [

--- a/pkgs/servers/pies/default.nix
+++ b/pkgs/servers/pies/default.nix
@@ -1,10 +1,11 @@
 { fetchurl, lib, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "pies-1.3";
+  pname = "pies";
+  version = "1.3";
 
   src = fetchurl {
-    url = "mirror://gnu/pies/${name}.tar.bz2";
+    url = "mirror://gnu/pies/${pname}-${version}.tar.bz2";
     sha256 = "12r7rjjyibjdj08dvwbp0iflfpzl4s0zhn6cr6zj3hwf9gbzgl1g";
   };
 

--- a/pkgs/servers/prayer/default.nix
+++ b/pkgs/servers/prayer/default.nix
@@ -5,10 +5,11 @@ let
     "-e 's/CCLIENT_SSL_ENABLE.*= false/CCLIENT_SSL_ENABLE=true/'";
 in
 stdenv.mkDerivation rec {
-  name = "prayer-1.3.5";
+  pname = "prayer";
+  version = "1.3.5";
 
   src = fetchurl {
-    url = "ftp://ftp.csx.cam.ac.uk/pub/software/email/prayer/${name}.tar.gz";
+    url = "ftp://ftp.csx.cam.ac.uk/pub/software/email/prayer/${pname}-${version}.tar.gz";
     sha256 = "135fjbxjn385b6cjys6qhbwfw61mdcl2akkll4jfpdzfvhbxlyda";
   };
 

--- a/pkgs/servers/unfs3/default.nix
+++ b/pkgs/servers/unfs3/default.nix
@@ -1,10 +1,11 @@
 { fetchurl, lib, stdenv, flex, bison }:
 
 stdenv.mkDerivation rec {
-  name = "unfs3-0.9.22";
+  pname = "unfs3";
+  version = "0.9.22";
 
   src = fetchurl {
-    url = "mirror://sourceforge/unfs3/${name}.tar.gz";
+    url = "mirror://sourceforge/unfs3/${pname}-${version}.tar.gz";
     sha256 = "076zkyqkn56q0a8n3h65n1a68fknk4hrrp6mbhajq5s1wp5248j8";
   };
 

--- a/pkgs/servers/ursadb/default.nix
+++ b/pkgs/servers/ursadb/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, cmake, zeromq, cppzmq }:
 
-stdenv.mkDerivation {
-  name = "ursadb";
+stdenv.mkDerivation rec {
+  pname = "ursadb";
   version = "1.2.0";
 
   src = fetchurl {

--- a/pkgs/servers/ursadb/default.nix
+++ b/pkgs/servers/ursadb/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.2.0";
 
   src = fetchurl {
-    url = "https://github.com/CERT-Polska/ursadb/archive/v1.2.0.tar.gz";
+    url = "https://github.com/CERT-Polska/ursadb/archive/v${version}.tar.gz";
     sha256 = "10dax3mswq0x4cfrpi31b7ii7bxl536wz1j11b7f5c0zw9pjxzym";
   };
 

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -847,12 +847,11 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
   # };
 
   NDeskOptions = stdenv.mkDerivation rec {
-    baseName = "NDesk.Options";
+    pname = "NDesk.Options";
     version = "0.2.1";
-    name = "${baseName}-${version}";
 
     src = fetchurl {
-      name = "${baseName}-${version}.tar.gz";
+      name = "${pname}-${version}.tar.gz";
       url = "http://www.ndesk.org/archive/ndesk-options/ndesk-options-0.2.1.tar.gz";
       sha256 = "1y25bfapafwmifakjzyb9c70qqpvza8g5j2jpf08j8wwzkrb6r28";
     };

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -852,7 +852,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
     src = fetchurl {
       name = "${pname}-${version}.tar.gz";
-      url = "http://www.ndesk.org/archive/ndesk-options/ndesk-options-0.2.1.tar.gz";
+      url = "http://www.ndesk.org/archive/ndesk-options/ndesk-options-${version}.tar.gz";
       sha256 = "1y25bfapafwmifakjzyb9c70qqpvza8g5j2jpf08j8wwzkrb6r28";
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
In pursuit of https://github.com/NixOS/nixpkgs/issues/103997, I present this PR which AFAICT gets rid of most if not all of the remaining usages of `name` in `mkDerivations`. I did a search through `pkgs/`, and fixed each manually. 

I only tackled `mkDerivations` with "literal" `name` usage. Functions that generate `mkDerivation`s with `name` are another beast. Also batch files for things like node/yarn/etc we're skipped. Instances of `mkDerivation` outside of `pkgs/` were not addressed.

Logs for `nixpkgs-review wip` can be found here: https://gist.github.com/samuela/a71de800aef3e31a2e0e116b10ff0aa5. There are three failures, but they seem unrelated to the changes in this PR. Perhaps these should packages should be marked broken?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
