### PR TITLE
Mark wayland broken on Darwin/Big Sur

### DIFF
--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -111,6 +111,8 @@ stdenv.mkDerivation rec {
     license = licenses.mit; # Expat version
     platforms = if withLibraries then platforms.linux else platforms.unix;
     maintainers = with maintainers; [ primeos codyopel qyliss ];
+    # big sur doesn't support gcc stdenv and wayland doesn't build with clang
+    broken = stdenv.isDarwin;
   };
 
   passthru.version = version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF: #122042, ping @NixOS/nixos-release-managers 

As mentioned in the comment, it seems like in the work @thefloweringash & co did to get nixpkgs working on Big Sur means that apps that need GCC to build no longer work (like Wayland). Maybe there is a way to bring support back, but at least for now it's broken. 

On a side note, is there a way to check if stdenv is using clang or gcc? maybe a better check would be to check for clang instead. 

Also, it does seem like GCC does work on big sur now https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97865 so maybe we can fix this. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
