### PR TITLE
wooting-udev-rules: add Lekker Edition rules

### DIFF
--- a/pkgs/os-specific/linux/wooting-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/wooting-udev-rules/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   # Source: https://wooting.helpscoutdocs.com/article/68-wootility-configuring-device-access-for-wootility-under-linux-udev-rules
   src = [ ./wooting.rules ];
 
-  unpackPhase = ":";
+  dontUnpack = true;
 
   installPhase = ''
     install -Dpm644 $src $out/lib/udev/rules.d/70-wooting.rules

--- a/pkgs/os-specific/linux/wooting-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/wooting-udev-rules/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "wooting-udev-rules";
-  version = "20190601";
+  version = "20210525";
 
   # Source: https://wooting.helpscoutdocs.com/article/68-wootility-configuring-device-access-for-wootility-under-linux-udev-rules
   src = [ ./wooting.rules ];

--- a/pkgs/os-specific/linux/wooting-udev-rules/wooting.rules
+++ b/pkgs/os-specific/linux/wooting-udev-rules/wooting.rules
@@ -7,3 +7,8 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", MODE:="0
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", MODE:="0660", GROUP="input"
 # Wooting Two update mode
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", MODE:="0660", GROUP="input"
+
+# Wooting Two Lekker Edition
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", ATTRS{idProduct}=="1210", MODE:="0660", GROUP="input"
+# Wooting Two Lekker Edition update mode
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", ATTRS{idProduct}=="121f", MODE:="0660", GROUP="input"


### PR DESCRIPTION
###### Motivation for this change
Vendored udev rules from hardware manufacturer were updated to support new models of keyboard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
