### PR TITLE
terraform-provider-hcloud: 1.22.0 -> 1.26.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/hcloud/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/hcloud/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "terraform-provider-hcloud";
-  version = "1.22.0";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "hetznercloud";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1h4kplrmpsbwa0nq3zyqa0cnvhv1s5avdrjyf1k1f2z6b6h4gynf";
+    sha256 = "04fa3qr65hg1ylq2933ark5q1za6k0a4ky36a6vrw2dcgpr4f9zs";
   };
 
-  vendorSha256 = "070p34g0ca55rmfdwf1l53yr8vyhmm5sb8hm8q036n066yp03yfs";
+  vendorSha256 = "15gcnwylxkgjriqscd4lagmwfssagq0ksrlb2svidw9aahmr7hw0";
 
   # Spends an awful time in other test folders, apparently tries to reach
   # opencensus and fails.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
