### PR TITLE
starboard-octant-plugin: 0.10.0 -> 0.10.3

### DIFF
--- a/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
+++ b/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
@@ -2,26 +2,29 @@
 
 buildGoModule rec {
   pname = "starboard-octant-plugin";
-  version = "0.10.0";
+  version = "0.10.3";
 
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-3BifigdAFuOCrhJRv/w4k7pT4BTHfINuEkeG6zaI0v8=";
+    sha256 = "sha256-9vl068ZTw6Czf+cWQ0k1lU0pqh7P0YZgLguHkk3M918=";
   };
 
-  vendorSha256 = "sha256-1NTneOGU4R1xzR9hAI9MJWYuYTPgYtLa5vH1H5wyHcM=";
+  vendorSha256 = "sha256-HOvZPDVKZEoL91yyaJRuKThHirY77xlKOtLKARthxn8=";
 
-  buildFlagsArray = [ "-ldflags=" "-s" "-w" ];
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w")
+  '';
 
   meta = with lib; {
+    homepage = "https://github.com/aquasecurity/starboard-octant-plugin";
+    changelog = "https://github.com/aquasecurity/starboard-octant-plugin/releases/tag/v${version}";
     description = "Octant plugin for viewing Starboard security information";
     longDescription = ''
       This is an Octant plugin for Starboard which provides visibility into vulnerability assessment reports for
       Kubernetes workloads stored as custom security resources.
     '';
-    homepage = src.meta.homepage;
     license = licenses.asl20;
     maintainers = with maintainers; [ jk ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump starboard-octant-plugin to `0.10.3`

`0.10.1` & `0.10.2` don't exist

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
