### PR TITLE
yuzu-{mainline,ea} && ryujinx: bump

### DIFF
--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -1,28 +1,30 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, makeWrapper, makeDesktopItem, linkFarmFromDrvs
 , dotnet-sdk_5, dotnetPackages, dotnetCorePackages, cacert
-, SDL2, libX11, libgdiplus, ffmpeg, openal, libsoundio
+, libX11, libgdiplus, ffmpeg
+, SDL2_mixer, openal, libsoundio, sndio
 , gtk3, gobject-introspection, gdk-pixbuf, wrapGAppsHook
 }:
 
 let
   runtimeDeps = [
-    SDL2
     gtk3
     libX11
     libgdiplus
     ffmpeg
+    SDL2_mixer
     openal
     libsoundio
+    sndio
   ];
 in stdenv.mkDerivation rec {
   pname = "ryujinx";
-  version = "1.0.6835"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
+  version = "1.0.6893"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
 
   src = fetchFromGitHub {
     owner = "Ryujinx";
     repo = "Ryujinx";
-    rev = "e520eecb5ba682d4b51bb782e3bc99fb1d6afe04";
-    sha256 = "1yy1xslnvvl0m7g0jszj2pjwdwf0pbv53crzfkhla3n68kvfy00f";
+    rev = "fb65f392d1c4b0e01f22b6ddebcc8317ba9769c3";
+    sha256 = "0ncrcbwyirz21j81vc6yvcjc2fn8nc5ilrfczclq6f8cpy09c3y8";
   };
 
   nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget cacert makeWrapper wrapGAppsHook gobject-introspection gdk-pixbuf ];

