### PR TITLE
matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: init at 0.1.17

### DIFF
--- a/pkgs/servers/matrix-synapse/plugins/default.nix
+++ b/pkgs/servers/matrix-synapse/plugins/default.nix
@@ -2,6 +2,7 @@
 
 {
   matrix-synapse-ldap3 = callPackage ./ldap3.nix { };
+  matrix-synapse-mjolnir-antispam = callPackage ./mjolnir-antispam.nix { };
   matrix-synapse-pam = callPackage ./pam.nix { };
   matrix-synapse-shared-secret-auth = callPackage ./shared-secret-auth.nix { };
 }

--- a/pkgs/servers/matrix-synapse/plugins/mjolnir-antispam.nix
+++ b/pkgs/servers/matrix-synapse/plugins/mjolnir-antispam.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchFromGitHub, matrix-synapse }:
+
+buildPythonPackage rec {
+  pname = "matrix-synapse-mjolnir-antispam";
+  version = "0.1.17";
+
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = "mjolnir";
+    rev = "v${version}";
+    sha256 = "sha256-uBI5AllXWgl3eL60WZ/j11Tt7QpY7CKcmFQOU74/Qjs=";
+  };
+
+  sourceRoot = "./source/synapse_antispam";
+
+  propagatedBuildInputs = [ matrix-synapse ];
+
+  doCheck = false; # no tests
+  pythonImportsCheck = [ "mjolnir" ];
+
+  meta = with lib; {
+    description = "AntiSpam / Banlist plugin to be used with mjolnir";
+    longDescription = ''
+      Primarily meant to block invites from undesired homeservers/users,
+      Mjolnir's Synapse module is a way to interpret ban lists and apply
+      them to your entire homeserver.
+    '';
+    homepage = "https://github.com/matrix-org/mjolnir#synapse-module";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the [mjolnir antispam](https://github.com/matrix-org/mjolnir#synapse-module) plugin for synapse. I recently migrated my matrix homeserver to NixOS and am running mjolnir as well (created a derivation for it, but that one needs to be cleaned up a little - I've modified the upstream source to be able to load additional configuration files, e.g. the secret parts like the password of the superuser). If there is interest to add mjolnir to nixpkgs i can create a PR for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
