### PR TITLE
kubernetes-helm: add updateScript

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, writeScript, installShellFiles }:
 
 buildGoModule rec {
   pname = "helm";
@@ -24,8 +24,17 @@ buildGoModule rec {
     installShellCompletion helm.{bash,zsh}
   '';
 
+  passthru.updateScript = writeScript "update-helm" ''
+    #! /usr/bin/env nix-shell
+    #! nix-shell -i bash -p common-updater-scripts curl findutils
+    set -eufo pipefail
+    curl -s https://api.github.com/repos/helm/helm/releases/latest |
+        jq -e -r '.tag_name | ltrimstr("v")' |
+        xargs update-source-version kubernetes-helm
+  '';
+
   meta = with lib; {
-    homepage = "https://github.com/kubernetes/helm";
+    inherit (src.meta) homepage;
     description = "A package manager for kubernetes";
     license = licenses.asl20;
     maintainers = with maintainers; [ rlupton20 edude03 saschagrunert Frostman Chili-Man ];


### PR DESCRIPTION
###### Motivation for this change

Add `passthru.updateScript` and fix `meta.homepage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
