### PR TITLE
QCElemental: init at 0.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9161,6 +9161,12 @@
     githubId = 1443459;
     name = "Sheena Artrip";
   };
+  sheepforce = {
+    email = "phillip.seeber@googlemail.com";
+    github = "sheepforce";
+    githubId = 16844216;
+    name = "Phillip Seeber";
+  };
   sheganinans = {
     email = "sheganinans@gmail.com";
     github = "sheganinans";

--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, lib, fetchPypi, numpy, pydantic, pint,
+  networkx, pytestrunner, pytestcov, pytest
+} :
+
+buildPythonPackage rec {
+  pname = "qcelemental";
+  version = "0.20.0";
+
+  checkInputs = [ pytestrunner pytestcov pytest ];
+  propagatedBuildInputs = [ numpy pydantic pint networkx ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "141vw36fmacj897q26kq2bl9l0d23lyqjfry6q46aa9087dcs7ni";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Periodic table, physical constants, and molecule parsing for quantum chemistry.";
+    homepage = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7007,6 +7007,8 @@ in {
 
   qasm2image = throw "qasm2image is no longer maintained (since November 2018), and is not compatible with the latest pythonPackages.qiskit versions."; # added 2020-12-09
 
+  qcelemental = callPackage ../development/python-modules/qcelemental { };
+
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 
   qdldl = callPackage ../development/python-modules/qdldl { };


### PR DESCRIPTION
###### Motivation for this change
Adds QCElemental python library. This is a scientific library, providing constants and tools for computational chemistry. Part of the packages @markuskowa and me want to merge from https://github.com/markuskowa/NixOS-QChem/issues/56.

(see also #124370)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
