### PR TITLE
[20.09] sssd: 1.16.4 -> 1.16.5

### DIFF
--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, glibc, augeas, dnsutils, c-ares, curl,
-  cyrus_sasl, ding-libs, libnl, libunistring, nss, samba, nfs-utils, doxygen,
+{ stdenv, fetchFromGitHub, autoreconfHook, fetchpatch, glibc, augeas, dnsutils, c-ares, curl,
+  cyrus_sasl, ding-libs, libnl, libunistring, nss, samba, nfs-utils, doxygen, pkg-config,
   python, python3, pam, popt, talloc, tdb, tevent, pkgconfig, ldb, openldap,
   pcre, kerberos, cifs-utils, glib, keyutils, dbus, fakeroot, libxslt, libxml2,
   libuuid, ldap, systemd, nspr, check, cmocka, uid_wrapper,
@@ -12,11 +12,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "sssd";
-  version = "1.16.4";
+  version = "1.16.5";
 
-  src = fetchurl {
-    url = "https://fedorahosted.org/released/sssd/${pname}-${version}.tar.gz";
-    sha256 = "0ngr7cgimyjc6flqkm7psxagp1m4jlzpqkn28pliifbmdg6i5ckb";
+  src = fetchFromGitHub {
+    owner = "SSSD";
+    repo = pname;
+    rev = "${pname}-${builtins.replaceStrings ["."] ["_"] version}";
+    sha256 = "0zbs04lkjbp7y92anmafl7gzamcnq1f147p13hc4byyvjk9rg6f7";
   };
   patches = [
     # Fix build failure against samba 4.12.0rc1
@@ -55,8 +57,9 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  nativeBuildInputs = [ autoreconfHook pkg-config doxygen ];
   buildInputs = [ augeas dnsutils c-ares curl cyrus_sasl ding-libs libnl libunistring nss
-                  samba nfs-utils doxygen python python3 popt
+                  samba nfs-utils python python3 popt
                   talloc tdb tevent pkgconfig ldb pam openldap pcre kerberos
                   cifs-utils glib keyutils dbus fakeroot libxslt libxml2
                   libuuid ldap systemd nspr check cmocka uid_wrapper
@@ -90,8 +93,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "System Security Services Daemon";
-    homepage = "https://fedorahosted.org/sssd/";
-    license = licenses.gpl3;
+    homepage = "https://sssd.io/";
+    changelog = "https://sssd.io/release-notes/sssd-${version}.html";
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.e-user ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2018-16838.
https://sssd.io/release-notes/sssd-1.16.5.html

(cherry picked from commit affda4029fdc80149c0f30c8cc6021cf4efda0e7)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
