### PR TITLE
sdrplay: init at 3.07.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -547,6 +547,7 @@
   ./services/misc/ripple-data-api.nix
   ./services/misc/serviio.nix
   ./services/misc/safeeyes.nix
+  ./services/misc/sdrplay.nix
   ./services/misc/sickbeard.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix

--- a/nixos/modules/services/misc/sdrplay.nix
+++ b/nixos/modules/services/misc/sdrplay.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+with lib;
+{
+  options.services.sdrplayApi = {
+    enable = mkOption {
+      default = false;
+      example = true;
+      description = ''
+        Whether to enable the SDRplay API service and udev rules.
+
+        <note><para>
+          To enable integration with SoapySDR and GUI applications like gqrx create an overlay containing
+          <literal>soapysdr-with-plugins = super.soapysdr.override { extraPackages = [ super.soapysdrplay ]; };</literal>
+        </para></note>
+      '';
+      type = lib.types.bool;
+    };
+  };
+
+  config = mkIf config.services.sdrplayApi.enable {
+    systemd.services.sdrplayApi = {
+      description = "SDRplay API Service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.sdrplay}/bin/sdrplay_apiService";
+        DynamicUser = true;
+        Restart = "on-failure";
+        RestartSec = "1s";
+      };
+    };
+    services.udev.packages = [ pkgs.sdrplay ];
+
+  };
+}

--- a/pkgs/applications/radio/sdrplay/default.nix
+++ b/pkgs/applications/radio/sdrplay/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, fetchurl, autoPatchelfHook, udev }:
+let
+  arch = if stdenv.isx86_64  then "x86_64"
+    else if stdenv.isi686    then "i686"
+    else throw "unsupported architecture";
+in stdenv.mkDerivation rec {
+  name = "sdrplay";
+  version = "3.07.1";
+
+  src = fetchurl {
+    url = "https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-${version}.run";
+    sha256 = "1a25c7rsdkcjxr7ffvx2lwj7fxdbslg9qhr8ghaq1r53rcrqgzmf";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ udev stdenv.cc.cc.lib ];
+
+  unpackPhase = ''
+    sh "$src" --noexec --target source
+  '';
+
+  sourceRoot = "source";
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib,include,lib/udev/rules.d}
+    majorVersion="${lib.concatStringsSep "." (lib.take 1 (builtins.splitVersion version))}"
+    majorMinorVersion="${lib.concatStringsSep "." (lib.take 2 (builtins.splitVersion version))}"
+    libName="libsdrplay_api"
+    cp "${arch}/$libName.so.$majorMinorVersion" $out/lib/
+    ln -s "$out/lib/$libName.so.$majorMinorVersion" "$out/lib/$libName.so.$majorVersion"
+    ln -s "$out/lib/$libName.so.$majorVersion" "$out/lib/$libName.so"
+    cp "${arch}/sdrplay_apiService" $out/bin/
+    cp -r inc/* $out/include/
+    cp 66-mirics.rules $out/lib/udev/rules.d/
+  '';
+
+  meta = with lib; {
+    description = "SDRplay API";
+    longDescription = ''
+      Proprietary library and api service for working with SDRplay devices. For documentation and licensing details see
+      https://www.sdrplay.com/docs/SDRplay_API_Specification_v${lib.concatStringsSep "." (lib.take 2 (builtins.splitVersion version))}.pdf
+    '';
+    homepage = "https://www.sdrplay.com/downloads/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.pmenke ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/radio/soapysdrplay/default.nix
+++ b/pkgs/applications/radio/soapysdrplay/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, soapysdr, sdrplay }:
+
+stdenv.mkDerivation {
+  name = "soapysdr-sdrplay3";
+  version = "20210425";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapySDRPlay3";
+    rev = "e6fdb719b611b1dfb7f26c56a4df1e241bd10129";
+    sha256 = "0rrylp3ikrva227hjy60v4n6d6yvdavjsad9kszw9s948mwiashi";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ soapysdr sdrplay ];
+
+  cmakeFlags = [
+    "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/"
+  ];
+
+  meta = with lib; {
+    description = "Soapy SDR module for SDRplay";
+    homepage = "https://github.com/pothosware/SoapySDRPlay3";
+    license = licenses.mit;
+    maintainers = [ maintainers.pmenke ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17833,6 +17833,8 @@ in
 
   sdnotify-wrapper = skawarePackages.sdnotify-wrapper;
 
+  sdrplay = callPackage ../applications/radio/sdrplay {};
+
   sblim-sfcc = callPackage ../development/libraries/sblim-sfcc {};
 
   selinux-sandbox = callPackage ../os-specific/linux/selinux-sandbox { };
@@ -17937,6 +17939,8 @@ in
   soapysdr = callPackage ../applications/radio/soapysdr { };
 
   soapyremote = callPackage ../applications/radio/soapyremote { };
+
+  soapysdrplay = callPackage ../applications/radio/soapysdrplay { };
 
   soapysdr-with-plugins = callPackage ../applications/radio/soapysdr {
     extraPackages = [


### PR DESCRIPTION
This adds support for software defined radio (SDR) devices by SDRPlay.
SDRPlay provides an unfree binary library and api-service as well
as a MIT licensed adapter library for SoapySDR for integration
with many popular SDR applications.

###### Motivation for this change

I own a RSP1A SDR, set it up under NixOS and would like to share the necessary expressions.

###### Notes

 - This is my first new package and my first module for NixOS. So my experience on "how it should be done" is limited :smile: I think it would good to have this reviewed by some experienced. I'm happy to learn and apply recommended changes.
 - I'm not 100% sure about the sdrplay lib/api-service license:
   - As it's packaged within some [run-binary](https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-3.07.1.run) I posted a copy of it [here](https://gist.github.com/pmenke-de/48009d91317a449042867f4def544e46).
   - It mentions, that »You may reproduce and distribute copies of the Product in any medium, without modifications, in Object form [...]«, but under conditions that (as far as I understand) the license text must somehow be "given" to the user.
   - As I'm not qualified to correctly interpret this, I set the `meta.license` to `unfree`. Maybe a case could be made for `unfreeRedistributable`.
 - [soapysdr-sdrplay3](https://github.com/pothosware/SoapySDRPlay3) doesn't have any releases or tags on github, what is the appropriate `version` attribute in this case? For now i've arbitrarily chosen `0.0.1`. 
 - @lasandell in #60337 you mentioned »working on support for SDRPlay«. Maybe this PR is interesting / relevant to you as well.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Manually tested SDR functionality with Gqrx and RSP1A hardware.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
