### PR TITLE
Iosevka-SS08: init at v6.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11557,6 +11557,7 @@
     github = "zupo";
     githubId = 311580;
   };
+<<<<<<< HEAD
    wearemnr = {                                                                     
      name = "wearemnr"; 
      email = "wearemnr@pm.me";
@@ -11566,4 +11567,15 @@
        longkeyid = "rsa4096/0x57ACCBC2EF186569";
        fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";
      }];
+=======
+  wearemnr = {                                                                     
+    name = "wearemnr"; 
+    email = "wearemnr@pm.me";
+    github = "wearemnr";        
+    githubId = 84216991;
+    keys = [{
+      longkeyid = "rsa4096/0x57ACCBC2EF186569";
+      fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";
+    }];
+>>>>>>> 6c60eaa2 (maintainer-list.nix: Removed whitespaces)
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11551,4 +11551,13 @@
     github = "zupo";
     githubId = 311580;
   };
+   wearemnr = {                                                                     
+     name = "wearemnr";                                                             
+     email = "wearemnr@pm.me";                                           
+     github = "wearemnr";                                                           
+     githubId = 84216991;                                                         
+     keys = [{                                                                   
+       longkeyid = "rsa4096/0x57ACCBC2EF186569";                                 
+       fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";       
+     }];
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11557,25 +11557,13 @@
     github = "zupo";
     githubId = 311580;
   };
-<<<<<<< HEAD
-   wearemnr = {                                                                     
-     name = "wearemnr"; 
-     email = "wearemnr@pm.me";
-     github = "wearemnr";        
-     githubId = 84216991;
-     keys = [{
-       longkeyid = "rsa4096/0x57ACCBC2EF186569";
-       fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";
-     }];
-=======
   wearemnr = {                                                                     
-    name = "wearemnr"; 
+    name = "wearemnr";
     email = "wearemnr@pm.me";
-    github = "wearemnr";        
+    github = "wearemnr";
     githubId = 84216991;
     keys = [{
       longkeyid = "rsa4096/0x57ACCBC2EF186569";
       fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";
     }];
->>>>>>> 6c60eaa2 (maintainer-list.nix: Removed whitespaces)
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11557,7 +11557,7 @@
     github = "zupo";
     githubId = 311580;
   };
-  wearemnr = {                                                                     
+  wearemnr = {
     name = "wearemnr";
     email = "wearemnr@pm.me";
     github = "wearemnr";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11558,12 +11558,12 @@
     githubId = 311580;
   };
    wearemnr = {                                                                     
-     name = "wearemnr";                                                             
-     email = "wearemnr@pm.me";                                           
-     github = "wearemnr";                                                           
-     githubId = 84216991;                                                         
-     keys = [{                                                                   
-       longkeyid = "rsa4096/0x57ACCBC2EF186569";                                 
-       fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";       
+     name = "wearemnr"; 
+     email = "wearemnr@pm.me";
+     github = "wearemnr";        
+     githubId = 84216991;
+     keys = [{
+       longkeyid = "rsa4096/0x57ACCBC2EF186569";
+       fingerprint = "8446 8A86 646F CEAA 9FA2  B823 57AC CBC2 EF18 6569";
      }];
 }

--- a/pkgs/data/fonts/iosevka-fixed-ss08/default.nix
+++ b/pkgs/data/fonts/iosevka-fixed-ss08/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchzip }:
+
+let
+  version = "6.1.3";
+in
+
+fetchzip rec {
+  name = "ttf-iosevka-fixed-ss08-${version}";
+
+  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/${name}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.ttf    -d $out/share/fonts/Iosevka-Fixed-SS08
+  '';
+
+  sha256 = "BYqybpqfEBu69H4K4/n7Dv3A9plNgM95sAg9E98GzoQ=";
+
+  meta = with lib; {
+    homepage = "https://github.com/be5invis/Iosevka";
+    description = "A font family with a great monospaced variant for programmers";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.wearemnr ];
+  };
+}

--- a/pkgs/data/fonts/iosevka-ss08/default.nix
+++ b/pkgs/data/fonts/iosevka-ss08/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchzip }:
+
+let
+  version = "6.1.3";
+in
+
+fetchzip rec {
+  name = "ttf-iosevka-ss08-${version}";
+
+  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/${name}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.ttf    -d $out/share/fonts/Iosevka-SS08
+  '';
+
+  sha256 = "nkmMsSBrkvTDfQQdJ0XXh4z5TapP1pEdYmMlgLhkm5A=";
+
+  meta = with lib; {
+    homepage = "https://github.com/be5invis/Iosevka";
+    description = "A font family with a great monospaced variant for programmers";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.wearemnr ];
+  };
+}

--- a/pkgs/data/fonts/iosevka-term-ss08/default.nix
+++ b/pkgs/data/fonts/iosevka-term-ss08/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchzip }:
+
+let
+  version = "6.1.3";
+in
+
+fetchzip rec {
+  name = "ttf-iosevka-term-ss08-${version}";
+
+  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/${name}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.ttf    -d $out/share/fonts/Iosevka-Term-SS08
+  '';
+
+  sha256 = "yKHCUtodZVzyxp1LJqqHl3nX6yjwZl/2g3kdReNxXMY=";
+
+  meta = with lib; {
+    homepage = "https://github.com/be5invis/Iosevka";
+    description = "A font family with a great monospaced variant for programmers";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.wearemnr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21793,6 +21793,10 @@ in
 
   inriafonts = callPackage ../data/fonts/inriafonts { };
 
+  iosevka-ss08 = callPackage ../data/fonts/iosevka-ss08 {};
+  iosevka-term-ss08 = callPackage ../data/fonts/iosevka-term-ss08 {};
+  iosevka-fixed-ss08 = callPackage ../data/fonts/iosevka-fixed-ss08 {};
+
   iosevka = callPackage ../data/fonts/iosevka {};
   iosevka-bin = callPackage ../data/fonts/iosevka/bin.nix {};
 


### PR DESCRIPTION
###### Motivation for this change
Iosevka-SS08: init at v6.1.3

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
