### PR TITLE
python3Packages.envoy-reader: init at 0.19.0

### DIFF
--- a/pkgs/development/python-modules/envoy-reader/default.nix
+++ b/pkgs/development/python-modules/envoy-reader/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, pytest-asyncio
+, pytest-raises
+, pytest-runner
+, pytestCheckHook
+, respx
+}:
+
+buildPythonPackage rec {
+  pname = "envoy-reader";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "jesserizzo";
+    repo = "envoy_reader";
+    rev = version;
+    sha256 = "0jyrgm7dc6k66c94gadc69a6xsv2b48wn3b3rbpwgbssi5s7iiz6";
+  };
+
+  nativeBuildInputs = [
+    pytest-runner
+  ];
+
+  propagatedBuildInputs = [
+    httpx
+  ];
+
+  checkInputs = [
+    pytest-raises
+    pytest-asyncio
+    pytestCheckHook
+    respx
+  ];
+
+  pythonImportsCheck = [ "envoy_reader" ];
+
+  meta = with lib; {
+    description = "Python module to read from Enphase Envoy units";
+    homepage = "https://github.com/jesserizzo/envoy_reader";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -225,7 +225,7 @@
     "emulated_roku" = ps: with ps; [ ]; # missing inputs: emulated_roku
     "enigma2" = ps: with ps; [ openwebifpy ];
     "enocean" = ps: with ps; [ ]; # missing inputs: enocean
-    "enphase_envoy" = ps: with ps; [ ]; # missing inputs: envoy_reader
+    "enphase_envoy" = ps: with ps; [ envoy-reader ];
     "entur_public_transport" = ps: with ps; [ ]; # missing inputs: enturclient
     "environment_canada" = ps: with ps; [ ]; # missing inputs: env_canada
     "envirophat" = ps: with ps; [ smbus-cffi ]; # missing inputs: envirophat

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -325,6 +325,7 @@ in with py.pkgs; buildPythonApplication rec {
     "efergy"
     "emonitor"
     "emulated_hue"
+    "enphase_envoy"
     "esphome"
     "everlights"
     "ezviz"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2193,6 +2193,8 @@ in {
 
   envs = callPackage ../development/python-modules/envs { };
 
+  envoy-reader = callPackage ../development/python-modules/envoy-reader { };
+
   enzyme = callPackage ../development/python-modules/enzyme { };
 
   epc = callPackage ../development/python-modules/epc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to read from Enphase Envoy units

https://github.com/jesserizzo/envoy_reader

This is a Home Assistant depedency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
