### PR TITLE
 picoscope: init at 6.14.44-4r5870

### DIFF
--- a/pkgs/applications/science/electronics/picoscope/default.nix
+++ b/pkgs/applications/science/electronics/picoscope/default.nix
@@ -1,0 +1,131 @@
+{ stdenv, lib, fetchurl, dpkg, makeWrapper, buildFHSUserEnvBubblewrap }:
+
+with lib;
+
+let
+  pkg = stdenv.mkDerivation rec {
+    pname = "picoscope";
+    # Make sure to update the dependencies to the correct versions when
+    # updating here!
+    version = "6.14.44-4r5870";
+
+    srcs = let base = "https://labs.picotech.com/debian/pool/main";
+    in [
+      (fetchurl {
+        url = "${base}/p/picoscope/${pname}_${version}_all.deb";
+        sha256 = "05ryzchk6xwcv6cssik05mxhi7bp8i7szc05gjrff60bnaygx324";
+      })
+      (fetchurl {
+        url = "${base}/libp/libpicoipp/libpicoipp_1.3.0-4r78_amd64.deb";
+        sha256 = "0qd7kdiw3dxfrnd9hyxab3bb3sahyrn0pqnv0x6ca7sg47955h67";
+      })
+      (fetchurl {
+        url = "${base}/libu/libusbdrdaq/libusbdrdaq_2.0.61-1r2597_amd64.deb";
+        sha256 = "1qacqzg8mh6f3pbjnkzdq1ffj9wbmgykf75x29vd9cbdhxpxpfj4";
+      })
+      (fetchurl {
+        url = "${base}/p/picomono/picomono_4.6.2.16-1r02_amd64.deb";
+        sha256 = "0cq4pfpsx2kfqn5x4v66zc7q5czcp4r5lm4mwgbfhzkj9rz93brb";
+      })
+      (fetchurl {
+        url = "${base}/libp/libpl1000/libpl1000_2.0.61-1r2597_amd64.deb";
+        sha256 = "1b4h6wl5kan5vrwgn88mrhiimb5r2hly8a1f3j1cz9r9c68vpdy6";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps2000/libps2000_3.0.63-3r2621_amd64.deb";
+        sha256 = "1b2mj9825h7mvq12mxpqxga1j5bksgn3dq46cc2wrn2kgyhgfjlv";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps2000a/libps2000a_2.1.61-5r2597_amd64.deb";
+        sha256 = "12ggs2j29av33pgyclr87fd28yig35rrk730x0wl82ik0inbzv6g";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps3000/libps3000_4.0.63-3r2621_amd64.deb";
+        sha256 = "0pnq4igblvcilgmfk5sja3hmh1rbdia4sjcg267wg59y8rrbhlkh";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps3000a/libps3000a_2.1.61-6r2597_amd64.deb";
+        sha256 = "03dvvw0bj0p1mgf89g6f589ff6c8aq9m3ff53mz8nshwfdv4iipv";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps4000/libps4000_2.1.61-2r2597_amd64.deb";
+        sha256 = "1hc3nd2wvlrhvcbilm0r7alwh72fjhgnxwym27pp7zyj0ng2kk44";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps4000a/libps4000a_2.1.61-2r2597_amd64.deb";
+        sha256 = "0c7fziq09vk4r6gn8hpl8p6fpvbqbprlv34ibx1pdvkx81adcf8q";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps5000/libps5000_2.1.61-3r2597_amd64.deb";
+        sha256 = "12nhjpn10ap193kzmndb5lsgfzzwh674p0igla9qxncgy0kxcazd";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps5000a/libps5000a_2.1.61-5r2597_amd64.deb";
+        sha256 = "0pkccacn81mkn200igy1441mxrknzr3yi1m8ggsrhw41qyxjizbq";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps6000/libps6000_2.1.61-6r2597_amd64.deb";
+        sha256 = "1bk67w8plxbp9czpsws2kzcysymw2j18467nvss7p0qvcqawy1dv";
+      })
+      (fetchurl {
+        url = "${base}/libp/libps6000a/libps6000a_1.0.61-0r2608_amd64.deb";
+        sha256 = "1ircb3ilqavm4xbpnw1ic23k1ynqi1yzy5cyf8rnhbqcwckiglsg";
+      })
+    ];
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    unpackPhase = ''
+      for source in ${toString srcs}; do
+        echo "unpacking $source"
+        dpkg-deb -x $source .
+      done
+    '';
+
+    installPhase = ''
+      mkdir -p "$out"
+      mv etc opt usr "$out"
+
+      mkdir -p "$out/bin"
+      makeWrapper "$out/opt/picomono/bin/mono" "$out/bin/picoscope" \
+        --add-flags "$out/opt/picoscope/lib/PicoScope.GTK.exe" \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [ "$out/opt/picoscope" ]
+        }
+    '';
+
+    meta = with lib; {
+      description = "Oscilloscope application that works with all PicoScope models";
+      longDescription = ''
+        PicoScope for Linux is a powerful oscilloscope application that works
+        with all PicoScope models. The most important features from PicoScope
+        for Windows are included—scope, spectrum analyzer, advanced triggers,
+        automated measurements, interactive zoom, persistence modes and signal
+        generator control. More features are being added all the time.
+
+        Waveform captures can be saved for off-line analysis, and shared with
+        PicoScope for Linux, PicoScope for macOS and PicoScope for Windows
+        users, or exported in text, CSV and MathWorks MATLAB 4 formats.
+      '';
+      homepage = "https://www.picotech.com/downloads/linux";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ expipiplus1 wirew0rm ];
+    };
+  }
+
+  ;
+
+in buildFHSUserEnvBubblewrap {
+  name = "picoscope";
+  targetPkgs = pkgs:
+    (with pkgs; [ pkg glib gtk2 libusb1 gtk-sharp-2_0 libpng12 ]);
+  runScript = "${pkg}/bin/${pkg.pname}";
+  extraBuildCommands = ''
+    ln -s ${pkg}/opt
+  '';
+}
+

