### PR TITLE
libass: drop enca dependency, not supported anymore

### DIFF
--- a/pkgs/development/libraries/libass/default.nix
+++ b/pkgs/development/libraries/libass/default.nix
@@ -1,13 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, yasm
 , freetype, fribidi, harfbuzz
-, encaSupport ? true, enca ? null # enca support
 , fontconfigSupport ? true, fontconfig ? null # fontconfig support
 , rasterizerSupport ? false # Internal rasterizer
 , largeTilesSupport ? false # Use larger tiles in the rasterizer
 , libiconv
 }:
 
-assert encaSupport -> enca != null;
 assert fontconfigSupport -> fontconfig != null;
 
 let
@@ -25,7 +23,6 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [
-    (mkFlag encaSupport "enca")
     (mkFlag fontconfigSupport "fontconfig")
     (mkFlag rasterizerSupport "rasterizer")
     (mkFlag largeTilesSupport "large-tiles")
@@ -34,7 +31,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config yasm ];
 
   buildInputs = [ freetype fribidi harfbuzz ]
-    ++ optional encaSupport enca
     ++ optional fontconfigSupport fontconfig
     ++ optional stdenv.isDarwin libiconv;
 


### PR DESCRIPTION
###### Motivation for this change

libass is a dependency of ffmpeg, which is depended upon by a lot of packages. Enca was a dependency previously, but it's unused since version 0.13.0. Let's drop it since it doesn't do anything.

This also enables cross-compilation, since enca didn't cross-compile properly. Since it isn't needed anymore, we don't have to attempt that.

I tried to build with and without this change using content-addressed derivations, that gave the same hash for both builds. That gives confidence that removing enca doesn't change anything.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
