### PR TITLE
amidst: init at 4.6

### DIFF
--- a/pkgs/tools/games/amidst/default.nix
+++ b/pkgs/tools/games/amidst/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, jre8 }: # TODO: Update this to the latest version of java upon the next release. This is currently not done because of https://github.com/toolbox4minecraft/amidst/issues/960
+
+stdenv.mkDerivation rec {
+  pname = "amidst";
+  version = "4.6";
+
+  src = fetchurl { # TODO: Compile from src
+    url = "https://github.com/toolbox4minecraft/amidst/releases/download/v${version}/amidst-v${lib.replaceStrings [ "." ] [ "-" ] version}.jar";
+    sha256 = "0nz6xfhshy36j8k81kqdfbbxih96l7f3s9156f9lmw0mi1qlyzqk";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ jre8 makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib/amidst}
+    cp $src $out/lib/amidst/amidst.jar
+    makeWrapper ${jre8}/bin/java $out/bin/amidst \
+      --add-flags "-jar $out/lib/amidst/amidst.jar"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/toolbox4minecraft/amidst";
+    description = "Advanced Minecraft Interface and Data/Structure Tracking";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -848,6 +848,8 @@ in
 
   auditwheel = callPackage ../tools/package-management/auditwheel { };
 
+  amidst = callPackage ../tools/games/amidst { };
+
   gobgp = callPackage ../tools/networking/gobgp { };
 
   metapixel = callPackage ../tools/graphics/metapixel { };


### PR DESCRIPTION

###### Motivation for this change
A pretty cool tool which is nice to have available in nixpkgs. I'm currently not building it from src, as that's a bit of a pain with java.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
