### PR TITLE
treewide: replace createFindlibDestdir with equivalent preInstall hook

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -784,6 +784,17 @@
           this up.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>createFindlibDestdir</literal> feature of the
+          <literal>findlib</literal> setup hook has been removed in all
+          ocaml package sets as it broke
+          <literal>nix-shell -A</literal>. If you still need this,
+          you’ll have to create <literal>$OCAMLFIND_DESTDIR</literal>
+          manually in <literal>preInstall</literal> or similar from now
+          on.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -200,3 +200,7 @@ pt-services.clipcat.enable).
 - The [networking.wireless.iwd](options.html#opt-networking.wireless.iwd.enable) module has a new [networking.wireless.iwd.settings](options.html#opt-networking.wireless.iwd.settings) option.
 
 - The [services.syncoid.enable](options.html#opt-services.syncoid.enable) module now properly drops ZFS permissions after usage. Before it delegated permissions to whole pools instead of datasets and didn't clean up after execution. You can manually look this up for your pools by running `zfs allow your-pool-name` and use `zfs unallow syncoid your-pool-name` to clean this up.
+
+- The `createFindlibDestdir` feature of the `findlib` setup hook has been removed in all
+  ocaml package sets as it broke `nix-shell -A`. If you still need this, you'll have to
+  create `$OCAMLFIND_DESTDIR` manually in `preInstall` or similar from now on.

--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml uutf ];
   propagatedBuildInputs = [ findlib omd ppx_blob ocf ptime uri xtmpl ocaml_lwt higlo ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p $OCAMLFIND_DESTDIR
+  '';
 
   patches = [ ./install.patch ./uri.patch ];
 

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -164,7 +164,9 @@ self = stdenv.mkDerivation {
   buildFlags = [ "revision" "coq" "coqide" "bin/votour" ];
   enableParallelBuilding = true;
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postInstall = ''
     cp bin/votour $out/bin/

--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -27,8 +27,11 @@ stdenv.mkDerivation (args // {
     ''
   else setupHook;
 
-  inherit createFindlibDestdir;
   inherit dontStrip;
 
   meta = defaultMeta // meta;
+} // lib.optionalAttrs createFindlibDestdir {
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '' + (args.preInstall or "");
 })

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation (args // {
 
   buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis ] ++ buildInputs;
 
-  inherit createFindlibDestdir;
   inherit dontStrip;
 
   buildPhase = ''
@@ -37,6 +36,9 @@ stdenv.mkDerivation (args // {
   installPhase = ''
     runHook preInstall
     mkdir -p $out
+  '' + lib.optionalString createFindlibDestdir ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '' + ''
     ocaml setup.ml -install
     runHook postInstall
   '';

--- a/pkgs/build-support/templaterpm/default.nix
+++ b/pkgs/build-support/templaterpm/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation {
     '';
 
   meta = with lib; {
+    # Needs to be ported to python3 since rpm doesn't work with 2.7 anymore.
+    broken = true;
     description = "Create templates of nix expressions from RPM .spec files";
     maintainers = with maintainers; [ tstrobel ];
     platforms = platforms.unix;

--- a/pkgs/build-support/templaterpm/nix-template-rpm.py
+++ b/pkgs/build-support/templaterpm/nix-template-rpm.py
@@ -219,13 +219,6 @@ class SPECTemplate(object):
     out = '  installPhase = \'\'\n    ' + self.rewriteCommands(self.spec.install) + '\n    \'\';\n';
     return out
 
-  @property
-  def ocamlExtra(self):
-    if "ocaml" in self.getBuildInputs("ALL"):
-      return '  createFindlibDestdir = true;\n'
-    else:
-      return ''
-
 
   @property
   def meta(self):
@@ -243,7 +236,7 @@ class SPECTemplate(object):
   def __str__(self):
     head = '{lib, stdenv, fetchurl, ' + ', '.join(self.getBuildInputs("ALL")) + '}:\n\n'
     head += 'stdenv.mkDerivation {\n'
-    body = [ self.name, self.src, self.patch, self.buildInputs, self.configure, self.build, self.ocamlExtra, self.install, self.meta ]
+    body = [ self.name, self.src, self.patch, self.buildInputs, self.configure, self.build, self.install, self.meta ]
     return head + '\n'.join(body)
 
 
@@ -255,7 +248,7 @@ class SPECTemplate(object):
     head += 'stdenv.mkDerivation {\n'
     head += '  inherit (buildRootInput.'+self.rewriteName(self.spec.sourceHeader['name'])+') name version src;\n'
     head += '  patches = buildRootInput.'+self.rewriteName(self.spec.sourceHeader['name'])+'.patches ++ [];\n\n'
-    body = [ self.buildInputs, self.configure, self.build, self.ocamlExtra, self.install, self.meta ]
+    body = [ self.buildInputs, self.configure, self.build, self.install, self.meta ]
     return head + '\n'.join(body)
 
 

--- a/pkgs/development/compilers/mezzo/default.nix
+++ b/pkgs/development/compilers/mezzo/default.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation {
     --replace '@1..3' '@1..2+3'
   '';
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postInstall = ''
     mkdir $out/bin

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
   doCheck = lib.versionAtLeast ocaml.version "4.04" && !stdenv.isAarch64;
   checkTarget = "test";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://batteries.forge.ocamlcore.org/";

--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ocaml_pcre ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://ocaml-benchmark.forge.ocamlcore.org/";

--- a/pkgs/development/ocaml-modules/biniou/1.0.nix
+++ b/pkgs/development/ocaml-modules/biniou/1.0.nix
@@ -18,13 +18,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib easy-format ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+    mkdir -p "$out/bin"
+  '';
 
   makeFlags = [ "PREFIX=$(out)" ];
-
-  preBuild = ''
-    mkdir $out/bin
-  '';
 
   meta = with lib; {
     description = "A binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve";

--- a/pkgs/development/ocaml-modules/bitv/default.nix
+++ b/pkgs/development/ocaml-modules/bitv/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ autoreconfHook which ocaml findlib ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "A bit vector library for OCaml";

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -43,7 +43,9 @@ EOF
   # option. Installation is handled by ocamlfind.
   dontAddPrefix = true;
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   buildFlags = [ "all" ];
 

--- a/pkgs/development/ocaml-modules/calendar/default.nix
+++ b/pkgs/development/ocaml-modules/calendar/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ocaml findlib];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta =  {
     homepage = "https://forge.ocamlcore.org/projects/calendar/";

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -39,7 +39,9 @@ stdenv.mkDerivation {
 
   inherit (param) patches;
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postPatch = param.postPatchInit + ''
     substituteInPlace Makefile \

--- a/pkgs/development/ocaml-modules/camomile/0.8.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.2.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ocaml findlib camlp4];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://camomile.sourceforge.net/";

--- a/pkgs/development/ocaml-modules/camomile/0.8.5.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.5.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ocaml findlib camlp4];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "https://github.com/yoriyuki/Camomile/tree/master/Camomile";

--- a/pkgs/development/ocaml-modules/cil/default.nix
+++ b/pkgs/development/ocaml-modules/cil/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ perl ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   preConfigure = ''
     substituteInPlace Makefile.in --replace 'MACHDEPCC=gcc' 'MACHDEPCC=$(CC)'

--- a/pkgs/development/ocaml-modules/config-file/default.nix
+++ b/pkgs/development/ocaml-modules/config-file/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib camlp4 ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://config-file.forge.ocamlcore.org/";

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
 
   dontConfigure = true;	# Skip configure phase
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://projects.camlcity.org/projects/cryptgps.html";

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -1,9 +1,5 @@
 { lib, buildDunePackage, cstruct, lwt }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
-then cstruct
-else
-
 buildDunePackage {
   pname = "cstruct-lwt";
   inherit (cstruct) version src useDune2 meta;

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -3,10 +3,6 @@
 , fetchpatch
 }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
-then cstruct
-else
-
 buildDunePackage {
   pname = "ppx_cstruct";
   inherit (cstruct) version src useDune2 meta;

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -1,9 +1,5 @@
 { lib, buildDunePackage, ocaml, alcotest, cstruct, sexplib }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
-then cstruct
-else
-
 buildDunePackage rec {
   pname = "cstruct-sexp";
   inherit (cstruct) version src useDune2 meta;

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -1,9 +1,5 @@
 { lib, buildDunePackage, cstruct }:
 
-if !lib.versionAtLeast (cstruct.version or "1") "3"
-then cstruct
-else
-
 buildDunePackage {
   pname = "cstruct-unix";
   inherit (cstruct) version src useDune2 meta;

--- a/pkgs/development/ocaml-modules/csv/1.5.nix
+++ b/pkgs/development/ocaml-modules/csv/1.5.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
-
   configurePhase = ''
     runHook preConfigure
     ocaml setup.ml -configure --prefix $out --enable-tests
@@ -34,6 +32,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
+    mkdir -p "$OCAMLFIND_DESTDIR"
     ocaml setup.ml -install
     runHook postInstall
   '';

--- a/pkgs/development/ocaml-modules/csv/1.5.nix
+++ b/pkgs/development/ocaml-modules/csv/1.5.nix
@@ -13,14 +13,30 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out --enable-tests";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml setup.ml -configure --prefix $out --enable-tests
+    runHook postConfigure
+  '';
 
-  buildPhase = "ocaml setup.ml -build";
+  buildPhase = ''
+    runHook preBuild
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
 
   doCheck = true;
-  checkPhase = "ocaml setup.ml -test";
+  checkPhase = ''
+    runHook preCheck
+    ocaml setup.ml -test
+    runHook postCheck
+  '';
 
-  installPhase = "ocaml setup.ml -install";
+  installPhase = ''
+    runHook preInstall
+    ocaml setup.ml -install
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A pure OCaml library to read and write CSV files";

--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
   # Fix build for recent ncurses versions
   NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS=1";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postPatch = ''
     substituteInPlace curses.ml --replace "pp gcc" "pp $CC"

--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "-C" "src" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "An OCaml library providing clean and flexible parsers for input languages";

--- a/pkgs/development/ocaml-modules/dolog/default.nix
+++ b/pkgs/development/ocaml-modules/dolog/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   doCheck = true;
   checkTarget = "test";

--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ easy-format ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/mjambon/dum";

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ocaml findlib];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   buildPhase = ''
     make

--- a/pkgs/development/ocaml-modules/easy-format/default.nix
+++ b/pkgs/development/ocaml-modules/easy-format/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   doCheck = true;
   checkTarget = "test";

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
   ++ lib.optional stdenv.isDarwin "--absolute-dylibs"
   ;
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "ETH LIbrary for Numerical Analysis";

--- a/pkgs/development/ocaml-modules/enumerate/default.nix
+++ b/pkgs/development/ocaml-modules/enumerate/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ type_conv camlp4 ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "https://ocaml.janestreet.com/";

--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "https://github.com/hannesm/xml";

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -16,9 +16,21 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
   propagatedBuildInputs = [ erm_xml mirage-crypto mirage-crypto-rng base64 ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-  buildPhase = "ocaml setup.ml -build";
-  installPhase = "ocaml setup.ml -install";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml setup.ml -configure --prefix $out
+    runHook postConfigure
+  '';
+  buildPhase = ''
+    runHook preBuild
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    ocaml setup.ml -install
+    runHook postInstall
+  '';
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -28,11 +28,10 @@ stdenv.mkDerivation rec {
   '';
   installPhase = ''
     runHook preInstall
+    mkdir -p "$OCAMLFIND_DESTDIR"
     ocaml setup.ml -install
     runHook postInstall
   '';
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "https://github.com/hannesm/xmpp";

--- a/pkgs/development/ocaml-modules/expat/0.9.nix
+++ b/pkgs/development/ocaml-modules/expat/0.9.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ocaml findlib ounit expat];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   patches = [ ./unittest.patch ];
 

--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
   doCheck = !lib.versionAtLeast ocaml.version "4.06";
   checkTarget = "testall";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "OCaml wrapper for the Expat XML parsing library";

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib cppo ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
   dontConfigure = true;
 
   makeFlags = lib.optional minimal "minimal=1";

--- a/pkgs/development/ocaml-modules/fieldslib/default.nix
+++ b/pkgs/development/ocaml-modules/fieldslib/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ type_conv camlp4 ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     homepage = "https://ocaml.janestreet.com/";

--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation {
 
   installTargets = [ "ocamlfind-install" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     homepage = "https://www.lri.fr/~filliatr/functory/";

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation {
   doCheck = true;
   checkTarget = "test";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "https://github.com/c-cube/gen";

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild opaline ];
 
-  createFindlibDestdir = true;
-
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
 
   installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";

--- a/pkgs/development/ocaml-modules/gtktop/default.nix
+++ b/pkgs/development/ocaml-modules/gtktop/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml camlp4 findlib ];
   propagatedBuildInputs = [ lablgtk-extras ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://zoggy.github.io/gtktop/";

--- a/pkgs/development/ocaml-modules/higlo/default.nix
+++ b/pkgs/development/ocaml-modules/higlo/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ xtmpl ulex ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   patches = ./install.patch;
 

--- a/pkgs/development/ocaml-modules/inifiles/default.nix
+++ b/pkgs/development/ocaml-modules/inifiles/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation {
 
   buildFlags = [ "all" "opt" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "A small OCaml library to read and write .ini files";

--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -32,7 +32,9 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkTarget = "test";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "Bindings for Linux’s filesystem monitoring interface, inotify";

--- a/pkgs/development/ocaml-modules/iri/default.nix
+++ b/pkgs/development/ocaml-modules/iri/default.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ sedlex uunf uutf ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "IRI (RFC3987) native OCaml implementation";

--- a/pkgs/development/ocaml-modules/iso8601/default.nix
+++ b/pkgs/development/ocaml-modules/iso8601/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ ocaml findlib ocamlbuild ];
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "https://ocaml-community.github.io/ISO8601.ml/";

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   preConfigure = "patchShebangs ./configure.sh";
 

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
       --subst-var-by XINCLUDES ""
   '';
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   buildFlags = [ "lib" "libopt" "glut" "glutopt" ];
 

--- a/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib camlp4 ];
   propagatedBuildInputs = [ config-file lablgtk xmlm ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib camlp4 ];
   propagatedBuildInputs = [ config-file lablgtk xmlm ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -54,7 +54,9 @@ stdenv.mkDerivation rec {
 
   buildFlags = [ "all" "opt" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postInstall = ''
     mkdir -p $OCAMLFIND_DESTDIR/stublibs

--- a/pkgs/development/ocaml-modules/lwt_react/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_react/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ lwt react ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "Helpers for using React with Lwt";

--- a/pkgs/development/ocaml-modules/macaque/default.nix
+++ b/pkgs/development/ocaml-modules/macaque/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
   propagatedBuildInputs = [ pgocaml ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     description = "Macros for Caml Queries";

--- a/pkgs/development/ocaml-modules/magick/default.nix
+++ b/pkgs/development/ocaml-modules/magick/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ which pkg-config ];
   buildInputs = [ ocaml findlib imagemagick ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   preConfigure = "substituteInPlace Makefile --replace gcc $CC";
 

--- a/pkgs/development/ocaml-modules/mlgmp/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmp/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
   preConfigure = "make clean";
   buildInputs = [ocaml findlib gmp mpfr ncurses];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   propagatedbuildInputs = [gmp mpfr ncurses];
 

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -27,7 +27,11 @@ stdenv.mkDerivation {
   buildInputs = [ findlib topkg ]
   ++ optional jsooSupport js_of_ocaml;
 
-  buildPhase = "${topkg.buildPhase} --with-js_of_ocaml ${boolToString jsooSupport}";
+  buildPhase = ''
+    runHook preBuild
+    ${topkg.run} build --with-js_of_ocaml ${boolToString jsooSupport}
+    runHook postBuild
+  '';
 
   inherit (topkg) installPhase;
 

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   propagatedBuildInputs = [ libmysqlclient ];
 

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -59,7 +59,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocamlbuild findlib topkg cpuid ocb-stubblr ];
   propagatedBuildInputs = [ cstruct ppx_deriving ppx_sexp_conv sexplib zarith ] ++ optional withLwt cstruct-lwt;
 
-  buildPhase = "${topkg.buildPhase} --accelerate false --with-lwt ${boolToString withLwt}";
+  buildPhase = ''
+    runHook preBuild
+    ${topkg.run} build --accelerate false --with-lwt ${boolToString withLwt}
+    runHook postBuild
+  '';
   inherit (topkg) installPhase;
 
   meta = {

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -23,8 +23,11 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ result uucp uuseg uutf ] ++
                           optional withLwt lwt;
 
-  buildPhase = topkg.buildPhase
-  + " --with-lwt ${boolToString withLwt}";
+  buildPhase = ''
+    runHook preBuild
+    ${topkg.run} build --with-lwt ${boolToString withLwt}
+    runHook postBuild
+  '';
 
   inherit (topkg) installPhase;
 

--- a/pkgs/development/ocaml-modules/num/default.nix
+++ b/pkgs/development/ocaml-modules/num/default.nix
@@ -19,8 +19,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ ocaml findlib ];
   buildInputs = [ ocaml findlib ];
 
-  createFindlibDestdir = true;
-
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "Legacy Num library for arbitrary-precision integer and rational arithmetic";

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml automake gnum4 autoconf
                   findlib freetype lablgtk cairo gdk-pixbuf gtk2 pango ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
  preConfigure = ''
    aclocal -I support

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -19,9 +19,13 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  buildPhase = "make all opt CPPFLAGS=-Wno-error";
+  buildPhase = ''
+    runHook preBuild
+    make all opt CPPFLAGS=-Wno-error
+    runHook postBuild
+  '';
 
-  installPhase = "make install-opt";
+  installTargets = [ "install-opt" ];
 
   meta = with lib; {
     description = "OCaml bindings for libvirt";

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/ocaml-modules/ocaml-text/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-text/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
 
   configurePhase = "iconv_prefix=${libiconv} ocaml setup.ml -configure";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocamlnat/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnat/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
 
   checkTarget = "test";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "OCaml native toplevel";

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config which ];
   buildInputs = [ ncurses ocaml findlib ocaml_pcre camlzip gnutls nettle ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/ocamlsdl/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlsdl/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ocaml findlib SDL SDL_image SDL_mixer SDL_ttf SDL_gfx lablgl];
 
   propagatedBuildInputs = [ SDL SDL_image SDL_mixer SDL_ttf SDL_gfx pkg-config ];
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://ocamlsdl.sourceforge.net/";

--- a/pkgs/development/ocaml-modules/ocf/default.nix
+++ b/pkgs/development/ocaml-modules/ocf/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ppx_tools ];
   propagatedBuildInputs = [ yojson ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   dontStrip = true;
 

--- a/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
+++ b/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
@@ -15,10 +15,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ocaml findlib astring pprint ];
-  createFindlibDestdir = true;
 
   installFlags = [ "BINDIR=$(out)/bin" ];
-  preInstall = "mkdir -p $out/bin";
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "A simple tool and library to embed files and directories inside OCaml executables";

--- a/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation {
 
   installFlags = [ "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "An OCaml library implementing a simplex algorithm, in a functional style, for solving systems of linear inequalities";

--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild oasis ocaml_optcomp camlp4 ]
   ++ (param.buildInputs or []);
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta =  {
     homepage = "https://github.com/ocsigen/deriving";

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -34,7 +34,9 @@ stdenv.mkDerivation rec {
 
   dontAddPrefix = true;
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postFixup =
   ''

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation rec {
   substituteInPlace "src/os_db.ml" --replace "citext" "text"
   '';
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   src = fetchFromGitHub {
     owner = "ocsigen";

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
  installPhase =
   ''
     export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
+    mkdir -p "$OCAMLFIND_DESTDIR"
     make install
     opaline -prefix $out
   '';
@@ -23,8 +24,6 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0jan5779nc0jf993hmvfii15ralcs20sm4mcnqwqrnhjbq6f6zpk";
   };
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "http://ocsigen.org/ocsigen-toolkit/";

--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkg-config ocaml findlib ncurses ];
   propagatedBuildInputs = [ curl lwt ];
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
   meta = {
     description = "OCaml bindings to libcurl";
     license = lib.licenses.mit;

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -16,9 +16,21 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
-  configurePhase = "ocaml setup.ml -configure";
-  buildPhase     = "ocaml setup.ml -build";
-  installPhase   = "ocaml setup.ml -install";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml setup.ml -configure
+    runHook postConfigure
+  '';
+  buildPhase = ''
+    runHook preBuild
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    ocaml setup.ml -install
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Store data using OCaml notation";

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild type_conv ounit camlp4 ];
 
-  createFindlibDestdir = true;
-
   configurePhase = ''
     runHook preConfigure
     ocaml setup.ml -configure
@@ -28,6 +26,7 @@ stdenv.mkDerivation {
   '';
   installPhase = ''
     runHook preInstall
+    mkdir -p "$OCAMLFIND_DESTDIR"
     ocaml setup.ml -install
     runHook postInstall
   '';

--- a/pkgs/development/ocaml-modules/omd/default.nix
+++ b/pkgs/development/ocaml-modules/omd/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   configurePhase = "ocaml setup.ml -configure --prefix $out";
 

--- a/pkgs/development/ocaml-modules/optcomp/default.nix
+++ b/pkgs/development/ocaml-modules/optcomp/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
     })
   ;
 
-  createFindlibDestdir = true;
-
   buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
 
   configurePhase = ''
@@ -29,6 +27,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin
+    mkdir -p "$OCAMLFIND_DESTDIR"
     cp _build/src/optcomp_o.native $out/bin/optcomp-o
     cp _build/src/optcomp_r.native $out/bin/optcomp-r
     ocamlfind install optcomp META _build/src/optcomp.{a,cma,cmxa,cmxs} _build/src/pa_optcomp.{cmi,cmx,mli}

--- a/pkgs/development/ocaml-modules/ounit/default.nix
+++ b/pkgs/development/ocaml-modules/ounit/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation {
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   installTargets = "install-ounit version='${ounit2.version}'";
 

--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -14,9 +14,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib piqi stdlib-shims ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
-  installPhase = "DESTDIR=$out make install";
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
 
   meta = with lib; {
     homepage = "http://piqi.org";

--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -17,14 +17,13 @@ stdenv.mkDerivation rec {
 
   patches = [ ./no-ocamlpath-override.patch ];
 
-  createFindlibDestdir = true;
-
   buildPhase = ''
     make
     make -C piqilib piqilib.cma
   '';
 
   installPhase = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
     make install;
     make ocaml-install;
   '';

--- a/pkgs/development/ocaml-modules/pprint/default.nix
+++ b/pkgs/development/ocaml-modules/pprint/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   dontBuild = true;
   installFlags = [ "-C" "src" ];

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -64,7 +64,9 @@ else
     nativeBuildInputs = [ ocaml findlib ];
     buildInputs = [ ocaml findlib ];
 
-    createFindlibDestdir = true;
+    preInstall = ''
+      mkdir -p "$OCAMLFIND_DESTDIR"
+    '';
 
     dontStrip = true;
 

--- a/pkgs/development/ocaml-modules/process/default.nix
+++ b/pkgs/development/ocaml-modules/process/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     description = "Easy process control in OCaml";

--- a/pkgs/development/ocaml-modules/pycaml/default.nix
+++ b/pkgs/development/ocaml-modules/pycaml/default.nix
@@ -31,10 +31,12 @@ stdenv.mkDerivation {
 
   # the Makefile is not shipped with an install target, hence we do it ourselves.
   installPhase = ''
+    runHook preInstall
     ocamlfind install pycaml \
      dllpycaml_stubs.so libpycaml_stubs.a pycaml.a pycaml.cma \
      pycaml.cmi pycaml.cmo pycaml.cmx pycaml.cmxa \
      META
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/pycaml/default.nix
+++ b/pkgs/development/ocaml-modules/pycaml/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation {
   patches = [ "../debian/patches/*.patch" ];
 
   buildInputs = [ ncurses ocaml findlib python ocaml_make ];
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   # the Makefile is not shipped with an install target, hence we do it ourselves.
   installPhase = ''

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -1,35 +1,20 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, dune_2, benchmark }:
+{ lib, buildDunePackage, fetchFromGitHub, ocaml, benchmark }:
 
-let param =
-  if lib.versionAtLeast ocaml.version "4.03"
-  then rec {
-    version = "0.6.2";
-    url = "https://github.com/Chris00/ocaml-rope/releases/download/${version}/rope-${version}.tbz";
-    sha256 = "15cvfa0s1vjx7gjd07d3fkznilishqf4z4h2q5f20wm9ysjh2h2i";
-    buildInputs = [ dune_2 ];
-    extra = {
-      buildPhase = "dune build -p rope";
-      installPhase = ''
-        dune install --prefix $out --libdir $OCAMLFIND_DESTDIR rope
-      '';
-    };
-  } else {
-    version = "0.5";
-    url = "https://forge.ocamlcore.org/frs/download.php/1156/rope-0.5.tar.gz";
-    sha256 = "05fr2f5ch2rqhyaj06rv5218sbg99p1m9pq5sklk04hpslxig21f";
-    buildInputs = [ ocamlbuild ];
-    extra = { createFindlibDestdir = true; };
-  };
-in
+buildDunePackage rec {
+  version = "0.6.2";
+  pname = "rope";
 
-stdenv.mkDerivation ({
-  name = "ocaml${ocaml.version}-rope-${param.version}";
+  useDune2 = true;
+  minimumOCamlVersion = "4.03";
 
-  src = fetchurl {
-    inherit (param) url sha256;
+  src = fetchFromGitHub {
+    owner = "Chris00";
+    repo = "ocaml-rope";
+    rev = "${version}";
+    sha256 = "1g828n359xzd3zk67kaarypbr861bxqghc3c7q37f5ihqb516bs1";
   };
 
-  buildInputs = [ ocaml findlib benchmark ] ++ param.buildInputs;
+  buildInputs = [ benchmark ];
 
   meta = {
     homepage = "http://rope.forge.ocamlcore.org/";
@@ -38,4 +23,4 @@ stdenv.mkDerivation ({
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ volth ];
   };
-} // param.extra)
+}

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation {
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   preConfigure = "patchShebangs ./configure.sh";
 

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   buildFlags = [ "all" "opt" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   dontStrip = true;
 

--- a/pkgs/development/ocaml-modules/seq/default.nix
+++ b/pkgs/development/ocaml-modules/seq/default.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation ({
 
   buildInputs = [ ocaml findlib ocamlbuild ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta.description = "Compatibility package for OCaml’s standard iterator type starting from 4.07";
 

--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ ctypes libsodium ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
 

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
 
   buildPhase = "make build";
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ ocaml_sqlite3 ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/mlin/ocaml-sqlite3EZ";

--- a/pkgs/development/ocaml-modules/syslog/default.nix
+++ b/pkgs/development/ocaml-modules/syslog/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
 
   buildFlags = [ "all" "opt" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/rixed/ocaml-syslog";

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -38,8 +38,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = param.propagatedBuildInputs or [];
 
-  buildPhase = "${run} build";
-  installPhase = "${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
+  buildPhase = ''
+    runHook preBuild
+    ${run} build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preBuild
+    ${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR
+    runHook postBuild
+  '';
 
   passthru = { inherit run; };
 

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = param.propagatedBuildInputs or [];
 
   buildPhase = "${run} build";
-  createFindlibDestdir = true;
   installPhase = "${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   passthru = { inherit run; };

--- a/pkgs/development/ocaml-modules/twt/default.nix
+++ b/pkgs/development/ocaml-modules/twt/default.nix
@@ -10,10 +10,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ];
 
-  createFindlibDestdir = true;
-
-  configurePhase = ''
-    mkdir $out/bin
+  preInstall = ''
+    mkdir -p "$out/bin"
   '';
 
   dontBuild = true;

--- a/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ocaml findlib camlp4];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = with lib; {
     homepage = "https://ocaml.janestreet.com/";

--- a/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ocaml findlib camlp4];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   meta = {
     homepage = "http://forge.ocamlcore.org/projects/type-conv/";

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
     inherit (param) sha256;
   };
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ camlp4 ];

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
-    ${topkg.buildPhase} --with-cmdliner false --tests ${lib.boolToString doCheck}
+    ${topkg.run} build --with-cmdliner false --tests ${lib.boolToString doCheck}
     runHook postBuild
   '';
 

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -34,11 +34,15 @@ stdenv.mkDerivation {
                           ++ optionals pdfBackend [ uutf otfm ]
                           ++ optionals htmlcBackend [ js_of_ocaml js_of_ocaml-ppx ];
 
-  buildPhase = topkg.buildPhase
-    + " --with-uutf ${boolToString pdfBackend}"
-    + " --with-otfm ${boolToString pdfBackend}"
-    + " --with-js_of_ocaml ${boolToString htmlcBackend}"
-    + " --with-cairo2 false";
+  buildPhase = ''
+    runHook preBuild
+    ${topkg.run} build \
+      --with-uutf ${boolToString pdfBackend} \
+      --with-otfm ${boolToString pdfBackend} \
+      --with-js_of_ocaml ${boolToString htmlcBackend} \
+      --with-cairo2 false
+    runHook postBuild
+  '';
 
   inherit (topkg) installPhase;
 

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "-C" "interpreter" ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   postInstall = ''
     mkdir $out/bin

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ];
 
-  createFindlibDestdir = true;
-
   buildPhase = ''
     runHook preBuild
     make all
@@ -24,6 +22,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
+    mkdir -p "$OCAMLFIND_DESTDIR"
     make install_ocamlfind
     mkdir -p $out/share
     cp -vai doc $out/share/

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -16,14 +16,18 @@ stdenv.mkDerivation {
   createFindlibDestdir = true;
 
   buildPhase = ''
+    runHook preBuild
     make all
     make opt
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     make install_ocamlfind
     mkdir -p $out/share
     cp -vai doc $out/share/
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ppx_tools js_of_ocaml js_of_ocaml-ppx ];
   propagatedBuildInputs = [ iri re ];
 
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p "$OCAMLFIND_DESTDIR"
+  '';
 
   dontStrip = true;
 

--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -54,8 +54,6 @@ stdenv.mkDerivation {
 
   inherit meta;
 
-  createFindlibDestdir = true;
-
   makeFlags = [ "PREFIX=$(out)" ];
 
   preBuild = ''

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -39,7 +39,11 @@ stdenv.mkDerivation rec {
         fi
         export OCAMLFIND_DESTDIR="''$out/lib/ocaml/${ocaml.version}/site-lib/"
         if test -n "''${createFindlibDestdir-}"; then
-          mkdir -p $OCAMLFIND_DESTDIR
+          echo "${placeholder "out"}:" \
+            "createFindlibDestdir is no longer supported by the findlib setup hook." \
+            "Instead create \$OCAMLFIND_DESTDIR manually in preInstall or similar." \
+            >&2
+          exit 100
         fi
     }
 

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -18,9 +18,21 @@ stdenv.mkDerivation {
       ocaml findlib ocamlbuild ocamlmod ocamlify
     ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-  buildPhase     = "ocaml setup.ml -build";
-  installPhase   = "ocaml setup.ml -install";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml setup.ml -configure --prefix $out
+    runHook postConfigure
+  '';
+  buildPhase = ''
+    runHook preBuild
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    ocaml setup.ml -install
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://oasis.forge.ocamlcore.org/";

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation {
     sha256 = "13ah03pbcvrjv5lmx971hvkm9rvbvimska5wmjfvgvd20ca0gn8w";
   };
 
-  createFindlibDestdir = true;
-
   buildInputs =
     [
       ocaml findlib ocamlbuild ocamlmod ocamlify
@@ -30,6 +28,7 @@ stdenv.mkDerivation {
   '';
   installPhase = ''
     runHook preInstall
+    mkdir -p "$OCAMLFIND_DESTDIR"
     ocaml setup.ml -install
     runHook postInstall
   '';

--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
     sha256 = "1hb5mcdz4wv7sh1pj7dq9q4fgz5h3zg7frpiya6s8zd3ypwzq0kh";
   };
 
-  createFindlibDestdir = true;
-
   buildInputs = [ ocaml findlib ];
 
   configurePhase = ''

--- a/pkgs/development/tools/ocaml/ocamlscript/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlscript/default.nix
@@ -14,8 +14,10 @@ stdenv.mkDerivation rec {
   buildFlags = [ "PREFIX=$(out)" ];
   installFlags = [ "PREFIX=$(out)" ];
 
-  preInstall = "mkdir $out/bin";
-  createFindlibDestdir = true;
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $OCAMLFIND_DESTDIR
+  '';
 
   meta = with lib; {
     homepage = "http://martin.jambon.free.fr/ocamlscript.html";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -653,7 +653,9 @@ let
 
     magic-mime = callPackage ../development/ocaml-modules/magic-mime { };
 
-    magick = callPackage ../development/ocaml-modules/magick { };
+    magick = callPackage ../development/ocaml-modules/magick {
+      imagemagick = pkgs.imagemagick6;
+    };
 
     mariadb = callPackage ../development/ocaml-modules/mariadb {
       inherit (pkgs) mariadb;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
