### PR TITLE
manim: use ffmpeg instead of ffmpeg_3

### DIFF
--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, fetchFromGitHub, pythonOlder, file, fetchpatch
-, cairo, ffmpeg_3, sox, xdg-utils, texlive
+, cairo, ffmpeg, sox, xdg-utils, texlive
 , colour, numpy, pillow, progressbar, scipy, tqdm, opencv , pycairo, pydub
 , pbr, fetchPypi
 }:
@@ -28,14 +28,14 @@ buildPythonApplication rec {
     pycairo
     pydub
 
-    cairo sox ffmpeg_3 xdg-utils
+    cairo sox ffmpeg xdg-utils
   ];
 
   # Test with texlive to see whether it works but don't propagate
   # because it's huge and optional
   # TODO: Use smaller TexLive distribution
   #       Doesn't need everything but it's hard to figure out what it needs
-  checkInputs = [ cairo sox ffmpeg_3 xdg-utils texlive.combined.scheme-full ];
+  checkInputs = [ cairo sox ffmpeg xdg-utils texlive.combined.scheme-full ];
 
   # Simple test and complex test with LaTeX
   checkPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/120705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Manim shouldn't use `python3Packages.callPackage` and non-Python dependencies shouldn't be in `propagatedBuildInputs`.

cc @sorokin @matthew-piziak 