### PR TITLE
frr: init at 7.5.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -692,6 +692,7 @@
   ./services/networking/flannel.nix
   ./services/networking/freenet.nix
   ./services/networking/freeradius.nix
+  ./services/networking/frr.nix
   ./services/networking/gateone.nix
   ./services/networking/gdomap.nix
   ./services/networking/ghostunnel.nix

--- a/nixos/modules/services/networking/frr.nix
+++ b/nixos/modules/services/networking/frr.nix
@@ -1,0 +1,201 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.frr;
+
+  services = [
+    "static"
+    "bgp"
+    "ospf"
+    "ospf6"
+    "rip"
+    "ripng"
+    "isis"
+    "pim"
+    "ldp"
+    "nhrp"
+    "eigrp"
+    "babel"
+    "sharp"
+    "pbr"
+    "bfd"
+    "fabric"
+  ];
+
+  allServices = services ++ [ "zebra" ];
+
+  isEnabled = service: cfg.${service}.enable;
+
+  daemonName = service: if service == "zebra" then service else "${service}d";
+
+  configFile = service:
+    let
+      scfg = cfg.${service};
+    in
+      if scfg.configFile != null then scfg.configFile
+      else pkgs.writeText "${daemonName service}.conf"
+        ''
+          ! FRR ${daemonName service} configuration
+          !
+          hostname ${config.networking.hostName}
+          log syslog
+          service password-encryption
+          !
+          ${scfg.config}
+          !
+          end
+        '';
+
+  serviceOptions = service:
+    {
+      enable = mkEnableOption "the FRR ${toUpper service} routing protocol";
+
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/etc/frr/${daemonName service}.conf";
+        description = ''
+          Configuration file to use for FRR ${daemonName service}.
+          By default the NixOS generated files are used.
+        '';
+      };
+
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        example =
+          let
+            examples = {
+              rip = ''
+                router rip
+                  network 10.0.0.0/8
+              '';
+
+              ospf = ''
+                router ospf
+                  network 10.0.0.0/8 area 0
+              '';
+
+              bgp = ''
+                router bgp 65001
+                  neighbor 10.0.0.1 remote-as 65001
+              '';
+            };
+          in
+            examples.${service} or "";
+        description = ''
+          ${daemonName service} configuration statements.
+        '';
+      };
+
+      vtyListenAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = ''
+          Address to bind to for the VTY interface.
+        '';
+      };
+
+      vtyListenPort = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          TCP Port to bind to for the VTY interface.
+        '';
+      };
+    };
+
+in
+
+{
+
+  ###### interface
+  imports = [
+    {
+      options.services.frr = {
+        zebra = (serviceOptions "zebra") // {
+          enable = mkOption {
+            type = types.bool;
+            default = any isEnabled services;
+            description = ''
+              Whether to enable the Zebra routing manager.
+
+              The Zebra routing manager is automatically enabled
+              if any routing protocols are configured.
+            '';
+          };
+        };
+      };
+    }
+    { options.services.frr = (genAttrs services serviceOptions); }
+  ];
+
+  ###### implementation
+
+  config = mkIf (any isEnabled allServices) {
+
+    environment.systemPackages = [
+      pkgs.frr # for the vtysh tool
+    ];
+
+    users.users.frr = {
+      description = "FRR daemon user";
+      isSystemUser = true;
+      group = "frr";
+    };
+
+    users.groups = {
+      frr = {};
+      # Members of the frrvty group can use vtysh to inspect the FRR daemons
+      frrvty = { members = [ "frr" ]; };
+    };
+
+    systemd.services =
+      let
+        frrService = service:
+          let
+            scfg = cfg.${service};
+            daemon = daemonName service;
+          in
+            nameValuePair daemon ({
+              wantedBy = [ "multi-user.target" ];
+              after = [ "network-pre.target" "systemd-sysctl.service" ];
+              wants = [ "network.target" ];
+
+              serviceConfig = {
+                Type = "forking";
+                PIDFile = "/run/frr/${daemon}.pid";
+                ExecStart = "@${pkgs.frr}/libexec/frr/${daemon} ${daemon} -d -f ${configFile service}"
+                  + optionalString (scfg.vtyListenAddress != "") " -A ${scfg.vtyListenAddress}"
+                  + optionalString (scfg.vtyListenPort != null) " -P ${toString scfg.vtyListenPort}";
+                ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+                Restart = "on-abnormal";
+              };
+            } // (
+              if service == "zebra" then
+                {
+                  description = "FRR Zebra routing manager";
+                  unitConfig.Documentation = "man:zebra(8)";
+                  preStart = ''
+                    install -m 0755 -o frr -g frr -d /run/frr
+                  '';
+                }
+              else
+                {
+                  description = "FRR ${toUpper service} routing daemon";
+                  unitConfig.Documentation = "man:${daemon}(8) man:zebra(8)";
+                  bindsTo = [ "zebra.service" ];
+                  after = [ "zebra.service" ];
+                }
+            ));
+       in
+         listToAttrs (map frrService (filter isEnabled allServices));
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ woffs ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -133,6 +133,7 @@ in
   fluentd = handleTest ./fluentd.nix {};
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
+  frr = handleTest ./frr.nix {};
   fsck = handleTest ./fsck.nix {};
   ft2-clone = handleTest ./ft2-clone.nix {};
   gerrit = handleTest ./gerrit.nix {};

