### PR TITLE
lispPackages: fix darwin builds

### DIFF
--- a/pkgs/development/lisp-modules/clwrapper/setup-hook.sh
+++ b/pkgs/development/lisp-modules/clwrapper/setup-hook.sh
@@ -9,7 +9,7 @@ addASDFPaths () {
 }
 
 setLisp () {
-    if [ -z "${NIX_LISP_COMMAND:-}" ]; then 
+    if [ -z "${NIX_LISP_COMMAND:-}" ]; then
       for j in "$1"/bin/*; do
           case "$(basename "$j")" in
               sbcl) NIX_LISP_COMMAND="$j" ;;
@@ -20,13 +20,13 @@ setLisp () {
           esac
       done
     fi
-    if [ -n "${NIX_LISP_COMMAND:-}" ] && [ -z "${NIX_LISP:-}" ]; then 
+    if [ -n "${NIX_LISP_COMMAND:-}" ] && [ -z "${NIX_LISP:-}" ]; then
         NIX_LISP="${NIX_LISP_COMMAND##*/}"
     fi
 }
 
 collectNixLispLDLP () {
-     if echo "$1/lib"/lib*.so* | grep . > /dev/null; then
+     if echo "$1/lib"/lib*.{so,dylib}* | grep . > /dev/null; then
 	 export NIX_LISP_LD_LIBRARY_PATH="${NIX_LISP_LD_LIBRARY_PATH-}${NIX_LISP_LD_LIBRARY_PATH:+:}$1/lib"
      fi
 }

--- a/pkgs/development/lisp-modules/clwrapper/setup-hook.sh
+++ b/pkgs/development/lisp-modules/clwrapper/setup-hook.sh
@@ -27,7 +27,7 @@ setLisp () {
 
 collectNixLispLDLP () {
      if echo "$1/lib"/lib*.{so,dylib}* | grep . > /dev/null; then
-	 export NIX_LISP_LD_LIBRARY_PATH="${NIX_LISP_LD_LIBRARY_PATH-}${NIX_LISP_LD_LIBRARY_PATH:+:}$1/lib"
+     export NIX_LISP_LD_LIBRARY_PATH="${NIX_LISP_LD_LIBRARY_PATH-}${NIX_LISP_LD_LIBRARY_PATH:+:}$1/lib"
      fi
 }
 


### PR DESCRIPTION
###### Motivation for this change

Some packages don't compile on darwin since they require library finishing with `.dylib` extension.

Example: `cl-ffi-gtk-gdk` doesn't compile without this PR.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
