### PR TITLE
[21.05] home-assistant: disable flaky test in prometheus component

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -677,6 +677,8 @@ in with py.pkgs; buildPythonApplication rec {
     "--deselect tests/components/shelly/test_config_flow.py::test_zeroconf_sleeping_device_error"
     "--deselect tests/components/shelly/test_config_flow.py::test_zeroconf_sleeping_device_error"
     "--deselect tests/components/shelly/test_config_flow.py::test_zeroconf_require_auth"
+    # prometheus/test_init.py: Spurious AssertionError regarding humidifier_target_humidity_percent metric
+    "--deselect tests/components/prometheus/test_init.py::test_view"
     # tests are located in tests/
     "tests"
     # dynamically add packages required for component tests


### PR DESCRIPTION


###### Motivation for this change

Backport #124444 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
