### PR TITLE
pythonPackages.pysmf: fix build with python 3.9

### DIFF
--- a/pkgs/development/python-modules/pysmf/default.nix
+++ b/pkgs/development/python-modules/pysmf/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pkg-config, libsmf, glib, pytest }:
+{ lib, buildPythonPackage, fetchPypi, pkg-config, libsmf, glib, pytest, cython }:
 
 buildPythonPackage rec {
   pname = "pysmf";
@@ -9,7 +9,11 @@ buildPythonPackage rec {
     sha256 = "10i7vvvdx6c3gl4afsgnpdanwgzzag087zs0fxvfipnqknazj806";
   };
 
-  nativeBuildInputs = [ pkg-config pytest ];
+  postUnpack = ''
+    rm $sourceRoot/src/smf.c
+  '';
+
+  nativeBuildInputs = [ pkg-config pytest cython ];
   buildInputs = [ libsmf glib ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042 

Cython pregenerated C source file was giving trouble. Now it's generated for every build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
