### PR TITLE
kubeone: init at 1.2.1

### DIFF
--- a/pkgs/applications/networking/cluster/kubeone/default.nix
+++ b/pkgs/applications/networking/cluster/kubeone/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "kubeone";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "kubermatic";
+    repo = "kubeone";
+    rev = "v${version}";
+    sha256 = "1abm7735c4pjv31pfggkvia7br19zbhjpp2w0n5zckwrjm9hxns6";
+  };
+
+  vendorSha256 = "01rl4sd9prfw4ivx7dwrr9irjr0xryihp4fzpcjd2zg8f1ibkwsn";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd kubeone \
+      --bash <($out/bin/kubeone completion bash) \
+      --zsh <($out/bin/kubeone completion zsh)
+  '';
+
+  meta = {
+    description = "Automate cluster operations on all your cloud, on-prem, edge, and IoT environments.";
+    homepage = "https://kubeone.io/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lblasc ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/cluster/kubeone/default.nix
+++ b/pkgs/applications/networking/cluster/kubeone/default.nix
@@ -32,6 +32,5 @@ buildGoModule rec {
     homepage = "https://kubeone.io/";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ lblasc ];
-    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13425,6 +13425,8 @@ in
 
   kubei = callPackage ../tools/security/kubei { };
 
+  kubeone = callPackage ../applications/networking/cluster/kubeone { };
+
   kubeprompt = callPackage ../development/tools/kubeprompt { };
 
   kubesec = callPackage ../tools/security/kubesec { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/kubermatic/kubeone

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
