### PR TITLE
spacenav-cube-example: fix darwin build

### DIFF
--- a/pkgs/applications/misc/spacenav-cube-example/default.nix
+++ b/pkgs/applications/misc/spacenav-cube-example/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ libX11 mesa_glu libspnav ];
 
-  configureFlags = [ "--disable-debug" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/libraries/libspnav/default.nix
+++ b/pkgs/development/libraries/libspnav/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, libX11}:
+{ stdenv, lib, fetchFromGitHub, libX11, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   version = "0.2.3";
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "098h1jhlj87axpza5zgy58prp0zn94wyrbch6x0s7q4mzh7dc8ba";
   };
 
+  nativeBuildInputs = lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [ libX11 ];
 
   configureFlags = [ "--disable-debug"];


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/143298267/log

I removed `configureFlags` because there is not configure script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
