### PR TITLE
linuxPackages.rtl8814au: move to a more maintained fork

### DIFF
--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
-stdenv.mkDerivation rec {
-  name = "rtl8814au-${kernel.version}-${version}";
-  version = "4.3.21";
+stdenv.mkDerivation {
+  pname = "rtl8814au";
+  version = "${kernel.version}-unstable-2021-05-18";
 
   src = fetchFromGitHub {
-    owner = "zebulon2";
-    repo = "rtl8814au";
-    rev = "a58c56a5a6cb99ffb872f07cb67b68197911854f";
-    sha256 = "1ffm67da183nz009gm5v9w1bab081hrm113kk8knl9s5qbqnn13q";
+    owner = "morrownr";
+    repo = "8814au";
+    rev = "388786c864f9b1437fc4d934b1eccf6d7f1e1355";
+    sha256 = "sha256-2EnheODPFWTGN/fz45LWRSOGeV6pTENEUrehahj+PJ4=";
   };
 
   buildInputs = kernel.moduleBuildDependencies;
@@ -31,9 +31,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Realtek 8814AU USB WiFi driver";
-    homepage = "https://github.com/zebulon2/rtl8814au";
-    license = licenses.gpl2;
+    homepage = "https://github.com/morrownr/8814au";
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.lassulus ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #122042 

move to a community maintained fork of rtl8814au
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
