### PR TITLE
containerd: 1.5.1 -> 1.5.2, use buildGoModule

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchFromGitHub
-, buildGoPackage
+, buildGoModule
 , btrfs-progs
 , go-md2man
 , installShellFiles
@@ -8,19 +8,21 @@
 , nixosTests
 }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "containerd";
-  version = "1.5.1";
+  version = "1.5.2";
+
+  outputs = [ "out" "man" ];
 
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";
     rev = "v${version}";
-    sha256 = "sha256-1u+H/gJaQhltf/pq7uaAPEUlQ5R6ZByall2neNkon8s=";
+    sha256 = "sha256-RDLAmPBjDHCx9al+gstUTrvKc/L0vAm8IEd/mvX5Als=";
   };
 
-  goPackagePath = "github.com/containerd/containerd";
-  outputs = [ "out" "man" ];
+  vendorSha256 = "sha256-f+53pRifaYXjUxrN3YVg8JHGbIUsqZSehPxGTSxS6/s=";
+  deleteVendor = true;
 
   nativeBuildInputs = [ go-md2man installShellFiles util-linux ];
 
@@ -28,11 +30,9 @@ buildGoPackage rec {
 
   buildFlags = [ "VERSION=v${version}" "REVISION=${src.rev}" ];
 
-  BUILDTAGS = [ ]
-    ++ lib.optional (btrfs-progs == null) "no_btrfs";
+  BUILDTAGS = lib.optionals (btrfs-progs == null) [ "no_btrfs" ];
 
   buildPhase = ''
-    cd go/src/${goPackagePath}
     patchShebangs .
     make binaries man $buildFlags
   '';

--- a/pkgs/applications/virtualization/docker/containerd.nix
+++ b/pkgs/applications/virtualization/docker/containerd.nix
@@ -1,0 +1,57 @@
+# this is pinned because it still uses the old buildGoPackage
+{ lib
+, fetchFromGitHub
+, buildGoPackage
+, btrfs-progs
+, go-md2man
+, installShellFiles
+, util-linux
+, nixosTests
+}:
+
+buildGoPackage rec {
+  pname = "containerd";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "containerd";
+    repo = "containerd";
+    rev = "v${version}";
+    sha256 = "sha256-1u+H/gJaQhltf/pq7uaAPEUlQ5R6ZByall2neNkon8s=";
+  };
+
+  goPackagePath = "github.com/containerd/containerd";
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ go-md2man installShellFiles util-linux ];
+
+  buildInputs = [ btrfs-progs ];
+
+  buildFlags = [ "VERSION=v${version}" "REVISION=${src.rev}" ];
+
+  BUILDTAGS = [ ]
+    ++ lib.optional (btrfs-progs == null) "no_btrfs";
+
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    patchShebangs .
+    make binaries man $buildFlags
+  '';
+
+  installPhase = ''
+    install -Dm555 bin/* -t $out/bin
+    installManPage man/*.[1-9]
+    installShellCompletion --bash contrib/autocomplete/ctr
+    installShellCompletion --zsh --name _ctr contrib/autocomplete/zsh_autocomplete
+  '';
+
+  passthru.tests = { inherit (nixosTests) docker; };
+
+  meta = with lib; {
+    homepage = "https://containerd.io/";
+    description = "A daemon to control runC";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ offline vdemeester ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -32,7 +32,7 @@ rec {
       patches = [];
     });
 
-    docker-containerd = containerd.overrideAttrs (oldAttrs: {
+    docker-containerd = (callPackage ./containerd.nix {}).overrideAttrs (oldAttrs: {
       name = "docker-containerd-${version}";
       inherit version;
       src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
Closes: #123739

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
