### PR TITLE
sublime4: init at 4107

### DIFF
--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -2,7 +2,6 @@
 
 { fetchurl, lib, stdenv, xorg, glib, glibcLocales, gtk3, cairo, pango, libredirect, makeWrapper, wrapGAppsHook
 , pkexecPath ? "/run/wrappers/bin/pkexec"
-, writeScript, common-updater-scripts, curl, gnugrep
 , openssl, bzip2, bash, unzip, zip
 }:
 
@@ -125,26 +124,6 @@ in stdenv.mkDerivation (rec {
       size=$(basename $directory)
       mkdir -p "$out/share/icons/hicolor/$size/apps"
       ln -s ''$${primaryBinary}/Icon/$size/* $out/share/icons/hicolor/$size/apps
-    done
-  '';
-
-  passthru.updateScript = writeScript "${pname}-update-script" ''
-    #!${stdenv.shell}
-    set -o errexit
-    PATH=${lib.makeBinPath [ common-updater-scripts curl gnugrep ]}
-
-    latestVersion=$(curl -s ${versionUrl})
-
-    if [[ "${buildVersion}" = "$latestVersion" ]]; then
-        echo "The new version same as the old version."
-        exit 0
-    fi
-
-    for platform in ${lib.concatStringsSep " " meta.platforms}; do
-        # The script will not perform an update when the version attribute is up to date from previous platform run
-        # We need to clear it before each run
-        update-source-version ${packageAttribute}.${primaryBinary} 0 0000000000000000000000000000000000000000000000000000000000000000 --file=${versionFile} --version-key=buildVersion --system=$platform
-        update-source-version ${packageAttribute}.${primaryBinary} $latestVersion --file=${versionFile} --version-key=buildVersion --system=$platform
     done
   '';
 

--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -1,0 +1,148 @@
+{ buildVersion, aarch64sha256, x64sha256, dev ? false }:
+
+{ fetchurl, stdenv, lib, xorg, glib, libglvnd, glibcLocales, gtk3, cairo, pango, makeWrapper, wrapGAppsHook
+, writeShellScript, common-updater-scripts, curl
+, openssl, bzip2, bash, unzip, zip
+}:
+
+let
+  pname = "sublimetext4";
+  packageAttribute = "sublime4${lib.optionalString dev "-dev"}";
+  binaries = [ "sublime_text" "plugin_host-3.3" "plugin_host-3.8" "crash_reporter" ];
+  primaryBinary = "sublime_text";
+  primaryBinaryAliases = [ "subl" "sublime" "sublime4" ];
+  downloadUrl = "https://download.sublimetext.com/sublime_text_build_${buildVersion}_${arch}.tar.xz";
+  versionUrl = "https://download.sublimetext.com/latest/${if dev then "dev" else "stable"}";
+  versionFile = builtins.toString ./packages.nix;
+  archSha256 = {
+    "aarch64-linux" = aarch64sha256;
+    "x86_64-linux" = x64sha256;
+  }.${stdenv.hostPlatform.system};
+  arch = {
+    "aarch64-linux" = "arm64";
+    "x86_64-linux" = "x64";
+  }.${stdenv.hostPlatform.system};
+
+  libPath = lib.makeLibraryPath [ xorg.libX11 xorg.libXtst glib libglvnd openssl gtk3 cairo pango ];
+in let
+  binaryPackage = stdenv.mkDerivation {
+    pname = "${pname}-bin";
+    version = buildVersion;
+
+    src = fetchurl {
+      url = downloadUrl;
+      sha256 = archSha256;
+    };
+
+    dontStrip = true;
+    dontPatchELF = true;
+    buildInputs = [ glib gtk3 ]; # for GSETTINGS_SCHEMAS_PATH
+    nativeBuildInputs = [ zip unzip makeWrapper wrapGAppsHook ];
+
+    # make exec.py in Default.sublime-package use own bash with an LD_PRELOAD instead of "/bin/bash"
+    patchPhase = ''
+      runHook prePatch
+
+      # TODO: Should not be necessary even in 3
+      mkdir Default.sublime-package-fix
+      ( cd Default.sublime-package-fix
+        unzip -q ../Packages/Default.sublime-package
+        substituteInPlace "exec.py" --replace \
+          "[\"/bin/bash\"" \
+          "[\"$out/sublime_bash\""
+        zip -q ../Packages/Default.sublime-package **/*
+      )
+      rm -r Default.sublime-package-fix
+
+      runHook postPatch
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      for binary in ${ builtins.concatStringsSep " " binaries }; do
+        patchelf \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.is64bit "64"} \
+          $binary
+      done
+
+      # Rewrite pkexec argument. Note that we cannot delete bytes in binary.
+      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' ${primaryBinary}
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r * $out/
+
+      # We can't just call /usr/bin/env bash because a relocation error occurs
+      # when trying to run a build from within Sublime Text
+      ln -s ${bash}/bin/bash $out/sublime_bash
+
+      runHook postInstall
+    '';
+
+    dontWrapGApps = true; # non-standard location, need to wrap the executables manually
+
+    postFixup = ''
+      sed -i 's#/usr/bin/pkexec#pkexec\x00\x00\x00\x00\x00\x00\x00\x00\x00#g' "$out/${primaryBinary}"
+
+      wrapProgram $out/${primaryBinary} \
+        --set LOCALE_ARCHIVE "${glibcLocales.out}/lib/locale/locale-archive" \
+        "''${gappsWrapperArgs[@]}"
+    '';
+  };
+in stdenv.mkDerivation (rec {
+  inherit pname;
+  version = buildVersion;
+
+  phases = [ "installPhase" ];
+
+  ${primaryBinary} = binaryPackage;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    makeWrapper "''$${primaryBinary}/${primaryBinary}" "$out/bin/${primaryBinary}"
+  '' + builtins.concatStringsSep "" (map (binaryAlias: "ln -s $out/bin/${primaryBinary} $out/bin/${binaryAlias}\n") primaryBinaryAliases) + ''
+    mkdir -p "$out/share/applications"
+    substitute "''$${primaryBinary}/${primaryBinary}.desktop" "$out/share/applications/${primaryBinary}.desktop" --replace "/opt/${primaryBinary}/${primaryBinary}" "$out/bin/${primaryBinary}"
+    for directory in ''$${primaryBinary}/Icon/*; do
+      size=$(basename $directory)
+      mkdir -p "$out/share/icons/hicolor/$size/apps"
+      ln -s ''$${primaryBinary}/Icon/$size/* $out/share/icons/hicolor/$size/apps
+    done
+  '';
+
+  passthru.updateScript = writeShellScript "${pname}-update-script" ''
+    set -o errexit
+    PATH=${lib.makeBinPath [ common-updater-scripts curl ]}
+
+    latestVersion=$(curl -s ${versionUrl})
+
+    if [[ "${buildVersion}" = "$latestVersion" ]]; then
+        echo "The new version same as the old version."
+        exit 0
+    fi
+
+    for platform in ${lib.concatStringsSep " " meta.platforms}; do
+        # The script will not perform an update when the version attribute is up to date from previous platform run
+        # We need to clear it before each run
+        update-source-version ${packageAttribute}.${primaryBinary} 0 0000000000000000000000000000000000000000000000000000000000000000 --file=${versionFile} --version-key=buildVersion --system=$platform
+        update-source-version ${packageAttribute}.${primaryBinary} $latestVersion --file=${versionFile} --version-key=buildVersion --system=$platform
+    done
+  '';
+
+  meta = with lib; {
+    description = "Sophisticated text editor for code, markup and prose";
+    homepage = "https://www.sublimetext.com/";
+    maintainers = with maintainers; [ jtojnar wmertens demin-dmitriy zimbatm ];
+    license = licenses.unfree;
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
+  };
+})

--- a/pkgs/applications/editors/sublime/4/packages.nix
+++ b/pkgs/applications/editors/sublime/4/packages.nix
@@ -1,0 +1,19 @@
+{ callPackage }:
+
+let
+  common = opts: callPackage (import ./common.nix opts);
+in
+  {
+    sublime4 = common {
+      buildVersion = "4107";
+      x64sha256 = "05ar7qd1d880442bx4w32mapsib7j27g9l96q2v2s7591r9fgnf7";
+      aarch64sha256 = "4MzwhZ17c6cYtlwPA+SBiey6GiVruADXOLJAeJlMrgM=";
+    } {};
+
+    sublime4-dev = common {
+      buildVersion = "4106";
+      dev = true;
+      x64sha256 = "09jnn52zb0mjxpj5xz4sixl34cr6j60x46c2dj1m0dlgxap0sh8x";
+      aarch64sha256 = "7blbeSZI0V6q89jMM+zi2ODEdoc1b3Am8F2b2jLr5O8=";
+    } {};
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26408,6 +26408,10 @@ in
 
   sublime3-dev = sublime3Packages.sublime3-dev;
 
+  inherit (recurseIntoAttrs (callPackage ../applications/editors/sublime/4/packages.nix { }))
+    sublime4
+    sublime4-dev;
+
   inherit (callPackage ../applications/version-management/sublime-merge {})
     sublime-merge
     sublime-merge-dev;


### PR DESCRIPTION
###### Motivation for this change
https://www.sublimetext.com/download

* works with my 7 year old license so far
* i686 is no longer supported
* aarch64 support has been added
* adds harware accelerated (needs libGL.so.1)
* adds python 3.8 plugin host (needs libssl.so and libcrypto.so)

Closes: https://github.com/NixOS/nixpkgs/pull/119351, https://github.com/NixOS/nixpkgs/pull/93437

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
