### PR TITLE
xvidcore: 1.3.5 -> 1.3.7

### DIFF
--- a/pkgs/development/libraries/xvidcore/default.nix
+++ b/pkgs/development/libraries/xvidcore/default.nix
@@ -3,11 +3,11 @@
 with lib;
 stdenv.mkDerivation rec {
   pname = "xvidcore";
-  version = "1.3.5";
+  version = "1.3.7";
 
   src = fetchurl {
-    url = "http://downloads.xvid.org/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "1d0hy1w9sn6491a3vhyf3vmhq4xkn6yd4ralx1191s6qz5wz483w";
+    url = "https://downloads.xvid.com/downloads/${pname}-${version}.tar.bz2";
+    sha256 = "1xyg3amgg27zf7188kss7y248s0xhh1vv8rrk0j9bcsd5nasxsmf";
   };
 
   preConfigure = ''


### PR DESCRIPTION
This also switches to the new upstream URL, since the old one is
deprecated and does not provide current versions.

###### Motivation for this change

Version 1.3.5 segfaults at initialisation with binutils ≥ 2.31.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
