### PR TITLE
1config: init at 0.21.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2245,6 +2245,12 @@
     email = "christoph.senjak@googlemail.com";
     name = "Christoph-Simon Senjak";
   };
+  davewm = {
+    name = "Dave Martin";
+    email = "mail@davemartin.me";
+    github = "davewm";
+    githubId = 5785709;
+  };
   davhau = {
     email = "d.hauer.it@gmail.com";
     name = "David Hauer";

--- a/pkgs/tools/misc/1config/default.nix
+++ b/pkgs/tools/misc/1config/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv
+, autoPatchelfHook
+, fetchurl
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  name = "1config";
+  version = "0.21.0";
+
+  buildInputs = [ stdenv.cc.cc.lib zlib ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  src = fetchurl {
+    url = "https://github.com/BrunoBonacci/1config/releases/download/${version}/1cfg-Linux";
+    sha256 = "0rynj8q903i3gypgmyvv43vk0hfz3q7bk2l65pmmk6fhyg9r2r9z";
+    executable = true;
+  };
+
+  uisrc = fetchurl {
+    url = "https://github.com/BrunoBonacci/1config/releases/download/${version}/1cfg-ui-beta";
+    sha256 = "059jf9pm13bsk2cpccdr7pdcg46nbhx83d6wscvbid7p34sl4w6q";
+    executable = true;
+  };
+
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/1cfg
+    cp $uisrc $out/bin/1cfg-ui-beta
+  '';
+
+  meta = with lib; {
+    description = "A tool and a library to manage application secrets and configuration safely and effectively";
+    homepage = "https://github.com/BrunoBonacci/1config";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ davewm ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -677,6 +677,8 @@ in
 
   _3mux = callPackage ../tools/misc/3mux { };
 
+  _1config = callPackage ../tools/misc/1config { };
+
   _1password = callPackage ../applications/misc/1password { };
 
   _1password-gui = callPackage ../applications/misc/1password-gui { };


### PR DESCRIPTION
###### Motivation for this change

To add the [1config](https://github.com/BrunoBonacci/1config) tool.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes

The package installs 2 binaries, `1cfg` and `1cfg-ui-beta`. To test `1cfg`, you should be able to just run `1cfg LIST`. To test `1cfg-ui-beta`, you'll need some AWS creds set up in `~/.aws/credentials`, then run `1cfg-ui-beta` and navigate to `localhost:5300` in the browser. 

