### PR TITLE
Synology Drive Client: init at 2.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4517,6 +4517,16 @@
     githubId = 938744;
     name = "John Chadwick";
   };
+  jcouyang = {
+    email = "oyanglulu@gmail.com";
+    github = "jcouyang";
+    githubId = 1235045;
+    name = "Jichao Ouyang";
+    keys = [{
+      longkeyid = "rsa2048/0xDA8B833B52604E63";
+      fingerprint = "A506 C38D 5CC8 47D0 DF01  134A DA8B 833B 5260 4E63";
+    }];
+  };
   jcumming = {
     email = "jack@mudshark.org";
     github = "jcumming";

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -21,7 +21,7 @@ let
   versionNumber = "2.0.4";
 in stdenv.mkDerivation {
   pname = "synology-drive-client";
-  
+
   version = versionNumber;
 
   srcs = [

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation {
     description = "Desktop application to synchronize files and folders between the computer and the Synology Drive server to access, browse, and share files via file browser";
     homepage = "https://www.synology.com/en-global/dsm/feature/drive";
     license = licenses.unfree;
+    maintainers = with maintainers; [ jcouyang ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -1,0 +1,79 @@
+{
+  stdenv
+, xorg
+, glib
+, freetype
+, libxkbcommon
+, fontconfig
+, pango
+, gtk3
+, gtk2-x11
+, gcc-unwrapped
+, dbus_libs
+, qt5
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, lib
+}:
+
+stdenv.mkDerivation {
+  pname = "synology-drive-client";
+  
+  version = "2.0.4";
+
+  srcs = [
+    (fetchurl {
+      url = "http://archive.ubuntu.com/ubuntu/pool/universe/q/qtlocation-opensource-src/libqt5positioning5_5.15.2+dfsg-2_amd64.deb";
+      sha256 = "01f9qgqkd6m3idr5f0w2k5cl9sjk7617fzp023d0qfnsw661wy56";
+    })
+    (fetchurl {
+      url = "https://global.download.synology.com/download/Utility/SynologyDriveClient/2.0.4-11112/Ubuntu/Installer/x86_64/synology-drive-client-11112.x86_64.deb";
+      sha256 = "0q9zyf98zw75j0yfwidqmc7jwf2zhg942xsqvkxxdqlrncmb4g01";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    xorg.libX11
+    glib
+    freetype
+    libxkbcommon
+    xorg.libICE
+    xorg.libXrender
+    xorg.libSM
+    fontconfig
+    pango
+    gtk3
+    gtk2-x11
+    gcc-unwrapped
+    dbus_libs
+    qt5.qtbase
+    qt5.qtx11extras
+  ];
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir -p $out
+    for _src in $srcs; do
+      dpkg -x $_src $out
+    done
+    rm -rf $out/usr/lib/nautilus
+    rm -rf $out/opt/Synology/SynologyDrive/package/cloudstation/icon-overlay
+    cp -r $out/usr/bin $out/bin
+  '';
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Desktop application to synchronize files and folders between the computer and the Synology Drive server to access, browse, and share files via file browser";
+    homepage = "https://www.synology.com/en-global/dsm/feature/drive";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/synology-drive-client/default.nix
+++ b/pkgs/applications/networking/synology-drive-client/default.nix
@@ -16,11 +16,13 @@
 , fetchurl
 , lib
 }:
-
-stdenv.mkDerivation {
+let
+  buildNumber = "11112";
+  versionNumber = "2.0.4";
+in stdenv.mkDerivation {
   pname = "synology-drive-client";
   
-  version = "2.0.4";
+  version = versionNumber;
 
   srcs = [
     (fetchurl {
@@ -28,7 +30,7 @@ stdenv.mkDerivation {
       sha256 = "01f9qgqkd6m3idr5f0w2k5cl9sjk7617fzp023d0qfnsw661wy56";
     })
     (fetchurl {
-      url = "https://global.download.synology.com/download/Utility/SynologyDriveClient/2.0.4-11112/Ubuntu/Installer/x86_64/synology-drive-client-11112.x86_64.deb";
+      url = "https://global.download.synology.com/download/Utility/SynologyDriveClient/${versionNumber}-${buildNumber}/Ubuntu/Installer/x86_64/synology-drive-client-${buildNumber}.x86_64.deb";
       sha256 = "0q9zyf98zw75j0yfwidqmc7jwf2zhg942xsqvkxxdqlrncmb4g01";
     })
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26029,6 +26029,8 @@ in
 
   sxiv = callPackage ../applications/graphics/sxiv { };
 
+  synology-drive-client = callPackage ../applications/networking/synology-drive-client { };
+
   resilio-sync = callPackage ../applications/networking/resilio-sync { };
 
   dropbox = callPackage ../applications/networking/dropbox { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add Synology Drive Client

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
