### PR TITLE
stdenv/mkDerivation: derive pname and version when not given

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -218,7 +218,15 @@ in rec {
               if attrs ? name
               then attrs.name + hostSuffix
               else "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}";
-        }) // {
+        }) // (let
+          # If only `name` is given, automatically derive pname and version:
+          pname = lib.getName attrs.name;
+          version = lib.getVersion attrs.name;
+        in
+          lib.optionalAttrs
+            (!(attrs ? pname || attrs ? version) && attrs ? name && pname != "" && version != "")
+            { inherit pname version; }
+        ) // {
           builder = attrs.realBuilder or stdenv.shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
           inherit stdenv;


### PR DESCRIPTION
###### Motivation for this change

Add `pname` and `version` to all packages automatically when not already given.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
