### PR TITLE
libredirect: Fix redirects not working for subprocesses

### DIFF
--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -28,6 +28,11 @@ stdenv.mkDerivation rec {
     runHook postBuild
   '';
 
+  # We want to retain debugging info to be able to use GDB on libredirect.so
+  # to more easily investigate which function overrides are missing or why
+  # existing ones do not have the intended effect.
+  dontStrip = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   outputs = ["out" "hook"];
 
   buildPhase = ''
+    runHook preBuild
+
     $CC -Wall -std=c99 -O3 -fPIC -ldl -shared \
       ${lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/$libName"} \
       -o "$libName" \
@@ -22,9 +24,13 @@ stdenv.mkDerivation rec {
     if [ -n "$doInstallCheck" ]; then
       $CC -Wall -std=c99 -O3 test.c -o test
     fi
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -vD "$libName" "$out/lib/$libName"
 
     mkdir -p "$hook/nix-support"
@@ -36,6 +42,8 @@ stdenv.mkDerivation rec {
     export LD_PRELOAD="$out/lib/$libName"
     ''}
     SETUP_HOOK
+
+    runHook postInstall
   '';
 
   doInstallCheck = true;

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -17,15 +17,22 @@ static int nrRedirects = 0;
 static char * from[MAX_REDIRECTS];
 static char * to[MAX_REDIRECTS];
 
+static int isInitialized = 0;
+
 // FIXME: might run too late.
 static void init() __attribute__((constructor));
 
 static void init()
 {
+    if (isInitialized) return;
+
     char * spec = getenv("NIX_REDIRECTS");
     if (!spec) return;
 
-    unsetenv("NIX_REDIRECTS");
+    // Ensure we only run this code once.
+    // We do not do `unsetenv("NIX_REDIRECTS")` to ensure that redirects
+    // also get initialized for subprocesses.
+    isInitialized = 1;
 
     char * spec2 = malloc(strlen(spec) + 1);
     strcpy(spec2, spec);

--- a/pkgs/build-support/libredirect/test.c
+++ b/pkgs/build-support/libredirect/test.c
@@ -10,6 +10,7 @@
 #include <sys/wait.h>
 
 #define TESTPATH "/foo/bar/test"
+#define SUBTEST "./test sub"
 
 extern char **environ;
 
@@ -36,7 +37,11 @@ void test_system(void) {
     assert(system(TESTPATH) == 0);
 }
 
-int main(void)
+void test_subprocess(void) {
+    assert(system(SUBTEST) == 0);
+}
+
+int main(int argc, char *argv[])
 {
     FILE *testfp;
     int testfd;
@@ -56,6 +61,14 @@ int main(void)
 
     test_spawn();
     test_system();
+
+    // Only run subprocess if no arguments are given
+    // as the subprocess will be called without argument
+    // otherwise we will have infinite recursion
+    if (argc == 1) {
+        test_subprocess();
+    }
+
     test_execv();
 
     /* If all goes well, this is never reached because test_execv() replaces


### PR DESCRIPTION
###### Motivation for this change

Fixes `libredirect` redirections not having any effect for subprocesses, because the environment variable was unset.

Found for example here: https://github.com/NixOS/nixpkgs/pull/124057#discussion_r637542270

The PR also enables debug symbols for better debugging of libredirect functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
