### PR TITLE
networkmanager: disable more logging

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -51,6 +51,7 @@ in stdenv.mkDerivation rec {
     "-Dlibaudit=yes-disabled-by-default"
     # We don't use firewalld in NixOS
     "-Dfirewalld_zone=false"
+    "-Dmore_logging=false"
   ];
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
NetworkManager enables `more_logging` by default, disable it for the
distribution build. Also done by Arch Linux, see [1].

[1]: https://github.com/archlinux/svntogit-packages/blob/991cd7dbed386bf253958c78e29ef9432192855b/trunk/PKGBUILD#L71

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
