### PR TITLE
python3Packages.scrapy: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -80,6 +80,7 @@ buildPythonPackage rec {
     "test_retry_dns_error"
     "test_custom_asyncio_loop_enabled_true"
     "test_custom_loop_asyncio"
+    "FileFeedStoragePreFeedOptionsTest"  # https://github.com/scrapy/scrapy/issues/5157
   ] ++ lib.optionals stdenv.isDarwin [
     "test_xmliter_encoding"
     "test_download"


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042 

This test will fail if `/tmp/foobar` already exists owned by a different user. Technically only observed to be a problem on darwin but in theory any system not using namespaced `/tmp` for their builder could run into this.

Issue opened upstream https://github.com/scrapy/scrapy/issues/5157

Edit: ok, so it looks like scrapy has been broken on `master` since the branch, but the backport of this is needed for 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
