### PR TITLE
WIP: Add `writeScript` function to shell package passthru

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShellPackage }:
 
 rec {
 
@@ -213,17 +213,7 @@ rec {
    *
   */
   writeShellScript = name: text:
-    writeTextFile {
-      inherit name;
-      executable = true;
-      text = ''
-        #!${runtimeShell}
-        ${text}
-        '';
-      checkPhase = ''
-        ${stdenv.shell} -n $out
-      '';
-    };
+    runtimeShellPackage.writeScript name {} text;
 
   /*
    * Similar to writeShellScript and writeScriptBin.
@@ -239,18 +229,7 @@ rec {
    *
   */
   writeShellScriptBin = name : text :
-    writeTextFile {
-      inherit name;
-      executable = true;
-      destination = "/bin/${name}";
-      text = ''
-        #!${runtimeShell}
-        ${text}
-        '';
-      checkPhase = ''
-        ${stdenv.shell} -n $out/bin/${name}
-      '';
-    };
+    runtimeShellPackage.writeScriptBin name {} text;
 
   # Create a C binary
   writeCBin = name: code:

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -4,6 +4,8 @@
 # patch for cygwin requires readline support
 , interactive ? stdenv.isCygwin, readline70 ? null
 , withDocs ? false, texinfo ? null
+
+, writeTextFile                 # To support writeScript.
 }:
 
 with lib;
@@ -22,120 +24,140 @@ let
     url = "mirror://gnu/bash/bash-4.4-patches/bash44-${nr}";
     inherit sha256;
   });
-in
 
