### PR TITLE
heisenbridge: init at unstable-2021-05-23

### DIFF
--- a/pkgs/servers/heisenbridge/default.nix
+++ b/pkgs/servers/heisenbridge/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "heisenbridge";
+  version = "unstable-2021-05-23";
+
+  src = fetchFromGitHub {
+    owner = "hifi";
+    repo = "heisenbridge";
+    rev = "1f8df49b7e89aaeb2cbb5fee68bd29cf3eda079a";
+    sha256 = "sha256-ta6n9hXRdIjfxsLy9jrzZkz6TS50/TYpFOb/BLrRWK4=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    aiohttp
+    irc
+    pyyaml
+  ];
+
+  checkInputs = [ python3Packages.pytestCheckHook ];
+
+  meta = with lib; {
+    description = "A bouncer-style Matrix-IRC bridge.";
+    homepage = "https://github.com/hifi/heisenbridge";
+    license = licenses.mit;
+    maintainers = [ maintainers.sumnerevans ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5515,6 +5515,8 @@ in
 
   heimdall-gui = heimdall.override { enableGUI = true; };
 
+  heisenbridge = callPackage ../servers/heisenbridge { };
+
   helio-workstation = callPackage ../applications/audio/helio-workstation { };
 
   hevea = callPackage ../tools/typesetting/hevea { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The [heisenbridge project](https://github.com/hifi/heisenbridge) has gotten a lot of attention with so many people moving away from freenode to matrix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
    ```
    $ nix-shell -p nixpkgs-review --run "nixpkgs-review rev be13f411cd0"
    [nix-shell ...] $ python -m heisenbridge -c ~/tmp/test --generate
    Registration file generated and saved to /home/sumner/tmp/test
    ```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
