### PR TITLE
atk: clean up cross-compilation logic

### DIFF
--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, meson, ninja, gettext, pkg-config, glib
 , fixDarwinDylibNames, gobject-introspection, gnome
-, withIntrospection ? stdenv.buildPlatform == stdenv.hostPlatform
 }:
 
 let
@@ -18,9 +17,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext glib ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames
-    ++ lib.optional withIntrospection gobject-introspection;
+  nativeBuildInputs = [ meson ninja pkg-config gettext gobject-introspection glib ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   propagatedBuildInputs = [
     # Required by atk.pc
@@ -34,7 +32,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dintrospection=${lib.boolToString withIntrospection}"
+    "-Dintrospection=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
   ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

Clean up based on review comments on other packages. See e.g. #123712.

Remove conditionally adding gobject-introspection as nativeBuildInput (it doesn't matter if it's available or not), remove input parameter that can just be inlined.

I think it's nicer to have the cross support be as minimal as possible to have a clean package definition.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @7c6f434c