### PR TITLE
lispPackages: init generic-cl and trivial-arguments from Quicklisp

### DIFF
--- a/pkgs/development/lisp-modules/README.txt
+++ b/pkgs/development/lisp-modules/README.txt
@@ -1,6 +1,6 @@
 Want to add a package?  There are 3 simple steps!
 1. Add the needed system names to quicklisp-to-nix-systems.txt.
-2. cd <path to quicklisp-to-nix-systems.txt> ; nix-shell --run 'quicklisp-to-nix .'
+2. cd <path to quicklisp-to-nix-systems.txt> ; nix-shell --pure --run 'quicklisp-to-nix .'
   You might want to specify also the --cacheSystemInfoDir and --cacheFaslDir
   parameters to preserve some data between runs. For example, it is very
   useful when you add new packages with native dependencies and fail to

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/agutil.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/agutil.nix
@@ -1,0 +1,42 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "agutil";
+  version = "20200325-git";
+
+  description = "A collection of utility functions not found in other utility libraries.";
+
+  deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/agutil/2020-03-25/agutil-20200325-git.tgz";
+    sha256 = "0jfbb2x3f8sm507r63qwrzx44lyyj98i36yyyaf4kpyqfir35z2k";
+  };
+
+  packageName = "agutil";
+
+  asdFilesToKeep = ["agutil.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM agutil DESCRIPTION
+    A collection of utility functions not found in other utility libraries.
+    SHA256 0jfbb2x3f8sm507r63qwrzx44lyyj98i36yyyaf4kpyqfir35z2k URL
+    http://beta.quicklisp.org/archive/agutil/2020-03-25/agutil-20200325-git.tgz
+    MD5 89e47bd15c0f9930a5025d04b9706b60 NAME agutil FILENAME agutil DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME introspect-environment FILENAME introspect-environment)
+     (NAME iterate FILENAME iterate)
+     (NAME lisp-namespace FILENAME lisp-namespace)
+     (NAME trivia FILENAME trivia)
+     (NAME trivia.balland2006 FILENAME trivia_dot_balland2006)
+     (NAME trivia.level0 FILENAME trivia_dot_level0)
+     (NAME trivia.level1 FILENAME trivia_dot_level1)
+     (NAME trivia.level2 FILENAME trivia_dot_level2)
+     (NAME trivia.trivial FILENAME trivia_dot_trivial)
+     (NAME trivial-cltl2 FILENAME trivial-cltl2) (NAME type-i FILENAME type-i))
+    DEPENDENCIES
+    (alexandria closer-mop introspect-environment iterate lisp-namespace trivia
+     trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
+     trivia.trivial trivial-cltl2 type-i)
+    VERSION 20200325-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/arrows.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/arrows.nix
@@ -1,0 +1,31 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "arrows";
+  version = "20181018-git";
+
+  parasites = [ "arrows/test" ];
+
+  description = "Implements -> and ->> from Clojure, as well as several expansions on the
+idea.";
+
+  deps = [ args."hu_dot_dwim_dot_stefil" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/arrows/2018-10-18/arrows-20181018-git.tgz";
+    sha256 = "1b13pnn71z1dv1cwysh6p5jfgjsp3q8ivsdxfspl1hg1nh9mqa7r";
+  };
+
+  packageName = "arrows";
+
+  asdFilesToKeep = ["arrows.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM arrows DESCRIPTION
+    Implements -> and ->> from Clojure, as well as several expansions on the
+idea.
+    SHA256 1b13pnn71z1dv1cwysh6p5jfgjsp3q8ivsdxfspl1hg1nh9mqa7r URL
+    http://beta.quicklisp.org/archive/arrows/2018-10-18/arrows-20181018-git.tgz
+    MD5 c60b5d79680de19baad018a0fe87bc48 NAME arrows FILENAME arrows DEPS
+    ((NAME hu.dwim.stefil FILENAME hu_dot_dwim_dot_stefil)) DEPENDENCIES
+    (hu.dwim.stefil) VERSION 20181018-git SIBLINGS NIL PARASITES (arrows/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-environments.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-environments.nix
@@ -1,0 +1,44 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "cl-environments";
+  version = "20210411-git";
+
+  parasites = [ "cl-environments/test" ];
+
+  description = "Implements the CLTL2 environment access functionality
+                for implementations which do not provide the
+                functionality to the programmer.";
+
+  deps = [ args."alexandria" args."anaphora" args."cl-ansi-text" args."cl-colors" args."cl-ppcre" args."closer-mop" args."collectors" args."iterate" args."optima" args."prove" args."prove-asdf" args."symbol-munger" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/cl-environments/2021-04-11/cl-environments-20210411-git.tgz";
+    sha256 = "1xs1wwf6fmzq5zxmv5d9f2mfmhc7j2w03519ky6id5md75j68lhk";
+  };
+
+  packageName = "cl-environments";
+
+  asdFilesToKeep = ["cl-environments.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-environments DESCRIPTION
+    Implements the CLTL2 environment access functionality
+                for implementations which do not provide the
+                functionality to the programmer.
+    SHA256 1xs1wwf6fmzq5zxmv5d9f2mfmhc7j2w03519ky6id5md75j68lhk URL
+    http://beta.quicklisp.org/archive/cl-environments/2021-04-11/cl-environments-20210411-git.tgz
+    MD5 87b7c0186d37d30d24df11d021ab4fba NAME cl-environments FILENAME
+    cl-environments DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
+     (NAME cl-ansi-text FILENAME cl-ansi-text)
+     (NAME cl-colors FILENAME cl-colors) (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME collectors FILENAME collectors) (NAME iterate FILENAME iterate)
+     (NAME optima FILENAME optima) (NAME prove FILENAME prove)
+     (NAME prove-asdf FILENAME prove-asdf)
+     (NAME symbol-munger FILENAME symbol-munger))
+    DEPENDENCIES
+    (alexandria anaphora cl-ansi-text cl-colors cl-ppcre closer-mop collectors
+     iterate optima prove prove-asdf symbol-munger)
+    VERSION 20210411-git SIBLINGS NIL PARASITES (cl-environments/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl.nix
@@ -1,0 +1,56 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "generic-cl";
+  version = "20201220-git";
+
+  parasites = [ "generic-cl/test" ];
+
+  description = "Standard Common Lisp functions implemented using generic functions.";
+
+  deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-ansi-text" args."cl-colors" args."cl-custom-hash-table" args."cl-environments" args."cl-ppcre" args."closer-mop" args."collectors" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."prove" args."prove-asdf" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/generic-cl/2020-12-20/generic-cl-20201220-git.tgz";
+    sha256 = "02awl64bfykkasv3z9xpiiwq3v9vgcacqagbwvigqdk15hqrknyl";
+  };
+
+  packageName = "generic-cl";
+
+  asdFilesToKeep = ["generic-cl.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM generic-cl DESCRIPTION
+    Standard Common Lisp functions implemented using generic functions. SHA256
+    02awl64bfykkasv3z9xpiiwq3v9vgcacqagbwvigqdk15hqrknyl URL
+    http://beta.quicklisp.org/archive/generic-cl/2020-12-20/generic-cl-20201220-git.tgz
+    MD5 76aa19981d3addb9a741fd4705d5d3ff NAME generic-cl FILENAME generic-cl
+    DEPS
+    ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
+     (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
+     (NAME cl-ansi-text FILENAME cl-ansi-text)
+     (NAME cl-colors FILENAME cl-colors)
+     (NAME cl-custom-hash-table FILENAME cl-custom-hash-table)
+     (NAME cl-environments FILENAME cl-environments)
+     (NAME cl-ppcre FILENAME cl-ppcre) (NAME closer-mop FILENAME closer-mop)
+     (NAME collectors FILENAME collectors)
+     (NAME introspect-environment FILENAME introspect-environment)
+     (NAME iterate FILENAME iterate)
+     (NAME lisp-namespace FILENAME lisp-namespace)
+     (NAME optima FILENAME optima) (NAME prove FILENAME prove)
+     (NAME prove-asdf FILENAME prove-asdf)
+     (NAME static-dispatch FILENAME static-dispatch)
+     (NAME symbol-munger FILENAME symbol-munger) (NAME trivia FILENAME trivia)
+     (NAME trivia.balland2006 FILENAME trivia_dot_balland2006)
+     (NAME trivia.level0 FILENAME trivia_dot_level0)
+     (NAME trivia.level1 FILENAME trivia_dot_level1)
+     (NAME trivia.level2 FILENAME trivia_dot_level2)
+     (NAME trivia.trivial FILENAME trivia_dot_trivial)
+     (NAME trivial-cltl2 FILENAME trivial-cltl2) (NAME type-i FILENAME type-i))
+    DEPENDENCIES
+    (agutil alexandria anaphora arrows cl-ansi-text cl-colors
+     cl-custom-hash-table cl-environments cl-ppcre closer-mop collectors
+     introspect-environment iterate lisp-namespace optima prove prove-asdf
+     static-dispatch symbol-munger trivia trivia.balland2006 trivia.level0
+     trivia.level1 trivia.level2 trivia.trivial trivial-cltl2 type-i)
+    VERSION 20201220-git SIBLINGS (generic-cl.util) PARASITES (generic-cl/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-dispatch.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-dispatch.nix
@@ -1,0 +1,55 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "static-dispatch";
+  version = "20210411-git";
+
+  parasites = [ "static-dispatch/test" ];
+
+  description = "Static generic function dispatch for Common Lisp.";
+
+  deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-ansi-text" args."cl-colors" args."cl-environments" args."cl-interpol" args."closer-mop" args."collectors" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."prove" args."prove-asdf" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/static-dispatch/2021-04-11/static-dispatch-20210411-git.tgz";
+    sha256 = "0dqkapripvb5qrhpim1b5y2ymn99s2zcwf38vmqyiqk3n3hvjjh1";
+  };
+
+  packageName = "static-dispatch";
+
+  asdFilesToKeep = ["static-dispatch.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM static-dispatch DESCRIPTION
+    Static generic function dispatch for Common Lisp. SHA256
+    0dqkapripvb5qrhpim1b5y2ymn99s2zcwf38vmqyiqk3n3hvjjh1 URL
+    http://beta.quicklisp.org/archive/static-dispatch/2021-04-11/static-dispatch-20210411-git.tgz
+    MD5 7af665c6a3a1aa3315fe0a651ca559de NAME static-dispatch FILENAME
+    static-dispatch DEPS
+    ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
+     (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
+     (NAME cl-ansi-text FILENAME cl-ansi-text)
+     (NAME cl-colors FILENAME cl-colors)
+     (NAME cl-environments FILENAME cl-environments)
+     (NAME cl-interpol FILENAME cl-interpol)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME collectors FILENAME collectors)
+     (NAME introspect-environment FILENAME introspect-environment)
+     (NAME iterate FILENAME iterate)
+     (NAME lisp-namespace FILENAME lisp-namespace)
+     (NAME optima FILENAME optima) (NAME prove FILENAME prove)
+     (NAME prove-asdf FILENAME prove-asdf)
+     (NAME symbol-munger FILENAME symbol-munger) (NAME trivia FILENAME trivia)
+     (NAME trivia.balland2006 FILENAME trivia_dot_balland2006)
+     (NAME trivia.level0 FILENAME trivia_dot_level0)
+     (NAME trivia.level1 FILENAME trivia_dot_level1)
+     (NAME trivia.level2 FILENAME trivia_dot_level2)
+     (NAME trivia.trivial FILENAME trivia_dot_trivial)
+     (NAME trivial-cltl2 FILENAME trivial-cltl2) (NAME type-i FILENAME type-i))
+    DEPENDENCIES
+    (agutil alexandria anaphora arrows cl-ansi-text cl-colors cl-environments
+     cl-interpol closer-mop collectors introspect-environment iterate
+     lisp-namespace optima prove prove-asdf symbol-munger trivia
+     trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
+     trivia.trivial trivial-cltl2 type-i)
+    VERSION 20210411-git SIBLINGS NIL PARASITES (static-dispatch/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-arguments.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-arguments.nix
@@ -1,0 +1,27 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "trivial-arguments";
+  version = "20200925-git";
+
+  description = "A simple library to retrieve the lambda-list of a function.";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/trivial-arguments/2020-09-25/trivial-arguments-20200925-git.tgz";
+    sha256 = "079xm6f1vmsng7dzgb2x3m7k46jfw19wskwf1l5cid5nm267d295";
+  };
+
+  packageName = "trivial-arguments";
+
+  asdFilesToKeep = ["trivial-arguments.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM trivial-arguments DESCRIPTION
+    A simple library to retrieve the lambda-list of a function. SHA256
+    079xm6f1vmsng7dzgb2x3m7k46jfw19wskwf1l5cid5nm267d295 URL
+    http://beta.quicklisp.org/archive/trivial-arguments/2020-09-25/trivial-arguments-20200925-git.tgz
+    MD5 3d7b76a729b272019c8827e40bfb6db8 NAME trivial-arguments FILENAME
+    trivial-arguments DEPS NIL DEPENDENCIES NIL VERSION 20200925-git SIBLINGS
+    NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -277,4 +277,6 @@ $out/lib/common-lisp/query-fs"
   md5 = ifLispNotIn ["sbcl" "ccl" "gcl"]
     (extraLispDeps (with quicklisp-to-nix-packages; [flexi-streams]));
   cl-gobject-introspection = addNativeLibs (with pkgs; [glib gobject-introspection]);
+  generic-cl = x: { parasites = []; };
+  static-dispatch = x: { parasites = []; };
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -123,6 +123,7 @@ fiveam
 flexi-streams
 form-fiddle
 fset
+generic-cl
 gettext
 http-body
 hu.dwim.asdf
@@ -189,6 +190,7 @@ swank
 swap-bytes
 symbol-munger
 trivia
+trivial-arguments
 trivial-backtrace
 trivial-clipboard
 trivial-features

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -289,6 +289,80 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "trivia_dot_quasiquote" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivia_dot_quasiquote" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivia_dot_quasiquote.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+       }));
+
+
+  "fare-quasiquote-readtable" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote-readtable" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote-readtable.nix {
+         inherit fetchurl;
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+       }));
+
+
+  "fare-quasiquote-optima" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote-optima" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote-optima.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+       }));
+
+
+  "fare-quasiquote-extras" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote-extras" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote-extras.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+       }));
+
+
   "type-i" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."type-i" or (x: {}))
