### PR TITLE
abseil-cpp: 20200923.3 -> 20210324.1

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/cmake-full-dirs.patch
+++ b/pkgs/development/libraries/abseil-cpp/cmake-full-dirs.patch
@@ -1,0 +1,15 @@
+diff --git a/CMake/AbseilHelpers.cmake b/CMake/AbseilHelpers.cmake
+index 1a80b5b..1fa57a7 100644
+--- a/CMake/AbseilHelpers.cmake
++++ b/CMake/AbseilHelpers.cmake
+@@ -171,8 +171,8 @@ function(absl_cc_library)
+       FILE(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/lib/pkgconfig/absl_${_NAME}.pc" CONTENT "\
+ prefix=${CMAKE_INSTALL_PREFIX}\n\
+ exec_prefix=\${prefix}\n\
+-libdir=\${prefix}/${CMAKE_INSTALL_LIBDIR}\n\
+-includedir=\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}\n\
++libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n\
++includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}\n\
+ \n\
+ Name: absl_${_NAME}\n\
+ Description: Abseil ${_NAME} library\n\

--- a/pkgs/development/libraries/abseil-cpp/default.nix
+++ b/pkgs/development/libraries/abseil-cpp/default.nix
@@ -1,15 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, cmake, static ? stdenv.hostPlatform.isStatic }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, static ? stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation rec {
   pname = "abseil-cpp";
-  version = "20200923.3";
+  version = "20210324.1";
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
     rev = version;
-    sha256 = "1p4djhm1f011ficbjjxx3n8428p8481p20j4glpaawnpsi362hkl";
+    sha256 = "16w63brfwgiayiyhvawsnr14xyy5hpp68k8fj0z6yk0bjzw6jvjw";
   };
+
+  patches = [
+    # Use CMAKE_INSTALL_FULL_{LIBDIR,INCLUDEDIR}
+    # https://github.com/abseil/abseil-cpp/pull/963
+    (fetchpatch {
+      url = "https://github.com/abseil/abseil-cpp/commit/5bfa70c75e621c5d5ec095c8c4c0c050dcb2957e.patch";
+      sha256 = "0nhjxqfxpi2pkfinnqvd5m4npf9l1kg39mjx9l3087ajhadaywl5";
+    })
+  ];
 
   cmakeFlags = [
     "-DCMAKE_CXX_STANDARD=17"

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , abseil-cpp
 , bzip2
@@ -17,24 +16,15 @@
 
 stdenv.mkDerivation rec {
   pname = "or-tools";
-  version = "8.1";
+  version = "9.0";
   disabled = python.pythonOlder "3.6";  # not supported upstream
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "or-tools";
     rev = "v${version}";
-    sha256 = "1zqgvkaw5vf2d8pwsa34g9jysbpiwplzxc8jyy8kdbzmj8ax3gpg";
+    sha256 = "0yihrsg8wj4b82xwg1hbn97my8zqd7xhw7dk7wm2axsyvqd6m3b3";
   };
-
-  patches = [
-    # This patch (on master as of Feb 11, 2021) fixes or-tools failing to respect
-    # USE_SCIP=OFF and then failing to find scip/scip.h
-    (fetchpatch {
-      url = "https://github.com/google/or-tools/commit/17321869832b5adaccd9864e7e5576122730a5d5.patch";
-      sha256 = "0bi2z1hqlpdm1if3xa5dzc2zv0qlm5xi2x979brx10f8k779ghn0";
-    })
-  ];
 
   # The original build system uses cmake which does things like pull
   # in dependencies through git and Makefile creation time. We

--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -32,7 +32,7 @@ let
   nudb = fetchgit rec {
     url = "https://github.com/CPPAlliance/NuDB.git";
     rev = "2.0.5";
-    sha256 = "02zbd07qvdjjsm4ivvhxah5n466bncvm6m03vmq0qdbbrlnp6s37";
+    sha256 = "07dwvglhyzpqnhzd33a2vs80wrdxy55a3sirnd739xp1k5v8s2fx";
     leaveDotGit = true;
     fetchSubmodules = true;
     postFetch = "cd $out && git tag ${rev}";
@@ -41,7 +41,7 @@ let
   rocksdb = fetchgit rec {
     url = "https://github.com/facebook/rocksdb.git";
     rev = "v6.7.3";
-    sha256 = "16qb636qs2yxqmz30hmvq8mllf038s80p37b0vyc0bazwlr93d9z";
+    sha256 = "0dzn5jg3i2mnnjj24dn9lzi3aajj5ga2akjf64lybyj481lq445k";
     deepClone = true;
     fetchSubmodules = false;
     leaveDotGit = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The bear build was broken due to grpc upgrade in #123855.  Upgrading abseil seemed liked the easiest fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
