### PR TITLE
inter: add font type option

### DIFF
--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -2,17 +2,39 @@
 
 let
   version = "3.18";
+  exts = {
+    "opentype" = ".otf";
+    "truetype" = ".ttf";
+  };
+  hashes = {
+    "opentype" = "sha256-+wbN1vSS8v1Z1VIfDNeY9DB8Kr6v7UnFg37EPPAD7wI=";
+    "truetype" = "1an10lnp2pvd1syh9j6rmgwy9fxjz9m3fm2i3g93hghkv5p5r0kc";
+  };
+
+in
+
+{ # select a font type to install.
+  # Default is opentype with file extension '.otf'
+  type ? "opentype"
+}:
+
+assert builtins.hasAttr type exts;
+assert builtins.hasAttr type hashes;
+
+let
+  ext = builtins.getAttr type exts;
+  sha256 = builtins.getAttr type hashes;
 in fetchzip {
-  name = "inter-${version}";
+  name = "inter-${version}-${type}";
 
   url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
 
   postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    mkdir -p $out/share/fonts/${type}
+    unzip -j $downloadedFile \*${ext} -d $out/share/fonts/${type}
   '';
 
-  sha256 = "sha256-+wbN1vSS8v1Z1VIfDNeY9DB8Kr6v7UnFg37EPPAD7wI=";
+  inherit sha256;
 
   meta = with lib; {
     homepage = "https://rsms.me/inter/";

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,4 +1,8 @@
-{ lib, fetchzip }:
+{ lib
+, fetchzip
+# select a font type to install.
+# Default is opentype with file extension '.otf'
+, type ? "opentype"}:
 
 let
   version = "3.18";
@@ -12,11 +16,6 @@ let
   };
 
 in
-
-{ # select a font type to install.
-  # Default is opentype with file extension '.otf'
-  type ? "opentype"
-}:
 
 assert builtins.hasAttr type exts;
 assert builtins.hasAttr type hashes;


### PR DESCRIPTION
add possibility to choose font type to install.
some applications may need truetype fonts instead of opentype.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Some applications may need the truetype version instead of the opentype.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
