### PR TITLE
imgcrypt: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6599,6 +6599,16 @@
     githubId = 1387206;
     name = "Mike Sperber";
   };
+  mikroskeem = {
+    email = "mikroskeem@mikroskeem.eu";
+    github = "mikroskeem";
+    githubId = 3490861;
+    name = "Mark Vainomaa";
+    keys = [{
+      longkeyid = "rsa4096/0xDA015B05B5A11B22";
+      fingerprint = "DB43 2895 CF68 F0CE D4B7  EF60 DA01 5B05 B5A1 1B22";
+    }];
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "milesbreslin";

--- a/pkgs/applications/virtualization/imgcrypt/default.nix
+++ b/pkgs/applications/virtualization/imgcrypt/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "imgcrypt";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "containerd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "177fs3p2xzwjsffcxqqllx6wi6ghfyqbvfgn95v3q7a2993yqk4k";
+  };
+
+  buildFlagsArray = [
+    "-ldflags=-X github.com/containerd/containerd/version.Version=${version}"
+  ];
+
+  vendorSha256 = null;
+  subPackages = [ "cmd/ctd-decoder" "cmd/ctr" ];
+
+  postFixup = ''
+    mv $out/bin/ctr $out/bin/ctr-enc
+  '';
+
+  meta = with lib; {
+    description = "Image encryption library and command line tool";
+    homepage = "https://github.com/containerd/imgcrypt";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mikroskeem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1563,6 +1563,8 @@ in
 
   imgpatchtools = callPackage ../development/mobile/imgpatchtools { };
 
+  imgcrypt = callPackage ../applications/virtualization/imgcrypt { };
+
   ipgrep = callPackage ../tools/networking/ipgrep { };
 
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package imgcrypt to add support for encrypted container images for e.g containerd and CRI-o

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
