### PR TITLE
element-desktop: set dbus default for firefox

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -45,7 +45,8 @@ in mkYarnPackage rec {
 
     # executable wrapper
     makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
-      --add-flags "$out/share/element/electron"
+      --add-flags "$out/share/element/electron" \
+      --set-default MOZ_DBUS_REMOTE 1
   '';
 
   # Do not attempt generating a tarball for element-web again.


### PR DESCRIPTION
###### Motivation for this change
allows me to open links in element-desktop in firefox-wayland on sway

until a solution based on https://github.com/NixOS/nixpkgs/issues/57602#issuecomment-820512097 is implemented in nixos, this seems to be the only way to fix this that doesn't involve every wayland user adding a fix for the issue

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/0yjnyhqaqhvxxzqazziz9w6kxwmmh05v-element-desktop-1.7.28	 1219371984`
  - `/nix/store/bb8pl84j5gfrhwy7z2bh25msdv3i35hw-element-desktop-1.7.28	 1219372032`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
