### PR TITLE
[21.05] phpExtensions.dom: fix build

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -235,7 +235,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
           internalDeps}
       '';
-      checkPhase = "echo n | make test";
+      checkPhase = "runHook preCheck; echo n | make test; runHook postCheck";
       outputs = [ "out" "dev" ];
       installPhase = ''
         mkdir -p $out/lib/php/extensions
@@ -270,6 +270,20 @@ lib.makeScope pkgs.newScope (self: with self; {
       { name = "dba"; }
       { name = "dom";
         buildInputs = [ libxml2 ];
+        patches = [
+          # https://github.com/php/php-src/pull/7030
+          (fetchpatch {
+            url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
+            sha256 = "11qsdiwj1zmpfc2pgh6nr0sn7qa1nyjg4jwf69cgwnd57qfjcy4k";
+            excludes = [ "ext/dom/tests/bug43364.phpt" "ext/dom/tests/bug80268.phpt" ];
+          })
+        ];
+        # For some reason `patch` fails to remove these files correctly.
+        # Since `postPatch` is already used in `mkExtension`, we have to make it here.
+        preCheck = ''
+          rm tests/bug43364.phpt
+          rm tests/bug80268.phpt
+        '';
         configureFlags = [ "--enable-dom" ]
           # Required to build on darwin.
           ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }


### PR DESCRIPTION
###### Motivation for this change
 Port #124193 to 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
