### PR TITLE
libpoly: fix darwin build

### DIFF
--- a/pkgs/applications/science/logic/poly/default.nix
+++ b/pkgs/applications/science/logic/poly/default.nix
@@ -12,6 +12,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-E2lHo8Bt4ujoGQ623fjkQbqRnDYJYilXdRt4lnF4wJk=";
   };
 
+  # https://github.com/SRI-CSL/libpoly/pull/52
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/CMakeLists.txt --replace \
+      '"utils/open_memstream.c ''${poly_SOURCES}"' \
+      'utils/open_memstream.c ''${poly_SOURCES}'
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ gmp python3 ];


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042

Seems to just be incorrect cmake quoting in a seldom-built configuration. Issue reported upstream @ https://github.com/SRI-CSL/libpoly/pull/52.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
