### PR TITLE
arc-theme: install AUTORS again

### DIFF
--- a/pkgs/data/themes/arc/default.nix
+++ b/pkgs/data/themes/arc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "jnsh";
     repo = pname;
     rev = version;
-    sha256 = "sha256-BNJirtBtdWsIzQfsJsZzg1zFbJEzZPq1j2qZ+1QjRH8=";
+    sha256 = "BNJirtBtdWsIzQfsJsZzg1zFbJEzZPq1j2qZ+1QjRH8=";
   };
 
   nativeBuildInputs = [
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
     # You will need to patch gdm to make use of this.
     "-Dgnome_shell_gresource=true"
   ];
+
+  postInstall = ''
+    install -Dm644 -t $out/share/doc/${pname} $src/AUTHORS $src/*.md
+  '';
 
   meta = with lib; {
     description = "Flat theme with transparent elements for GTK 3, GTK 2 and Gnome Shell";


### PR DESCRIPTION
###### Motivation for this change

Previously the AUTHORS and other documentation files
were installed into doc/, this was removed during the upgrade.

Also switches to use fetchSubmodules=false which downloads
the github tarball directly instead of cloning the repo

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
