### PR TITLE
[21.05] openconnect-head: init at 2021-05-05

### DIFF
--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -1,4 +1,19 @@
-{ lib, stdenv, fetchurl, pkg-config, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib, fetchgit, darwin } :
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, openssl ? null
+, gnutls ? null
+, gmp
+, libxml2
+, stoken
+, zlib
+, fetchgit
+, darwin
+, head ? false
+  , fetchFromGitLab
+  , autoreconfHook
+}:
 
 assert (openssl != null) == (gnutls == null);
 
@@ -9,15 +24,20 @@ let vpnc = fetchgit {
 };
 
 in stdenv.mkDerivation rec {
-  pname = "openconnect";
-  version = "8.10";
+  pname = "openconnect${lib.optionalString head "-head"}";
+  version = if head then "2021-05-05" else "8.10";
 
-  src = fetchurl {
-    urls = [
-      "ftp://ftp.infradead.org/pub/openconnect/${pname}-${version}.tar.gz"
-    ];
-    sha256 = "1cdsx4nsrwawbsisfkldfc9i4qn60g03vxb13nzppr2br9p4rrih";
-  };
+  src =
+    if head then fetchFromGitLab {
+      owner = "openconnect";
+      repo = "openconnect";
+      rev = "684f6db1aef78e61e01f511c728bf658c30b9114";
+      sha256 = "0waclawcymgd8sq9xbkn2q8mnqp4pd0gpyv5wrnb7i0nsv860wz8";
+    }
+    else fetchurl {
+      url = "ftp://ftp.infradead.org/pub/openconnect/${pname}-${version}.tar.gz";
+      sha256 = "1cdsx4nsrwawbsisfkldfc9i4qn60g03vxb13nzppr2br9p4rrih";
+    };
 
   outputs = [ "out" "dev" ];
 
@@ -29,7 +49,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ openssl gnutls gmp libxml2 stoken zlib ]
     ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.PCSC;
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config ]
+    ++ lib.optional head autoreconfHook;
 
   meta = with lib; {
     description = "VPN Client for Cisco's AnyConnect SSL VPN";

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "VPN Client for Cisco's AnyConnect SSL VPN";
     homepage = "http://www.infradead.org/openconnect/";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     maintainers = with maintainers; [ pradeepchhetri tricktron ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9429,6 +9429,11 @@ in
     openssl = null;
   };
 
+  openconnect_head = callPackage ../tools/networking/openconnect {
+    head = true;
+    openssl = null;
+  };
+
   ding-libs = callPackage ../tools/misc/ding-libs { };
 
   sssd = callPackage ../os-specific/linux/sssd {


### PR DESCRIPTION
###### Motivation for this change

Backport of #122617 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS (aarch64, i686, x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
