### PR TITLE
weechatScripts.weechat-matrix: fix matrix_sso_helper path

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
@@ -73,6 +73,7 @@ in buildPythonPackage {
   postFixup = ''
     addToSearchPath program_PYTHONPATH $out/${python.sitePackages}
     patchPythonScript $out/share/matrix.py
+    substituteInPlace $out/${python.sitePackages}/matrix/server.py --replace \"matrix_sso_helper\" \"$out/bin/matrix_sso_helper\"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
server.py tries to launch a matrix_sso_helper binary when connecting to
a homeserver that uses some SSO mechanism instead of plain login and
password, but doesn't have $out/bin in $PATH.

Using substituteInPlace to patch `server.py` so that the helper process is
started by using its actual filesystem location instead of relying on
$PATH.

Fixes: https://github.com/NixOS/nixpkgs/issues/124186

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
