### PR TITLE
xh: add shell completion, xhs symlink

### DIFF
--- a/pkgs/tools/networking/xh/default.nix
+++ b/pkgs/tools/networking/xh/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, openssl, pkg-config, rustPlatform, fetchFromGitHub, Security
-, libiconv }:
+, libiconv, installShellFiles }:
 
 rustPlatform.buildRustPackage rec {
   pname = "xh";
@@ -9,19 +9,27 @@ rustPlatform.buildRustPackage rec {
     owner = "ducaale";
     repo = "xh";
     rev = "v${version}";
-    sha256 = "sha256-eOP9sc1qmQuc3HecNNZDMarVkXmEfGZkan0H9598LC0=";
+    sha256 = "0b9cgjgzf1vxd9j6cz44g68xbaii8gb3973pvjf0p6barnqzvqvq";
   };
 
-  cargoSha256 = "sha256-JXywHuZPQVhuWBVUNi9k8TwgE8KCNDtucjxxDi6unVM=";
+  cargoSha256 = "0lwxmqp0ww9wf9p3nd42q89j0g7ichpkcm0mb1p5hhagwqgb0z15";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ installShellFiles pkg-config ];
 
   buildInputs = if stdenv.isDarwin then [ Security libiconv ] else [ openssl ];
 
   # Get openssl-sys to use pkg-config
   OPENSSL_NO_VENDOR = 1;
 
-  checkFlagsArray = [ "--skip=basic_options" ];
+  postInstall = ''
+    installShellCompletion --cmd xh \
+      --bash completions/xh.bash \
+      --fish completions/xh.fish \
+      --zsh completions/_xh
+
+    # https://github.com/ducaale/xh#xh-and-xhs
+    ln -s $out/bin/xh $out/bin/xhs
+  '';
 
   # Nix build happens in sandbox without internet connectivity
   # disable tests as some of them require internet due to nature of application
@@ -29,10 +37,11 @@ rustPlatform.buildRustPackage rec {
   doInstallCheck = true;
   postInstallCheck = ''
     $out/bin/xh --help > /dev/null
+    $out/bin/xhs --help > /dev/null
   '';
 
   meta = with lib; {
-    description = "Yet another HTTPie clone in Rust";
+    description = "Friendly and fast tool for sending HTTP requests";
     homepage = "https://github.com/ducaale/xh";
     changelog = "https://github.com/ducaale/xh/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

Update version, contains fix for https://github.com/ducaale/xh/issues/135.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).