### PR TITLE
tts: 0.0.13 -> 0.0.14

### DIFF
--- a/pkgs/development/python-modules/coqpit/default.nix
+++ b/pkgs/development/python-modules/coqpit/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "coqpit";
+  version = "0.0.6.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "coqui-ai";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wb5wf84i5h4ycm732kn4316v7schhm91s2rrklfw9sny5dqmdnh";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "coqpit"
+    "coqpit.coqpit"
+  ];
+
+  meta = with lib; {
+    description = "Simple but maybe too simple config management through python data classes";
+    longDescription = ''
+      Simple, light-weight and no dependency config handling through python data classes with to/from JSON serialization/deserialization.
+    '';
+    homepage = "https://github.com/coqui-ai/coqpit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/phonemizer/default.nix
+++ b/pkgs/development/python-modules/phonemizer/default.nix
@@ -65,6 +65,6 @@ buildPythonApplication rec {
     homepage = "https://github.com/bootphon/phonemizer";
     description = "Simple text to phones converter for multiple languages";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ hexa ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/segments/default.nix
+++ b/pkgs/development/python-modules/segments/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Unicode Standard tokenization routines and orthography profile segmentation";
     homepage = "https://github.com/cldf/segments";
     license = licenses.asl20;
-    maintainers = with maintainers; [ hexa ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1283,6 +1283,8 @@ in {
 
   connect-box = callPackage ../development/python-modules/connect_box { };
 
+  coqpit = callPackage ../development/python-modules/coqpit { };
+
   cerberus = callPackage ../development/python-modules/cerberus { };
 
   cert-chain-resolver = callPackage ../development/python-modules/cert-chain-resolver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
❯ ./result/bin/tts --text "To help with the large amounts of pull requests, we would appreciate your reviews of other pull requests, especially simple package updates. Just leave a comment describing what you have tested in the relevant package/service. Reviewing helps to reduce the average time-to-merge for everyone. Thanks a lot if you do\!"
 > tts_models/en/ljspeech/tacotron2-DDC is already downloaded.
 > vocoder_models/en/ljspeech/hifigan_v2 is already downloaded.
 > Using model: Tacotron2
 > Generator Model: hifigan_generator
Removing weight norm...
 > Text: To help with the large amounts of pull requests, we would appreciate your reviews of other pull requests, especially simple package updates. Just leave a comment describing what you have tested in the relevant package/service. Reviewing helps to reduce the average time-to-merge for everyone. Thanks a lot if you do!
 > Text splitted to sentences.
['To help with the large amounts of pull requests, we would appreciate your reviews of other pull requests, especially simple package updates.', 'Just leave a comment describing what you have tested in the relevant package/service.', 'Reviewing helps to reduce the average time-to-merge for everyone.', 'Thanks a lot if you do!']
 > Processing time: 9.217151880264282
 > Real-time factor: 0.4302393793181552
 > Saving output to tts_output.wav
```

https://shells.darmstadt.ccc.de/~hexa/tts-0.0.14.wav

No model changes. 
The test phase is quite a bit longer, but not unbearable: `🏁 tts-0.0.14 ⏲ 00:25:27`.

Due to licensing incompatibilities tts (MPL 2.0) doesn't rely on phonemizer (GPLv3) any more. That makes phonemizer/segments leaf packages that I don't intend to maintain anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
