### PR TITLE
pcmsolver: init at 1.3.0

### DIFF
--- a/pkgs/development/libraries/pcmsolver/default.nix
+++ b/pkgs/development/libraries/pcmsolver/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub, cmake, perl, gfortran, python
+, boost, eigen, zlib
+} :
+
+stdenv.mkDerivation rec {
+  pname = "pcmsolver";
+  version = "1.3.0";
+
+  src = fetchFromGitHub  {
+    owner = "PCMSolver";
+    repo = pname;
+    rev = "v${version}";
+    sha256= "0jrxr8z21hjy7ik999hna9rdqy221kbkl3qkb06xw7g80rc9x9yr";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    perl
+    python
+  ];
+
+  buildInputs = [
+    boost
+    eigen
+    zlib
+  ];
+
+  cmakeFlags = [ "-DENABLE_OPENMP=ON" ];
+
+  hardeningDisable = [ "format" ];
+
+  # Requires files, that are not installed.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An API for the Polarizable Continuum Model";
+    homepage = "https://pcmsolver.readthedocs.io/en/stable/";
+    license = licenses.lgpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7156,6 +7156,8 @@ in
 
   pasystray = callPackage ../tools/audio/pasystray { };
 
+  pcmsolver = callPackage ../development/libraries/pcmsolver { };
+
   phash = callPackage ../development/libraries/phash { };
 
   pnmixer = callPackage ../tools/audio/pnmixer { };


### PR DESCRIPTION
###### Motivation for this change
Adds PCMSolver library. This is a scientific library, providing an API for continuum solvent models. Part of the packages @markuskowa and me want to merge from markuskowa/NixOS-QChem#56.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
