### PR TITLE
wordpress: packages for plugins and themes

### DIFF
--- a/pkgs/servers/web-apps/wordpress/plugins.nix
+++ b/pkgs/servers/web-apps/wordpress/plugins.nix
@@ -1,0 +1,187 @@
+{ lib
+, pkgs
+, fetchurl
+, stdenv
+}:
+
+let
+
+  mkWordpressPlugin = a@{
+    pluginName,
+    namePrefix ? "wordpressplugin-",
+    src,
+    unpackPhase ? "",
+    configurePhase ? ":",
+    buildPhase ? ":",
+    addonInfo ? null,
+    preInstall ? "",
+    postInstall ? "",
+    path ? lib.getName pluginName,
+    ...
+  }:
+    stdenv.mkDerivation (a // {
+      pname = namePrefix + pluginName;
+
+      inherit pluginName unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
+
+      installPhase = "mkdir -p $out; cp -R * $out/";
+    });
+
+in rec {
+  inherit mkWordpressPlugin;
+
+  anti-spam-bee = mkWordpressPlugin {
+    pluginName = "anti-spam-bee";
+    version = "2.9.4";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/antispam-bee.2.9.4.zip";
+      sha256 = "00d2z2z9g08wx8510yd81b6axxhv5cfllrkdvsd6ysa649172ny9";
+    };
+    buildInputs = [ pkgs.unzip ];
+  };
+
+  code-syntax-block = mkWordpressPlugin {
+    pluginName = "code-syntax-block";
+    version = "2.0.3";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/code-syntax-block.2.0.3.zip";
+      sha256 = "1mmwyw8mc9nfh6qil1zji25ghrrhi5z1m8bvk76w6z8xs79q9jmr";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  lightbox-with-photoswipe = mkWordpressPlugin {
+    pluginName = "lightbox-with-photoswipe";
+    version = "3.1.12";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/lightbox-photoswipe.3.1.12.zip";
+      sha256 = "0gzr5cmzrn7ydgi0l7xdmhg2ms2fyhz8j02dccxc3kgd61j9lmzw";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  wp-gdpr-compliance = mkWordpressPlugin {
+    pluginName = "wp-gdpr-compliance";
+    version = "1.5.6";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/wp-gdpr-compliance.1.5.6.zip";
+      sha256 = "1n7wphnc9kj75xigp3rhkw779lv586ni1cnd6g0slyjc1x7s975g";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  co-authors-plus = mkWordpressPlugin {
+    pluginName = "co-authors-plus";
+    version = "3.4.5";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/co-authors-plus.3.4.5.zip";
+      sha256 = "18zzkmpl8m0y4f5ab3vjwn5jx8nla66g89r2lc02gc4mks47j04w";
+    };
+    buildInputs = [ pkgs.unzip pkgs.php ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  wp-statistics = mkWordpressPlugin {
+    pluginName = "wp-statistics";
+    version = "13.0.8";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/wp-statistics.13.0.8.zip";
+      sha256 = "16325x9n9rgkl6nii84vbcvjsrza1dlzrf1n4p3nihfanpd6dgrg";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  wp-user-avatar = mkWordpressPlugin {
+    pluginName = "wp-user-avatar";
+    version = "1.4.0";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/wp-user-avatars.zip";
+      sha256 = "1a1iliq8p20qnn5jq8qyz07cw03kiyggjvd8457dmlf5vhbljp0l";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  opengraph = mkWordpressPlugin {
+    pluginName = "opengraph";
+    version = "1.10.0";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/opengraph.1.10.0.zip";
+      sha256 = "0b9scyppj0l4m416d3sm2pbfz0zlpglrbqpffdk2qvljqdlma8nv";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  simple-login-captcha = mkWordpressPlugin {
+    pluginName = "simple-login-captcha";
+    version = "1.3.3";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/simple-login-captcha.1.3.3.zip";
+      sha256 = "0p2df3h9knfhxfaz4z5b8samq3s9v4pn7ivclldcwwvg9kcmfhmw";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  disable-xml-rpc = mkWordpressPlugin {
+    pluginName = "disable-xml-rpc";
+    version = "1.0.1";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/disable-xml-rpc.1.0.1.zip";
+      sha256 = "1q99yjikc0agpbrm5wrcc0kzrczwfq82w2nvrj13g2b8cix3yaya";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  async-javascript = mkWordpressPlugin {
+    pluginName = "async-javascript";
+    version = "2.20.12.09";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/async-javascript.2.20.12.09.zip";
+      sha256 = "0vgcxs5cmifq931lsla04maif9gvs54139wd55azbraxrh0fxr8f";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  webp-converter-for-media = mkWordpressPlugin {
+    pluginName = "webp-converter-for-media";
+    version = "3.0.1";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/webp-converter-for-media.zip";
+      sha256 = "1rf2h3gpyfdqh43qippplqrflkh50hdypssig1xnvjwga86abwc8";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  breeze = mkWordpressPlugin {
+    pluginName = "breeze";
+    version = "1.2.0";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/breeze.1.2.0.zip";
+      sha256 = "0zjc32fzvqkflva3h0ghz0qwajfza0dzc2hnd1yb02hf4qbyv8vz";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+  jetpack = mkWordpressPlugin {
+    pluginName = "jetpack";
+    version = "9.7";
+    src = fetchurl {
+      url = "https://downloads.wordpress.org/plugin/jetpack.9.7.zip";
+      sha256 = "16sbbk26fc40yngmifs78dqdcsblpfyjj02b9c88ymf2yc0fslxv";
+    };
+    buildInputs = [ pkgs.unzip ];
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
+
+}
+

--- a/pkgs/servers/web-apps/wordpress/plugins.nix
+++ b/pkgs/servers/web-apps/wordpress/plugins.nix
@@ -95,12 +95,12 @@ in rec {
     installPhase = "mkdir -p $out; cp -R * $out/";
   };
 
-  wp-user-avatar = mkWordpressPlugin {
-    pluginName = "wp-user-avatar";
+  wp-user-avatars = mkWordpressPlugin {
+    pluginName = "wp-user-avatars";
     version = "1.4.0";
     src = fetchurl {
       url = "https://downloads.wordpress.org/plugin/wp-user-avatars.zip";
-      sha256 = "1a1iliq8p20qnn5jq8qyz07cw03kiyggjvd8457dmlf5vhbljp0l";
+      sha256 = "1hllvg9xq4ahzj0mjwnzp5slh73f6w99ayg6885cr5imkwbal7v3";
     };
     buildInputs = [ pkgs.unzip ];
     installPhase = "mkdir -p $out; cp -R * $out/";
@@ -152,10 +152,10 @@ in rec {
 
   webp-converter-for-media = mkWordpressPlugin {
     pluginName = "webp-converter-for-media";
-    version = "3.0.1";
+    version = "3.0.3";
     src = fetchurl {
       url = "https://downloads.wordpress.org/plugin/webp-converter-for-media.zip";
-      sha256 = "1rf2h3gpyfdqh43qippplqrflkh50hdypssig1xnvjwga86abwc8";
+      sha256 = "0i55cq2xz3rv60l38iqmldjy4msmd22bnfgk2w6l0ahgfrxn58fq";
     };
     buildInputs = [ pkgs.unzip ];
     installPhase = "mkdir -p $out; cp -R * $out/";

--- a/pkgs/servers/web-apps/wordpress/themes.nix
+++ b/pkgs/servers/web-apps/wordpress/themes.nix
@@ -1,0 +1,44 @@
+{ lib
+, pkgs
+, fetchurl
+, stdenv
+}:
+
+let
+
+  mkWordpressTheme = a@{
+    themeName,
+    namePrefix ? "wordpresstheme-",
+    src,
+    unpackPhase ? "",
+    configurePhase ? ":",
+    buildPhase ? ":",
+    addonInfo ? null,
+    preInstall ? "",
+    postInstall ? "",
+    path ? lib.getName themeName,
+    ...
+  }:
+    stdenv.mkDerivation (a // {
+      pname = namePrefix + themeName;
+
+      inherit themeName unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
+
+      installPhase = "mkdir -p $out; cp -R * $out/";
+    });
+
+in rec {
+  inherit mkWordpressTheme;
+
+  geist = mkWordpressTheme {
+    themeName = "geist";
+    version = "2.0.2";
+    src = fetchurl {
+      url = "https://github.com/christophery/geist/archive/refs/tags/2.0.2.zip";
+      sha256 = "1w1kwas46hcx10n7dy638vr6bjsw0fla4g9wg2d2b3pbpnj0q5mn";
+    };
+    buildInputs = [ pkgs.unzip ];
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31165,9 +31165,10 @@ in
 
   wordpress = callPackage ../servers/web-apps/wordpress { };
 
-  wordpressPlugins = recurseIntoAttrs (callPackage ../servers/web-apps/wordpress/plugins.nix { });
-
-  wordpressThemes = recurseIntoAttrs (callPackage ../servers/web-apps/wordpress/themes.nix { });
+  wordpressPackages = {
+    plugins = recurseIntoAttrs (callPackage ../servers/web-apps/wordpress/plugins.nix { });
+    themes = recurseIntoAttrs (callPackage ../servers/web-apps/wordpress/themes.nix { });
+  };
 
   wprecon = callPackage ../tools/security/wprecon { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31165,6 +31165,10 @@ in
 
   wordpress = callPackage ../servers/web-apps/wordpress { };
 
+  wordpressPlugins = recurseIntoAttrs (callPackage ../servers/web-apps/wordpress/plugins.nix { });
+
+  wordpressThemes = recurseIntoAttrs (callPackage ../servers/web-apps/wordpress/themes.nix { });
+
   wprecon = callPackage ../tools/security/wprecon { };
 
   wraith = callPackage ../applications/networking/irc/wraith {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I packaged some Wordpress themes and plugins in the subset ``wordpressPackages.plugins`` and ``wordpressPackages.themes``. These packages can be used in a Wordpress installation like this:

```
services.wordpress = {
  webserver = "caddy";
  sites."blog.${config.networking.domain}" = {
    plugins = with wordpressPackages.plugins; [
      anti-spam-bee
      code-syntax-block
      lightbox-with-photoswipe
      wp-gdpr-compliance
    ];
    themes = [ wordpressPackages.themes.geist ];
  };
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
