### PR TITLE
python3Packages.pynacl: switch to pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -1,16 +1,17 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, pytestCheckHook
+, pythonOlder
 , libsodium
 , cffi
-, six
 , hypothesis
 }:
 
 buildPythonPackage rec {
   pname = "pynacl";
   version = "1.4.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit version;
@@ -18,15 +19,22 @@ buildPythonPackage rec {
     sha256 = "01b56hxrbif3hx8l6rwz5kljrgvlbj7shmmd2rjh0hn7974a5sal";
   };
 
-  checkInputs = [ pytest hypothesis ];
-  buildInputs = [ libsodium ];
-  propagatedBuildInputs = [ cffi six ];
+  buildInputs = [
+    libsodium
+  ];
+
+  propagatedBuildInputs = [
+    cffi
+  ];
+
+  checkInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
 
   SODIUM_INSTALL = "system";
 
-  checkPhase = ''
-    py.test
-  '';
+  pythonImportsCheck = [ "nacl" ];
 
   meta = with lib; {
     maintainers = with maintainers; [ va1entin ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Switch to `pytestCheckHook`

- Disable on older Python releases
- Remove no longer needed dependency
- Add `pythonImportsCheck`
-
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
