### PR TITLE
maubot: init at 0.1.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/maubot/default.nix
+++ b/pkgs/applications/networking/instant-messengers/maubot/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, python3
+}:
+
+with python3.pkgs; buildPythonApplication rec {
+  pname = "maubot";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m2n9ly38gqf301qpw38fc6dqx78amf9i2lkyyifvzr1kvky4gv9";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    alembic
+    attrs
+    bcrypt
+    click
+    colorama
+    CommonMark
+    jinja2
+    mautrix
+    packaging
+    pyinquirer
+    ruamel_yaml
+    sqlalchemy
+    yarl
+  ];
+
+  checkPhase = ''
+    $out/bin/mbc --help > /dev/null
+  '';
+
+  pythonImportsCheck = [
+    "maubot"
+  ];
+
+  meta = with lib; {
+    description = "A plugin-based Matrix bot system written in Python";
+    homepage = "https://github.com/maubot/maubot";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -1,32 +1,67 @@
-{ lib, buildPythonPackage, fetchPypi, aiohttp, pythonOlder
-, sqlalchemy, ruamel_yaml, CommonMark, lxml
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, aiohttp
+, asyncpg
+, attrs
+, CommonMark
+, lxml
+, prometheus_client
+, pycryptodome
+, python-olm
+, python_magic
+, ruamel_yaml
+, sqlalchemy
+, unpaddedbase64
+, uvloop
+, yarl
 }:
 
 buildPythonPackage rec {
   pname = "mautrix";
-  version = "0.8.17";
+  version = "0.9.2";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9a15a8e39f9d0b36c91dfe0f5dd1efc8752cc1d317057840a3dbffd6ee90e068";
+    sha256 = "0nv9nnr02asvkxziibdsb1vjc8crhil41l5a5zxw9h2vb0k2hjgx";
   };
 
   propagatedBuildInputs = [
+    # requirements.txt
     aiohttp
+    attrs
+    yarl
 
-    # defined in optional-requirements.txt
-    sqlalchemy
-    ruamel_yaml
+    # optional-requirements.txt
     CommonMark
+    asyncpg
     lxml
+    prometheus_client
+    pycryptodome
+    python-olm
+    python_magic
+    ruamel_yaml
+    sqlalchemy
+    unpaddedbase64
+    uvloop
   ];
-
-  disabled = pythonOlder "3.7";
 
   # no tests available
   doCheck = false;
 
-  pythonImportsCheck = [ "mautrix" ];
+  pythonImportsCheck = [
+    # https://github.com/tulir/mautrix-python#components
+    "mautrix"
+    "mautrix.api"
+    "mautrix.client.api"
+    "mautrix.appservice"
+    "mautrix.crypto"
+    "mautrix.bridge"
+    "mautrix.client"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/tulir/mautrix-python";

--- a/pkgs/development/python-modules/pyinquirer/default.nix
+++ b/pkgs/development/python-modules/pyinquirer/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, prompt_toolkit1
+, regex
+, pygments
+, pytest-html
+, pytest-xdist
+, pytestCheckHook
+, ptyprocess
+}:
+
+buildPythonPackage rec {
+  pname = "PyInquirer";
+  version = "1.0.3";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "CITGuru";
+    repo = pname;
+    rev = version;
+    sha256 = "1qv2bfcmnnblzysksgp6qd9ipm6hrk9vjm72ava869qhcfn11zni";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "prompt_toolkit==1.0.14" "prompt_toolkit<2.0"
+  '';
+
+  propagatedBuildInputs = [
+    prompt_toolkit1
+    pygments
+    regex
+  ];
+
+  # The tests have been in a broken state for a while, with gems like this:
+  #   AssertionError: assert '? Do you like bacon?  No\n' == '? Do you lik...pizza?  (y/N)'
+  doCheck = false;
+
+  checkInputs = [
+    pytest-html
+    pytest-xdist
+    pytestCheckHook
+    ptyprocess
+  ];
+
+  pythonImportsCheck = [
+    "PyInquirer"
+  ];
+
+  meta = with lib; {
+    description = "A Python module for common interactive command line user interfaces";
+    homepage = "https://github.com/CITGuru/PyInquirer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6181,6 +6181,8 @@ in
 
   matrix-corporal = callPackage ../servers/matrix-corporal { };
 
+  maubot = callPackage ../applications/networking/instant-messengers/maubot { };
+
   mautrix-signal = recurseIntoAttrs (callPackage ../servers/mautrix-signal { });
 
   mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5271,6 +5271,8 @@ in {
 
   prompt_toolkit = callPackage ../development/python-modules/prompt_toolkit { };
 
+  prompt_toolkit1 = callPackage ../development/python-modules/prompt_toolkit/1.nix { };
+
   property-manager = callPackage ../development/python-modules/property-manager { };
 
   protego = callPackage ../development/python-modules/protego { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5749,6 +5749,8 @@ in {
 
   pyinputevent = callPackage ../development/python-modules/pyinputevent { };
 
+  pyinquirer = callPackage ../development/python-modules/pyinquirer { };
+
   pyinsteon = callPackage ../development/python-modules/pyinsteon { };
 
   pyintesishome = callPackage ../development/python-modules/pyintesishome { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/maubot/maubot is a pretty versatile Matrix Bot written in Python and based on python-mautrix. It uses a plugin architecture to add more functionality, although I have not packaged any plugins yet and haven't looked into how they integrate.

It ticks the bot for GitHub Webhook integration and karma bot at least.

This introduces the pyinquirer dependency, which is a bit undermaintained and requires me to introduce the existing python2Packages.prompt_toolkit1 package into the python3 packageset.

I tried to add a passthru test, but there is no `--version` flag and all other commands either interactive or end in an error, that no server was configured yet.

```
❯ ./result/bin/mbc auth
? Homeserver  
```

I think this bot could be useful in improving our matrix experience.

**I have not tested this beyond verifying it doesn't crash on any of the CLI commands. We don't need to merge it, if we think it is not what we are looking for.**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
