### PR TITLE
betterlockscreen: readd patch for i3color

### DIFF
--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  patches = [ ./replace-i3lock.patch ];
+
   installPhase =
     let
       PATH =

--- a/pkgs/misc/screensavers/betterlockscreen/replace-i3lock.patch
+++ b/pkgs/misc/screensavers/betterlockscreen/replace-i3lock.patch
@@ -1,0 +1,14 @@
+diff --git a/betterlockscreen b/betterlockscreen
+index 6dd06e0..746d820 100755
+--- a/betterlockscreen
++++ b/betterlockscreen
+@@ -87,7 +87,7 @@ prelock() {
+ lock() {
+ 	#$1 image path
+ 
+-	i3lock \
++	i3lock-color \
+ 		-c 00000000 \
+ 		-t -i "$1" \
+ 		--timepos='x+110:h-70' \
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Readds the patch for betterlockscreen, as it was removed here - https://github.com/NixOS/nixpkgs/pull/123457 but added back in the next release here - https://github.com/pavanjadhaw/betterlockscreen/releases/tag/3.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
