### PR TITLE
python3Packages.rasterio: 1.1.5 → 1.2.6

### DIFF
--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -1,24 +1,25 @@
-{ buildPythonPackage, lib, fetchFromGitHub, isPy3k
+{ buildPythonPackage, lib, fetchFromGitHub, pythonOlder
 , cython, setuptools
-, numpy, affine, attrs, cligj, click-plugins, snuggs, gdal
-, pytest, pytestcov, packaging, hypothesis, boto3, mock
+, matplotlib, numpy, affine, attrs, boto3, cligj, click-plugins, snuggs, gdal
+, pytest, pytestcov, hypothesis, shapely
 }:
 
 buildPythonPackage rec {
   pname = "rasterio";
-  version = "1.1.5";
+  version = "1.2.6";
+  disabled = pythonOlder "3.6";
 
   # Pypi doesn't ship the tests, so we fetch directly from GitHub
   src = fetchFromGitHub {
     owner = "mapbox";
     repo = "rasterio";
     rev = version;
-    sha256 = "168b6hmx026jsvhnq6s5k0qfhzda02mmx1alax6wqk16mk63mqcz";
+    sha256 = "sha256-rf2qdUhbS4Z2+mvlN1RzZvlgTgjqiBoQzry4z5QLSUc=";
   };
 
-  checkInputs = [ boto3 pytest pytestcov packaging hypothesis ] ++ lib.optional (!isPy3k) mock;
+  checkInputs = [ pytest pytestcov hypothesis shapely ];
   nativeBuildInputs = [ cython gdal ];
-  propagatedBuildInputs = [ gdal numpy attrs affine cligj click-plugins snuggs setuptools ];
+  propagatedBuildInputs = [ gdal matplotlib numpy attrs affine boto3 cligj click-plugins snuggs setuptools ];
 
   meta = with lib; {
     description = "Python package to read and write geospatial raster data";


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/mapbox/rasterio/blob/master/CHANGES.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
