### PR TITLE
linuxPackages.perf: mark broken for kernels<5

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation {
     description = "Linux tools to profile with performance counters";
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; linux;
+    broken = kernel.kernelOlder "5";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Mark failing builds as broken

https://hydra.nixos.org/eval/1672757?filter=perf.x86_64-linux&compare=1672648&full=#tabs-still-fail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
