### PR TITLE
pulumi-bin: 3.1.0 -> 3.3.0

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,48 +1,52 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.1.0";
+  version = "3.3.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.1.0-linux-x64.tar.gz";
-        sha256 = "103r0rih8qzpswij3bxls9gsb832n4ykwrzbki9b21w2ymj7k3x1";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.3.0-linux-x64.tar.gz";
+        sha256 = "0kcq7zwgbp465lx7p80l5xc50xdmydq32djzis0973hxlkgliiq6";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.0.0-linux-amd64.tar.gz";
-        sha256 = "1f6r59qk48x73nm17swcs3cp3qw616m7p36bvgsc1s96h23k805w";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.1.0-linux-amd64.tar.gz";
+        sha256 = "0vws9mll2k42qx04idyf13vai018552wyrvr1jxjf4fl93yrayz7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.0.0-linux-amd64.tar.gz";
-        sha256 = "12rnb18p7z709gvw50hvmx9v7f2wd3pwcncwz4g3ragd7f6a4kja";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.5.1-linux-amd64.tar.gz";
+        sha256 = "0mz9zxlx4vc26g0khvdlg5kzc74shdc4lca8h1l9sxqwgkmyga7q";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.0.0-linux-amd64.tar.gz";
         sha256 = "0xs7i9l871x5kr22jg7jjw0rgyvs4j4hazr4n9375xgzc8ysrk09";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "08588m5s6j1xhig4jprlkjgxk1sif4h3f6as7ixnvssin2vhhhl9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0bfs64za4i5bmk3r8qyhgh0x58cdrn88gv0i3vm4prry53zgy3ny";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "01dqah12p23658awcp0sx5h696rdyjl79vd9dm5075jdaix1f648";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v3.2.0-linux-amd64.tar.gz";
+        sha256 = "0s1z33iqf0nvrgpq6rqnm79sr8bnnkfspq8qnfynybcn80drn7vd";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.0.0-linux-amd64.tar.gz";
-        sha256 = "0m8q1cswdml0hsc4vkq38pm2izs3lig57fg4a8ghqqi3ykni344d";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.2.0-linux-amd64.tar.gz";
+        sha256 = "0gk60n5s9hjfsaz09aknivqpz1cw41vs6j84fdb3chkip8xzwdr7";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.0.0-linux-amd64.tar.gz";
         sha256 = "06j5k599i8giy5v6scggw8zx1pyfm6w20biwcizv81zk0zkg3fzp";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.0.0-linux-amd64.tar.gz";
-        sha256 = "1bzy4zf473w49fz2n9lg5ncgblq2a5jh70nf6cfwc7kcla407in0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-linux-amd64.tar.gz";
+        sha256 = "0yhdcjscdkvvai95z2v6xabvvsfvaqi38ngpqrb73ahlwqhz3nys";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.0.0-linux-amd64.tar.gz";
-        sha256 = "0d17ccf84jj6a9hpdrnsziyw790i0y5zk18qgqh4qq79irwz6df2";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.4.0-linux-amd64.tar.gz";
+        sha256 = "1rsqkp76sck0162hz3s5yljs79gis886k1v99k77hr1gbk08rx71";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.0.2-linux-amd64.tar.gz";
+        sha256 = "0g5x5wycgbn0iwp9y4fp0aqf36pfa3210n1rmiavx1a2g2zj9zvx";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.0.0-linux-amd64.tar.gz";
@@ -53,86 +57,90 @@
         sha256 = "0lqnb1xrb5ma8ssvn63lh92ihja6zx4nrx40pici1ggaln4sphn0";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "0s7an3qvczhajs54i0ir3jjmwxpv9w94viqrik506k198j0qnl3b";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.2.0-linux-amd64.tar.gz";
+        sha256 = "010j0xmrb5msva2mcmrpr0h8dhpk7x6bswbsbkkdjrf88baryyq0";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "0ljxjv8rm4li61vgjbpmxw8w6d2pym5li3w61dqi3kka4ix25aww";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0q1bi1a80jwgx52m9hy0vp67hdv3nbhd0gqxj3jaf5w4dnh48dca";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "1mxkwcricqnnbj0dp3wqidci6rgfn7daxkjprcnrndhgcdghq7sv";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0g392a6zyycdijjn0nswf2x5h31x1hcffgwwkmbjr304n2ycbb50";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-amd64.tar.gz";
         sha256 = "04gaimdzh04v7f11xw1b7p95rbb142kbnix1zqas68wd6vpw9kyp";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "1535c95ncgdifyz5m29gagpcr7lhhddlffmj9lmwch55w2xlk86k";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.2.0-linux-amd64.tar.gz";
