### PR TITLE
diffoscope: fix build

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -35,6 +35,10 @@ python3Packages.buildPythonApplication rec {
 
     # When generating manpage, use the installed version
     substituteInPlace doc/Makefile --replace "../bin" "$out/bin"
+
+    # https://salsa.debian.org/reproducible-builds/diffoscope/-/issues/258
+    substituteInPlace tests/data/mp3_expected_diff \
+      --replace "  Stream" "Stream"
   '';
 
   nativeBuildInputs = [ docutils help2man installShellFiles ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ZHF #122042
Failing Hydra build: https://hydra.nixos.org/build/143815905

Currently the diff-check for `.mp3`-files is failing. The only reason
for that is that right now is that there are too spaces too much on the
last line[1].

[1] https://salsa.debian.org/reproducible-builds/diffoscope/-/blob/175/tests/data/mp3_expected_diff

cc @NixOS/release-engineers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
