### PR TITLE
nixos/atop: Add defaultText to types.package options, Fix timing-related test failures.

### DIFF
--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -19,6 +19,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.atop;
+        defaultText = "pkgs.atop";
         description = ''
           Which package to use for Atop.
         '';
@@ -36,6 +37,7 @@ in
         package = mkOption {
           type = types.package;
           default = config.boot.kernelPackages.netatop;
+          defaultText = "config.boot.kernelPackages.netatop";
           description = ''
             Which package to use for netatop.
           '';

--- a/nixos/tests/atop.nix
+++ b/nixos/tests/atop.nix
@@ -14,7 +14,10 @@ let assertions = rec {
   '';
   unit = name: state: ''
     with subtest("Unit ${name} should be ${state}"):
-        machine.require_unit_state("${name}", "${state}")
+        if "${state}" == "active":
+            machine.wait_for_unit("${name}")
+        else:
+            machine.require_unit_state("${name}", "${state}")
   '';
   version = ''
     import re
@@ -44,9 +47,19 @@ let assertions = rec {
     if present then
       unit "atop.service" "active"
       + ''
-        with subtest("atop.service should have written some data to /var/log/atop"):
-            files = int(machine.succeed("ls -1 /var/log/atop | wc -l"))
-            assert files > 0, "Expected at least 1 data file"
+        with subtest("atop.service should write some data to /var/log/atop"):
+
+            def has_data_files(last: bool) -> bool:
+                files = int(machine.succeed("ls -1 /var/log/atop | wc -l"))
+                if files == 0:
+                    machine.log("Did not find at least one 1 data file")
+                    if not last:
+                        machine.log("Will retry...")
+                    return False
+                return True
+
+            with machine.nested("Waiting for data files"):
+                retry(has_data_files)
       '' else unit "atop.service" "inactive";
   atopRotateTimer = present:
     unit "atop-rotate.timer" (if present then "active" else "inactive");
@@ -55,11 +68,21 @@ let assertions = rec {
       unit "atopacct.service" "active"
       + ''
         with subtest("atopacct.service should enable process accounting"):
-            machine.succeed("test -f /run/pacct_source")
+            machine.wait_until_succeeds("test -f /run/pacct_source")
 
         with subtest("atopacct.service should write data to /run/pacct_shadow.d"):
-            files = int(machine.succeed("ls -1 /run/pacct_shadow.d | wc -l"))
-            assert files >= 1, "Expected at least 1 pacct_shadow.d file"
+
+            def has_data_files(last: bool) -> bool:
+                files = int(machine.succeed("ls -1 /run/pacct_shadow.d | wc -l"))
+                if files == 0:
+                    machine.log("Did not find at least one 1 data file")
+                    if not last:
+                        machine.log("Will retry...")
+                    return False
+                return True
+
+            with machine.nested("Waiting for data files"):
+                retry(has_data_files)
       '' else unit "atopacct.service" "inactive";
   netatop = present:
     if present then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In https://github.com/NixOS/nixpkgs/pull/123053#discussion_r637205826 @samueldr informed me about missing `defaultText` attributes on `types.package` options leading to a downstream build failure.

While trying to run the tests locally, I noticed intermittent timing-related test failures, so I added another patch that uses `wait_` test driver methods for some things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
