### PR TITLE
python3Packages.connect-box: 0.2.8 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/connect_box/default.nix
+++ b/pkgs/development/python-modules/connect_box/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "connect-box";
-  version = "0.2.8";
+  version = "0.3.0";
 
   src = fetchPypi {
     pname = "connect_box";
     inherit version;
-    sha256 = "1lvz7g2f0a9ifnjczmbavn105miirdgyayr4sixhzgdgadcdhz3l";
+    sha256 = "sha256-d1KqVKaHlZDm2o1GJ7r8KoONwfd1lxXexJxavCvjfW8=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.0

Change log: https://github.com/home-assistant-ecosystem/python-connect-box/releases/tag/0.3.0

- Related Home Assistant change: -
- Target Home Assistant release: current (only dependency update, no code changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
