### PR TITLE
libAfterImage: unvendor dependencies

### DIFF
--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, giflib, libjpeg, libpng, zlib }:
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, giflib, libjpeg, libpng, zlib
+, static ? stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation {
   pname = "libAfterImage";
@@ -52,11 +53,16 @@ stdenv.mkDerivation {
     rm -rf {libjpeg,libpng,libungif,zlib}/
     substituteInPlace Makefile.in \
       --replace "include .depend" ""
+  '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile.in \
+      --replace "-soname," "-install_name,$out/lib/"
   '';
 
   configureFlags = [
     "--with-gif"
     "--disable-mmx-optimization"
+    "--${if static then "enable" else "disable"}-staticlibs"
+    "--${if !static then "enable" else "disable"}-sharedlibs"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "--with-gif"
+    "--disable-mmx-optimization"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, giflib, libjpeg, libpng, zlib
-, static ? stdenv.hostPlatform.isStatic }:
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, giflib, libjpeg, libpng, libX11, zlib
+, static ? stdenv.hostPlatform.isStatic
+, withX ? !stdenv.isDarwin }:
 
 stdenv.mkDerivation {
   pname = "libAfterImage";
@@ -47,7 +48,7 @@ stdenv.mkDerivation {
   patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ giflib libjpeg libpng zlib ];
+  buildInputs = [ giflib libjpeg libpng zlib ] ++ lib.optional withX libX11;
 
   preConfigure = ''
     rm -rf {libjpeg,libpng,libungif,zlib}/
@@ -63,7 +64,7 @@ stdenv.mkDerivation {
     "--disable-mmx-optimization"
     "--${if static then "enable" else "disable"}-staticlibs"
     "--${if !static then "enable" else "disable"}-sharedlibs"
-  ];
+  ] ++ lib.optional withX "--with-x";
 
   meta = with lib; {
     homepage = "http://www.afterstep.org/afterimage/";

--- a/pkgs/development/libraries/libAfterImage/default.nix
+++ b/pkgs/development/libraries/libAfterImage/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, zlib }:
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook, giflib, libjpeg, libpng, zlib }:
 
 stdenv.mkDerivation {
   pname = "libAfterImage";
@@ -13,7 +13,50 @@ stdenv.mkDerivation {
     sha256 = "0n74rxidwig3yhr6fzxsk7y19n1nq1f296lzrvgj5pfiyi9k48vf";
   };
 
-  buildInputs = [ zlib ];
+  patches = [
+    # add back --with-gif option
+    (fetchpatch {
+      name = "libafterimage-gif.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/libafterimage/files/libafterimage-gif.patch?id=4aa4fca00611b0b3a4007870da43cc5fd63f76c4";
+      sha256 = "16pa94wlqpd7h6mzs4f0qm794yk1xczrwsgf93kdd3g0zbjq3rnr";
+    })
+
+    # fix build with newer giflib
+    (fetchpatch {
+      name = "libafterimage-giflib5-v2.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/libafterimage/files/libafterimage-giflib5-v2.patch?id=4aa4fca00611b0b3a4007870da43cc5fd63f76c4";
+      sha256 = "0qwydqy9bm73cg5n3vm97aj4jfi70p7fxqmfbi54vi78z593brln";
+      stripLen = 1;
+    })
+
+    # fix build with newer libpng
+    (fetchpatch {
+      name = "libafterimage-libpng15.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/libafterimage/files/libafterimage-libpng15.patch?id=4aa4fca00611b0b3a4007870da43cc5fd63f76c4";
+      sha256 = "1qyvf7786hayasfnnilfbri3p99cfz5wjpbli3gdqj2cvk6mpydv";
+    })
+
+    # fix an ldconfig problem
+    (fetchpatch {
+      name = "libafterimage-makefile.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/libafterimage/files/libafterimage-makefile.in.patch?id=4aa4fca00611b0b3a4007870da43cc5fd63f76c4";
+      sha256 = "1n6fniz6dldms615046yhc4mlg9gb53y4yfia8wfz6szgq5zicj4";
+    })
+  ];
+  patchFlags = [ "-p0" ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ giflib libjpeg libpng zlib ];
+
+  preConfigure = ''
+    rm -rf {libjpeg,libpng,libungif,zlib}/
+    substituteInPlace Makefile.in \
+      --replace "include .depend" ""
+  '';
+
+  configureFlags = [
+    "--with-gif"
+  ];
 
   meta = with lib; {
     homepage = "http://www.afterstep.org/afterimage/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: #123408

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
