### PR TITLE
ruby: improve reproducibility of gem builds

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -218,7 +218,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     # looks like useless files which break build repeatability and consume space
     pushd $out/${ruby.gemPath}
     find doc/ -iname created.rid -delete -print
-    find gems/*/ext/ extensions/ \( -iname Makefile -o -iname mkmf.log -o -iname gem_make.out \) -delete -print
+    find gems/*/ext/ extensions/ \( -iname Makefile -o -iname mkmf.log -o -iname gem_make.out -o \( -type d -regex '.*/.gem\.[0-9]+-.*' \) \) -delete -print
     ${if keepGemCache then "" else "rm -fvr cache"}
     popd
 


### PR DESCRIPTION
###### Motivation for this change

By default, the gem build will leave a path like:
  lib/ruby/gems/2.7.0/gems/racc-1.5.2/ext/racc/cparse/.gem.20210503-6-csuqdb

putting the build date in the output hurts the build reproducibility
efforts

see #123718

This is the tmp directory here https://github.com/ruby/ruby/blob/adcbae8d49ec04d365ce13274783b1495c3c7d0e/lib/rubygems/ext/ext_conf_builder.rb#L15
https://github.com/ruby/ruby/blob/adcbae8d49ec04d365ce13274783b1495c3c7d0e/lib/tmpdir.rb#L140
that is not collected correctly.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
