### PR TITLE
pythonPackages.xtensor-python: init at 0.25.1

### DIFF
--- a/pkgs/development/python-modules/xtensor-python/default.nix
+++ b/pkgs/development/python-modules/xtensor-python/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, gtest
+, xtensor
+, pybind11
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "xtensor-python";
+  version = "0.25.1";
+
+  src = fetchFromGitHub {
+    owner = "xtensor-stack";
+    repo = pname;
+    rev = version;
+    sha256 = "17la76hn4r1jv67dzz8x2pzl608r0mnvz854407mchlzj6rhsxza";
+  };
+
+  nativeBuildInputs = [ cmake pybind11 ];
+
+  propagatedBuildInputs = [ xtensor numpy ];
+
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+  dontUseSetuptoolsCheck = true;
+
+  checkInputs = [
+    gtest
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/xtensor-stack/xtensor-python";
+    description = "Python bindings for the xtensor C++ multi-dimensional array library";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lsix ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9187,6 +9187,8 @@ in {
 
   xstatic-pygments = callPackage ../development/python-modules/xstatic-pygments { };
 
+  xtensor-python = callPackage ../development/python-modules/xtensor-python { };
+
   xvfbwrapper = callPackage ../development/python-modules/xvfbwrapper {
     inherit (pkgs.xorg) xorgserver;
   };


### PR DESCRIPTION
###### Motivation for this change

Adds `xtensor` and `xtensor-python` to `nixpkgs`. Those are libraries used to create multidimensional arrays with broadcasting (`numpy`-like) and lazy computation in c++, and associated python bindings.

All those packages provide c++ header only libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
