### PR TITLE
llvmPackages_11.compiler-rt: fix build on x86_64-darwin

### DIFF
--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -213,14 +213,14 @@ let
 
     compiler-rt-libc = callPackage ./compiler-rt {
       inherit llvm_meta;
-      stdenv = if (stdenv.hostPlatform.useLLVM or false) || stdenv.hostPlatform.isDarwin
+      stdenv = if (stdenv.hostPlatform.useLLVM or false) || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
                then overrideCC stdenv buildLlvmTools.clangNoCompilerRtWithLibc
                else stdenv;
     };
 
     compiler-rt-no-libc = callPackage ./compiler-rt {
       inherit llvm_meta;
-      stdenv = if (stdenv.hostPlatform.useLLVM or false) || stdenv.hostPlatform.isDarwin
+      stdenv = if (stdenv.hostPlatform.useLLVM or false) || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
                then overrideCC stdenv buildLlvmTools.clangNoCompilerRt
                else stdenv;
     };
@@ -236,21 +236,21 @@ let
 
     libcxx = callPackage ./libcxx {
       inherit llvm_meta;
-      stdenv = if (stdenv.hostPlatform.useLLVM or false) || stdenv.hostPlatform.isDarwin
+      stdenv = if (stdenv.hostPlatform.useLLVM or false) || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
                then overrideCC stdenv buildLlvmTools.clangNoLibcxx
                else stdenv;
     };
 
     libcxxabi = callPackage ./libcxxabi {
       inherit llvm_meta;
-      stdenv = if (stdenv.hostPlatform.useLLVM or false) || stdenv.hostPlatform.isDarwin
+      stdenv = if (stdenv.hostPlatform.useLLVM or false) || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
                then overrideCC stdenv buildLlvmTools.clangNoLibcxx
                else stdenv;
     };
 
     libunwind = callPackage ./libunwind {
       inherit llvm_meta;
-      stdenv = if (stdenv.hostPlatform.useLLVM or false) || stdenv.hostPlatform.isDarwin
+      stdenv = if (stdenv.hostPlatform.useLLVM or false) || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
                then overrideCC stdenv buildLlvmTools.clangNoLibcxx
                else stdenv;
     };


### PR DESCRIPTION
Amendment to changes in 56fcbcd1543188fcc855df7e79fee0a8df259681.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

llvmPackages_11.compiler-rt is broken on staging-next, see [Hydra](https://hydra.nixos.org/build/143101833).

The diff is slightly more confusing than it could be, since it's an amendment to an earlier commit. To see the logical diff use:
```
git diff c99904e11307cbade607ad855a29f07694762f37 82a616d815fa452168c9009697a00d43481c9453 -- pkgs/development/compilers/llvm/11
```

Tested up to llvmPackages_11.libcxx for both x86_64-darwin native and x86_64-darwin->aarch64-darwin cross. I'm building aarch64-darwin native, but it will take a few hours to test and I want to unblock staging-next.

I'm not as confident as I would like to be about the state of llvm bootstrapping on darwin, but at least this contains the interesting logic to aarch64-darwin.

cc @Ericson2314 @NixOS/release-engineers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
