### PR TITLE
jdk8: Remove default java.library.path

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -106,6 +106,7 @@ let
       ./fix-java-home-jdk8.patch
       ./read-truststore-from-env-jdk8.patch
       ./currency-date-range-jdk8.patch
+      ./fix-library-path-jdk8.patch
     ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk8.patch
     ];

--- a/pkgs/development/compilers/openjdk/fix-library-path-jdk8.patch
+++ b/pkgs/development/compilers/openjdk/fix-library-path-jdk8.patch
@@ -1,0 +1,37 @@
+diff --git a/hotspot/src/os/linux/vm/os_linux.cpp b/hotspot/src/os/linux/vm/os_linux.cpp
+index c477851c1b..ff5e28d95b 100644
+--- a/hotspot/src/os/linux/vm/os_linux.cpp
++++ b/hotspot/src/os/linux/vm/os_linux.cpp
+@@ -368,13 +368,13 @@ void os::init_system_properties_values() {
+ //        ...
+ //        7: The default directories, normally /lib and /usr/lib.
+ #if defined(AMD64) || defined(_LP64) && (defined(SPARC) || defined(PPC) || defined(S390))
+-#define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
++#define DEFAULT_LIBPATH ""
+ #else
+-#define DEFAULT_LIBPATH "/lib:/usr/lib"
++#define DEFAULT_LIBPATH ""
+ #endif
+ 
+ // Base path of extensions installed on the system.
+-#define SYS_EXT_DIR     "/usr/java/packages"
++#define SYS_EXT_DIR     ""
+ #define EXTENSIONS_DIR  "/lib/ext"
+ #define ENDORSED_DIR    "/lib/endorsed"
+ 
+@@ -437,13 +437,13 @@ void os::init_system_properties_values() {
+                                                      strlen(v) + 1 +
+                                                      sizeof(SYS_EXT_DIR) + sizeof("/lib/") + strlen(cpu_arch) + sizeof(DEFAULT_LIBPATH) + 1,
+                                                      mtInternal);
+-    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib/%s:" DEFAULT_LIBPATH, v, v_colon, cpu_arch);
++    sprintf(ld_library_path, "%s%s", v);
+     Arguments::set_library_path(ld_library_path);
+     FREE_C_HEAP_ARRAY(char, ld_library_path, mtInternal);
+   }
+ 
+   // Extensions directories.
+-  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
++  sprintf(buf, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
+   Arguments::set_ext_dirs(buf);
+ 
+   // Endorsed standards default directory.


### PR DESCRIPTION
###### Motivation for this change

This patch fixes https://github.com/NixOS/nixpkgs/issues/103493 for **JDK8 only**.

I'm upstreaming only for JDK8 to get quorum on the approach and then
adding the patches to the remaining versions.

```bash
❯ ./result/bin/java -XshowSettings:properties
Property settings:
    awt.toolkit = sun.awt.X11.XToolkit
    file.encoding = UTF-8
    file.encoding.pkg = sun.io
    file.separator = /
    java.awt.graphicsenv = sun.awt.X11GraphicsEnvironment
    java.awt.printerjob = sun.print.PSPrinterJob
    java.class.path = .
    java.class.version = 52.0
    java.endorsed.dirs = /nix/store/nhlpy8zcxncw52ylmk8aacii3h00cmf0-openjdk-8u272-b10/lib/openjdk/jre
    java.ext.dirs = /nix/store/nhlpy8zcxncw52ylmk8aacii3h00cmf0-openjdk-8u272-b10/lib/openjdk/jre
    java.home = /nix/store/nhlpy8zcxncw52ylmk8aacii3h00cmf0-openjdk-8u272-b10/lib/openjdk/jre
    java.io.tmpdir = /tmp
    java.library.path = (null)
```

See  `java.library.path = (null)`
Previously it was:
```
java.library.path = /usr/java/packages/lib
        /usr/lib/x86_64-linux-gnu/jni
        /lib/x86_64-linux-gnu
        /usr/lib/x86_64-linux-gnu
        /usr/lib/jni
        /lib
        /usr/lib
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