+        sha256 = "1np74bfvp4hr70izb8sarxvga3nnvyi9j7y6f0lqqgrfk2ixn48r";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-linux-amd64.tar.gz";
         sha256 = "0glbjhgrb2hiyhd6kwmy7v384j8zw641pw9737g1fczv3x16a3s3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "13j13kp0sbwp65l73mdcqiv4cszslxin567ccdkk2rw8vs1ni7x0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.0.1-linux-amd64.tar.gz";
+        sha256 = "16z2jcixwqasj0rdj83gvsjb51xw5k6kj474sfdx8n0150hplma9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.0.0-linux-amd64.tar.gz";
-        sha256 = "0pah7s9wwaj8zp371blmj4c1bgyhh0dgsfr9axj0k4lhpqlyikmj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.1.1-linux-amd64.tar.gz";
+        sha256 = "1lc1i4irkrlv1cxy6xzl1fw8205rvhrdp2if09w4givq351lrmbm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.0.0-linux-amd64.tar.gz";
-        sha256 = "0bk26k1igqljjpwkkvri6dp14cfw9l9a2dvg2as3v5930w4jxql8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.1.0-linux-amd64.tar.gz";
+        sha256 = "0npszs37q6j1x5h2sp9j1c6qnhr03lxp2r2ci0d4z3x7vyk06rja";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "1lxb03z80r8a2vfckyw5yf036ii30gdi3rch4sriksfv30il9kbc";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0xvkkqgfgmw3f2nbmfvn1kwc9088awaw52kx1kxnp217g5r3c0fx";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.1.0-darwin-x64.tar.gz";
-        sha256 = "1lfqm4s72bwrycspr9nbgfvf5i6p50x8lk81pcs6zbzz6iff4x7z";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.3.0-darwin-x64.tar.gz";
+        sha256 = "1znjqjwasnw9wjdkrwss9shxvizsn5pav1a8rd8c1c6kcgpi01r7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.0.0-darwin-amd64.tar.gz";
-        sha256 = "0nycqlz3lkwirr8rs4sqdqbzn2igv51hjyfjjsgnhx85kjzlkas6";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.1.0-darwin-amd64.tar.gz";
+        sha256 = "11cpidiasmsy6d29ycpzwkn0vfac9cd1ng410ljhjw8bmmrgfg6f";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.0.0-darwin-amd64.tar.gz";
-        sha256 = "1kim1lk9dycsanc2vcsr4fgfhk90zyjf24vvwmmkk70nq1lnwqp3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.5.1-darwin-amd64.tar.gz";
+        sha256 = "195wrwyw25kaixv277ww38mbw19rq6f56m40f3p0rgicjn2dsgyh";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.0.0-darwin-amd64.tar.gz";
         sha256 = "0kvr057hdwcxf7gj788sv6ysz25ap3z0akqhhb20mlzv3shwiiji";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "14d530fbzmq5m3njl31qkgwwfyipad9iqjhv3cd8pcl87blaxxki";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "0q4lb32j1bm34sag39w9s6415fni169800k1qyym193s13c4gk89";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "0q29dyrnramr2bl89503gnbm4zq2x3bn7kaiwbhg6r17xa6rkji4";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v3.2.0-darwin-amd64.tar.gz";
+        sha256 = "167hg0j3rzxv9bsadhzgv5sz2jhqxdfn0sx35ws8v8b1rblmxywc";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.0.0-darwin-amd64.tar.gz";
-        sha256 = "0v8iha0n1kqvaxrjll2mv9znc9lzqj7mqxgxig2g89qqjs6p69ql";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.2.0-darwin-amd64.tar.gz";
+        sha256 = "12r9k2ywxi8myvd80gmk1hvhgjmr5js6i5n6jghsyh083kh5wam7";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.0.0-darwin-amd64.tar.gz";
         sha256 = "0ffic6mqr1zyskrv60q9wg7jc0hq23l5g0pdh3clpnn2m1xnxnxm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.0.0-darwin-amd64.tar.gz";
-        sha256 = "1793qry84bch32zbc70c777y04qgys6n0vxsxzxqgz2j4r9vmi6a";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-darwin-amd64.tar.gz";
+        sha256 = "1dpsbq3b0fz86355jy7rz4kcsa1lnw4azn25vzlis89ay1ncbblc";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.0.0-darwin-amd64.tar.gz";
-        sha256 = "1lzjjk2da1xla012xrs9jfcdsbpmkh48n6lypmbr2ixh13pdwk1b";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.4.0-darwin-amd64.tar.gz";
+        sha256 = "121yaplx4nnq9is30iczbqibj1069jh9bqzgbriscd07kifyrpbw";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.0.2-darwin-amd64.tar.gz";
+        sha256 = "06nkd2pd4hwahbyh8ygn54xq5hdpbphfkkfhrg4jwgmfgacnz5x9";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.0.0-darwin-amd64.tar.gz";
@@ -143,44 +151,44 @@
         sha256 = "1lkrx2cayhhv432dvzvz8q4i1gfi659rkl59c0y0dkwbs8x425zb";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "10439p96wpxr13pxhii7li2cjq53pgr8c48ir63d2n4b8fn8iklr";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.2.0-darwin-amd64.tar.gz";
