### PR TITLE
igraph,arpack: correct libblas.dylib's path on darwin, fixing python3Packages.python-igraph

### DIFF
--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -96,6 +96,10 @@ stdenv.mkDerivation rec {
     cp -r doc "$out/share"
   '';
 
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change libblas.dylib ${blas}/lib/libblas.dylib $out/lib/libigraph.dylib
+  '';
+
   meta = with lib; {
     description = "The network analysis package";
     homepage = "https://igraph.org/";

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
     export OMP_NUM_THREADS=2
   '';
 
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change libblas.dylib ${blas}/lib/libblas.dylib $out/lib/libarpack.dylib
+  '';
+
   meta = {
     homepage = "https://github.com/opencollab/arpack-ng";
     description = ''


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042

On darwin, the outputs of these two packages fail to link to `libblas.dylib`:

```
$ otool -L /nix/store/8x2axg396qh7wvrxy5iyr4qjxknmz4x4-igraph-0.9.3/lib/libigraph.dylib
/nix/store/8x2axg396qh7wvrxy5iyr4qjxknmz4x4-igraph-0.9.3/lib/libigraph.dylib:
        /nix/store/8x2axg396qh7wvrxy5iyr4qjxknmz4x4-igraph-0.9.3/lib/libigraph.0.dylib (compatibility version 0.0.0, current version 0.0.0)
        /nix/store/aai56n0b8xz2x7m22nbv949zxwxqikjm-arpack-3.8.0/lib/libarpack.2.dylib (compatibility version 2.0.0, current version 2.1.0)
        libblas.dylib (compatibility version 0.0.0, current version 0.0.0)
        /nix/store/f6dapxvcnwvn26amfgihddhv95zxx2qk-suitesparse-5.9.0/lib/libcxsparse.3.2.0.dylib (compatibility version 3.0.0, current version 3.2.0)
        /nix/store/i47zfqnvigw713im2dcjhgjrawnnz37q-glpk-4.65/lib/libglpk.40.dylib (compatibility version 44.0.0, current version 44.0.0)
        /nix/store/npgb696f2x7v2cb1br8p5a906gxf9g6b-gmp-6.2.1/lib/libgmp.10.dylib (compatibility version 15.0.0, current version 15.1.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
        /nix/store/1q5l12bhf4iiswqzcl7g8q61djs1k25v-libxml2-2.9.10/lib/libxml2.2.dylib (compatibility version 12.0.0, current version 12.10.0)
        /nix/store/d51irgw2cb1md3yn5xx7snikm8m1zz3f-libc++-7.1.0/lib/libc++.1.0.dylib (compatibility version 1.0.0, current version 1.0.0)
```

Instead naming a pathless `libblas.dylib`. This causes `python-igraph` to fail: https://nix-cache.s3.amazonaws.com/log/hfl3hcf5l29plqkblxidvjjqb3kvp5qf-python3.8-python-igraph-0.9.1.drv

Though from the looks of it I think any user of these packages would run into similar problems  if they don't otherwise link to libblas themselves.

Only failures from `nixpkgs-review` on macos 10.15 are pre-existing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
