### PR TITLE
harfbuzz: cross compilation

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -28,6 +28,7 @@ let
   inherit (lib) optional optionals optionalString;
   mesonFeatureFlag = opt: b:
     "-D${opt}=${if b then "enabled" else "disabled"}";
+  isNativeCompilation = stdenv.buildPlatform == stdenv.hostPlatform;
 in
 
 stdenv.mkDerivation {
@@ -56,6 +57,7 @@ stdenv.mkDerivation {
     (mesonFeatureFlag "graphite" withGraphite2)
     (mesonFeatureFlag "icu" withIcu)
     (mesonFeatureFlag "coretext" withCoreText)
+    (mesonFeatureFlag "introspection" isNativeCompilation)
   ];
 
   nativeBuildInputs = [
@@ -71,7 +73,8 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [ glib freetype cairo ] # recommended by upstream
-    ++ lib.optionals withCoreText [ ApplicationServices CoreText ];
+    ++ lib.optionals withCoreText [ ApplicationServices CoreText ]
+    ++ lib.optionals isNativeCompilation [ gobject-introspection ];
 
   propagatedBuildInputs = optional withGraphite2 graphite2
     ++ optionals withIcu [ icu harfbuzz ];

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -73,8 +73,7 @@ stdenv.mkDerivation {
   buildInputs = [ glib freetype cairo ] # recommended by upstream
     ++ lib.optionals withCoreText [ ApplicationServices CoreText ];
 
-  propagatedBuildInputs = [ ]
-    ++ optional withGraphite2 graphite2
+  propagatedBuildInputs = optional withGraphite2 graphite2
     ++ optionals withIcu [ icu harfbuzz ];
 
   doCheck = true;

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -1,13 +1,26 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, glib, freetype, cairo, libintl
-, meson, ninja
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, glib
+, freetype
+, cairo
+, libintl
+, meson
+, ninja
 , gobject-introspection
-, icu, graphite2, harfbuzz # The icu variant uses and propagates the non-icu one.
-, ApplicationServices, CoreText
+, icu
+, graphite2
+, harfbuzz # The icu variant uses and propagates the non-icu one.
+, ApplicationServices
+, CoreText
 , withCoreText ? false
 , withIcu ? false # recommended by upstream as default, but most don't needed and it's big
 , withGraphite2 ? true # it is small and major distros do include it
 , python3
-, gtk-doc, docbook-xsl-nons, docbook_xml_dtd_43
+, gtk-doc
+, docbook-xsl-nons
+, docbook_xml_dtd_43
 }:
 
 let
@@ -21,9 +34,9 @@ stdenv.mkDerivation {
   name = "harfbuzz${optionalString withIcu "-icu"}-${version}";
 
   src = fetchFromGitHub {
-    owner  = "harfbuzz";
-    repo   = "harfbuzz";
-    rev    = version;
+    owner = "harfbuzz";
+    repo = "harfbuzz";
+    rev = version;
     sha256 = "sha256-JnvOFGK2HWIpzuwgZtyt0IfKfnoXD1LMeVb3RzMmyY4=";
   };
 
@@ -60,7 +73,7 @@ stdenv.mkDerivation {
   buildInputs = [ glib freetype cairo ] # recommended by upstream
     ++ lib.optionals withCoreText [ ApplicationServices CoreText ];
 
-  propagatedBuildInputs = []
+  propagatedBuildInputs = [ ]
     ++ optional withGraphite2 graphite2
     ++ optionals withIcu [ icu harfbuzz ];
 


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation by disabling introspection. Tested by building for aarch64-multiplatform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
