### PR TITLE
octave.buildEnv: Handle better no packages situation

### DIFF
--- a/pkgs/development/interpreters/octave/build-env.nix
+++ b/pkgs/development/interpreters/octave/build-env.nix
@@ -40,11 +40,15 @@ in buildEnv {
          cd $out
       fi
 
-      # Remove symlinks to the input tarballs, they aren't needed.
-      rm $out/*.tar.gz
+      # Remove symlinks to the input tarballs, they aren't needed, use -f so it
+      # will not fail if no .tar.gz symlinks are there - for example if
+      # sommething which is not a tarball used as a package
+      rm -f $out/*.tar.gz
 
       createOctavePackagesPath $out ${octave}
 
+      # Create the file even if the loop afterwards has no packages to run over
+      touch $out/.octave_packages
       for path in ${lib.concatStringsSep " " packages}; do
           if [ -e $path/*.tar.gz ]; then
              $out/bin/octave-cli --eval "pkg local_list $out/.octave_packages; \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/123964 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
