### PR TITLE
open-watcom-v2: init at unstable 2021-11-30

### DIFF
--- a/pkgs/development/compilers/open-watcom/bin.nix
+++ b/pkgs/development/compilers/open-watcom/bin.nix
@@ -87,6 +87,7 @@ in
 stdenvNoCC.mkDerivation rec {
   pname = "open-watcom-bin";
   version = "1.9";
+  name = "${pname}-unwrapped-${version}";
 
   src = fetchurl {
     url = "http://ftp.openwatcom.org/install/open-watcom-c-linux-${version}";

--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -1,0 +1,119 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+
+# Docs cause an immense increase in build time, up to 2 additional hours
+, withDocs ? false
+, dosbox
+, ghostscript
+, withGUI ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "open-watcom-v2";
+  version = "unstable-2021-11-30";
+  name = "${pname}-unwrapped-${version}";
+
+  src = fetchFromGitHub {
+    owner = "open-watcom";
+    repo = "open-watcom-v2";
+    rev = "982c958eb4840e1c6a98773ba0600f652500f5a7";
+    sha256 = "18dp9nd1gjnpd1870149v67vzxbna25l6zi052z1r51xvaqwc3cx";
+  };
+
+  postPatch = ''
+    patchShebangs *.sh
+
+    for dateSource in cmnvars.sh bld/wipfc/configure; do
+      substituteInPlace $dateSource \
+        --replace '`date ' '`date -ud "@$SOURCE_DATE_EPOCH" '
+    done
+
+    substituteInPlace bld/watcom/h/banner.h \
+      --replace '__DATE__' "\"$(date -ud "@$SOURCE_DATE_EPOCH" +'%b %d %Y')\"" \
+      --replace '__TIME__' "\"$(date -ud "@$SOURCE_DATE_EPOCH" +'%T')\""
+
+    substituteInPlace build/makeinit \
+      --replace '%__CYEAR__' '%OWCYEAR'
+  '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace build/mif/local.mif \
+      --replace '-static' ""
+  '';
+
+  nativeBuildInputs = [ ]
+    ++ lib.optional (withDocs || withGUI) dosbox
+    ++ lib.optional withDocs ghostscript;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export OWROOT=$(realpath $PWD)
+    export OWTOOLS=${if stdenv.cc.isClang then "CLANG" else "GCC"}
+    export OWDOCBUILD=${if withDocs then "1" else "0"}
+    export OWGHOSTSCRIPTPATH=${lib.optionalString withDocs "${ghostscript}/bin"}
+    export OWGUINOBUILD=${if withGUI then "0" else "1"}
+    export OWNOBUILD=
+    export OWDISTRBUILD=0
+    export OWDOSBOX=${lib.optionalString (withDocs || withGUI) "${dosbox}/bin/dosbox"}
+    export OWVERBOSE=0
+    export OWRELROOT=$out
+
+    source cmnvars.sh
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./build.sh build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ./build.sh cprel
+
+    runHook postInstall
+  '';
+
+  # Stripping breaks many tools
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "The v2 fork of the Open Watcom suite of compilers and tools";
+    longDescription = ''
+      A fork of Open Watcom: A C/C++/Fortran compiler and assembler suite
+      targeting a multitude of architectures (x86, IA-32, Alpha AXP, MIPS,
+      PowerPC) and operating systems (DOS, OS/2, Windows, Linux).
+
+      Main differences from Open Watcom 1.9:
+
+      - New two-phase build system - Open Watcom can be built by the host's
+        native C/C++ compiler or by itself
+      - Code generator properly initializes pointers by DLL symbol addresses
+      - DOS tools now support long file names (LFN) if appropriate LFN driver
+        is loaded by DOS
+      - Open Watcom is ported to 64-bit hosts (Win64, Linux x64)
+      - Librarian supports x64 CPU object modules and libraries
+      - RDOS 32-bit C run-time compact memory model libraries are fixed
+      - Resource compiler and Resource editors support Win64 executables
+      - Open Watcom text editor is now self-contained, it can be used as
+        standalone tool without any requirements for any additional files or
+        configuration
+      - Broken C++ compiler pre-compiled header template support is fixed
+      - Many C++ compiler crashes are fixed
+      - Debugger has no length limit for any used environment variable
+    '' + lib.optionalString (!withDocs) ''
+
+      The documentation has been excluded from this build for build time reasons. It can be found here:
+      https://github.com/open-watcom/open-watcom-v2/wiki/Open-Watcom-Documentation
+    '';
+    homepage = "https://open-watcom.github.io";
+    license = licenses.watcom;
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "x86_64-windows" "i686-windows" ];
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}

