### PR TITLE
fix jupyterlab on darwin

### DIFF
--- a/pkgs/development/python-modules/jupyter_server/default.nix
+++ b/pkgs/development/python-modules/jupyter_server/default.nix
@@ -77,6 +77,8 @@ buildPythonPackage rec {
     "test_delete"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.";
     homepage = "https://github.com/jupyter-server/jupyter_server";

--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage rec {
     "test_get_language_pack"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "JupyterLab Server";
     homepage = "https://jupyter.org";

--- a/pkgs/development/python-modules/nbclassic/default.nix
+++ b/pkgs/development/python-modules/nbclassic/default.nix
@@ -28,6 +28,8 @@ buildPythonPackage rec {
     pytest-tornasync
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Jupyter lab environment notebook server extension.";
     license = with licenses; [ bsd3 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The jupyterlab stack was broken on mac: https://hydra.nixos.org/build/143189378

ZHF: #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
