### PR TITLE
texlab: 3.0.0 → 3.0.1

### DIFF
--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "texlab";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-jOxneMqeyvMQWKPNha59H6qWSFmx+Z71SU2+M5VWMsA=";
+    hash = "sha256-hiz3dMEYNKKd9dZiGghAhGqoXXKJiZG6sECfsCYVscU=";
   };
 
-  cargoHash = "sha256-H6czxSTw93RNTaN0OJyv0RfwmGAiFkpDgUtXHCD+jrY=";
+  cargoHash = "sha256-sCvQFU9/ENVi1RHV3QDngzI/S1xuHvpWxsrxT73jdI0=";
 
   outputs = [ "out" "man" ];
 
@@ -43,5 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://texlab.netlify.app";
     license = licenses.mit;
     maintainers = with maintainers; [ doronbehar kira-bruneau ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/latex-lsp/texlab/releases/tag/v3.0.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).