### PR TITLE
tcltls: 1.6.7 -> 1.7.21

### DIFF
--- a/pkgs/development/libraries/tcltls/default.nix
+++ b/pkgs/development/libraries/tcltls/default.nix
@@ -2,11 +2,11 @@
 
 tcl.mkTclDerivation rec {
   pname = "tcltls";
-  version = "1.6.7";
+  version = "1.7.21";
 
   src = fetchurl {
-    url = "mirror://sourceforge/tls/tls${version}-src.tar.gz";
-    sha256 = "1f53sfcnrridjl5ayrq1xrqkahs8khf8c3d0m2brndbhahzdw6ai";
+    url = "https://core.tcl-lang.org/tcltls/uv/tcltls-${version}.tar.gz";
+    sha256 = "0xf1rfsnn4k9j1bd2a1p8ir0xr4a3phgr9lcgbazh4084l2y8sl0";
   };
 
   buildInputs = [ openssl ];
@@ -16,8 +16,9 @@ tcl.mkTclDerivation rec {
   ];
 
   meta = {
-    homepage = "http://tls.sourceforge.net/";
+    homepage = "https://core.tcl-lang.org/tcltls/index";
     description = "An OpenSSL / RSA-bsafe Tcl extension";
+    maintainers = [ lib.maintainers.agbrooks ];
     license = lib.licenses.tcltk;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/tcltls/default.nix
+++ b/pkgs/development/libraries/tcltls/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, tcl, openssl }:
+{ lib, fetchurl, tcl, openssl }:
 
 tcl.mkTclDerivation rec {
   pname = "tcltls";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18080,9 +18080,7 @@ in
 
   tcllib = callPackage ../development/libraries/tcllib { };
 
-  tcltls = callPackage ../development/libraries/tcltls {
-    openssl = openssl_1_0_2;
-  };
+  tcltls = callPackage ../development/libraries/tcltls { };
 
   tclx = callPackage ../development/libraries/tclx { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR addresses #38406 by upgrading `tcltls` to a version that builds against the default `openssl`.

I'm requesting to merge to `staging` because this PR won't fix #38406 without the changes included in #122472 (the changes in #122472 haven't yet made it to `master` at the time of writing). Please let me know if there's a better way to handle this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
