### PR TITLE
runc: 1.0.0-rc94 -> 1.0.0-rc95

### DIFF
--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -16,13 +16,13 @@
 
 buildGoPackage rec {
   pname = "runc";
-  version = "1.0.0-rc94";
+  version = "1.0.0-rc95";
 
   src = fetchFromGitHub {
     owner = "opencontainers";
     repo = "runc";
     rev = "v${version}";
-    sha256 = "sha256-53P48jNSfC6ELpZNI30yAf7kofUsrJpNY96u0UT+ITg=";
+    sha256 = "sha256-q4sXcvJO9gyo7m0vlaMrwh7ZZHYa58FJy3GatWndS6M=";
   };
 
   goPackagePath = "github.com/opencontainers/runc";


### PR DESCRIPTION

###### Motivation for this change

Update to the latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @NixOS/podman @offline