### PR TITLE
gnome-extensions-gTile

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6417,6 +6417,10 @@
     githubId = 44469426;
     name = "Matheus de Souza Pessanha";
     email = "matheus_pessanha2001@outlook.com";
+    keys = [{
+      longkeyid = "rsa4096/6DFD656220A3B849";
+      fingerprint = "2D4D 488F 17FB FF75 664E  C016 6DFD 6562 20A3 B849";
+    }];
   };
   meatcar = {
     email = "nixpkgs@denys.me";

--- a/pkgs/desktops/gnome/extensions/gtile/default.nix
+++ b/pkgs/desktops/gnome/extensions/gtile/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-gtile";
+  version = "44";
+
+  src = fetchFromGitHub {
+    owner = "gTile";
+    repo = "gTile";
+    rev = "V${version}";
+    sha256 = "0i00psc1ky70zljd14jzr627y7nd8xwnwrh4xpajl1f6djabh12s";
+  };
+
+  uuid = "gTile@vibou";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r * $out/share/gnome-shell/extensions/${uuid}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A window tiling extension for Gnome. This is the new official home of the vibou.gTile extension.";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ mdsp ];
+    platforms = platforms.linux;
+    homepage = "https://github.com/gTile/gTile";
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A window tiling gnome extension! It allows to tile windows with
keyboard shortcuts or mouse. Also have a auto tiling option!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
