### PR TITLE
qemu: fix darwin build

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -103,10 +103,17 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  # Otherwise tries to ensure /var/run exists.
   postPatch = ''
+    # Otherwise tries to ensure /var/run exists.
     sed -i "/install_subdir('run', install_dir: get_option('localstatedir'))/d" \
         qga/meson.build
+
+    # TODO: On aarch64-darwin, we automatically codesign everything, but qemu
+    # needs specific entitlements and does its own signing. This codesign
+    # command fails, but we have no fix at the moment, so this disables it.
+    # This means `-accel hvf` is broken for now, on aarch64-darwin only.
+    substituteInPlace meson.build \
+      --replace 'if exe_sign' 'if false'
   '';
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hoping to beat the branch-off, but I guess there's no real hurry in it either. We can always backport. 🙂

Fixes #121903. This is simply the workaround created by @mroi from this comment: https://github.com/NixOS/nixpkgs/issues/121903#issuecomment-836315774

I suggest we try move ahead with this and create a separate ticket for the aarch64-darwin issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
