### PR TITLE
xpra: Add NVENC support

### DIFF
--- a/pkgs/development/libraries/nv-codec-headers/10_x.nix
+++ b/pkgs/development/libraries/nv-codec-headers/10_x.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  pname = "nv-codec-headers";
+  version = "10.0.26.2";
+
+  src = fetchgit {
+    url = "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git";
+    rev = "n${version}";
+    sha256 = "0n5jlwjfv5irx1if1g0n52m279bw7ab6bd3jz2v4vwg9cdzbxx85";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "FFmpeg version of headers for NVENC";
+    homepage = "https://ffmpeg.org/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.MP2E ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/tools/X11/xpra/nvenc.pc
+++ b/pkgs/tools/X11/xpra/nvenc.pc
@@ -1,0 +1,11 @@
+prefix=@out@
+includedir=${prefix}/include
+libdir=@nvidia_x11@/lib
+
+Name: nvenc
+Description: NVENC
+Version: 10
+Requires:
+Conflicts:
+Libs: -L${libdir} -lnvidia-encode
+Cflags: -I${includedir}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27614,6 +27614,10 @@ in
   libxpdf = callPackage ../applications/misc/xpdf/libxpdf.nix { };
 
   xpra = callPackage ../tools/X11/xpra { };
+  xpraWithNvenc = callPackage ../tools/X11/xpra {
+    withNvenc = true;
+    nvidia_x11 = linuxPackages.nvidia_x11.override { libsOnly = true; };
+  };
   libfakeXinerama = callPackage ../tools/X11/xpra/libfakeXinerama.nix { };
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17164,6 +17164,7 @@ in
   nuspellWithDicts = dicts: callPackage ../development/libraries/nuspell/wrapper.nix { inherit dicts; };
 
   nv-codec-headers = callPackage ../development/libraries/nv-codec-headers { };
+  nv-codec-headers-10 = callPackage ../development/libraries/nv-codec-headers/10_x.nix { };
 
   mkNvidiaContainerPkg = { name, containerRuntimePath, configTemplate, additionalPaths ? [] }:
     let


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds a variant of Xpra (`xpraWithNvenc`) with the NVENC encoder which requires proprietary NVIDIA drivers. Tested with the Tesla M40 card with [a workaround patch](https://github.com/Xpra-org/xpra/issues/3136) (not included). Upstream documentations are available [here](https://github.com/Xpra-org/xpra/blob/master/docs/Usage/NVENC.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