--- a/nixos/tests/frr.nix
+++ b/nixos/tests/frr.nix
@@ -1,0 +1,89 @@
+# This test runs FRR and checks if OSPF routing works.
+#
+# Network topology:
+#   [ client ]--net1--[ router1 ]--net2--[ router2 ]--net3--[ server ]
+#
+# All interfaces are in OSPF Area 0.
+
+import ./make-test-python.nix ({ pkgs, ... }:
+  let
+
+    ifAddr = node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ipv4.addresses).address;
+
+    ospfConf = ''
+      interface eth2
+        ip ospf hello-interval 1
+        ip ospf dead-interval 5
+      !
+      router ospf
+        network 192.168.0.0/16 area 0
+    '';
+
+  in
+    {
+      name = "frr";
+
+      meta = with pkgs.lib.maintainers; {
+        maintainers = [ ];
+      };
+
+      nodes = {
+
+        client =
+          { nodes, ... }:
+          {
+            virtualisation.vlans = [ 1 ];
+            networking.defaultGateway = ifAddr nodes.router1 "eth1";
+          };
+
+        router1 =
+          { ... }:
+          {
+            virtualisation.vlans = [ 1 2 ];
+            boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+            networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospf -j ACCEPT";
+            services.frr.ospf = {
+              enable = true;
+              config = ospfConf;
+            };
+          };
+
+        router2 =
+          { ... }:
+          {
+            virtualisation.vlans = [ 3 2 ];
+            boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+            networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospf -j ACCEPT";
+            services.frr.ospf = {
+              enable = true;
+              config = ospfConf;
+            };
+          };
+
+        server =
+          { nodes, ... }:
+          {
+            virtualisation.vlans = [ 3 ];
+            networking.defaultGateway = ifAddr nodes.router2 "eth1";
+          };
+      };
+
+      testScript =
+        { ... }:
+        ''
+          start_all()
+
+          # Wait for the networking to start on all machines
+          for machine in client, router1, router2, server:
+              machine.wait_for_unit("network.target")
+
+          with subtest("Wait for OSPF to form adjacencies"):
+              for gw in router1, router2:
+                  gw.wait_for_unit("ospfd")
+                  gw.wait_until_succeeds("vtysh -c 'show ip ospf neighbor' | grep Full")
+                  gw.wait_until_succeeds("vtysh -c 'show ip route' | grep '^O>'")
+
+          with subtest("Test ICMP"):
+              client.wait_until_succeeds("ping -c 3 server >&2")
+        '';
+    })

