### PR TITLE
Revert "nixos/nix-daemon: fix sandbox-paths option"

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -12,8 +12,6 @@ let
 
   isNix23 = versionAtLeast nixVersion "2.3pre";
 
-  isNix24 = versionAtLeast nixVersion "2.4pre";
-
   makeNixBuildUser = nr: {
     name  = "nixbld${toString nr}";
     value = {
@@ -43,11 +41,7 @@ let
         max-jobs = ${toString (cfg.maxJobs)}
         cores = ${toString (cfg.buildCores)}
         sandbox = ${if (builtins.isBool cfg.useSandbox) then boolToString cfg.useSandbox else cfg.useSandbox}
-        ${if isNix24 then ''
-          sandbox-paths = ${toString cfg.sandboxPaths}
-        '' else ''
-          extra-sandbox-paths = ${toString cfg.sandboxPaths}
-        ''}
+        extra-sandbox-paths = ${toString cfg.sandboxPaths}
         substituters = ${toString cfg.binaryCaches}
         trusted-substituters = ${toString cfg.trustedBinaryCaches}
         trusted-public-keys = ${toString cfg.binaryCachePublicKeys}


### PR DESCRIPTION
This reverts commit aeeee447bcc181d57a19d348f857326f4e1959fe.

The Nix bug that caused `extra-sandbox-paths` not to be recognized has been fixed some months ago (https://github.com/NixOS/nix/commit/b87f84cf55b4ca666b31c511e2489789e3322da4), and hardcoding `sandbox-paths` in `nix.conf` breaks Nix by overriding the default `/bin/sh=/nix/store/...busybox.../bin/busybox`.
