### PR TITLE
espanso: add runtime dependencies correctly, nixos/espanso remove path hack

### DIFF
--- a/nixos/modules/services/desktops/espanso.nix
+++ b/nixos/modules/services/desktops/espanso.nix
@@ -12,7 +12,6 @@ in {
   config = mkIf cfg.enable {
     systemd.user.services.espanso = {
       description = "Espanso daemon";
-      path = with pkgs; [ espanso libnotify xclip ];
       serviceConfig = {
         ExecStart = "${pkgs.espanso}/bin/espanso daemon";
         Restart = "on-failure";

--- a/pkgs/applications/office/espanso/default.nix
+++ b/pkgs/applications/office/espanso/default.nix
@@ -10,6 +10,7 @@
 , openssl
 , xclip
 , xdotool
+, makeWrapper
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,6 +29,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     extra-cmake-modules
     pkg-config
+    makeWrapper
   ];
 
   buildInputs = [
@@ -36,11 +38,17 @@ rustPlatform.buildRustPackage rec {
     libXi
     libnotify
     openssl
+    xclip
     xdotool
   ];
 
   # Some tests require networking
   doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/espanso \
+      --prefix PATH : ${lib.makeBinPath [ libnotify xclip ]}
+  '';
 
   meta = with lib; {
     description = "Cross-platform Text Expander written in Rust";


### PR DESCRIPTION
###### Motivation for this change
Espanso wouldn't work if the dependencies weren't installed, because they weren't added to the path.
The nixos/espanso module works around this by adding them to the path

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
