### PR TITLE
nixos/bitwarden_rs: fix startup on 32 thread machines

### DIFF
--- a/nixos/modules/services/security/bitwarden_rs/default.nix
+++ b/nixos/modules/services/security/bitwarden_rs/default.nix
@@ -121,7 +121,6 @@ in {
         EnvironmentFile = [ configFile ] ++ optional (cfg.environmentFile != null) cfg.environmentFile;
         ExecStart = "${bitwarden_rs}/bin/bitwarden_rs";
         LimitNOFILE = "1048576";
-        LimitNPROC = "64";
         PrivateTmp = "true";
         PrivateDevices = "true";
         ProtectHome = "true";


### PR DESCRIPTION
###### Motivation for this change

LimitNPROC=64 is too low for bitwarden_rs to start on a 32 thread machine.
Remove the limit.

This fixes:

```
bitwarden_rs[38701]: /--------------------------------------------------------------------\
bitwarden_rs[38701]: |                       Starting Bitwarden_RS                        |
bitwarden_rs[38701]: |--------------------------------------------------------------------|
bitwarden_rs[38701]: | This is an *unofficial* Bitwarden implementation, DO NOT use the   |
bitwarden_rs[38701]: | official channels to report bugs/features, regardless of client.   |
bitwarden_rs[38701]: | Send usage/configuration questions or feature requests to:         |
bitwarden_rs[38701]: |   https://bitwardenrs.discourse.group/                             |
bitwarden_rs[38701]: | Report suspected bugs/issues in the software itself at:            |
bitwarden_rs[38701]: |   https://github.com/dani-garcia/bitwarden_rs/issues/new           |
bitwarden_rs[38701]: \--------------------------------------------------------------------/
bitwarden_rs[38701]: [INFO] No .env file found.
bitwarden_rs[38701]: [2021-05-24 03:34:41.121][bitwarden_rs::api::core::sends][INFO] Initiating send deletion
bitwarden_rs[38701]: [2021-05-24 03:34:41.122][start][INFO] Rocket has launched from http://127.0.0.1:8222
bitwarden_rs[38701]: [2021-05-24 03:34:41.126][panic][ERROR] thread 'unnamed' panicked at 'failed to spawn thread: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }': /build/rustc-1.52.1-src/library/std/src/thread/mod.rs:620
bitwarden_rs[38701]:    0: bitwarden_rs::init_logging::{{closure}}
bitwarden_rs[38701]:    1: std::panicking::rust_panic_with_hook
bitwarden_rs[38701]:    2: std::panicking::begin_panic_handler::{{closure}}
bitwarden_rs[38701]:    3: std::sys_common::backtrace::__rust_end_short_backtrace
bitwarden_rs[38701]:    4: rust_begin_unwind
bitwarden_rs[38701]:    5: core::panicking::panic_fmt
bitwarden_rs[38701]:    6: core::result::unwrap_failed
bitwarden_rs[38701]:    7: hyper::server::listener::spawn_with
bitwarden_rs[38701]:    8: hyper::server::listener::ListenerPool<A>::accept
bitwarden_rs[38701]:    9: std::sys_common::backtrace::__rust_begin_short_backtrace
bitwarden_rs[38701]:   10: core::ops::function::FnOnce::call_once{{vtable.shim}}
bitwarden_rs[38701]:   11: std::sys::unix::thread::Thread::new::thread_start
bitwarden_rs[38701]:   12: start_thread
bitwarden_rs[38701]:   13: __GI___clone
bitwarden_rs[38701]: [2021-05-24 03:34:41.126][panic][ERROR] thread 'main' panicked at 'internal error: entered unreachable code: the call to `handle_threads` should block on success': /build/bitwarden_rs-1.20.0-vendor.tar.gz/rocket/src/rocket.rs:751
bitwarden_rs[38701]:    0: bitwarden_rs::init_logging::{{closure}}
bitwarden_rs[38701]:    1: std::panicking::rust_panic_with_hook
bitwarden_rs[38701]:    2: std::panicking::begin_panic_handler::{{closure}}
bitwarden_rs[38701]:    3: std::sys_common::backtrace::__rust_end_short_backtrace
bitwarden_rs[38701]:    4: rust_begin_unwind
bitwarden_rs[38701]:    5: core::panicking::panic_fmt
bitwarden_rs[38701]:    6: rocket::rocket::Rocket::launch
bitwarden_rs[38701]:    7: bitwarden_rs::main
bitwarden_rs[38701]:    8: std::sys_common::backtrace::__rust_begin_short_backtrace
bitwarden_rs[38701]:    9: std::rt::lang_start::{{closure}}
bitwarden_rs[38701]:   10: std::rt::lang_start_internal
bitwarden_rs[38701]:   11: main
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer @msteen