--- a/pkgs/applications/science/electronics/picoscope/default.nix
+++ b/pkgs/applications/science/electronics/picoscope/default.nix
@@ -1,104 +1,124 @@
-{ stdenv, lib, fetchurl, dpkg, makeWrapper, buildFHSUserEnvBubblewrap }:
-
-with lib;
+{ stdenv, lib, fetchurl, dpkg, makeWrapper , mono, gtk-sharp-2_0
+, glib, libusb1 , zlib, gtk2-x11, gnome2, callPackage
+, scopes ? [
+  "pl1000"
+  "ps2000"
+  "ps2000a"
+  "ps3000"
+  "ps3000a"
+  "ps4000"
+  "ps4000a"
+  "ps5000"
+  "ps5000a"
+  "ps6000"
+  "ps6000a"
+  "usbdrdaq"
+] }:
 
 let
-  pkg = stdenv.mkDerivation rec {
-    pname = "picoscope";
-    # Make sure to update the dependencies to the correct versions when
-    # updating here!
-    version = "6.14.44-4r5870";
+  shared_meta = lib:
+    with lib; {
+      homepage = "https://www.picotech.com/downloads/linux";
+      maintainers = with maintainers; [ expipiplus1 yorickvp wirew0rm ];
+      platforms = [ "x86_64-linux" "armv7l-linux" ];
+      license = licenses.unfree;
+    };
 
-    srcs = let base = "https://labs.picotech.com/debian/pool/main";
-    in [
-      (fetchurl {
-        url = "${base}/p/picoscope/${pname}_${version}_all.deb";
-        sha256 = "05ryzchk6xwcv6cssik05mxhi7bp8i7szc05gjrff60bnaygx324";
-      })
-      (fetchurl {
-        url = "${base}/libp/libpicoipp/libpicoipp_1.3.0-4r78_amd64.deb";
-        sha256 = "0qd7kdiw3dxfrnd9hyxab3bb3sahyrn0pqnv0x6ca7sg47955h67";
-      })
-      (fetchurl {
-        url = "${base}/libu/libusbdrdaq/libusbdrdaq_2.0.61-1r2597_amd64.deb";
-        sha256 = "1qacqzg8mh6f3pbjnkzdq1ffj9wbmgykf75x29vd9cbdhxpxpfj4";
-      })
-      (fetchurl {
-        url = "${base}/p/picomono/picomono_4.6.2.16-1r02_amd64.deb";
-        sha256 = "0cq4pfpsx2kfqn5x4v66zc7q5czcp4r5lm4mwgbfhzkj9rz93brb";
-      })
-      (fetchurl {
-        url = "${base}/libp/libpl1000/libpl1000_2.0.61-1r2597_amd64.deb";
-        sha256 = "1b4h6wl5kan5vrwgn88mrhiimb5r2hly8a1f3j1cz9r9c68vpdy6";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps2000/libps2000_3.0.63-3r2621_amd64.deb";
-        sha256 = "1b2mj9825h7mvq12mxpqxga1j5bksgn3dq46cc2wrn2kgyhgfjlv";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps2000a/libps2000a_2.1.61-5r2597_amd64.deb";
-        sha256 = "12ggs2j29av33pgyclr87fd28yig35rrk730x0wl82ik0inbzv6g";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps3000/libps3000_4.0.63-3r2621_amd64.deb";
-        sha256 = "0pnq4igblvcilgmfk5sja3hmh1rbdia4sjcg267wg59y8rrbhlkh";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps3000a/libps3000a_2.1.61-6r2597_amd64.deb";
-        sha256 = "03dvvw0bj0p1mgf89g6f589ff6c8aq9m3ff53mz8nshwfdv4iipv";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps4000/libps4000_2.1.61-2r2597_amd64.deb";
-        sha256 = "1hc3nd2wvlrhvcbilm0r7alwh72fjhgnxwym27pp7zyj0ng2kk44";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps4000a/libps4000a_2.1.61-2r2597_amd64.deb";
-        sha256 = "0c7fziq09vk4r6gn8hpl8p6fpvbqbprlv34ibx1pdvkx81adcf8q";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps5000/libps5000_2.1.61-3r2597_amd64.deb";
-        sha256 = "12nhjpn10ap193kzmndb5lsgfzzwh674p0igla9qxncgy0kxcazd";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps5000a/libps5000a_2.1.61-5r2597_amd64.deb";
-        sha256 = "0pkccacn81mkn200igy1441mxrknzr3yi1m8ggsrhw41qyxjizbq";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps6000/libps6000_2.1.61-6r2597_amd64.deb";
-        sha256 = "1bk67w8plxbp9czpsws2kzcysymw2j18467nvss7p0qvcqawy1dv";
-      })
-      (fetchurl {
-        url = "${base}/libp/libps6000a/libps6000a_1.0.61-0r2608_amd64.deb";
-        sha256 = "1ircb3ilqavm4xbpnw1ic23k1ynqi1yzy5cyf8rnhbqcwckiglsg";
-      })
-    ];
+  libpicoipp = callPackage ({ stdenv, lib, fetchurl, autoPatchelfHook, dpkg }:
+    stdenv.mkDerivation rec {
+      pname = "libpicoipp";
+      inherit (sources.libpicoipp) version;
+      src = fetchurl { inherit (sources.libpicoipp) url sha256; };
+      nativeBuildInputs = [ dpkg autoPatchelfHook ];
+      buildInputs = [ stdenv.cc.cc.lib ];
+      sourceRoot = ".";
+      unpackCmd = "dpkg-deb -x $src .";
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/lib
+        cp -d opt/picoscope/lib/* $out/lib
+        install -Dt $out/usr/share/doc/libpicoipp usr/share/doc/libpicoipp/copyright
+        runHook postInstall
+      '';
+      meta = with lib;
+        shared_meta lib // {
+          description = "library for picotech oscilloscope software";
+        };
+    }) { };
+  sources =
+    (builtins.fromJSON (builtins.readFile ./sources.json)).${stdenv.system};
+  scopePkg = name:
+    { url, version, sha256 }:
+    stdenv.mkDerivation rec {
+      pname = "lib${name}";
+      inherit version;
+      src = fetchurl { inherit url sha256; };
+      # picoscope does a signature check, so we can't patchelf these
+      nativeBuildInputs = [ dpkg ];
+      sourceRoot = ".";
+      unpackCmd = "dpkg-deb -x $src .";
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/lib
+        cp -d opt/picoscope/lib/* $out/lib
+         runHook postInstall
+      '';
+      meta = with lib;
+        shared_meta lib // {
+          description = "library for picotech oscilloscope ${name} series";
+        };
+    };
 
-    nativeBuildInputs = [ dpkg makeWrapper ];
+  scopePkgs = lib.mapAttrs scopePkg sources;
 
-    dontConfigure = true;
-    dontBuild = true;
+in stdenv.mkDerivation rec {
+  pname = "picoscope";
+  inherit (sources.picoscope) version;
 
-    unpackPhase = ''
-      for source in ${toString srcs}; do
-        echo "unpacking $source"
-        dpkg-deb -x $source .
-      done
-    '';
+  src = fetchurl { inherit (sources.picoscope) url sha256; };
 
-    installPhase = ''
-      mkdir -p "$out"
-      mv etc opt usr "$out"
+  nativeBuildInputs = [ dpkg makeWrapper ];
+  buildInputs = [ gtk-sharp-2_0 mono glib libusb1 zlib ];
 
-      mkdir -p "$out/bin"
-      makeWrapper "$out/opt/picomono/bin/mono" "$out/bin/picoscope" \
-        --add-flags "$out/opt/picoscope/lib/PicoScope.GTK.exe" \
-        --prefix LD_LIBRARY_PATH : ${
-          lib.makeLibraryPath [ "$out/opt/picoscope" ]
-        }
-    '';
+  unpackCmd = "dpkg-deb -x $src .";
+  sourceRoot = ".";
+  scopeLibs = lib.attrVals (map (x: "lib${x}") scopes) scopePkgs;
+  MONO_PATH = "${gtk-sharp-2_0}/lib/mono/gtk-sharp-2.0:" + (lib.makeLibraryPath
+    ([
+      glib
+      gtk2-x11
+      gnome2.libglade
+      gtk-sharp-2_0
+      libpicoipp
+      libusb1
+      zlib
+      stdenv.cc.cc.lib
+    ] ++ scopeLibs));
 
-    meta = with lib; {
-      description = "Oscilloscope application that works with all PicoScope models";
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/
+    cp -dr usr/share $out/share
+    cp -dr opt/picoscope/* $out/
+    makeWrapper "$(command -v mono)" $out/bin/picoscope \
+      --add-flags $out/lib/PicoScope.GTK.exe \
+      --prefix MONO_PATH : "$MONO_PATH" \
+      --prefix LD_LIBRARY_PATH : "$MONO_PATH"
+    runHook postInstall
+  '';
+
+  # usage:
+  # services.udev.packages = [ pkgs.picoscope.rules ];
+  # users.groups.pico = {};
+  # users.users.you.extraGroups = [ "pico" ];
+  passthru.rules = lib.writeTextDir "lib/udev/rules.d/95-pico.rules" ''
+    SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ce9", MODE="664",GROUP="pico"
+  '';
+
+  meta = with lib;
+    shared_meta lib // {
+      description =
+        "Oscilloscope application that works with all PicoScope models";
       longDescription = ''
         PicoScope for Linux is a powerful oscilloscope application that works
         with all PicoScope models. The most important features from PicoScope
@@ -110,22 +130,6 @@ let
         PicoScope for Linux, PicoScope for macOS and PicoScope for Windows
         users, or exported in text, CSV and MathWorks MATLAB 4 formats.
       '';
-      homepage = "https://www.picotech.com/downloads/linux";
-      license = licenses.unfree;
-      platforms = platforms.linux;
-      maintainers = with maintainers; [ expipiplus1 wirew0rm ];
     };
-  }
-
-  ;
-
-in buildFHSUserEnvBubblewrap {
-  name = "picoscope";
-  targetPkgs = pkgs:
-    (with pkgs; [ pkg glib gtk2 libusb1 gtk-sharp-2_0 libpng12 ]);
-  runScript = "${pkg}/bin/${pkg.pname}";
-  extraBuildCommands = ''
-    ln -s ${pkg}/opt
-  '';
 }
 

--- a/pkgs/applications/science/electronics/picoscope/sources.json
+++ b/pkgs/applications/science/electronics/picoscope/sources.json
@@ -1,0 +1,146 @@
+{
+  "armv7l-linux": {
+    "libpl1000": {
+      "sha256": "10827029023fb1fd8085f216fc75e09010acb081fdaa4a65f81cfd7436bed84b",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libpl1000/libpl1000_2.0.61-1r2597_armhf.deb",
+      "version": "2.0.61-1r2597"
+    },
+    "libps2000": {
+      "sha256": "21d09b8a792ad7c6cd90dc51ba073c21c7dbd17ec6e5c88752b7c2c5a15be73f",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000/libps2000_3.0.63-3r2621_armhf.deb",
+      "version": "3.0.63-3r2621"
+    },
+    "libps2000a": {
+      "sha256": "8293fe86d6d0f12dcefc67d3bf694ec7922dd28c80baab8aa6bc5a01a152e0a9",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000a/libps2000a_2.1.61-5r2597_armhf.deb",
+      "version": "2.1.61-5r2597"
+    },
+    "libps3000": {
+      "sha256": "3289ad3671767ab767f9308106d664a57a09578142a82fc62ec4b68df23e8ef1",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000/libps3000_4.0.63-3r2621_armhf.deb",
+      "version": "4.0.63-3r2621"
+    },
+    "libps3000a": {
+      "sha256": "e5c8c1dc94cc9924ec08a821fd92351c8ef05df8bb53bd2855e59d81358a33d6",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000a/libps3000a_2.1.61-6r2597_armhf.deb",
+      "version": "2.1.61-6r2597"
+    },
+    "libps4000": {
+      "sha256": "5c2abeb819964c2902e5a17b22ecf184d5fb78cd399cf56b3d0301428f7e4631",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000/libps4000_2.1.61-2r2597_armhf.deb",
+      "version": "2.1.61-2r2597"
+    },
+    "libps4000a": {
+      "sha256": "fd3a37c9d22137bed5c7a7013e0afc408e7dc9abac759b900ac23733fcd736e8",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000a/libps4000a_2.1.61-2r2597_armhf.deb",
+      "version": "2.1.61-2r2597"
+    },
+    "libps5000": {
+      "sha256": "5554829e24778b77da4a4ea30d074859bec30b56c1400aa4771429961050a7d6",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000/libps5000_2.1.61-3r2597_armhf.deb",
+      "version": "2.1.61-3r2597"
+    },
+    "libps5000a": {
+      "sha256": "ee88e0c5f4f1f398c62b9672c30a08a94b14e1402d4769b66ed90c3dd9368d38",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000a/libps5000a_2.1.61-5r2597_armhf.deb",
+      "version": "2.1.61-5r2597"
+    },
+    "libps6000": {
+      "sha256": "1470ca16d2b48141d0385e903d5aab883164fa6c9f29abd79713b52abc532442",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000/libps6000_2.1.61-6r2597_armhf.deb",
+      "version": "2.1.61-6r2597"
+    },
+    "libps6000a": {
+      "sha256": "7eb5668fe22c6f042a63a218e1b2eed983d8d9d92bfc525a98bd95a37f3de3ef",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000a/libps6000a_1.0.61-0r2608_armhf.deb",
+      "version": "1.0.61-0r2608"
+    },
+    "libusbdrdaq": {
+      "sha256": "3dc7c4ea506eb0384d2b81214c00f39951bfaf196988ccf373a3e3e2dd342c41",
+      "url": "https://labs.picotech.com/debian/pool/main/libu/libusbdrdaq/libusbdrdaq_2.0.61-1r2597_armhf.deb",
+      "version": "2.0.61-1r2597"
+    },
+    "picoscope": {
+      "sha256": "448cfebcb20b18e7b27c05b0af4f44779d087b2d6046ad99d98c773321fb3e17",
+      "url": "https://labs.picotech.com/debian/pool/main/p/picoscope/picoscope_6.14.44-4r5870_all.deb",
+      "version": "6.14.44-4r5870"
+    }
+  },
+  "x86_64-linux": {
+    "libpicoipp": {
+      "sha256": "c7c052d2214f1fc54c07dbe20b6cf650e9b1d658aa7b989acdaeb7c1639ba761",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libpicoipp/libpicoipp_1.3.0-4r78_amd64.deb",
+      "version": "1.3.0-4r78"
+    },
+    "libpl1000": {
+      "sha256": "c6b7bb916129a7cf821c2e28e42914b9ac1a23cc1521fb78dec5aa59283790ac",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libpl1000/libpl1000_2.0.61-1r2597_amd64.deb",
+      "version": "2.0.61-1r2597"
+    },
+    "libps2000": {
+      "sha256": "9b4af7a07f53d8cc056386e036ecd3731519d4ebf8f62a02def5c022509255ac",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000/libps2000_3.0.63-3r2621_amd64.deb",
+      "version": "3.0.63-3r2621"
+    },
+    "libps2000a": {
+      "sha256": "cfecbf6c04330a4439e8609c9973192f7a249a3b2853e6df1d63ab24a4d0ef89",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps2000a/libps2000a_2.1.61-5r2597_amd64.deb",
+      "version": "2.1.61-5r2597"
+    },
+    "libps3000": {
+      "sha256": "7052b872463e95c78f118f494d546c2b0758e1505297e9eaa3916dba5e24d85e",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000/libps3000_4.0.63-3r2621_amd64.deb",
+      "version": "4.0.63-3r2621"
+    },
+    "libps3000a": {
+      "sha256": "fbc64876731c6a8b7e1dc5b95113568819e7122acebc84dcabe102b900dfbb0d",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps3000a/libps3000a_2.1.61-6r2597_amd64.deb",
+      "version": "2.1.61-6r2597"
+    },
+    "libps4000": {
+      "sha256": "84cc299e05d2ff73ef11d5f36e1f944e1cc8a93a19541a17db30d3cd45b383c1",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000/libps4000_2.1.61-2r2597_amd64.deb",
+      "version": "2.1.61-2r2597"
+    },
+    "libps4000a": {
+      "sha256": "1839d654407dee76435f918c4df35d78edebcc45f442649fc964ee0470fcee30",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps4000a/libps4000a_2.1.61-2r2597_amd64.deb",
+      "version": "2.1.61-2r2597"
+    },
+    "libps5000": {
+      "sha256": "ed2bd627f08fd98e93a22f824b8e81fc7ff7342dabd9fae748e12a10ec95d08a",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000/libps5000_2.1.61-3r2597_amd64.deb",
+      "version": "2.1.61-3r2597"
+    },
+    "libps5000a": {
+      "sha256": "78fd28bbc7817098f57ba886e847fe76e65e0321c1bf0880b0b3066499626c5e",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps5000a/libps5000a_2.1.61-5r2597_amd64.deb",
+      "version": "2.1.61-5r2597"
+    },
+    "libps6000": {
+      "sha256": "bb05cf15661b837bb4def618828214bc7aedd99f42737d3f4b77757a113f66ae",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000/libps6000_2.1.61-6r2597_amd64.deb",
+      "version": "2.1.61-6r2597"
+    },
+    "libps6000a": {
+      "sha256": "4fd31727e30c2f6833729e15ff7d88d8fa30876031707b5727752b4ce3582cc7",
+      "url": "https://labs.picotech.com/debian/pool/main/libp/libps6000a/libps6000a_1.0.61-0r2608_amd64.deb",
+      "version": "1.0.61-0r2608"
+    },
+    "libusbdrdaq": {
+      "sha256": "44badb6f876db1d47612bd1c37fdab8b27e95cc0ed4f2bd71dcec08adec74ce1",
+      "url": "https://labs.picotech.com/debian/pool/main/libu/libusbdrdaq/libusbdrdaq_2.0.61-1r2597_amd64.deb",
+      "version": "2.0.61-1r2597"
+    },
+    "picomono": {
+      "sha256": "2baf917e4e727ee8d6e395545a32b9ecb3820ffbc66cd28bc56e8aaeafbb0433",
+      "url": "https://labs.picotech.com/debian/pool/main/p/picomono/picomono_4.6.2.16-1r02_amd64.deb",
+      "version": "4.6.2.16-1r02"
+    },
+    "picoscope": {
+      "sha256": "448cfebcb20b18e7b27c05b0af4f44779d087b2d6046ad99d98c773321fb3e17",
+      "url": "https://labs.picotech.com/debian/pool/main/p/picoscope/picoscope_6.14.44-4r5870_all.deb",
+      "version": "6.14.44-4r5870"
+    }
+  }
+}

--- a/pkgs/applications/science/electronics/picoscope/update.py
+++ b/pkgs/applications/science/electronics/picoscope/update.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i python3 -p "python3.withPackages (ps: with ps; [ requests ])"
+import json
+import os
+import requests
+import sys
+
+def parse_packages(text):
+    res = []
+    for package in resp.text.split("\n\n"):
+        if not package: continue
+        pkg = {}
+        for field in package.split("\n"):
+            if field.startswith(" "): # multiline string
+                pkg[k] += "\n" + field[1:]
+            else:
+                [k, v] = field.split(": ", 1)
+                pkg[k] = v
+        res.append(pkg)
+    return res
+
+def generate_sources(packages):
+    sources_spec = {}
+    for pkg in pkgs:
+        sources_spec[pkg['Package']] = {
+            "url": "https://labs.picotech.com/debian/" + pkg["Filename"],
+            "sha256": pkg["SHA256"],
+            "version": pkg["Version"]
+        }
+    return sources_spec
+
+out = {}
+for nix_system, release in {"x86_64-linux": "amd64", "armv7l-linux": "armhf"}.items():
+    resp = requests.get("https://labs.picotech.com/debian/dists/picoscope/main/binary-"+release+"/Packages")
+    if resp.status_code != 200:
+        print("error: could not fetch data for release {} (code {})".format(release, resp.code), file=sys.stderr)
+        sys.exit(1)
+    pkgs = parse_packages(resp.text)
+    out[nix_system] = generate_sources(pkgs)
+
+with open(os.path.dirname(__file__) + "/sources.json", "w") as f:
+    json.dump(out, f, indent=2, sort_keys=True)
+    f.write('\n')
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3980,6 +3980,8 @@ in
     tk = tk-8_5;
   };
 
+  picoscope = callPackage ../applications/science/electronics/picoscope { };
+
   picotts = callPackage ../tools/audio/picotts { };
 
   wgetpaste = callPackage ../tools/text/wgetpaste { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Based on https://github.com/NixOS/nixpkgs/pull/122160

This switches to a wrapper-based approach, using nixpkgs' own mono. Sadly, I had to move to mono 5, since gtk-sharp-2.0 doesn't build with mono 6. I'm not sure that this preserves the functionality, I don't have access to the hardware right now.

It also switches to a sources.json file with an update.py script that parses the file at https://labs.picotech.com/debian/dists/picoscope/main/binary-amd64/Packages .

Closure size is still 942.6M, mainly via gtk-sharp-2_0 (807.4M).
cc @expipiplus1 @wirew0rm @SuperSandro2000 @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
