### PR TITLE
xpra: 4.1.3 -> 4.2

### DIFF
--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -16,19 +16,6 @@ index f962330..b02b6dd 100755
              f.write(b"DEF ENABLE_DEVICE_CAPS=%i" % ENABLE_DEVICE_CAPS)
      cython_add(Extension("xpra.codecs.v4l2.pusher",
      
-diff --git a/xpra/x11/bindings/keyboard_bindings.pyx b/xpra/x11/bindings/keyboard_bindings.pyx
-index bd7023d..064c6b5 100644
---- a/xpra/x11/bindings/keyboard_bindings.pyx
-+++ b/xpra/x11/bindings/keyboard_bindings.pyx
-@@ -21,7 +21,7 @@ from libc.stdlib cimport free, malloc
-
- DEF PATH_MAX = 1024
- DEF DFLT_XKB_RULES_FILE = b"base"
--DEF DFLT_XKB_CONFIG_ROOT = b"/usr/share/X11/xkb"
-+DEF DFLT_XKB_CONFIG_ROOT = b"@xkeyboardconfig@/share/X11/xkb"
-
- ###################################
- # Headers, python magic
 diff --git a/xpra/x11/fakeXinerama.py b/xpra/x11/fakeXinerama.py
 index c867258..617af7c 100755
 --- a/xpra/x11/fakeXinerama.py


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix xpra not starting

###### Things done
- Updated Xpra src
- Xpra generated Xorg command line was not starting due to newlines
- Disable xpra_Xdummy wrapper script, it is not needed since this doesn't use a setuid Xorg
- Add librsvg to resize large icons for faster menus
- Set xkb config dir in wrapper args using new xpra option

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
