### PR TITLE
wlrctl: init at 0.2.1

### DIFF
--- a/pkgs/tools/wayland/wlrctl/default.nix
+++ b/pkgs/tools/wayland/wlrctl/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromSourcehut, cmake, meson, pkg-config, libxkbcommon, wayland, scdoc, ninja }:
+
+stdenv.mkDerivation rec {
+  name = "wlrctl-${version}";
+  version = "0.2.1";
+  src = fetchFromSourcehut {
+    owner = "~brocellous";
+    repo = "wlrctl";
+    rev = "v${version}";
+    sha256 = "039cxc82k7x473n6d65jray90rj35qmfdmr390zy0c7ic7vn4b78";
+  };
+  dontUseCmakeConfigure = true;
+  nativeBuildInputs = [ cmake meson pkg-config scdoc ninja ];
+  buildInputs = [ libxkbcommon wayland ];
+
+  meta = with lib; {
+    description = "Command line utility for miscellaneous wlroots Wayland extensions";
+    homepage = "https://git.sr.ht/~brocellous/wlrctl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ puffnfresh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/wayland/wlrctl/default.nix
+++ b/pkgs/tools/wayland/wlrctl/default.nix
@@ -1,8 +1,9 @@
 { lib, stdenv, fetchFromSourcehut, cmake, meson, pkg-config, libxkbcommon, wayland, scdoc, ninja }:
 
 stdenv.mkDerivation rec {
-  name = "wlrctl-${version}";
+  pname = "wlrctl";
   version = "0.2.1";
+
   src = fetchFromSourcehut {
     owner = "~brocellous";
     repo = "wlrctl";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2193,6 +2193,8 @@ in
 
   wlr-randr = callPackage ../tools/wayland/wlr-randr { };
 
+  wlrctl = callPackage ../tools/wayland/wlrctl { };
+
   wlsunset = callPackage ../tools/wayland/wlsunset { };
 
   wob = callPackage ../tools/wayland/wob { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
