### PR TITLE
pythonPackages.karton-yaramatcher: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/karton-yaramatcher/default.nix
+++ b/pkgs/development/python-modules/karton-yaramatcher/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "karton-yaramatcher";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0yb9l5z826zli5cpcj234dmjdjha2g1lcwxyvpxm95whkhapc2cf";
+    sha256 = "0mv8v1gk6p21pw9kx6cxr76l6c5fxd3p6dk85cwfzz100h8mdvar";
   };
 
   propagatedBuildInputs = [
@@ -24,7 +24,6 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "karton-core==4.0.5" "karton-core" \
       --replace "yara-python==4.0.2" "yara-python" \
   '';
 

--- a/pkgs/development/python-modules/karton-yaramatcher/default.nix
+++ b/pkgs/development/python-modules/karton-yaramatcher/default.nix
@@ -22,11 +22,6 @@ buildPythonPackage rec {
     yara-python
   ];
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "yara-python==4.0.2" "yara-python" \
-  '';
-
   checkPhase = ''
     runHook preCheck
     ${python.interpreter} -m unittest discover


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
