### PR TITLE
uhhyou.lv2: unstable-2020-07-31 -> unstable-2021-02-08

### DIFF
--- a/pkgs/applications/audio/uhhyou.lv2/default.nix
+++ b/pkgs/applications/audio/uhhyou.lv2/default.nix
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
   # this is what upstream calls the package, see:
   # https://github.com/ryukau/LV2Plugins#uhhyou-plugins-lv2
   pname = "uhhyou.lv2";
-  version = "unstable-2020-07-31";
+  version = "unstable-2021-02-08";
 
   src = fetchFromGitHub {
     owner = "ryukau";
     repo =  "LV2Plugins";
-    rev = "6189be67acaeb95452f8adab73a731d94a7b6f47";
+    rev = "df67460fc344f94db4306d4ee21e4207e657bbee";
     fetchSubmodules = true;
-    sha256 = "049gigx2s89z8vf17gscs00c150lmcdwya311nbrwa18fz4bx242";
+    sha256 = "1a23av35cw26zgq93yzmmw35084hsj29cb7sb04j2silv5qisila";
   };
 
   nativeBuildInputs = [ pkg-config python3 ];
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
 
   prePatch = ''
-    patchShebangs generate-ttl.sh
-    cp patch/NanoVG.cpp lib/DPF/dgl/src/NanoVG.cpp
+    patchShebangs generate-ttl.sh patch.sh patch/apply.sh
   '';
 
   enableParallelBuilding = true;
@@ -41,6 +40,7 @@ stdenv.mkDerivation rec {
     description = "Audio plugins for Linux";
     longDescription = ''
       Plugin List:
+      - CollidingCombSynth
       - CubicPadSynth
       - EnvelopedSine
       - EsPhaser


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
