### PR TITLE
nixos/flatpak: Remove `guiPackages` internal option

### DIFF
--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -15,18 +15,6 @@ in {
   options = {
     services.flatpak = {
       enable = mkEnableOption "flatpak";
-
-      guiPackages = mkOption {
-        internal = true;
-        type = types.listOf types.package;
-        default = [];
-        example = literalExample "[ pkgs.gnome.gnome-software ]";
-        description = ''
-          Packages that provide an interface for flatpak
-          (like gnome-software) that will be automatically available
-          to all users when flatpak is enabled.
-        '';
-      };
     };
   };
 
@@ -40,7 +28,7 @@ in {
       }
     ];
 
-    environment.systemPackages = [ pkgs.flatpak ] ++ cfg.guiPackages;
+    environment.systemPackages = [ pkgs.flatpak ];
 
     services.dbus.packages = [ pkgs.flatpak ];
 

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -291,11 +291,6 @@ in
 
        # If gnome is installed, build vim for gtk3 too.
       nixpkgs.config.vim.gui = "gtk3";
-
-      # Install gnome-software if flatpak is enabled
-      services.flatpak.guiPackages = [
-        pkgs.gnome.gnome-software
-      ];
     })
 
     (mkIf flashbackEnabled {
@@ -466,31 +461,39 @@ in
 
     # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-38/elements/core/meta-gnome-core-utilities.bst
     (mkIf serviceCfg.core-utilities.enable {
-      environment.systemPackages = (with pkgs.gnome; removePackagesByName [
-        baobab
-        cheese
-        eog
-        epiphany
-        gedit
-        gnome-calculator
-        gnome-calendar
-        gnome-characters
-        gnome-clocks
-        gnome-contacts
-        gnome-font-viewer
-        gnome-logs
-        gnome-maps
-        gnome-music
-        pkgs.gnome-photos
-        gnome-screenshot
-        gnome-system-monitor
-        gnome-weather
-        nautilus
-        pkgs.gnome-connections
-        simple-scan
-        totem
-        yelp
-      ] config.environment.gnome.excludePackages);
+      environment.systemPackages =
+        with pkgs.gnome;
+        removePackagesByName
+          ([
+            baobab
+            cheese
+            eog
+            epiphany
+            gedit
+            gnome-calculator
+            gnome-calendar
+            gnome-characters
+            gnome-clocks
+            gnome-contacts
+            gnome-font-viewer
+            gnome-logs
+            gnome-maps
+            gnome-music
+            pkgs.gnome-photos
+            gnome-screenshot
+            gnome-system-monitor
+            gnome-weather
+            nautilus
+            pkgs.gnome-connections
+            simple-scan
+            totem
+            yelp
+          ] ++ lib.optionals config.services.flatpak.enable [
+            # Since PackageKit Nix support is not there yet,
+            # only install gnome-software if flatpak is enabled.
+            gnome-software
+          ])
+          config.environment.gnome.excludePackages;
 
       # Enable default program modules
       # Since some of these have a corresponding package, we only


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
It was basically just a `environment.systemPackages` synonym, only GNOME used it, and it was stretching the responsibilities of the flatpak module too far.

It also makes it cleaner to avoid installing the program using GNOME module’s `excludePackages` option.

Partially reverts: https://github.com/NixOS/nixpkgs/pull/101516
Fixes: https://github.com/NixOS/nixpkgs/issues/110310



###### Things done

GNOME VM still evaluates.