### PR TITLE
st: support cross-compilation

### DIFF
--- a/pkgs/applications/terminal-emulators/st/default.nix
+++ b/pkgs/applications/terminal-emulators/st/default.nix
@@ -1,5 +1,17 @@
-{ lib, stdenv, fetchurl, pkg-config, writeText, libX11, ncurses
-, libXft, conf ? null, patches ? [], extraLibs ? []}:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, writeText
+, libX11
+, ncurses
+, fontconfig
+, freetype
+, libXft
+, conf ? null
+, patches ? [ ]
+, extraLibs ? [ ]
+}:
 
 with lib;
 
@@ -14,15 +26,29 @@ stdenv.mkDerivation rec {
 
   inherit patches;
 
-  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  configFile = optionalString (conf != null) (writeText "config.def.h" conf);
 
-  postPatch = optionalString (conf!=null) "cp ${configFile} config.def.h"
-            + optionalString stdenv.isDarwin ''
+  postPatch = optionalString (conf != null) "cp ${configFile} config.def.h"
+    + optionalString stdenv.isDarwin ''
     substituteInPlace config.mk --replace "-lrt" ""
   '';
 
-  nativeBuildInputs = [ pkg-config ncurses ];
-  buildInputs = [ libX11 libXft ] ++ extraLibs;
+  strictDeps = true;
+
+  makeFlags = [
+    "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    ncurses
+    fontconfig
+    freetype
+  ];
+  buildInputs = [
+    libX11
+    libXft
+  ] ++ extraLibs;
 
   installPhase = ''
     TERMINFO=$out/share/terminfo make install PREFIX=$out

--- a/pkgs/applications/terminal-emulators/st/default.nix
+++ b/pkgs/applications/terminal-emulators/st/default.nix
@@ -51,7 +51,9 @@ stdenv.mkDerivation rec {
   ] ++ extraLibs;
 
   installPhase = ''
+    runHook preInstall
     TERMINFO=$out/share/terminfo make install PREFIX=$out
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Support cross-compiling st (at least for aarch64-multiplatform).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
