### PR TITLE
bozohttpd: init

### DIFF
--- a/pkgs/servers/http/bozohttpd/0001-include-stdint.h.patch
+++ b/pkgs/servers/http/bozohttpd/0001-include-stdint.h.patch
@@ -1,0 +1,12 @@
+diff --git a/libexec/httpd/bozohttpd.c b/libexec/httpd/bozohttpd.c
+index 67083b2c6782..273cb5f5a42b 100644
+--- a/libexec/httpd/bozohttpd.c
++++ b/libexec/httpd/bozohttpd.c
+@@ -138,6 +138,7 @@
+ #include <grp.h>
+ #include <stdarg.h>
+ #include <stdlib.h>
++#include <stdint.h>
+ #include <strings.h>
+ #include <string.h>
+ #include <syslog.h>

--- a/pkgs/servers/http/bozohttpd/0002-dont-use-host-BUFSIZ.patch
+++ b/pkgs/servers/http/bozohttpd/0002-dont-use-host-BUFSIZ.patch
@@ -1,0 +1,88 @@
+diff --git a/libexec/httpd/auth-bozo.c b/libexec/httpd/auth-bozo.c
+index a2f2ee4304c1..c9eefe3313dd 100644
+--- a/libexec/httpd/auth-bozo.c
++++ b/libexec/httpd/auth-bozo.c
+@@ -54,7 +54,7 @@ bozo_auth_check(bozo_httpreq_t *request, const char *file)
+ 	bozohttpd_t *httpd = request->hr_httpd;
+ 	struct stat sb;
+ 	char dir[MAXPATHLEN], authfile[MAXPATHLEN], *basename;
+-	char user[BUFSIZ], *pass;
++	char user[BOZO_MINBUFSIZE], *pass;
+ 	FILE *fp;
+ 	int len;
+ 
+@@ -144,7 +144,7 @@ bozo_auth_check_headers(bozo_httpreq_t *request, char *val, char *str,
+ 
+ 	if (strcasecmp(val, "authorization") == 0 &&
+ 	    strncasecmp(str, "Basic ", 6) == 0) {
+-		char	authbuf[BUFSIZ];
++		char	authbuf[BOZO_MINBUFSIZE];
+ 		char	*pass = NULL;
+ 		ssize_t	alen;
+ 
+diff --git a/libexec/httpd/bozohttpd.c b/libexec/httpd/bozohttpd.c
+index 273cb5f5a42b..f619567ba822 100644
+--- a/libexec/httpd/bozohttpd.c
++++ b/libexec/httpd/bozohttpd.c
+@@ -2275,7 +2275,7 @@ bozo_http_error(bozohttpd_t *httpd, int code, bozo_httpreq_t *request,
+ 		}
+ #endif /* !NO_USER_SUPPORT */
+ 
+-		size = snprintf(httpd->errorbuf, BUFSIZ,
++		size = snprintf(httpd->errorbuf, BOZO_MINBUFSIZE,
+ 		    "<html><head><title>%s</title></head>\n"
+ 		    "<body><h1>%s</h1>\n"
+ 		    "%s%s: <pre>%s</pre>\n"
+@@ -2285,10 +2285,10 @@ bozo_http_error(bozohttpd_t *httpd, int code, bozo_httpreq_t *request,
+ 		    user ? user : "", file,
+ 		    reason, hostname, portbuf, hostname, portbuf);
+ 		free(user);
+-		if (size >= (int)BUFSIZ) {
++		if (size >= (int)BOZO_MINBUFSIZE) {
+ 			bozowarn(httpd,
+ 				"bozo_http_error buffer too small, truncated");
+-			size = (int)BUFSIZ;
++			size = (int)BOZO_MINBUFSIZE;
+ 		}
+ 
+ 		if (file_alloc)
+@@ -2515,7 +2515,7 @@ bozo_init_httpd(bozohttpd_t *httpd)
+ 	httpd->mmapsz = BOZO_MMAPSZ;
+ 
+ 	/* error buffer for bozo_http_error() */
+-	if ((httpd->errorbuf = malloc(BUFSIZ)) == NULL) {
++	if ((httpd->errorbuf = malloc(BOZO_MINBUFSIZE)) == NULL) {
+ 		fprintf(stderr,
+ 			"bozohttpd: memory_allocation failure\n");
+ 		return 0;
+diff --git a/libexec/httpd/bozohttpd.h b/libexec/httpd/bozohttpd.h
+index c83bd112d9d7..7b19494cf5ad 100644
+--- a/libexec/httpd/bozohttpd.h
++++ b/libexec/httpd/bozohttpd.h
+@@ -227,6 +227,8 @@ typedef struct bozoprefs_t {
+ /* only allow this many total headers bytes */
+ #define BOZO_HEADERS_MAX_SIZE (16 * 1024)
+ 
++#define BOZO_MINBUFSIZE (4 * 1024)
++
+ /* debug flags */
+ #define DEBUG_NORMAL	1
+ #define DEBUG_FAT	2
+diff --git a/libexec/httpd/testsuite/t10.out b/libexec/httpd/testsuite/t10.out
+index cf410110627c..b3ab88f94fb9 100644
+--- a/libexec/httpd/testsuite/t10.out
++++ b/libexec/httpd/testsuite/t10.out
+@@ -1,8 +1,8 @@
+ HTTP/1.0 404 Not Found
+ Content-Type: text/html
+-Content-Length: 1024
+-Server: bozohttpd/20140708
++Content-Length: 4096
++Server: bozohttpd/20210403
+ 
+ <html><head><title>404 Not Found</title></head>
+ <body><h1>404 Not Found</h1>
+-/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+\ No newline at end of file
++/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+\ No newline at end of file

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -64,7 +64,8 @@ stdenv.mkDerivation rec {
   ++ optional (!cgiSupport) "-DNO_CGIBIN_SUPPORT"
   ++ optional (htpasswdSupport) "-DDO_HTPASSWD";
 
-  _LDADD = [ "-lcrypt" "-lm" ]
+  _LDADD = [ "-lm" ]
+    ++ optional (stdenv.hostPlatform.libc != "libSystem") "-lcrypt"
     ++ optional (luaSupport) "-llua"
     ++ optionals (sslSupport) [ "-lssl" "-lcrypto" ];
   makeFlags = [ "LDADD=$(_LDADD)" "prefix=$(out)" "MANDIR=$(out)/share/man" "BINOWN=" ];

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -45,25 +45,24 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl ] ++ optional (luaSupport) lua;
   nativeBuildInputs = [ bmake groff ];
 
-  COPTS =
-    [
-      "-D_DEFAULT_SOURCE"
-      "-D_GNU_SOURCE"
+  COPTS = [
+    "-D_DEFAULT_SOURCE"
+    "-D_GNU_SOURCE"
 
-      # Ensure that we can serve >2GB files even on 32-bit systems.
-      "-D_LARGEFILE_SOURCE"
-      "-D_FILE_OFFSET_BITS=64"
+    # ensure that we can serve >2GB files even on 32-bit systems.
+    "-D_LARGEFILE_SOURCE"
+    "-D_FILE_OFFSET_BITS=64"
 
-      # unpackaged dependency: https://man.netbsd.org/blocklist.3
-      "-DNO_BLOCKLIST_SUPPORT"
-    ]
-    ++ optional (!userSupport) "-DNO_USER_SUPPORT"
-    ++ optional (!dirIndexSupport) "-DNO_DIRINDEX_SUPPORT"
-    ++ optional (!dynamicContentSupport) "-DNO_DYNAMIC_CONTENT"
-    ++ optional (!luaSupport) "-DNO_LUA_SUPPORT"
-    ++ optional (!sslSupport) "-DNO_SSL_SUPPORT"
-    ++ optional (!cgiSupport) "-DNO_CGIBIN_SUPPORT"
-    ++ optional (htpasswdSupport) "-DDO_HTPASSWD";
+    # unpackaged dependency: https://man.netbsd.org/blocklist.3
+    "-DNO_BLOCKLIST_SUPPORT"
+  ]
+  ++ optional (!userSupport) "-DNO_USER_SUPPORT"
+  ++ optional (!dirIndexSupport) "-DNO_DIRINDEX_SUPPORT"
+  ++ optional (!dynamicContentSupport) "-DNO_DYNAMIC_CONTENT"
+  ++ optional (!luaSupport) "-DNO_LUA_SUPPORT"
+  ++ optional (!sslSupport) "-DNO_SSL_SUPPORT"
+  ++ optional (!cgiSupport) "-DNO_CGIBIN_SUPPORT"
+  ++ optional (htpasswdSupport) "-DDO_HTPASSWD";
 
   _LDADD = [ "-lcrypt" "-lm" ]
     ++ optional (luaSupport) "-llua"

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -46,7 +46,15 @@ stdenv.mkDerivation rec {
 
   COPTS =
     [
-      "-DNO_BLOCKLIST_SUPPORT" # unpackaged dependency: https://man.netbsd.org/blocklist.3
+      "-D_DEFAULT_SOURCE"
+      "-D_GNU_SOURCE"
+
+      # Ensure that we can serve >2GB files even on 32-bit systems.
+      "-D_LARGEFILE_SOURCE"
+      "-D_FILE_OFFSET_BITS=64"
+
+      # unpackaged dependency: https://man.netbsd.org/blocklist.3
+      "-DNO_BLOCKLIST_SUPPORT"
     ]
     ++ optional (!userSupport) "-DNO_USER_SUPPORT"
     ++ optional (!dirIndexSupport) "-DNO_DIRINDEX_SUPPORT"

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -59,16 +59,11 @@ stdenv.mkDerivation rec {
   _LDADD = [ "-lcrypt" "-lm" ]
     ++ optional (luaSupport) "-llua"
     ++ optionals (sslSupport) [ "-lssl" "-lcrypto" ];
-  makeFlags = [ "LDADD=$(_LDADD)" ];
+  makeFlags = [ "LDADD=$(_LDADD)" "prefix=$(out)" "MANDIR=$(out)/share/man" "BINOWN=" ];
 
   doCheck = true;
   checkInputs = [ inetutils wget ];
   checkFlags = [ "-dx" "VERBOSE=yes" ] ++ optional (!cgiSupport) "CGITESTS=";
-
-  installPhase = ''
-    install -m755 -Dt $out/bin bozohttpd
-    install -m644 -Dt $out/share/man/man8 bozohttpd.8
-  '';
 
   meta = with lib; {
     description = "Bozotic HTTP server; small and secure";

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkInputs = [ inetutils wget ];
-  checkFlags = [ "-dx" "VERBOSE=yes" ] ++ optional (!cgiSupport) "CGITESTS=";
+  checkFlags = optional (!cgiSupport) "CGITESTS=";
 
   meta = with lib; {
     description = "Bozotic HTTP server; small and secure";

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchurl
+, bmake
+, groff
+, inetutils
+, wget
+, openssl
+, userSupport ? true
+, cgiSupport ? true
+, dirIndexSupport ? true
+, dynamicContentSupport ? true
+, sslSupport ? true
+, luaSupport ? true
+, lua
+, htpasswdSupport ? true
+}:
+
+let inherit (lib) optional optionals;
+in
+stdenv.mkDerivation rec {
+  pname = "bozohttpd";
+  version = "20210227";
+
+  # bozohttpd is developed in-tree in pkgsrc, canonical hashes can be found at:
+  # http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/www/bozohttpd/distinfo
+  src = fetchurl {
+    url = "http://www.eterna.com.au/${pname}/${pname}-${version}.tar.bz2";
+    sha512 = "b838498626ffb7f7e84f31611e0e99aaa3af64bd9376e1a13ec16313c182eebfd9ea2c2d03904497239af723bf34a3d2202dac1f2d3e55f9fd076f6d45ccfa33";
+  };
+
+  # backport two unreleased commits to fix builds on non-netbsd platforms.
+  patches = [
+    # add missing `#include <stdint.h>`
+    # https://freshbsd.org/netbsd/src/commit/qMGNoXfgeieZBVRC
+    ./0001-include-stdint.h.patch
+
+    # BUFSIZ is not guaranteed to be large enough
+    # https://freshbsd.org/netbsd/src/commit/A4ueIHIp3JgjNVRC
+    ./0002-dont-use-host-BUFSIZ.patch
+  ];
+  patchFlags = [ "-p3" ];
+
+  buildInputs = [ openssl ] ++ optional (luaSupport) lua;
+  nativeBuildInputs = [ bmake groff ];
+
+  COPTS =
+    [
+      "-DNO_BLOCKLIST_SUPPORT" # unpackaged dependency: https://man.netbsd.org/blocklist.3
+    ]
+    ++ optional (!userSupport) "-DNO_USER_SUPPORT"
+    ++ optional (!dirIndexSupport) "-DNO_DIRINDEX_SUPPORT"
+    ++ optional (!dynamicContentSupport) "-DNO_DYNAMIC_CONTENT"
+    ++ optional (!luaSupport) "-DNO_LUA_SUPPORT"
+    ++ optional (!sslSupport) "-DNO_SSL_SUPPORT"
+    ++ optional (!cgiSupport) "-DNO_CGIBIN_SUPPORT"
+    ++ optional (htpasswdSupport) "-DDO_HTPASSWD";
+
+  _LDADD = [ "-lcrypt" "-lm" ]
+    ++ optional (luaSupport) "-llua"
+    ++ optionals (sslSupport) [ "-lssl" "-lcrypto" ];
+  makeFlags = [ "LDADD=$(_LDADD)" ];
+
+  doCheck = true;
+  checkInputs = [ inetutils wget ];
+  checkFlags = [ "-dx" "VERBOSE=yes" ] ++ optional (!cgiSupport) "CGITESTS=";
+
+  installPhase = ''
+    install -m755 -Dt $out/bin bozohttpd
+    install -m644 -Dt $out/share/man/man8 bozohttpd.8
+  '';
+
+  meta = with lib; {
+    description = "Bozotic HTTP server; small and secure";
+    longDescription = ''
+      bozohttpd is a small and secure HTTP version 1.1 server. Its main
+      feature is the lack of features, reducing the code size and improving
+      verifiability.
+
+      It supports CGI/1.1, HTTP/1.1, HTTP/1.0, HTTP/0.9, ~user translations,
+      virtual hosting support, as well as multiple IP-based servers on a
+      single machine. It is capable of servicing pages via the IPv6 protocol.
+      It has SSL support. It has no configuration file by design.
+    '';
+    homepage = "http://www.eterna.com.au/bozohttpd/";
+    changelog = "http://www.eterna.com.au/bozohttpd/CHANGES";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.embr ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -6,14 +6,15 @@
 , inetutils
 , wget
 , openssl
-, userSupport ? true
-, cgiSupport ? true
-, dirIndexSupport ? true
-, dynamicContentSupport ? true
-, sslSupport ? true
-, luaSupport ? true
+, minimal ? false
+, userSupport ? !minimal
+, cgiSupport ? !minimal
+, dirIndexSupport ? !minimal
+, dynamicContentSupport ? !minimal
+, sslSupport ? !minimal
+, luaSupport ? !minimal
 , lua
-, htpasswdSupport ? true
+, htpasswdSupport ? !minimal
 }:
 
 let inherit (lib) optional optionals;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1954,6 +1954,7 @@ in
   boxfs = callPackage ../tools/filesystems/boxfs { };
 
   bozohttpd = callPackage ../servers/http/bozohttpd { };
+  bozohttpd-minimal = callPackage ../servers/http/bozohttpd { minimal = true; };
 
   bpytop = callPackage ../tools/system/bpytop { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1953,6 +1953,8 @@ in
 
   boxfs = callPackage ../tools/filesystems/boxfs { };
 
+  bozohttpd = callPackage ../servers/http/bozohttpd { };
+
   bpytop = callPackage ../tools/system/bpytop { };
 
   brasero-original = lowPrio (callPackage ../tools/cd-dvd/brasero { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I would like to be able to run the bozohttpd web server on NixOS. It's popular on netbsd, where it's developed in-tree, and is designed to run via inetd.

Includes a couple of patches to make it build on non-netbsd platforms, which have been upstreamed but not yet included in a release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
