### PR TITLE
web/cypress: fixed binary_state.json to be in opt

### DIFF
--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation rec {
     # Cypress now verifies version by reading bin/resources/app/package.json
     mkdir -p $out/bin/resources/app
     printf '{"version":"%b"}' $version > $out/bin/resources/app/package.json
-    # Cypress now looks for binary_state.json in bin
-    echo '{"verified": true}' > $out/binary_state.json
+    # Cypress now looks for binary_state.json in opt
+    echo '{"verified": true}' > $out/opt/binary_state.json
     ln -s $out/opt/cypress/Cypress $out/bin/Cypress
 
     runHook postInstall


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Cypress does not run with the official nix derivation

```
  ✖  Verifying Cypress can run /nix/store/1b7qag5jsl7slqskh0034rc17m5j2kal-cypress-7.1.0/bin
    → EROFS: read-only file system, open '/nix/store/1b7qag5jsl7slqskh0034rc17m5j2kal-cypress-7.1.0/binary_state.json'
An unexpected error occurred while verifying the Cypress executable.

Please search Cypress documentation for possible solutions:

https://on.cypress.io

Check if there is a GitHub issue describing this crash:

https://github.com/cypress-io/cypress/issues

Consider opening a new issue.

----------

Error: EROFS: read-only file system, open '/nix/store/1b7qag5jsl7slqskh0034rc17m5j2kal-cypress-7.1.0/binary_state.json'

----------

Platform: linux (Raspbian - 20.09.20210228.df8e3bd)
Cypress Version: 7.1.0


```

Just for reference, it was tested on NixOS, not on Raspbian, opposed to the error message output.

This was easy to fix, by placing the `binary_state.json` file into the correct directory. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
