### PR TITLE
schismtracker: fix darwin build

### DIFF
--- a/pkgs/applications/audio/schismtracker/default.nix
+++ b/pkgs/applications/audio/schismtracker/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1n6cgjiw3vkv7a1h1nki5syyjxjb6icknr9s049w2jrag10bxssn";
   };
 
-  configureFlags = [ "--enable-dependency-tracking" ];
+  configureFlags = [ "--enable-dependency-tracking" ]
+    ++ lib.optional stdenv.isDarwin "--disable-sdltest";
 
   nativeBuildInputs = [ autoreconfHook python ];
 


### PR DESCRIPTION
###### Motivation for this change

Hydra failure: https://hydra.nixos.org/build/143564805/log

This hang happens because Hydra runs the job while logged out. The conftest for SDL 1 runs a small program that includes SDL.h, thus uses SDL_main, thus tries to boot AppKit. The actual application main is supposed to run from applicationDidFinishLaunching, but that never happens.

Unfortunately, it doesn't seem to really work yet. When launching it, it shows just a blank window. (Seeing this with more SDL 1 apps, perhaps it's just broken on Big Sur?) But this should at least save us a CI hang every time it tries to rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
