### PR TITLE
nerdfonts-patcher: init at v2.1.0

### DIFF
--- a/pkgs/data/fonts/nerdfonts-patcher/default.nix
+++ b/pkgs/data/fonts/nerdfonts-patcher/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nerdfonts-patcher-unwrapped";
+  version = "v2.1.0";
+
+  # This repo is approximately 2.2GB in size, and the font patcher isn't available separately
+  # see this issue: https://github.com/ryanoasis/nerd-fonts/issues/484
+  # The fork mentioned in the issue could be used, but I don't know how updated it is and will be.
+  src = fetchFromGitHub {
+    owner = "ryanoasis";
+    repo = "nerd-fonts";
+    rev = version;
+    sha256 = "sha256-j0cLZHOLyoItdvLOQVQVurY3ARtndv0FZTynaYJPR9E=";
+  };
+
+  # Only install what we actually need (font-patcher and src/glyphs/*)
+  installPhase = ''
+    mkdir -p $out
+    cp font-patcher $out
+    mkdir -p $out/src/glyphs
+    cp src/glyphs/* $out/src/glyphs/
+  '';
+
+  meta = with lib; {
+    description = "Iconic font aggregator, collection, & patcher. 3,600+ icons, 50+ patched fonts";
+    longDescription = ''
+      Nerd Fonts is a project that attempts to patch as many developer targeted
+      and/or used fonts as possible. The patch is to specifically add a high
+      number of additional glyphs from popular 'iconic fonts' such as Font
+      Awesome, Devicons, Octicons, and others.
+    '';
+    homepage = "https://nerdfonts.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      nomisiv
+    ];
+  };
+}

--- a/pkgs/data/fonts/nerdfonts-patcher/wrapper.nix
+++ b/pkgs/data/fonts/nerdfonts-patcher/wrapper.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, nerdfonts-patcher-unwrapped
+, python3
+, fontforge
+
+, fontPackage ? null
+, fontName ? null
+, glyphFlags ? "-c"
+}:
+
+# assert fontPackage != null;
+# assert fontName != null;
+
+stdenv.mkDerivation rec {
+  pname = toString fontName + "-nerd-font";
+  version = "v2.1.0";
+
+  nativeBuildInputs = [
+    nerdfonts-patcher-unwrapped
+    python3
+    fontforge
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $out/share/fonts
+    find ${toString fontPackage}/share/fonts/**/*.{ttf,otf} \
+      -exec python ${nerdfonts-patcher-unwrapped}/font-patcher \
+      ${glyphFlags} -o $out/share/fonts/ {} \;
+    runHook postBuild
+  '';
+
+  meta = with lib; {
+    description = "Iconic font aggregator, collection, & patcher. 3,600+ icons, 50+ patched fonts";
+    longDescription = ''
+      Nerd Fonts is a project that attempts to patch as many developer targeted
+      and/or used fonts as possible. The patch is to specifically add a high
+      number of additional glyphs from popular 'iconic fonts' such as Font
+      Awesome, Devicons, Octicons, and others.
+    '';
+    homepage = "https://nerdfonts.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      nomisiv
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6939,6 +6939,10 @@ in
 
   nerdfonts = callPackage ../data/fonts/nerdfonts { };
 
+  nerdfonts-patcher-unwrapped = callPackage ../data/fonts/nerdfonts-patcher { };
+
+  nerdfonts-patcher = callPackage ../data/fonts/nerdfonts-patcher/wrapper.nix { };
+
   nestopia = callPackage ../misc/emulators/nestopia { };
 
   netatalk = callPackage ../tools/filesystems/netatalk { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The official nerdfonts package for NixOS doesn't support patching any font, so I made this package to do that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
