### PR TITLE
qcengine: init at 0.19.0

### DIFF
--- a/pkgs/development/python-modules/qcengine/default.nix
+++ b/pkgs/development/python-modules/qcengine/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage, lib, fetchPypi, pyyaml, qcelemental, pydantic
+, py-cpuinfo, psutil, pytestrunner, pytest, pytestcov
+} :
+
+buildPythonPackage rec {
+  pname = "qcengine";
+  version = "0.19.0";
+
+  checkInputs = [
+    pytestrunner
+    pytestcov
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    pyyaml
+    qcelemental
+    pydantic
+    py-cpuinfo
+    psutil
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0lz9r0fh31mcixdhayiwfc69cp8if9b3nkrk7gxdrb6vhbfrxhij";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Quantum chemistry program executor and IO standardizer (QCSchema) for quantum chemistry";
+    homepage = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7009,6 +7009,8 @@ in {
 
   qcelemental = callPackage ../development/python-modules/qcelemental { };
 
+  qcengine = callPackage ../development/python-modules/qcengine { };
+
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 
   qdldl = callPackage ../development/python-modules/qdldl { };


### PR DESCRIPTION
###### Motivation for this change
Adds QCEngine python library. This is a scientific library, providing abstract python wrapper tools to computational chemistry packages. Part of the packages @markuskowa and me want to merge from markuskowa/NixOS-QChem#56.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
