### PR TITLE
adguardhome: add support for platforms other than x86_64-linux

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4565,6 +4565,16 @@
     githubId = 2789926;
     name = "Imran Hossain";
   };
+  iagoq = {
+    email = "18238046+iagocq@users.noreply.github.com";
+    github = "iagocq";
+    githubId = 18238046;
+    name = "Iago Manoel Brito";
+    keys = [{
+      longkeyid = "rsa4096/0x35D39F9A9A1BC8DA";
+      fingerprint = "DF90 9D58 BEE4 E73A 1B8C  5AF3 35D3 9F9A 9A1B C8DA";
+    }];
+  };
   iammrinal0 = {
     email = "nixpkgs@mrinalpurohit.in";
     github = "iammrinal0";

--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,0 +1,19 @@
+{ fetchurl, fetchzip }:
+{
+"x86_64-darwin" = fetchzip {
+  sha256 = "sha256-ec1l4KxKJH4Iwg9hW+xlxLADGLN1vParYaWIw7nCfKA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.106.3/AdGuardHome_darwin_amd64.zip";
+};
+"i686-linux" = fetchurl {
+  sha256 = "sha256-9aGyC76WyzwHlAkR72kuNcd/68XdWWC3gfT92IuW2LY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.106.3/AdGuardHome_linux_386.tar.gz";
+};
+"x86_64-linux" = fetchurl {
+  sha256 = "sha256-qJMymTxmoPlIhuJD6zFBWWwzz+CFx+9+MOrRiFtA4IY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.106.3/AdGuardHome_linux_amd64.tar.gz";
+};
+"aarch64-linux" = fetchurl {
+  sha256 = "sha256-Z5hekNxeemqWsMu7n3UTmYCzdKp5Xsp9ku0G2LOqC80=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.106.3/AdGuardHome_linux_arm64.tar.gz";
+};
+}

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -1,23 +1,24 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, fetchzip, system ? stdenv.targetPlatform }:
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
   version = "0.106.3";
 
-  src = fetchurl {
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v${version}/AdGuardHome_linux_amd64.tar.gz";
-    sha256 = "11p081dqilga61zfziw5w37k6v2r84qynhz2hr4gk8367jck54x8";
-  };
+  src = (import ./bins.nix { inherit fetchurl fetchzip; }).${system};
 
   installPhase = ''
     install -m755 -D ./AdGuardHome $out/bin/adguardhome
   '';
 
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
   meta = with lib; {
     homepage = "https://github.com/AdguardTeam/AdGuardHome";
     description = "Network-wide ads & trackers blocking DNS server";
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ numkem ];
-    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ numkem iagoq ];
+    license = licenses.gpl3Only;
   };
 }

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -1,0 +1,38 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl gnugrep nix-prefetch jq
+
+# This file is based on /pkgs/servers/gotify/update.sh
+
+set -euo pipefail
+
+dirname="$(dirname "$0")"
+bins="$dirname/bins.nix"
+
+latest_release=$(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHome/releases/latest)
+version=$(jq -r '.tag_name' <<<"$latest_release")
+
+echo "got version $version"
+
+declare -A systems
+systems[linux_386]=i686-linux
+systems[linux_amd64]=x86_64-linux
+systems[linux_arm64]=aarch64-linux
+systems[darwin_amd64]=x86_64-darwin
+
+echo '{ fetchurl, fetchzip }:' > "$bins"
+echo '{'        >> "$bins"
+
+for asset in $(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHome/releases/latest | jq -c '.assets[]') ; do
+    url="$(jq -r '.browser_download_url' <<< "$asset")"
+    adg_system="$(grep -Eo '(darwin|linux)_(386|amd64|arm64)' <<< "$url" || true)"
+    if [ -n "$adg_system" ]; then
+        fetch="$(grep '\.zip$' <<< "$url" > /dev/null && echo fetchzip || echo fetchurl)"
+        nix_system=${systems[$adg_system]}
+        nix_src="$(nix-prefetch -s --output nix $fetch --url $url)"
+        echo "\"$nix_system\" = $fetch $nix_src;" >> $bins
+    fi
+done
+
+echo '}' >> "$bins"
+
+sed -i -r -e "s/version\s*?=\s*?.*?;/version = \"${version#v}\";/" "$dirname/default.nix"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To fix #113900 and make adguardhome run on more than just x86_64-linux.

###### Things done

This downloads the correct binary from the AdGuardHome Github page depending on the host platform. An update.sh script was also added to update the derivation to newer versions with little effort, and also to add more host systems that have a binary release upstream but currently aren't listed here.

I tested the resulting binary on my desktop (x86_64-linux) and a Raspberry Pi 3B (aarch64-linux), both running NixOS. Both ran the binary through the nixos/adguardhome module fine.

While building from source would be ideal, there are many problems in doing that because of how the upstream project is organized (npm, yarn (frontend) and go (backend)). I could only figure out how to build the frontend correctly, but that required not using the makefile provided by the project.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
