### PR TITLE
spacenavd: fix darwin build

### DIFF
--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, libX11 }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, libX11, IOKit }:
 
 stdenv.mkDerivation rec {
   version = "0.8";
@@ -11,9 +11,20 @@ stdenv.mkDerivation rec {
     sha256 = "1zz0cm5cgvp9s5n4nzksl8rb11c7sw214bdafzra74smvqfjcjcf";
   };
 
-  buildInputs = [ libX11 ];
+  patches = [
+    # Fixes Darwin: https://github.com/FreeSpacenav/spacenavd/pull/38
+    (fetchpatch {
+      url = "https://github.com/FreeSpacenav/spacenavd/commit/d6a25d5c3f49b9676d039775efc8bf854737c43c.patch";
+      sha256 = "02pdgcvaqc20qf9hi3r73nb9ds7yk2ps9nnxaj0x9p50xjnhfg5c";
+    })
+  ];
 
-  configureFlags = [ "--disable-debug"];
+  buildInputs = [ libX11 ]
+    ++ lib.optional stdenv.isDarwin IOKit;
+
+  configureFlags = [ "--disable-debug" ];
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   meta = with lib; {
     homepage = "http://spacenav.sourceforge.net/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30792,7 +30792,9 @@ in
     hasktags = haskellPackages.hasktags;
   };
 
-  spacenavd = callPackage ../misc/drivers/spacenavd { };
+  spacenavd = callPackage ../misc/drivers/spacenavd {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
 
   spacenav-cube-example = callPackage ../applications/misc/spacenav-cube-example { };
 


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142946017/nixlog/1

Upstream PR: https://github.com/FreeSpacenav/spacenavd/pull/38

~~Draft, because we may have to wait for upstream response before the fetchpatch URL becomes permanent.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
