### PR TITLE
sublime4: Reintroduce libredirect to fix pkexec invocations

### DIFF
--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -68,6 +68,7 @@ in let
       done
 
       # Rewrite pkexec argument. Note that we cannot delete bytes in binary.
+      # Sublime uses it to elevate privileges for saving files the user does not own.
       sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' ${primaryBinary}
 
       runHook postBuild

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation {
     fi
   '';
 
+  # We want to retain debugging info to be able to use GDB on libredirect.so
+  # to more easily investigate which function overrides are missing or why
+  # existing ones do not have the intended effect.
+  dontStrip = true;
+
   installPhase = ''
     install -vD "$libName" "$out/lib/$libName"
 

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -16,15 +16,22 @@ static int nrRedirects = 0;
 static char * from[MAX_REDIRECTS];
 static char * to[MAX_REDIRECTS];
 
+static int isInitialized = 0;
+
 // FIXME: might run too late.
 static void init() __attribute__((constructor));
 
 static void init()
 {
+    if (isInitialized) return;
+
     char * spec = getenv("NIX_REDIRECTS");
     if (!spec) return;
 
-    unsetenv("NIX_REDIRECTS");
+    // Ensure we only run this code once.
+    // We do not do `unsetenv("NIX_REDIRECTS")` to ensure that redirects
+    // also get initialized for subprocesses.
+    isInitialized = 1;
 
     char * spec2 = malloc(strlen(spec) + 1);
     strcpy(spec2, spec);


### PR DESCRIPTION
###### TODO

* [ ] Based on top of #124157, merge that first.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/124057#pullrequestreview-666212102

@jtojnar Could you try whether you still have problems introduced by the `libredirect` as mentioned on https://github.com/NixOS/nixpkgs/pull/124057#discussion_r637457922 ?

> * it is inherited by children and symbol clashing occurs – this happens a lot for me with ST (crashing child `git`)

I cound not find crashing `git` children, or at least git support in the sidebar seems to work fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
