### PR TITLE
python3Packages.frozenlist: init at 1.1.1, python3Packages.aiosignal: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/aiosignal/default.nix
+++ b/pkgs/development/python-modules/aiosignal/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, frozenlist
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aiosignal";
+  version = "1.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "aio-libs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0a9md2dy83qwg2an57nqrzp9nb7krq27y9zz0f7qxcrv0xd42djy";
+  };
+
+  propagatedBuildInputs = [
+    frozenlist
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--cov=aiosignal" ""
+  '';
+
+  pythonImportsCheck = [ "aiosignal" ];
+
+  meta = with lib; {
+    description = "Python list of registered asynchronous callbacks";
+    homepage = "https://github.com/aio-libs/aiosignal";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/frozenlist/default.nix
+++ b/pkgs/development/python-modules/frozenlist/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, cython
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "frozenlist";
+  version = "1.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "aio-libs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07z33vid7s8fjwvybyn8357yvs0f6nlhizv1l3qj1bczi3jbdkbh";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--cov=frozenlist" ""
+  '';
+
+  preBuild = ''
+    cython frozenlist/_frozenlist.pyx
+  '';
+
+  pythonImportsCheck = [ "frozenlist" ];
+
+  meta = with lib; {
+    description = "Python module for list-like structure";
+    homepage = "https://github.com/aio-libs/frozenlist";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -333,6 +333,8 @@ in {
 
   aioshelly = callPackage ../development/python-modules/aioshelly { };
 
+  aiosignal = callPackage ../development/python-modules/aiosignal { };
+
   aiosmb = callPackage ../development/python-modules/aiosmb { };
 
   aiosmtpd = callPackage ../development/python-modules/aiosmtpd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2619,6 +2619,8 @@ in {
 
   frozendict = callPackage ../development/python-modules/frozendict { };
 
+  frozenlist = callPackage ../development/python-modules/frozenlist { };
+
   fs = callPackage ../development/python-modules/fs { };
 
   fs-s3fs = callPackage ../development/python-modules/fs-s3fs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python list of registered asynchronous callbacks.

https://github.com/aio-libs/aiosignal

FrozenList is a list-like structure which implements collections.abc.MutableSequence, and which can be made immutable.

https://github.com/aio-libs/frozenlist

This will become a new dependency for `aiohttp` > 4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
