### PR TITLE
python3Packages.xgboost: fix tests for darwin

### DIFF
--- a/pkgs/development/python-modules/xgboost/default.nix
+++ b/pkgs/development/python-modules/xgboost/default.nix
@@ -1,4 +1,5 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , pytestCheckHook
 , cmake
 , scipy
@@ -56,6 +57,11 @@ buildPythonPackage {
   disabledTests = [
     "test_cli_binary_classification"
     "test_model_compatibility"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # fails to connect to the com.apple.fonts daemon in sandboxed mode
+    "test_plotting"
+    "test_sklearn_plotting"
   ];
 
+  __darwinAllowLocalNetworking = true;
 }


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042 

Similar to GEGL, the plotting tests attempt to connect to apple's font server, which is a no-go in sandboxed mode. There's also another tests requiring local networking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
