### PR TITLE
gfshare: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8721,6 +8721,12 @@
     githubId = 221121;
     name = "Robert P. Seaton";
   };
+  rraval = {
+    email = "ronuk.raval@gmail.com";
+    github = "rraval";
+    githubId = 373566;
+    name = "Ronuk Raval";
+  };
   rszibele = {
     email = "richard@szibele.com";
     github = "rszibele";

--- a/pkgs/tools/security/gfshare/default.nix
+++ b/pkgs/tools/security/gfshare/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchgit, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "gfshare";
+  version = "2.0.0";
+
+  src = fetchgit {
+    url = "git://git.gitano.org.uk/libgfshare.git";
+    rev = version;
+    sha256 = "0s37xn9pr5p820hd40489xwra7kg3gzqrxhc2j9rnxnd489hl0pr";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  doCheck = true;
+
+  outputs = [ "bin" "lib" "dev" "out" ];
+
+  meta = with lib; {
+    # Not the most descriptive homepage but it's what Debian and Ubuntu use
+    # https://packages.debian.org/sid/libgfshare2
+    # https://launchpad.net/ubuntu/impish/+source/libgfshare/+copyright
+    homepage = "https://git.gitano.org.uk/libgfshare.git/";
+    description = "Shamir's secret-sharing method in the Galois Field GF(2**8)";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.rraval ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -852,6 +852,8 @@ in
 
   amidst = callPackage ../tools/games/amidst { };
 
+  gfshare = callPackage ../tools/security/gfshare { };
+
   gobgp = callPackage ../tools/networking/gobgp { };
 
   metapixel = callPackage ../tools/graphics/metapixel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

gfshare is one of the few [FOSS implementations of Shamir Secret Sharing](https://security.stackexchange.com/a/5428), which in itself is a low level cryptographic operation that securely splits a file into `m` shares. The original file can be recovered by combining any `n` shares, where `n` can be smaller than `m`.

This secret sharing primitive can then be used to build a variety of cryptographic protocols that require n-of-m coordination.

[Ubuntu has provided this package since at least 2011](https://launchpad.net/ubuntu/+source/libgfshare/1.0.5-1).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
