### PR TITLE
airwindows: init at unstable-2022-01-29

### DIFF
--- a/pkgs/applications/audio/airwindows/default.nix
+++ b/pkgs/applications/audio/airwindows/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, lib, fetchFromGitHub, requireFile, fetchzip, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "airwindows";
+  version = "unstable-2022-01-29";
+
+  src = fetchFromGitHub {
+    owner = "airwindows";
+    repo = "airwindows";
+    rev = "f1e7313c284110347f2907ebe47ad1c03a9b2e9e";
+    sha256 = "sha256-3P65nnSTceSoFHSFkYLr5yXCyRGgV5Zg6L0R4wP7XTw=";
+  };
+
+  # equal to vst-sdk in ../oxefmsynth/default.nix
+  vst-sdk = stdenv.mkDerivation rec {
+    name = "vstsdk3610_11_06_2018_build_37";
+    src = fetchzip {
+      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${name}.zip";
+      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
+    };
+    installPhase = ''
+      cp -r . $out
+    '';
+  };
+
+  airwindows-ports = stdenv.mkDerivation rec {
+    name = "airwindows-ports";
+    src = fetchFromGitHub {
+      owner = "ech2";
+      repo = "airwindows-ports";
+      rev = "0.4.0";
+      sha256 = "1ya4qbc63sb52nzisdapsydrnnpqnjsl5kgxibbr3dxf32474g89";
+    };
+    installPhase = "cp -r . $out";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  postPatch = ''
+    cd plugins/LinuxVST
+    mkdir -p include/vstsdk
+    cp -r ${airwindows-ports}/include/vstsdk/CMakeLists.txt include/vstsdk/
+    cp -r ${vst-sdk}/VST2_SDK/pluginterfaces include/vstsdk/pluginterfaces
+    cp -r ${vst-sdk}/VST2_SDK/public.sdk/source/vst2.x/* include/vstsdk/
+    chmod -R 755 include/vstsdk/pluginterfaces
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    for so_file in *.so; do
+      install -vDm 644 $so_file -t "$out/lib/lxvst"
+    done;
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Handsewn bespoke linuxvst plugins";
+    homepage = "https://www.airwindows.com/airwindows-linux/";
+    # airwindows is mit, but the vst sdk is unfree
+    licenses = with licenses; [ mit unfree ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -976,6 +976,8 @@ with pkgs;
 
   airtame = callPackage ../applications/misc/airtame { };
 
+  airwindows = callPackage ../applications/audio/airwindows { };
+
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
   ajour = callPackage ../tools/games/ajour {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated to latest commit on 2022-01-29
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
