### PR TITLE
bmake: fix build on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -18,6 +18,31 @@ stdenv.mkDerivation rec {
     ./fix-unexport-env-test.patch
   ];
 
+  # The generated makefile is a small wrapper for calling ./boot-strap
+  # with a given op. On a case-insensitive filesystem this generated
+  # makefile clobbers a distinct, shipped, Makefile and causes
+  # infinite recursion during tests which eventually fail with
+  # "fork: Resource temporarily unavailable"
+  configureFlags = [
+    "--without-makefile"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./boot-strap --prefix=$out -o . op=build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ./boot-strap --prefix=$out -o . op=install
+
+    runHook postInstall
+  '';
+
   setupHook = ./setup-hook.sh;
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix build on darwin, noticed by @sternenseemann.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (aarch64-linux)
   - [x] macOS (x86_64-darwin, aarch64-darwin)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
