### PR TITLE
[21.05] php74.extensions.iconv: fix error signalling

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -322,10 +322,16 @@ lib.makeScope pkgs.newScope (self: with self; {
         configureFlags = [ "--with-gmp=${gmp.dev}" ]; }
       { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
       { name = "iconv";
-        configureFlags = if stdenv.isDarwin then
-                           [ "--with-iconv=${libiconv}" ]
-                         else
-                           [ "--with-iconv" ];
+        configureFlags = [
+          "--with-iconv${lib.optionalString stdenv.isDarwin "=${libiconv}"}"
+        ];
+        patches = lib.optionals (lib.versionOlder php.version "8.0") [
+          # Header path defaults to FHS location, preventing the configure script from detecting errno support.
+          (fetchpatch {
+            url = "https://github.com/fossar/nix-phps/raw/263861a8c9bdafd7abe44db6db4ef0179643680c/pkgs/iconv-header-path.patch";
+            sha256 = "7GHnEUu+hcsQ4h3itDwk6p46ZKfib9JZ2XpWlXrdn6E=";
+          })
+        ];
         doCheck = false; }
       { name = "imap";
         buildInputs = [ uwimap openssl pam pcre' ];


### PR DESCRIPTION
###### Motivation for this change
Port #124075 to 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
