### PR TITLE
megasync: temporarily remove ffmpeg dependency

### DIFF
--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -7,7 +7,7 @@
 , curl
 , doxygen
 , fetchFromGitHub
-, ffmpeg
+  #, ffmpeg
 , libmediainfo
 , libraw
 , libsodium
@@ -52,7 +52,8 @@ mkDerivation rec {
     c-ares
     cryptopp
     curl
-    ffmpeg
+    # temporarily disable until patched for ffmpeg 4.4
+    #ffmpeg
     libmediainfo
     libraw
     libsodium
@@ -94,7 +95,8 @@ mkDerivation rec {
     "--with-cares"
     "--with-cryptopp"
     "--with-curl"
-    "--with-ffmpeg"
+    # temporarily disable until patched for ffmpeg 4.4
+    #"--with-ffmpeg"
     "--without-freeimage" # unreferenced even when found
     "--without-readline"
     "--without-termcap"


### PR DESCRIPTION
until patched to work with ffmpeg 4.4

See https://github.com/NixOS/nixpkgs/issues/120705#issuecomment-843316773

Upstream issue: https://github.com/meganz/MEGAsync/issues/578

Honestly, I haven't noticed a difference when compiled without ffmpeg.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).