--- a/pkgs/development/libraries/libyang/default.nix
+++ b/pkgs/development/libraries/libyang/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pcre
+, pkg-config
+, genericUpdater
+, common-updater-scripts
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libyang";
+  version = "1.0.240";
+
+  src = fetchFromGitHub {
+    owner = "CESNET";
+    repo = "libyang";
+    rev = "v${version}";
+    sha256 = "12hzwm0jszhnbmn0a03pljpz18dzsrqn91z6y62ghci26qi3xcxn";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ pcre ];
+  cmakeFlags = [ "-DENABLE_LYD_PRIV=ON" "-DCMAKE_BUILD_TYPE:String=Release" ];
+
+  passthru.updateScript = genericUpdater {
+    inherit pname version;
+    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
+    ignoredVersions = "^2\.";
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "YANG data modelling language parser and toolkit";
+    longDescription = ''
+      libyang is a YANG data modelling language parser and toolkit written (and
+      providing API) in C. The library is used e.g. in libnetconf2, Netopeer2,
+      sysrepo or FRRouting projects.
+    '';
+    homepage = "https://github.com/CESNET/libyang";
+    license = with licenses; [ bsd3 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ woffs ];
+  };
+}

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, libcap
+, json_c
+, readline
+, net-snmp
+, perl
+, texinfo
+, pkg-config
+, c-ares
+, python3
+, python3Packages
+, libyang
+, flex
+, bison
+, openssl
+, czmq
+, nixosTests
+}:
+
+stdenv.mkDerivation rec {
+  pname = "frr";
+  version = "7.5.1";
+
+  src = fetchFromGitHub {
+    owner = "FRRouting";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0lzsvi3kl9zcd4k04vc3363z9v2yrp7wc8bziv6w9h5fznh2vkxp";
+  };
+
+  buildInputs = [ readline net-snmp c-ares json_c python3 libyang openssl czmq ]
+    ++ lib.optionals stdenv.isLinux [ libcap ];
+
+  nativeBuildInputs = [ pkg-config perl texinfo autoreconfHook python3Packages.sphinx python3Packages.pytest flex bison ];
+
+  configureFlags = [
+    "--sysconfdir=/etc/frr"
+    "--localstatedir=/run/frr"
+    "--sbindir=$(out)/libexec/frr"
+    "--disable-exampledir"
+    "--enable-user=frr"
+    "--enable-group=frr"
+    "--enable-configfile-mask=0640"
+    "--enable-logfile-mask=0640"
+    "--enable-vty-group=frrvty"
+    "--enable-snmp"
+    "--enable-multipath=64"
+  ];
+
+  postPatch = ''
+    substituteInPlace tools/frr-reload --replace /usr/lib/frr/ $out/libexec/frr/
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.tests = { inherit (nixosTests) frr; };
+
+  meta = with lib; {
+    description = "FRR BGP/OSPF/ISIS/RIP/RIPNG routing daemon suite";
+    longDescription = ''
+      FRRouting (FRR) is a free and open source Internet routing protocol suite
+      for Linux and Unix platforms. It implements BGP, OSPF, RIP, IS-IS, PIM,
+      LDP, BFD, Babel, PBR, OpenFabric and VRRP, with alpha support for EIGRP
+      and NHRP.
+
+      FRR’s seamless integration with native Linux/Unix IP networking stacks
+      makes it a general purpose routing stack applicable to a wide variety of
+      use cases including connecting hosts/VMs/containers to the network,
+      advertising network services, LAN switching and routing, Internet access
+      routers, and Internet peering.
+
+      FRR has its roots in the Quagga project. In fact, it was started by many
+      long-time Quagga developers who combined their efforts to improve on
+      Quagga’s well-established foundation in order to create the best routing
+      protocol stack available. We invite you to participate in the FRRouting
+      community and help shape the future of networking.
+
+      Join the ranks of network architects using FRR for ISPs, SaaS
+      infrastructure, web 2.0 businesses, hyperscale services, and Fortune 500
+      private clouds.
+    '';
+    homepage = "https://frrouting.org/";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ woffs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4727,6 +4727,8 @@ in
 
   flvstreamer = callPackage ../tools/networking/flvstreamer { };
 
+  frr = callPackage ../servers/frr { };
+
   hmetis = pkgsi686Linux.callPackage ../applications/science/math/hmetis { };
 
   libbsd = callPackage ../development/libraries/libbsd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17018,6 +17018,8 @@ in
       };
   });
 
+  libyang = callPackage ../development/libraries/libyang { };
+
   libykclient = callPackage ../development/libraries/libykclient { };
 
   libykneomgr = callPackage ../development/libraries/libykneomgr { };


### PR DESCRIPTION
###### Motivation for this change

- FRRouting is a successor of no-longer maintained quagga (#120195)
- new dependency: libyang
- NixOS: old quagga service and test adapted to frr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
