### PR TITLE
[21.05] darwin/make-bootstrap-tools: move "lib" from install name to rpath

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -136,9 +136,7 @@ in rec {
         local libs=$(${stdenv.cc.targetPrefix}otool -L "$1" | tail -n +2 | grep -o "$NIX_STORE.*-\S*") || true
         local newlib
         for lib in $libs; do
-          newlib=''${lib:${toString (storePrefixLen + 1)}}
-          newlib=''${newlib#*/}
-          ${stdenv.cc.targetPrefix}install_name_tool -change $lib "@rpath/$newlib" "$1"
+          ${stdenv.cc.targetPrefix}install_name_tool -change $lib "@rpath/$(basename "$lib")" "$1"
         done
       }
 
@@ -160,7 +158,7 @@ in rec {
       for i in $out/bin/*; do
         if test -x "$i" -a ! -L "$i" -a "$(basename $i)" != codesign; then
           echo "Adding @executable_path to rpath in $i"
-          ${stdenv.cc.targetPrefix}install_name_tool -add_rpath '@executable_path/..' $i
+          ${stdenv.cc.targetPrefix}install_name_tool -add_rpath '@executable_path/../lib' $i
         fi
       done
 


### PR DESCRIPTION
###### Motivation for this change
backport #124228 , backport action still is broken

The rpath structure for the bootstrap tools was reworked to minimize
the amount of rewriting required on unpack, but the test was not
updated to match the different structure.

Additionally [1] builds that use the bootstrap version of libc++
cannot find libc++abi if the reference includes the "lib"
component (ie, libc++ refers to libc++abi with
@rpath/lib/libc++abi.dylib).

[1] https://logs.nix.samueldr.com/nix-darwin/2021-05-18#4993282

Test failure observed on Hydra: https://hydra.nixos.org/build/143130126

(cherry picked from commit 38207735f425a06563482c726b25a0967bc9011d)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
