### PR TITLE
[21.05] python3Packages.cocotb: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/development/python-modules/cocotb-bus/default.nix
+++ b/pkgs/development/python-modules/cocotb-bus/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "cocotb-bus";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cc9b0bb00c95061a67f650caf96e3a294bb74ef437124dea456dd9e2a9431854";
+  };
+
+  postPatch = ''
+    # remove circular dependency cocotb from setup.py
+    substituteInPlace setup.py --replace '"cocotb>=1.5.0.dev,<2.0"' ""
+  '';
+
+  # tests require cocotb, disable for now to avoid circular dependency
+  doCheck = false;
+
+  # checkPhase = ''
+  #   export PATH=$out/bin:$PATH
+  #   make test
+  # '';
+
+  meta = with lib; {
+    description = "Pre-packaged testbenching tools and reusable bus interfaces for cocotb";
+    homepage = "https://github.com/cocotb/cocotb-bus";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -1,19 +1,31 @@
-{ lib, stdenv, buildPythonPackage, fetchFromGitHub, setuptools, swig, verilog }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, setuptools-scm
+, cocotb-bus
+, pytest
+, swig
+, verilog
+}:
 
 buildPythonPackage rec {
   pname = "cocotb";
-  version = "1.5.1";
+  version = "1.5.2";
 
-  src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "02bw2i03vd4rcvdk10qdjl2lbvvy81cn9qpr8vzq8cm9h45689mv";
+  # - we need to use the tarball from PyPi
+  #   or the full git checkout (with .git)
+  # - using fetchFromGitHub will cause a build failure,
+  #   because it does not include required metadata
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9f4f3e6eb9caeb479e98d604770645b57469cd25b39e28df1916ffcd593efbe6";
   };
 
-  propagatedBuildInputs = [
-    setuptools
-  ];
+  nativeBuildInputs = [ setuptools-scm ];
+
+  buildInputs = [ setuptools ];
 
   postPatch = ''
     patchShebangs bin/*.py
@@ -25,16 +37,14 @@ buildPythonPackage rec {
     do
       substituteInPlace $f --replace 'shell which' 'shell command -v'
     done
+
+    # remove circular dependency cocotb-bus from setup.py
+    substituteInPlace setup.py --replace "'cocotb-bus<1.0'" ""
   '';
 
-  checkInputs = [ swig verilog ];
+  checkInputs = [ cocotb-bus pytest swig verilog ];
 
   checkPhase = ''
-    # test expected failures actually pass because of a fix in our icarus version
-    # https://github.com/cocotb/cocotb/issues/1952
-    substituteInPlace tests/test_cases/test_discovery/test_discovery.py \
-      --replace 'def access_single_bit' $'def foo(x): pass\ndef foo'
-
     export PATH=$out/bin:$PATH
     make test
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1481,6 +1481,8 @@ in {
 
   cocotb = callPackage ../development/python-modules/cocotb { };
 
+  cocotb-bus = callPackage ../development/python-modules/cocotb-bus { };
+
   codecov = callPackage ../development/python-modules/codecov { };
 
   codespell = callPackage ../development/python-modules/codespell { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/116168 fixing the build of cocotb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
