### PR TITLE
[21.05] nixos/manual: document how to install over a serial port

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -46,6 +46,12 @@
    to increase the font size.
   </para>
 
+  <para>
+    To install over a serial port connect with <literal>115200n8</literal>
+    (e.g. <command>picocom -b 115200 /dev/ttyUSB0</command>). When the
+    bootloader lists boot entries, select the serial console boot entry.
+  </para>
+
   <section xml:id="sec-installation-booting-networking">
    <title>Networking in the installer</title>
 


### PR DESCRIPTION
(cherry picked from commit 81e04717e8f30496ec9ec9edb6b0588deca41ee2)

Backported from https://github.com/NixOS/nixpkgs/pull/118993

###### Motivation for this change
This will allow 21.05 users to find docs on how to install via serial port.

###### Things done

I followed https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#backporting-changes .

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
