### PR TITLE
CODEOWNERS: Add GNOME

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,3 +224,6 @@
 
 # Cinnamon
 /pkgs/desktops/cinnamon @mkg20001
+
+# GNOME
+/pkgs/desktops/gnome            @NixOS/GNOME


### PR DESCRIPTION
###### Motivation for this change

I'd like to get notified whenever the GNOME extensions are changed. Then I noticed that `./pkgs/desktops/gnome` has no owner at the moment. Adding @NixOS/gnome here seems sensible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
