### PR TITLE
nixos/cinnamon: add cinnamon-translations to systemPackages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -128,6 +128,7 @@ in
         cinnamon-session
         cinnamon-desktop
         cinnamon-menus
+        cinnamon-translations
 
         # utils needed by some scripts
         killall

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -6,6 +6,7 @@
 , cinnamon-desktop
 , cinnamon-menus
 , cinnamon-session
+, cinnamon-translations
 , cjs
 , fetchFromGitHub
 , gdk-pixbuf
@@ -115,7 +116,10 @@ stdenv.mkDerivation rec {
     gtk-doc
   ];
 
-  configureFlags = [ "--disable-static" "--with-ca-certificates=${cacert}/etc/ssl/certs/ca-bundle.crt" "--with-libxml=${libxml2.dev}/include/libxml2" "--enable-gtk-doc=no" ];
+  # use locales from cinnamon-translations (not using --localedir because datadir is used)
+  postInstall = ''
+    ln -s ${cinnamon-translations}/share/locale $out/share/locale
+  '';
 
   postPatch = ''
     find . -type f -exec sed -i \

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -28,6 +28,7 @@
 , gdk-pixbuf
 , meson
 , ninja
+, cinnamon-translations
 }:
 
 stdenv.mkDerivation rec {
@@ -83,7 +84,10 @@ stdenv.mkDerivation rec {
   '';
 
   mesonFlags = [
+    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
     "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+    # use locales from cinnamon-translations
+    "--localedir=${cinnamon-translations}/share/locale"
   ];
 
   preInstall = ''

--- a/pkgs/desktops/cinnamon/cinnamon-session/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-session/default.nix
@@ -1,6 +1,7 @@
 { fetchFromGitHub
 , cinnamon-desktop
 , cinnamon-settings-daemon
+, cinnamon-translations
 , dbus-glib
 , docbook_xsl
 , docbook_xml_dtd_412
@@ -80,8 +81,14 @@ stdenv.mkDerivation rec {
     xmlto
   ];
 
-  # TODO: https://github.com/NixOS/nixpkgs/issues/36468
-  mesonFlags = [ "-Dc_args=-I${glib.dev}/include/gio-unix-2.0" "-Dgconf=false" "-DENABLE_IPV6=true" ];
+  mesonFlags = [
+    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+    "-Dgconf=false"
+    "-DENABLE_IPV6=true"
+    # use locales from cinnamon-translations
+    "--localedir=${cinnamon-translations}/share/locale"
+  ];
 
   postPatch = ''
     chmod +x data/meson_install_schemas.py # patchShebangs requires executable file

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -1,5 +1,6 @@
 { fetchFromGitHub
 , cinnamon-desktop
+, cinnamon-translations
 , colord
 , glib
 , gsettings-desktop-schemas
@@ -102,6 +103,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed "s|/usr/share/zoneinfo|${tzdata}/share/zoneinfo|g" -i plugins/datetime/system-timezone.h
+  '';
+
+  # use locales from cinnamon-translations (not using --localedir because datadir is used)
+  postInstall = ''
+    ln -s ${cinnamon-translations}/share/locale $out/share/locale
   '';
 
   # So the polkit policy can reference /run/current-system/sw/bin/cinnamon-settings-daemon/csd-backlight-helper

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -16,6 +16,7 @@
 , exempi
 , intltool
 , shared-mime-info
+, cinnamon-translations
 }:
 
 stdenv.mkDerivation rec {
@@ -57,6 +58,8 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     # TODO: https://github.com/NixOS/nixpkgs/issues/36468
     "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+    # use locales from cinnamon-translations
+    "--localedir=${cinnamon-translations}/share/locale"
   ];
 
   meta = with lib; {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This allows other cinnamon applications to use the locales

Without this the cinnamon UI is not properly translated


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
