### PR TITLE
androidStudioPackages.{beta, canary}: update

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -14,9 +14,8 @@ let
     sha256Hash = "074y6i0h8zamjgvvs882im44clds3g6aq8rssl7sq1wx6hrn5q36";
   };
   betaVersion = {
-    version = "4.2.0.24"; # "Android Studio 4.2.0"
-    build = "202.7322048";
-    sha256Hash = "1ii1zf8mv7xyql56wwkcdj5l4g3zaprdszv6r9md9r5zh78k4ccz";
+    version = "2020.3.1.16"; # "Android Studio Arctic Fox (2020.3.1) Beta 1"
+    sha256Hash = "0mp1cmxkqc022nv8cggywbwcf8lp6r802nh8hcw5j00hcdnhkcq0";
   };
   latestVersion = { # canary & dev
     version = "2020.3.1.15"; # "Android Studio Arctic Fox (2020.3.1) Canary 15"

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -18,8 +18,8 @@ let
     sha256Hash = "0mp1cmxkqc022nv8cggywbwcf8lp6r802nh8hcw5j00hcdnhkcq0";
   };
   latestVersion = { # canary & dev
-    version = "2020.3.1.15"; # "Android Studio Arctic Fox (2020.3.1) Canary 15"
-    sha256Hash = "0k66ibflqwdlgapir5w2v1d4zjwn6464yk2hvlmif9lsfdvd0ivv";
+    version = "2021.1.1.1"; # "Android Studio Bumblebee (2021.1.1) Canary 1"
+    sha256Hash = "0aavmk8byw817356jm28rl998gcp3zm7x3fq14hm2awzhk5jaklm";
   };
 in {
   # Attributes are named by their corresponding release channels


### PR DESCRIPTION
###### Motivation for this change

Update Android Studio packages to use latest available versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
