### PR TITLE
poppler: drop patches already contained in src

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -30,7 +30,7 @@
 let
   mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
 in
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "poppler-${suffix}-${version}";
   version = "21.05.0"; # beware: updates often break cups-filters build, check texlive and scribusUnstable too!
 
@@ -110,17 +110,4 @@ stdenv.mkDerivation (rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ] ++ teams.freedesktop.members;
   };
-} // lib.optionalAttrs stdenv.isDarwin {
-  patches = [
-    # Fix build due to improperly used volatile in poppler-glib.
-    # https://gitlab.freedesktop.org/poppler/poppler/merge_requests/836
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/poppler/poppler/commit/47de887d7658cfd68df44b3acf710971054f957b.patch";
-      sha256 = "uvYibBn2fOEqdotxK0Wpf8KhGYZXrpHdmS4jjlRNCj8=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/poppler/poppler/commit/bdd110b45a38e8a4f80f522892e4c4a9e432abd5.patch";
-      sha256 = "WDUYXX6v5zk7tusz7DGBP58yFzgEvoBlNSLbfk7+QTc=";
-    })
-  ];
-})
+}


### PR DESCRIPTION
###### Motivation for this change
It fails :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] N/A NixOS
   - [ ] macOS
   - [ ] N/A other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
