### PR TITLE
python3Packages.pydicom: disable flaky test on darwin

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -53,6 +53,9 @@ buildPythonPackage {
   ] ++ lib.optionals stdenv.isAarch64 [
     # https://github.com/pydicom/pydicom/issues/1386
     "test_array"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # flaky, hard to reproduce failure outside hydra
+    "test_time_check"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042

I invite anyone with a darwin machine to please try and reproduce hydra's failure https://nix-cache.s3.amazonaws.com/log/rn0cjj0hjdv2gl2g04kd587piszd3l52-python3.8-pydicom-2.1.2.drv on current `master`. I am unable to reproduce it on macos 10.15. Sandbox enabled, sandbox disabled, :shrug: 

The failure is also "just" the lack of a file modification warning (though yes, I realize the importance of paranoia around DICOM implementations).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
