### PR TITLE
pythonPackages.karton-dashboard: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/karton-dashboard/default.nix
+++ b/pkgs/development/python-modules/karton-dashboard/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "karton-dashboard";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "101qmx6nmiim0vrz2ldk973ns498hnxla1xy7nys9kh9wijg4msk";
+    sha256 = "0qygv9lkd1jad5b4l0zz6hsi7m8q0fmpwaa6hpp7p9x6ql7gnyl8";
   };
 
   propagatedBuildInputs = [
@@ -27,8 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "Flask==1.1.1" "Flask" \
-      --replace "karton-core==4.1.0" "karton-core"
+      --replace "Flask==1.1.1" "Flask"
   '';
 
   # Project has no tests. pythonImportsCheck requires MinIO configuration


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
