### PR TITLE
helmfile: 0.139.3 -> 0.139.6

### DIFF
--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "helmfile";
-  version = "0.139.3";
+  version = "0.139.6";
 
   src = fetchFromGitHub {
     owner = "roboll";
     repo = "helmfile";
     rev = "v${version}";
-    sha256 = "sha256-Cg4FFTowrWMDfpaMJwrOSs3ykZxH378OMR+1+vJt5e8=";
+    sha256 = "sha256-pAo8MmQqqSICB4rguhkGHJqyB9fBBzpp7NEaa59rVb4=";
   };
 
   vendorSha256 = "sha256-Hs09CT/KSwYL2AKLseOjWB5Xvvr5TvbzwDywsGQ9kMw=";

--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, makeWrapper, kubernetes-helm }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, writeScript, kubernetes-helm }:
 
 buildGoModule rec {
   pname = "helmfile";
@@ -24,6 +24,12 @@ buildGoModule rec {
   postInstall = ''
     wrapProgram $out/bin/helmfile \
       --prefix PATH : ${lib.makeBinPath [ kubernetes-helm ]}
+  '';
+
+  passthru.updateScript = writeScript "update-helmfile" ''
+    set -eufo pipefail
+    latestTag=$(curl -s https://api.github.com/repos/${src.owner}/${src.repo}/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+    update-source-version ${pname} "''${latestTag#v}"
   '';
 
   meta = {

--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -27,9 +27,12 @@ buildGoModule rec {
   '';
 
   passthru.updateScript = writeScript "update-helmfile" ''
+    #! /usr/bin/env nix-shell
+    #! nix-shell -i bash -p common-updater-scripts curl findutils
     set -eufo pipefail
-    latestTag=$(curl -s https://api.github.com/repos/${src.owner}/${src.repo}/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-    update-source-version ${pname} "''${latestTag#v}"
+    curl -s https://api.github.com/repos/roboll/${pname}/releases/latest |
+        jq -e -r '.tag_name | ltrimstr("v")' |
+        xargs update-source-version ${pname}
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update to latest version, and add `passthru.updateScript`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
