### PR TITLE
add himalaya Vim plugin

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -288,8 +288,8 @@ self: super: {
   });
 
   himalaya-vim = buildVimPluginFrom2Nix {
-    inherit (himalaya) src version;
     pname = "himalaya-vim";
+    inherit (himalaya) src version;
     configurePhase = "cd vim/";
     dependencies = with self; [ himalaya ];
     preFixup = ''

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -294,9 +294,7 @@ self: super: {
     dependencies = with self; [ himalaya ];
     preFixup = ''
       substituteInPlace $out/share/vim-plugins/himalaya-vim/plugin/himalaya.vim \
-        --replace \
-          'if !executable("himalaya")' \
-          'if v:false'
+        --replace 'if !executable("himalaya")' 'if v:false'
     '';
     postFixup = ''
       mkdir -p $out/bin

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -21,6 +21,7 @@
 , direnv
 , fzf
 , gnome
+, himalaya
 , khard
 , languagetool
 , llvmPackages
@@ -285,6 +286,23 @@ self: super: {
       license = lib.licenses.mit;
     };
   });
+
+  himalaya-vim = buildVimPluginFrom2Nix {
+    inherit (himalaya) src version;
+    pname = "himalaya-vim";
+    configurePhase = "cd vim/";
+    dependencies = with self; [ himalaya ];
+    preFixup = ''
+      substituteInPlace $out/share/vim-plugins/himalaya-vim/plugin/himalaya.vim \
+        --replace \
+          'if !executable("himalaya")' \
+          'if v:false'
+    '';
+    postFixup = ''
+      mkdir -p $out/bin
+      ln -s ${himalaya}/bin/himalaya $out/bin/himalaya
+    '';
+  };
 
   LanguageClient-neovim =
     let


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The plugin was missing despite it being in the codebase

@yanganto Is this the best way to do this? I added the package to the `flake.nix` in this [PR](https://github.com/soywod/himalaya/pull/157), but a) it's not merged, and b) I don't understand how to pull in a flake output package into the Vim plugins, so I went with what I did. Also, I'm not sure how to get the bin in scope for the plugin.

This bug fixes https://github.com/soywod/himalaya/issues/139


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