--- a/pkgs/misc/emulators/ryujinx/deps.nix
+++ b/pkgs/misc/emulators/ryujinx/deps.nix
@@ -21,13 +21,13 @@
   })
   (fetchNuGet {
     name = "DiscordRichPresence";
-    version = "1.0.166";
-    sha256 = "019rz0br8hamydmdrgzcc6280jfhm4i4ix27jh66a7h37alvdi3a";
+    version = "1.0.175";
+    sha256 = "180sax976327d70qbinv07f65g3w2zbw80n49hckg8wd4rw209vd";
   })
   (fetchNuGet {
     name = "FFmpeg.AutoGen";
-    version = "4.3.0";
-    sha256 = "03lb3xzgwxik8nljq87pr1b9bsxbsl3a4kvy0kqkw9f57n29ihvk";
+    version = "4.4.0";
+    sha256 = "02n4az1jv30078019png9gbspygz051inxsn6w4iar20dqp55g2w";
   })
   (fetchNuGet {
     name = "GdkSharp";
@@ -45,14 +45,14 @@
     sha256 = "1j8i5izk97ga30z1qpd765zqd2q5w71y8bhnkqq4bj59768fyxp5";
   })
   (fetchNuGet {
-    name = "GtkSharp";
-    version = "3.22.25.128";
-    sha256 = "0z0wx0p3gc02r8d7y88k1rw307sb2vapbr1k1yc5qdc38fxz5jsy";
-  })
-  (fetchNuGet {
     name = "GtkSharp.Dependencies";
     version = "1.1.0";
     sha256 = "1g1rhcn38ww97638rds6l5bysra43hkhv47fy71fvq89623zgyxn";
+  })
+  (fetchNuGet {
+    name = "GtkSharp";
+    version = "3.22.25.128";
+    sha256 = "0z0wx0p3gc02r8d7y88k1rw307sb2vapbr1k1yc5qdc38fxz5jsy";
   })
   (fetchNuGet {
     name = "LibHac";
@@ -88,6 +88,11 @@
     name = "Microsoft.DotNet.InternalAbstractions";
     version = "1.0.0";
     sha256 = "0mp8ihqlb7fsa789frjzidrfjc1lrhk88qp3xm5qvr7vf4wy4z8x";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.8.0";
+    sha256 = "1ln2mva7j2mpsj9rdhpk8vhm3pgd8wn563xqdcwd38avnhp74rm9";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.App.Host.osx-x64";
@@ -143,11 +148,6 @@
     name = "Microsoft.NETCore.Targets";
     version = "1.1.0";
     sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
-  })
-  (fetchNuGet {
-    name = "Microsoft.NET.Test.Sdk";
-    version = "16.8.0";
-    sha256 = "1ln2mva7j2mpsj9rdhpk8vhm3pgd8wn563xqdcwd38avnhp74rm9";
   })
   (fetchNuGet {
     name = "Microsoft.TestPlatform.ObjectModel";
@@ -280,24 +280,19 @@
     sha256 = "00j6nv2xgmd3bi347k00m7wr542wjlig53rmj28pmw7ddcn97jbn";
   })
   (fetchNuGet {
-    name = "runtime.any.System.Globalization";
-    version = "4.3.0";
-    sha256 = "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x";
-  })
-  (fetchNuGet {
     name = "runtime.any.System.Globalization.Calendars";
     version = "4.3.0";
     sha256 = "1ghhhk5psqxcg6w88sxkqrc35bxcz27zbqm2y5p5298pv3v7g201";
   })
   (fetchNuGet {
+    name = "runtime.any.System.Globalization";
+    version = "4.3.0";
+    sha256 = "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x";
+  })
+  (fetchNuGet {
     name = "runtime.any.System.IO";
     version = "4.3.0";
     sha256 = "0l8xz8zn46w4d10bcn3l4yyn4vhb3lrj2zw8llvz7jk14k4zps5x";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Reflection";
-    version = "4.3.0";
-    sha256 = "02c9h3y35pylc0zfq3wcsvc5nqci95nrkq0mszifc0sjx7xrzkly";
   })
   (fetchNuGet {
     name = "runtime.any.System.Reflection.Extensions";
@@ -310,14 +305,14 @@
     sha256 = "0x1mm8c6iy8rlxm8w9vqw7gb7s1ljadrn049fmf70cyh42vdfhrf";
   })
   (fetchNuGet {
+    name = "runtime.any.System.Reflection";
+    version = "4.3.0";
+    sha256 = "02c9h3y35pylc0zfq3wcsvc5nqci95nrkq0mszifc0sjx7xrzkly";
+  })
+  (fetchNuGet {
     name = "runtime.any.System.Resources.ResourceManager";
     version = "4.3.0";
     sha256 = "03kickal0iiby82wa5flar18kyv82s9s6d4xhk5h4bi5kfcyfjzl";
-  })
-  (fetchNuGet {
-    name = "runtime.any.System.Runtime";
-    version = "4.3.0";
-    sha256 = "1cqh1sv3h5j7ixyb7axxbdkqx6cxy00p4np4j91kpm492rf4s25b";
   })
   (fetchNuGet {
     name = "runtime.any.System.Runtime.Handles";
@@ -330,14 +325,19 @@
     sha256 = "0c3g3g3jmhlhw4klrc86ka9fjbl7i59ds1fadsb2l8nqf8z3kb19";
   })
   (fetchNuGet {
-    name = "runtime.any.System.Text.Encoding";
+    name = "runtime.any.System.Runtime";
     version = "4.3.0";
-    sha256 = "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3";
+    sha256 = "1cqh1sv3h5j7ixyb7axxbdkqx6cxy00p4np4j91kpm492rf4s25b";
   })
   (fetchNuGet {
     name = "runtime.any.System.Text.Encoding.Extensions";
     version = "4.3.0";
     sha256 = "0lqhgqi0i8194ryqq6v2gqx0fb86db2gqknbm0aq31wb378j7ip8";
+  })
+  (fetchNuGet {
+    name = "runtime.any.System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3";
   })
   (fetchNuGet {
     name = "runtime.any.System.Threading.Tasks";
@@ -365,16 +365,6 @@
     sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
   })
   (fetchNuGet {
-    name = "runtime.native.System";
-    version = "4.0.0";
-    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
-  })
-  (fetchNuGet {
-    name = "runtime.native.System";
-    version = "4.3.0";
-    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
-  })
-  (fetchNuGet {
     name = "runtime.native.System.IO.Compression";
     version = "4.1.0";
     sha256 = "0d720z4lzyfcabmmnvh0bnj76ll7djhji2hmfh3h44sdkjnlkknk";
@@ -385,14 +375,24 @@
     sha256 = "1hgv2bmbaskx77v8glh7waxws973jn4ah35zysnkxmf0196sfxg6";
   })
   (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+  })
