### PR TITLE
betterdiscordctl: 1.7.1 -> 2.0.0

### DIFF
--- a/pkgs/tools/misc/betterdiscordctl/default.nix
+++ b/pkgs/tools/misc/betterdiscordctl/default.nix
@@ -2,22 +2,28 @@
 
 stdenv.mkDerivation rec {
   pname = "betterdiscordctl";
-  version = "1.7.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "bb010g";
     repo = "betterdiscordctl";
     rev = "v${version}";
-    sha256 = "12c3phcfwl4p2jfh22ihm57vxw4nq5kwqirb7y4gzc91swfh5yj1";
+    sha256 = "1wys3wbcz5hq8275ia2887kr5fzz4b3gkcp56667j9k0p3k3zfac";
   };
 
-  preBuild = "sed -i 's/^nix=$/&yes/g;s/^DISABLE_UPGRADE=$/&yes/g' ./betterdiscordctl";
+  postPatch = ''
+    substituteInPlace betterdiscordctl \
+      --replace "DISABLE_SELF_UPGRADE=" "DISABLE_SELF_UPGRADE=yes"
+  '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/doc/betterdiscordctl
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/share/doc/betterdiscordctl"
     install -Dm744 betterdiscordctl $out/bin/betterdiscordctl
     install -Dm644 README.md $out/share/doc/betterdiscordctl/README.md
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

New release. Should be backported to `release-21.05`, as v1.7.1 was broken by Discord.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