@@ -325,26 +399,6 @@ let quicklisp-to-nix-packages = rec {
            "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
            "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
            "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
-           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
-       }));
-
-
-  "trivia_dot_quasiquote" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."trivia_dot_quasiquote" or (x: {}))
-       (import ./quicklisp-to-nix-output/trivia_dot_quasiquote.nix {
-         inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
-           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
-           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
-           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
-           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
-           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
-           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
-           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
-           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
-           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
            "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
        }));
 
@@ -401,6 +455,39 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "static-dispatch" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."static-dispatch" or (x: {}))
+       (import ./quicklisp-to-nix-output/static-dispatch.nix {
+         inherit fetchurl;
+           "agutil" = quicklisp-to-nix-packages."agutil";
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "arrows" = quicklisp-to-nix-packages."arrows";
+           "cl-ansi-text" = quicklisp-to-nix-packages."cl-ansi-text";
+           "cl-colors" = quicklisp-to-nix-packages."cl-colors";
+           "cl-environments" = quicklisp-to-nix-packages."cl-environments";
+           "cl-interpol" = quicklisp-to-nix-packages."cl-interpol";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "collectors" = quicklisp-to-nix-packages."collectors";
+           "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "optima" = quicklisp-to-nix-packages."optima";
+           "prove" = quicklisp-to-nix-packages."prove";
+           "prove-asdf" = quicklisp-to-nix-packages."prove-asdf";
+           "symbol-munger" = quicklisp-to-nix-packages."symbol-munger";
+           "trivia" = quicklisp-to-nix-packages."trivia";
+           "trivia_dot_balland2006" = quicklisp-to-nix-packages."trivia_dot_balland2006";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+           "type-i" = quicklisp-to-nix-packages."type-i";
+       }));
+
+
   "introspect-environment" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."introspect-environment" or (x: {}))
