### PR TITLE
llvmPackages*.clang: fix linker invocation with LLVMgold plugin

### DIFF
--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -46,6 +46,10 @@ let
       # https://reviews.llvm.org/D51899
       ./compiler-rt-baremetal.patch
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ../../clang-6-10-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -64,12 +68,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, fetchpatch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, fetchpatch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -57,6 +57,10 @@ let
         excludes = [ "docs/*" "test/*" ];
         sha256 = "0gxgmi0qbm89mq911dahallhi8m6wa9vpklklqmxafx4rplrr8ph";
       })
+      (substituteAll {
+        src = ../../clang-11-12-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -75,12 +79,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/12/clang/default.nix
+++ b/pkgs/development/compilers/llvm/12/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -44,6 +44,10 @@ let
       ./purity.patch
       # https://reviews.llvm.org/D51899
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ../../clang-11-12-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -59,12 +63,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/5/clang/LLVMgold-path.patch
+++ b/pkgs/development/compilers/llvm/5/clang/LLVMgold-path.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/Driver/ToolChains/CommonArgs.cpp b/lib/Driver/ToolChains/CommonArgs.cpp
+index 00bd60bc24bb..17416b0bd3c0 100644
+--- a/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -376,8 +376,7 @@ void tools::AddGoldPlugin(const ToolChain &ToolChain, const ArgList &Args,
+   // as gold requires -plugin to come before any -plugin-opt that -Wl might
+   // forward.
+   CmdArgs.push_back("-plugin");
+-  std::string Plugin =
+-      ToolChain.getDriver().Dir + "/../lib" CLANG_LIBDIR_SUFFIX "/LLVMgold.so";
++  std::string Plugin = "@libllvmLibdir@" "/LLVMgold.so";
+   CmdArgs.push_back(Args.MakeArgString(Plugin));
+ 
+   // Try to pass driver level flags relevant to LTO code generation down to

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -43,6 +43,10 @@ let
     patches = [
       ./purity.patch
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ./LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -58,12 +62,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -43,6 +43,10 @@ let
     patches = [
       ./purity.patch
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ../../clang-6-10-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -58,12 +62,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -52,6 +52,10 @@ let
       # needed for our bootstrapping to not interfere with C.
       ./unwindlib.patch
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ../../clang-6-10-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -70,12 +74,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -59,6 +59,10 @@ let
       # make clang -xhip use $PATH to find executables
       ./HIP-use-PATH-8.patch
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ../../clang-6-10-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -77,12 +81,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, llvm_meta, fetch, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
+{ lib, stdenv, llvm_meta, fetch, substituteAll, cmake, libxml2, libllvm, version, clang-tools-extra_src, python3
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
@@ -52,6 +52,10 @@ let
       # make clang -xhip use $PATH to find executables
       ./HIP-use-PATH-9.patch
       ./gnu-install-dirs.patch
+      (substituteAll {
+        src = ../../clang-6-10-LLVMgold-path.patch;
+        libllvmLibdir = "${libllvm.lib}/lib";
+      })
     ];
 
     postPatch = ''
@@ -70,12 +74,7 @@ let
 
     outputs = [ "out" "lib" "dev" "python" ];
 
-    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      if [ -e ${libllvm.lib}/lib/LLVMgold.so ]; then
-        ln -sv ${libllvm.lib}/lib/LLVMgold.so $lib/lib
-      fi
-
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/clang-11-12-LLVMgold-path.patch
+++ b/pkgs/development/compilers/llvm/clang-11-12-LLVMgold-path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Driver/ToolChains/CommonArgs.cpp b/lib/Driver/ToolChains/CommonArgs.cpp
+index 6b6e276b8ce7..7896542a1202 100644
+--- a/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -409,7 +409,7 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
+ 
+     SmallString<1024> Plugin;
+     llvm::sys::path::native(
+-        Twine(D.Dir) + "/../lib" CLANG_LIBDIR_SUFFIX "/LLVMgold" + Suffix,
++        Twine("@libllvmLibdir@" "/LLVMgold") + Suffix,
+         Plugin);
+     CmdArgs.push_back(Args.MakeArgString(Plugin));
+   }

--- a/pkgs/development/compilers/llvm/clang-6-10-LLVMgold-path.patch
+++ b/pkgs/development/compilers/llvm/clang-6-10-LLVMgold-path.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/Driver/ToolChains/CommonArgs.cpp b/lib/Driver/ToolChains/CommonArgs.cpp
+index 37ec73468570..b73e75aa6e59 100644
+--- a/lib/Driver/ToolChains/CommonArgs.cpp
++++ b/lib/Driver/ToolChains/CommonArgs.cpp
+@@ -370,8 +370,8 @@ void tools::AddGoldPlugin(const ToolChain &ToolChain, const ArgList &Args,
+ #endif
+ 
+   SmallString<1024> Plugin;
+-  llvm::sys::path::native(Twine(ToolChain.getDriver().Dir) +
+-                              "/../lib" CLANG_LIBDIR_SUFFIX "/LLVMgold" +
++  llvm::sys::path::native(Twine("@libllvmLibdir@"
++                                "/LLVMgold") +
+                               Suffix,
+                           Plugin);
+   CmdArgs.push_back(Args.MakeArgString(Plugin));


### PR DESCRIPTION
When using GNU binutils, clang passes the LLVMgold.so plugin to the
linker for certain operations that require special support in the linker
like doing link time optimization (LTO). When passing the plugin to the
linker's command line, clang assumes that llvm and itself are installed
in the same prefix and thus `/path/to/clang/bin/../lib/LLVMgold.so` is
the plugin.

Since we install clang and llvm to separate store paths, this assumption
does not hold. When clang-unwrapped only had a single output, we worked
around this issue by symlinking `$out/lib/LLVMgold.so` to
`${llvm}/lib/LLVMgold.so`. However since we split all llvm packages into
multiple outputs clang's `$out` no longer has a lib directory and clang
can't discover clangs lib output on its own. As a result LTO was broken.

Instead of introducing yet another hack and having a symlink to
LLVMgold.so in `$out/lib` (despite having `$lib/lib` as well), we patch
clang to use a hard coded path to `${libllvm.lib}/lib` for discovering
`LLVMgold.so`.


Resolves #123361.

Drawback of this that the patch is not upstreamable at all and may become a
maintenance burden. An alternative solution would be to continue symlinking,
moving the symlink for `LLVMgold.so` from `$lib` to `$out`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested in the following manner:

```nix
{ pkgs ? import ./. { } }:

let
  testBuild = llvmPackages:
    pkgs.runCommandWith {
      name = "test-${llvmPackages.clang-unwrapped.name}";
      inherit (llvmPackages) stdenv;
      derivationArgs = {
        test = ''
          #include <stdio.h>
          int main() {
            puts("Hello");
            return 0;
          }
        '';
        passAsFile = [ "test" ];
      };
    } ''
      $CC -o $out -flto -x c $testPath
    '';
in
  builtins.map testBuild [
    pkgs.llvmPackages_5
    pkgs.llvmPackages_6
    pkgs.llvmPackages_7
    pkgs.llvmPackages_8
    pkgs.llvmPackages_9
    pkgs.llvmPackages_10
    pkgs.llvmPackages_11
    pkgs.llvmPackages_12
  ]

```

```console
$ nix-build test.nix
/nix/store/kyhxyd24gpx7zals2gn6wxa75xnk3mwp-test-clang-5.0.2
/nix/store/nixj9by6lmsg7n75d92bakvcb63jf0jf-test-clang-6.0.1
/nix/store/qn97crvm3z6hp5j1hg98kn4pgccb7y0g-test-clang-7.1.0
/nix/store/lhq9jkwzs2shpi96yv9kg2ii71p1fq9s-test-clang-8.0.1
/nix/store/fq99xc97zk1lgl5ylfh2acn5h744fj51-test-clang-9.0.1
/nix/store/xfllpp4w0yzkzbxjk590chr8kb8gjs63-test-clang-10.0.1
/nix/store/mjw6lhf3mk4b3l6hs44zcm29wlkl3jyp-test-clang-11.1.0
/nix/store/9zr0rjhp2q80s63iplfa4lykpjwf3zja-test-clang-12.0.0
```

(Note that this was tested against the merge-base of staging and staging-next to lessen required rebuilds for testing.)
