### PR TITLE
init: octave_kernel at 0.32.0, metakernel at 0.27.5

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/octave/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, callPackage
+, runCommand
+, makeWrapper
+, octave
+, imagemagick
+, python3
+}:
+
+# To test:
+# $(nix-build -E 'with import <nixpkgs> {}; jupyter.override { definitions = { octave = octave-kernel.definition; }; }')/bin/jupyter-notebook
+
+let
+  kernel = callPackage ./kernel.nix {
+    python3Packages = python3.pkgs;
+  };
+
+in
+
+rec {
+  launcher = runCommand "octave-kernel-launcher" {
+    inherit octave;
+    python = python3.withPackages (ps: [ ps.traitlets ps.jupyter_core ps.ipykernel ps.metakernel kernel ]);
+    buildInputs = [ makeWrapper ];
+  } ''
+    mkdir -p $out/bin
+
+    makeWrapper $python/bin/python $out/bin/octave-kernel \
+      --add-flags "-m octave_kernel" \
+      --suffix PATH : $octave/bin
+  '';
+
+  sizedLogo = size: stdenv.mkDerivation {
+    name = ''octave-logo-${octave.version}-${size}x${size}.png'';
+
+    src = octave.src;
+
+    buildInputs = [ imagemagick ];
+
+    dontConfigure = true;
+    dontInstall = true;
+
+    buildPhase = ''
+      convert ./libgui/src/icons/logo.png -resize ${size}x${size} $out
+    '';
+  };
+
+  definition = {
+    displayName = "Octave";
+    argv = [
+      "${launcher}/bin/octave-kernel"
+      "-f"
+      "{connection_file}"
+    ];
+    language = "octave";
+    logo32 = sizedLogo "32";
+    logo64 = sizedLogo "64";
+  };
+}

--- a/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
@@ -1,0 +1,30 @@
+{ lib, octave, python3Packages }:
+
+with python3Packages;
+
+buildPythonPackage rec {
+  pname = "octave-kernel";
+  version = "0.32.0";
+
+  src = fetchPypi {
+    pname = "octave_kernel";
+    inherit version;
+    sha256 = "0dfbxfcf3bz4jswnpkibnjwlkgy0y4j563nrhaqxv3nfa65bksif";
+  };
+
+  propagatedBuildInputs = [ metakernel ipykernel ];
+
+  # Tests require jupyter_kernel_test to run, but it hasn't seen a
+  # release since 2017 and seems slightly abandoned.
+  # Doing fetchPypi on it doesn't work, even though it exists here:
+  # https://pypi.org/project/jupyter_kernel_test/.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Jupyter kernel for Octave.";
+    homepage = "https://github.com/Calysto/octave_kernel";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thomasjm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/metakernel/default.nix
+++ b/pkgs/development/python-modules/metakernel/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ipykernel
+, isPy27
+, mock
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "metakernel";
+  version = "0.27.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0aqq9zil6h7kxsg3v2008nr6lv47qvcsash8qzmi1xh6r4x606zy";
+  };
+
+  propagatedBuildInputs = [ ipykernel ];
+
+  # Tests hang, so disable
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Jupyter/IPython Kernel Tools";
+    homepage = "https://github.com/Calysto/metakernel";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thomasjm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12095,6 +12095,8 @@ in
     overridePlatforms = ["x86_64-linux" "x86_64-darwin"];
   };
 
+  octave-kernel = callPackage ../applications/editors/jupyter-kernels/octave { };
+
   octavePackages = recurseIntoAttrs octave.pkgs;
 
   ocropus = callPackage ../applications/misc/ocropus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4220,6 +4220,8 @@ in {
 
   mesonpep517 = callPackage ../development/python-modules/mesonpep517 { };
 
+  metakernel = callPackage ../development/python-modules/metakernel { };
+
   metar = callPackage ../development/python-modules/metar { };
 
   mezzanine = callPackage ../development/python-modules/mezzanine { };


### PR DESCRIPTION
###### Motivation for this change

Init the Octave Jupyter kernel. Needed to add the Python `metakernel` package as a dependency as well.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Ubuntu 20.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
