### PR TITLE
mdk4: init at unstable-2021-04-27

### DIFF
--- a/pkgs/tools/networking/mdk4/default.nix
+++ b/pkgs/tools/networking/mdk4/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, libnl, libpcap, pkg-config }:
+
+stdenv.mkDerivation {
+  pname = "mdk4";
+  version = "unstable-2021-04-27";
+
+  src = fetchFromGitHub {
+    owner = "aircrack-ng";
+    repo = "mdk4";
+    rev = "e94422ce8e4b8dcd132d658345814df7e63bfa41";
+    sha256 = "sha256-pZS7HQBKlSZJGqoZlSyBUzXC3osswcB56cBzgm+Sbwg=";
+  };
+
+  preBuild = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man
+
+    substituteInPlace src/Makefile --replace '/usr/local/src/mdk4' '$out'
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libnl libpcap ];
+
+  makeFlags = [ "PREFIX=$(out)" "SBINDIR=$(PREFIX)/bin" ];
+
+  meta = with lib; {
+    description = "A tool that injects data into wireless networks";
+    homepage = "https://github.com/aircrack-ng/mdk4";
+    maintainers = with maintainers; [ fortuneteller2k ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6757,6 +6757,8 @@ in
 
   mdk = callPackage ../development/tools/mdk { };
 
+  mdk4 = callPackage ../tools/networking/mdk4 { };
+
   mdp = callPackage ../applications/misc/mdp { };
 
   mednafen = callPackage ../misc/emulators/mednafen { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
