### PR TITLE
[20.09] chromiumBeta: Backport patches to fix the build

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -155,11 +155,6 @@ let
       ./patches/fix-missing-atspi2-dependency.patch
     ++ optionals (chromiumVersionAtLeast "91") [
       ./patches/closure_compiler-Use-the-Java-binary-from-the-system.patch
-      (githubPatch
-        # Revert "Reland #7 of "Force Python 3 to be used in build.""
-        "38b6a9a8e5901766613879b6976f207aa163588a"
-        "1lvxbd7rl6hz5j6kh6q83yb6vd9g7anlqbai8g1w1bp6wdpgwvp9"
-      )
     ];
 
     postPatch = lib.optionalString (chromiumVersionAtLeast "91") ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -7,7 +7,7 @@
 , xdg_utils, yasm, nasm, minizip, libwebp
 , libusb1, pciutils, nss, re2
 
-, python2Packages, perl, pkgconfig
+, python2Packages, python3Packages, perl, pkgconfig
 , nspr, systemd, kerberos
 , utillinux, alsaLib
 , bison, gperf
@@ -42,6 +42,16 @@ with stdenv.lib;
 
 let
   jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+  # TODO: Python 3 support is incomplete and "python3 ../../build/util/python2_action.py"
+  # currently doesn't work due to mixed Python 2/3 dependencies:
+  pythonPackages = if chromiumVersionAtLeast "93"
+    then python3Packages
+    else python2Packages;
+  forcePython3Patch = (githubPatch
+    # Reland #8 of "Force Python 3 to be used in build."":
+    "a2d3c362802d9e6b62f895fcda75a3695b77b1b8"
+    "1r9spr2wmjk9x9l3m1gzn6692mlvbxdz0r5hlr5rfwiwr900rxi2"
+  );
 
   # The additional attributes for creating derivations based on the chromium
   # source tree.
@@ -127,9 +137,9 @@ let
 
     nativeBuildInputs = [
       llvmPackages.lldClang.bintools
-      ninja which python2Packages.python perl pkgconfig
-      python2Packages.ply python2Packages.jinja2 nodejs
-      gnutar python2Packages.setuptools
+      ninja which pythonPackages.python perl pkgconfig
+      pythonPackages.ply pythonPackages.jinja2 nodejs
+      gnutar pythonPackages.setuptools
     ];
 
     buildInputs = defaultDependencies ++ [
@@ -160,6 +170,8 @@ let
     postPatch = lib.optionalString (chromiumVersionAtLeast "91") ''
       # Required for patchShebangs (unsupported):
       chmod -x third_party/webgpu-cts/src/tools/deno
+    '' + optionalString (chromiumVersionAtLeast "92") ''
+      patch -p1 --reverse < ${forcePython3Patch}
     '' + ''
       # remove unused third-party
       for lib in ${toString gnSystemLibraries}; do

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -162,7 +162,10 @@ let
       )
     ];
 
-    postPatch = ''
+    postPatch = lib.optionalString (chromiumVersionAtLeast "91") ''
+      # Required for patchShebangs (unsupported):
+      chmod -x third_party/webgpu-cts/src/tools/deno
+    '' + ''
       # remove unused third-party
       for lib in ${toString gnSystemLibraries}; do
         if [ -d "third_party/$lib" ]; then

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -7,7 +7,7 @@
 , xdg_utils, yasm, nasm, minizip, libwebp
 , libusb1, pciutils, nss, re2
 
-, python2Packages, python3Packages, perl, pkgconfig
+, python2, python3, perl, pkgconfig
 , nspr, systemd, kerberos
 , utillinux, alsaLib
 , bison, gperf
@@ -43,16 +43,12 @@ with stdenv.lib;
 
 let
   jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-  # TODO: Python 3 support is incomplete and "python3 ../../build/util/python2_action.py"
