### PR TITLE
python3Packages.geopandas: 0.8.1 → 0.9.0

### DIFF
--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -1,45 +1,33 @@
-{ lib, stdenv, buildPythonPackage, fetchFromGitHub, isPy27
-, pandas, shapely, fiona, descartes, pyproj
-, pytestCheckHook, Rtree, fetchpatch }:
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
+, pandas, shapely, fiona, pyproj
+, pytestCheckHook, Rtree }:
 
 buildPythonPackage rec {
   pname = "geopandas";
-  version = "0.8.1";
-  disabled = isPy27;
+  version = "0.9.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "geopandas";
     repo = "geopandas";
     rev = "v${version}";
-    sha256 = "0618p0s0biisxk2s0h43hkc3bs1nwjk84rxbfyd6brfvs9yx4vq7";
+    sha256 = "sha256-58X562OkRzZ4UTNMTwXW4U5czoa5tbSMBCcE90DqbaE=";
   };
-
-  patches = [
-    # Fix for test test_numerical_operations: https://github.com/geopandas/geopandas/issues/1541
-    (fetchpatch {
-      url = "https://github.com/geopandas/geopandas/pull/1544/commits/6ce868a33a2f483b071089d51e178030fa4414d0.patch";
-      sha256 = "1sjgxrqgbhz5krx51hrv230ywszcdl6z8q3bj6830kfad8n8b5dq";
-    })
-    # Fix GeoJSON for Fiona>=1.8.16 (Sep. 7, 2020).
-    # https://github.com/geopandas/geopandas/issues/1606
-    # Will be included in next upstream release after 0.8.1
-    (fetchpatch {
-      url = "https://github.com/geopandas/geopandas/commit/72427d3d8c128039bfce1d54a76c0b652887b276.patch";
-      sha256 = "1726mrpddgmba0ngff73a5bsb6ywpsg63a2pdd2grp9339bgvi4a";
-    })
-  ];
 
   propagatedBuildInputs = [
     pandas
     shapely
     fiona
-    descartes
     pyproj
   ];
 
   doCheck = !stdenv.isDarwin;
   checkInputs = [ pytestCheckHook Rtree ];
-  disabledTests = [ "web" ];
+  disabledTests = [
+    # requires network access
+    "test_read_file_remote_geojson_url"
+    "test_read_file_remote_zipfile_url"
+  ];
   pytestFlagsArray = [ "geopandas" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/geopandas/geopandas/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
