### PR TITLE
python3Packages.jupyter_server: disable failing tests on darwin

### DIFF
--- a/pkgs/development/python-modules/jupyter_server/default.nix
+++ b/pkgs/development/python-modules/jupyter_server/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
@@ -71,6 +72,9 @@ buildPythonPackage rec {
     "test_list_formats"
     "test_base_url"
     "test_culling"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # attempts to use trashcan, build env doesn't allow this
+    "test_delete"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042

`test_delete` tests attempt to use the trashcan, which the build env won't allow.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
