### PR TITLE
ppsspp: fix build against ffmpeg 4.4

### DIFF
--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -28,8 +28,9 @@ mkDerivation rec {
   };
 
   patches = [
+     # fix compability with ffmpeg 4.4, remove on next release after 1.11
     (fetchpatch {
-      name = "fix_ffmpeg_4.4.patch"; # to be removed with next release
+      name = "fix_ffmpeg_4.4.patch";
       url = "https://patch-diff.githubusercontent.com/raw/hrydgard/ppsspp/pull/14176.patch";
       sha256 = "sha256-ecDoOydaLfL6+eFpahcO1TnRl866mZZVHlr6Qrib1mo=";
     })

--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , SDL2
 , cmake
 , ffmpeg
@@ -25,6 +26,14 @@ mkDerivation rec {
     fetchSubmodules = true;
     sha256 = "sha256-vfp/vacIItlPP5dR7jzDT7oOUNFnjvvdR46yi79EJKU=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix_ffmpeg_4.4.patch"; # to be removed with next release
+      url = "https://patch-diff.githubusercontent.com/raw/hrydgard/ppsspp/pull/14176.patch";
+      sha256 = "sha256-ecDoOydaLfL6+eFpahcO1TnRl866mZZVHlr6Qrib1mo=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace git-version.cmake --replace unknown ${src.rev}


### PR DESCRIPTION
###### Motivation for this change

Applying the same fix for compilation against ffmpeg 4.4 that I used for the libretro core in #123842.

I can't verify the resulting binary works. It crashes with an OpenGL error for me, but so does ppsspp on 20.09 so it's something on my end.

edit to ping the ppsspp maintainer: @AndersonTorres

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
