### PR TITLE
htmldoc: 1.9.11 -> 1.9.12

### DIFF
--- a/pkgs/tools/typesetting/htmldoc/default.nix
+++ b/pkgs/tools/typesetting/htmldoc/default.nix
@@ -1,20 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, zlib, libpng, SystemConfiguration, Foundation }:
+{ lib, stdenv, fetchFromGitHub, zlib, libpng, libjpeg, SystemConfiguration, Foundation, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "htmldoc";
-  version = "1.9.11";
+  version = "1.9.12";
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = "htmldoc";
     rev = "v${version}";
-    sha256 = "0660829zjfdm6vzx14z7gvsfipsb7h0z74gbkyp2ncg3g2432s4n";
+    sha256 = "1dqima0g3j301wwzjxdhzk5pvfj724rl615gf8ssxxajfnid1gl0";
   };
-  buildInputs = [ zlib libpng ]
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ zlib libpng libjpeg ]
     ++ lib.optionals stdenv.isDarwin [ Foundation SystemConfiguration ];
 
   meta = with lib; {
     description = "Converts HTML files to PostScript and PDF";
     homepage    = "https://michaelrsweet.github.io/htmldoc";
+    changelog   = "https://github.com/michaelrsweet/htmldoc/releases/tag/v${version}";
     license     = licenses.gpl2Only;
     maintainers = with maintainers; [ shanemikel ];
     platforms   = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-20308.

https://github.com/michaelrsweet/htmldoc/releases/tag/v1.9.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>htmldoc</li>
  </ul>
</details>