### PR TITLE
Add backporting action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
         with:
           # required to find all branches
           fetch-depth: 0

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,20 @@
+name: Backport
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  backport:
+    name: Create backport PRs
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          # required to find all branches
+          fetch-depth: 0
+      - name: Create backport PRs
+        uses: zeebe-io/backport-action@9b8949dcd4295d364b0939f07d0c7593598d26cd
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}
+          version: 9b8949dcd4295d364b0939f07d0c7593598d26cd

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,8 +13,10 @@ jobs:
           # required to find all branches
           fetch-depth: 0
       - name: Create backport PRs
+        # should be kept in sync with `version`
         uses: zeebe-io/backport-action@9b8949dcd4295d364b0939f07d0c7593598d26cd
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}
+          # should be kept in sync with `uses`
           version: 9b8949dcd4295d364b0939f07d0c7593598d26cd

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   backport:
     name: Create backport PRs
-    if: github.event.pull_request.merged == true
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4

--- a/doc/contributing/submitting-changes.chapter.md
+++ b/doc/contributing/submitting-changes.chapter.md
@@ -248,6 +248,8 @@ For cherry-picking a commit to a stable release branch (“backporting”), use 
 
 Add a reason for the backport by using `git cherry-pick -xe <original commit>` instead when it is not obvious from the original commit message. It is not needed when it's a minor version update that includes security and bug fixes but don't add new features or when the commit fixes an otherwise broken package.
 
+For backporting Pull Requests to stable branches, assign label `backport <branch>` to the original Pull Requests and automation should take care of the rest once the Pull Requests is merged.
+
 Here is an example of a cherry-picked commit message with good reason description:
 
 ```


### PR DESCRIPTION
If `backport <branch>` label is applied to a PR,
once the PR is merged, github-actions bot will create another PR targeting
<branch> and cherry-picking commits.

[example](https://github.com/domenkozar/nixpkgs/pull/9)

It takes a couple of minutes to fetch full history and all branches when backporting.

Once this PR is merged I'll create `backport release-21.05` label.

Where do I document this workflow for maintainers?