### PR TITLE
liquidsoap: fix build, add missing zlib

### DIFF
--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -2,7 +2,7 @@
 , ocamlPackages
 , libao, portaudio, alsaLib, libpulseaudio, libjack2
 , libsamplerate, libmad, taglib, lame, libogg
-, libvorbis, speex, libtheora, libopus
+, libvorbis, speex, libtheora, libopus, zlib
 , faad2, flac, ladspaH, ffmpeg, frei0r, dssi
 }:
 
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
     [ which ocamlPackages.ocaml ocamlPackages.findlib
       libao portaudio alsaLib libpulseaudio libjack2
       libsamplerate libmad taglib lame libogg
-      libvorbis speex libtheora libopus
+      libvorbis speex libtheora libopus zlib
       faad2 flac ladspaH ffmpeg frei0r dssi
       ocamlPackages.xmlm ocamlPackages.ocaml_pcre
       ocamlPackages.camomile


### PR DESCRIPTION
###### Motivation for this change
Saw it failing in another review. #123782

ZHF: #122042

ping: me

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
