### PR TITLE
pythonPackages.mercantile: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/mercantile/default.nix
+++ b/pkgs/development/python-modules/mercantile/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, click
+, pytestCheckHook
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "mercantile";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-DiDXO2XnD3We6NhP81z7aIHzHrHDi/nkqy98OT9986w=";
+  };
+
+  propagatedBuildInputs = [ click ];
+
+  checkInputs = [ pytestCheckHook hypothesis ];
+
+  meta = with lib; {
+    description = "Spherical mercator tile and coordinate utilities";
+    homepage = "https://github.com/mapbox/mercantile";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4169,6 +4169,8 @@ in {
 
   memory_profiler = callPackage ../development/python-modules/memory_profiler { };
 
+  mercantile = callPackage ../development/python-modules/mercantile { };
+
   mercurial = toPythonModule (pkgs.mercurial.override {
     python3Packages = self;
   });


### PR DESCRIPTION
###### Motivation for this change
[**Mercantile**](https://github.com/mapbox/mercantile) - spherical mercator coordinate and tile utilities.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
