### PR TITLE
rubygems: ensure temporary directories are cleaned up

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -12,7 +12,7 @@ let
   opString = lib.optionalString;
   patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
   config = import ./config.nix { inherit fetchFromSavannah; };
-  rubygems = import ./rubygems { inherit stdenv lib fetchurl; };
+  rubygems = import ./rubygems { inherit stdenv lib fetchurl fetchpatch; };
 
   # Contains the ruby version heuristics
   rubyVersion = import ./ruby-version.nix { inherit lib; };

--- a/pkgs/development/interpreters/ruby/rubygems/default.nix
+++ b/pkgs/development/interpreters/ruby/rubygems/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl }:
+{ stdenv, lib, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "rubygems";
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
     ./0001-add-post-extract-hook.patch
     ./0002-binaries-with-env-shebang.patch
     ./0003-gem-install-default-to-user.patch
+    # Ensure tmp directory are not left behind
+    # https://github.com/rubygems/rubygems/pull/4610
+    (fetchpatch {
+      url = "https://github.com/rubygems/rubygems/commit/2c2ffde6e4a9f7f571d38af687034fb8507a833d.patch";
+      sha256 = "sha256-bs2dXALKiJvMgk7lKjMx0NzGqlEqDYBBO35UrzNifms=";
+    })
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

rubygems was leaving empty directories like:
```
lib/ruby/gems/2.7.0/gems/racc-1.5.2/ext/racc/cparse/.gem.20210503-6-csuqdb
```

see #123718 https://github.com/rubygems/rubygems/pull/4610

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
