### PR TITLE
nixos/doc/releases: Do not tag the release

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -191,15 +191,6 @@ echo -n "20.03" > .version
     </listitem>
     <listitem>
      <para>
-      Tag the final release
-     </para>
-<programlisting>
-git tag --annotate --message="Release 19.09" 19.09
-git push upstream 19.09
-</programlisting>
-    </listitem>
-    <listitem>
-     <para>
       Update <link xlink:href="https://github.com/NixOS/nixos-homepage">nixos-homepage</link> for the release.
      </para>
      <orderedlist>


### PR DESCRIPTION
I have seen a customer use the release tag as a pinned version
and the same can happen in flake input urls or similar input
configs, like `niv --branch`.
This results in a out of date version of the _all_ system
packages, putting users at risk of security vulnerabilities
and other issues that are addressed during the lifetime of a
Nixpkgs/NixOS release.

So clearly the tag poses a risk, but does it have a benefit?
I don't think so. It does not name the branch-off point, so we
don't need it for git operations. It does not represent the
best or canonical version of the release either, as further
fixes always occur after the release date. If it were the case,
we'd tag all channel updates, but we don't, so for the same
reasons, we should not tag the release.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Always use the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
