### PR TITLE
retro-gtk: init at 1.0.2

### DIFF
--- a/pkgs/development/libraries/retro-gtk/default.nix
+++ b/pkgs/development/libraries/retro-gtk/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, meson
+, ninja
+, pkg-config
+, epoxy
+, glib
+, gtk3
+, libpulseaudio
+, libsamplerate
+, gobject-introspection
+, vala
+, gtk-doc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "retro-gtk";
+  version = "1.0.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/retro-gtk/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1lnb7dwcj3lrrvdzd85dxwrlid28xf4qdbrgfjyg1wn1z6sv063i";
+  };
+
+  patches = [
+    # https://gitlab.gnome.org/GNOME/retro-gtk/-/merge_requests/150
+    ./gio-unix.patch
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    gtk-doc
+    meson
+    ninja
+    pkg-config
+    vala
+  ];
+
+  buildInputs = [
+    epoxy
+    glib
+    gtk3
+    libpulseaudio
+    libsamplerate
+  ];
+
+  meta = with lib; {
+    description = "The GTK Libretro frontend framework";
+    longDescription = ''
+      Libretro is a plugin format design to implement video game
+      console emulators, video games and similar multimedia
+      software. Such plugins are called Libretro cores.
+
+      RetroGTK is a framework easing the use of Libretro cores in
+      conjunction with GTK.
+
+      It encourages the cores to be installed in a well defined
+      centralized place — namely the libretro subdirectory of your lib
+      directory — and it recommends them to come with Libretro core
+      descriptors.
+    '';
+    homepage = "https://gitlab.gnome.org/GNOME/retro-gtk";
+    changelog = "https://gitlab.gnome.org/GNOME/retro-gtk/-/blob/master/NEWS";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.DamienCassou ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/retro-gtk/gio-unix.patch
+++ b/pkgs/development/libraries/retro-gtk/gio-unix.patch
@@ -1,0 +1,11 @@
+--- a/retro-gtk/meson.build 2021-03-21 20:25:51.000000000 +0100
++++ b/retro-gtk/meson.build 2021-05-23 17:36:46.793693816 +0200
+@@ -103,6 +103,7 @@
+ retro_gtk_deps = [
+   epoxy,
+   gio,
++  gio_unix,
+   glib,
+   gmodule,
+   gobject,
+   

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17903,6 +17903,8 @@ in
 
   randomx = callPackage ../development/libraries/randomx { };
 
+  retro-gtk = callPackage ../development/libraries/retro-gtk { };
+
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };
 
   rhino = callPackage ../development/libraries/java/rhino {


### PR DESCRIPTION
###### Motivation for this change

First step to get [Gnome Games](https://gitlab.gnome.org/GNOME/gnome-games) which has been asked in #68863.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
