### PR TITLE
xwallpaper: 0.6.6 -> 0.7.0

### DIFF
--- a/pkgs/tools/X11/xwallpaper/default.nix
+++ b/pkgs/tools/X11/xwallpaper/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , pkg-config
 , autoreconfHook
+, installShellFiles
 , pixman
 , xcbutil
 , xcbutilimage
@@ -13,19 +14,21 @@
 
 stdenv.mkDerivation rec {
   pname = "xwallpaper";
-  version = "0.6.6";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "stoeckmann";
     repo = "xwallpaper";
     rev = "v${version}";
-    sha256 = "sha256-WYtbwMFzvJ0Xr84gGoKSofSSnmb7Qn6ioGMOnQOqdII=";
+    sha256 = "1bpymspnllbscha8j9y67w9ck2l6yv66zdbknv8s13hz5qi1ishk";
   };
 
-  preConfigure = "./autogen.sh";
-
-  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  nativeBuildInputs = [ pkg-config autoreconfHook installShellFiles ];
   buildInputs = [ pixman xcbutilimage xcbutil libseccomp libjpeg libpng libXpm ];
+
+  postInstall = ''
+    installShellCompletion --zsh _xwallpaper
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/stoeckmann/xwallpaper";


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/stoeckmann/xwallpaper/releases/tag/v0.7.0 for details about the changes in this release.

This PR also adds shell completion for zsh, which unfortunately I believe is the only shell currently supported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
