### PR TITLE
nixos/tests/cagebreak: use wayland-info instead of wallutils

### DIFF
--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -33,7 +33,7 @@ in
 
     hardware.opengl.enable = true;
     programs.xwayland.enable = true;
-    environment.systemPackages = [ pkgs.cagebreak pkgs.wallutils ];
+    environment.systemPackages = [ pkgs.cagebreak pkgs.wayland-utils ];
 
     virtualisation.memorySize = 1024;
     # Need to switch to a different VGA card / GPU driver than the default one (std) so that Cagebreak can launch:
@@ -51,7 +51,7 @@ in
     machine.wait_for_file("${XDG_RUNTIME_DIR}/wayland-0")
 
     with subtest("ensure wayland works with wayinfo from wallutils"):
-        print(machine.succeed("env XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} wayinfo"))
+        print(machine.succeed("env XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} wayland-info"))
 
     # TODO: Fix the XWayland test (log the cagebreak output to debug):
     # with subtest("ensure xwayland works with xterm"):


### PR DESCRIPTION
###### Motivation for this change

wayland-info from wayland-utils is already used in other Wayland
tests whereas wallutils' wayinfo is not.

cc: @primeos 

This is a quick and simple merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
