### PR TITLE
pythonPackages.matplotlib: fix headless detection

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchPypi, writeText, python, buildPythonPackage, isPy3k, pycairo, backports_functools_lru_cache
-, which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
+{ lib, stdenv, fetchPypi, writeText, buildPythonPackage, isPy3k, pycairo
+, which, cycler, dateutil, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, qhull, libpng, pkg-config, mock, pytz, pygobject3, gobject-introspection
 , certifi, pillow
 , enableGhostscript ? true, ghostscript, gtk3
@@ -10,7 +10,6 @@
 # required for headless detection
 , libX11, wayland
 , Cocoa
-, pythonOlder
 }:
 
 let

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -5,11 +5,17 @@
 , enableGhostscript ? true, ghostscript, gtk3
 , enableGtk3 ? false, cairo
 # darwin has its own "MacOSX" backend
-, enableTk ? !stdenv.isDarwin, tcl, tk, tkinter, libX11
+, enableTk ? !stdenv.isDarwin, tcl, tk, tkinter
 , enableQt ? false, pyqt5
+# required for headless detection
+, libX11, wayland
 , Cocoa
 , pythonOlder
 }:
+
+let
+  interactive = enableTk || enableGtk3 || enableQt;
+in
 
 buildPythonPackage rec {
   version = "3.4.1";
@@ -62,8 +68,14 @@ buildPythonPackage rec {
     let
       tcl_tk_cache = ''"${tk}/lib", "${tcl}/lib", "${lib.strings.substring 0 3 tk.version}"'';
     in
-    lib.optionalString enableTk
-      "sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py";
+    lib.optionalString enableTk ''
+      sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py
+    '' + lib.optionalString (stdenv.isLinux && interactive) ''
+      # fix paths to libraries in dlopen calls (headless detection)
+      substituteInPlace src/_c_internal_utils.c \
+        --replace libX11.so.6 ${libX11}/lib/libX11.so.6 \
+        --replace libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
+    '';
 
   # Matplotlib needs to be built against a specific version of freetype in
   # order for all of the tests to pass.

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -83,6 +83,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python plotting library, making publication quality plots";
     homepage    = "https://matplotlib.org/";
+    license     = with licenses; [ psfl bsd0 ];
     maintainers = with maintainers; [ lovek323 veprbl ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

The default backend is chosen based on the content of the $DISPLAY
variable *and* a successfull call to libX11, loaded via dlopen().
The test fails because dlopen looks in /usr/lib and /lib, so matplotlib
falls back to a headless backend.

To reproduce try running:

    $ nix-shell -I nixpkgs=$PWD -p \
      'python3.withPackages (p: [ p.matplotlib ])' --run python
    >>> import matplotlib.pyplot as plt
    >>> assert plt.get_backend() == "TkAgg"

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via the above method
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (none)
- [x] Added a release notes entry if the change is major or breaking (it's not)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
