### PR TITLE
CODEOWNERS: merge the neovim lines as they are not additive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,8 +179,7 @@
 /pkgs/top-level/emacs-packages.nix     @adisbladis
 
 # Neovim
-/pkgs/applications/editors/neovim      @jonringer
-/pkgs/applications/editors/neovim      @teto
+/pkgs/applications/editors/neovim      @jonringer @teto
 
 # VimPlugins
 /pkgs/misc/vim-plugins         @jonringer @softinio


### PR DESCRIPTION
###### Motivation for this change

CODEOWNERS files always take that *last* match for a specific match.
Having two lines for the same path will only ever result in the last
line being used. The intention here was that both of these individuals
are owners of the neovim space and not just one.



