### PR TITLE
zthrottle: init

### DIFF
--- a/pkgs/tools/misc/zthrottle/default.nix
+++ b/pkgs/tools/misc/zthrottle/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, zsh }:
+
+stdenv.mkDerivation rec {
+  pname = "zthrottle";
+  version = "unstable-2017-7-24";
+
+  src = fetchFromGitHub {
+    owner = "anko";
+    repo = pname;
+    rev = "f62066661e49375baeb891fa8e43ad4527cbd0a0";
+    sha256 = "1ipvwmcsigzmxlg7j22cxpvdcgqckkmfpsnvzy18nbybd5ars9l5";
+  };
+
+  buildInputs = [ zsh ];
+
+  installPhase = ''
+    install -D zthrottle $out/bin/zthrottle
+  '';
+
+  meta = with lib; {
+    description = "A program that throttles a pipeline, only letting a line through at most every $1 seconds.";
+    homepage = "https://github.com/anko/zthrottle";
+    license = licenses.unlicense;
+    maintainers = [ maintainers.ronthecookie ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31643,5 +31643,7 @@ in
 
   xcolor = callPackage ../tools/graphics/xcolor { };
 
+  zthrottle = callPackage ../tools/misc/zthrottle { };
+
   zktree = callPackage ../applications/misc/zktree {};
 }


### PR DESCRIPTION
###### Motivation for this change
I needed it packaged so I could use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
