### PR TITLE
nixos/plocate: basic WIP module

### DIFF
--- a/nixos/modules/programs/plocate.nix
+++ b/nixos/modules/programs/plocate.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.plocate;
+
+  inherit (lib) mkEnableOption mkIf mkOption types;
+
+in
+{
+  meta.maintainers = with lib.maintainers; [ peterhoeg ];
+
+  options.toupstream.programs.plocate = {
+    enable = mkEnableOption "plocate";
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ package ];
+
+    security.wrappers = {
+      plocate = {
+        source = "${lib.getBin package}/bin/plocate";
+        owner = "root";
+        group = "plocate";
+      };
+    };
+
+    systemd = {
+      packages = [ package ];
+
+      timers.plocate-updatedb.wantedBy = [ "timers.target" ];
+
+      tmpfiles.rules = [
+        "d /var/lib/plocate 0775 root plocate -"
+      ];
+    };
+
+    users.groups.plocate = { };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This shouldn't be merged as it should instead be incorporated into the existing `locate` framework in NixOS.

Requires: #124259
Related to: #124081

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
