### PR TITLE
pythonPackages.fastpair : Updated version and pytest enabled

### DIFF
--- a/pkgs/development/python-modules/fastpair/default.nix
+++ b/pkgs/development/python-modules/fastpair/default.nix
@@ -1,35 +1,28 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pytestrunner, pytest, scipy }:
+{ lib, buildPythonPackage, fetchFromGitHub, pytestrunner, pytest, scipy, pytestCheckHook }:
 
 buildPythonPackage {
   pname = "fastpair";
-  version = "2016-07-05";
+  version = "2021-05-19";
 
   src = fetchFromGitHub {
     owner = "carsonfarmer";
     repo = "fastpair";
-    rev = "92364962f6b695661f35a117bf11f96584128a8d";
-    sha256 = "1pv9sxycxdk567s5gs947rhlqngrb9nn9yh4dhdvg1ix1i8dca71";
+    rev = "d3170fd7e4d6e95312e7e1cb02e84077a3f06379";
+    sha256 = "1l8zgr8awg27lhlkpa2dsvghrb7b12jl1bkgpzg5q7pg8nizl9mx";
   };
 
   nativeBuildInputs = [ pytestrunner ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest pytestCheckHook ];
 
   propagatedBuildInputs = [
     scipy
   ];
 
-  # Does not support pytest 4 https://github.com/carsonfarmer/fastpair/issues/14
-  doCheck = false;
-
-  checkPhase = ''
-    pytest fastpair
-  '';
-
   meta = with lib; {
     homepage = "https://github.com/carsonfarmer/fastpair";
     description = "Data-structure for the dynamic closest-pair problem";
     license = licenses.mit;
-    maintainers = with maintainers; [ cmcdragonkai ];
+    maintainers = with maintainers; [ cmcdragonkai rakesh4g ];
   };
 }


### PR DESCRIPTION
pythonPackages.fastpair : Updated version and pytest enabled

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
bug fixes and updated pytest support

https://github.com/carsonfarmer/fastpair/pull/16
https://github.com/carsonfarmer/fastpair/pull/17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
