### PR TITLE
mosquitto: use libwebsockets 4.x

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -5,6 +5,8 @@
 , openssl
 , zlib
 , libuv
+# External poll is required for e.g. mosquitto, but discouraged by the maintainer.
+, withExternalPoll ? false
 }:
 
 let
@@ -29,7 +31,8 @@ let
       "-DLWS_WITH_SOCKS5=ON"
       # Required since v4.2.0
       "-DLWS_BUILD_HASH=no_hash"
-    ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON";
+    ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
+      ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON";
 
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-error=unused-but-set-variable";
 

--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -8,13 +8,19 @@
 , cjson
 , libuuid
 , libuv
-, libwebsockets_3_1
+, libwebsockets
 , openssl
 , withSystemd ? stdenv.isLinux
 , systemd
 , fetchpatch
 }:
 
+let
+  # Mosquitto needs external poll enabled in libwebsockets.
+  libwebsockets' = libwebsockets.override {
+    withExternalPoll = true;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "mosquitto";
   version = "2.0.12";
@@ -54,7 +60,7 @@ stdenv.mkDerivation rec {
     cjson
     libuuid
     libuv
-    libwebsockets_3_1
+    libwebsockets'
     openssl
   ] ++ lib.optional withSystemd systemd;
 


### PR DESCRIPTION
###### Motivation for this change

Mosquitto now seems to support libwebsockets 4.x, so let's start using that instead of keeping it on an old version.

Websockets is also updated in https://github.com/NixOS/nixpkgs/pull/123137.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I haven't tested the websockets functionality specifically.