### PR TITLE
deadbeef: ffmpeg_3 -> ffmpeg

### DIFF
--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -17,7 +17,7 @@
 , aacSupport ? true, faad2 ? null
 , opusSupport ? true, opusfile ? null
 , wavpackSupport ? false, wavpack ? null
-, ffmpegSupport ? false, ffmpeg_3 ? null
+, ffmpegSupport ? false, ffmpeg ? null
 , apeSupport ? true, yasm ? null
 # misc plugins
 , zipSupport ? true, libzip ? null
@@ -45,7 +45,7 @@ assert cdaSupport -> (libcdio != null && libcddb != null);
 assert aacSupport -> faad2 != null;
 assert opusSupport -> opusfile != null;
 assert zipSupport -> libzip != null;
-assert ffmpegSupport -> ffmpeg_3 != null;
+assert ffmpegSupport -> ffmpeg != null;
 assert apeSupport -> yasm != null;
 assert artworkSupport -> imlib2 != null;
 assert hotkeysSupport -> libX11 != null;
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     ++ optional aacSupport faad2
     ++ optional opusSupport opusfile
     ++ optional zipSupport libzip
-    ++ optional ffmpegSupport ffmpeg_3
+    ++ optional ffmpegSupport ffmpeg
     ++ optional apeSupport yasm
     ++ optional artworkSupport imlib2
     ++ optional hotkeysSupport libX11


### PR DESCRIPTION
###### Motivation for this change
 #120705

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Still builds with ffmpegSupport enabled.