### PR TITLE
pythonPackages.vdf: 3.3 → 3.4

### DIFF
--- a/pkgs/development/python-modules/vdf/default.nix
+++ b/pkgs/development/python-modules/vdf/default.nix
@@ -1,19 +1,23 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, pytest, pytestcov, mock }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "vdf";
-  version = "3.3";
+  version = "3.4";
 
   src = fetchFromGitHub {
     owner = "ValvePython";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0d9bhxdznry7kzyma00cxwjn6rqnd6vw8v5ym68k6qswgfzb569i";
+    hash = "sha256-6ozglzZZNKDtADkHwxX2Zsnkh6BE8WbcRcC9HkTTgPU=";
   };
 
-  checkInputs = [ pytest pytestcov mock ];
-  checkPhase = "make test";
+  checkInputs = [ mock pytestCheckHook ];
+  pythonImportsCheck = [ "vdf" ];
 
   meta = with lib; {
     description = "Library for working with Valve's VDF text format";


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/ValvePython/vdf/releases/tag/v3.4

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  _`vdf` doesn't produce any binaries, but I tested `protontricks`, which is the only package that depends on `vdf`._
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).