### PR TITLE
haskellPackages.taffybar: override src until next Hackage update

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1954,4 +1954,19 @@ EOT
     testTarget = "libarchive-test --test-options='-j1'";
   };
 
+  # 2021-05-23: Override for a quite recent Hackage release.
+  taffybar =
+    if pkgs.lib.versionAtLeast super.taffybar.version "3.2.5"
+    then throw "Drop src override for taffybar >= 3.2.5"
+    else overrideCabal super.taffybar (drv: {
+      src = pkgs.fetchFromGitHub {
+        owner = "taffybar";
+        repo = "taffybar";
+        rev = "91c83e01e131d560e704b12f0d798905e4289a3d";
+        sha256 = "1kkpkjdyd1yv8z1qlzr3jrzyk9lxac5m4f9py8igyars2nwnhhzr";
+      };
+      version = "3.2.5";
+      editedCabalFile = null;
+    });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super


### PR DESCRIPTION
###### Motivation for this change

Taffybar 3.2.5 fixes dyre compatibility, but is not in Hackage as of 2021-05-19T07:17:55Z.

To be merged into #123682.

cc @IvanMalison @cdepillabout 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
