### PR TITLE
exempi: disable tests for i686

### DIFF
--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -11,12 +11,14 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-boost=${boost.dev}"
+  ] ++ lib.optionals (!doCheck) [
+    "--enable-unittest=no"
   ];
 
   buildInputs = [ expat zlib boost ]
     ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.CoreServices ];
 
-  doCheck = stdenv.isLinux;
+  doCheck = stdenv.isLinux && stdenv.is64bit;
 
   meta = with lib; {
     description = "An implementation of XMP (Adobe's Extensible Metadata Platform)";


### PR DESCRIPTION

###### Motivation for this change
A bunch of nixosTests are failing on i686 because this package fails to build. Example: https://hydra.nixos.org/build/143981264#tabs-summary

Unable to find boost unittest framework.

Tests are still ran on the x86_64 platform

ZHF:  #122042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
