### PR TITLE
libreoffice-still: 7.0.4.2 -> 7.0.6.2

### DIFF
--- a/pkgs/applications/office/libreoffice/src-still/download.nix
+++ b/pkgs/applications/office/libreoffice/src-still/download.nix
@@ -721,25 +721,25 @@
     md5name = "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca-libpng-1.6.37.tar.xz";
   }
   {
-    name = "poppler-0.82.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/poppler-0.82.0.tar.xz";
-    sha256 = "234f8e573ea57fb6a008e7c1e56bfae1af5d1adf0e65f47555e1ae103874e4df";
+    name = "poppler-21.01.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/poppler-21.01.0.tar.xz";
+    sha256 = "016dde34e5f868ea98a32ca99b643325a9682281500942b7113f4ec88d20e2f3";
     md5 = "";
-    md5name = "234f8e573ea57fb6a008e7c1e56bfae1af5d1adf0e65f47555e1ae103874e4df-poppler-0.82.0.tar.xz";
+    md5name = "016dde34e5f868ea98a32ca99b643325a9682281500942b7113f4ec88d20e2f3-poppler-21.01.0.tar.xz";
   }
   {
-    name = "postgresql-9.2.24.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/postgresql-9.2.24.tar.bz2";
-    sha256 = "a754c02f7051c2f21e52f8669a421b50485afcde9a581674d6106326b189d126";
+    name = "postgresql-13.1.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/postgresql-13.1.tar.bz2";
+    sha256 = "12345c83b89aa29808568977f5200d6da00f88a035517f925293355432ffe61f";
     md5 = "";
-    md5name = "a754c02f7051c2f21e52f8669a421b50485afcde9a581674d6106326b189d126-postgresql-9.2.24.tar.bz2";
+    md5name = "12345c83b89aa29808568977f5200d6da00f88a035517f925293355432ffe61f-postgresql-13.1.tar.bz2";
   }
   {
-    name = "Python-3.7.7.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.7.7.tar.xz";
-    sha256 = "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136";
+    name = "Python-3.7.10.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.7.10.tar.xz";
+    sha256 = "f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b";
     md5 = "";
-    md5name = "06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136-Python-3.7.7.tar.xz";
+    md5name = "f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b-Python-3.7.10.tar.xz";
   }
   {
     name = "QR-Code-generator-1.4.0.tar.gz";

--- a/pkgs/applications/office/libreoffice/src-still/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-still/primary.nix
@@ -8,7 +8,7 @@ rec {
 
   major = "7";
   minor = "0";
-  patch = "4";
+  patch = "6";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1g9akxvm7fh6lnprnc3g184qdy8gbinhb4rb60gjpw82ip6d5acz";
+    sha256 = "0bk1dc6g8z5akrprfxxy3dm0vdmihaaxnsprxpqbqmqrqzkzg8cn";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "1v3kpk56fm783d5wihx41jqidpclizkfxrg4n0pq95d79hdiljsl";
+    sha256 = "04f76r311hppil656ajab52x0xwqszazlgssyi5w97wak2zkmqgj";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "1np9f799ww12kggl5az6piv5fi9rf737il5a5r47r4wl2li56qqb";
+    sha256 = "1xmvlj9nrmg8448k4zfaxn5qqxa4amnvvhs1l1smi2bz3xh4xn2d";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This will avoid false positives with [CVE-2021-25631](https://www.libreoffice.org/about-us/security/advisories/cve-2021-25631/) (only impact Windows).
It also includes bugfixes:
https://wiki.documentfoundation.org/Releases/7.0.5/RC1
https://wiki.documentfoundation.org/Releases/7.0.5/RC2
https://wiki.documentfoundation.org/Releases/7.0.6/RC1
https://wiki.documentfoundation.org/Releases/7.0.6/RC2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
