### PR TITLE
rofimoji: 4.3.0 -> 5.1.0

### DIFF
--- a/pkgs/applications/misc/rofimoji/default.nix
+++ b/pkgs/applications/misc/rofimoji/default.nix
@@ -6,7 +6,6 @@
 , x11Support ? true
 
 , ConfigArgParse
-, pyxdg
 , rofi
 , wl-clipboard
 , wtype
@@ -16,18 +15,18 @@
 
 buildPythonApplication rec {
   pname = "rofimoji";
-  version = "4.3.0";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "fdw";
     repo = "rofimoji";
     rev = version;
-    sha256 = "08ayndpifr04njpijc5n5ii5nvibfpab39p6ngyyj0pb43792a8j";
+    sha256 = "sha256-bLV0hYDjVH11euvNHUHZFcCVywuceRljkCqyX4aANVs=";
   };
 
   # `rofi` and the `waylandSupport` and `x11Support` dependencies
   # contain binaries needed at runtime.
-  propagatedBuildInputs = with lib; [ ConfigArgParse pyxdg rofi ]
+  propagatedBuildInputs = with lib; [ ConfigArgParse rofi ]
     ++ optionals waylandSupport [ wl-clipboard wtype ]
     ++ optionals x11Support [ xdotool xsel ];
 
@@ -35,7 +34,6 @@ buildPythonApplication rec {
   # and has additional dependencies.
   postPatch = ''
     rm -rf extractors
-    substituteInPlace setup.py --replace 'pyxdg==0.26' 'pyxdg'
   '';
 
   # no tests executed

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25738,7 +25738,7 @@ in
   rofi-systemd = callPackage ../tools/system/rofi-systemd { };
 
   rofimoji = callPackage ../applications/misc/rofimoji {
-    inherit (python3Packages) buildPythonApplication ConfigArgParse pyxdg;
+    inherit (python3Packages) buildPythonApplication ConfigArgParse;
   };
 
   rootlesskit = callPackage ../tools/virtualization/rootlesskit {};


### PR DESCRIPTION
`pyxdg` dependency was removed in 5.0, so I've removed it.

Tested only on X11, but I don't expect any problems on Wayland if it was working before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
