### PR TITLE
poppler: build with nss by default for signature support

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -65,10 +65,9 @@ stdenv.mkDerivation rec {
     cairo
     lcms
     curl
+    nss
   ] ++ lib.optionals qt5Support [
     qtbase
-  ] ++ lib.optionals utils [
-    nss
   ] ++ lib.optionals introspectionSupport [
     gobject-introspection
   ];


### PR DESCRIPTION
###### Motivation for this change

Since 21.01, poppler supports PDF signing. As applications like okular
start to make use of that feature, nss support for poppler is enabled by
default to avoid unnecessary package duplication.
When building a `minimal` version of poppler, nss is disabled as well.

closes #120928

needs a backport to 21.05, sorry for missing the deadline

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
