### PR TITLE
podman-compose: 0.1.5 -> 0.2.0pre-2021-05-18

### DIFF
--- a/pkgs/applications/virtualization/podman-compose/default.nix
+++ b/pkgs/applications/virtualization/podman-compose/default.nix
@@ -1,12 +1,19 @@
-{ lib, buildPythonApplication, fetchPypi, pyyaml }:
+{ lib, buildPythonApplication, fetchFromGitHub, pyyaml }:
 
 buildPythonApplication rec {
-  version = "0.1.5";
+  version = "0.2.0pre-2021-05-18";
   pname = "podman-compose";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1sgbc889zq127qhxa9frhswa1mid19fs5qnyzfihx648y5i968pv";
+  # "This project is still under development." -- README.md
+  #
+  # As of May 2021, the latest release (0.1.5) has fewer than half of all
+  # commits. This project seems to have no release management, so the last
+  # commit is the best one until proven otherwise.
+  src = fetchFromGitHub {
+    repo = "podman-compose";
+    owner = "containers";
+    rev = "62d2024feecf312e9591cc145f49cee9c70ab4fe";
+    sha256 = "sha256:17992imkvi6129wvajsp0iz5iicfmh53i20qy2mzz17kcz30r2pp";
   };
 
   propagatedBuildInputs = [ pyyaml ];

--- a/pkgs/applications/virtualization/podman-compose/default.nix
+++ b/pkgs/applications/virtualization/podman-compose/default.nix
@@ -13,7 +13,7 @@ buildPythonApplication rec {
     repo = "podman-compose";
     owner = "containers";
     rev = "62d2024feecf312e9591cc145f49cee9c70ab4fe";
-    sha256 = "sha256:17992imkvi6129wvajsp0iz5iicfmh53i20qy2mzz17kcz30r2pp";
+    sha256 = "17992imkvi6129wvajsp0iz5iicfmh53i20qy2mzz17kcz30r2pp";
   };
 
   propagatedBuildInputs = [ pyyaml ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

podman-compose hasn't produced a release since _over half of its commits_ (84 on Sep 2019 to 182 today), so I figured it's time for an upgrade nonetheless.

With this version, you can stop NixOS-based containers properly. I don't know what else was fixed and improved, but y'know, half of its history happened :)

> This project seems to have no release management, so the last commit is the best one until proven otherwise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/podman @sikmir