### PR TITLE
cgreen: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7165,6 +7165,12 @@
     githubId = 10180857;
     name = "Anmol Sethi";
   };
+  nichtsfrei = {
+    email = "philipp.eder@posteo.net";
+    github = "nichtsfrei";
+    githubId = 1665818;
+    name = "Philipp Eder";
+  };
   nickhu = {
     email = "me@nickhu.co.uk";
     github = "nickhu";

--- a/pkgs/development/libraries/cgreen/default.nix
+++ b/pkgs/development/libraries/cgreen/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "cgreen";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "cgreen-devs";
+    repo = "cgreen";
+    rev = version;
+    sha256 = "JEpvkM0EZiiQUZRngICNxHbNqS/qjqkEdMPckGbdWac=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cgreen-devs/cgreen";
+    description = "The Modern Unit Test and Mocking Framework for C and C++";
+    license = licenses.isc;
+    maintainers = [ maintainers.nichtsfrei ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3483,6 +3483,8 @@ in
 
   cfdg = callPackage ../tools/graphics/cfdg { };
 
+  cgreen = callPackage ../development/libraries/cgreen { };
+
   checkinstall = callPackage ../tools/package-management/checkinstall { };
 
   checkmake = callPackage ../development/tools/checkmake { };


### PR DESCRIPTION
Cgreen is a modern unit test and mocking framework for C and C++.

To make it easy to write C in a test driven fashion with proper output
and relatively easy integration Cgreen is usually a good choice. To make
it easy to write C programs on nixos it would be great to have this
library available.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
