### PR TITLE
openvpn: 2.5.0 -> 2.5.2, openvpn_24: 2.4.9 -> 2.4.11

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -83,7 +83,7 @@ in
   };
 
   openvpn = generic {
-    version = "2.5.0";
-    sha256 = "sha256-AppCbkTWVstOEYkxnJX+b8mGQkdyT1WZ2Z35xMNHj70=";
+    version = "2.5.2";
+    sha256 = "sha256-sSdDg2kB82Xvr4KrJJOWfhshwh60POmo2hACoXycHcg=";
   };
 }

--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -78,8 +78,8 @@ let
 in
 {
   openvpn_24 = generic {
-    version = "2.4.9";
-    sha256 = "1qpbllwlha7cffsd5dlddb8rl22g9rar5zflkz1wrcllhvfkl7v4";
+    version = "2.4.11";
+    sha256 = "06s4m0xvixjhd3azrzbsf4j86kah4xwr2jp6cmcpc7db33rfyyg5";
   };
 
   openvpn = generic {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2020-15078.
https://community.openvpn.net/openvpn/wiki/CVE-2020-15078

fixes https://github.com/NixOS/nixpkgs/issues/124659 and fixes https://github.com/NixOS/nixpkgs/issues/124660

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>libsForQt512.plasma-nm</li>
    <li>libsForQt514.plasma-nm</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>openvpn-auth-ldap</li>
  </ul>
</details>
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>connman</li>
    <li>connman-gtk</li>
    <li>connman-ncurses</li>
    <li>connmanFull</li>
    <li>connman_dmenu</li>
    <li>crowbar</li>
    <li>networkmanager-openvpn (gnome.networkmanager-openvpn ,networkmanager_openvpn)</li>
    <li>plasma-nm (libsForQt5.plasma-nm)</li>
    <li>openvpn</li>
    <li>protonvpn-cli</li>
    <li>protonvpn-gui</li>
  </ul>
</details>

The build failure for openvpn-auth-ldap is not introduced by this change.