### PR TITLE
pythonPackages.hypercorn: init at 0.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2427,6 +2427,12 @@
     githubId = 4708206;
     name = "Daniel Fox Franke";
   };
+  dgliwka = {
+    email = "dawid.gliwka@gmail.com";
+    github = "dgliwka";
+    githubId = 33262214;
+    name = "Dawid Gliwka";
+  };
   dgonyeo = {
     email = "derek@gonyeo.com";
     github = "dgonyeo";

--- a/pkgs/development/python-modules/hypercorn/default.nix
+++ b/pkgs/development/python-modules/hypercorn/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, pythonOlder
+, typing-extensions
+, wsproto
+, toml
+, h2
+, priority
+, mock
+, pytest-asyncio
+, pytest-cov
+, pytest-sugar
+, pytest-trio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "Hypercorn";
+  version = "0.11.2";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitLab {
+    owner = "pgjones";
+    repo = pname;
+    rev = version;
+    sha256 = "0v80v6l2xqac5mgrmh2im7y23wpvz4yc2v4h9ryhvl88c2jk9mvh";
+  };
+
+  propagatedBuildInputs = [ wsproto toml h2 priority ]
+    ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-cov
+    pytest-sugar
+    pytest-trio
+    pytestCheckHook
+  ] ++ lib.optionals (pythonOlder "3.8") [ mock ];
+
+  pythonImportsCheck = [ "hypercorn" ];
+
+  meta = with lib; {
+    homepage = "https://pgjones.gitlab.io/hypercorn/";
+    description = "The ASGI web server inspired by Gunicorn";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dgliwka ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3213,6 +3213,8 @@ in {
 
   hypchat = callPackage ../development/python-modules/hypchat { };
 
+  hypercorn = callPackage ../development/python-modules/hypercorn { };
+
   hyperframe = callPackage ../development/python-modules/hyperframe { };
 
   hyperion-py = callPackage ../development/python-modules/hyperion-py { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[Hypercorn](https://pgjones.gitlab.io/hypercorn/) - an ASGI Server based on Hyper libraries and inspired by Gunicorn.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): 132.3M
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
