### PR TITLE
rymcast: init at 1.0.6

### DIFF
--- a/pkgs/applications/audio/rymcast/default.nix
+++ b/pkgs/applications/audio/rymcast/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchzip, autoPatchelfHook, makeWrapper
+, alsaLib, curl, gtk3, webkitgtk, zenity }:
+
+stdenv.mkDerivation rec {
+  pname = "rymcast";
+  version = "1.0.6";
+
+  src = fetchzip {
+    url = "https://www.inphonik.com/files/rymcast/rymcast-${version}-linux-x64.tar.gz";
+    hash = "sha256:0vjjhfrwdibjjgz3awbg30qxkjrzc4cya1f4pigwjh3r0vvrq0ga";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  buildInputs = [ alsaLib curl gtk3 stdenv.cc.cc.lib webkitgtk zenity ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp RYMCast "$out/bin/"
+    wrapProgram "$out/bin/RYMCast" \
+        --set PATH "${lib.makeBinPath [ zenity ]}"
+  '';
+
+  meta = with lib; {
+    description = "Player for Mega Drive/Genesis VGM files";
+    homepage = "https://www.inphonik.com/products/rymcast-genesis-vgm-player/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ astsmtl ];
+  };
+}

--- a/pkgs/applications/audio/rymcast/default.nix
+++ b/pkgs/applications/audio/rymcast/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     cp RYMCast "$out/bin/"
     wrapProgram "$out/bin/RYMCast" \
-        --set PATH "${lib.makeBinPath [ zenity ]}"
+      --set PATH "${lib.makeBinPath [ zenity ]}"
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26068,6 +26068,10 @@ in
 
   runc = callPackage ../applications/virtualization/runc {};
 
+  rymcast = callPackage ../applications/audio/rymcast {
+    inherit (gnome) zenity;
+  };
+
   uade123 = callPackage ../applications/audio/uade123 {};
 
   udevil = callPackage ../applications/misc/udevil {};


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
