### PR TITLE
diopser: init at unstable-2021-5-13

### DIFF
--- a/pkgs/applications/audio/diopser/default.nix
+++ b/pkgs/applications/audio/diopser/default.nix
@@ -1,0 +1,76 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, libjack2, alsaLib, freetype, libX11, libXrandr, libXinerama, libXext, libXcursor
+}:
+
+let
+
+  # Derived from subprojects/function2.wrap
+  function2 = rec {
+    version = "4.1.0";
+    src = fetchFromGitHub {
+      owner = "Naios";
+      repo = "function2";
+      rev = version;
+      hash = "sha256-JceZU8ZvtYhFheh8BjMvjjZty4hcYxHEK+IIo5X4eSk=";
+    };
+  };
+
+  juce = rec {
+    version = "unstable-2021-04-07";
+    src = fetchFromGitHub {
+      owner = "juce-framework";
+      repo = "JUCE";
+      rev = "1a5fb5992a1a4e28e998708ed8dce2cc864a30d7";
+      sha256= "1ri7w4sz3sy5xilibg53ls9526fx7jwbv8rc54ccrqfhxqyin308";
+    };
+  };
+
+
+in  stdenv.mkDerivation rec {
+  pname = "diopser";
+  version = "unstable-2021-5-13";
+
+  src = fetchFromGitHub {
+    owner = "robbert-vdh";
+    repo = pname;
+    fetchSubmodules = true;
+    rev = "d5fdc92f1caf5a828e071dac99e106e58f06d84d";
+    sha256 = "06y1h895yxh44gp4vxzrna59lf7nlfw7aacd3kk4l1g56jhy9pdx";
+  };
+
+  postUnpack = ''
+    (
+      cd "$sourceRoot"
+      cp -R --no-preserve=mode,ownership ${function2.src} function2
+      cp -R --no-preserve=mode,ownership ${juce.src} JUCE
+      sed -i 's@CPMAddPackage("gh:juce-framework/JUCE.*@add_subdirectory(JUCE)@g' CMakeLists.txt
+      sed -i 's@CPMAddPackage("gh:Naios/function2.*@add_subdirectory(function2)@g' CMakeLists.txt
+      patchShebangs .
+    )
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/vst3
+    cp -r Diopser_artefacts/Release/VST3/Diopser.vst3 $out/lib/vst3
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    libjack2 alsaLib freetype libX11 libXrandr libXinerama libXext
+    libXcursor
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${stdenv.cc.cc}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${stdenv.cc.cc}/bin/gcc-ranlib"
+  ];
+
+  meta = with lib; {
+    description = "A totally original phase rotation plugin";
+    homepage = "https://github.com/robbert-vdh/diopser";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1355,6 +1355,8 @@ in
 
   dfmt = callPackage ../tools/text/dfmt { };
 
+  diopser = callPackage ../applications/audio/diopser { };
+
   diskonaut = callPackage ../tools/misc/diskonaut { };
 
   diskus = callPackage ../tools/misc/diskus {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
