### PR TITLE
laravel-mix: init at 6.0.19

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -107,7 +107,16 @@ let
       nativeBuildInputs = drv.nativeBuildInputs or [] ++ [ pkgs.psc-package self.pulp ];
     });
 
-    makam =  super.makam.override {
+    laravel-mix = super.laravel-mix.override (drv: {
+      buildInputs = [ nodejs pkgs.makeWrapper ];
+      postFixup = ''
+        # laravel-mix wants to find npx on the PATH
+        wrapProgram "$out/bin/mix" \
+          --prefix PATH : ${pkgs.lib.makeBinPath [ nodejs ]}
+      '';
+     });
+
+    makam = super.makam.override {
       buildInputs = [ pkgs.nodejs pkgs.makeWrapper ];
       postFixup = ''
         wrapProgram "$out/bin/makam" --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs ]}

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -142,6 +142,7 @@
 , "kaput-cli"
 , "katex"
 , "karma"
+, "laravel-mix"
 , "lcov-result-merger"
 , "leetcode-cli"
 , "vsc-leetcode-cli"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2822,6 +2822,8 @@ in
 
   languagetool = callPackage ../tools/text/languagetool {  };
 
+  inherit (nodePackages) laravel-mix;
+
   lepton = callPackage ../tools/graphics/lepton { };
 
   lexicon = callPackage ../tools/admin/lexicon { };


### PR DESCRIPTION
###### Motivation for this change

To be able to build a webapp created with laravel-mix locally

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).