### PR TITLE
[staging-next] firefox: take LLVM tools from buildStdenv

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -327,11 +327,11 @@ buildStdenv.mkDerivation ({
     "BUILD_OFFICIAL=1"
   ]
   ++ lib.optionals ltoSupport [
-    "AR=${llvmPackages.bintools}/bin/llvm-ar"
-    "LLVM_OBJDUMP=${llvmPackages.bintools}/bin/llvm-objdump"
-    "NM=${llvmPackages.bintools}/bin/llvm-nm"
-    "RANLIB=${llvmPackages.bintools}/bin/llvm-ranlib"
-    "STRIP=${llvmPackages.bintools}/bin/llvm-strip"
+    "AR=${buildStdenv.cc.bintools.bintools}/bin/llvm-ar"
+    "LLVM_OBJDUMP=${buildStdenv.cc.bintools.bintools}/bin/llvm-objdump"
+    "NM=${buildStdenv.cc.bintools.bintools}/bin/llvm-nm"
+    "RANLIB=${buildStdenv.cc.bintools.bintools}/bin/llvm-ranlib"
+    "STRIP=${buildStdenv.cc.bintools.bintools}/bin/llvm-strip"
   ]
   ++ extraMakeFlags;
 


### PR DESCRIPTION
Since 37194a325de0 llvmPackages*.bintools is a bintools-wrapper. Thus it
only contains a wrapper for `as` and `ld`. This change makes sense, but
causes regressions like this one. Since we need the LLVM tools
specifically opting to use llvmPackages.llvm instead of the alternative
which would be using the passed through “raw” bintools derivation
llvmPackages.bintools.bintools.

---

Untested, but verified all paths in `firefox-unwrapped.makeFlags` are now correct.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
