### PR TITLE
avell-unofficial-control-center: init at 1.0.4 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8595,6 +8595,12 @@
     githubId = 449990;
     name = "Cedric Cellier";
   };
+  rkitover = {
+    email = "rkitover@gmail.com";
+    github = "rkitover";
+    githubId = 77611;
+    name = "Rafael Kitover";
+  };
   rkoe = {
     email = "rk@simple-is-better.org";
     github = "rkoe";

--- a/pkgs/applications/misc/avell-unofficial-control-center/default.nix
+++ b/pkgs/applications/misc/avell-unofficial-control-center/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "avell-unofficial-control-center";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "rodgomesc";
+    repo = "avell-unofficial-control-center";
+    # https://github.com/rodgomesc/avell-unofficial-control-center/issues/58
+    rev = "e32e243e31223682a95a719bc58141990eef35e6";
+    sha256 = "1qz1kv7p09nxffndzz9jlkzpfx26ppz66f8603zyamjq9dqdmdin";
+  };
+
+  # No tests included
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [ pyusb elevate ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rodgomesc/avell-unofficial-control-center";
+    description = "Software for controlling RGB keyboard lights on some gaming laptops that use ITE Device(8291) Rev 0.03";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rkitover ];
+  };
+}

--- a/pkgs/development/python-modules/elevate/default.nix
+++ b/pkgs/development/python-modules/elevate/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchPypi, buildPythonPackage, fetchpatch, setuptools-scm }:
+
+buildPythonPackage rec {
+  pname = "elevate";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "53ad19fa1de301fb1de3f8768fb3a5894215716fd96a475690c4d0ff3b1de209";
+  };
+
+  patches = [
+    (fetchpatch {
+    # This is for not calling shell wrappers through Python, which fails.
+    url = "https://github.com/rkitover/elevate/commit/148b2bf698203ea39c9fe5d635ecd03cd94051af.patch";
+    sha256 = "1ky3z1jxl1g28wbwbx8qq8jgx8sa8pr8s3fdcpdhdx1blw28cv61";
+    })
+  ];
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  # No tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "elevate" ];
+
+  meta = with lib; {
+    description = "Python module for re-launching the current process as super-user";
+    homepage = "https://github.com/barneygale/elevate";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rkitover ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30173,6 +30173,8 @@ in
 
   autotiling = python3Packages.callPackage ../misc/autotiling { };
 
+  avell-unofficial-control-center = python3Packages.callPackage ../applications/misc/avell-unofficial-control-center { };
+
   beep = callPackage ../misc/beep { };
 
   bees = callPackage ../tools/filesystems/bees { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2193,6 +2193,8 @@ in {
 
   elementpath = callPackage ../development/python-modules/elementpath { };
 
+  elevate = callPackage ../development/python-modules/elevate { };
+
   eliot = callPackage ../development/python-modules/eliot { };
 
   elmax = callPackage ../development/python-modules/elmax { };


### PR DESCRIPTION
###### Motivation for this change

This software controls the RGB lights on the keyboard of my gaming laptop.

It's Python software that depends on pyusb, this makes it very tricky to install on the system in NixOS or in a Python virtual environment. Having a package makes this very simple.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
