### PR TITLE
python3Packages.cirq: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -1,0 +1,98 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, matplotlib
+, networkx
+, numpy
+, pandas
+, requests
+, scipy
+, sortedcontainers
+, sympy
+, tqdm
+, typing-extensions
+  # Contrib requirements
+, withContribRequires ? false
+, autoray ? null
+, opt-einsum
+, ply
+, pylatex ? null
+, pyquil ? null
+, quimb ? null
+  # test inputs
+, pytestCheckHook
+, freezegun
+, pytest-asyncio
+}:
+buildPythonPackage rec {
+  pname = "cirq-core";
+  version = "0.11.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "quantumlib";
+    repo = "cirq";
+    rev = "v${version}";
+    hash = "sha256-JaKTGnkYhzIFb35SGaho8DRupoT0JFYKA5+rJEq4oXw=";
+  };
+
+  sourceRoot = "source/${pname}";
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "matplotlib~=3.0" "matplotlib" \
+      --replace "networkx~=2.4" "networkx" \
+      --replace "numpy~=1.16" "numpy" \
+      --replace "requests~=2.18" "requests"
+  '';
+
+  propagatedBuildInputs = [
+    matplotlib
+    networkx
+    numpy
+    pandas
+    requests
+    scipy
+    sortedcontainers
+    sympy
+    tqdm
+    typing-extensions
+  ] ++ lib.optionals withContribRequires [
+    autoray
+    opt-einsum
+    ply
+    pylatex
+    pyquil
+    quimb
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    freezegun
+  ];
+
+  pytestFlagsArray = lib.optionals (!withContribRequires) [
+    # requires external (unpackaged) libraries, so untested.
+    "--ignore=cirq/contrib/"
+  ];
+  disabledTests = [
+    "test_metadata_search_path" # tries to import flynt, which isn't in Nixpkgs
+    "test_benchmark_2q_xeb_fidelities" # fails due pandas MultiIndex. Maybe issue with pandas version in nix?
+  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+    # Seem to fail due to math issues on aarch64?
+    "expectation_from_wavefunction"
+    "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
+  ];
+
+  meta = with lib; {
+    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
+    homepage = "https://github.com/quantumlib/cirq";
+    changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, cirq-core
+, google-api-core
+, protobuf
+# test inputs
+, pytestCheckHook
+, freezegun
+}:
+
+buildPythonPackage rec {
+  pname = "cirq-google";
+  inherit (cirq-core) version src meta;
+
+  sourceRoot = "source/${pname}";
+
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "protobuf~=3.13.0" "protobuf"
+  '';
+
+  propagatedBuildInputs = [
+    cirq-core
+    google-api-core
+    protobuf
+  ];
+
+  checkInputs = [ pytestCheckHook freezegun ];
+}

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -1,114 +1,28 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonPackage
-, pythonOlder
-, fetchFromGitHub
-, google-api-core
-, matplotlib
-, networkx
-, numpy
-, pandas
-, protobuf
-, requests
-, scipy
-, sortedcontainers
-, sympy
-, tqdm
-, typing-extensions
+, cirq-core
+, cirq-google
   # test inputs
-, freezegun
 , pytestCheckHook
-, pytest-asyncio
-, pytest-benchmark
-, ply
-, pydot
-, pyyaml
-, pygraphviz
 }:
 
 buildPythonPackage rec {
   pname = "cirq";
-  version = "0.10.0";
-
-  disabled = pythonOlder "3.6";
-
-  src = fetchFromGitHub {
-    owner = "quantumlib";
-    repo = "cirq";
-    rev = "v${version}";
-    sha256 = "0xinml44n2lfl0q2lb2apmn69gsszlwim83082f66vyk0gpwd4lr";
-  };
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "matplotlib~=3.0" "matplotlib" \
-      --replace "networkx~=2.4" "networkx" \
-      --replace "numpy~=1.16" "numpy" \
-      --replace "protobuf~=3.13.0" "protobuf"
-  '';
+  inherit (cirq-core) version src meta;
 
   propagatedBuildInputs = [
-    google-api-core
-    matplotlib
-    networkx
-    numpy
-    pandas
-    protobuf
-    requests
-    scipy
-    sortedcontainers
-    sympy
-    tqdm
-    typing-extensions
+    cirq-core
+    cirq-google
   ];
 
   # pythonImportsCheck = [ "cirq" "cirq.Circuit" ];  # cirq's importlib hook doesn't work here
-  checkInputs = [
-    pytestCheckHook
-    freezegun
-    pytest-asyncio
-    pytest-benchmark
-    ply
-    pydot
-    pyyaml
-    pygraphviz
+  checkInputs = [ pytestCheckHook ];
+
+  # Don't run submodule or development tool tests
+  disabledTestPaths = [
+    "cirq-google"
+    "cirq-core"
+    "dev_tools"
   ];
 
-  pytestFlagsArray = [
-    "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
-    "--ignore=cirq/contrib/"  # requires external (unpackaged) python packages, so untested.
-    "--benchmark-disable" # Don't need to run benchmarks when packaging.
-  ];
-  disabledTests = lib.optionals stdenv.isAarch64 [
-    # Seem to fail due to math issues on aarch64?
-    "expectation_from_wavefunction"
-    "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
-  ] ++ [
-    # slow tests, for quicker building
-    "test_anneal_search_method_calls"
-    "test_density_matrix_from_state_tomography_is_correct"
-    "test_example_runs_qubit_characterizations"
-    "test_example_runs_hello_line_perf"
-    "test_example_runs_bc_mean_field_perf"
-    "test_main_loop"
-    "test_clifford_circuit_2"
-    "test_decompose_specific_matrices"
-    "test_two_qubit_randomized_benchmarking"
-    "test_kak_decomposition_perf"
-    "test_example_runs_simon"
-    "test_decompose_random_unitary"
-    "test_decompose_size_special_unitary"
-    "test_api_retry_5xx_errors"
-    "test_xeb_fidelity"
-    "test_example_runs_phase_estimator_perf"
-    "test_cross_entropy_benchmarking"
-  ];
-
-  meta = with lib; {
-    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
-    homepage = "https://github.com/quantumlib/cirq";
-    changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ drewrisinger ];
-  };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1363,6 +1363,8 @@ in {
 
   cirq-core = callPackage ../development/python-modules/cirq-core { };
 
+  cirq-google = callPackage ../development/python-modules/cirq-google { };
+
   ciscomobilityexpress = callPackage ../development/python-modules/ciscomobilityexpress { };
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1361,6 +1361,8 @@ in {
 
   cirq = callPackage ../development/python-modules/cirq { };
 
+  cirq-core = callPackage ../development/python-modules/cirq-core { };
+
   ciscomobilityexpress = callPackage ../development/python-modules/ciscomobilityexpress { };
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/quantumlib/Cirq/releases/tag/v0.11.0

Breaks the main cirq package into subpackages, which are combined into a metapackage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
