### PR TITLE
moc: always use newest ffmpeg

### DIFF
--- a/pkgs/applications/audio/moc/default.nix
+++ b/pkgs/applications/audio/moc/default.nix
@@ -14,11 +14,10 @@
 , musepackSupport ? true, libmpc, libmpcdec, taglib
 , vorbisSupport ? true, libvorbis
 , speexSupport ? true, speex
-, ffmpegSupport ? true, ffmpeg_3
+, ffmpegSupport ? true, ffmpeg
 , sndfileSupport ? true, libsndfile
 , wavpackSupport ? true, wavpack
 # Misc
-, withffmpeg4 ? false, ffmpeg_4
 , curlSupport ? true, curl
 , samplerateSupport ? true, libsamplerate
 , withDebug ? false
@@ -39,7 +38,7 @@ in stdenv.mkDerivation rec {
   };
 
   patches = []
-    ++ opt withffmpeg4 ./moc-ffmpeg4.patch
+    ++ opt ffmpegSupport ./moc-ffmpeg4.patch
     ++ opt pulseSupport ./pulseaudio.patch;
 
   nativeBuildInputs = [ pkg-config ]
@@ -60,8 +59,7 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals musepackSupport [ libmpc libmpcdec taglib ]
     ++ opt vorbisSupport libvorbis
     ++ opt speexSupport speex
-    ++ opt (ffmpegSupport && !withffmpeg4) ffmpeg_3
-    ++ opt (ffmpegSupport && withffmpeg4) ffmpeg_4
+    ++ opt ffmpegSupport ffmpeg
     ++ opt sndfileSupport libsndfile
     ++ opt wavpackSupport wavpack
     # Misc


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/120705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
