### PR TITLE
[21.05] redis: 6.2.1 -> 6.2.3

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -5,20 +5,22 @@
 
 stdenv.mkDerivation rec {
   pname = "redis";
-  version = "6.2.1";
+  version = "6.2.3";
 
   src = fetchurl {
     url = "https://download.redis.io/releases/${pname}-${version}.tar.gz";
-    sha256 = "sha256-zSIlBQEsziCyVoL8qTHsk70hrpLLSr/nQs97dqqQdSA=";
+    sha256 = "sha256-mO19UytelnH13wglu3Hw83SDoWVGNkBJOExj24dkUSs=";
   };
 
   # Cross-compiling fixes
   configurePhase = ''
+    runHook preConfigure
     ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
       # This fixes hiredis, which has the AR awkwardly coded.
       # Probably a good candidate for a patch upstream.
       makeFlagsArray+=('STLIB_MAKE_CMD=${stdenv.cc.targetPrefix}ar rcs $(STLIBNAME)')
     ''}
+    runHook postConfigure
   '';
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-29477 and CVE-2021-29478.

https://github.com/redis/redis/blob/6.2.3/00-RELEASENOTES
(cherry picked from commit 0d1b14161acc0c79b0712ea4f4c476684bfa41a3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
