### PR TITLE
phosh: Fix session management

### DIFF
--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -24,6 +24,7 @@
 , networkmanager
 , polkit
 , libsecret
+, writeShellScript
 , writeText
 }:
 
@@ -36,9 +37,15 @@ let
     sha256 = "0a4qh5pgyjki904qf7qmvqz2ksxb0p8xhgl2aixfbhixn0pw6saw";
   };
 
-  executable = writeText "phosh" ''
+  executable = writeShellScript "phosh" ''
+    if [ -z "$ENABLE_SYSTEMD_SESSION" ]; then
+      SESSION_MANAGER="--builtin"
+    else
+      SESSION_MANAGER="--systemd"
+    fi
+
     PHOC_INI=@out@/share/phosh/phoc.ini
-    GNOME_SESSION_ARGS="--disable-acceleration-check --session=phosh --debug"
+    GNOME_SESSION_ARGS="--disable-acceleration-check --session=phosh --debug $SESSION_MANAGER"
 
     if [ -f /etc/phosh/phoc.ini ]; then
       PHOC_INI=/etc/phosh/phoc.ini


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR enables the session management mode of gnome-session to be configured in the `phosh` launch script. It defaults to the legacy mode (`--builtin`) which starts gnome-settings-daemon without proper systemd user units for Phosh.

This is a stop-gap solution to #123735 while [patches](https://github.com/zhaofengli/nixpkgs/commits/phosh-systemd) to add systemd session management support to Phosh are being upstreamed.

cc @jtojnar @dotlambda @samueldr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
