### PR TITLE
python3Packages.corsair-scan: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/corsair-scan/default.nix
+++ b/pkgs/development/python-modules/corsair-scan/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, pythonOlder
+, requests
+, tldextract
+, urllib3
+, validators
+}:
+
+buildPythonPackage rec {
+  pname = "corsair-scan";
+  version = "0.2.0";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "Santandersecurityresearch";
+    repo = "corsair_scan";
+    rev = "v${version}";
+    sha256 = "09jsv5bag7mjy0rxsxjzmg73rjl7qknzr0d7a7himd7v6a4ikpmk";
+  };
+
+  propagatedBuildInputs = [
+    validators
+    requests
+    urllib3
+    tldextract
+    click
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'," ""
+  '';
+
+  pythonImportsCheck = [ "corsair_scan" ];
+
+  meta = with lib; {
+    description = "Python module to check for Cross-Origin Resource Sharing (CORS) misconfigurations";
+    homepage = "https://github.com/Santandersecurityresearch/corsair_scan";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1356,6 +1356,8 @@ in
 
   coolreader = libsForQt5.callPackage ../applications/misc/coolreader {};
 
+  corsair = with python3Packages; toPythonApplication corsair-scan;
+
   corsmisc = callPackage ../tools/security/corsmisc { };
 
   cosign = callPackage ../tools/security/cosign {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1574,6 +1574,8 @@ in {
 
   coronavirus = callPackage ../development/python-modules/coronavirus { };
 
+  corsair-scan = callPackage ../development/python-modules/corsair-scan { };
+
   cot = callPackage ../development/python-modules/cot { };
 
   covCore = callPackage ../development/python-modules/cov-core { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module/CLI to check for Cross-Origin Resource Sharing (CORS) misconfigurations

https://github.com/Santandersecurityresearch/corsair_scan

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
