### PR TITLE
crackle: init at unstable-2020-12-13

### DIFF
--- a/pkgs/tools/networking/crackle/default.nix
+++ b/pkgs/tools/networking/crackle/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, libpcap, coreutils }:
+
+stdenv.mkDerivation {
+  pname = "crackle";
+  version = "unstable-2020-12-13";
+
+  src = fetchFromGitHub {
+    owner = "mikeryan";
+    repo = "crackle";
+    rev = "d83b4b6f4145ca53c46c36bbd7ccad751af76b75";
+    sha256 = "sha256-Dy4s/hr9ySrogltyk2GVsuAvwNF5+b6CDjaD+2FaPHA=";
+  };
+
+  buildInputs = [ libpcap ];
+
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" "INSTALL=${coreutils}/bin/install" ];
+
+  meta = with lib; {
+    description = "Crack and decrypt BLE encryption";
+    homepage = "https://github.com/mikeryan/crackle";
+    maintainers = with maintainers; [ fortuneteller2k ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -269,6 +269,8 @@ in
 
   cpu-x = callPackage ../applications/misc/cpu-x { };
 
+  crackle = callPackage ../tools/networking/crackle { };
+
   crow-translate = libsForQt5.callPackage ../applications/misc/crow-translate { };
 
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
