### PR TITLE
sudo-font: 0.52 -> 0.53.1

### DIFF
--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,21 +1,20 @@
 { lib, fetchzip }:
 
 let
-  version = "0.52";
+  version = "0.53.1";
 in fetchzip {
   name = "sudo-font-${version}";
-  url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
-  sha256 = "1j5p7apclyy5gfj2kklmgcncdsp5iik4gd6mdl29anzijknd0kja";
+  url = "https://github.com/jenskutilek/sudo-font/raw/v${version}/dist/sudo.zip";
+  sha256 = "1jil43j9ngz4422m76x67bafvxz75rncqqi57xd7fdxgcff7i8dp";
 
   postFetch = ''
     mkdir -p $out/share/fonts/
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff/
-    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2/
   '';
   meta = with lib; {
     description = "Font for programmers and command line users";
     homepage = "https://www.kutilek.de/sudo-font/";
+    changelog = "https://github.com/jenskutilek/sudo-font/raw/v${version}/sudo/FONTLOG.txt";
     license = licenses.ofl;
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
