### PR TITLE
[21.05] python3Packages.scikit-learn: unbreak darwin

### DIFF
--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -66,10 +66,23 @@ buildPythonPackage rec {
 
   doCheck = !stdenv.isAarch64;
 
-  # Skip test_feature_importance_regression - does web fetch
-  disabledTests = [ "test_feature_importance_regression" ];
+  disabledTests = [
+    # Skip test_feature_importance_regression - does web fetch
+    "test_feature_importance_regression"
+  ];
 
-  pytestFlagsArray = [ "-n" "$NIX_BUILD_CORES" "--pyargs" "sklearn" ];
+  pytestFlagsArray = [
+    # verbose build outputs needed to debug hard-to-reproduce hydra failures
+    "-v"
+    "--pyargs" "sklearn"
+    # NuSVC memmap tests causes segmentation faults in certain environments
+    # (e.g. Hydra Darwin machines) related to a long-standing joblib issue
+    # (https://github.com/joblib/joblib/issues/563). See also:
+    # https://github.com/scikit-learn/scikit-learn/issues/17582
+    "-k 'not (NuSVC and memmap)'"
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    "-n" "$NIX_BUILD_CORES"
+  ];
 
   preCheck = ''
     cd $TMPDIR

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -69,18 +69,25 @@ buildPythonPackage rec {
   disabledTests = [
     # Skip test_feature_importance_regression - does web fetch
     "test_feature_importance_regression"
+
+    # failing on macos
+    "check_regressors_train"
+    "check_classifiers_train"
+    "xfail_ignored_in_check_estimator"
   ];
 
   pytestFlagsArray = [
     # verbose build outputs needed to debug hard-to-reproduce hydra failures
     "-v"
     "--pyargs" "sklearn"
+
     # NuSVC memmap tests causes segmentation faults in certain environments
     # (e.g. Hydra Darwin machines) related to a long-standing joblib issue
     # (https://github.com/joblib/joblib/issues/563). See also:
     # https://github.com/scikit-learn/scikit-learn/issues/17582
-    "-k 'not (NuSVC and memmap)'"
-  ] ++ lib.optionals (!stdenv.isDarwin) [
+    # Since we are overriding '-k' we need to include the 'disabledTests' from above manually.
+    "-k" "'not (NuSVC and memmap) ${toString (lib.forEach disabledTests (t: "and not ${t}"))}'"
+
     "-n" "$NIX_BUILD_CORES"
   ];
 
@@ -102,6 +109,6 @@ buildPythonPackage rec {
       "https://scikit-learn.org/stable/whats_new/v${major}.${minor}.html#version-${dashVer}";
     homepage = "https://scikit-learn.org";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ davhau ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Backport of #124255

ZHF #122042 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
