### PR TITLE
nixos/logiops init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11147,6 +11147,12 @@
     email = "zef@zef.me";
     name = "Zef Hemel";
   };
+  zeorin = {
+    name = "Xandor Schiefer";
+    email = "me@xandor.co.za";
+    github = "zeorin";
+    githubId = 1187078;
+  };
   zeratax = {
     email = "mail@zera.tax";
     github = "ZerataX";

--- a/nixos/modules/services/hardware/logiops.nix
+++ b/nixos/modules/services/hardware/logiops.nix
@@ -1,0 +1,139 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.logiops;
+  # settingsFormat = pkgs.formats.libconfig {};
+in {
+  options.services.logiops = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable `logiops`, an unofficial driver for Logitech mice and keyboards.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Configuration for `logiops`, see
+        <link xlink:href="https://github.com/PixlOne/logiops/wiki/Configuration"/>
+        for supported values.
+      '';
+      example = ''
+        devices: (
+        {
+            name: "Wireless Mouse MX Master";
+            smartshift:
+            {
+                on: true;
+                threshold: 30;
+            };
+            hiresscroll:
+            {
+                hires: true;
+                invert: false;
+                target: false;
+            };
+            dpi: 1000;
+
+            buttons: (
+                {
+                    cid: 0xc3;
+                    action =
+                    {
+                        type: "Gestures";
+                        gestures: (
+                            {
+                                direction: "Up";
+                                mode: "OnRelease";
+                                action =
+                                {
+                                    type: "Keypress";
+                                    keys: ["KEY_UP"];
+                                };
+                            },
+                            {
+                                direction: "Down";
+                                mode: "OnRelease";
+                                action =
+                                {
+                                    type: "Keypress";
+                                    keys: ["KEY_DOWN"];
+                                };
+                            },
+                            {
+                                direction: "Left";
+                                mode: "OnRelease";
+                                action =
+                                {
+                                    type: "CycleDPI";
+                                    dpis: [400, 600, 800, 1000, 1200, 1400, 1600];
+                                };
+                            },
+                            {
+                                direction: "Right";
+                                mode: "OnRelease";
+                                action =
+                                {
+                                    type = "ToggleSmartshift";
+                                }
+                            },
+                            {
+                                direction: "None"
+                                mode: "NoPress"
+                            }
+                        );
+                    };
+                },
+                {
+                    cid: 0xc4;
+                    action =
+                    {
+                        type: "Keypress";
+                        keys: ["KEY_A"];
+                    };
+                }
+            );
+        }
+        );
+      '';
+    };
+
+    # settings = mkOption {
+    #   type = types.submodule {
+    #     # Declare that the settings option supports arbitrary format values, libconfig here
+    #     freeformType = settingsFormat.type;
+    #   };
+    #   default = {};
+    #   # Add upstream documentation to the settings description
+    #   description = ''
+    #     Configuration for `logiops`, see
+    #     <link xlink:href="https://github.com/PixlOne/logiops/wiki/Configuration"/>
+    #     for supported values.
+    #   '';
+    # };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.logiops = {
+      description = "Logitech Configuration Daemon";
+      startLimitIntervalSec = 0;
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.logiops}/bin/logid";
+        User = "root";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        Restart = "on-failure";
+      };
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ pkgs.logiops ];
+    };
+
+    # environment.etc."logid.cfg".source = settingsFormat.generate "logid.cfg" cfg.settings;
+    environment.etc."logid.cfg".text = cfg.extraConfig;
+  };
+}

--- a/pkgs/tools/inputmethods/logiops/default.nix
+++ b/pkgs/tools/inputmethods/logiops/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libevdev
+, libudev
+, libconfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "logiops";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "PixlOne";
+    repo = "logiops";
+    rev = "v${version}";
+    sha256 = "1wgv6m1kkxl0hppy8vmcj1237mr26ckfkaqznj1n6cy82vrgdznn";
+  };
+
+  patches = [ ./logiops-no-systemd-service.patch ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libevdev libudev libconfig ];
+
+  meta = with lib; {
+    description = "An unofficial userspace driver for HID++ Logitech mice and keyboards";
+    longDescription = ''
+      Logiops is an unofficial userspace driver for HID++ Logitech mice and keyboards.
+
+      It can configure features like: easy programmable buttons, DPI selection,
+      Smartshift (hyperfast and click-to-click wheel mode), HiresScroll, gestures.
+
+      It is meant to run as a service, see `services.logiops`.
+
+      Currently only compatible with HID++ >2.0 devices.
+    '';
+    license = licenses.gpl3;
+    homepage = "https://github.com/PixlOne/logiops";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zeorin ];
+  };
+}

--- a/pkgs/tools/inputmethods/logiops/logiops-no-systemd-service.patch
+++ b/pkgs/tools/inputmethods/logiops/logiops-no-systemd-service.patch
@@ -1,0 +1,15 @@
+diff --git i/src/logid/CMakeLists.txt w/src/logid/CMakeLists.txt
+index 00ee796..c8300a5 100644
+--- i/src/logid/CMakeLists.txt
++++ w/src/logid/CMakeLists.txt
+@@ -96,10 +96,6 @@ if (SYSTEMD_FOUND AND "${SYSTEMD_SERVICES_INSTALL_DIR}" STREQUAL "")
+     string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SERVICES_INSTALL_DIR
+            "${SYSTEMD_SERVICES_INSTALL_DIR}")
+     configure_file(logid.service.cmake ${CMAKE_BINARY_DIR}/logid.service)
+-    message(STATUS "systemd units will be installed at ${SYSTEMD_SERVICES_INSTALL_DIR}")
+-    install(FILES ${CMAKE_BINARY_DIR}/logid.service
+-            DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}
+-            COMPONENT cp)
+ elseif(NOT SYSTEMD_FOUND AND SYSTEMD_SERVICES_INSTALL_DIR)
+     message(FATAL_ERROR "systemd is not found w/ pkg-config but SYSTEMD_SERVICES_INSTALL_DIR is defined.")
+ endif()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6157,6 +6157,8 @@ in
 
   lockfileProgs = callPackage ../tools/misc/lockfile-progs { };
 
+  logiops = callPackage ../tools/inputmethods/logiops { };
+
   logstash6 = callPackage ../tools/misc/logstash/6.x.nix {
     # https://www.elastic.co/support/matrix#logstash-and-jvm
     jre = jdk11_headless;


### PR DESCRIPTION
###### Motivation for this change

`logiops` was requested in #122208.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### To do

The service definition doesn't really specify any options, other than `enable` and `extraConfig`.

@hawkw, [you mentioned that you'd started on a config for this](https://github.com/NixOS/nixpkgs/issues/122208#issuecomment-840671986). Would you like to contribute that to this module?

There's also the accepted [settings RFC](https://github.com/NixOS/rfcs/pull/42) to consider. I think that the `libconfig`-style configs would lend themselves well to this approach, but there doesn't seem to be a parser yet for this in nixpkgs. I had started on this approach before just using `extraConfig`. The code for that is still in the file, commented out. This should be removed before submitting the PR.