### PR TITLE
linuxPackages.rtl8821au: switch to a more maintained fork

### DIFF
--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel, bc, nukeReferences }:
 
 stdenv.mkDerivation rec {
-  name = "rtl8821au-${kernel.version}-${version}";
-  version = "5.1.5+41";
+  pname = "rtl8821au";
+  version = "${kernel.version}-unstable-2021-05-18";
 
   src = fetchFromGitHub {
-    owner = "zebulon2";
-    repo = "rtl8812au";
-    rev = "ecd3494c327c54110d21346ca335ef9e351cb0be";
-    sha256 = "1kmdxgbh0s0v9809kdsi39p0jbm5cf10ivy40h8qj9hn70g1gw8q";
+    owner = "morrownr";
+    repo = "8821au";
+    rev = "6f6a9d5772bb2b75f18374c01c82c6b3e8e3244d";
+    sha256 = "sha256-RqtLR3sNcLXhUrNloSTRKubL1SVwzbVe73AsBYYSXNE=";
   };
 
   nativeBuildInputs = [ bc nukeReferences ];
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "rtl8821AU, rtl8812AU and rtl8811AU chipset driver with firmware";
-    homepage = "https://github.com/zebulon2/rtl8812au";
-    license = licenses.gpl2;
+    description = "rtl8821AU and rtl8812AU chipset driver with firmware";
+    homepage = "https://github.com/morrownr/8821au";
+    license = licenses.gpl2Only;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = with maintainers; [ plchldr ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
