### PR TITLE
nixos/release-notes: fix `slaptest` command for openldap section

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -436,7 +436,7 @@
     </para>
     <programlisting>
       TMPDIR=$(mktemp -d)
-      slaptest -f /path/to/slapd.conf $TMPDIR
+      slaptest -f /path/to/slapd.conf -F $TMPDIR
       slapcat -F $TMPDIR -n0 -H 'ldap:///???(!(objectClass=olcSchemaConfig))'
     </programlisting>
     <para>


### PR DESCRIPTION
###### Motivation for this change

When running - as suggested - `slaptest -f slapd.conf $TMPDIR` I get the
following result:

    [root@ldap:/tmp/tmp.De46ABIbFf]# slaptest -f /nix/store/lks3ihydj40ff6yqvz0k33ycrc9vbyry-slapd.conf $TMPDIR
    usage: slaptest [-v] [-d debuglevel] [-f configfile] [-F configdir] [-o <name>[=<value>]] [-n databasenumber] [-u] [-Q]

    [root@ldap:/tmp/tmp.De46ABIbFf]# echo $?
    1

Adding a `-F` option fixes the issue.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
