### PR TITLE
uade: init at 2.13

### DIFF
--- a/pkgs/applications/audio/uade/default.nix
+++ b/pkgs/applications/audio/uade/default.nix
@@ -1,0 +1,28 @@
+{lib, stdenv, fetchurl, pkg-config, which, libao}:
+
+stdenv.mkDerivation {
+  name = "uade-2.13";
+  src = fetchurl {
+    url = "http://zakalwe.fi/uade/uade2/uade-2.13.tar.bz2";
+    sha256 = "04nn5li7xy4g5ysyjjngmv5d3ibxppkbb86m10vrvadzxdd4w69v";
+  };
+
+  buildInputs = [ pkg-config which libao ];
+
+  preBuild = ''
+    # Force not using -Wformat to become an error
+    sed -i -e "s|-Wno-format|-Wno-format -Wno-error=format-security|g" src/Makefile
+
+    # Fix warnings are errors problem related to the missing return types of freopen and fscanf
+    sed -i -e 's|freopen ("cpuemu.c|(void)!freopen ("cpuemu.c|' \
+      -e 's|fscanf (file, "Total|(void)!fscanf (file, "Total|' src/gencpu.c
+  '';
+
+  meta = with lib; {
+    description = "UADE plays old Amiga tunes through UAE emulation and cloned m68k-assembler Eagleplayer API";
+    homepage = "http://zakalwe.fi/uade/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ sander ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9178,6 +9178,8 @@ in
 
   ua = callPackage ../tools/networking/ua { };
 
+  uade = callPackage ../applications/audio/uade { };
+
   ubidump = python3Packages.callPackage ../tools/filesystems/ubidump { };
 
   ubridge = callPackage ../tools/networking/ubridge { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
