### PR TITLE
python3Packages.hdbscan: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -35,6 +35,12 @@ buildPythonPackage rec {
     rm __init__.py
   '';
   checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # known flaky tests: https://github.com/scikit-learn-contrib/hdbscan/issues/420
+    "test_mem_vec_diff_clusters"
+    "test_all_points_mem_vec_diff_clusters"
+    "test_approx_predict_diff_clusters"
+  ];
 
   meta = with lib; {
     description = "Hierarchical Density-Based Spatial Clustering of Applications with Noise, a clustering algorithm with a scikit-learn compatible API";


### PR DESCRIPTION
###### Motivation for this change
This test is acknowledged to be flaky: https://github.com/scikit-learn-contrib/hdbscan/issues/420

ZHF #122042
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
