### PR TITLE
papi: 5.6.0 -> 6.0.0.1

### DIFF
--- a/pkgs/development/libraries/science/benchmark/papi/default.nix
+++ b/pkgs/development/libraries/science/benchmark/papi/default.nix
@@ -2,19 +2,17 @@
 , fetchurl
 }:
 
-stdenv.mkDerivation {
-  version = "5.6.0";
+stdenv.mkDerivation rec {
+  version = "6.0.0.1";
   pname = "papi";
 
   src = fetchurl {
-    url = "https://bitbucket.org/icl/papi/get/papi-5-6-0-t.tar.gz";
-    sha256 = "13mngf9kl0y2wfxqvkad0smdaag7k8fvw82b4312gx62nwhc1i6r";
+    url = "https://bitbucket.org/icl/papi/get/papi-${lib.replaceStrings ["."] ["-"] version}-t.tar.gz";
+    sha256 = "1jd67yadyffzxwsqlylsi0bx8ishb0cgj2ziz1wdslaz6ylvyf9j";
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
-
-  preConfigure = ''
-    cd src
+  setSourceRoot = ''
+    sourceRoot=$(echo */src)
   '';
 
   doCheck = true;
@@ -22,9 +20,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://icl.utk.edu/papi/";
-    description = "PAPI provides the tool designer and application engineer with a consistent interface and methodology for use of the performance counter hardware found in most major microprocessors";
+    description = "Library providing access to various hardware performance counters";
     license = licenses.bsdOriginal;
     platforms = platforms.linux;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc zhaofengli ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~Also created `papi_5_7` though the API breakage is minimal.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