--- a/pkgs/development/compilers/open-watcom/wrapper.nix
+++ b/pkgs/development/compilers/open-watcom/wrapper.nix
@@ -1,0 +1,128 @@
+# Arguments that this derivation gets when it is created with `callPackage`
+{ stdenv
+, lib
+, symlinkJoin
+, makeWrapper
+, runCommand
+, file
+}:
+
+open-watcom:
+
+let
+  wrapper =
+    {}:
+    let
+      binDirs = with stdenv.hostPlatform; if isWindows then [
+        (lib.optionalString is64bit "binnt64")
+        "binnt"
+        (lib.optionalString is32bit "binw")
+      ] else if (isDarwin && is64bit) then [
+        "osx64"
+      ] else [
+        (lib.optionalString is64bit "binl64")
+        "binl"
+      ];
+      includeDirs = with stdenv.hostPlatform; [
+        "h"
+      ]
+      ++ lib.optional isWindows "h/nt"
+      ++ lib.optional isLinux "lh";
+      listToDirs = list: lib.strings.concatMapStringsSep ":" (dir: "${placeholder "out"}/${dir}") list;
+      name = "${open-watcom.pname}-${open-watcom.version}";
+    in
+    symlinkJoin {
+      inherit name;
+
+      paths = [ open-watcom ];
+
+      buildInputs = [ makeWrapper ];
+
+      postBuild = ''
+        mkdir $out/bin
+
+        for binDir in ${lib.strings.concatStringsSep " " binDirs}; do
+          for exe in $(find ${open-watcom}/$binDir \
+          -type f -executable \
+          ${lib.optionalString stdenv.hostPlatform.isLinux "-not -iname '*.so' -not -iname '*.exe'"} \
+          ); do
+            if [ ! -f $out/bin/$(basename $exe) ]; then
+              makeWrapper $exe $out/bin/$(basename $exe) \
+                --set WATCOM ${open-watcom} \
+                --prefix PATH : ${listToDirs binDirs} \
+                --set EDPATH ${open-watcom}/eddat \
+                --set INCLUDE ${listToDirs includeDirs}
+            fi
+          done
+        done
+      '';
+
+      passthru = {
+        unwrapped = open-watcom;
+        tests = let
+          wrapped = wrapper { };
+        in {
+          simple = runCommand "${name}-test-simple" { nativeBuildInputs = [ wrapped ]; } ''
+            cat <<EOF >test.c
+            #include <stdio.h>
+            int main() {
+              printf ("Testing OpenWatcom C89 compiler.\n");
+              return 0;
+            }
+            EOF
+            cat test.c
+            # Darwin target not supported, only host
+            wcl386 -fe=test_c test.c
+            ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "./test_c"}
+
+            cat <<EOF >test.cpp
+            #include <string>
+            #include <iostream>
+            int main() {
+              std::cout << "Testing OpenWatcom C++ library implementation." << std::endl;
+              watcom::istring HELLO ("HELLO");
+              if (HELLO != "hello") {
+                return 1;
+              }
+              if (HELLO.find ("ello") != 1) {
+                return 2;
+              }
+              return 0;
+            }
+            EOF
+            cat test.cpp
+            # Darwin target not supported, only host
+            wcl386 -fe=test_cpp test.cpp
+            ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "./test_cpp"}
+            touch $out
+          '';
+          cross = runCommand "${name}-test-cross" { nativeBuildInputs = [ wrapped file ]; } ''
+            cat <<EOF >test.c
+            #include <stdio.h>
+            int main() {
+              printf ("Testing OpenWatcom cross-compilation.\n");
+              return 0;
+            }
+            EOF
+            cat test.c
+
+            echo "Test compiling"
+            wcl386 -bcl=linux -fe=linux test.c
+            wcl386 -bcl=nt -fe=nt test.c
+            wcl386 -bcl=dos4g -fe=dos4g test.c
+            wcl -bcl=windows -fe=windows test.c
+            wcl -bcl=dos -fe=dos test.c
+
+            echo "Test file format"
+            file ./linux | grep "32-bit" | grep "Linux"
+            file ./nt.exe | grep "PE32" | grep "Windows"
+            file ./dos4g.exe | grep "MS-DOS" | grep "LE executable"
+            file ./windows.exe | grep "MS-DOS" | grep "Windows 3.x"
+            file ./dos.exe | grep "MS-DOS" | grep -v "LE" | grep -v "Windows 3.x"
+            touch $out
+          '';
+        };
+      };
+    };
+in
+lib.makeOverridable wrapper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12651,7 +12651,11 @@ with pkgs;
 
   opam-installer = callPackage ../development/tools/ocaml/opam/installer.nix { };
 