-stdenv.mkDerivation rec {
-  name = "bash-${optionalString interactive "interactive-"}${version}-p${toString (builtins.length upstreamPatches)}";
-  version = "4.4";
+  bash = stdenv.mkDerivation rec {
+    name = "bash-${optionalString interactive "interactive-"}${version}-p${toString (builtins.length upstreamPatches)}";
+    version = "4.4";
 
-  src = fetchurl {
-    url = "mirror://gnu/bash/bash-${version}.tar.gz";
-    sha256 = "1jyz6snd63xjn6skk7za6psgidsd53k05cr3lksqybi0q6936syq";
-  };
+    src = fetchurl {
+      url = "mirror://gnu/bash/bash-${version}.tar.gz";
+      sha256 = "1jyz6snd63xjn6skk7za6psgidsd53k05cr3lksqybi0q6936syq";
+    };
 
-  hardeningDisable = [ "format" ];
+    hardeningDisable = [ "format" ];
 
-  outputs = [ "out" "dev" "man" "doc" "info" ];
+    outputs = [ "out" "dev" "man" "doc" "info" ];
 
-  NIX_CFLAGS_COMPILE = ''
-    -DSYS_BASHRC="/etc/bashrc"
-    -DSYS_BASH_LOGOUT="/etc/bash_logout"
-    -DDEFAULT_PATH_VALUE="/no-such-path"
-    -DSTANDARD_UTILS_PATH="/no-such-path"
-    -DNON_INTERACTIVE_LOGIN_SHELLS
-    -DSSH_SOURCE_BASHRC
-  '';
-
-  patchFlags = [ "-p0" ];
-
-  patches = upstreamPatches
-    ++ [ ./pgrp-pipe-4.4.patch ]
-    ++ optional stdenv.hostPlatform.isCygwin ./cygwin-bash-4.4.11-2.src.patch
-    # https://lists.gnu.org/archive/html/bug-bash/2016-10/msg00006.html
-    ++ optional stdenv.hostPlatform.isMusl (fetchurl {
-      url = "https://lists.gnu.org/archive/html/bug-bash/2016-10/patchJxugOXrY2y.patch";
-      sha256 = "1m4v9imidb1cc1h91f2na0b8y9kc5c5fgmpvy9apcyv2kbdcghg1";
-    });
-
-  configureFlags = [
-    (if interactive then "--with-installed-readline" else "--disable-readline")
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "bash_cv_job_control_missing=nomissing"
-    "bash_cv_sys_named_pipes=nomissing"
-    "bash_cv_getcwd_malloc=yes"
-  ] ++ optionals stdenv.hostPlatform.isCygwin [
-    "--without-libintl-prefix"
-    "--without-libiconv-prefix"
-    "--with-installed-readline"
-    "bash_cv_dev_stdin=present"
-    "bash_cv_dev_fd=standard"
-    "bash_cv_termcap_lib=libncurses"
-  ] ++ optionals (stdenv.hostPlatform.libc == "musl") [
-    "--without-bash-malloc"
-    "--disable-nls"
-  ];
-
-  # Note: Bison is needed because the patches above modify parse.y.
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ bison ]
-    ++ optional withDocs texinfo
-    ++ optional stdenv.hostPlatform.isDarwin binutils
-    ++ optional (stdenv.hostPlatform.libc == "musl") autoconf;
-
-  buildInputs = optional interactive readline70;
-
-  # Bash randomly fails to build because of a recursive invocation to
-  # build `version.h'.
-  enableParallelBuilding = false;
-
-  makeFlags = optional stdenv.hostPlatform.isCygwin [
-    "LOCAL_LDFLAGS=-Wl,--export-all,--out-implib,libbash.dll.a"
-    "SHOBJ_LIBS=-lbash"
-  ];
-
-  checkInputs = [ util-linux ];
-  doCheck = false; # dependency cycle, needs to be interactive
-
-  postInstall = ''
-    ln -s bash "$out/bin/sh"
-    rm -f $out/lib/bash/Makefile.inc
-  '';
-
-  postFixup = if interactive
-    then ''
-      substituteInPlace "$out/bin/bashbug" \
-        --replace '${stdenv.shell}' "$out/bin/bash"
-    ''
-    # most space is taken by locale data
-    else ''
-      rm -rf "$out/share" "$out/bin/bashbug"
+    NIX_CFLAGS_COMPILE = ''
+      -DSYS_BASHRC="/etc/bashrc"
+      -DSYS_BASH_LOGOUT="/etc/bash_logout"
+      -DDEFAULT_PATH_VALUE="/no-such-path"
+      -DSTANDARD_UTILS_PATH="/no-such-path"
+      -DNON_INTERACTIVE_LOGIN_SHELLS
+      -DSSH_SOURCE_BASHRC
     '';
 
-  meta = with lib; {
-    homepage = "https://www.gnu.org/software/bash/";
-    description =
-      "GNU Bourne-Again Shell, the de facto standard shell on Linux" +
-        (if interactive then " (for interactive use)" else "");
+    patchFlags = [ "-p0" ];
 
-    longDescription = ''
-      Bash is the shell, or command language interpreter, that will
-      appear in the GNU operating system.  Bash is an sh-compatible
-      shell that incorporates useful features from the Korn shell
-      (ksh) and C shell (csh).  It is intended to conform to the IEEE
-      POSIX P1003.2/ISO 9945.2 Shell and Tools standard.  It offers
-      functional improvements over sh for both programming and
-      interactive use.  In addition, most sh scripts can be run by
-      Bash without modification.
+    patches = upstreamPatches
+      ++ [ ./pgrp-pipe-4.4.patch ]
+      ++ optional stdenv.hostPlatform.isCygwin ./cygwin-bash-4.4.11-2.src.patch
+      # https://lists.gnu.org/archive/html/bug-bash/2016-10/msg00006.html
+      ++ optional stdenv.hostPlatform.isMusl (fetchurl {
+        url = "https://lists.gnu.org/archive/html/bug-bash/2016-10/patchJxugOXrY2y.patch";
+        sha256 = "1m4v9imidb1cc1h91f2na0b8y9kc5c5fgmpvy9apcyv2kbdcghg1";
+      });
+
+    configureFlags = [
+      (if interactive then "--with-installed-readline" else "--disable-readline")
+    ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "bash_cv_job_control_missing=nomissing"
+      "bash_cv_sys_named_pipes=nomissing"
+      "bash_cv_getcwd_malloc=yes"
+    ] ++ optionals stdenv.hostPlatform.isCygwin [
+      "--without-libintl-prefix"
+      "--without-libiconv-prefix"
+      "--with-installed-readline"
+      "bash_cv_dev_stdin=present"
+      "bash_cv_dev_fd=standard"
+      "bash_cv_termcap_lib=libncurses"
+    ] ++ optionals (stdenv.hostPlatform.libc == "musl") [
+      "--without-bash-malloc"
+      "--disable-nls"
+    ];
+
+    # Note: Bison is needed because the patches above modify parse.y.
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    nativeBuildInputs = [ bison ]
+      ++ optional withDocs texinfo
+      ++ optional stdenv.hostPlatform.isDarwin binutils
+      ++ optional (stdenv.hostPlatform.libc == "musl") autoconf;
+
+    buildInputs = optional interactive readline70;
+
+    # Bash randomly fails to build because of a recursive invocation to
+    # build `version.h'.
+    enableParallelBuilding = false;
+
+    makeFlags = optional stdenv.hostPlatform.isCygwin [
+      "LOCAL_LDFLAGS=-Wl,--export-all,--out-implib,libbash.dll.a"
+      "SHOBJ_LIBS=-lbash"
+    ];
+
+    checkInputs = [ util-linux ];
+    doCheck = false; # dependency cycle, needs to be interactive
+
+    postInstall = ''
+      ln -s bash "$out/bin/sh"
+      rm -f $out/lib/bash/Makefile.inc
     '';
 
-    license = licenses.gpl3Plus;
+    postFixup = if interactive
+      then ''
+        substituteInPlace "$out/bin/bashbug" \
+          --replace '${stdenv.shell}' "$out/bin/bash"
+      ''
+      # most space is taken by locale data
+      else ''
+        rm -rf "$out/share" "$out/bin/bashbug"
+      '';
 
-    platforms = platforms.all;
+    meta = with lib; {
+      homepage = "https://www.gnu.org/software/bash/";
+      description =
+        "GNU Bourne-Again Shell, the de facto standard shell on Linux" +
+          (if interactive then " (for interactive use)" else "");
 
-    maintainers = [ maintainers.peti ];
+      longDescription = ''
+        Bash is the shell, or command language interpreter, that will
+        appear in the GNU operating system.  Bash is an sh-compatible
+        shell that incorporates useful features from the Korn shell
+        (ksh) and C shell (csh).  It is intended to conform to the IEEE
+        POSIX P1003.2/ISO 9945.2 Shell and Tools standard.  It offers
+        functional improvements over sh for both programming and
+        interactive use.  In addition, most sh scripts can be run by
+        Bash without modification.
+      '';
+
+      license = licenses.gpl3Plus;
+
+      platforms = platforms.all;
+
+      maintainers = [ maintainers.peti ];
+    };
+
+    passthru = rec {
+      shellPath = "/bin/bash";
+
+      writeScript =
+        name:
+        { executable ? true, destination ? "", packages ? [] }:
+        text:
+          writeTextFile {
+            inherit name executable destination;
+            text = concatStringsSep "\n" (
+              optional executable "#!${bash}${shellPath}"
+              ++ optional (packages != []) ''
+                export PATH=${lib.makeBinPath packages}''${PATH:+:$PATH}''
+              ++ [ text ]
+            );
+            checkPhase = ''
+              ${bash}${shellPath} -n $out${destination}
+            '';
+          };
+
+      writeScriptBin = name: opts: text:
+        writeScript name (opts // { destination = "/bin/${name}"; }) text;
+    };
   };
-
-  passthru = {
-    shellPath = "/bin/bash";
-  };
-}
+in bash

--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -1,44 +1,69 @@
-{ lib, stdenv, buildPackages, autoreconfHook, fetchurl, libedit }:
+{ lib, stdenv, buildPackages, autoreconfHook, fetchurl, libedit
+, writeTextFile                 # To support writeScript.
+}:
 
-stdenv.mkDerivation rec {
-  pname = "dash";
-  version = "0.5.11.2";
+let
 
-  src = fetchurl {
-    url = "http://gondor.apana.org.au/~herbert/dash/files/${pname}-${version}.tar.gz";
-    sha256 = "0pvdpm1cgfbc25ramn4305a0158yq031q1ain4dc972rnxl7vyq0";
+  dash =stdenv.mkDerivation rec {
+    pname = "dash";
+    version = "0.5.11.2";
+
+    src = fetchurl {
+      url = "http://gondor.apana.org.au/~herbert/dash/files/${pname}-${version}.tar.gz";
+      sha256 = "0pvdpm1cgfbc25ramn4305a0158yq031q1ain4dc972rnxl7vyq0";
+    };
+
+    hardeningDisable = [ "format" ];
+
+    patches = [
+      (fetchurl {
+        # Dash executes code when noexec ("-n") is specified
+        # https://www.openwall.com/lists/oss-security/2020/11/11/3
+        url = "https://git.kernel.org/pub/scm/utils/dash/dash.git/patch/?id=29d6f2148f10213de4e904d515e792d2cf8c968e";
+        sha256 = "08q90bx36ixwlcj331dh7420qyj8i0qh1cc1gljrhd83fhl9w0y5";
+      })
+    ] ++ lib.optionals stdenv.isDarwin [
+        # Temporary fix until a proper one is accepted upstream
+      ./0001-fix-dirent64-et-al-on-darwin.patch
+    ];
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    nativeBuildInputs = lib.optional stdenv.isDarwin autoreconfHook;
+    buildInputs = [ libedit ];
+
+    configureFlags = [ "--with-libedit" ];
+
+    enableParallelBuilding = true;
+
+    meta = with lib; {
+      homepage = "http://gondor.apana.org.au/~herbert/dash/";
+      description = "A POSIX-compliant implementation of /bin/sh that aims to be as small as possible";
+      platforms = platforms.unix;
+      license = with licenses; [ bsd3 gpl2 ];
+    };
+
+    passthru = rec {
+      shellPath = "/bin/dash";
+
+      writeScript =
+        name:
+        { executable ? true, destination ? "", packages ? [] }:
+        text:
+          writeTextFile {
+            inherit name executable destination;
+            text = lib.concatStringsSep "\n" (
+              lib.optional executable "#!${dash}${shellPath}"
+              ++ lib.optional (packages != []) ''
+                export PATH=${lib.makeBinPath packages}''${PATH:+:$PATH}''
+              ++ [ text ]
+            );
+            checkPhase = ''
+              ${dash}${shellPath} -n $out${destination}
+            '';
+          };
+
+      writeScriptBin = name: opts: text:
+        writeScript name (opts // { destination = "/bin/${name}"; }) text;
+    };
   };
-
-  hardeningDisable = [ "format" ];
-
-  patches = [
-    (fetchurl {
-      # Dash executes code when noexec ("-n") is specified
-      # https://www.openwall.com/lists/oss-security/2020/11/11/3
-      url = "https://git.kernel.org/pub/scm/utils/dash/dash.git/patch/?id=29d6f2148f10213de4e904d515e792d2cf8c968e";
-      sha256 = "08q90bx36ixwlcj331dh7420qyj8i0qh1cc1gljrhd83fhl9w0y5";
-    })
-  ] ++ lib.optionals stdenv.isDarwin [
-      # Temporary fix until a proper one is accepted upstream
-    ./0001-fix-dirent64-et-al-on-darwin.patch
-  ];
-
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = lib.optional stdenv.isDarwin autoreconfHook;
-  buildInputs = [ libedit ];
-
-  configureFlags = [ "--with-libedit" ];
-
-  enableParallelBuilding = true;
-
-  meta = with lib; {
-    homepage = "http://gondor.apana.org.au/~herbert/dash/";
-    description = "A POSIX-compliant implementation of /bin/sh that aims to be as small as possible";
-    platforms = platforms.unix;
-    license = with licenses; [ bsd3 gpl2 ];
-  };
-
-  passthru = {
-    shellPath = "/bin/dash";
-  };
-}
+in dash

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -72,7 +72,7 @@ let
   trivialBuilders = self: super:
     import ../build-support/trivial-builders.nix {
       inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.pkgsBuildHost.xorg) lndir;
-      inherit (self) runtimeShell;
+      inherit (self) runtimeShellPackage;
     };
 
   stdenvBootstappingAndPlatforms = self: super: let


### PR DESCRIPTION
Inspired by #123608

Example:

```console
$ nix-build -E '(import ./. {}).bash.writeScript "test" {} "echo Hello, world!"'
/nix/store/fxdsl25ggzg8j8ikyw6454mhxirsqzfp-test

$ /nix/store/fxdsl25ggzg8j8ikyw6454mhxirsqzfp-test
Hello, world!

$ nix-build -E '(import ./. {}).bash.writeScriptBin "test" {} "echo Hello, world!"'
/nix/store/8wa81g2kk2n5rk7vyfx9b7q45gkvi7b1-test

$ /nix/store/8wa81g2kk2n5rk7vyfx9b7q45gkvi7b1-test/bin/test
Hello, world!

$ nix-build -E 'let p = import ./. {}; in p.bash.writeScript "test" { packages = [ p.cowsay ]; } "cowsay Hello, world!"'
/nix/store/h8w0qk3v1dwzayj4ra6r32jlh7hja2b7-test

$ /nix/store/h8w0qk3v1dwzayj4ra6r32jlh7hja2b7-test
 _______________
< Hello, world! >
 ---------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

Note, enable "Hide whitespace changes" to see a more relevant diff.