### PR TITLE
closureInfo: disallow substitutes, instead of only prefering local build

### DIFF
--- a/pkgs/build-support/closure-info.nix
+++ b/pkgs/build-support/closure-info.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   exportReferencesGraph.closure = rootPaths;
 
-  preferLocalBuild = true;
+  allowSubstitutes = false;
 
   PATH = "${buildPackages.coreutils}/bin:${buildPackages.jq}/bin";
 


### PR DESCRIPTION

"exportReferencesGraph" combined with "__structuredAttrs = true" "includes
the sizes and hashes of paths". If the result of the closureInfo is
substituted, but the contents of any path of the closure differs between
the binary cache and the local store, which can easily happen, because
not everything is perfectly reproducible, this leads to hash mismatches in
the image builders, which pass the output of closureInfo to
"nix-store --load-db".


Also see https://github.com/NixOS/nix/issues/4840

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
