### PR TITLE
qtwebengine: only set -webengine-webrtc-pipewire with qt >= 5.15

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -142,7 +142,7 @@ qtModule {
   '';
 
   qmakeFlags = [ "--" "-system-ffmpeg" ]
-    ++ optional stdenv.isLinux "-webengine-webrtc-pipewire"
+    ++ optional (stdenv.isLinux && (lib.versionAtLeast qtCompatVersion "5.15")) "-webengine-webrtc-pipewire"
     ++ optional enableProprietaryCodecs "-proprietary-codecs";
 
   propagatedBuildInputs = [
@@ -176,6 +176,7 @@ qtModule {
     xorg.xrandr libXScrnSaver libXcursor libXrandr xorg.libpciaccess libXtst
     xorg.libXcomposite xorg.libXdamage libdrm
 
+  ] ++ optionals (stdenv.isLinux && (lib.versionAtLeast qtCompatVersion "5.15")) [
     # Pipewire
     pipewire_0_2
   ]


### PR DESCRIPTION
This fails the build of qt514.qtwebengine otherwise:

```
QMAKEPATH=/nix/store/29n056mi3pji6si51b128pa67b1qr7wq-qtbase-5.14.2-dev:/nix/store/g7wady1f1r23wlmy4q1f3b8j2fj5q2sq-qtdeclarative-dev:/nix/store/xfqnh2pma99915d4gsanls68z1jikcpx-qtsvg-dev:/nix/store/zlnsjdj5yv1ivi1miq49j9gp382byl35-qtlocation-dev:/nix/store/lb7cidi60cabpa7swv51xnss9045vqzi-qtmultimedia-dev:/nix/store/jrk6bcqihxwsszwy6rwy2vnfc2sb4rv9-qtwebchannel-dev
qmake PREFIX=/nix/store/pa3jhipp59f6ykh9k8l8z8jf88k52bz8-qtwebengine NIX_OUTPUT_OUT=/nix/store/pa3jhipp59f6ykh9k8l8z8jf88k52bz8-qtwebengine NIX_OUTPUT_DEV=/nix/store/jngs3qilw9iiv97rawb9sb9sd6qdbp2s-qtwebengine-dev NIX_OUTPUT_BIN=/nix/store/91hqv88qvg2wb91lv1h1pd4d8wwrkd5d-qtwebengine-bin NIX_OUTPUT_DOC=/nix/store/jngs3qilw9iiv97rawb9sb9sd6qdbp2s-qtwebengine-dev/share/doc/qt-5.14.2 NIX_OUTPUT_QML=/nix/store/91hqv88qvg2wb91lv1h1pd4d8wwrkd5d-qtwebengine-bin/lib/qt-5.14.2/qml NIX_OUTPUT_PLUGIN=/nix/store/91hqv88qvg2wb91lv1h1pd4d8wwrkd5d-qtwebengine-bin/lib/qt-5.14.2/plugins CONFIG+=release -- -system-ffmpeg -webengine-webrtc-pipewire -proprietary-codecs
Info: creating stash file /build/qtwebengine-everywhere-src-5.14.2/.qmake.stash
Info: creating cache file /build/qtwebengine-everywhere-src-5.14.2/.qmake.cache
ERROR: Unknown command line option '-webengine-webrtc-pipewire'.
builder for '/nix/store/g6dvr7789sswmahlxc6zs5pr8k2g5pgy-qtwebengine.drv' failed with exit code 3
```

Also, only bring in pipewire_0_2 if we enable pipewire support.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix builds of packages still using qt514.qtwebengine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
