### PR TITLE
expat: 2.2.10 -> 2.4.1 (CVE-2013-0340)

### DIFF
--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -5,13 +5,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-let
+stdenv.mkDerivation rec {
+  pname = "expat";
   version = "2.4.1";
-in stdenv.mkDerivation rec {
-  name = "expat-${version}";
 
   src = fetchurl {
-    url = "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${name}.tar.xz";
+    url = "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.xz";
     sha256 = "sha256-zwMtDbqbkoY2VI4ysyei1msaq2PE9KE90TLC0dLy+2o=";
   };
 
@@ -25,8 +24,7 @@ in stdenv.mkDerivation rec {
   doCheck = true; # not cross;
 
   preCheck = ''
-    patchShebangs ./run.sh
-    patchShebangs ./test-driver-wrapper.sh
+    patchShebangs ./configure ./run.sh ./test-driver-wrapper.sh
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -6,13 +6,13 @@
 # files.
 
 let
-  version = "2.2.10";
+  version = "2.4.1";
 in stdenv.mkDerivation rec {
   name = "expat-${version}";
 
   src = fetchurl {
     url = "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${name}.tar.xz";
-    sha256 = "sha256-Xf5Tj4tbY/A+mO2sUg19mmpNIuSC5cltTQb8xUhcJfI=";
+    sha256 = "sha256-zwMtDbqbkoY2VI4ysyei1msaq2PE9KE90TLC0dLy+2o=";
   };
 
   outputs = [ "out" "dev" ]; # TODO: fix referrers
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.libexpat.org/";
+    homepage = "https://libexpat.github.io/";
     description = "A stream-oriented XML parser library written in C";
     platforms = platforms.all;
     license = licenses.mit; # expat version


### PR DESCRIPTION
- Superseds #122275
- Targets `staging` because of @prusnak's comment https://github.com/NixOS/nixpkgs/pull/122275#issuecomment-835737257
- Blog post about the release: https://blog.hartwork.org/posts/cve-2013-0340-billion-laughs-fixed-in-expat-2-4-0/
- Upstream change log: https://github.com/libexpat/libexpat/blob/R_2_4_1/expat/Changes
- If anyone wants to take over this pull request, please go ahead

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Security fixes (CVE-2013-0340)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
