### PR TITLE
plocate: init at 1.1.7

### DIFF
--- a/pkgs/tools/misc/plocate/default.nix
+++ b/pkgs/tools/misc/plocate/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "1.1.7";
 
   src = fetchgit {
-    url = "http://git.sesse.net/plocate";
+    url = "https://git.sesse.net/plocate";
     rev = version;
     sha256 = "sha256-5Ie4qgiKUoI9Kma6YvjXirvBbpbKVuaMSSAZa36zN3M=";
   };

--- a/pkgs/tools/misc/plocate/default.nix
+++ b/pkgs/tools/misc/plocate/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchgit
+, pkg-config
+, meson
+, ninja
+, systemd
+, liburing
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "plocate";
+  version = "1.1.7";
+
+  src = fetchgit {
+    url = "http://git.sesse.net/plocate";
+    rev = version;
+    sha256 = "sha256-5Ie4qgiKUoI9Kma6YvjXirvBbpbKVuaMSSAZa36zN3M=";
+  };
+
+  postPatch = ''
+    sed -i meson.build \
+      -e "s@unitdir =.*@unitdir = '$out/lib/systemd/system'@" \
+      -e '/mkdir\.sh/d'
+  '';
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  buildInputs = [ systemd liburing zstd ];
+
+  mesonFlags = [
+    # I don't know why we can't do this but instead have to resort to patching meson.build
+    #   "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+    "-Dsharedstatedir=/var/lib"
+  ];
+
+  meta = with lib; {
+    description = "Much faster locate";
+    homepage = "https://plocate.sesse.net/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25356,6 +25356,8 @@ in
 
   mlocate = callPackage ../tools/misc/mlocate { };
 
+  plocate = callPackage ../tools/misc/plocate { };
+
   mypaint = callPackage ../applications/graphics/mypaint { };
 
   mypaint-brushes1 = callPackage ../development/libraries/mypaint-brushes/1.0.nix { };


### PR DESCRIPTION
###### Motivation for this change

#124081

Been using a slighly earlier version as a daily driver for a few months.

Cc: @KenMacD

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
