### PR TITLE
thelounge: update publicity config

### DIFF
--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -1,25 +1,24 @@
 { pkgs, lib, config, ... }:
 
 with lib;
-
 let
   cfg = config.services.thelounge;
   dataDir = "/var/lib/thelounge";
   configJsData = "module.exports = " + builtins.toJSON (
-    { private = cfg.private; port = cfg.port; } // cfg.extraConfig
+    { public = cfg.public; port = cfg.port; } // cfg.extraConfig
   );
-in {
+in
+{
   options.services.thelounge = {
     enable = mkEnableOption "The Lounge web IRC client";
 
-    private = mkOption {
+    public = mkOption {
       type = types.bool;
       default = false;
       description = ''
-        Make your The Lounge instance private. You will need to configure user
-        accounts by using the (<command>thelounge</command>) command or by adding
-        entries in <filename>${dataDir}/users</filename>. You might need to restart
-        The Lounge after making changes to the state directory.
+        Make your The Lounge instance public.
+        Anyone can connect to IRC networks in this mode.
+        All IRC connections and channel scrollbacks are lost when a user leaves the client.
       '';
     };
 
@@ -30,7 +29,7 @@ in {
     };
 
     extraConfig = mkOption {
-      default = {};
+      default = { };
       type = types.attrs;
       example = literalExample ''{
         reverseProxy = true;
@@ -58,7 +57,7 @@ in {
       group = "thelounge";
       isSystemUser = true;
     };
-    users.groups.thelounge = {};
+    users.groups.thelounge = { };
     systemd.services.thelounge = {
       description = "The Lounge web IRC client";
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
The Lounge now uses the public key to set instance publicity.

###### Motivation for this change
Private config option no longer affects instance publicity status. Updated to use new option, public

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
