### PR TITLE
goldendict: use ffmpeg instead of ffmpeg_3

### DIFF
--- a/pkgs/applications/misc/goldendict/0001-dont-use-maclibs.patch
+++ b/pkgs/applications/misc/goldendict/0001-dont-use-maclibs.patch
@@ -1,14 +1,16 @@
 diff --git i/goldendict.pro w/goldendict.pro
-index 328dc20..5202a07 100644
+index 4a4a3094..082b728f 100644
 --- i/goldendict.pro
 +++ w/goldendict.pro
-@@ -210,21 +210,18 @@ mac {
+@@ -212,22 +212,19 @@ mac {
          -llzo2
      !CONFIG( no_ffmpeg_player ) {
          LIBS += -lao \
+-            -lswresample-gd \
 -            -lavutil-gd \
 -            -lavformat-gd \
 -            -lavcodec-gd
++            -lswresample \
 +            -lavutil \
 +            -lavformat \
 +            -lavcodec
@@ -29,7 +31,7 @@ index 328dc20..5202a07 100644
                        cp -R locale/*.qm GoldenDict.app/Contents/MacOS/locale/ & \
                        mkdir -p GoldenDict.app/Contents/MacOS/help & \
                        cp -R $${PWD}/help/*.qch GoldenDict.app/Contents/MacOS/help/
-@@ -232,15 +229,6 @@ mac {
+@@ -235,15 +232,6 @@ mac {
      CONFIG += zim_support
      !CONFIG( no_chinese_conversion_support ) {
          CONFIG += chinese_conversion_support
@@ -46,17 +48,15 @@ index 328dc20..5202a07 100644
  }
  DEFINES += PROGRAM_VERSION=\\\"$$VERSION\\\"
 diff --git i/tiff.cc w/tiff.cc
-index e3cb8bf..9ff880f 100644
+index e3cb8bf5..95dd812f 100644
 --- i/tiff.cc
 +++ w/tiff.cc
-@@ -6,8 +6,8 @@
+@@ -5,7 +5,7 @@
+ 
  #include "tiff.hh"
  
- #if defined (Q_OS_MAC) || defined (Q_OS_WIN)
--#include "tiff/tiff.h"
--#include "tiff/tiffio.h"
-+#include "tiff.h"
-+#include "tiffio.h"
+-#if defined (Q_OS_MAC) || defined (Q_OS_WIN)
++#if defined (Q_OS_WIN)
+ #include "tiff/tiff.h"
+ #include "tiff/tiffio.h"
  #else
- #include "tiff.h"
- #include "tiffio.h"

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -4,19 +4,19 @@
 , withCC ? true, opencc
 , withEpwing ? true, libeb
 , withExtraTiff ? true, libtiff
-, withFFmpeg ? true, libao, ffmpeg_3
+, withFFmpeg ? true, libao, ffmpeg
 , withMultimedia ? true
 , withZim ? true, zstd }:
 
 mkDerivation rec {
   pname = "goldendict";
-  version = "2020-12-09";
+  version = "2021-03-09";
 
   src = fetchFromGitHub {
     owner = "goldendict";
     repo = pname;
-    rev = "261e45a5d79f9df2fbc050292410bed0f4ef3132";
-    sha256 = "01pny06d4cmwf998hpqd7xx7mccbbasb8js1bv3rkdi1ljg01f7n";
+    rev = "b2e673961d28ca5eb920a909091252d3321f09d6";
+    sha256 = "sha256-+AAamnICq0/B54ggFpgF/Uupm1a4YiEYgHXrhIK4M0E=";
   };
 
   patches = [
@@ -39,7 +39,7 @@ mkDerivation rec {
     ++ lib.optional withCC opencc
     ++ lib.optional withEpwing libeb
     ++ lib.optional withExtraTiff libtiff
-    ++ lib.optionals withFFmpeg [ libao ffmpeg_3 ]
+    ++ lib.optionals withFFmpeg [ libao ffmpeg ]
     ++ lib.optional withZim zstd;
 
   qmakeFlags = with lib; [


### PR DESCRIPTION
###### Motivation for this change
* use ffmpeg instead of ffmpeg_3 (#120705)
* [changelog](https://github.com/goldendict/goldendict/compare/261e45a5d79f9df2fbc050292410bed0f4ef3132...b2e673961d28ca5eb920a909091252d3321f09d6)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
