### PR TITLE
packet-cli: 0.3.0 -> 0.5.0

### DIFF
--- a/pkgs/development/tools/packet-cli/default.nix
+++ b/pkgs/development/tools/packet-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "packet-cli";
-  version = "0.3.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "packethost";
     repo = pname;
     rev = version;
-    sha256 = "sha256-P1Bn6vli0d/MroHUsioTWBrjWN+UZmSo3qmzo+fCDwM=";
+    sha256 = "0dlcx186l8kh6w3i4dvj7v90lhjkgvq1xkjb2vijy6399z41grw2";
   };
 
-  vendorSha256 = "sha256-PjKiUdhN87guPAa0loZrWYuwbl0HaspuIjmKgyq4Zp8=";
+  vendorSha256 = "1y1c369gsaf5crkdvv5g8d9p2g5602x2gcj8zy1q3wjx9lwhl0i6";
 
   postInstall = ''
     ln -s $out/bin/packet-cli $out/bin/packet
@@ -23,6 +23,6 @@ buildGoModule rec {
     description = "Official Packet CLI";
     homepage = "https://github.com/packethost/packet-cli";
     license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne ];
+    maintainers = with maintainers; [ Br1ght0ne nshalman ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New release is available: https://github.com/packethost/packet-cli/releases/tag/0.5.0

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
