### PR TITLE
[20.09] rxvt-unicode: 9.22 -> 9.26; rxvt, mrxvt, eterm: mark with knownVulnerable

### DIFF
--- a/pkgs/applications/misc/eterm/default.nix
+++ b/pkgs/applications/misc/eterm/default.nix
@@ -22,5 +22,8 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
+    knownVulnerabilities = [
+      "Usage of ANSI escape sequences causes unexpected newline-termination, leading to unexpected command execution (https://www.openwall.com/lists/oss-security/2021/05/17/1)"
+    ];
   };
 }

--- a/pkgs/applications/misc/mrxvt/default.nix
+++ b/pkgs/applications/misc/mrxvt/default.nix
@@ -36,5 +36,8 @@ stdenv.mkDerivation {
     homepage = "https://sourceforge.net/projects/materm";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    knownVulnerabilities = [
+      "Usage of ANSI escape sequences causes unexpected newline-termination, leading to unexpected command execution (https://www.openwall.com/lists/oss-security/2021/05/17/1)"
+    ];
   };
 }

--- a/pkgs/applications/misc/rxvt-unicode/default.nix
+++ b/pkgs/applications/misc/rxvt-unicode/default.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "rxvt-unicode";
-  version = "9.22";
+  version = "9.26";
   description = "A clone of the well-known terminal emulator rxvt";
 
   desktopItem = makeDesktopItem {
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${version}.tar.bz2";
-    sha256 = "1pddjn5ynblwfrdmskylrsxb9vfnk3w4jdnq2l8xn2pspkljhip9";
+    sha256 = "12y9p32q0v7n7rhjla0j2g9d5rj2dmwk20c9yhlssaaxlawiccb4";
   };
 
   buildInputs =

--- a/pkgs/applications/misc/rxvt/default.nix
+++ b/pkgs/applications/misc/rxvt/default.nix
@@ -35,5 +35,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ AndersonTorres ];
     license = licenses.gpl2;
     platforms = platforms.linux;
+    knownVulnerabilities = [
+      "Usage of ANSI escape sequences causes unexpected newline-termination, leading to unexpected command execution (https://www.openwall.com/lists/oss-security/2021/05/17/1)"
+    ];
   };
 }


### PR DESCRIPTION
(cherry picked from commit d6c64b2816f7fc221155fbb9b4b0371dcec0a769)<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport #123531 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
