### PR TITLE
sqlar: fix darwin build

### DIFF
--- a/pkgs/development/libraries/sqlite/sqlar.nix
+++ b/pkgs/development/libraries/sqlite/sqlar.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, fuse, zlib }:
+{ lib, stdenv, fetchurl, fuse, zlib
+, withFuse ? true }:
 
 stdenv.mkDerivation {
   pname = "sqlar";
@@ -9,12 +10,21 @@ stdenv.mkDerivation {
     sha256 = "09pikkbp93gqypn3da9zi0dzc47jyypkwc9vnmfzhmw7kpyv8nm9";
   };
 
-  buildInputs = [ fuse zlib ];
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace 'gcc' '${stdenv.cc.targetPrefix}cc'
+  '';
 
-  buildFlags = [ "sqlar" "sqlarfs" "CFLAGS=-Wno-error" ];
+  buildInputs = [ zlib ]
+    ++ lib.optional withFuse fuse;
+
+  buildFlags = [ "CFLAGS=-Wno-error" "sqlar" ]
+    ++ lib.optional withFuse "sqlarfs";
 
   installPhase = ''
-    install -D -t $out/bin sqlar sqlarfs
+    install -D -t $out/bin sqlar
+  '' + lib.optionalString withFuse ''
+    install -D -t $out/bin sqlarfs
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/142939374/nixlog/1

I made the fuse component optional and disabled it on darwin. Here is the error I'm getting:

```
build flags: SHELL=/nix/store/0hjiwn27k8av06bj17rykr4d5qfs7l29-bash-4.4-p23/bin/bash CC=cc CFLAGS=-Wno-error sqlar sqlarfs
cc  -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION -c sqlite3.c
cc -o sqlar  sqlar.c sqlite3.o -lz
cc -o sqlarfs  sqlarfs.c sqlite3.o -lz -lfuse -lpthread -ldl
In file included from sqlarfs.c:10:
In file included from /nix/store/vp11npm0xq09lwrgl5x4f2np33jrax7m-macfuse-stubs-4.1.0/include/fuse.h:9:
In file included from /nix/store/vp11npm0xq09lwrgl5x4f2np33jrax7m-macfuse-stubs-4.1.0/include/fuse/fuse.h:31:
/nix/store/vp11npm0xq09lwrgl5x4f2np33jrax7m-macfuse-stubs-4.1.0/include/fuse/fuse_common.h:52:2: error: Please add -D_FILE_OFFSET_BITS=64 to your compile flags!
#error Please add -D_FILE_OFFSET_BITS=64 to your compile flags!
 ^
1 error generated.
make: *** [Makefile:18: sqlarfs] Error 1
```

I'm not sure if it's safe to just do what it says there, and don't know much about fuse in general.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
