### PR TITLE
nixos/services/torrent/transmission.nix: add the web UI files to appa…

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -98,6 +98,8 @@ in stdenv.mkDerivation {
       rwk /tmp/tr_session_id_*,
       r /run/systemd/resolve/stub-resolv.conf,
 
+      r $out/share/transmission/web/**,
+
       include <local/bin.transmission-daemon>
     }
     EOF


### PR DESCRIPTION
…rmor allowed paths

###### Motivation for this change

Transmission web UI was no longer accessible since `05d334cfe265f021b16c41375e3e5a4c4a07fc74` that deleted the apparmor rule granting access to transmission-daemon UI files.
This commits puts that line back.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
