### PR TITLE
raylib: 3.5.0 -> 3.7.0

### DIFF
--- a/pkgs/development/libraries/raylib/default.nix
+++ b/pkgs/development/libraries/raylib/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   patches = [
     # fixes incorrect version being set by cmake
     (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/raysan5/raylib/pull/1761.patch";
+      url = "https://github.com/raysan5/raylib/commit/204aa4c46fdd6986aa0130eeba658562c540759f.patch";
       sha256 = "10pl7828iy4kadach0wy4fs95vr7k08z3mxw90j8dm9xak1ri8fz";
     })
   ];

--- a/pkgs/development/libraries/raylib/default.nix
+++ b/pkgs/development/libraries/raylib/default.nix
@@ -3,25 +3,26 @@
   libX11, libXi, libXcursor, libXrandr, libXinerama,
   alsaSupport ? stdenv.hostPlatform.isLinux, alsaLib,
   pulseSupport ? stdenv.hostPlatform.isLinux, libpulseaudio,
+  sharedLib ? true,
   includeEverything ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "raylib";
-  version = "3.5.0";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "raysan5";
     repo = pname;
     rev = version;
-    sha256 = "0syvd5js1lbx3g4cddwwncqg95l6hb3fdz5nsh5pqy7fr6v84kwj";
+    sha256 = "1w8v747hqy0ils6zmy8sm056f24ybjhn9bamqzlxvbqhvh9vvly1";
   };
 
   patches = [
-    # fixes examples not compiling in 3.5.0
+    # fixes incorrect version being set by cmake
     (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/raysan5/raylib/pull/1470.patch";
-      sha256 = "1ff5l839wl8dxwrs2bwky7kqa8kk9qmsflg31sk5vbil68dzbzg0";
+      url = "https://patch-diff.githubusercontent.com/raw/raysan5/raylib/pull/1761.patch";
+      sha256 = "10pl7828iy4kadach0wy4fs95vr7k08z3mxw90j8dm9xak1ri8fz";
     })
   ];
 
@@ -34,9 +35,9 @@ stdenv.mkDerivation rec {
   # https://github.com/raysan5/raylib/wiki/CMake-Build-Options
   cmakeFlags = [
     "-DUSE_EXTERNAL_GLFW=ON"
-    "-DSHARED=ON"
     "-DBUILD_EXAMPLES=OFF"
-  ] ++ lib.optional includeEverything "-DINCLUDE_EVERYTHING=ON";
+  ] ++ lib.optional includeEverything "-DINCLUDE_EVERYTHING=ON"
+    ++ lib.optional sharedLib "-DBUILD_SHARED_LIBS=ON";
 
   # fix libasound.so/libpulse.so not being found
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

* Update raylib from 3.5.0 to 3.7.0
* Make shared/static build configurable for local development

###### Things done

Built examples (commented out BUILD_EXAMPLES=OFF) and tested them. No issues with windowing, audio, or OpenGL graphics.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