-  open-watcom-bin = callPackage ../development/compilers/open-watcom-bin { };
+  wrapWatcom = callPackage ../development/compilers/open-watcom/wrapper.nix { };
+  open-watcom-v2-unwrapped = callPackage ../development/compilers/open-watcom/v2.nix { };
+  open-watcom-v2 = wrapWatcom open-watcom-v2-unwrapped { };
+  open-watcom-bin-unwrapped = callPackage ../development/compilers/open-watcom/bin.nix { };
+  open-watcom-bin = wrapWatcom open-watcom-bin-unwrapped { };
 
   passerine = callPackage ../development/compilers/passerine { };
 


### PR DESCRIPTION
###### Motivation for this change
Packaging the v2 fork of Open Watcom, a C/C++/F77 compiler & assembler for targeting anything from DOS & OS/2 to Windows & Linux, from x86 & IA-32 to MIPS & Alpha AXP.

This is a source build of the v2 fork. We already have the last official OW 1.9 binary release packaged as `open-watcom-bin`. I renamed the `open-watcom-bin` directory to just `open-watcom`, moved the binary package from `default.nix` to `bin.nix` and made this source package the new `default.nix` for `open-watcom`. Maybe we could also add a source build of 1.9 à la `open-watcom-1_9`?

Tasks:

- [x] ~~Some x86_64(-linux?) binaries crash with SIGSEGV~~
      ~~I don't know if that's expected (I could fix all other crashes so far), I'll talk with upstream about it.~~
      Confirmed upstream bug. Fixed with bump.
- [x] Docs building is disabled because it takes *hours*, check if that's fixable
      The docs rely on an old DOS-only tool that gets run via DOSBox. I don't know if tweaking any settings would help, but building the docs adds anywhere from 1 to 2½ hours to the build time for me (with the toolchain itself needing only ½h). The wiki mentions something to fix DOSBox never returning (which may be referring to this?)
      https://github.com/open-watcom/open-watcom-v2/wiki/Build#troubleshooting
- [x] There seems to be ARM support on Linux & macOS (meta.platforms in general could need another look-over)
      The build process errors on "Unknown CPU architecture" if I try to build it on my RPi though. I'm not sure if the `__arm__` etc defines it's checking for exist on AArch64 and if this is an error on their part or if there genuinely is no support for 64-bit ARM (yet).
      [Relevant code here](https://github.com/open-watcom/open-watcom-v2/blob/047386398d3b538c8ba9792714e6143b1f44f0ca/bld/wmake/c/mglob.c#L118-L133).
- [x] Somewhere, the current date is being inserted into the build. Still need to figure out where & patch it out.
- [x] Maybe some tests to check if the whole toolchain & its targets work?

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (x86_64-linux)
   - [ ] macOS (x86_64-darwin)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
