### PR TITLE
linuxPackages.mxu11x0: mark broken for kernel>=5.4

### DIFF
--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ uralbash ];
     platforms = platforms.linux;
+    broken = kernel.kernelAtLeast "5.4";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Largely broken for more recent kernels:

https://hydra.nixos.org/eval/1672757?filter=mxu11x0&compare=1672648&full=#tabs-still-fail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
