### PR TITLE
powerline-mem-segment: init at 2.4.1

### DIFF
--- a/pkgs/development/python-modules/powerline-mem-segment/default.nix
+++ b/pkgs/development/python-modules/powerline-mem-segment/default.nix
@@ -1,0 +1,24 @@
+{ lib,
+  buildPythonPackage,
+  fetchPypi,
+  psutil
+}:
+
+buildPythonPackage rec {
+  pname = "powerline-mem-segment";
+  version = "2.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0507zw7g449zk7dcq56adcdp71inbqfdmp6y5yk4x4j7kkp6pii9";
+  };
+
+  buildInputs = [ psutil ];
+
+  meta = with lib; {
+    description = "Segment for Powerline showing the current memory usage in percent or absolute values.";
+    homepage = https://github.com/mKaloer/powerline_mem_segment;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ thomasjm ];
+  };
+}

--- a/pkgs/development/python-modules/powerline-mem-segment/default.nix
+++ b/pkgs/development/python-modules/powerline-mem-segment/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     sha256 = "0507zw7g449zk7dcq56adcdp71inbqfdmp6y5yk4x4j7kkp6pii9";
   };
 
-  buildInputs = [ psutil ];
+  propagatedBuildInputs = [ psutil ];
 
   meta = with lib; {
     description = "Segment for Powerline showing the current memory usage in percent or absolute values.";

--- a/pkgs/development/python-modules/powerline-mem-segment/default.nix
+++ b/pkgs/development/python-modules/powerline-mem-segment/default.nix
@@ -1,7 +1,7 @@
-{ lib,
-  buildPythonPackage,
-  fetchPypi,
-  psutil
+{ lib
+, buildPythonPackage
+, fetchPypi
+, psutil
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/powerline-mem-segment/default.nix
+++ b/pkgs/development/python-modules/powerline-mem-segment/default.nix
@@ -15,9 +15,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ psutil ];
 
+  pythonImportsCheck = [ "powerlinemem" ];
+
   meta = with lib; {
     description = "Segment for Powerline showing the current memory usage in percent or absolute values.";
-    homepage = https://github.com/mKaloer/powerline_mem_segment;
+    homepage = "https://github.com/mKaloer/powerline_mem_segment";
     license = licenses.asl20;
     maintainers = with maintainers; [ thomasjm ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5203,6 +5203,8 @@ in {
 
   powerline = callPackage ../development/python-modules/powerline { };
 
+  powerlineMemSegment = callPackage ../development/python-modules/powerline-mem-segment { };
+
   pox = callPackage ../development/python-modules/pox { };
 
   poyo = callPackage ../development/python-modules/poyo { };


### PR DESCRIPTION
###### Motivation for this change

Add a useful segment for Powerline.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Ubuntu 20.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
