### PR TITLE
microplane: 0.0.28 -> 0.0.31

### DIFF
--- a/pkgs/tools/misc/microplane/default.nix
+++ b/pkgs/tools/misc/microplane/default.nix
@@ -2,19 +2,19 @@
 
 buildGoModule rec {
   pname = "microplane";
-  version = "0.0.28";
+  version = "0.0.31";
 
   src = fetchFromGitHub {
     owner = "Clever";
     repo = "microplane";
     rev = "v${version}";
-    sha256 = "00ayci0a4lv67sg2bb4fw5wpdlps4pjqiiam595dar82lsjwj63j";
+    sha256 = "sha256-PcojOFe3SHhnFy09kcxHhb5kd07TG7Uq+coPUNbJjx4=";
   };
 
-  vendorSha256 = "0hn2gsm9bgmrm620fn2cx28l2gj1yfgvjix9ds50m7kwkx6q0dga";
+  vendorSha256 = "sha256-5HHdxSXg3ZIUyFQALaYgvf4pQwNxG58cF4vnCnMgAuY=";
 
   buildFlagsArray = ''
-    -ldflags="-s -w -X main.version=v${version}"
+    -ldflags=-s -w -X main.version=${version}
   '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updating to the newest version:
https://github.com/Clever/microplane/releases/tag/v0.0.31

Removing some double quotes from the ldflags, since it was preventing `main.version` from being set successfully.

Also tried `nix-update` for the first time. Super helpful tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>microplane</li>
  </ul>

