### PR TITLE
dnsname-cni: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6599,6 +6599,16 @@
     githubId = 1387206;
     name = "Mike Sperber";
   };
+  mikroskeem = {
+    email = "mikroskeem@mikroskeem.eu";
+    github = "mikroskeem";
+    githubId = 3490861;
+    name = "Mark Vainomaa";
+    keys = [{
+      longkeyid = "rsa4096/0xDA015B05B5A11B22";
+      fingerprint = "DB43 2895 CF68 F0CE D4B7  EF60 DA01 5B05 B5A1 1B22";
+    }];
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "milesbreslin";

--- a/pkgs/applications/networking/cluster/dnsname-cni/default.nix
+++ b/pkgs/applications/networking/cluster/dnsname-cni/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, fetchFromGitHub, lib, dnsmasq }:
+
+buildGoModule rec {
+  pname = "cni-plugin-dnsname";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "dnsname";
+    rev = "v${version}";
+    sha256 = "090kpq2ppan9ayajdk5vwbvww30nphylgajn2p3441d4jg2nvsm3";
+  };
+
+  patches = [ ./hardcode-dnsmasq-path.patch ];
+
+  postPatch = ''
+    substituteInPlace plugins/meta/dnsname/service.go --replace '@DNSMASQ@' '${dnsmasq}/bin/dnsmasq'
+  '';
+
+  vendorSha256 = null;
+  subPackages = [ "plugins/meta/dnsname" ];
+
+  doCheck = false; # NOTE: requires root privileges
+
+  meta = with lib; {
+    description = "DNS name resolution for containers";
+    homepage = "https://github.com/containers/dnsname";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mikroskeem ];
+  };
+}

--- a/pkgs/applications/networking/cluster/dnsname-cni/hardcode-dnsmasq-path.patch
+++ b/pkgs/applications/networking/cluster/dnsname-cni/hardcode-dnsmasq-path.patch
@@ -1,0 +1,19 @@
+diff --git a/plugins/meta/dnsname/service.go b/plugins/meta/dnsname/service.go
+index fc05f75..f6b4caf 100644
+--- a/plugins/meta/dnsname/service.go
++++ b/plugins/meta/dnsname/service.go
+@@ -16,10 +16,14 @@ import (
+ 
+ // newDNSMasqFile creates a new instance of a dnsNameFile
+ func newDNSMasqFile(domainName, networkInterface, networkName string) (dnsNameFile, error) {
++	/*
+ 	dnsMasqBinary, err := exec.LookPath("dnsmasq")
+ 	if err != nil {
+ 		return dnsNameFile{}, errors.Errorf("the dnsmasq cni plugin requires the dnsmasq binary be in PATH")
+ 	}
++	*/
++	_ = errors.Errorf // XXX(mikroskeem): reduce diff
++	dnsMasqBinary := "@DNSMASQ@"
+ 	masqConf := dnsNameFile{
+ 		ConfigFile:       makePath(networkName, confFileName),
+ 		Domain:           domainName,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22858,6 +22858,8 @@ in
   cni = callPackage ../applications/networking/cluster/cni {};
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix {};
 
+  dnsname-cni = callPackage ../applications/networking/cluster/dnsname-cni {};
+
   multus-cni = callPackage ../applications/networking/cluster/multus-cni {};
 
   cntr = callPackage ../applications/virtualization/cntr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
