### PR TITLE
luajit_2_0: 2.0.5-2020-12-28 -> 2.0.5-2021-05-17, luajit_2_1: 2.1.0-2020-12-28 -> 2.1.0-2021-05-22

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,10 +1,10 @@
 { self, callPackage, lib }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.0.5-2020-12-28";
-  rev = "56c04accf975bff2519c34721dccbbdb7b8e6963";
+  version = "2.0.5-2021-05-17";
+  rev = "44684fa71d8af6fa8b3051c7d763bbfdcf7915d7";
   isStable = true;
-  sha256 = "0mmx7dy843iqdpyxxdfks860np0311gg58gi4zczx10h62y6jacm";
+  sha256 = "049d3l0miv4n0cnm35ml8flrb9vs12zvbda2743vypckymidliqp";
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: p != "aarch64-linux")
       (platforms.linux ++ platforms.darwin);

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,8 +1,8 @@
 { self, callPackage }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.1.0-2020-12-28";
-  rev = "65378759f38bb946e40f31799992434effd01bba";
+  version = "2.1.0-2021-05-22";
+  rev = "5783ba1bf73c53ca56e64ed0c462c62224f0393c";
   isStable = false;
-  sha256 = "1h78gydlrmvkdrql4ra5a3xr78iiq12bfmny6kiq65v1jbk8f19g";
+  sha256 = "1j25xnbradks58lwsqnxcc7k29wsk2hnky0b1vjzpadrj0sxxc42";
 }


### PR DESCRIPTION
###### Motivation for this change

*luajit_2_0*
Documentation updates.

https://github.com/LuaJIT/LuaJIT/compare/56c04accf975bff2519c34721dccbbdb7b8e6963...44684fa71d8af6fa8b3051c7d763bbfdcf7915d7

*luajit_2_1*
Various bugfixes, it also includes new `string.buffer` module https://htmlpreview.github.io/?https://github.com/LuaJIT/LuaJIT/blob/v2.1/doc/ext_buffer.html - "pickle" for luajit.

https://github.com/LuaJIT/LuaJIT/compare/65378759f38bb946e40f31799992434effd01bba...5783ba1bf73c53ca56e64ed0c462c62224f0393c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
