### PR TITLE
soju: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6104,6 +6104,12 @@
     githubId = 2914269;
     name = "Malo Bourgon";
   };
+  malvo = {
+    email = "malte@malvo.org";
+    github = "malte-v";
+    githubId = 34393802;
+    name = "Malte Voos";
+  };
   malyn = {
     email = "malyn@strangeGizmo.com";
     github = "malyn";

--- a/pkgs/applications/networking/soju/default.nix
+++ b/pkgs/applications/networking/soju/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildGoModule, fetchFromSourcehut, installShellFiles, scdoc }:
+
+buildGoModule rec {
+  pname = "soju";
+  version = "0.1.2";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "soju";
+    rev = "v${version}";
+    sha256 = "sha256-dauhGfwSjjRt1vl2+OPhtcme/QaRNTs43heQVnI7oRU=";
+  };
+
+  vendorSha256 = "sha256-0JLbqqybLZ/cYyHAyNR4liAVJI2oIsHELJLWlQy0qjE=";
+
+  subPackages = [
+    "cmd/soju"
+    "cmd/sojuctl"
+    "contrib/znc-import.go"
+  ];
+
+  nativeBuildInputs = [
+    scdoc
+    installShellFiles
+  ];
+
+  postInstall = ''
+    scdoc < doc/soju.1.scd > doc/soju.1
+    installManPage doc/soju.1
+  '';
+
+  meta = with lib; {
+    description = "A user-friendly IRC bouncer";
+    homepage = "https://soju.im";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ malvo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3065,6 +3065,8 @@ in
 
   socklog = callPackage ../tools/system/socklog { };
 
+  soju = callPackage ../applications/networking/soju { };
+
   spacevim = callPackage ../applications/editors/spacevim { };
 
   ssmsh = callPackage ../tools/admin/ssmsh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add soju, a user-friendly IRC bouncer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
