### PR TITLE
pr-tracker: init at 1.0.0

### DIFF
--- a/pkgs/servers/pr-tracker/default.nix
+++ b/pkgs/servers/pr-tracker/default.nix
@@ -1,0 +1,35 @@
+{ rustPlatform
+, lib
+, fetchgit
+, openssl
+, pkg-config
+, systemd
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pr-tracker";
+  version = "1.0.0";
+
+  src = fetchgit {
+    url = "https://git.qyliss.net/pr-tracker";
+    rev = version;
+    sha256 = "sha256-NHtY05Llrvfvcb3uyagLd6kaVW630TIP3IreFrY3wl0=";
+  };
+
+  cargoSha256 = "sha256-SgSASfIanADV31pVy+VIwozTLxq7P3oMDIiAAQ8s+k0=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl systemd ];
+
+  meta = with lib; {
+    description = "Nixpkgs pull request channel tracker";
+    longDescription = ''
+      A web server that displays the path a Nixpkgs pull request will take
+      through the various release channels.
+    '';
+    platforms = platforms.linux;
+    homepage = "https://git.qyliss.net/pr-tracker";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ sumnerevans ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7826,6 +7826,8 @@ in
 
   polygraph = callPackage ../tools/networking/polygraph { };
 
+  pr-tracker = callPackage ../servers/pr-tracker { };
+
   progress = callPackage ../tools/misc/progress { };
 
   ps3netsrv = callPackage ../servers/ps3netsrv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://git.qyliss.net/pr-tracker/tag/?h=1.0.0

This is the project behind https://nixpk.gs/pr-tracker.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Instructions for Testers

After building, run using:
```
systemd-socket-activate \
  -l 0.0.0.0:8000 \
  ./result/bin/pr-tracker \
    --path /path/to/local/nixpkgs \
    --remote origin \
    --user-agent 'pr-tracker' \
    --source-url https://example.com/pr-tracker.tar.gz \
    </path/to/your/github/api/token
```