### PR TITLE
Extend writeShellScript and friends

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -1,5 +1,31 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, zsh, dash, bash}:
 
+let
+  runtime = { 
+    preamble = "#!${runtimeShell}";
+    checkPhase = ''
+      ${stdenv.shell} -n $out
+    '';
+  };
+  bash = { 
+    preamble = "#!${lib.getBin bash}/bin/bash"; 
+    checkPhase = ''
+      ${lib.getBin bash}/bin/bash -n $out
+    '';
+  };
+  zsh = { 
+    preamble = "#!${lib.getBin zsh}/bin/zsh"; 
+    checkPhase = ''
+      ${lib.getBin zsh}/bin/zsh -n $out
+    '';
+  };
+  dash = { 
+    preamble = "#!${lib.getBin dash}/bin/dash"; 
+    checkPhase = ''
+      ${lib.getBin dash}/bin/dash -n $out
+    '';
+  };
+in
 rec {
 
   /* Run the shell command `buildCommand' to produce a store path named
@@ -120,7 +146,7 @@ rec {
         passAsFile = [ "text" ];
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;
-        allowSubstitutes = false;
+        allowSubstituNixOStes = false;
       }
       ''
         n=$out${destination}
@@ -212,17 +238,88 @@ rec {
    *   '';
    *
   */
+  writeShellText = name: text:
+    writeTextFile {
+      inherit name;
+      inherit (runtime) checkPhase;
+      text = ''
+        ${runtime.preamble}
+        ${text}
+        '';
+    };
+  
   writeShellScript = name: text:
     writeTextFile {
       inherit name;
       executable = true;
+      inherit (runtime) checkPhase;
       text = ''
-        #!${runtimeShell}
+        ${runtime.preamble}
         ${text}
         '';
-      checkPhase = ''
-        ${stdenv.shell} -n $out
-      '';
+    };
+  
+  writeBashText = name: text:
+    writeTextFile {
+      inherit name;
+      inherit (bash) checkPhase;
+      text = ''
+        ${bash.preamble}
+        ${text}
+        '';
+    };
+  
+  writeBashScript = name: text:
+    writeTextFile {
+      inherit name;
+      executable = true;
+      inherit (bash) checkPhase;
+      text = ''
+        ${bash.preamble}
+        ${text}
+        '';
+    };
+  
+  writeZSHText = name: text:
+    writeTextFile {
+      inherit name;
+      inherit (zsh) checkPhase;
+      text = ''
+        ${zsh.preamble}
+        ${text}
+        '';
+    };
+  
+  writeZSHScript = name: text:
+    writeTextFile {
+      inherit name;
+      executable = true;
+      inherit (zsh) checkPhase;
+      text = ''
+        ${zsh.preamble}
+        ${text}
+        '';
+    };
+  
+  writeDashText = name: text:
+    writeTextFile {
+      inherit name;
+      inherit (dash) checkPhase;
+      text = ''
+        ${dash.preamble}
+        ${text}
+        '';
+    };
+  
+  writeDashScript = name: text:
+    writeTextFile {
+      inherit name;
+      executable = true;
+      inherit (dash) checkPhase;
+      text = ''
+        ${dash.preamble}
+        ${text}
+        '';
     };
 
   /*

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -243,7 +243,6 @@ rec {
       inherit name;
       inherit (runtime) checkPhase;
       text = ''
-        ${runtime.preamble}
         ${text}
         '';
     };
@@ -264,7 +263,6 @@ rec {
       inherit name;
       inherit (bash) checkPhase;
       text = ''
-        ${bash.preamble}
         ${text}
         '';
     };
@@ -285,7 +283,6 @@ rec {
       inherit name;
       inherit (zsh) checkPhase;
       text = ''
-        ${zsh.preamble}
         ${text}
         '';
     };
@@ -306,7 +303,6 @@ rec {
       inherit name;
       inherit (dash) checkPhase;
       text = ''
-        ${dash.preamble}
         ${text}
         '';
     };


### PR DESCRIPTION
###### Motivation for this change

From [this discussion](https://github.com/nix-community/home-manager/issues/2015) over at home-manager it came up that it would be useful to extend `writeShellScript` to provide both executable and non-executable variants (`writeShellScript` and `writeShellText`, resp.), and to support additional shells (e.g. `writeZSHScript` and `writeZSHText`).

The motivation for this change is taken from home-manager where a large number of modules generate shell text (e.g. .bashrc) or scripts. Making sure these files are correct is critical to avoiding a corrupted system (the other day I had to jump into the terminal and debug a broken .profile). These files may or may not be executable and run in a variety different shells. The same issue arises for NixOS modules. We discussed adding these functions in home-manager, but thought nixpkgs would be a better home.

This PR is just a sketch as I wasn't sure how the bootstrapping worked in pkgs/top-level/stage.nix and because there's a significant amount of duplication in its current form.

I figured I'd solicit feedback before cleaning things up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
