### PR TITLE
toppler: fix darwin build

### DIFF
--- a/pkgs/games/toppler/default.nix
+++ b/pkgs/games/toppler/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
+  # The conftest hangs on Hydra runners, because they are not logged in.
+  configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
+
   meta = with lib; {
     description = "Jump and run game, reimplementation of Tower Toppler/Nebulus";
     homepage = "http://toppler.sourceforge.net/";


### PR DESCRIPTION
###### Motivation for this change

Hydra failure: https://hydra.nixos.org/build/143706720/log

This hang happens because Hydra runs the job while logged out. The conftest for SDL 1 runs a small program that includes SDL.h, thus uses SDL_main, thus tries to boot AppKit. The actual application main is supposed to run from applicationDidFinishLaunching, but that never happens.

Unfortunately, it doesn't seem to really work yet. When launching it, it sometimes segfaults, other times shows just a blank window. (Seeing this with more SDL 1 apps, perhaps it's just broken on Big Sur?) But this should at least save us a CI hang every time it tries to rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
