### PR TITLE
quartus-prime-lite: Add postInstall option

### DIFF
--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,5 +1,7 @@
-{ buildFHSUserEnv, makeDesktopItem, writeScript, stdenv, lib, requireFile, unstick,
-  supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ] }:
+{ buildFHSUserEnv, makeDesktopItem, writeScript, stdenv, lib, requireFile, unstick
+, supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
+, postInstall ? ""
+}:
 
 let
   deviceIds = {
@@ -82,6 +84,8 @@ let
         --mode unattended --installdir $out --accept_eula 1
 
       rm -r $out/uninstall $out/logs
+
+      ${postInstall}
     '';
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

quartus-prime-lite has a pretty large closure size of about 15GB. This option allows cutting out unneeded parts before the package is stored permanently in the nix store.

For example, if you're only going to use the twentynm platform and you're not going to use the builtin C compiler, you can cut the closure size in half with:

    quartus-prime-lite.override {
      postInstall = ''
        rm -r $out/nios2eds/bin/gnu
        find $out/modelsim_ase/altera/{verilog,vhdl}/* ! -name src ! -path '*twentynm*' -delete
      '';
    }

###### Things done

I tested a `postInstall` similar to the above and was still able to produce fpga images.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
