### PR TITLE
heimdall: fix non-GUI build on darwin

### DIFF
--- a/pkgs/tools/misc/heimdall/default.nix
+++ b/pkgs/tools/misc/heimdall/default.nix
@@ -31,7 +31,7 @@ mkDerivation {
     substituteInPlace libpit/CMakeLists.txt --replace "-std=gnu++11" ""
   '';
 
-  installPhase = lib.optionalString stdenv.isDarwin ''
+  installPhase = lib.optionalString (stdenv.isDarwin && enableGUI) ''
     mkdir -p $out/Applications
     mv bin/heimdall-frontend.app $out/Applications/heimdall-frontend.app
     wrapQtApp $out/Applications/heimdall-frontend.app/Contents/MacOS/heimdall-frontend


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/143245774/log

I broke the non-GUI build in #123215. This fixes that. Tested both `heimdall` and `heimdall-gui` this time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
