### PR TITLE
microplane: 0.0.31 -> 0.0.32

### DIFF
--- a/pkgs/tools/misc/microplane/default.nix
+++ b/pkgs/tools/misc/microplane/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "microplane";
-  version = "0.0.31";
+  version = "0.0.32";
 
   src = fetchFromGitHub {
     owner = "Clever";
     repo = "microplane";
     rev = "v${version}";
-    sha256 = "sha256-PcojOFe3SHhnFy09kcxHhb5kd07TG7Uq+coPUNbJjx4=";
+    sha256 = "sha256-QYii/UmYus5hloTUsbVKsw50bSfI4bArUgGzFSK8Cas=";
   };
 
-  vendorSha256 = "sha256-5HHdxSXg3ZIUyFQALaYgvf4pQwNxG58cF4vnCnMgAuY=";
+  vendorSha256 = "sha256-1XtpoGqQ//2ccJdl8E7jnSBQhYoA4/YVBbHeI+OfaR0=";
 
   buildFlagsArray = ''
     -ldflags=-s -w -X main.version=${version}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Used nix-update to bump to newest 0.0.32:
https://github.com/Clever/microplane/releases/tag/v0.0.32
https://github.com/Clever/microplane/blob/v0.0.32/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>microplane</li>
  </ul>
</details>