### PR TITLE
ats-acc: init at 2018-10-21

### DIFF
--- a/pkgs/development/tools/ats-acc/default.nix
+++ b/pkgs/development/tools/ats-acc/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchFromGitHub, ats2 }:
+
+stdenv.mkDerivation rec {
+  pname = "ats-acc";
+  version = "unstable-2018-10-21";
+
+  src = fetchFromGitHub {
+    owner = "sparverius";
+    repo = pname;
+    rev = "2d49f4e76d0fe1f857ceb70deba4aed13c306dcb";
+    sha256 = "sha256-Wp39488YNL40GKp4KaJwhi75PsYP+gMtrZqAvs4Q/sw=";
+  };
+
+  nativeBuildInputs = [ ats2 ];
+
+  meta = with lib; {
+    description = "Pretty-print error messages of the ATS Compiler";
+    homepage = "https://github.com/sparverius/ats-acc";
+    maintainers = with maintainers; [ fortuneteller2k ];
+    license = licenses.unfree; # Upstream has no license
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10218,6 +10218,8 @@ in
   ats = callPackage ../development/compilers/ats { };
   ats2 = callPackage ../development/compilers/ats2 { };
 
+  ats-acc = callPackage ../development/tools/ats-acc { };
+
   avra = callPackage ../development/compilers/avra { };
 
   bigloo = callPackage ../development/compilers/bigloo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
