### PR TITLE
[21.05] lean: substitute release commit sha1

### DIFF
--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -7,7 +7,11 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "leanprover-community";
     repo   = "lean";
-    rev    = "v${version}";
+    # lean's version string contains the commit sha1 it was built
+    # from. this is then used to check whether an olean file should be
+    # rebuilt. don't use a tag as rev because this will get replaced into
+    # src/githash.h.in in preConfigure.
+    rev    = "a5822ea47ebc52eec6323d8f1b60f6ec025daf99";
     sha256 = "sha256-gJhbkl19iilNyfCt2TfPmghYA3yCjg6kS+yk/x/k14Y=";
   };
 
@@ -19,6 +23,13 @@ stdenv.mkDerivation rec {
   # Running the tests is required to build the *.olean files for the core
   # library.
   doCheck = true;
+
+  preConfigure = assert builtins.stringLength src.rev == 40; ''
+     substituteInPlace src/githash.h.in \
+       --subst-var-by GIT_SHA1 "${src.rev}"
+     substituteInPlace library/init/version.lean.in \
+       --subst-var-by GIT_SHA1 "${src.rev}"
+  '';
 
   postPatch = "patchShebangs .";
 


### PR DESCRIPTION
###### Motivation for this change

Backport of #124507, cherry-picked from cbaf78c.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
