### PR TITLE
[20.09] nginx: Fix off-by-one in DNS resolver heap write

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -116,6 +116,14 @@ stdenv.mkDerivation {
       '';
     })
     ./nix-skip-check-logs-path.patch
+    (fetchpatch {
+      # http://mailman.nginx.org/pipermail/nginx-announce/2021/000300.html
+      # https://www.openwall.com/lists/oss-security/2021/05/25/5
+      name = "CVE-2021-23017.patch";
+      url = "https://nginx.org/download/patch.2021.resolver.txt";
+      sha256 = "1npdjifgqxkd57iqhf96jiq4lw83nxpb1dk4h5iniawbx4s2ddpc";
+      extraPrefix = "";
+    })
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/openwrt/packages/master/net/nginx/patches/102-sizeof_test_fix.patch";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-23027

https://www.openwall.com/lists/oss-security/2021/05/25/5

I originally tried applying https://nginx.org/download/patch.2021.resolver.txt, but that patch for some reason didn't find the src file.

```sh
❯ nix-build -A nginx
these derivations will be built:
  /nix/store/vf7sgcpb59jkk60l8aykkmsb1z9aijii-nginx-1.18.0.drv
building '/nix/store/vf7sgcpb59jkk60l8aykkmsb1z9aijii-nginx-1.18.0.drv' on 'ssh://hexa@phoibe.cysec.de'...
unpacking sources
unpacking source archive /nix/store/hxa3gqx34w019jgdjp756pdfwnlq5nry-nginx-1.18.0.tar.gz
source root is nginx-1.18.0
setting SOURCE_DATE_EPOCH to timestamp 1587478146 of file nginx-1.18.0/CHANGES
patching sources
# prePatch ls works!
src/core/ngx_resolver.c
applying patch /nix/store/sc131zdz663kid2crlba7axarykyjirx-nix-etag-1.15.4.patch
patching file src/http/ngx_http_core_module.c
Hunk #1 succeeded at 1657 (offset 74 lines).
Hunk #2 succeeded at 1674 (offset 74 lines).
applying patch /nix/store/zwz37yd9whxjj8inym5vg21b5plp1k0x-nix-skip-check-logs-path.patch
patching file auto/install
applying patch /nix/store/6ib35bgpv3c943csgwhhckzfl3pnr4za-CVE-2021-23017.patch
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- src/core/ngx_resolver.c
|+++ src/core/ngx_resolver.c
--------------------------
File to patch:
Skip this patch? [y]
Skipping patch.
1 out of 1 hunk ignored

```

Related: #124400 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
