### PR TITLE
haskell.packages: deal with evaluation fall out of most recent stackage update

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1937,4 +1937,19 @@ EOT
   # https://github.com/kcsongor/generic-lens/issues/133
   generic-optics = dontCheck super.generic-optics;
 
+  # 2021-05-19: Allow random 1.2.0
+  # Remove at (presumably next release) which is > 1.3.1.0
+  hashable = overrideCabal super.hashable (drv: {
+    patches = [
+      (pkgs.fetchpatch {
+        url = "https://github.com/haskell-unordered-containers/hashable/commit/78fa8fdb4f8bec5d221f34110d6afa0d0a00b5f9.patch";
+        sha256 = "0bzgp9qf53zk4rzk73x5cf2kfqncvlmihcallpplaibpslzalyi4";
+      })
+    ] ++ (drv.patches or []);
+    # fix line endings preventing patch from applying
+    prePatch = ''
+      ${pkgs.dos2unix}/bin/dos2unix hashable.cabal
+    '' + (drv.prePatch or "");
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -267,7 +267,7 @@ self: super: {
   GLFW-b = dontCheck super.GLFW-b;                      # https://github.com/bsl/GLFW-b/issues/50
   #next release supports random 1.1; jailbroken because i didn't know about vty when glguy was updating the bounds
   #should be fixed soon. maybe even before this is merged. currently glirc is 2.37
-  glirc = doJailbreak (super.glirc.override { random = self.random_1_2_0; });
+  glirc = doJailbreak super.glirc;
   hackport = dontCheck super.hackport;
   hadoop-formats = dontCheck super.hadoop-formats;
   haeredes = dontCheck super.haeredes;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1461,9 +1461,6 @@ self: super: {
     ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_0_0_4;
   });
 
-  # 2021-03-09: Overrides because nightly is to old for hls 1.0.0
-  lsp-test = doDistribute (dontCheck self.lsp-test_0_14_0_0);
-
   # 2021-03-21 Test hangs
   # https://github.com/haskell/haskell-language-server/issues/1562
   # Jailbreak because of: https://github.com/haskell/haskell-language-server/pull/1595

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -47,8 +47,6 @@ self: super: {
   cabal-install = super.cabal-install.overrideScope (self: super: {
     Cabal = self.Cabal_3_4_0_0;
     base16-bytestring = self.base16-bytestring_0_1_1_7;
-    random = dontCheck super.random_1_2_0;  # break infinite recursion
-    hashable = doJailbreak super.hashable;  # allow random 1.2.x
   });
 
   # cabal-install-parsers is written for Cabal 3.4

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -60,8 +60,6 @@ self: super: {
   cabal-install = super.cabal-install.overrideScope (self: super: {
     Cabal = self.Cabal_3_4_0_0;
     base16-bytestring = self.base16-bytestring_0_1_1_7;
-    random = dontCheck super.random_1_2_0;  # break infinite recursion
-    hashable = doJailbreak super.hashable;  # allow random 1.2.x
   });
 
   # Ignore overly restrictive upper version bounds.

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -48,8 +48,6 @@ self: super: {
   cabal-install = (doJailbreak super.cabal-install).overrideScope (self: super: {
     Cabal = null;
     base16-bytestring = self.base16-bytestring_0_1_1_7;
-    random = dontCheck super.random_1_2_0;  # break infinite recursion
-    hashable = doJailbreak super.hashable;  # allow random 1.2.x
   });
 
   # Jailbreaks & Version Updates

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -803,4 +803,9 @@ self: super: builtins.intersectAttrs super {
   hw-prim-bits = overrideCabal super.hw-prim-bits {
     platforms = pkgs.lib.platforms.x86;
   };
+
+  # random 1.2.0 has tests that indirectly depend on
+  # itself causing an infinite recursion at evaluation
+  # time
+  random = dontCheck super.random;
 }


### PR DESCRIPTION
random 1.2.0 has a new test suite with a lot of dependencies. Among
other packages it depends on doctest which depends on syb which depends
on tasty which depends on optparse-applicative which depends on
QuickCheck which depends on -- you guessed it -- random!

The cycle could be broken at any point of course, I've disabled the
tests on random here because it has seen the change that causes all
of this. However, we may also want to consider doing this for
optparse-applicative instead, since random seems like a more critical
package to run the tests for possibly? Not sure, looking for feedback.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
