### PR TITLE
python3Packages.clickhouse-driver: unbreak

### DIFF
--- a/pkgs/development/python-modules/clickhouse-driver/default.nix
+++ b/pkgs/development/python-modules/clickhouse-driver/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , setuptools
 , pytz
 , tzlocal
@@ -10,15 +10,20 @@
 , freezegun
 , mock
 , nose
+, pytestCheckHook
+, pytest-xdist
 }:
 
 buildPythonPackage rec {
   pname = "clickhouse-driver";
   version = "0.2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "62d37f93872d5a13eb6b0d52bab2b593ed0e14cf9200949aa2d02f9801064c0f";
+  # pypi source doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "mymarilyn";
+    repo = "clickhouse-driver";
+    rev = "96b7ba448c63ca2670cc9aa70d4a0e08826fb650";
+    sha256 = "sha256-HFKUxJOlBCVlu7Ia8heGpwX6+HdKuwSy92s3v+GKGwE=";
   };
 
   propagatedBuildInputs = [
@@ -34,9 +39,30 @@ buildPythonPackage rec {
     freezegun
     mock
     nose
+    pytest-xdist
+    pytestCheckHook
   ];
 
-  doCheck = true;
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "lz4<=3.0.1" "lz4<=4"
+  '';
+
+  # remove source to prevent pytest testing source instead of the build artifacts
+  # (the source doesn't contain the extension modules)
+  preCheck = ''
+    rm -rf clickhouse_driver
+  '';
+
+  # some test in test_buffered_reader.py doesn't seem to return
+  disabledTestPaths = [ "tests/test_buffered_reader.py" ];
+
+  pytestFlagsArray = [ "-n" "$NIX_BUILD_CORES" ];
+
+  # most tests require `clickhouse`
+  # TODO: enable tests after `clickhouse` unbroken
+  doCheck = false;
+
   pythonImportsCheck = [ "clickhouse_driver" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF: #122042

###### Things done
- lift the version restriction for zstd from `<=3.0.1` to `<=4`
- configure testing but disable for now since tests depend on https://github.com/NixOS/nixpkgs/pull/123488

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
