### PR TITLE
spice-vdagent: fix build error with glib > 2.68

### DIFF
--- a/pkgs/applications/virtualization/spice-vdagent/default.nix
+++ b/pkgs/applications/virtualization/spice-vdagent/default.nix
@@ -8,6 +8,10 @@ stdenv.mkDerivation rec {
     url = "https://www.spice-space.org/download/releases/${pname}-${version}.tar.bz2";
     sha256 = "0n8jlc1pv6mkry161y656b1nk9hhhminjq6nymzmmyjl7k95ymzx";
   };
+
+  # FIXME: May no longer be needed with spice-vdagent versions over 0.21.0
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
   postPatch = ''
     substituteInPlace data/spice-vdagent.desktop --replace /usr $out
   '';


### PR DESCRIPTION
The recent upgrade to glib 2.68.1 caused some deprecation errors in
spice-vdagent related to g_memdup, which is now deprecated in favor of
g_memdup2.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1943059

The simplest workaround (until this gets fixed upstream) is to allow
deprecated declarations to be treated as warnings rather than fatal
errors.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix hydra build failure. See: https://hydra.nixos.org/build/142595715

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@aboseley @LeSuisse @siraben