### PR TITLE
cpython: enable conservative performance improvement that doesn't harm reproducibility

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -41,6 +41,8 @@
 , enableOptimizations ? false
 # enableNoSemanticInterposition is a subset of the enableOptimizations flag that doesn't harm reproducibility.
 , enableNoSemanticInterposition ? true
+# enableLTO is a subset of the enableOptimizations flag that doesn't harm reproducibility.
+, enableLTO ? true
 , reproducibleBuild ? true
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:
@@ -102,6 +104,8 @@ let
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     buildPackages.stdenv.cc
     pythonForBuild
+  ] ++ optionals (stdenv.cc.isClang && enableLTO) [
+    stdenv.cc.cc.libllvm.out
   ];
 
   buildInputs = filter (p: p != null) ([
@@ -276,6 +280,8 @@ in with passthru; stdenv.mkDerivation {
     "--with-system-ffi"
   ] ++ optionals enableOptimizations [
     "--enable-optimizations"
+  ] ++ optionals enableLTO [
+    "--with-lto"
   ] ++ optionals (pythonOlder "3.7") [
     # This is unconditionally true starting in CPython 3.7.
     "--with-threads"

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -39,6 +39,8 @@
 , includeSiteCustomize ? true
 , static ? stdenv.hostPlatform.isStatic
 , enableOptimizations ? false
+# enableNoSemanticInterposition is a subset of the enableOptimizations flag that doesn't harm reproducibility.
+, enableNoSemanticInterposition ? true
 , reproducibleBuild ? true
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:
@@ -323,6 +325,17 @@ in with passthru; stdenv.mkDerivation {
     export DETERMINISTIC_BUILD=1;
   '' + optionalString stdenv.hostPlatform.isMusl ''
     export NIX_CFLAGS_COMPILE+=" -DTHREAD_STACK_SIZE=0x100000"
+  '' +
+
+  # enableNoSemanticInterposition essentially sets that CFLAG -fno-semantic-interposition
+  # which changes how symbols are looked up. This essentially means we can't override
+  # libpython symbols via LD_PRELOAD anymore. This is common enough as every build
+  # that uses --enable-optimizations has the same "issue".
+  #
+  # The Fedora wiki has a good article about their journey towards enabling this flag:
+  # https://fedoraproject.org/wiki/Changes/PythonNoSemanticInterpositionSpeedup
+  optionalString enableNoSemanticInterposition ''
+    export CFLAGS_NODIST="-fno-semantic-interposition"
   '';
 
   setupHook = python-setup-hook sitePackages;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -225,6 +225,7 @@ in {
     stripBytecode = true;
     includeSiteCustomize = false;
     enableOptimizations = false;
+    enableLTO = false;
     mimetypesSupport = false;
   } // sources.python39)).overrideAttrs(old: {
     pname = "python3-minimal";


### PR DESCRIPTION
###### Motivation for this change

Since a large portion of the Nix ecosystem has moved the discussions to Matrix I started running Synapse homeservers. Now, knowing that we have a bit of a sub-optimal performance situation with Python, I started digging what could be done without harming our reproducibility efforts.

This PR contains two commits that can be picked up individually but collectively provide a nice improvement to our Python performance.

The LTO patch (2nd commit) is probably debatable as the improvements aren't as clear as those proposed in the first.

Both of these are a subset of the `--enable-optimizations` hammer that we currently aren't enabling as PGO (which is enabled when providing that flag) isn't entirely reproducible.

On both of the changes running the build twice with `--check` on my AMD box did reproduce successfully. We should also test this with Intel CPUs.

In good faith I've enabled both of these flags regardless of the fact that the build environment is based on Clang. I've not yet tried this on a Darwin machine but I will do so and eventually make the required adjustments.

Here are the benchmark results (of all the proposed changes) relative to our base version in unstable:

```
+-------------------------+---------------+------------------------+--------------+------------------------+
| Benchmark               | py39.nix.json | py39-nsip-lto.nix.json | Change       | Significance           |
+=========================+===============+========================+==============+========================+
| 2to3                    | 666 ms        | 620 ms                 | 1.07x faster | Significant (t=24.89)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| chameleon               | 15.0 ms       | 14.4 ms                | 1.04x faster | Significant (t=15.98)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| chaos                   | 198 ms        | 182 ms                 | 1.08x faster | Significant (t=14.40)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| crypto_pyaes            | 185 ms        | 172 ms                 | 1.07x faster | Significant (t=15.90)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| deltablue               | 12.3 ms       | 11.2 ms                | 1.10x faster | Significant (t=14.74)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| django_template         | 85.1 ms       | 81.4 ms                | 1.04x faster | Significant (t=9.42)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| dulwich_log             | 102 ms        | 99.8 ms                | 1.02x faster | Significant (t=8.11)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| fannkuch                | 670 ms        | 638 ms                 | 1.05x faster | Significant (t=8.25)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| float                   | 182 ms        | 189 ms                 | 1.04x slower | Significant (t=-2.36)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| go                      | 393 ms        | 365 ms                 | 1.08x faster | Significant (t=15.33)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| hexiom                  | 15.8 ms       | 15.1 ms                | 1.05x faster | Significant (t=11.08)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| json_dumps              | 19.3 ms       | 18.5 ms                | 1.04x faster | Significant (t=8.48)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| json_loads              | 38.4 us       | 37.3 us                | 1.03x faster | Significant (t=7.08)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| logging_format          | 15.0 us       | 14.3 us                | 1.05x faster | Significant (t=5.78)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| logging_silent          | 328 ns        | 313 ns                 | 1.05x faster | Significant (t=6.25)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| logging_simple          | 13.8 us       | 13.2 us                | 1.05x faster | Significant (t=7.55)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| mako                    | 25.2 ms       | 23.3 ms                | 1.08x faster | Significant (t=13.59)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| meteor_contest          | 133 ms        | 128 ms                 | 1.04x faster | Significant (t=7.90)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| nbody                   | 222 ms        | 201 ms                 | 1.10x faster | Significant (t=27.18)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| nqueens                 | 161 ms        | 154 ms                 | 1.04x faster | Significant (t=7.55)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pathlib                 | 28.4 ms       | 26.2 ms                | 1.09x faster | Significant (t=13.88)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pickle                  | 13.8 us       | 13.7 us                | 1.00x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pickle_dict             | 32.7 us       | 27.1 us                | 1.21x faster | Significant (t=28.81)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pickle_list             | 4.39 us       | 4.31 us                | 1.02x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pickle_pure_python      | 782 us        | 759 us                 | 1.03x faster | Significant (t=6.59)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pidigits                | 184 ms        | 181 ms                 | 1.02x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| pyflate                 | 1.02 sec      | 974 ms                 | 1.05x faster | Significant (t=16.47)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| python_startup          | 34.3 ms       | 31.4 ms                | 1.09x faster | Significant (t=33.66)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| python_startup_no_site  | 15.5 ms       | 14.5 ms                | 1.07x faster | Significant (t=24.08)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| raytrace                | 912 ms        | 846 ms                 | 1.08x faster | Significant (t=11.43)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| regex_compile           | 273 ms        | 261 ms                 | 1.05x faster | Significant (t=6.02)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| regex_dna               | 188 ms        | 221 ms                 | 1.18x slower | Significant (t=-39.97) |
+-------------------------+---------------+------------------------+--------------+------------------------+
| regex_effbot            | 3.37 ms       | 3.98 ms                | 1.18x slower | Significant (t=-34.45) |
+-------------------------+---------------+------------------------+--------------+------------------------+
| regex_v8                | 29.8 ms       | 29.3 ms                | 1.02x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| richards                | 119 ms        | 110 ms                 | 1.08x faster | Significant (t=15.46)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| scimark_fft             | 625 ms        | 590 ms                 | 1.06x faster | Significant (t=20.15)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| scimark_lu              | 273 ms        | 265 ms                 | 1.03x faster | Significant (t=6.43)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| scimark_monte_carlo     | 186 ms        | 177 ms                 | 1.05x faster | Significant (t=6.52)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| scimark_sor             | 330 ms        | 315 ms                 | 1.05x faster | Significant (t=9.59)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| scimark_sparse_mat_mult | 9.03 ms       | 8.33 ms                | 1.08x faster | Significant (t=20.25)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| spectral_norm           | 247 ms        | 229 ms                 | 1.08x faster | Significant (t=19.81)  |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sqlalchemy_declarative  | 194 ms        | 183 ms                 | 1.06x faster | Significant (t=7.17)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sqlalchemy_imperative   | 28.2 ms       | 27.6 ms                | 1.02x faster | Significant (t=2.70)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sqlite_synth            | 4.89 us       | 4.73 us                | 1.03x faster | Significant (t=7.72)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sympy_expand            | 833 ms        | 819 ms                 | 1.02x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sympy_integrate         | 33.0 ms       | 31.8 ms                | 1.04x faster | Significant (t=6.15)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sympy_str               | 490 ms        | 479 ms                 | 1.02x faster | Significant (t=8.22)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| sympy_sum               | 254 ms        | 247 ms                 | 1.03x faster | Significant (t=5.58)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| telco                   | 11.6 ms       | 11.4 ms                | 1.02x faster | Significant (t=4.85)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| tornado_http            | 175 ms        | 172 ms                 | 1.02x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| unpack_sequence         | 51.4 ns       | 51.2 ns                | 1.00x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| unpickle                | 20.3 us       | 19.5 us                | 1.04x faster | Significant (t=8.75)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| unpickle_list           | 5.41 us       | 5.75 us                | 1.06x slower | Significant (t=-13.77) |
+-------------------------+---------------+------------------------+--------------+------------------------+
| unpickle_pure_python    | 544 us        | 522 us                 | 1.04x faster | Significant (t=7.08)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| xml_etree_generate      | 154 ms        | 148 ms                 | 1.04x faster | Significant (t=8.73)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
| xml_etree_iterparse     | 130 ms        | 131 ms                 | 1.00x slower | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| xml_etree_parse         | 178 ms        | 177 ms                 | 1.01x faster | Not significant        |
+-------------------------+---------------+------------------------+--------------+------------------------+
| xml_etree_process       | 123 ms        | 119 ms                 | 1.04x faster | Significant (t=8.15)   |
+-------------------------+---------------+------------------------+--------------+------------------------+
```

###### Things done

- [x] I've built python 3.9 on x86_64-linux NixOS (including the required stdenv bootstrap) using sandboxing.

###### Things to be done

 - [ ] Another person (preferably on an Intel CPU) should reproduce the Python build (twice)
 - [ ] Smoke testing of the python ecosystem to ensure nothing breaks. Especially python packages that require C extensions might be affected by this change.
