### PR TITLE
rustup: 1.24.1 -> 1.24.2

### DIFF
--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -10,16 +10,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "rustup";
-  version = "1.24.1";
+  version = "1.24.2";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustup";
     rev = version;
-    sha256 = "sha256-GKvKawvfm/4eBU4mn/Q9fhu3Ml+j+BsxVNPvbvcnMLU=";
+    sha256 = "sha256-uRCzVeTr5rr0CvE/1Uz7RHcw4Kt/sOItwcbZJBjjNjg=";
   };
 
-  cargoSha256 = "sha256-tWww+rR4DQgRacVeLqnOBcuXA7o/NYmJBcJgWX3aLRY=";
+  cargoSha256 = "sha256-+E6Wa4QrMG/Ow3KehsxIzLzubXJQxCWo/rowC4MPdgk=";
 
   nativeBuildInputs = [ makeWrapper pkg-config ];
 


### PR DESCRIPTION
###### Motivation for this change

Rustup update; Pretty minor, seems to mostly be a bugfix update.

Announcement post: https://blog.rust-lang.org/2021/05/17/Rustup-1.24.2.html
Changelog: https://github.com/rust-lang/rustup/blob/755e2b07e88ec6980a6b42cab9ce11bb5f3b9c27/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>rustup</li>
  </ul>
</details>
