### PR TITLE
calibre-web: Update Babel dependency requirement

### DIFF
--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -21,7 +21,8 @@ python3.pkgs.buildPythonApplication rec {
         --replace "singledispatch>=3.4.0.0,<3.5.0.0" "" \
         --replace "requests>=2.11.1,<2.25.0" "requests>=2.11.1,<2.26.0" \
         --replace "unidecode>=0.04.19,<1.2.0" "unidecode>=0.04.19" \
-        --replace "cps = calibreweb:main" "calibre-web = calibreweb:main"
+        --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
+        --replace "Babel>=1.3, <2.9" "Babel>=1.3, <=2.9"
   '';
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Babel requirement is <2.9 and nixpkgs provides 2.9.0

Updated the requirement definition. According to the Babel changelogs, there were no breaking changes between 2.8 and 2.9. Upstream has also updated the requirement to <3.0 but has not yet have another release.

Server started up properly and was accessible in browser, no further functionality test, though.

ZHF: #122042

@jonringer 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
