### PR TITLE
sage: update tests to adapt to matplotlib and sphinx upgrades

### DIFF
--- a/pkgs/applications/science/math/sage/patches/sphinx-3.5-code-output.patch
+++ b/pkgs/applications/science/math/sage/patches/sphinx-3.5-code-output.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/misc/sagedoc.py b/src/sage/misc/sagedoc.py
+index 6bad826a88..f4d7b8651c 100644
+--- a/src/sage/misc/sagedoc.py
++++ b/src/sage/misc/sagedoc.py
+@@ -24,7 +24,7 @@ see :trac:`12849`::
+     ....:     for line in fobj:
+     ....:         if "#sage.symbolic.expression.Expression.numerical_approx" in line:
+     ....:             print(line)
+-    <code class="sig-name descname">numerical_approx</code><span class="sig-paren">(</span><em class="sig-param"><span class="n">prec</span><span class="o">=</span><span class="default_value">None</span></em>, <em class="sig-param"><span class="n">digits</span><span class="o">=</span><span class="default_value">None</span></em>, <em class="sig-param"><span class="n">algorithm</span><span class="o">=</span><span class="default_value">None</span></em><span class="sig-paren">)</span>...
++    <code class="sig-name descname"><span class="pre">numerical_approx</span></code><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">prec</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">digits</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">algorithm</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span>...
+ 
+ Check that sphinx is not imported at Sage start-up::
+ 

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -79,6 +79,13 @@ stdenv.mkDerivation rec {
     # ignore a deprecation warning for usage of `cmp` in the attrs library in the doctests
     ./patches/ignore-cmp-deprecation.patch
 
+    # sphinx 3.5 pretty-prints code slightly differently than sphinx
+    # 3.1--3.3. a similar patch is available at the sphinx 4 ticket
+    # (https://trac.sagemath.org/ticket/31696), but sphinx 3.5 uses
+    # <code> tags while sphinx 4 uses <span> tags so we cannot just
+    # import the patch from trac.
+    ./patches/sphinx-3.5-code-output.patch
+
     # remove use of matplotlib function deprecated in 3.4
     # https://trac.sagemath.org/ticket/31827
     (fetchSageDiff {

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -79,6 +79,15 @@ stdenv.mkDerivation rec {
     # ignore a deprecation warning for usage of `cmp` in the attrs library in the doctests
     ./patches/ignore-cmp-deprecation.patch
 
+    # remove use of matplotlib function deprecated in 3.4
+    # https://trac.sagemath.org/ticket/31827
+    (fetchSageDiff {
+      base = "9.3";
+      name = "remove-matplotlib-deprecated-function.patch";
+      rev = "32b2bcaefddc4fa3d2aee6fa690ce1466cbb5948";
+      sha256 = "sha256-SXcUGBMOoE9HpuBzgKC3P6cUmM5MiktXbe/7dVdrfWo=";
+    })
+
     # https://trac.sagemath.org/ticket/30801. this patch has
     # positive_review but has not been merged upstream yet, so we
     # don't use fetchSageDiff because it returns a file that contains

--- a/pkgs/applications/science/math/sage/sagedoc.nix
+++ b/pkgs/applications/science/math/sage/sagedoc.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     mv html/en/_static{,.tmp}
     for _dir in `find -name _static` ; do
           rm -r $_dir
-          ln -s /share/doc/sage/html/en/_static $_dir
+          ln -s html/en/_static $_dir
     done
     mv html/en/_static{.tmp,}
   '';


### PR DESCRIPTION
###### Motivation for this change

Sage is currently broken on Nixpkgs master because the Matplotlib upgrade from #119008 just graduated from staging-next.

ZHF: #122042
@NixOS/nixos-release-managers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
