### PR TITLE
python3Packages.aiopvpc: 2.0.2 -> 2.1.2

### DIFF
--- a/pkgs/development/python-modules/aiopvpc/default.nix
+++ b/pkgs/development/python-modules/aiopvpc/default.nix
@@ -1,28 +1,28 @@
 { lib
 , aiohttp
 , async-timeout
+, backports-zoneinfo
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , pytest-asyncio
 , pytest-timeout
 , pytestCheckHook
 , pythonOlder
-, pytz
+, tzdata
 }:
 
 buildPythonPackage rec {
   pname = "aiopvpc";
-  version = "2.0.2";
-  disabled = pythonOlder "3.7";
+  version = "2.1.2";
+  disabled = pythonOlder "3.8";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "azogue";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ajs4kbdlfn4h7f3d6lwkp4yl1rl7zyvj997nhsz93jjwxbajkpv";
+    sha256 = "0s8ki46dh39kw6qvsjcfcxa0gblyi33m3hry137kbi4lw5ws6qhr";
   };
 
   nativeBuildInputs = [
@@ -31,7 +31,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiohttp
-    pytz
+    backports-zoneinfo
+    tzdata
     async-timeout
   ];
 
@@ -41,17 +42,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  patches = [
-    # Switch to poetry-core, https://github.com/azogue/aiopvpc/pull/10
-    (fetchpatch {
-      name = "use-peotry-core.patch";
-      url = "https://github.com/azogue/aiopvpc/commit/4bc2740ffd485a60acf579b4f3eb5ee6a353245c.patch";
-      sha256 = "0ynj7pqq3akdvdrvqcwnnslay3mn1q92qhk8fg95ppflzscixli6";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace pytest.ini --replace \
+    substituteInPlace pyproject.toml --replace \
       " --cov --cov-report term --cov-report html" ""
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.2

Change log:
- https://github.com/azogue/aiopvpc/releases/tag/v2.1.2
- https://github.com/azogue/aiopvpc/releases/tag/v2.1.1
- https://github.com/azogue/aiopvpc/releases/tag/v2.1.0

--
 
- Related Home Assistant change: https://github.com/home-assistant/core/pull/51320
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
