### PR TITLE
tree-sitter: 0.19.3 -> 0.19.5

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -28,9 +28,9 @@ let
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.19.3";
-  sha256 = "0zd1p9x32bwdc5cdqr0x8i9fpcykk1zczb8zdjawrrr92465d26y";
-  cargoSha256 = "1n63lxp8rknb5xqp02csj649cxs7d891a520djl3lb4k1finhsjj";
+  version = "0.19.5";
+  sha256 = "1qmb0sva28zv6r3c3j7xs9pc8bpwwhkb9vxxndw2zbdn9wkvmbmn";
+  cargoSha256 = "0hnjik3pymb1s7frhfpfzvd6w2k3lgpsmh6milpriwxmqsmkwdzz";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -29,7 +29,10 @@
   tree-sitter-scala = (builtins.fromJSON (builtins.readFile ./tree-sitter-scala.json));
   tree-sitter-svelte = (builtins.fromJSON (builtins.readFile ./tree-sitter-svelte.json));
   tree-sitter-swift = (builtins.fromJSON (builtins.readFile ./tree-sitter-swift.json));
+  tree-sitter-toml = (builtins.fromJSON (builtins.readFile ./tree-sitter-toml.json));
+  tree-sitter-tsq = (builtins.fromJSON (builtins.readFile ./tree-sitter-tsq.json));
   tree-sitter-typescript = (builtins.fromJSON (builtins.readFile ./tree-sitter-typescript.json));
   tree-sitter-verilog = (builtins.fromJSON (builtins.readFile ./tree-sitter-verilog.json));
   tree-sitter-yaml = (builtins.fromJSON (builtins.readFile ./tree-sitter-yaml.json));
