### PR TITLE
julia-mono: 0.037 -> 0.039

### DIFF
--- a/pkgs/data/fonts/julia-mono/default.nix
+++ b/pkgs/data/fonts/julia-mono/default.nix
@@ -1,16 +1,17 @@
 { lib, fetchzip }:
 
 let
-  version = "0.037";
+  version = "0.039";
 
-in fetchzip {
-  name = "JuliaMono-${version}";
-  url = "https://github.com/cormullion/juliamono/releases/download/v${version}/JuliaMono.zip";
-  sha256 = "06hyl7fri39s7jxjqayi00r83cbf1ca47h5xq55a19igdm1xl79q";
+in
+fetchzip {
+  name = "JuliaMono-ttf-${version}";
+  url = "https://github.com/cormullion/juliamono/releases/download/v${version}/JuliaMono-ttf.tar.gz";
+  sha256 = "sha256-M9T78xnSN1hcHLXkut09eD2IFrgCRTG9fAPqMv4MXWY=";
 
   postFetch = ''
     mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    tar xf $downloadedFile -C $out/share/fonts/truetype
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New version released: https://github.com/cormullion/juliamono/releases/tag/v0.039

I moved from `.zip` to `.tar.gz` because now instead of being about the same size, the tarball is about half the size. The project also changed the name of the downloaded files because now they have webfonts ala WOFF2 which aren't needed on the OS.

@suhr 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