@@ -409,57 +496,53 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
-  "fare-quasiquote-readtable" = buildLispPackage
+  "cl-environments" = buildLispPackage
     ((f: x: (x // (f x)))
-       (qlOverrides."fare-quasiquote-readtable" or (x: {}))
-       (import ./quicklisp-to-nix-output/fare-quasiquote-readtable.nix {
+       (qlOverrides."cl-environments" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-environments.nix {
          inherit fetchurl;
-           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
-           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
-           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "cl-ansi-text" = quicklisp-to-nix-packages."cl-ansi-text";
+           "cl-colors" = quicklisp-to-nix-packages."cl-colors";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "collectors" = quicklisp-to-nix-packages."collectors";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "optima" = quicklisp-to-nix-packages."optima";
+           "prove" = quicklisp-to-nix-packages."prove";
+           "prove-asdf" = quicklisp-to-nix-packages."prove-asdf";
+           "symbol-munger" = quicklisp-to-nix-packages."symbol-munger";
        }));
 
 
-  "fare-quasiquote-optima" = buildLispPackage
+  "arrows" = buildLispPackage
     ((f: x: (x // (f x)))
-       (qlOverrides."fare-quasiquote-optima" or (x: {}))
-       (import ./quicklisp-to-nix-output/fare-quasiquote-optima.nix {
+       (qlOverrides."arrows" or (x: {}))
+       (import ./quicklisp-to-nix-output/arrows.nix {
          inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
-           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
-           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
-           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
-           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
-           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
-           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
-           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
-           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
-           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
-           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
-           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+           "hu_dot_dwim_dot_stefil" = quicklisp-to-nix-packages."hu_dot_dwim_dot_stefil";
        }));
 
 
-  "fare-quasiquote-extras" = buildLispPackage
+  "agutil" = buildLispPackage
     ((f: x: (x // (f x)))
-       (qlOverrides."fare-quasiquote-extras" or (x: {}))
-       (import ./quicklisp-to-nix-output/fare-quasiquote-extras.nix {
+       (qlOverrides."agutil" or (x: {}))
+       (import ./quicklisp-to-nix-output/agutil.nix {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "closer-mop" = quicklisp-to-nix-packages."closer-mop";
-           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
-           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
-           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
-           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
+           "iterate" = quicklisp-to-nix-packages."iterate";
            "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
-           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "trivia" = quicklisp-to-nix-packages."trivia";
+           "trivia_dot_balland2006" = quicklisp-to-nix-packages."trivia_dot_balland2006";
            "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
            "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
            "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
-           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
            "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
            "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+           "type-i" = quicklisp-to-nix-packages."type-i";
        }));
 
 
@@ -1556,6 +1639,14 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "trivial-arguments" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivial-arguments" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivial-arguments.nix {
+         inherit fetchurl;
+       }));
+
+
   "trivia" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."trivia" or (x: {}))
@@ -2411,6 +2502,41 @@ let quicklisp-to-nix-packages = rec {
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
            "yacc" = quicklisp-to-nix-packages."yacc";
+       }));
+
+
+  "generic-cl" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."generic-cl" or (x: {}))
+       (import ./quicklisp-to-nix-output/generic-cl.nix {
+         inherit fetchurl;
+           "agutil" = quicklisp-to-nix-packages."agutil";
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "anaphora" = quicklisp-to-nix-packages."anaphora";
+           "arrows" = quicklisp-to-nix-packages."arrows";
+           "cl-ansi-text" = quicklisp-to-nix-packages."cl-ansi-text";
+           "cl-colors" = quicklisp-to-nix-packages."cl-colors";
+           "cl-custom-hash-table" = quicklisp-to-nix-packages."cl-custom-hash-table";
+           "cl-environments" = quicklisp-to-nix-packages."cl-environments";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "collectors" = quicklisp-to-nix-packages."collectors";
+           "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "optima" = quicklisp-to-nix-packages."optima";
+           "prove" = quicklisp-to-nix-packages."prove";
+           "prove-asdf" = quicklisp-to-nix-packages."prove-asdf";
+           "static-dispatch" = quicklisp-to-nix-packages."static-dispatch";
+           "symbol-munger" = quicklisp-to-nix-packages."symbol-munger";
+           "trivia" = quicklisp-to-nix-packages."trivia";
+           "trivia_dot_balland2006" = quicklisp-to-nix-packages."trivia_dot_balland2006";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+           "type-i" = quicklisp-to-nix-packages."type-i";
        }));
 
 


### PR DESCRIPTION
###### Motivation for this change

Packages the `generic-cl` and `trivial-arguments` Lisp systems, as well as their dependencies.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
