### PR TITLE
molot-lite: use fork with bugfix and extra features.

### DIFF
--- a/pkgs/applications/audio/molot-lite/default.nix
+++ b/pkgs/applications/audio/molot-lite/default.nix
@@ -1,35 +1,31 @@
-{ lib, stdenv, fetchurl, unzip, lv2 }:
+{ lib, stdenv, fetchFromGitHub, lv2 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+
   pname = "molot-lite";
-  version = "unstable-2014-04-23";
+  version = "1.0.0";
 
-  src = fetchurl {
-    # fetchzip does not accept urls that do not end with .zip.
-    url = "https://sourceforge.net/p/molot/code/ci/c4eddc426f8d5821e8ebcf1d67265365e4c8c52a/tree/molot_src.zip?format=raw";
-    sha256 = "1c47dwfgrmn9459px8s5zikcqyr0777v226qzcxlr6azlcjwr51b";
+  src = fetchFromGitHub {
+    owner = "magnetophon";
+    repo = pname;
+    rev = version;
+    sha256 = "0xbvicfk1rgp01nlg6hlym9bnygry0nrbv88mv7w6hnacvl63ba4";
   };
 
-  nativeBuildInputs = [ unzip ];
   buildInputs = [ lv2 ];
 
-  unpackPhase = ''
-    unzip $src
-  '';
-
-  buildPhase = ''
-    make -C Molot_Mono_Lite
-    make -C Molot_Stereo_Lite
-  '';
+  makeFlags = [ "INSTALL_DIR=$out/lib/lv2" ];
 
   installPhase = ''
+    runHook preInstall
     make install INSTALL_DIR=$out/lib/lv2 -C Molot_Mono_Lite
     make install INSTALL_DIR=$out/lib/lv2 -C Molot_Stereo_Lite
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Stereo and mono audio signal dynamic range compressor in LV2 format";
-    homepage = "https://sourceforge.net/projects/molot/";
+    homepage = "https://github.com/magnetophon/molot-lite";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;


### PR DESCRIPTION
The original only had the mono version working; the stereo one just
passed the sound.

https://github.com/magnetophon/molot-lite/commit/06c055a94709f06ebc2537eb45bdfd45cd9a5127

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
