### PR TITLE
kodi-retroarch-advanced-launchers: take `lib` arg

### DIFF
--- a/pkgs/misc/emulators/retroarch/kodi-advanced-launchers.nix
+++ b/pkgs/misc/emulators/retroarch/kodi-advanced-launchers.nix
@@ -1,8 +1,6 @@
-{ stdenv, pkgs, cores, runtimeShell }:
+{ stdenv, pkgs, lib, cores, runtimeShell }:
 
 assert cores != [];
-
-with pkgs.lib;
 
 let
 


### PR DESCRIPTION
This package was changed to refer to `lib` instead of `stdenv.lib`, but
`lib` was not actually in scope. I don't know what this package is about
or how evaluation got to that point, but this is clearly more correct.

###### Motivation for this change

nix-env -qasP errored out with a non-empty retroarch attrset in my nixpkgs config

###### Things done

[x] nix-env -qasP doesn't error out anymore. i didn't actually build anything

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
