### PR TITLE
atk: support cross-compilation by disabling introspection

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, meson, ninja, gettext, pkg-config, glib
 , fixDarwinDylibNames, gobject-introspection, gnome
+, withIntrospection ? stdenv.buildPlatform == stdenv.hostPlatform
 }:
 
 let
@@ -17,8 +18,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext gobject-introspection glib ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = [ meson ninja pkg-config gettext glib ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames
+    ++ lib.optional withIntrospection gobject-introspection;
 
   propagatedBuildInputs = [
     # Required by atk.pc
@@ -29,6 +31,10 @@ stdenv.mkDerivation rec {
     # meson builds an incorrect .pc file
     # glib should be Requires not Requires.private
     ./fix_pc.patch
+  ];
+
+  mesonFlags = [
+    "-Dintrospection=${lib.boolToString withIntrospection}"
   ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for atk.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
