### PR TITLE
ChowKick: init at 1.1.1

### DIFF
--- a/pkgs/applications/audio/ChowKick/default.nix
+++ b/pkgs/applications/audio/ChowKick/default.nix
@@ -1,0 +1,106 @@
+{ alsa-lib
+, at-spi2-core
+, brotli
+, cmake
+, curl
+, dbus
+, epoxy
+, fetchFromGitHub
+, freeglut
+, freetype
+, gtk2-x11
+, lib
+, libGL
+, libXcursor
+, libXdmcp
+, libXext
+, libXinerama
+, libXrandr
+, libXtst
+, libdatrie
+, libjack2
+, libpsl
+, libselinux
+, libsepol
+, libsysprof-capture
+, libthai
+, libxkbcommon
+, lv2
+, pcre
+, pkg-config
+, python3
+, sqlite
+, stdenv
+, util-linuxMinimal
+, webkitgtk
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ChowKick";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Chowdhury-DSP";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0amnp0p7ckbbr9dcbdnld1ryv46kvza2dj8m6hzmi7c1s4df8x5q";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    brotli
+    curl
+    dbus
+    epoxy
+    freeglut
+    freetype
+    gtk2-x11
+    libGL
+    libXcursor
+    libXdmcp
+    libXext
+    libXinerama
+    libXrandr
+    libXtst
+    libdatrie
+    libjack2
+    libpsl
+    libselinux
+    libsepol
+    libsysprof-capture
+    libthai
+    libxkbcommon
+    lv2
+    pcre
+    python3
+    sqlite
+    util-linuxMinimal
+    webkitgtk
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${stdenv.cc.cc}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${stdenv.cc.cc}/bin/gcc-ranlib"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2 $out/lib/vst3 $out/bin
+    cp -r ChowKick_artefacts/Release/LV2//${pname}.lv2 $out/lib/lv2
+    cp -r ChowKick_artefacts/Release/VST3/${pname}.vst3 $out/lib/vst3
+    cp ChowKick_artefacts/Release/Standalone/${pname}  $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Chowdhury-DSP/ChowKick";
+    description = "Kick synthesizer based on old-school drum machine circuits";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23773,6 +23773,8 @@ with pkgs;
 
   boops = callPackage ../applications/audio/boops { };
 
+  ChowKick  = callPackage ../applications/audio/ChowKick { };
+
   CHOWTapeModel = callPackage ../applications/audio/CHOWTapeModel { };
 
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});


### PR DESCRIPTION
Both the standalone application and the plugins work now, both the LV2 and the VST3.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
