### PR TITLE
nixos/nsd: make nsd-checkconf work when configuration contains keys (#118140)

### DIFF
--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -43,6 +43,10 @@ in import ./make-test-python.nix ({ pkgs, ...} : {
       services.nsd.enable = true;
       services.nsd.rootServer = true;
       services.nsd.interfaces = lib.mkForce [];
+      services.nsd.keys."tsig.example.com." = {
+        algorithm = "hmac-sha256";
+        keyFile = pkgs.writeTextFile { name = "tsig.example.com."; text = "aR3FJA92+bxRSyosadsJ8Aeeav5TngQW/H/EF9veXbc="; };
+      };
       services.nsd.zones."example.com.".data = ''
         @ SOA ns.example.com noc.example.com 666 7200 3600 1209600 3600
         ipv4 A 1.2.3.4
@@ -51,6 +55,7 @@ in import ./make-test-python.nix ({ pkgs, ...} : {
         ns A 192.168.0.1
         ns AAAA dead:beef::1
       '';
+      services.nsd.zones."example.com.".provideXFR = [ "0.0.0.0 tsig.example.com." ];
       services.nsd.zones."deleg.example.com.".data = ''
         @ SOA ns.example.com noc.example.com 666 7200 3600 1209600 3600
         @ A 9.8.7.6
@@ -71,6 +76,10 @@ in import ./make-test-python.nix ({ pkgs, ...} : {
     clientv6.wait_for_unit("network.target")
     server.wait_for_unit("nsd.service")
 
+    with subtest("server tsig.example.com."):
+        expected_tsig = "  secret: \"aR3FJA92+bxRSyosadsJ8Aeeav5TngQW/H/EF9veXbc=\"\n"
+        tsig=server.succeed("cat /var/lib/nsd/private/tsig.example.com.")
+        assert expected_tsig == tsig, f"Expected /var/lib/nsd/private/tsig.example.com. to contain '{expected_tsig}', but found '{tsig}'"
 
     def assert_host(type, rr, query, expected):
         self = clientv4 if type == 4 else clientv6


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[see #118140]
When `services.nsd.keys` is used, the `nsd-checkconf` fails because the included files are not present at build time.
This patch replaces the `include: ` directives with mock keys with the appropriate algorithm. After the `nsd-checkconf` succeeds, the original file is restored.
I chose to use `tsig-keygen` to generate keys that have the same algorithm as the original ones. Its `-r` option was deprecated (so we can't -r `/dev/zero` to sidestep the RNG). However, as the generated keys don't remain in `$out`, the build should still be repeatable. I'm open for suggestions on this though.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
