### PR TITLE
python3Packages.nassl: fix build

### DIFF
--- a/pkgs/development/python-modules/nassl/default.nix
+++ b/pkgs/development/python-modules/nassl/default.nix
@@ -90,7 +90,7 @@ buildPythonPackage rec {
       ${opensslLegacyStatic.out}/lib/libcrypto.a \
       deps/openssl-OpenSSL_${legacyOpenSSLVersion}/
     ln -s ${opensslLegacyStatic.out.dev}/include deps/openssl-OpenSSL_${legacyOpenSSLVersion}/include
-    ln -s ${opensslLegacyStatic.bin} deps/openssl-OpenSSL_${legacyOpenSSLVersion}/apps
+    ln -s ${opensslLegacyStatic.bin}/bin deps/openssl-OpenSSL_${legacyOpenSSLVersion}/apps
 
     mkdir -p deps/openssl-OpenSSL_${modernOpenSSLVersion}/
     cp ${opensslStatic.out}/lib/libssl.a \


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042

Was broken when #119825 fixed `openssl.bin`'s `/bin` location.

An _interesting_ package. Got to wonder if we should mark it as vulnerable to all  openssl vulnerabilities back to 1.0.2e/1.1.1h..

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
