### PR TITLE
php.buildEnv: Provide a `dev` output with utilities pointing to us

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -345,6 +345,7 @@ rec {
         };
     in runCommand name args (
       ''
+        (
         set -o errexit -o pipefail -o nounset -o errtrace
         shopt -s inherit_errexit
 
@@ -369,6 +370,7 @@ rec {
             mv propagated-build-inputs $output_path/nix-support/propagated-build-inputs
           fi
         '') secondaryOutputs + ''
+        )
         ${postBuild}
       '');
 

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -347,9 +347,10 @@ rec {
         done
 
         for output in ${toString secondaryOutputs}; do
-          eval output_path=\$$output
+          output_path=''${!output}
           mkdir -p $output_path
-          for i in $(eval cat \$${output}PathsPath); do
+          output_paths_path_var=''${output}PathsPath
+          for i in $(cat ''${!output_paths_path_var}); do
             ${lndir}/bin/lndir -silent $i $output_path
 
             # Replace previously propagated build outputs with our

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -300,12 +300,17 @@ rec {
    *     |       `-- stack.fish -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/share/fish/vendor_completions.d/stack.fish
    * ...
    *
-
    * # creates multiple outputs, where the `out` output is the result
    * # of combining the main outputs of all packages in `paths`, and
-   * # `bin` and `dev` are the result of combining their corresponding
+   * # `dev` and `man` are the result of combining their corresponding
    * # outputs of all packages in `paths`
-   * symlinkJoin { name = "multiexample"; paths = [ pkgs.libpng pkgs.openssl ]; outputs = [ "out" "bin" "dev" ]; }
+   * symlinkJoin { name = "multiexample"; paths = [ pkgs.libpng pkgs.openssl ]; outputs = [ "out" "dev" "man" ]; }
+   *
+   * Note that this means that if a package uses `out` as a secondary
+   * output, you need to explicitly include it if you're interested in
+   * its contents. For example, if you want the `openssl`'s `out`
+   * output, add `pkgs.openssl.out` to `paths`.
+   *
    *
    * symlinkJoin and linkFarm are similar functions, but they output
    * derivations with different structure.

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -121,6 +121,7 @@ let
                   };
                 };
                 paths = [ php ];
+                outputs = [ "out" "dev" ];
                 postBuild = ''
                   ln -s ${extraInit} $out/lib/php.ini
 
@@ -135,6 +136,18 @@ let
                   if test -e $out/bin/phpdbg; then
                     wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
                   fi
+
+                  for i in php-config phpize; do
+                    target=$dev/bin/$i
+                    if test -e $target; then
+                      bin="$(readlink -f $target)"
+                      rm $target
+                      cp $bin $target
+                      substituteInPlace $target \
+                        --replace '${php}' "$out" \
+                        --replace '${php.dev}' "$dev"
+                    fi
+                  done
                 '';
               };
             in

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -200,6 +200,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       , configureFlags ? [ "--enable-${name}" ]
       , internalDeps ? []
       , postPhpize ? ""
+      , preCheck ? ""
       , buildInputs ? []
       , zendExtension ? false
       , doCheck ? true
@@ -212,7 +213,13 @@ lib.makeScope pkgs.newScope (self: with self; {
       sourceRoot = "php-${php.version}/ext/${name}";
 
       enableParallelBuilding = true;
-      nativeBuildInputs = [ php.unwrapped autoconf pkg-config re2c ];
+      nativeBuildInputs = [
+        (php.unwrapped.withExtensions ({...}: internalDeps))
+        autoconf
+        pkg-config
+        re2c
+      ];
+
       inherit configureFlags internalDeps buildInputs
         zendExtension doCheck;
 
@@ -234,6 +241,10 @@ lib.makeScope pkgs.newScope (self: with self; {
         ${lib.concatMapStringsSep "\n"
           (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
           internalDeps}
+      '';
+      preCheck = ''
+        substituteInPlace Makefile --replace '|(zend_)?extension(_debug)?(_ts)?' ""
+        ${preCheck}
       '';
       checkPhase = "runHook preCheck; echo n | make test; runHook postCheck";
       outputs = [ "out" "dev" ];
@@ -379,8 +390,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         ]; doCheck = false; }
       { name = "mysqli";
         internalDeps = [ php.extensions.mysqlnd ];
-        configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ];
-        doCheck = false; }
+        configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
       { name = "mysqlnd";
         buildInputs = [ zlib openssl ];
         # The configure script doesn't correctly add library link
@@ -552,7 +562,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "xsl";
         buildInputs = [ libxslt libxml2 ];
-        doCheck = lib.versionOlder php.version "8.0";
+        internalDeps = [ php.extensions.dom ];
         configureFlags = [ "--with-xsl=${libxslt.dev}" ]; }
       { name = "zend_test"; }
       { name = "zip";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -201,6 +201,8 @@ lib.makeScope pkgs.newScope (self: with self; {
       , internalDeps ? []
       , postPhpize ? ""
       , preCheck ? ""
+      , prePatch ? ""
+      , postPatch ? ""
       , buildInputs ? []
       , zendExtension ? false
       , doCheck ? true
@@ -223,8 +225,15 @@ lib.makeScope pkgs.newScope (self: with self; {
       inherit configureFlags internalDeps buildInputs
         zendExtension doCheck;
 
-      prePatch = "pushd ../..";
-      postPatch = "popd";
+      prePatch = ''
+        ${prePatch}
+        pushd ../..
+      '';
+
+      postPatch = ''
+        popd
+        ${postPatch}
+      '';
 
       preConfigure = ''
         nullglobRestore=$(shopt -p nullglob)
@@ -290,8 +299,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           })
         ];
         # For some reason `patch` fails to remove these files correctly.
-        # Since `postPatch` is already used in `mkExtension`, we have to make it here.
-        preCheck = ''
+        postPatch = ''
           rm tests/bug43364.phpt
           rm tests/bug80268.phpt
         '';

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -71,7 +71,10 @@ let
 
   trivialBuilders = self: super:
     import ../build-support/trivial-builders.nix {
-      inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.pkgsBuildHost.xorg) lndir;
+      inherit lib;
+      inherit (self) stdenv stdenvNoCC;
+      inherit (self.pkgsBuildHost.xorg) lndir;
+      inherit (self.pkgsBuildHost) replace;
       inherit (self) runtimeShell;
     };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
An attempt at a fix for #110826 and related issues. This makes `symlinkJoin` able to handle multiple outputs, a change which should probably be handled in a separate PR.

cc @mjsir911 @jcleng

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
