### PR TITLE
pythonPackages.karton-autoit-ripper: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/karton-autoit-ripper/default.nix
+++ b/pkgs/development/python-modules/karton-autoit-ripper/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "karton-autoit-ripper";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vdsxkbjcr0inpcfjh45gl72ipzklkhgs06fdpkyy9y0cfx3zq7z";
+    sha256 = "1bsqpf9w6d9fjysmnafaglg2w41gsafs2xz4dzcgc7n92shpcs8w";
   };
 
   propagatedBuildInputs = [
@@ -28,7 +28,6 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "autoit-ripper==1.0.0" "autoit-ripper" \
-      --replace "karton.core==4.0.4" "karton-core" \
       --replace "malduck==3.1.0" "malduck>=3.1.0" \
       --replace "regex==2020.2.20" "regex>=2020.2.20"
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
