### PR TITLE
firebird: 4.0.0-rc1 -> 4.0.0

### DIFF
--- a/nixos/modules/services/databases/firebird.nix
+++ b/nixos/modules/services/databases/firebird.nix
@@ -43,17 +43,15 @@ in
       enable = mkEnableOption "the Firebird super server";
 
       package = mkOption {
-        default = pkgs.firebirdSuper;
-        defaultText = "pkgs.firebirdSuper";
+        default = pkgs.firebird;
+        defaultText = "pkgs.firebird";
         type = types.package;
-        /*
-          Example: <code>package = pkgs.firebirdSuper.override { icu =
-            pkgs.icu; };</code> which is not recommended for compatibility
-            reasons. See comments at the firebirdSuper derivation
-        */
-
+        example = ''
+          <code>package = pkgs.firebird_3;</code>
+        '';
         description = ''
-          Which firebird derivation to use.
+          Which Firebird package to be installed: <code>pkgs.firebird_3</code>
+          For SuperServer use override: <code>pkgs.firebird_3.override { superServer = true; };</code>
         '';
       };
 
@@ -74,7 +72,7 @@ in
       };
 
       baseDir = mkOption {
-        default = "/var/db/firebird"; # ubuntu is using /var/lib/firebird/2.1/data/.. ?
+        default = "/var/lib/firebird";
         type = types.str;
         description = ''
           Location containing data/ and system/ directories.
@@ -109,6 +107,14 @@ in
           ''
             if ! test -e "${systemDir}/security2.fdb"; then
                 cp ${firebird}/security2.fdb "${systemDir}"
+            fi
+
+            if ! test -e "${systemDir}/security3.fdb"; then
+                cp ${firebird}/security3.fdb "${systemDir}"
+            fi
+
+            if ! test -e "${systemDir}/security4.fdb"; then
+                cp ${firebird}/security4.fdb "${systemDir}"
             fi
 
             chmod -R 700         "${dataDir}" "${systemDir}" /var/log/firebird

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -9,7 +9,7 @@ let base = {
     changelog = "https://github.com/FirebirdSQL/firebird/blob/master/CHANGELOG.md";
     license = [ "IDPL" "Interbase-1.0" ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ marcweber ];
+    maintainers = with maintainers; [ marcweber superherointj ];
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -29,7 +29,7 @@ let base = {
     runHook postInstall
   '';
 
-}; in {
+}; in rec {
 
   firebird_2_5 = stdenv.mkDerivation (base // rec {
     version = "2.5.9";
@@ -69,16 +69,17 @@ let base = {
   });
 
   firebird_4 = stdenv.mkDerivation (base // rec {
-    version = "4.0.0-rc1";
+    version = "4.0.0";
 
     src = fetchFromGitHub {
       owner = "FirebirdSQL";
       repo = "firebird";
-      rev = "T4_0_0_RC1";
-      sha256 = "sha256-FLaRePosF5dtJ+fmrfvzkE6wawC9Z9YLhT/ZWkwWXb4=";
+      rev = "v${version}";
+      sha256 = "sha256-a4ex19FMfiJsUEhWUYd2YXKgJ24Jnpoab2t6x9sUuyQ=";
     };
 
     buildInputs = base.buildInputs ++ [ zlib unzip libtommath libtomcrypt ];
   });
 
+  firebird = firebird_4;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18980,8 +18980,7 @@ in
 
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 
-  inherit (callPackages ../servers/firebird { }) firebird_4 firebird_3 firebird_2_5;
-  firebird = firebird_3;
+  inherit (callPackages ../servers/firebird { }) firebird_4 firebird_3 firebird_2_5 firebird;
 
   freeradius = callPackage ../servers/freeradius { };
 


### PR DESCRIPTION
firebird: update version from 4.0.0-rc1 to 4.0.0

nixos/firebird:
* updated package from firebirdSuper to firebird.
* #26256: migrated /var/db/firebird to /var/lib/firebird.
* fix security{2,3,4}.fdb path error

Note: Firebird package was broken for a long period and I fixed it (on another PR only recently). So I expect there is nobody using this.