### PR TITLE
matrix-appservice-irc, matrix-appservice-slack, mx-puppet-discord: set pname

### DIFF
--- a/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
@@ -10,6 +10,8 @@ let
   };
 in
 ourNodePackages."${packageName}".override {
+  pname = "matrix-appservice-irc";
+
   nativeBuildInputs = [ makeWrapper nodePackages.node-gyp-build ];
 
   postInstall = ''

--- a/pkgs/servers/matrix-synapse/matrix-appservice-slack/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-slack/default.nix
@@ -13,6 +13,8 @@ let
   };
 in
 nodePackages.package.override {
+  pname = "matrix-appservice-slack";
+
   inherit src;
 
   nativeBuildInputs = [ pkgs.makeWrapper ];

--- a/pkgs/servers/mx-puppet-discord/default.nix
+++ b/pkgs/servers/mx-puppet-discord/default.nix
@@ -16,7 +16,10 @@ let
   };
 
 in myNodePackages.package.override {
+  pname = "mx-puppet-discord";
+
   inherit src;
+
   nativeBuildInputs = [ nodePackages.node-pre-gyp pkg-config ];
   buildInputs = [ libjpeg pixman cairo pango ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Since they are based on node using `lib.getName` on these packages returns `node-<name>`. So overwriting pname prevents that.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
