### PR TITLE
podman: replace LD_LIBRARY_PATH wrapper with patchelf

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , pkg-config
 , installShellFiles
-, makeWrapper
 , buildGoModule
 , gpgme
 , lvm2
@@ -37,7 +36,7 @@ buildGoModule rec {
 
   outputs = [ "out" "man" ];
 
-  nativeBuildInputs = [ pkg-config go-md2man installShellFiles makeWrapper ];
+  nativeBuildInputs = [ pkg-config go-md2man installShellFiles ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     btrfs-progs
@@ -70,8 +69,6 @@ buildGoModule rec {
     installShellCompletion --zsh completions/zsh/*
     MANDIR=$man/share/man make install.man-nobuild
   '' + lib.optionalString stdenv.isLinux ''
-    wrapProgram $out/bin/podman \
-      --prefix LD_LIBRARY_PATH : "${lib.getLib systemd}/lib"
     install -Dm644 contrib/tmpfile/podman.conf -t $out/lib/tmpfiles.d
     install -Dm644 contrib/systemd/system/podman.{socket,service} -t $out/lib/systemd/system
   '' + ''

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -75,6 +75,11 @@ buildGoModule rec {
     runHook postInstall
   '';
 
+  postFixup = lib.optionalString stdenv.isLinux ''
+    RPATH=$(patchelf --print-rpath $out/bin/podman)
+    patchelf --set-rpath "${lib.makeLibraryPath [ systemd ]}":$RPATH $out/bin/podman
+  '';
+
   passthru.tests = { inherit (nixosTests) podman; };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
this is a follow up of  #123997 
###### Things done
although the previous pr did fix the issue around libsystemd, @dramforever suggests that there can be a cleaner approach by adding systemd to the rpath.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
