### PR TITLE
vmTools: update distributions

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -997,6 +997,23 @@ rec {
       packages = commonDebPackages ++ [ "diffutils" "libc-bin" ];
     };
 
+    ubuntu2104x86_64 = {
+      name = "ubuntu-21.04-hirsute-amd64";
+      fullName = "Ubuntu 21.04 Hirsute Hippo (amd64)";
+      packagesLists =
+        [ (fetchurl {
+            url = "mirror://ubuntu/dists/hirsute/main/binary-amd64/Packages.xz";
+            sha256 = "sha256-MJPu1K7xLSh8euH6MByreNWPxI49j6vN261gFt/eZCU=";
+          })
+          (fetchurl {
+            url = "mirror://ubuntu/dists/hirsute/universe/binary-amd64/Packages.xz";
+            sha256 = "sha256-jTUn5zjAutez0U3DhfV0nyCYzkMISlhWUwHckXaFYuA=";
+          })
+        ];
+      urlPrefix = "mirror://ubuntu";
+      packages = commonDebPackages ++ [ "diffutils" "libc-bin" ];
+    };
+
     debian8i386 = {
       name = "debian-8.11-jessie-i386";
       fullName = "Debian 8.11 Jessie (i386)";
@@ -1041,6 +1058,16 @@ rec {
       packages = commonDebianPackages;
     };
 
+    debian10x86_64 = {
+      name = "debian-10.9-buster";
+      fullName = "Debian 10.9 Buster (amd64)";
+      packagesList = fetchurl {
+        url = "http://snapshot.debian.org/archive/debian/20210518T203004Z/dists/buster/main/binary-amd64/Packages.xz";
+        sha256 = "sha256-k13toY1b3CX7GBPQ7Jm24OMqCEsgPlGK8M99x57o69o=";
+      };
+      urlPrefix = "mirror://debian";
+      packages = commonDebianPackages;
+    };
 
   };
 
@@ -1168,7 +1195,7 @@ rec {
     "passwd"
   ];
 
-  commonDebianPackages = commonDebPackages ++ [ "sysvinit" "diff" "mktemp" ];
+  commonDebianPackages = commonDebPackages ++ [ "sysvinit" "diff" ];
 
 
   /* A set of functions that build the Linux distributions specified


### PR DESCRIPTION
add Ubuntu 21.04
add Debian 10.09

Is there anything where i should add those for automatic testing in hydra?
pkgs/build-support/vm/test.nix does not seem to be used anywhere.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
