### PR TITLE
fetchutils: init at unstable-2021-03-16

### DIFF
--- a/pkgs/tools/misc/fetchutils/default.nix
+++ b/pkgs/tools/misc/fetchutils/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenvNoCC, fetchFromGitHub, bash, scdoc }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "fetchutils";
+  version = "unstable-2021-03-16";
+
+  src = fetchFromGitHub {
+    owner = "lptstr";
+    repo = pname;
+    rev = "882781a297e86f4ad4eaf143e0777fb3e7c69526";
+    sha256 = "sha256-ONrVZC6GBV5v3TeBekW9ybZjDHF3FNyXw1rYknqKRbk=";
+  };
+
+  buildInputs = [ bash scdoc ];
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  postPatch = ''
+    patchShebangs --host src/*
+  '';
+
+  meta = with lib; {
+    description = "A collection of small shell utilities to fetch system information";
+    homepage = "https://github.com/lptstr/fetchutils";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -381,6 +381,8 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
+  fetchutils = callPackage ../tools/misc/fetchutils { };
+
   fet-sh = callPackage ../tools/misc/fet-sh { };
 
   fetchbower = callPackage ../build-support/fetchbower {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
