### PR TITLE
postgresqlPackages.pg_rational: init at 0.0.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_rational.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_rational.nix
@@ -9,15 +9,13 @@ stdenv.mkDerivation rec {
   version = "0.0.2";
 
   src = fetchFromGitHub {
-    owner = "begriffs";
-    repo = "pg_rational";
-    rev = "v${version}";
+    owner  = "begriffs";
+    repo   = "pg_rational";
+    rev    = "v${version}";
     sha256 = "sha256-Sp5wuX2nP3KGyWw7MFa11rI1CPIKIWBt8nvBSsASIEw=";
   };
 
-  buildInputs = [
-    postgresql
-  ];
+  buildInputs = [ postgresql ];
 
   installPhase = ''
     runHook preInstall
@@ -33,8 +31,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Precise fractional arithmetic for PostgreSQL";
-    homepage = "https://github.com/begriffs/pg_rational";
+    homepage    = "https://github.com/begriffs/pg_rational";
     maintainers = with maintainers; [ netcrns ];
-    license = licenses.mit;
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.mit;
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pg_rational.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_rational.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, postgresql
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pg_rational";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "begriffs";
+    repo = "pg_rational";
+    rev = "v${version}";
+    sha256 = "sha256-Sp5wuX2nP3KGyWw7MFa11rI1CPIKIWBt8nvBSsASIEw=";
+  };
+
+  buildInputs = [
+    postgresql
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Precise fractional arithmetic for PostgreSQL";
+    homepage = "https://github.com/begriffs/pg_rational";
+    maintainers = with maintainers; [ netcrns ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -14,6 +14,8 @@ self: super: {
 
     pg_ed25519 = super.callPackage ./ext/pg_ed25519.nix { };
 
+    pg_rational = super.callPackage ./ext/pg_rational.nix { };
+
     pg_repack = super.callPackage ./ext/pg_repack.nix { };
 
     pg_similarity = super.callPackage ./ext/pg_similarity.nix { };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -603,6 +603,7 @@ mapAliases ({
   cstore_fdw = postgresqlPackages.cstore_fdw;
   pg_hll = postgresqlPackages.pg_hll;
   pg_cron = postgresqlPackages.pg_cron;
+  pg_rational = postgresqlPackages.pg_rational;
   pg_topn = postgresqlPackages.pg_topn;
   pinentry_curses = pinentry-curses; # added 2019-10-14
   pinentry_emacs = pinentry-emacs; # added 2019-10-14

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -603,7 +603,6 @@ mapAliases ({
   cstore_fdw = postgresqlPackages.cstore_fdw;
   pg_hll = postgresqlPackages.pg_hll;
   pg_cron = postgresqlPackages.pg_cron;
-  pg_rational = postgresqlPackages.pg_rational;
   pg_topn = postgresqlPackages.pg_topn;
   pinentry_curses = pinentry-curses; # added 2019-10-14
   pinentry_emacs = pinentry-emacs; # added 2019-10-14


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
