### PR TITLE
dconf2nix: 0.0.7 -> 0.0.8

### DIFF
--- a/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
+++ b/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
@@ -1,13 +1,13 @@
-{ mkDerivation, base, containers, fetchgit, hedgehog
-, optparse-applicative, parsec, lib, template-haskell, text
+{ mkDerivation, base, containers, fetchgit, hedgehog, lib
+, optparse-applicative, parsec, template-haskell, text
 }:
 mkDerivation {
   pname = "dconf2nix";
-  version = "0.0.7";
+  version = "0.0.8";
   src = fetchgit {
     url = "https://github.com/gvolpe/dconf2nix.git";
-    sha256 = "04p8di1ckv5fkfa61pjg5xp8vcw091lz1kw39lh4w8ks2zjwaha1";
-    rev = "34c523e920b79208c3b4c0ad371900b0948799f7";
+    sha256 = "19jk3p0ys3lbqk21lm37a7alkg2vhnmkvcffjqfxrw8p4737hxid";
+    rev = "6bf3d7d4ca9f553a9e1ba4a70a65640114d230b2";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
