### PR TITLE
top-level/release-haskell.nix: test static linking as well

### DIFF
--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -81,6 +81,9 @@ let
 
   recursiveUpdateMany = builtins.foldl' lib.recursiveUpdate {};
 
+  staticHaskellPackagesPlatforms =
+    packagePlatforms pkgs.pkgsStatic.haskellPackages;
+
   jobs = recursiveUpdateMany [
     (mapTestOn {
       haskellPackages = packagePlatforms pkgs.haskellPackages;
@@ -91,6 +94,16 @@ let
       in {
         haskell = testPlatforms.haskell;
         writers = testPlatforms.writers;
+      };
+
+      # test some statically linked packages to catch regressions
+      # and get some cache going for static compilation with GHC
+      pkgsStatic.haskellPackages = {
+        inherit (staticHaskellPackagesPlatforms)
+          hello
+          random
+          lens
+          ;
       };
 
       # top-level packages that depend on haskellPackages
@@ -272,6 +285,17 @@ let
           (builtins.map
             (name: jobs.haskellPackages."${name}")
             (maintainedPkgNames pkgs.haskellPackages));
+      };
+      staticHaskellPackages = pkgs.releaseTools.aggregate {
+        name = "static-haskell-packages";
+        meta = {
+          description = "Static haskell builds using the pkgsStatic infrastructure";
+          maintainers = [
+            lib.maintainers.sternenseemann
+            lib.maintainers.rnhmjoj
+          ];
+        };
+        constituents = accumulateDerivations [ jobs.pkgsStatic ];
       };
     }
   ];


### PR DESCRIPTION
This way we can keep track of any new regressions to this as well as
have some binary cache, so using this infrastructure doesn't require
compiling GHC all the time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
