### PR TITLE
gnomeExtensions: normalize pnames

### DIFF
--- a/pkgs/desktops/gnome/extensions/arcmenu/default.nix
+++ b/pkgs/desktops/gnome/extensions/arcmenu/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitLab, glib, gettext, substituteAll, gnome-menus }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-arcmenu";
+  pname = "gnome-shell-extension-arcmenu";
   version = "10";
 
   src = fetchFromGitLab {

--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -19,7 +19,7 @@ let
   }:
 
   stdenv.mkDerivation {
-    inherit pname;
+    pname = "gnome-shell-extension-${pname}";
     version = builtins.toString version;
     src = fetchzip {
       url = "https://extensions.gnome.org/extension-data/${

--- a/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-dash-to-dock";
+  pname = "gnome-shell-extension-dash-to-dock";
   version = "69";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome/extensions/dash-to-panel/default.nix
+++ b/pkgs/desktops/gnome/extensions/dash-to-panel/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, glib, gettext }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-dash-to-panel";
+  pname = "gnome-shell-extension-dash-to-panel";
   version = "40";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome/extensions/emoji-selector/default.nix
+++ b/pkgs/desktops/gnome/extensions/emoji-selector/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, glib, gettext }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-emoji-selector";
+  pname = "gnome-shell-extension-emoji-selector";
   version = "19";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome/extensions/freon/default.nix
+++ b/pkgs/desktops/gnome/extensions/freon/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, glib }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-freon";
+  pname = "gnome-shell-extension-freon";
   version = "40";
 
   uuid = "freon@UshakovVasilii_Github.yahoo.com";

--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -18,7 +18,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-gsconnect";
+  pname = "gnome-shell-extension-gsconnect";
   version = "46";
 
   outputs = [ "out" "installedTests" ];

--- a/pkgs/desktops/gnome/extensions/impatience/default.nix
+++ b/pkgs/desktops/gnome/extensions/impatience/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, glib }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-impatience";
+  pname = "gnome-shell-extension-impatience";
   version = "unstable-2019-09-23";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome/extensions/noannoyance/default.nix
+++ b/pkgs/desktops/gnome/extensions/noannoyance/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "noannoyance";
+  pname = "gnome-shell-extension-noannoyance";
   version = "unstable-2021-01-17";
 
   src = fetchFromGitHub {

--- a/pkgs/desktops/gnome/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome/extensions/system-monitor/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, substituteAll, fetchFromGitHub, glib, glib-networking, libgtop, gnome }:
 
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-system-monitor";
+  pname = "gnome-shell-extension-system-monitor";
   version = "unstable-2021-05-04";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
They should have gnome-shell-extension prefix like most other extension packages.
This is what other distros listed on Repology use so Repology will be able to unify them.

Exception is chrome-gnome-shell, which is estabilished under that name.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
