### PR TITLE
tests.trivial: Avoid evaluation and ${pkgs.path} dep

### DIFF
--- a/pkgs/build-support/trivial-builders/test.nix
+++ b/pkgs/build-support/trivial-builders/test.nix
@@ -43,4 +43,11 @@ nixosTest {
       ${./test.sh} 2>/dev/console
     """)
   '';
+  meta = {
+    license = lib.licenses.mit; # nixpkgs license
+    maintainers = with lib.maintainers; [
+      roberth
+    ];
+    description = "Run the Nixpkgs trivial builders tests";
+  };
 }

--- a/pkgs/build-support/trivial-builders/test.nix
+++ b/pkgs/build-support/trivial-builders/test.nix
@@ -1,5 +1,27 @@
-{ lib, nixosTest, path, writeText, hello, figlet, stdenvNoCC }:
+{ lib, nixosTest, pkgs, writeText, hello, figlet, stdenvNoCC }:
 
+# -------------------------------------------------------------------------- #
+#
+#                         trivial-builders test
+#
+# -------------------------------------------------------------------------- #
+#
+#  This file can be run independently (quick):
+#
+#      $ pkgs/build-support/trivial-builders/test.sh
+#
+#  or in the build sandbox with a ~20s VM overhead
+#
+#      $ nix-build -A tests.trivial-builders
+#
+# -------------------------------------------------------------------------- #
+
+let
+  invokeSamples = file:
+    lib.concatStringsSep " " (
+      lib.attrValues (import file { inherit pkgs; })
+    );
+in
 nixosTest {
   name = "nixpkgs-trivial-builders";
   nodes.machine = { ... }: {
@@ -10,11 +32,15 @@ nixosTest {
     environment.etc."pre-built-paths".source = writeText "pre-built-paths" (
       builtins.toJSON [hello figlet stdenvNoCC]
     );
+    environment.variables = {
+      SAMPLE = invokeSamples ./test/sample.nix;
+      REFERENCES = invokeSamples ./test/invoke-writeReferencesToFile.nix;
+      DIRECT_REFS = invokeSamples ./test/invoke-writeDirectReferencesToFile.nix;
+    };
   };
   testScript = ''
     machine.succeed("""
-      cd ${lib.cleanSource path}
-      ./pkgs/build-support/trivial-builders/test.sh 2>/dev/console
+      ${./test.sh} 2>/dev/console
     """)
   '';
 }

--- a/pkgs/build-support/trivial-builders/test/invoke-writeDirectReferencesToFile.nix
+++ b/pkgs/build-support/trivial-builders/test/invoke-writeDirectReferencesToFile.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import ../../../.. { config = {}; overlays = []; } }:
+pkgs.lib.mapAttrs
+  (k: v: pkgs.writeDirectReferencesToFile v)
+  (import ./sample.nix { inherit pkgs; })

--- a/pkgs/build-support/trivial-builders/test/invoke-writeReferencesToFile.nix
+++ b/pkgs/build-support/trivial-builders/test/invoke-writeReferencesToFile.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import ../../../.. { config = {}; overlays = []; } }:
+pkgs.lib.mapAttrs
+  (k: v: pkgs.writeReferencesToFile v)
+  (import ./sample.nix { inherit pkgs; })

--- a/pkgs/build-support/trivial-builders/test/sample.nix
+++ b/pkgs/build-support/trivial-builders/test/sample.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import ../../../.. { config = {}; overlays = []; } }:
+let
+  inherit (pkgs)
+    figlet
+    hello
+    writeText
+    ;
+in
+{
+  hello = hello;
+  figlet = figlet;
+  norefs = writeText "hi" "hello";
+  helloRef = writeText "hi" "hello ${hello}";
+  helloFigletRef = writeText "hi" "hello ${hello} ${figlet}";
+}


### PR DESCRIPTION
> There is an issue in the test added by #123111.
> [it] introduces a dependency on the contents of nixpkgs,
> making every change evaluate with a different hash.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #123572 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @veprbl @Profpatsch 