### PR TITLE
megacmd: temporarily remove ffmpeg dependency

### DIFF
--- a/pkgs/applications/misc/megacmd/default.nix
+++ b/pkgs/applications/misc/megacmd/default.nix
@@ -6,7 +6,9 @@
 , cryptopp
 , curl
 , fetchFromGitHub
-, ffmpeg_3 # build fails with latest ffmpeg, see https://github.com/meganz/MEGAcmd/issues/523
+  # build fails with latest ffmpeg, see https://github.com/meganz/MEGAcmd/issues/523.
+  # to be re-enabled when patch available
+  # , ffmpeg
 , freeimage
 , gcc-unwrapped
 , libmediainfo
@@ -44,7 +46,7 @@ stdenv.mkDerivation rec {
     c-ares
     cryptopp
     curl
-    ffmpeg_3
+    # ffmpeg
     freeimage
     gcc-unwrapped
     libmediainfo
@@ -67,7 +69,7 @@ stdenv.mkDerivation rec {
     "--with-cares"
     "--with-cryptopp"
     "--with-curl"
-    "--with-ffmpeg"
+    # "--with-ffmpeg"
     "--with-freeimage"
     "--with-libmediainfo"
     "--with-libuv"


### PR DESCRIPTION
###### Motivation for this change

Build fails against ffmpeg 4.4, and ffmpeg_3 is to be marked insecure.

Can check off megacmd on #120705 once merged. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