-  # currently doesn't work due to mixed Python 2/3 dependencies:
-  pythonPackages = if chromiumVersionAtLeast "93"
-    then python3Packages
-    else python2Packages;
-  forcePython3Patch = (githubPatch
-    # Reland #8 of "Force Python 3 to be used in build."":
-    "a2d3c362802d9e6b62f895fcda75a3695b77b1b8"
-    "1r9spr2wmjk9x9l3m1gzn6692mlvbxdz0r5hlr5rfwiwr900rxi2"
-  );
+  python2WithPackages = python2.withPackages(ps: with ps; [
+    ply jinja2 setuptools
+  ]);
+  python3WithPackages = python3.withPackages(ps: with ps; [
+    ply jinja2 setuptools
+  ]);
 
   # The additional attributes for creating derivations based on the chromium
   # source tree.
@@ -140,10 +136,12 @@ let
     };
 
     nativeBuildInputs = [
+      ninja pkgconfig
+      python2WithPackages perl nodejs
+      gnutar which
       llvmPackages.lldClang.bintools
-      ninja which pythonPackages.python perl pkgconfig
-      pythonPackages.ply pythonPackages.jinja2 nodejs
-      gnutar pythonPackages.setuptools
+    ] ++ lib.optionals (chromiumVersionAtLeast "92") [
+      python3WithPackages
     ];
 
     buildInputs = defaultDependencies ++ [
@@ -175,8 +173,6 @@ let
     postPatch = lib.optionalString (chromiumVersionAtLeast "91") ''
       # Required for patchShebangs (unsupported):
       chmod -x third_party/webgpu-cts/src/tools/deno
-    '' + optionalString (chromiumVersionAtLeast "92") ''
-      patch -p1 --reverse < ${forcePython3Patch}
     '' + ''
       # remove unused third-party
       for lib in ${toString gnSystemLibraries}; do
@@ -314,7 +310,7 @@ let
 
       # This is to ensure expansion of $out.
       libExecPath="${libExecPath}"
-      python build/linux/unbundle/replace_gn_files.py --system-libraries ${toString gnSystemLibraries}
+      ${python2}/bin/python2 build/linux/unbundle/replace_gn_files.py --system-libraries ${toString gnSystemLibraries}
       ${gnChromium}/bin/gn gen --args=${escapeShellArg gnFlags} out/Release | tee gn-gen-outputs.txt
 
       # Fail if `gn gen` contains a WARNING.

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -20,6 +20,7 @@
 , pipewire
 , libva
 , libdrm, wayland, mesa, libxkbcommon # Ozone
+, curl
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -156,6 +157,7 @@ let
       pipewire
       libva
       libdrm wayland mesa.drivers libxkbcommon
+      curl
     ] ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "91.0.4472.27",
