### PR TITLE
openmolcas: 20.10 -> 21.02

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -1,12 +1,13 @@
 { lib, stdenv, fetchFromGitLab, cmake, gfortran, perl
 , openblas, hdf5-cpp, python3, texlive
 , armadillo, mpi, globalarrays, openssh
-, makeWrapper, fetchpatch
+, makeWrapper
 } :
 
 let
-  version = "20.10";
-  gitLabRev = "v${version}";
+  version = "21.02";
+  # The tag keeps moving, fix a hash instead
+  gitLabRev = "41cee871945ac712e86ee971425a49a8fc60a936";
 
   python = python3.withPackages (ps : with ps; [ six pyparsing ]);
 
@@ -18,13 +19,13 @@ in stdenv.mkDerivation {
     owner = "Molcas";
     repo = "OpenMolcas";
     rev = gitLabRev;
-    sha256 = "0xr9plgb0cfmxxqmd3wrhvl0hv2jqqfqzxwzs1jysq2m9cxl314v";
+    sha256 = "0cap53gy1wds2qaxbijw09fqhvfxphfkr93nhp9xdq84yxh4wzv6";
   };
 
   patches = [
     # Required to handle openblas multiple outputs
     ./openblasPath.patch
-];
+  ];
 
   nativeBuildInputs = [ perl cmake texlive.combined.scheme-minimal makeWrapper ];
   buildInputs = [
@@ -55,6 +56,10 @@ in stdenv.mkDerivation {
     # The Makefile will install pymolcas during the build grrr.
     mkdir -p $out/bin
     export PATH=$PATH:$out/bin
+  '';
+
+  postInstall = ''
+    mv $out/pymolcas $out/bin
   '';
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change
A new version 2021.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
