### PR TITLE
radarr: 3.1.1.4954 -> 3.2.1.5070

### DIFF
--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -9,14 +9,14 @@ let
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   hash = {
-    x64-linux_hash = "sha256-uuD22/K8jxGzqkuHsG6NyhxNo/7ZJyTXkEuCKhP8lMM=";
-    arm64-linux_hash = "sha256-bADOyqMtoiisugHF78BNYlUr6rHEODEw05ZkA4IMVgc=";
-    x64-osx_hash = "sha256-ZjJY4KgoLS9OcuE/SDFcPeFdIj/MkCCn+egK6fBGVmc=";
+    x64-linux_hash = "sha256-/9W8VwA3d7R2pYH45QvGC1q9f9M9C867nKuhSlU6zsg=";
+    arm64-linux_hash = "sha256-QjIg+XY5vTmYH+wYqU3VZ5MfxSAcUcGVvapyrlMDbLI=";
+    x64-osx_hash = "sha256-K17tzGdLKpHkkLSOT3a4FXXfeGz6LJ6cxd20IuJ2zVs=";
   }."${arch}-${os}_hash";
 
 in stdenv.mkDerivation rec {
   pname = "radarr";
-  version = "3.2.0.5048";
+  version = "3.2.1.5070";
 
   src = fetchurl {
     url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.master.${version}.${os}-core-${arch}.tar.gz";

--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -9,14 +9,14 @@ let
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   hash = {
-    x64-linux_hash = "sha256-5W4X1E7794hFVPo4+s826CNIrw6Z/n0cDjj6pmsj2Dk=";
-    arm64-linux_hash = "sha256-gqCgToAVIS+IEulFY4mo2Mtcb3nyFpzDBqVEewREQcs=";
-    x64-osx_hash = "sha256-MFpIzSYAvAWVHMdEd+aP67s3po+yb3qWzSd/Ko++5Jc=";
+    x64-linux_hash = "sha256-uuD22/K8jxGzqkuHsG6NyhxNo/7ZJyTXkEuCKhP8lMM=";
+    arm64-linux_hash = "sha256-bADOyqMtoiisugHF78BNYlUr6rHEODEw05ZkA4IMVgc=";
+    x64-osx_hash = "sha256-ZjJY4KgoLS9OcuE/SDFcPeFdIj/MkCCn+egK6fBGVmc=";
   }."${arch}-${os}_hash";
 
 in stdenv.mkDerivation rec {
   pname = "radarr";
-  version = "3.1.1.4954";
+  version = "3.2.0.5048";
 
   src = fetchurl {
     url = "https://github.com/Radarr/Radarr/releases/download/v${version}/Radarr.master.${version}.${os}-core-${arch}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change
* https://github.com/Radarr/Radarr/releases/tag/v3.2.0.5048
* https://github.com/Radarr/Radarr/releases/tag/v3.2.1.5070

###### Things done
Used the provided `./update.sh` to update, I've also updated my own running instance and encountered no issues.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
