### PR TITLE
rxvt-unicode: 9.22 -> 9.26; rxvt, mrxvt, eterm: set knownVulerabilities

### DIFF
--- a/pkgs/applications/terminal-emulators/eterm/default.nix
+++ b/pkgs/applications/terminal-emulators/eterm/default.nix
@@ -39,5 +39,8 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
+    knownVulnerabilities = [
+      "Usage of ANSI escape sequences causes unexpected newline-termination, leading to unexpected command execution (https://www.openwall.com/lists/oss-security/2021/05/17/1)"
+    ];
   };
 }

--- a/pkgs/applications/terminal-emulators/mrxvt/default.nix
+++ b/pkgs/applications/terminal-emulators/mrxvt/default.nix
@@ -36,5 +36,8 @@ stdenv.mkDerivation {
     homepage = "https://sourceforge.net/projects/materm";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    knownVulnerabilities = [
+      "Usage of ANSI escape sequences causes unexpected newline-termination, leading to unexpected command execution (https://www.openwall.com/lists/oss-security/2021/05/17/1)"
+    ];
   };
 }

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "rxvt-unicode";
-  version = "9.22";
+  version = "9.26";
   description = "A clone of the well-known terminal emulator rxvt";
 
   desktopItem = makeDesktopItem {
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${version}.tar.bz2";
-    sha256 = "1pddjn5ynblwfrdmskylrsxb9vfnk3w4jdnq2l8xn2pspkljhip9";
+    sha256 = "12y9p32q0v7n7rhjla0j2g9d5rj2dmwk20c9yhlssaaxlawiccb4";
   };
 
   buildInputs =

--- a/pkgs/applications/terminal-emulators/rxvt/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt/default.nix
@@ -35,5 +35,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ AndersonTorres ];
     license = licenses.gpl2;
     platforms = platforms.linux;
+    knownVulnerabilities = [
+      "Usage of ANSI escape sequences causes unexpected newline-termination, leading to unexpected command execution (https://www.openwall.com/lists/oss-security/2021/05/17/1)"
+    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

>  In rxvt-based terminals, ANSI escape sequence ESC G Q (\eGQ, \033GQ, \x1bGQ)
>  queries the availability of graphics and the response is received from stdin.
>  However, rxvt responds to the query with a newline-terminated message, which
>  is ******** and exposes ******-wide gaping security holes in many popular CLI
>  programs when executed inside an rxvt terminal window.

https://www.openwall.com/lists/oss-security/2021/05/17/1

> The issue was quietly fixed in rxvt-unicode upstream in 2017. Most Linux
> distributions ship unpatched rxvt-unicode 9.22 (2016-01-23) because the
> first official fixed release version is rxvt-unicode 9.25 (2021-05-14).
> Yes, version numbers 9.23 & 9.24 were skipped in upstream. In any case,
> the vulnerability still counts as 0day against non-unicode rxvt 2.7.10,
> and forks such as mrxvt 0.5.4 and Enlightenment's eterm 0.9.7 terminal.

- Updated rxvt-unicode to 9.26
- Marked the other terminals with knownVulerabilities

In fact I think we should drop those unmaintained terminals after the branch-off, rxvt has not seen a release in close to 20 years!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
