### PR TITLE
SDL_Pango: fix darwin build

### DIFF
--- a/pkgs/development/libraries/SDL_Pango/default.nix
+++ b/pkgs/development/libraries/SDL_Pango/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = "autoreconf -i -f";
+  configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ SDL pango ];


### PR DESCRIPTION
###### Motivation for this change

Hydra failure: https://hydra.nixos.org/build/143733592/log

This hang happens because Hydra runs the job while logged out. The conftest for SDL 1 runs a small program that includes `SDL.h`, thus uses `SDL_main`, thus tries to boot AppKit. The actual application `main` is supposed to run from `applicationDidFinishLaunching`, but that never happens.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
