### PR TITLE
samblaster: fix darwin build

### DIFF
--- a/pkgs/applications/science/biology/samblaster/default.nix
+++ b/pkgs/applications/science/biology/samblaster/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0g24fq5hplnfgqkh3xqpg3lgx3wmxwnh9c7m6yw7pbi40lmgl1jv";
   };
 
+  makeFlags = [ "CPP=${stdenv.cc.targetPrefix}c++" ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp samblaster $out/bin


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142940255/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
