### PR TITLE
Elixir remove setup hook

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -1,5 +1,14 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, erlang, makeWrapper,
-  coreutils, curl, bash, debugInfo ? false }:
+{ pkgs
+, lib
+, stdenv
+, fetchFromGitHub
+, erlang
+, makeWrapper
+, coreutils
+, curl
+, bash
+, debugInfo ? false
+}:
 
 { baseName ? "elixir"
 , version
@@ -13,62 +22,62 @@ let
   inherit (lib) getVersion versionAtLeast optional;
 
 in
-  assert versionAtLeast (getVersion erlang) minimumOTPVersion;
+assert versionAtLeast (getVersion erlang) minimumOTPVersion;
 
-  stdenv.mkDerivation ({
-    name = "${baseName}-${version}";
+stdenv.mkDerivation ({
+  name = "${baseName}-${version}";
 
-    inherit src version;
+  inherit src version;
 
-    nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ erlang ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ erlang ];
 
-    LANG = "C.UTF-8";
-    LC_TYPE = "C.UTF-8";
+  LANG = "C.UTF-8";
+  LC_TYPE = "C.UTF-8";
 
-    setupHook = ./setup-hook.sh;
+  setupHook = ./setup-hook.sh;
 
-    inherit debugInfo;
+  inherit debugInfo;
 
-    buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
+  buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
 
-    preBuild = ''
-      patchShebangs lib/elixir/generate_app.escript || true
+  preBuild = ''
+    patchShebangs lib/elixir/generate_app.escript || true
 
-      substituteInPlace Makefile \
-        --replace "/usr/local" $out
+    substituteInPlace Makefile \
+      --replace "/usr/local" $out
+  '';
+
+  postFixup = ''
+    # Elixir binaries are shell scripts which run erl. Add some stuff
+    # to PATH so the scripts can run without problems.
+
+    for f in $out/bin/*; do
+     b=$(basename $f)
+      if [ "$b" = mix ]; then continue; fi
+      wrapProgram $f \
+        --prefix PATH ":" "${lib.makeBinPath [ erlang coreutils curl bash ]}"
+    done
+
+    substituteInPlace $out/bin/mix \
+          --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
+  '';
+
+  pos = builtins.unsafeGetAttrPos "sha256" args;
+  meta = with lib; {
+    homepage = "https://elixir-lang.org/";
+    description = "A functional, meta-programming aware language built on top of the Erlang VM";
+
+    longDescription = ''
+      Elixir is a functional, meta-programming aware language built on
+      top of the Erlang VM. It is a dynamic language with flexible
+      syntax and macro support that leverages Erlang's abilities to
+      build concurrent, distributed and fault-tolerant applications
+      with hot code upgrades.
     '';
 
-    postFixup = ''
-      # Elixir binaries are shell scripts which run erl. Add some stuff
-      # to PATH so the scripts can run without problems.
-
-      for f in $out/bin/*; do
-       b=$(basename $f)
-        if [ "$b" = mix ]; then continue; fi
-        wrapProgram $f \
-          --prefix PATH ":" "${lib.makeBinPath [ erlang coreutils curl bash ]}"
-      done
-
-      substituteInPlace $out/bin/mix \
-            --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
-    '';
-
-    pos = builtins.unsafeGetAttrPos "sha256" args;
-    meta = with lib; {
-      homepage = "https://elixir-lang.org/";
-      description = "A functional, meta-programming aware language built on top of the Erlang VM";
-
-      longDescription = ''
-        Elixir is a functional, meta-programming aware language built on
-        top of the Erlang VM. It is a dynamic language with flexible
-        syntax and macro support that leverages Erlang's abilities to
-        build concurrent, distributed and fault-tolerant applications
-        with hot code upgrades.
-      '';
-
-      license = licenses.epl10;
-      platforms = platforms.unix;
-      maintainers = teams.beam.members;
-    };
-  })
+    license = licenses.epl10;
+    platforms = platforms.unix;
+    maintainers = teams.beam.members;
+  };
+})

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -27,7 +27,7 @@ assert versionAtLeast (getVersion erlang) minimumOTPVersion;
 stdenv.mkDerivation ({
   name = "${baseName}-${version}";
 
-  inherit src version;
+  inherit src version debugInfo;
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ erlang ];
@@ -36,8 +36,6 @@ stdenv.mkDerivation ({
   LC_TYPE = "C.UTF-8";
 
   setupHook = ./setup-hook.sh;
-
-  inherit debugInfo;
 
   buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
 

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation ({
   LANG = "C.UTF-8";
   LC_TYPE = "C.UTF-8";
 
-  setupHook = ./setup-hook.sh;
-
   buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
 
   preBuild = ''

--- a/pkgs/development/interpreters/elixir/setup-hook.sh
+++ b/pkgs/development/interpreters/elixir/setup-hook.sh
@@ -1,5 +1,0 @@
-addErlLibPath() {
-    addToSearchPath ERL_LIBS $1/lib/elixir/lib
-}
-
-addEnvHooks "$hostOffset" addErlLibPath


### PR DESCRIPTION
###### Motivation for this change

close #85265 

we do not know for sure why that hook was added. I propose to remove until we can figure out why it was added.

In case we detect a breakage, I will take the responsability to merge a fix rapidly.

@cw789 thank you for researching the issue

@ericbmerritt in case you have more information about why the hook was added in https://github.com/NixOS/nixpkgs/commit/2d6d9682bb8a910f3eb5f0be8d5687c753e9732c in the first place, that would be useful.

I will leave this open for a little longer, to give a chance for different people to test.

@NixOS/beam 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
