### PR TITLE
python3Packages.pyvisa: init at 1.11.3, python3Packages.pyvisa-py: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/pyvisa-py/default.nix
+++ b/pkgs/development/python-modules/pyvisa-py/default.nix
@@ -2,20 +2,22 @@
 , fetchFromGitHub
 , buildPythonPackage
 , setuptools-scm
-, setuptools
+, pyserial
+, pyusb
+, pyvisa
 , typing-extensions
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
-  pname = "pyvisa";
-  version = "1.11.3";
+  pname = "pyvisa-py";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "pyvisa";
-    repo = "pyvisa";
+    repo = "pyvisa-py";
     rev = version;
-    hash = "sha256-Qe7W1zPI1aedLDnhkLTDPTa/lsNnCGik5Hu+jLn+meA=";
+    hash = "sha256-V1BS+BvHVI8h/rynLnOHvQdIR6RwQrNa2p2S6GQug98=";
   };
 
   nativeBuildInputs = [
@@ -23,17 +25,14 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    pyserial
+    pyusb
+    pyvisa
     typing-extensions
-    setuptools
   ];
 
   checkInputs = [
     pytestCheckHook
-  ];
-
-  # Test can't find cli tool bin path correctly
-  disabledTests = [
-    "test_visa_info"
   ];
 
   postConfigure = ''
@@ -41,8 +40,8 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "Python package for support of the Virtual Instrument Software Architecture (VISA)";
-    homepage = "https://github.com/pyvisa/pyvisa";
+    description = "PyVISA backend that implements a large part of the Virtual Instrument Software Architecture in pure Python";
+    homepage = "https://github.com/pyvisa/pyvisa-py";
     license = licenses.mit;
     maintainers = with maintainers; [ mvnetbiz ];
   };

--- a/pkgs/development/python-modules/pyvisa/default.nix
+++ b/pkgs/development/python-modules/pyvisa/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, setuptools_scm
+, setuptools
+, typing-extensions
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyvisa";
+  version = "1.11.3";
+
+  src = fetchFromGitHub {
+    owner = "pyvisa";
+    repo = "pyvisa";
+    rev = version;
+    hash = "sha256-Qe7W1zPI1aedLDnhkLTDPTa/lsNnCGik5Hu+jLn+meA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # Test can't find cli tool bin path correctly
+  disabledTests = [
+    "test_visa_info"
+  ];
+
+  postConfigure = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="v${version}"
+  '';
+
+  meta = with lib; {
+    description = "Python package for support of the Virtual Instrument Software Architecture (VISA)";
+    homepage = "https://github.com/pyvisa/pyvisa";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mvnetbiz ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6905,6 +6905,8 @@ in {
 
   pyvisa = callPackage ../development/python-modules/pyvisa { };
 
+  pyvisa-py = callPackage ../development/python-modules/pyvisa-py { };
+
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
   pyvizio = callPackage ../development/python-modules/pyvizio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6903,6 +6903,8 @@ in {
 
   pyvicare = callPackage ../development/python-modules/pyvicare { };
 
+  pyvisa = callPackage ../development/python-modules/pyvisa { };
+
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
   pyvizio = callPackage ../development/python-modules/pyvizio { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add python library for communicating with test instruments (oscilloscope, waveform generator, power supply, etc.)

###### Things done

Added pyvisa and pyvisa-py (pure python backend)
Tested connecting to instruments over IP and basic queries work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
