### PR TITLE
eclib: 20190909 -> 20210625, import sage update patch

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -126,6 +126,15 @@ stdenv.mkDerivation rec {
       rev = "bc84af8c795b7da433d2000afc3626ee65ba28b8";
       sha256 = "sha256-5Kvs9jarC8xRIU1rdmvIWxQLC25ehiTLJpg5skh8WNM=";
     })
+
+    # eclib 20210625 update
+    # https://trac.sagemath.org/ticket/31443
+    (fetchSageDiff {
+      base = "9.4.beta3";
+      name = "eclib-20210625.patch";
+      rev = "789550ca04c94acfb1e803251538996a34962038";
+      sha256 = "sha256-VlyEn5hg3joG8t/GwiRfq9TzJ54AoHxLolsNQ3shc2c=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/development/libraries/eclib/default.nix
+++ b/pkgs/development/libraries/eclib/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchFromGitHub
+, fetchurl
 , autoreconfHook
 , pari
 , ntl
@@ -14,16 +14,22 @@ assert withFlint -> flint != null;
 
 stdenv.mkDerivation rec {
   pname = "eclib";
-  version = "20190909"; # upgrade might break the sage interface
+  version = "20210625"; # upgrade might break the sage interface
   # sage tests to run:
   # src/sage/interfaces/mwrank.py
   # src/sage/libs/eclib
   # ping @timokau for more info
-  src = fetchFromGitHub {
-    owner = "JohnCremona";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0y1vdi4120gdw56gg2dn3wh625yr9wpyk3wpbsd25w4lv83qq5da";
+  src = fetchurl {
+    # all releases for this project appear on its GitHub releases page
+    # by definition! other distros sometimes update whenever they see
+    # a version bump in configure.ac or a new tag (and this might show
+    # up on repology). however, a version bump or a new tag may not
+    # represent a new release, and a new release might not be tagged.
+    #
+    # see https://github.com/JohnCremona/eclib/issues/64#issuecomment-789788561
+    # for upstream's explanation of the above
+    url = "https://github.com/JohnCremona/eclib/releases/download/${version}/eclib-${version}.tar.bz2";
+    sha256 = "sha256-fA3MPz/L+Q39sA8wxAYOUowlHRcgOd8VF4tpsBGI6BA=";
   };
   buildInputs = [
     pari


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package update. 

This employs the same "`fetchpatch` to fetch a diff from `sagetrac-mirror`" strategy used in #122624 because the [eclib Sage update ticket](https://trac.sagemath.org/ticket/31443) was [positively reviewed](https://trac.sagemath.org/ticket/31443#comment:91) but has not been merged yet. I am not in a hurry to get this in 21.05 because I think few (if any) people use eclib outside Sage, and since Sage 9.3 ships with eclib 20190909 no one expects a more recent version. But I am not the best person to decide this, so here's a PR to make all options available.

Fixes #114960. 

(I didn't check if the diff/patch distinction matters this time. `.diff` just seemed better because there were 20-ish commits in the Trac ticket.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
