### PR TITLE
vnstat: 2.6 -> 2.7

### DIFF
--- a/pkgs/applications/networking/vnstat/default.nix
+++ b/pkgs/applications/networking/vnstat/default.nix
@@ -1,12 +1,20 @@
-{ lib, stdenv, fetchurl, pkg-config, gd, ncurses, sqlite, check }:
+{ lib, stdenv
+, fetchFromGitHub
+, pkg-config
+, gd, ncurses
+, sqlite
+, check
+}:
 
 stdenv.mkDerivation rec {
   pname = "vnstat";
-  version = "2.6";
+  version = "2.7";
 
-  src = fetchurl {
-    sha256 = "1xvzkxkq1sq33r2s4f1967f4gnca4xw411sbapdkx541f856w9w9";
-    url = "https://humdi.net/${pname}/${pname}-${version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "vergoh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "105krrc7hl5mbj89i1k3w8yzqrg4f0q96lmyv4rc7fhhds5zam2h";
   };
 
   postPatch = ''
@@ -32,5 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://humdi.net/vnstat/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ evils ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
i use it, the monthly figure stopped updating, i tried out the latest release, this didn't help
but now i have an update around...
and there seems to be some new features someone may want to use
https://github.com/vergoh/vnstat/releases/tag/v2.7

###### Things done

change to fetchFromGitHub
use latest version
and set myself as a maintainer

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/8bp2c0pan8wx39d8pvja4c2ihmy04dk1-vnstat-2.6	   51285536`
  - `/nix/store/xfm3c7gnhiinjjysvw6dirw9gl0fxys3-vnstat-2.7	   51313800`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).