### PR TITLE
[21.05] devpi-client, devpi-server: set __darwinAllowLocalNetworking

### DIFF
--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -49,6 +49,8 @@ buildPythonApplication rec {
 
   LC_ALL = "en_US.UTF-8";
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     homepage = "http://doc.devpi.net";
     description = "Client for devpi, a pypi index server and packaging meta tool";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -55,6 +55,8 @@ python3Packages.buildPythonApplication rec {
     "TestMirrorIndexThings"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib;{
     homepage = "http://doc.devpi.net";
     description = "Github-style pypi index server and packaging meta tool";


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042 

Backport of #124428

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
