### PR TITLE
wlc: init at 1.11

### DIFF
--- a/pkgs/tools/misc/wlc/default.nix
+++ b/pkgs/tools/misc/wlc/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, python3
+}:
+
+with python3.pkgs;
+
+buildPythonPackage rec {
+  pname = "wlc";
+  version = "1.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0ysx250v2qycy1m3jj0wxmyf2f5n8fxf6br69vcbyq2cnqw609nx";
+  };
+
+  propagatedBuildInputs = [
+    argcomplete
+    python-dateutil
+    requests
+    pyxdg
+    pre-commit
+    responses
+    twine
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "wlc is a Weblate commandline client using Weblate's REST API.";
+    homepage = "https://github.com/WeblateOrg/wlc";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ paperdigits ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27039,6 +27039,8 @@ in
 
   write_stylus = libsForQt5.callPackage ../applications/graphics/write_stylus { };
 
+  wlc = callPackage  ../tools/misc/wlc { };
+
   wllvm = callPackage  ../development/tools/wllvm { };
 
   wmname = callPackage ../applications/misc/wmname { };


### PR DESCRIPTION
###### Motivation for this change
To include the weblate client in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
