### PR TITLE
virt-manager: add tests

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -5,6 +5,7 @@
 , gtksourceview4, docutils
 , spiceSupport ? true, spice-gtk ? null
 , cpio, e2fsprogs, findutils, gzip
+, cdrtools
 }:
 
 with lib;
@@ -53,8 +54,21 @@ python3Packages.buildPythonApplication rec {
     gappsWrapperArgs+=(--prefix PATH : "${makeBinPath [ cpio e2fsprogs file findutils gzip ]}")
   '';
 
-  # Failed tests
-  doCheck = false;
+  checkInputs = with python3Packages; [ cpio cdrtools pytestCheckHook ];
+
+  disabledTestPaths = [
+    "tests/test_cli.py"
+    "tests/test_disk.py"
+    "tests/test_checkprops.py"
+  ]; # Error logs: https://gist.github.com/superherointj/fee040872beaafaaa19b8bf8f3ff0be5
+
+  preCheck = ''
+    export HOME=.
+  ''; # <- Required for "tests/test_urldetect.py".
+
+  postCheck = ''
+    $out/bin/virt-manager --version | grep -Fw ${version} > /dev/null
+  '';
 
   meta = with lib; {
     homepage = "http://virt-manager.org";


### PR DESCRIPTION
Currently full tests errors as:
```
Error: --disk /var,device=floppy,snapshot=no,perms=rw: Size must be specified for non existent volume 'var'
```
Logs: https://termbin.com/qlbjf

Creating /var using mkdir errors:
```
> mkdir: cannot create directory ‘/var’: Permission denied
```

On Matrix:
```
superherointj: How can I have /var folder when building a package?
symphorien: you can't by design
IIUC: you can't. What is your use case. If you build without sandboxing you will see the host /var.
symphorien: usually the builder passes --prefix=$out to ./configure so that the build system writes to $out/var instead
symphorien: you may use libredirect to fake that /var exists
```

As I failed to use [libredirect](https://nixos.wiki/wiki/Packaging/Quirks_and_Caveats), I'm proposing partial tests until a (better) solution is found.

## Partial Tests

After ignoring [ "tests/test_cli.py" "tests/test_disk.py" ] new errors appeared:
```
PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
```
Logs: https://termbin.com/esgv

After ignoring [  "tests/test_urldetect.py" "tests/test_checkprops.py" ] it passes.