### PR TITLE
ffmpeg_3: mark as insecure

### DIFF
--- a/pkgs/development/libraries/ffmpeg/3.4.nix
+++ b/pkgs/development/libraries/ffmpeg/3.4.nix
@@ -9,4 +9,7 @@ callPackage ./generic.nix (rec {
   branch = "3.4.8";
   sha256 = "1d0r4yja2dkkyhdwx1migq46gsrcbajiv66263a5sq5bfr9dqkch";
   darwinFrameworks = [ Cocoa CoreMedia ];
+  knownVulnerabilities = [
+    "CVE-2021-30123"
+  ];
 } // args)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
closes #120372

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Currently, this has impact on the following packages:
```
59 packages removed:
airtame (†3.3.0) ardour (†6.5) attract-mode (†2.6.1) betaflight-configurator (†10.7.0) capture-unstable (†2019-03-10) devede (†4.16.0) docear (†1.2) doodle (†0.7.2) dr14_tmeter (†1.0.16) dvd-slideshow (†0.8.4-2) ffmpeg (†3.4.8) gnunet (†0.14.1) gnunet-gtk (†0.14.0) goldendict (†2020-12-09) gopro (†1.0) ib-controller (†2.14.0) ib-tws (†9542) javacard-devkit (†2.2.2) libextractor (†1.11) libgroove (†4.3.0) liblinphone (†4.5.1) libretro-ppsspp (†2020-03-06) libvdpau-va-gl (†0.4.2) libvdpau-va-gl (†0.4.2) lightspark (†0.8.4.1) linphone-desktop (†4.2.5) manim (†0.1.10) mediastreamer2 (†4.5.1) mediatomb (†0.12.1) megacmd (†1.4.0) moc (†2.5.2) msilbc (†2.1.2) msopenh264-unstable (†2020-03-03) natron (†2.3.15) nwjs (†0.33.4) nwjs (†0.33.4) openmw (†0.46.0) openmw-tes3mp (†2019-11-19) openrw (†2019-10-26) oraclejdk (†8u281) oraclejdk (†8u281) oraclejre (†8u281) oraclejre (†8u281) oraclejre-with-plugin (†8u281) oven-media-engine (†0.10.9-hotfix) processing (†3.5.4) processing (†3.5.4) qstopmotion (†2.5.2) renpy (†7.3.5) retroshare (†0.6.2) retroshare (†0.6.2) ring-daemon (†2017-07-11) sqldeveloper (†20.4.0.379.2205) tvheadend (†4.2.8) ultrastardx (†2021-04-03) ultrastardx (†2021-04-03) vdr-vaapidevice (†20190525) xscast-unstable (†2016-07-26) yaxg-unstable (†2018-05-03)
```

cc @NixOS/nixos-release-managers 