### PR TITLE
python3Packages.cssutils: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/cssutils/default.nix
+++ b/pkgs/development/python-modules/cssutils/default.nix
@@ -5,19 +5,21 @@
 , setuptools-scm
 , toml
 , importlib-metadata
+, cssselect
+, lxml
 , mock
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "cssutils";
-  version = "2.2.0";
+  version = "2.3.0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5bef59f6b59bdccbea8e36cb292d2be1b6be1b485fc4a9f5886616f19eb31aaf";
+    sha256 = "sha256-stOxYEfKroLlxZADaTW6+htiHPRcLziIWvS+SDjw/QA=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +32,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    cssselect
+    lxml
     mock
     pytestCheckHook
   ];
@@ -38,6 +42,12 @@ buildPythonPackage rec {
     # access network
     "test_parseUrl"
     "encutils"
+    "website.logging"
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    # AttributeError: module 'importlib.resources' has no attribute 'files'
+    "test_parseFile"
+    "test_parseString"
+    "test_combine"
   ];
 
   pythonImportsCheck = [ "cssutils" ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/jaraco/cssutils/blob/v2.3.0/CHANGES.rst


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
