### PR TITLE
ccls: fix libc++ header path

### DIFF
--- a/pkgs/development/tools/misc/ccls/default.nix
+++ b/pkgs/development/tools/misc/ccls/default.nix
@@ -21,17 +21,11 @@ stdenv.mkDerivation rec {
     cmakeFlagsArray+=(-DCMAKE_CXX_FLAGS="-fvisibility=hidden -fno-rtti")
   '';
 
+  clang = llvmPackages.clang;
   shell = runtimeShell;
+
   postFixup = ''
-    # We need to tell ccls where to find the standard library headers.
-
-    standard_library_includes="\\\"-isystem\\\", \\\"${lib.getDev stdenv.cc.libc}/include\\\""
-    standard_library_includes+=", \\\"-isystem\\\", \\\"${llvmPackages.libcxx}/include/c++/v1\\\""
-    export standard_library_includes
-
-    wrapped=".ccls-wrapped"
-    export wrapped
-
+    export wrapped=".ccls-wrapped"
     mv $out/bin/ccls $out/bin/$wrapped
     substituteAll ${./wrapper} $out/bin/ccls
     chmod --reference=$out/bin/$wrapped $out/bin/ccls

--- a/pkgs/development/tools/misc/ccls/wrapper
+++ b/pkgs/development/tools/misc/ccls/wrapper
@@ -1,12 +1,9 @@
 #! @shell@ -e
 
-initString="--init={\"clang\":{\"extraArgs\": [@standard_library_includes@"
-
-if [ "${NIX_CFLAGS_COMPILE}" != "" ]; then
-  read -a cflags_array <<< ${NIX_CFLAGS_COMPILE}
-  initString+=$(printf ', \"%s\"' "${cflags_array[@]}")
-fi
-
-initString+="]}}"
+printf -v extraArgs ',\"%s\"' \
+  $(cat @clang@/nix-support/libc-cflags \
+        @clang@/nix-support/libcxx-cxxflags) \
+  ${NIX_CFLAGS_COMPILE}
+initString="--init={\"clang\":{\"extraArgs\":[${extraArgs:1}]}}"
 
 exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "$@"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ccls couldn't find the `<algorithm>` header (or anything else from the C++ standard library).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