-    "sha256": "09mhrzfza9a2zfsnxskbdbk9cwxnswgprhnyv3pj0f215cva20sq",
-    "sha256bin64": "1iwjf993pmhm9r92h4hskfxqc9fhky3aabvmdsqys44251j3hvwg",
+    "version": "91.0.4472.38",
+    "sha256": "13kikqyxs7p25j7mxnr42614y92vmwsjqfd51dwdjh7wc2hb644a",
+    "sha256bin64": "1kjawp7q6r1r50h69jwrw84gqrya1jc8bq6x7bdplxlzgvy9qs3z",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "92.0.4496.0",
-    "sha256": "1kk1bybl6nx3z80agyljsvdb7yi3nna14aag71xhv4n6pygqfgdi",
-    "sha256bin64": "0b12ab20g5vay9x8j1zpj9zapdmm3him7rrm15jvsdakn60czdpr",
+    "version": "92.0.4503.0",
+    "sha256": "1fp4xz6x80m3ipcy4myzazyy1yj95qamyl6wf38mk2i6302gi2gb",
+    "sha256bin64": "0fwq8rn3v1dijj9xh6z7jw3xx2ihq0qcyh3bbcdd066w5ny6padm",
     "deps": {
       "gn": {
-        "version": "2021-04-29",
+        "version": "2021-05-07",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "6771ce569fb4803dad7a427aa2e2c23e960b917e",
-        "sha256": "0lv1zs38qr862hwxrd3g6wz3l6v8j6p7b60nxyc5fhiglqxqz0im"
+        "rev": "39a87c0b36310bdf06b692c098f199a0d97fc810",
+        "sha256": "0x63jr5hssm9dl6la4q5ahy669k4gxvbapqxi5w32vv107jrj8v4"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "92.0.4484.7",
-    "sha256": "1111b1vj4zqcz57c65pjbxjilvv2ps8cjz2smxxz0vjd432q2fdf",
-    "sha256bin64": "0qb5bngp3vwn7py38bn80k43safm395qda760nd5kzfal6c98fi1",
+    "version": "92.0.4491.6",
+    "sha256": "0dwmcqzr7ysy7555l5amzppz8rxgxbgf6fy8lq4ykn2abx4m8n8a",
+    "sha256bin64": "041j6nm49w03qadwlsav50avdp6pwf1a8asybgvkjaxy4fpck376",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "92.0.4491.6",
-    "sha256": "0dwmcqzr7ysy7555l5amzppz8rxgxbgf6fy8lq4ykn2abx4m8n8a",
-    "sha256bin64": "041j6nm49w03qadwlsav50avdp6pwf1a8asybgvkjaxy4fpck376",
+    "version": "92.0.4496.0",
+    "sha256": "1kk1bybl6nx3z80agyljsvdb7yi3nna14aag71xhv4n6pygqfgdi",
+    "sha256bin64": "0b12ab20g5vay9x8j1zpj9zapdmm3him7rrm15jvsdakn60czdpr",
     "deps": {
       "gn": {
-        "version": "2021-04-06",
+        "version": "2021-04-29",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "dba01723a441c358d843a575cb7720d54ddcdf92",
-        "sha256": "199xkks67qrn0xa5fhp24waq2vk8qb78a96cb3kdd8v1hgacgb8x"
+        "rev": "6771ce569fb4803dad7a427aa2e2c23e960b917e",
+        "sha256": "0lv1zs38qr862hwxrd3g6wz3l6v8j6p7b60nxyc5fhiglqxqz0im"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "91.0.4472.19",
-    "sha256": "0p51cxz0dm9ss9k7b91c0nd560mgi2x4qdcpg12vdf8x24agai5x",
-    "sha256bin64": "0pf0sw8sskv4x057w7l6jh86q5mdvm800iikzy6fvambhh7bvd1i",
+    "version": "91.0.4472.27",
+    "sha256": "09mhrzfza9a2zfsnxskbdbk9cwxnswgprhnyv3pj0f215cva20sq",
+    "sha256bin64": "1iwjf993pmhm9r92h4hskfxqc9fhky3aabvmdsqys44251j3hvwg",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "91.0.4472.57",
-    "sha256": "1kbd5zyi5ndbln5pibdg3yhv65m84arfwfv4v00js3cbr13pyjzv",
-    "sha256bin64": "1bk30b9kn5bxp4yywdiy3dqd6km5q3rrf2z82kd1qyr9cc45hz8s",
+    "version": "91.0.4472.69",
+    "sha256": "0yqc7py5x48wqg5x90j57vp07qfc20w1j0f30rmyxbgl6v346s0z",
+    "sha256bin64": "1z82i6pq4wbx44d6ij32dkappywdpaxlfp23kl3p7x4x9hv1c0yq",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "90.0.4430.72",
-    "sha256": "0hw916j55lm3qnidfp92i8w6zywdd47rhihn9pn23b7ziz58ik55",
-    "sha256bin64": "1ddj2pk4m26dpl1ja0r56fvm67c1z1hq5rq5an8px6ixy78s2760",
+    "version": "90.0.4430.85",
+    "sha256": "08j9shrc6p0vpa3x7av7fj8wapnkr7h6m8ag1gh6gaky9d6mki81",
+    "sha256bin64": "0aw76phm8r9k2zlqywyggzdqa467c8naqa717m24dk3nvv2rfkg2",
     "deps": {
       "gn": {
         "version": "2021-02-09",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "91.0.4472.10",
-    "sha256": "168121aznynks5waj3mm2m036mbrlmqmp2kmnn9r4ibq2x01dpxm",
-    "sha256bin64": "05bk6gmmfsh50jjlb6lmwqhhbs0v0hlijsmxpk9crdx2gw071rlr",
+    "version": "91.0.4472.19",
+    "sha256": "0p51cxz0dm9ss9k7b91c0nd560mgi2x4qdcpg12vdf8x24agai5x",
+    "sha256bin64": "1x1901f5782c6aj6sbj8i4hhj545vjl4pplf35i4bjbcaxq3ckli",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,15 +18,15 @@
     }
   },
   "beta": {
-    "version": "90.0.4430.85",
-    "sha256": "08j9shrc6p0vpa3x7av7fj8wapnkr7h6m8ag1gh6gaky9d6mki81",
-    "sha256bin64": "0aw76phm8r9k2zlqywyggzdqa467c8naqa717m24dk3nvv2rfkg2",
+    "version": "91.0.4472.19",
+    "sha256": "0p51cxz0dm9ss9k7b91c0nd560mgi2x4qdcpg12vdf8x24agai5x",
+    "sha256bin64": "0pf0sw8sskv4x057w7l6jh86q5mdvm800iikzy6fvambhh7bvd1i",
     "deps": {
       "gn": {
-        "version": "2021-02-09",
+        "version": "2021-04-06",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "dfcbc6fed0a8352696f92d67ccad54048ad182b3",
-        "sha256": "1941bzg37c4dpsk3sh6ga3696gpq6vjzpcw9rsnf6kdr9mcgdxvn"
+        "rev": "dba01723a441c358d843a575cb7720d54ddcdf92",
+        "sha256": "199xkks67qrn0xa5fhp24waq2vk8qb78a96cb3kdd8v1hgacgb8x"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "91.0.4469.4",
-    "sha256": "08lffqjfcszniwwshililab553a0dvycaa72h1dklxvxf360nz5f",
-    "sha256bin64": "14xyzjwzcyp6idscq6i87yh2fibjamkz5xfsb2y0hrf2diaqijw1",
+    "version": "91.0.4472.10",
+    "sha256": "168121aznynks5waj3mm2m036mbrlmqmp2kmnn9r4ibq2x01dpxm",
+    "sha256bin64": "05bk6gmmfsh50jjlb6lmwqhhbs0v0hlijsmxpk9crdx2gw071rlr",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "91.0.4472.19",
-    "sha256": "0p51cxz0dm9ss9k7b91c0nd560mgi2x4qdcpg12vdf8x24agai5x",
-    "sha256bin64": "1x1901f5782c6aj6sbj8i4hhj545vjl4pplf35i4bjbcaxq3ckli",
+    "version": "92.0.4484.7",
+    "sha256": "1111b1vj4zqcz57c65pjbxjilvv2ps8cjz2smxxz0vjd432q2fdf",
+    "sha256bin64": "0qb5bngp3vwn7py38bn80k43safm395qda760nd5kzfal6c98fi1",
     "deps": {
       "gn": {
         "version": "2021-04-06",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "92.0.4503.0",
-    "sha256": "1fp4xz6x80m3ipcy4myzazyy1yj95qamyl6wf38mk2i6302gi2gb",
-    "sha256bin64": "0fwq8rn3v1dijj9xh6z7jw3xx2ihq0qcyh3bbcdd066w5ny6padm",
+    "version": "92.0.4512.4",
+    "sha256": "0ycwr11bz2hlzczs6cajxn5k32m44ndhmqh86iykcbi982dj7jq2",
+    "sha256bin64": "0wv29rghcbin725qbl8cq20j8w5mlcjmjaqdcr73m753dv3jv8rq",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "91.0.4472.38",
-    "sha256": "13kikqyxs7p25j7mxnr42614y92vmwsjqfd51dwdjh7wc2hb644a",
-    "sha256bin64": "1kjawp7q6r1r50h69jwrw84gqrya1jc8bq6x7bdplxlzgvy9qs3z",
+    "version": "91.0.4472.57",
+    "sha256": "1kbd5zyi5ndbln5pibdg3yhv65m84arfwfv4v00js3cbr13pyjzv",
+    "sha256bin64": "1bk30b9kn5bxp4yywdiy3dqd6km5q3rrf2z82kd1qyr9cc45hz8s",
     "deps": {
       "gn": {
         "version": "2021-04-06",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should fix the build of Chromium M91 which is required to provide security updates for one month after the NixOS 21.05 release. I'm currently verifying that `chromium` still builds. Note: Not all of these patches are required but backporting all of them is easier (to verify, etc.).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
