### PR TITLE
git-vendor: init at 1.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-vendor/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-vendor/default.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, fetchFromGitHub, writeShellScriptBin, skawarePackages
+}:
+
+let
+  version = "1.2.0";
+  sha256 = "1z9fmrfxqi56pj7f1506q2z41crz702jk88gv57baf6fz63m93v2";
+
+in stdenv.mkDerivation {
+  pname = "git-vendor";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "brettlangdon";
+    repo = "git-vendor";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  outputs = [ "bin" "man" "doc" "out" ];
+
+  PREFIX = (placeholder "out");
+  BINPREFIX = "${placeholder "bin"}/bin";
+  MANPREFIX = "${placeholder "man"}/share/man/man1";
+
+  buildInputs = [
+    # stubbing out a `git config` check that `make install` tries to do
+    (writeShellScriptBin "git" "")
+  ];
+
+  postInstall = ''
+    ${skawarePackages.cleanPackaging.commonFileActions {
+        docFiles = [
+          "LICENSE"
+          "README.md"
+        ];
+        noiseFiles = [
+          "bin/git-vendor"
+          "Makefile"
+          "etc/bash_completion.sh"
+          "man"
+          "install.sh"
+        ];
+      }} $doc/share/doc/git-vendor
+  '';
+
+  postFixup = ''
+    ${skawarePackages.cleanPackaging.checkForRemainingFiles}
+  '';
+
+  meta = {
+    description = "A git command for managing vendored dependencies";
+    longDescription = ''
+      git-vendor is a wrapper around git-subtree commands for checking out and updating vendored dependencies.
+
+      By default git-vendor conforms to the pattern used for vendoring golang dependencies:
+        * Dependencies are stored under vendor/ directory in the repo.
+        * Dependencies are stored under the fully qualified project path.
+            e.g. https://github.com/brettlangdon/forge will be stored under vendor/github.com/brettlangdon/forge.
+    '';
+    homepage = "https://github.com/brettlangdon/git-vendor";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.Profpatsch ];
+    platforms = lib.platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5078,6 +5078,8 @@ in
 
   git-vanity-hash = callPackage ../applications/version-management/git-and-tools/git-vanity-hash { };
 
+  git-vendor = callPackage ../applications/version-management/git-and-tools/git-vendor { };
+
   git-when-merged = callPackage ../applications/version-management/git-and-tools/git-when-merged { };
 
   git-workspace = callPackage ../applications/version-management/git-and-tools/git-workspace {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