+  tree-sitter-zig = (builtins.fromJSON (builtins.readFile ./tree-sitter-zig.json));
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "09749b7b5428e770cc2ebdf2e90029c0f4a2d411",
-  "date": "2021-04-13T07:05:48+01:00",
-  "path": "/nix/store/w99nivk866bglvijxb5m0c789qh99x1m-tree-sitter-c-sharp",
-  "sha256": "17n7r1j1ib3gzjf0qw88512flzamjrvilksbf1p15dqa17rmwyq1",
+  "rev": "5b6bfbdcdbdda7da4839d7163ce579ed98410282",
+  "date": "2021-05-21T15:22:56+02:00",
+  "path": "/nix/store/msyjbgxf3y3rj6m3w2apd65cvr9x523r-tree-sitter-c-sharp",
+  "sha256": "0ls2qic3jb20zv4m5pdrc3ikfb66afay3krvc6gsq1fi9hbxrmvv",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "2a83dfdd759a632651f852aa4dc0af2525fae5cd",
-  "date": "2021-03-09T16:11:33-05:00",
-  "path": "/nix/store/2jk1bacllxsii8nlbc5lyi3k376ylf3q-tree-sitter-go",
-  "sha256": "001p8kb8g4vghn78690bnav42inkypld2k1mbd5pbmd5svvacfav",
+  "rev": "eb306e6e60f393df346cfc8cbfaf52667a37128a",
+  "date": "2021-05-04T14:03:16-07:00",
+  "path": "/nix/store/xgi4w5by155m1zqhqf2s7hmngy6sxdq3-tree-sitter-go",
+  "sha256": "03x3nkjxdfck9a4z2i50wq065vixqqk4v5w6fnd870q63v0zrc7c",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "ee8e358637e05188f9f65d8d1ad88a4412c975ce",
-  "date": "2021-04-20T10:40:14-04:00",
-  "path": "/nix/store/8612qackwqdsvbfc03lzc5vds6mvqwxf-tree-sitter-java",
-  "sha256": "19qxfimy8w49gqc97siknd27kvkz73qp2v2118pvdbdz7c5dv27r",
+  "rev": "2efe37f92d2e6aeb25186e9da07455bb4a30163c",
+  "date": "2021-05-04T14:05:05-07:00",
+  "path": "/nix/store/bzljwaraqj6zqpq85cz9xb0vwh7c10yj-tree-sitter-java",
+  "sha256": "09v3xg1356ghc2n0yi8iqkp80lbkav0jpfgz8iz2j1sl7ihbvkyw",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "a263a8f53266f8f0e47e21598e488f0ef365a085",
-  "date": "2021-04-20T10:37:09-04:00",
-  "path": "/nix/store/y6qbdzdx4g1g1sa2rb7dnk9snjs6lhpp-tree-sitter-javascript",
-  "sha256": "04s1jb9c96kwq0nrh6516idlh58d2b1k66amqa2sl5kk32pl9pmm",
+  "rev": "6c8cfae935f67dd9e3a33982e5e06be0ece6399a",
+  "date": "2021-05-11T09:51:32-07:00",
+  "path": "/nix/store/dhh1gz45l3h3p31jfg5fgy1kns1lbw6d-tree-sitter-javascript",
+  "sha256": "1mw6miw4yp6s1i0b08hflamfvrjdim4fnnj6fy461n05jp1s1i78",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "0ba7a24b062b671263ae08e707e9e94383b25bb7",
-  "date": "2021-03-04T14:52:13-08:00",
-  "path": "/nix/store/2ni8p1cgyrkn1mcccl4zqdpkfm63a10m-tree-sitter-julia",
-  "sha256": "1pbnmvhy2gq4vg1b0sjzmjm4s2gsgdjh7h01yj8qrrqbcl29c463",
+  "rev": "12ea597262125fc22fd2e91aa953ac69b19c26ca",
+  "date": "2021-05-03T17:44:45-07:00",
+  "path": "/nix/store/lbz23r698hn7cha09qq0dbfay7dh74gg-tree-sitter-julia",
+  "sha256": "0rmd7k3rv567psxrlqv17gvckijs19xs6mxni045rpayxmk441sk",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "d5287aac195ab06da4fe64ccf93a76ce7c918445",
-  "date": "2021-04-21T19:11:29-05:00",
-  "path": "/nix/store/6labzn2qd3wyn4k2ddb09z2avpgqwbp1-tree-sitter-nix",
-  "sha256": "0mapqdqrinskdxlarrrvyd55mjg97gbd6jm9vbjmdm4xi2hhzvxa",
+  "rev": "50f38ceab667f9d482640edfee803d74f4edeba5",
+  "date": "2021-04-27T17:21:51-05:00",
+  "path": "/nix/store/fhf3mvxg17g0xli59cgmmwqy4g21fbzj-tree-sitter-nix",
+  "sha256": "11gifb9b7x9v223hsrcb6wlkqpxbc4p5v4ny9aixzi9k8g0jhb3d",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "2f962cf4eb0bee87bba755347a79ee501cd58313",
-  "date": "2021-03-11T02:13:42+01:00",
-  "path": "/nix/store/pwf6di3pdghsnb83c87vvm3w0d5aanvp-tree-sitter-ocaml",
-  "sha256": "1dfan7kbs7i0nz9dkxv8ipn0b341j1fr9fn0a2zfqsx6xxkra56r",
+  "rev": "0348562f385bc2bd67ecf181425e1afd6d454192",
+  "date": "2021-05-07T21:05:16+02:00",
+  "path": "/nix/store/s2499rsi28k0nrwx8wl2idsp86zsx2iz-tree-sitter-ocaml",
+  "sha256": "0iqmwcz3c2ai4gyx4xli1rhn6hi6a0f60dn20f8jas9ham9dc2df",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "4dcc061668fbc68b79421c72eb8a8baeeb0f3693",
-  "date": "2021-04-19T12:44:47-04:00",
-  "path": "/nix/store/2i80zds4dbynrdim9ngc8yp6yn825byb-tree-sitter-php",
-  "sha256": "0hs6dfw9n6sp7vbp7zfid0f0sxydyya3dyp5ghckz7al069g3vx2",
+  "rev": "6a271f4075e11815e787df9055a950fb844ee63b",
+  "date": "2021-05-13T12:41:22+02:00",
+  "path": "/nix/store/n6hycd1scxa990xchk5h09ilxi7w18f5-tree-sitter-php",
+  "sha256": "1ijxc6brd0d35hr89ic8k5ispc6sj4mxln7bznd9n6zrgjvfdjqb",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-toml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-toml.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/ikatyang/tree-sitter-toml",
+  "rev": "8bd2056818b21860e3d756b5a58c4f6e05fb744e",
+  "date": "2021-05-11T12:47:32+08:00",
+  "path": "/nix/store/isgpadcxmgkb14w9yg67pb8lx7wlfhnn-tree-sitter-toml",
+  "sha256": "0yasw5fp4mq6vzrdwlc3dxlss8a94bsffv4mzrfp0b3iw0s1dlyg",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tsq.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tsq.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/tree-sitter/tree-sitter-tsq",
+  "rev": "b665659d3238e6036e22ed0e24935e60efb39415",
+  "date": "2021-05-18T15:57:40-04:00",
+  "path": "/nix/store/j59y4s3bsv6d5nbmhhdgb043hmk8157k-tree-sitter-tsq",
+  "sha256": "03bch2wp2jwxk69zjplvm0gbyw06qqdy7il9qkiafvhrbh03ayd9",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "82916165120f840164f11119f268a4de819ea90b",
-  "date": "2021-04-19T18:16:19-07:00",
-  "path": "/nix/store/0c0kkiiamms3yl3mf1clyrqcjwp5j920-tree-sitter-typescript",
-  "sha256": "1jnf0hn6hmn4x2cvy29mk8g1wlp0afs8immp461by3q5hcq8fzb4",
+  "rev": "28e757a2f498486931b3cb13a100a1bcc9261456",
+  "date": "2021-05-04T14:04:30-07:00",
+  "path": "/nix/store/d90hgv5g374a6mrwhq9vcxk6d6lp2ags-tree-sitter-typescript",
+  "sha256": "0dxy5h68hhypzq0z15q8iawjgw3kx7dlpw76zv6xkxh25idqgxqh",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ikatyang/tree-sitter-yaml",
-  "rev": "6129a83eeec7d6070b1c0567ec7ce3509ead607c",
-  "date": "2021-04-18T14:25:59+08:00",
-  "path": "/nix/store/8wrwm71z9flfk00phrh9aaxpvsrw1m67-tree-sitter-yaml",
-  "sha256": "1bimf5fq85wn8dwlk665w15n2bj37fma5rsfxrph3i9yb0lvzi3q",
+  "rev": "0e36bed171768908f331ff7dff9d956bae016efb",
+  "date": "2021-05-11T12:47:24+08:00",
+  "path": "/nix/store/7d7m4zs4ydnwbn3xnfm3pvpy7gvkrmg8-tree-sitter-yaml",
+  "sha256": "0wyvjh62zdp5bhd2y8k7k7x4wz952l55i1c8d94rhffsbbf9763f",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/GrayJack/tree-sitter-zig",
+  "rev": "41bbc7f7b94bde3e948e41e4d42673945238ff03",
+  "date": "2021-03-30T12:55:10-03:00",
+  "path": "/nix/store/av4xgzr3c1rhr7v4fa9mm68krd2qv1lg-tree-sitter-zig",
+  "sha256": "0gjxac43qpqc4332bp3mpdbvh7rqv0q3hvw8834b30ml5q0r0qr0",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -35,6 +35,7 @@ let
     "tree-sitter-jsdoc"
     "tree-sitter-ql"
     "tree-sitter-embedded-template"
+    "tree-sitter-tsq"
   ];
   knownTreeSitterOrgGrammarReposJson = jsonFile "known-tree-sitter-org-grammar-repos" knownTreeSitterOrgGrammarRepos;
 
@@ -60,6 +61,8 @@ let
     "tree-sitter.github.io"
     # not maintained
     "tree-sitter-razor"
+    # rust library for constructing arbitrary graph structures from source code
+    "tree-sitter-graph"
   ];
   ignoredTreeSitterOrgReposJson = jsonFile "ignored-tree-sitter-org-repos" ignoredTreeSitterOrgRepos;
 
@@ -90,6 +93,14 @@ let
     "tree-sitter-yaml" = {
       orga = "ikatyang";
       repo = "tree-sitter-yaml";
+    };
+    "tree-sitter-toml" = {
+      orga = "ikatyang";
+      repo = "tree-sitter-toml";
+    };
+    "tree-sitter-zig" = {
+      orga = "GrayJack";
+      repo = "tree-sitter-zig";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

package update and some new grammars:

* tree-sitter-tsq (this one is upstream and I personally don't care about)
* tree-sitter-zig (this one I'm interested in)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
