### PR TITLE
nixos/boot: test on aarch64

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -292,7 +292,12 @@ class Machine:
             net_frontend += "," + args["netFrontendArgs"]
 
         start_command = (
-            "qemu-kvm -m 384 " + net_backend + " " + net_frontend + " $QEMU_OPTS "
+            args.get("qemuBinary", "qemu-kvm")
+            + " -m 384 "
+            + net_backend
+            + " "
+            + net_frontend
+            + " $QEMU_OPTS "
         )
 
         if "hda" in args:

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -43,7 +43,7 @@ in
   bitcoind = handleTest ./bitcoind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};
   blockbook-frontend = handleTest ./blockbook-frontend.nix {};
-  boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
+  boot = handleTestOn ["x86_64-linux" "aarch64-linux"] ./boot.nix {};
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};
   botamusique = handleTest ./botamusique.nix {};

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -4,6 +4,7 @@
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
+with import ../lib/qemu-flags.nix { inherit pkgs; };
 with pkgs.lib;
 
 let
@@ -21,7 +22,10 @@ let
 
   makeBootTest = name: extraConfig:
     let
-      machineConfig = pythonDict ({ qemuFlags = "-m 768"; } // extraConfig);
+      machineConfig = pythonDict ({
+        qemuBinary = qemuBinary pkgs.qemu_test;
+        qemuFlags = "-m 768";
+      } // extraConfig);
     in
       makeTest {
         inherit iso;
@@ -61,6 +65,7 @@ let
         ];
       };
       machineConfig = pythonDict ({
+        qemuBinary = qemuBinary pkgs.qemu_test;
         qemuFlags = "-boot order=n -m 2000";
         netBackendArgs = "tftp=${ipxeBootDir},bootfile=netboot.ipxe";
       } // extraConfig);
@@ -75,8 +80,27 @@ let
             machine.shutdown()
           '';
       };
+  uefiBinary = {
+    x86_64-linux = "${pkgs.OVMF.fd}/FV/OVMF.fd";
+    aarch64-linux = "${pkgs.OVMF.fd}/FV/QEMU_EFI.fd";
+  }.${pkgs.stdenv.hostPlatform.system};
 in {
+    uefiCdrom = makeBootTest "uefi-cdrom" {
+      cdrom = "${iso}/iso/${iso.isoName}";
+      bios = uefiBinary;
+    };
 
+    uefiUsb = makeBootTest "uefi-usb" {
+      usb = "${iso}/iso/${iso.isoName}";
+      bios = uefiBinary;
+    };
+
+    uefiNetboot = makeNetbootTest "uefi" {
+      bios = uefiBinary;
+      # Custom ROM is needed for EFI PXE boot. I failed to understand exactly why, because QEMU should still use iPXE for EFI.
+      netFrontendArgs = "romfile=${pkgs.ipxe}/ipxe.efirom";
+    };
+} // optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
     biosCdrom = makeBootTest "bios-cdrom" {
       cdrom = "${iso}/iso/${iso.isoName}";
     };
@@ -85,21 +109,5 @@ in {
       usb = "${iso}/iso/${iso.isoName}";
     };
 
-    uefiCdrom = makeBootTest "uefi-cdrom" {
-      cdrom = "${iso}/iso/${iso.isoName}";
-      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
-    };
-
-    uefiUsb = makeBootTest "uefi-usb" {
-      usb = "${iso}/iso/${iso.isoName}";
-      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
-    };
-
     biosNetboot = makeNetbootTest "bios" {};
-
-    uefiNetboot = makeNetbootTest "uefi" {
-      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
-      # Custom ROM is needed for EFI PXE boot. I failed to understand exactly why, because QEMU should still use iPXE for EFI.
-      netFrontendArgs = "romfile=${pkgs.ipxe}/ipxe.efirom";
-    };
 }

