### PR TITLE
python3Packages.bravia-tv: 1.0.8 -> 1.0.11

### DIFF
--- a/pkgs/development/python-modules/bravia-tv/default.nix
+++ b/pkgs/development/python-modules/bravia-tv/default.nix
@@ -1,20 +1,25 @@
-{ lib, fetchFromGitHub, buildPythonPackage, isPy27, requests }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, requests
+}:
 
 buildPythonPackage rec {
   pname = "bravia-tv";
-  version = "1.0.8";
-  disabled = isPy27;
+  version = "1.0.11";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "dcnielsen90";
     repo = "python-bravia-tv";
     rev = "v${version}";
-    sha256 = "0djwy4z1y173q3mnbngp754yrwzmm6h3x0rshvrvd64b78x1bsmp";
+    sha256 = "sha256-g47bDd5bZl0jad3o6T1jJLcnZj8nx944kz3Vxv8gD2U=";
   };
 
   propagatedBuildInputs = [ requests ];
 
-  # package does not include tests
+  # Package does not include tests
   doCheck = false;
 
   pythonImportsCheck = [ "bravia_tv" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.11

Change log: https://github.com/dcnielsen90/python-bravia-tv/releases/tag/v1.0.11

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50726
- Target Home Assistant release: 2021.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
