### PR TITLE
Revert "nixos/nix-daemon: fix sandbox-paths option"

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -12,8 +12,6 @@ let
 
   isNix23 = versionAtLeast nixVersion "2.3pre";
 
-  isNix24 = versionAtLeast nixVersion "2.4pre";
-
   makeNixBuildUser = nr: {
     name  = "nixbld${toString nr}";
     value = {
@@ -43,11 +41,7 @@ let
         max-jobs = ${toString (cfg.maxJobs)}
         cores = ${toString (cfg.buildCores)}
         sandbox = ${if (builtins.isBool cfg.useSandbox) then boolToString cfg.useSandbox else cfg.useSandbox}
-        ${if isNix24 then ''
-          sandbox-paths = ${toString cfg.sandboxPaths}
-        '' else ''
-          extra-sandbox-paths = ${toString cfg.sandboxPaths}
-        ''}
+        extra-sandbox-paths = ${toString cfg.sandboxPaths}
         substituters = ${toString cfg.binaryCaches}
         trusted-substituters = ${toString cfg.trustedBinaryCaches}
         trusted-public-keys = ${toString cfg.binaryCachePublicKeys}


### PR DESCRIPTION
This reverts commit aeeee447bcc181d57a19d348f857326f4e1959fe.

(cherry picked from commit 113823669b9b71fff84bc592d1fd6022635c28eb)
Signed-off-by: Domen Kožar <domen@dev.si>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
