### PR TITLE
ceph-csi: init at 3.3.1

### DIFF
--- a/pkgs/tools/filesystems/ceph-csi/default.nix
+++ b/pkgs/tools/filesystems/ceph-csi/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, go, ceph, fetchFromGitHub }:
+
+stdenv.mkDerivation rec{
+  pname = "ceph-csi";
+  version = "3.3.1";
+
+  nativeBuildInputs = [ go ];
+  buildInputs = [ ceph ];
+
+  src = fetchFromGitHub {
+    owner = "ceph";
+    repo = "ceph-csi";
+    rev = "v${version}";
+    sha256 = "16nh4bh8a9s2zbxnnhq1ldww4dzp2fmf5idgq99vkyw2kfp017lf";
+  };
+
+  preConfigure = ''
+    export GOCACHE=$(pwd)/.cache
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./_output/* $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://ceph.com/";
+    description = "Container Storage Interface (CSI) driver for Ceph RBD and CephFS";
+    license = [ licenses.asl20 ];
+    maintainers = with maintainers; [ johanot ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}
+

--- a/pkgs/tools/filesystems/ceph-csi/default.nix
+++ b/pkgs/tools/filesystems/ceph-csi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, go, ceph, fetchFromGitHub }:
 
-stdenv.mkDerivation rec{
+stdenv.mkDerivation rec {
   pname = "ceph-csi";
   version = "3.3.1";
 
@@ -31,4 +31,3 @@ stdenv.mkDerivation rec{
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3405,6 +3405,8 @@ in
 
   nrg2iso = callPackage ../tools/cd-dvd/nrg2iso { };
 
+  ceph-csi = callPackage ../tools/filesystems/ceph-csi { };
+
   libceph = ceph.lib;
   inherit (callPackages ../tools/filesystems/ceph {
     boost = boost17x.override { enablePython = true; python = python3; };


### PR DESCRIPTION
###### Motivation for this change

To provide the ceph-csi package and binary in nixpkgs.

It is far from ideal that this package depend on the entire ceph package. It needs only `ceph.dev`, but since that is derived from the big ceph closure anyway, pulling that in explicitly doesn't make a difference in closure size. In fact, all that is needed here are the rados header files, so something like `${ceph.src}/src/include` would be sufficient. But.. I think it's up to a separate PR to split the ceph package.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
