### PR TITLE
elixir_1_12: init

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -4,6 +4,12 @@
 
 In this document and related Nix expressions, we use the term, _BEAM_, to describe the environment. BEAM is the name of the Erlang Virtual Machine and, as far as we're concerned, from a packaging perspective, all languages that run on the BEAM are interchangeable. That which varies, like the build system, is transparent to users of any given BEAM package, so we make no distinction.
 
+## Available versions and deprecations schedule
+
+### Elixir
+
+nixpkgs follows the [official elixir deprecation schedule](https://hexdocs.pm/elixir/compatibility-and-deprecations.html) and keeps the last 5 released versions of Elixir available.
+
 ## Structure {#beam-structure}
 
 All BEAM-related expressions are available via the top-level `beam` attribute, which includes:

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -40,7 +40,12 @@ let
       erlang-ls = callPackage ./erlang-ls { };
 
       # BEAM-based languages.
-      elixir = elixir_1_11;
+      elixir = elixir_1_12;
+
+      elixir_1_12 = lib'.callElixir ../interpreters/elixir/1.12.nix {
+        inherit erlang;
+        debugInfo = true;
+      };
 
       elixir_1_11 = lib'.callElixir ../interpreters/elixir/1.11.nix {
         inherit erlang;
@@ -62,15 +67,14 @@ let
         debugInfo = true;
       };
 
+      # Remove old versions of elixir, when the supports fades out:
+      # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
       elixir_1_7 = lib'.callElixir ../interpreters/elixir/1.7.nix {
         inherit erlang;
         debugInfo = true;
       };
 
       elixir_ls = callPackage ./elixir_ls.nix { inherit elixir fetchMixDeps mixRelease; };
-
-      # Remove old versions of elixir, when the supports fades out:
-      # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
       lfe = lfe_1_3;
       lfe_1_2 = lib'.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };

--- a/pkgs/development/interpreters/elixir/1.12.nix
+++ b/pkgs/development/interpreters/elixir/1.12.nix
@@ -1,0 +1,9 @@
+{ mkDerivation }:
+
+# How to obtain `sha256`:
+# nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
+mkDerivation {
+  version = "1.12.0";
+  sha256 = "sha256-Jnxi0vFYMnwEgTqkPncZbj+cR57hjvH77RCseJdUoFs=";
+  minimumOTPVersion = "22";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11916,7 +11916,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR24 erlangR23 erlangR22 erlangR21 erlangR20 erlangR19 erlangR18
     erlang_odbc erlang_javac erlang_odbc_javac erlang_basho_R16B02
-    elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7
+    elixir elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7
     elixir_ls;
 
   erlang_nox = beam_nox.interpreters.erlang;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -126,7 +126,7 @@ rec {
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR23.elixir`.
     inherit (packages.erlang)
-      elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_ls;
+      elixir elixir_1_12 elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_ls;
 
     inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };


### PR DESCRIPTION
###### Motivation for this change

elixir 1.12 release

@NixOS/beam I would like to propose something else.
- Keep 4 elixir versions by default (which corresponds to about 2 years). Meaning that after this is merged, we would drop 1.7. If you feel this is too conservative, let me know, I personally don't use anything else than the latest.
- Wait 3 months before making the latest release the default one. I think in 3 months, all the bugs should have appeared.

@minijackson @cw789 @ydlr @Ma27  you might be interested in this

I'll leave this one day open in case anybody is interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