+  (fetchNuGet {
     name = "runtime.native.System.Security.Cryptography";
     version = "4.0.0";
     sha256 = "0k57aa2c3b10wl3hfqbgrl7xq7g8hh3a3ir44b31dn5p61iiw3z9";
   })
   (fetchNuGet {
-    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    name = "runtime.native.System";
+    version = "4.0.0";
+    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
     version = "4.3.0";
-    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
   })
   (fetchNuGet {
     name = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
@@ -511,8 +511,8 @@
   })
   (fetchNuGet {
     name = "Ryujinx.Graphics.Nvdec.Dependencies";
-    version = "4.3.0";
-    sha256 = "0szgbdhyhvzpw8nb9k2ww37p5qipab1pdll8idkk57y5xnl2f7ll";
+    version = "4.4.0-build7";
+    sha256 = "0g1l3lgs0ffxp64ka81v6q1cgsdirl1qlf73255v29r3v337074m";
   })
   (fetchNuGet {
     name = "SharpZipLib";
@@ -525,19 +525,19 @@
     sha256 = "0r0aw8xxd32rwcawawcz6asiyggz02hnzg5hvz8gimq8hvwx1wql";
   })
   (fetchNuGet {
-    name = "SixLabors.ImageSharp";
-    version = "1.0.2";
-    sha256 = "0fhk9sn8k18slfb26wz8mal0j699f7djwhxgv97snz6b10wynfaj";
-  })
-  (fetchNuGet {
     name = "SixLabors.ImageSharp.Drawing";
     version = "1.0.0-beta11";
     sha256 = "0hl0rs3kr1zdnx3gdssxgli6fyvmwzcfp99f4db71s0i8j8b2bp5";
   })
   (fetchNuGet {
+    name = "SixLabors.ImageSharp";
+    version = "1.0.2";
+    sha256 = "0fhk9sn8k18slfb26wz8mal0j699f7djwhxgv97snz6b10wynfaj";
+  })
+  (fetchNuGet {
     name = "SPB";
-    version = "0.0.2";
-    sha256 = "178z9mi7zlk0laj79nkjh75ych47jjajiaj33hnh7zfmz05d8h6r";
+    version = "0.0.3-build15";
+    sha256 = "0h00yi2j65q31r5npsziq2rpiw832vf9r72j1hjqibp2l5m6v6yw";
   })
   (fetchNuGet {
     name = "System.AppContext";
@@ -565,16 +565,6 @@
     sha256 = "14zs2wqkmdlxzj8ikx19n321lsbarx5vl2a8wrachymxn8zb5njh";
   })
   (fetchNuGet {
-    name = "System.Collections";
-    version = "4.0.11";
-    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
-  })
-  (fetchNuGet {
-    name = "System.Collections";
-    version = "4.3.0";
-    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
-  })
-  (fetchNuGet {
     name = "System.Collections.Concurrent";
     version = "4.0.12";
     sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
@@ -590,9 +580,14 @@
     sha256 = "1sdwkma4f6j85m3dpb53v9vcgd0zyc9jb33f8g63byvijcj39n20";
   })
   (fetchNuGet {
-    name = "System.ComponentModel";
+    name = "System.Collections";
+    version = "4.0.11";
+    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
     version = "4.3.0";
-    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
+    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
   })
   (fetchNuGet {
     name = "System.ComponentModel.EventBasedAsync";
@@ -608,6 +603,11 @@
     name = "System.ComponentModel.TypeConverter";
     version = "4.3.0";
     sha256 = "17ng0p7v3nbrg3kycz10aqrrlw4lz9hzhws09pfh8gkwicyy481x";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel";
+    version = "4.3.0";
+    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
   })
   (fetchNuGet {
     name = "System.Console";
@@ -660,16 +660,6 @@
     sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
   })
   (fetchNuGet {
-    name = "System.Globalization";
-    version = "4.0.11";
-    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
-  })
-  (fetchNuGet {
-    name = "System.Globalization";
-    version = "4.3.0";
-    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
-  })
-  (fetchNuGet {
     name = "System.Globalization.Calendars";
     version = "4.0.1";
     sha256 = "0bv0alrm2ck2zk3rz25lfyk9h42f3ywq77mx1syl6vvyncnpg4qh";
@@ -685,19 +675,14 @@
     sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
   })
   (fetchNuGet {
-    name = "System.IO";
-    version = "4.1.0";
-    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+    name = "System.Globalization";
+    version = "4.0.11";
+    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
   })
   (fetchNuGet {
-    name = "System.IO";
+    name = "System.Globalization";
     version = "4.3.0";
-    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
-  })
-  (fetchNuGet {
-    name = "System.IO.Compression";
-    version = "4.1.0";
-    sha256 = "0iym7s3jkl8n0vzm3jd6xqg9zjjjqni05x45dwxyjr2dy88hlgji";
+    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
   })
   (fetchNuGet {
     name = "System.IO.Compression.ZipFile";
@@ -705,14 +690,9 @@
     sha256 = "0h72znbagmgvswzr46mihn7xm7chfk2fhrp5krzkjf29pz0i6z82";
   })
   (fetchNuGet {
-    name = "System.IO.FileSystem";
-    version = "4.0.1";
-    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
-  })
-  (fetchNuGet {
-    name = "System.IO.FileSystem";
-    version = "4.3.0";
-    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+    name = "System.IO.Compression";
+    version = "4.1.0";
+    sha256 = "0iym7s3jkl8n0vzm3jd6xqg9zjjjqni05x45dwxyjr2dy88hlgji";
   })
   (fetchNuGet {
     name = "System.IO.FileSystem.Primitives";
@@ -725,6 +705,31 @@
     sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
   })
   (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.1.0";
+    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.3.0";
+    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.1.0";
+    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
+  })
+  (fetchNuGet {
     name = "System.Linq";
     version = "4.1.0";
     sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
@@ -733,11 +738,6 @@
     name = "System.Linq";
     version = "4.3.0";
     sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
-  })
-  (fetchNuGet {
-    name = "System.Linq.Expressions";
-    version = "4.1.0";
-    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
   })
   (fetchNuGet {
     name = "System.Management";
@@ -785,26 +785,6 @@
     sha256 = "04r1lkdnsznin0fj4ya1zikxiqr0h6r6a1ww2dsm60gqhdrf0mvx";
   })
   (fetchNuGet {
-    name = "System.Reflection";
-    version = "4.1.0";
-    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
-  })
-  (fetchNuGet {
-    name = "System.Reflection";
-    version = "4.3.0";
-    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
-  })
-  (fetchNuGet {
-    name = "System.Reflection.Emit";
-    version = "4.0.1";
-    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
-  })
-  (fetchNuGet {
-    name = "System.Reflection.Emit";
-    version = "4.3.0";
-    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
-  })
-  (fetchNuGet {
     name = "System.Reflection.Emit.ILGeneration";
     version = "4.0.1";
     sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
@@ -823,6 +803,16 @@
     name = "System.Reflection.Emit.Lightweight";
     version = "4.3.0";
     sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.0.1";
+    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.3.0";
+    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
   })
   (fetchNuGet {
     name = "System.Reflection.Extensions";
@@ -855,6 +845,16 @@
     sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
   })
   (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.1.0";
+    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.3.0";
+    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+  })
+  (fetchNuGet {
     name = "System.Resources.ResourceManager";
     version = "4.0.1";
     sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
@@ -863,16 +863,6 @@
     name = "System.Resources.ResourceManager";
     version = "4.3.0";
     sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
-  })
-  (fetchNuGet {
-    name = "System.Runtime";
-    version = "4.1.0";
-    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
-  })
-  (fetchNuGet {
-    name = "System.Runtime";
-    version = "4.3.0";
-    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
   })
   (fetchNuGet {
     name = "System.Runtime.CompilerServices.Unsafe";
@@ -905,16 +895,6 @@
     sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
   })
   (fetchNuGet {
-    name = "System.Runtime.InteropServices";
-    version = "4.1.0";
-    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
-  })
-  (fetchNuGet {
-    name = "System.Runtime.InteropServices";
-    version = "4.3.0";
-    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
-  })
-  (fetchNuGet {
     name = "System.Runtime.InteropServices.RuntimeInformation";
     version = "4.0.0";
     sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
@@ -925,6 +905,16 @@
     sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
   })
   (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.1.0";
+    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+  })
+  (fetchNuGet {
     name = "System.Runtime.Numerics";
     version = "4.0.1";
     sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
@@ -933,6 +923,16 @@
     name = "System.Runtime.Serialization.Primitives";
     version = "4.1.1";
     sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.1.0";
+    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.3.0";
+    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
   })
   (fetchNuGet {
     name = "System.Security.AccessControl";
@@ -985,11 +985,6 @@
     sha256 = "0clg1bv55mfv5dq00m19cp634zx6inm31kf8ppbq1jgyjf2185dh";
   })
   (fetchNuGet {
-    name = "System.Security.Principal";
-    version = "4.3.0";
-    sha256 = "12cm2zws06z4lfc4dn31iqv7072zyi4m910d4r6wm8yx85arsfxf";
-  })
-  (fetchNuGet {
     name = "System.Security.Principal.Windows";
     version = "4.3.0";
     sha256 = "00a0a7c40i3v4cb20s2cmh9csb5jv2l0frvnlzyfxh848xalpdwr";
@@ -1005,14 +1000,9 @@
     sha256 = "1mpk7xj76lxgz97a5yg93wi8lj0l8p157a5d50mmjy3gbz1904q8";
   })
   (fetchNuGet {
-    name = "System.Text.Encoding";
-    version = "4.0.11";
-    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
-  })
-  (fetchNuGet {
-    name = "System.Text.Encoding";
+    name = "System.Security.Principal";
     version = "4.3.0";
-    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+    sha256 = "12cm2zws06z4lfc4dn31iqv7072zyi4m910d4r6wm8yx85arsfxf";
   })
   (fetchNuGet {
     name = "System.Text.Encoding.Extensions";
@@ -1025,6 +1015,16 @@
     sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
   })
   (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.0.11";
+    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+  })
+  (fetchNuGet {
     name = "System.Text.RegularExpressions";
     version = "4.1.0";
     sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
@@ -1035,29 +1035,9 @@
     sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
   })
   (fetchNuGet {
-    name = "System.Threading";
-    version = "4.0.11";
-    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
-  })
-  (fetchNuGet {
-    name = "System.Threading";
-    version = "4.3.0";
-    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
-  })
-  (fetchNuGet {
     name = "System.Threading.Overlapped";
     version = "4.3.0";
     sha256 = "1nahikhqh9nk756dh8p011j36rlcp1bzz3vwi2b4m1l2s3vz8idm";
-  })
-  (fetchNuGet {
-    name = "System.Threading.Tasks";
-    version = "4.0.11";
-    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
-  })
-  (fetchNuGet {
-    name = "System.Threading.Tasks";
-    version = "4.3.0";
-    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
   })
   (fetchNuGet {
     name = "System.Threading.Tasks.Extensions";
@@ -1068,6 +1048,16 @@
     name = "System.Threading.Tasks.Extensions";
     version = "4.3.0";
     sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.0.11";
+    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
   })
   (fetchNuGet {
     name = "System.Threading.Thread";
@@ -1083,6 +1073,16 @@
     name = "System.Threading.Timer";
     version = "4.0.1";
     sha256 = "15n54f1f8nn3mjcjrlzdg6q3520571y012mx7v991x2fvp73lmg6";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.0.11";
+    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.3.0";
+    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
   })
   (fetchNuGet {
     name = "System.Xml.ReaderWriter";
@@ -1105,13 +1105,13 @@
     sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
   })
   (fetchNuGet {
-    name = "System.Xml.XPath";
-    version = "4.3.0";
-    sha256 = "1cv2m0p70774a0sd1zxc8fm8jk3i5zk2bla3riqvi8gsm0r4kpci";
-  })
-  (fetchNuGet {
     name = "System.Xml.XPath.XmlDocument";
     version = "4.3.0";
     sha256 = "1h9lh7qkp0lff33z847sdfjj8yaz98ylbnkbxlnsbflhj9xyfqrm";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath";
+    version = "4.3.0";
+    sha256 = "1cv2m0p70774a0sd1zxc8fm8jk3i5zk2bla3riqvi8gsm0r4kpci";
   })
 ]

