### PR TITLE
monero-gui: 0.17.2.1 -> 0.17.2.2

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -19,13 +19,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.17.2.1";
+  version = "0.17.2.2";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1apjvpvn6hg0k0ak6wpg4prcdcslnb6fqhzzg2p4iy846f0ai9ji";
+    sha256 = "1k3grbd3wydy5gv6d8x35skv1v97lhh6awd9i87im9lz4kn8ywkd";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test
- [x] Tested compilation of all pkgs that depend on this change (just this)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
