### PR TITLE
emacs-modes: add buildInputs override for erlang

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -116,6 +116,13 @@ let
           stripDebugList = [ "share" ];
         });
 
+        erlang = super.erlang.overrideAttrs (attrs: {
+          buildInputs = attrs.buildInputs ++ [
+            pkgs.perl
+            pkgs.ncurses
+          ];
+        });
+
         # https://github.com/syl20bnr/evil-escape/pull/86
         evil-escape = super.evil-escape.overrideAttrs (attrs: {
           postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Erlang mode needs perl5 and ncurses to build, add buildInputs override.

###### Things done

Using this branch as my nixpkgs upstream, I've compiled this with the latest commit nix-community/emacs-overlay@f9f4e40f55c9e3d9b0fba29f14ac5d7cffecf675.  Everything checked out, I was able to build.  Without this change, the erlang-mode fails to build due to missing buildInputs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
