### PR TITLE
reproxy: fix darwin build

### DIFF
--- a/pkgs/servers/reproxy/default.nix
+++ b/pkgs/servers/reproxy/default.nix
@@ -15,6 +15,12 @@ buildGoModule rec {
     # Requires network access
     substituteInPlace app/main_test.go \
       --replace "Test_Main" "Skip_Main"
+
+    # Fails on Darwin.
+    # https://github.com/umputun/reproxy/issues/77
+    substituteInPlace app/discovery/provider/file_test.go \
+      --replace "TestFile_Events" "SkipFile_Events" \
+      --replace "TestFile_Events_BusyListener" "SkipFile_Events_BusyListener"
   '';
 
   vendorSha256 = null;


### PR DESCRIPTION
###### Motivation for this change

ZHF: #122042
cc @NixOS/nixos-release-managers

Hydra failure: https://hydra.nixos.org/build/143427730/log

It seems these tests keep failing despite upstream changes we merged in #123579. Upstream is of the opinion that their testing is sufficient (https://github.com/umputun/reproxy/issues/77), so this disables the failing tests. It's still a bit of a mystery to me why it fails, though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
