### PR TITLE
python3Packages.geojson-client: 0.5 -> 0.6

### DIFF
--- a/pkgs/development/python-modules/geojson-client/default.nix
+++ b/pkgs/development/python-modules/geojson-client/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "geojson-client";
-  version = "0.5";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-geojson-client";
     rev = "v${version}";
-    sha256 = "1cc6ymbn45dv7xdl1r8bbizlmsdbxjmsfza442yxmmm19nxnnqjv";
+    sha256 = "sha256-8eSLimCgFRn3cHTz5TE9fAUAbwFO72b23C0lg6fVOLQ=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6

Change log: https://github.com/exxamalte/python-geojson-client/releases/tag/v0.6

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50985
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