--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, perl, cdrkit, syslinux, xz, openssl, gnu-efi, mtools
+{ stdenv, lib, fetchFromGitHub, perl, cdrkit, xz, openssl, gnu-efi, mtools
+, syslinux ? null
 , embedScript ? null
 , additionalTargets ? {}
 }:
@@ -8,12 +9,20 @@ let
     "bin-x86_64-efi/ipxe.efi" = null;
     "bin-x86_64-efi/ipxe.efirom" = null;
     "bin-x86_64-efi/ipxe.usb" = "ipxe-efi.usb";
-  } // {
+  } // lib.optionalAttrs (stdenv.isi686 || stdenv.isx86_64) {
     "bin/ipxe.dsk" = null;
     "bin/ipxe.usb" = null;
     "bin/ipxe.iso" = null;
     "bin/ipxe.lkrn" = null;
     "bin/undionly.kpxe" = null;
+  } // lib.optionalAttrs stdenv.isAarch32 {
+    "bin-arm32-efi/ipxe.efi" = null;
+    "bin-arm32-efi/ipxe.efirom" = null;
+    "bin-arm32-efi/ipxe.usb" = "ipxe-efi.usb";
+  } // lib.optionalAttrs stdenv.isAarch64 {
+    "bin-arm64-efi/ipxe.efi" = null;
+    "bin-arm64-efi/ipxe.efirom" = null;
+    "bin-arm64-efi/ipxe.usb" = "ipxe-efi.usb";
   };
 in
 
@@ -21,7 +30,7 @@ stdenv.mkDerivation rec {
   pname = "ipxe";
   version = "1.21.1";
 
-  nativeBuildInputs = [ perl cdrkit syslinux xz openssl gnu-efi mtools ];
+  nativeBuildInputs = [ perl cdrkit xz openssl gnu-efi mtools ] ++ lib.optional (stdenv.isi686 || stdenv.isx86_64) syslinux;
 
   src = fetchFromGitHub {
     owner = "ipxe";
@@ -37,6 +46,7 @@ stdenv.mkDerivation rec {
 
   makeFlags =
     [ "ECHO_E_BIN_ECHO=echo" "ECHO_E_BIN_ECHO_E=echo" # No /bin/echo here.
+    ] ++ lib.optionals (stdenv.isi686 || stdenv.isx86_64) [
       "ISOLINUX_BIN_LIST=${syslinux}/share/syslinux/isolinux.bin"
       "LDLINUX_C32=${syslinux}/share/syslinux/ldlinux.c32"
     ] ++ lib.optional (embedScript != null) "EMBED=${embedScript}";
@@ -80,6 +90,6 @@ stdenv.mkDerivation rec {
       homepage = "https://ipxe.org/";
       license = licenses.gpl2;
       maintainers = with maintainers; [ ehmry ];
-      platforms = [ "x86_64-linux" "i686-linux" ];
+      platforms = platforms.linux;
     };
 }

--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -72,6 +72,8 @@ stdenv.mkDerivation rec {
   buildFlags = lib.attrNames targets;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList (from: to:
       if to == null
@@ -81,6 +83,8 @@ stdenv.mkDerivation rec {
     # Some PXE constellations especially with dnsmasq are looking for the file with .0 ending
     # let's provide it as a symlink to be compatible in this case.
     ln -s undionly.kpxe $out/undionly.kpxe.0
+
+    runHook postInstall
   '';
 
   enableParallelBuilding = true;
@@ -88,7 +92,7 @@ stdenv.mkDerivation rec {
   meta = with lib;
     { description = "Network boot firmware";
       homepage = "https://ipxe.org/";
-      license = licenses.gpl2;
+      license = licenses.gpl2Only;
       maintainers = with maintainers; [ ehmry ];
       platforms = platforms.linux;
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add aarch64 support for `nixosTests.boot.uefiCdrom` `nixosTests.boot.uefiUsb` and `nixosTests.boot.uefiNetboot`.

Related: https://github.com/NixOS/nixpkgs/issues/106304

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