+        sha256 = "1ix5x92h7i6dlzcpnm819vf4nx1q3p88ky01mfs000xh9pl324ch";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "1n35b1cqglpwvcxdcgxwmv5j1qp8gwrjzh25884l0b72krna9alr";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "13rq01ylrqp48n62cp640a4mdqbrqnibb0xaw9pcpddl3a3nnck0";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "0qx4p0jz3n66r3kgpgs25qbzlmwdqf80353nywyijv3ham6hpicf";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "0awksrbsmvkgfszdsxfv8wfs1m16y1551jnz0rf51dq0cn9963hq";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-amd64.tar.gz";
         sha256 = "18vrp0zzi92x4l5nkjszvd0zr7pk6nl6s3h5a3hvsz5qrj2830q3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "0159ng9c9hshmng8ipss7hncqs5qp8plmr1qjadka6vyp1mxn2c3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.2.0-darwin-amd64.tar.gz";
+        sha256 = "08rmknpwrbc9h57a3ddg05s0idxbbrcf46i2gkqknjzs7dr6wzas";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-darwin-amd64.tar.gz";
         sha256 = "0621njipng32x43lw8n49mapq10lnvibg8vlvgciqsfvrbpz1yp5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "0h9zdiaanvm2yds9z0c5fmz0f05apdhm4w28d2i929djxh57jqrr";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.0.1-darwin-amd64.tar.gz";
+        sha256 = "00b6i6dai21b8biqdw5ybj2dk7267i99bji2siicvj0nvi3s2wzx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.0.0-darwin-amd64.tar.gz";
-        sha256 = "15pzcymjr9bzx47sq86llzfg0hydyf4cn0bb95zxjqrx8y37rql8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.1.1-darwin-amd64.tar.gz";
+        sha256 = "1ja36fh8760sw8sb3wzp5kbv71wv1544ir74ffkw6l0v4q29bwlq";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.0.0-darwin-amd64.tar.gz";
-        sha256 = "1wkak84yg5a4b5791pdwcl0fr089yjk853hwp44x3rhdh8xrdq1p";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.1.0-darwin-amd64.tar.gz";
+        sha256 = "0nasbip85f1xjp6dfibw0nh133gf9cy5n4gdqnv5759bg92am7kg";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "1g2q3zbhxmpk2qp3c9hz0vn0xh95pnl7pd5b5kcizbrdfgjlaabq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "0r3zmd4q9nhwbn52vva62m5j9nsrxbfgljrvfyyh19i2hm7l0kcl";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -3,32 +3,33 @@
 
 # Version of Pulumi from
 # https://www.pulumi.com/docs/get-started/install/versions/
-VERSION="3.1.0"
+VERSION="3.3.0"
 
 # Grab latest release ${VERSION} from
 # https://github.com/pulumi/pulumi-${NAME}/releases
 plugins=(
-    "auth0=2.0.0"
-    "aws=4.0.0"
+    "auth0=2.1.0"
+    "aws=4.5.1"
     "cloudflare=3.0.0"
-    "consul=3.0.0"
-    "datadog=3.0.0"
-    "digitalocean=4.0.0"
+    "consul=3.1.0"
+    "datadog=3.2.0"
+    "digitalocean=4.2.0"
     "docker=3.0.0"
-    "gcp=5.0.0"
-    "github=4.0.0"
+    "equinix-metal=2.0.0"
+    "gcp=5.4.0"
+    "github=4.0.2"
     "gitlab=4.0.0"
     "hcloud=1.0.0"
-    "kubernetes=3.0.0"
-    "linode=3.0.0"
-    "mailgun=3.0.0"
+    "kubernetes=3.2.0"
+    "linode=3.1.0"
+    "mailgun=3.1.0"
     "mysql=3.0.0"
-    "openstack=3.0.0"
+    "openstack=3.2.0"
     "packet=3.2.2"
-    "postgresql=3.0.0"
-    "random=4.0.0"
-    "vault=4.0.0"
-    "vsphere=3.0.0"
+    "postgresql=3.0.1"
+    "random=4.1.1"
+    "vault=4.1.0"
+    "vsphere=3.1.0"
 )
 
 function genMainSrc() {


### PR DESCRIPTION
###### Motivation for this change

Update Pulumi and plugins.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).