### PR TITLE
[21.05] python3Packages.lightgbm: fix for darwin

### DIFF
--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -23,19 +23,7 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  # we never actually explicitly call the install command so this is the only way
-  # to inject these options to it - however, openmp-library doesn't appear to have
-  # any effect, so we have to inject it into NIX_LDFLAGS manually below
-  postPatch = lib.optionalString stdenv.cc.isClang ''
-    cat >> setup.cfg <<EOF
-
-    [install]
-    openmp-include-dir=${llvmPackages.openmp}/include
-    openmp-library=${llvmPackages.openmp}/lib/libomp.dylib
-
-    EOF
-  '';
-
+  buildInputs = lib.optional stdenv.cc.isClang [ llvmPackages.openmp ];
   propagatedBuildInputs = [
     numpy
     scipy
@@ -44,14 +32,13 @@ buildPythonPackage rec {
 
   postConfigure = ''
     export HOME=$(mktemp -d)
-  '' + lib.optionalString stdenv.cc.isClang ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -L${llvmPackages.openmp}/lib -lomp"
   '';
 
   # The pypi package doesn't distribute the tests from the GitHub
   # repository. It contains c++ tests which don't seem to wired up to
   # `make check`.
   doCheck = false;
+  pythonImportsCheck = [ "lightgbm" ];
 
   meta = with lib; {
     description = "A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework";


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042 

Backport of #124316

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
