### PR TITLE
xscast: use ffmpeg instead of ffmpeg_3

### DIFF
--- a/pkgs/applications/video/xscast/default.nix
+++ b/pkgs/applications/video/xscast/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, ffmpeg_3, imagemagick, dzen2, xorg }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, ffmpeg, imagemagick, dzen2, xorg }:
 
 stdenv.mkDerivation {
   pname = "xscast-unstable";
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     patchShebangs $out/bin
 
     wrapProgram "$out/bin/xscast" \
-      --prefix PATH : ${lib.makeBinPath [ ffmpeg_3 dzen2 xorg.xwininfo xorg.xinput xorg.xmodmap imagemagick ]}
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg dzen2 xorg.xwininfo xorg.xinput xorg.xmodmap imagemagick ]}
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/120705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
