### PR TITLE
[21.05] pkg-config-wrapper: mangle PKG_CONFIG_PATH{,_FOR_BUILD} correctly

### DIFF
--- a/pkgs/build-support/pkg-config-wrapper/add-flags.sh
+++ b/pkgs/build-support/pkg-config-wrapper/add-flags.sh
@@ -6,7 +6,7 @@ var_templates_list=(
 accumulateRoles
 
 for var in "${var_templates_list[@]}"; do
-    mangleVarList "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
+    mangleVarListGeneric ":" "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
 done
 
 export NIX_PKG_CONFIG_WRAPPER_FLAGS_SET_@suffixSalt@=1

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -13,7 +13,9 @@ accumulateRoles() {
     fi
 }
 
-mangleVarList() {
+mangleVarListGeneric() {
+    local sep="$1"
+    shift
     local var="$1"
     shift
     local -a role_suffixes=("$@")
@@ -25,9 +27,13 @@ mangleVarList() {
     for suffix in "${role_suffixes[@]}"; do
         local inputVar="${var}${suffix}"
         if [ -v "$inputVar" ]; then
-            export ${outputVar}+="${!outputVar:+ }${!inputVar}"
+            export ${outputVar}+="${!outputVar:+$sep}${!inputVar}"
         fi
     done
+}
+
+mangleVarList() {
+    mangleVarListGeneric " " "$@"
 }
 
 mangleVarBool() {


### PR DESCRIPTION
Previously, mangleVarList would be used which would concatenate the
variables using a space as a separator. Paths are however separated by
`:` in PKG_CONFIG_PATH leading to entries being broken.

This is fixed by introducing mangleVarListGeneric which allows us to
specify the desired separator.

Reproducer for the issue prior to this change:

    $ nix-shell -A pkgsLLVM.wayland
    [nix-shell] $ pkg-config --libs expat
    Package expat was not found in the pkg-config search path.
    Perhaps you should add the directory containing `expat.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'expat' found
    $ printf 'Host: %s\nBuild: %s' $PKG_CONFIG_PATH $PKG_CONFIG_PATH_FOR_BUILD
    Host: /nix/store/5h308a4ab8w7prcp8iflh5pnl78mayi2-expat-2.2.10-x86_64-unknown-linux-gnu-dev/lib/pkgconfig:/nix/store/z3y9ska2h4l1map25m195iq577g7g3gz-libxml2-x86_64-unknown-linux-gnu-2.9.12-dev/lib/pkgconfig:/nix/store/lbz5m1s0r7zn0cxvl21czfspli6ribzb-zlib-1.2.11-x86_64-unknown-linux-gnu-dev/lib/pkgconfig:/nix/store/rfhvp8r8n3ygpzh8j0l34lk8hwwi3z0h-libffi-3.3-x86_64-unknown-linux-gnu-dev/lib/pkgconfig
    Build: /nix/store/dw11ywy7qwfz53qisz0dggbgix88jah2-wayland-1.19.0-bin/lib/pkgconfig

strace reveals the issue:

    stat("/nix/store/dw11ywy7qwfz53qisz0dggbgix88jah2-wayland-1.19.0-bin/lib/pkgconfig /nix/store/5h308a4ab8w7prcp8iflh5pnl78mayi2-expat-2.2.10-x86_64-unknown-linux-gnu-dev/lib/pkgconfig/expat-uninstalled.pc", 0x7fff49829fa0) = -1 ENOENT (No such file or directory)

In the pkg-config wrapper $PKG_CONFIG_PATH_FOR_BUILD and
$PKG_CONFIG_PATH are concatenated with a space which leads to two paths
being messed up. This issue likely only affects native cross
compilation.

(cherry picked from commit b11d65c8508542efbd161c5922d51b55b431fe90)

Backport of #123415.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
