### PR TITLE
linuxPackages_5_12.rtl88xxau-aircrack: fix build

### DIFF
--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, kernel }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel }:
 
+let
+  rev = "3a64331a1c809bbbc21eca63b825970f213ec5ac";
+in
 stdenv.mkDerivation rec {
-  name = "rtl88xxau-aircrack-${kernel.version}-${version}";
-  rev = "c0ce81745eb3471a639f0efd4d556975153c666e";
-  version = "${builtins.substring 0 6 rev}";
+  pname = "rtl88xxau-aircrack";
+  version = "${kernel.version}-${builtins.substring 0 6 rev}";
 
   src = fetchFromGitHub {
     owner = "aircrack-ng";
     repo = "rtl8812au";
     inherit rev;
-    sha256 = "131cwwg3czq0i1xray20j71n836g93ac064nvf8wi13c2wr36ppc";
+    sha256 = "sha256-goaN80imfCeUwiHokJd10CFKskE3iL5BO/xOQk6PtHE=";
   };
 
   buildInputs = kernel.moduleBuildDependencies;
@@ -17,6 +19,14 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" ];
 
   NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
+
+  # Fix build for 5.12 kernels
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/aircrack-ng/rtl8812au/commit/9b4c60a89c2a55f36454b950a86246b6b86a9681.patch";
+      sha256 = "sha256-HPhTLstqAePF3H6WeM9Fu4/8UjNL+9xl4L8xq3NOWuM=";
+    })
+  ];
 
   prePatch = ''
     substituteInPlace ./Makefile \
@@ -33,7 +43,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Aircrack-ng kernel module for Realtek 88XXau network cards\n(8811au, 8812au, 8814au and 8821au chipsets) with monitor mode and injection support.";
     homepage = "https://github.com/aircrack-ng/rtl8812au";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = [ maintainers.jethro ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fix the last failing to build realtek driver

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
