### PR TITLE
podman: add systemd to LD_LIBRARY_PATH for journald log driver

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pkg-config
 , installShellFiles
+, makeWrapper
 , buildGoModule
 , gpgme
 , lvm2
@@ -36,7 +37,7 @@ buildGoModule rec {
 
   outputs = [ "out" "man" ];
 
-  nativeBuildInputs = [ pkg-config go-md2man installShellFiles ];
+  nativeBuildInputs = [ pkg-config go-md2man installShellFiles makeWrapper ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     btrfs-progs
@@ -69,6 +70,8 @@ buildGoModule rec {
     installShellCompletion --zsh completions/zsh/*
     MANDIR=$man/share/man make install.man-nobuild
   '' + lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/podman \
+      --prefix LD_LIBRARY_PATH : "${lib.getLib systemd}/lib"
     install -Dm644 contrib/tmpfile/podman.conf -t $out/lib/tmpfiles.d
     install -Dm644 contrib/systemd/system/podman.{socket,service} -t $out/lib/systemd/system
   '' + ''


### PR DESCRIPTION
###### Motivation for this change
Using podman with journald log driver results in `podman logs` failing due to  unable to find libsystemd.
Reference: [dlopen called in go-systemd/sdjournal](https://github.com/coreos/go-systemd/blob/9b43fbe5552b6e9e247a1a513c41474bc29c63a4/sdjournal/functions.go#L46)
This PR adds systemdMinimal to podman's LD_LIBRARY_PATH to fix that.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