--- a/pkgs/misc/emulators/ryujinx/log.patch
+++ b/pkgs/misc/emulators/ryujinx/log.patch
@@ -1,8 +1,16 @@
-diff --git a/Ryujinx.Common/Configuration/LoggerModule.cs b/Ryujinx.Common/Configuration/LoggerModule.cs
-index 20c0fb46..534576bc 100644
---- a/Ryujinx.Common/Configuration/LoggerModule.cs
-+++ b/Ryujinx.Common/Configuration/LoggerModule.cs
-@@ -75,7 +75,7 @@ namespace Ryujinx.Configuration
+diff --git a/Ryujinx/Configuration/LoggerModule.cs b/Ryujinx/Configuration/LoggerModule.cs
+index 44631ea0..534576bc 100644
+--- a/Ryujinx/Configuration/LoggerModule.cs
++++ b/Ryujinx/Configuration/LoggerModule.cs
+@@ -1,6 +1,7 @@
+ ﻿using Ryujinx.Common;
+ using Ryujinx.Common.Logging;
+ using System;
++using System.IO;
+
+ namespace Ryujinx.Configuration
+ {
+@@ -74,7 +75,7 @@ namespace Ryujinx.Configuration
              if (e.NewValue)
              {
                  Logger.AddTarget(new AsyncLogTargetWrapper(

--- a/pkgs/misc/emulators/yuzu/base.nix
+++ b/pkgs/misc/emulators/yuzu/base.nix
@@ -44,6 +44,9 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
+    "-DYUZU_USE_BUNDLED_QT=OFF"
+    "-DYUZU_USE_BUNDLED_SDL2=OFF"
+    "-DYUZU_USE_BUNDLED_FFMPEG=OFF"
     "-DENABLE_QT_TRANSLATION=ON"
     "-DYUZU_USE_QT_WEB_ENGINE=ON"
     "-DUSE_DISCORD_PRESENCE=ON"

--- a/pkgs/misc/emulators/yuzu/default.nix
+++ b/pkgs/misc/emulators/yuzu/default.nix
@@ -4,25 +4,25 @@ let
 in {
   mainline = libsForQt5.callPackage ./base.nix rec {
     pname = "yuzu-mainline";
-    version = "576";
+    version = "633";
     branchName = branch;
     src = fetchFromGitHub {
       owner = "yuzu-emu";
       repo = "yuzu-mainline";
       rev = "mainline-0-${version}";
-      sha256 = "121pn3kmghpcf4pzs0mc8z3viyp32rzm7rssva7cdd5016z2648k";
+      sha256 = "1zq20dd6x3kk179ls7y3mc5rj9vr73qs12bdj52bl3kscphxybf1";
       fetchSubmodules = true;
     };
   };
   early-access = libsForQt5.callPackage ./base.nix rec {
     pname = "yuzu-ea";
-    version = "1536";
+    version = "1704";
     branchName = branch;
     src = fetchFromGitHub {
       owner = "pineappleEA";
       repo = "pineapple-src";
       rev = "EA-${version}";
-      sha256 = "0smrx05xxr4b96i8bw6n6pynkl9r21ydfvpjdzxkr9amin20r54y";
+      sha256 = "07pcldcmn8ammzbnxki6by7hgacr6z0548dvhv2p5lp9qcf3xz22";
     };
   };
 }.${branch}


### PR DESCRIPTION
###### Motivation for this change
Update both Nintendo Switch emulators in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
