### PR TITLE
tiramisu: 1.0 -> unstable-2021-05-20

### DIFF
--- a/pkgs/applications/misc/tiramisu/default.nix
+++ b/pkgs/applications/misc/tiramisu/default.nix
@@ -1,19 +1,15 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, glib }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "tiramisu";
-  version = "1.0";
+  version = "unstable-2021-05-20";
 
   src = fetchFromGitHub {
     owner = "Sweets";
-    repo = pname;
-    rev = version;
-    sha256 = "0aw17riwgrhsmcndzh7sw2zw8xvn3d203c2gcrqi9nk5pa7fwp9m";
+    repo = "tiramisu";
+    rev = "e53833d0b5b0ae41ceb7dc434d8e25818fe62291";
+    sha256 = "sha256-F4oaTOAQQfOkEXeBVbGH+0CHc9v9Ac08GyzHliOdAfc=";
   };
-
-  postPatch = ''
-    sed -i 's/printf(element_delimiter)/printf("%s", element_delimiter)/' src/output.c
-  '';
 
   buildInputs = [ glib ];
 
@@ -24,13 +20,13 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Desktop notifications, the UNIX way";
     longDescription = ''
-    tiramisu is a notification daemon based on dunst that outputs notifications
-    to STDOUT in order to allow the user to process notifications any way they
-    prefer.
+      tiramisu is a notification daemon based on dunst that outputs notifications
+      to STDOUT in order to allow the user to process notifications any way they
+      prefer.
     '';
     homepage = "https://github.com/Sweets/tiramisu";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wishfort36 ];
+    maintainers = with maintainers; [ wishfort36 fortuneteller2k ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
