### PR TITLE
bcal: cleanup package, enable aarch64-darwin build

### DIFF
--- a/pkgs/applications/science/math/bcal/default.nix
+++ b/pkgs/applications/science/math/bcal/default.nix
@@ -1,6 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, python3Packages, readline, bc }:
-
-with lib;
+{ lib
+, stdenv
+, fetchFromGitHub
+, readline
+, bc
+, python3Packages
+}:
 
 stdenv.mkDerivation rec {
   pname = "bcal";
@@ -13,23 +17,21 @@ stdenv.mkDerivation rec {
     sha256 = "4vR5rcbNkoEdSRNoMH9qMHP3iWFxejkVfXNiYfwbo/A=";
   };
 
-  nativeBuildInputs = [ python3Packages.pytest ];
-
   buildInputs = [ readline ];
 
+  installFlags = [ "PREFIX=$(out)" ];
+
   doCheck = true;
-  checkInputs = [ bc ];
-  checkPhase = ''
-    python3 -m pytest test.py
-  '';
 
-  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+  checkInputs = [ bc python3Packages.pytestCheckHook ];
 
-  meta = {
+  pytestFlagsArray = [ "test.py" ];
+
+  meta = with lib; {
     description = "Storage conversion and expression calculator";
     homepage = "https://github.com/jarun/bcal";
     license = licenses.gpl3Only;
-    platforms = [ "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
+    platforms = platforms.unix;
     maintainers = with maintainers; [ jfrankenau ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- cleanup package
- enable aarch64-darwin build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
