### PR TITLE
Make warning about authorizedKeys+NixOps more nuanced

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -38,8 +38,11 @@ let
           daemon reads in addition to the the user's authorized_keys file.
           You can combine the <literal>keys</literal> and
           <literal>keyFiles</literal> options.
-          Warning: If you are using <literal>NixOps</literal> then don't use this
-          option since it will replace the key required for deployment via ssh.
+          Warning: If you are using <literal>NixOps</literal> with
+          <literal>deployment.provisionSSHKey</literal> set to
+          <literal>true</literal> (the default) then don't use this option for
+          user root, since it will replace the key required for deployment via
+          ssh.
         '';
       };
 


### PR DESCRIPTION
_This is a documentation-only change._

###### Motivation for this change

The warning about authorizedKeys in combination with NixOps is a bit too alarming. I'm using NixOps and provision my own keys, for which using authorizedKeys is just fine. Also, for non-root users there's also no problem.

###### Things done

Built the manual and visually checked that the change looked okay.