### PR TITLE
emacsWithPackages: Fix auto-complete-clang-async and irony

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -80,8 +80,8 @@ let
 
         auto-complete-clang-async = super.auto-complete-clang-async.overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.llvmPackages.llvm ];
-          CFLAGS = "-I${pkgs.llvmPackages.clang}/include";
-          LDFLAGS = "-L${pkgs.llvmPackages.clang}/lib";
+          CFLAGS = "-I${pkgs.llvmPackages.libclang.lib}/include";
+          LDFLAGS = "-L${pkgs.llvmPackages.libclang.lib}/lib";
         });
 
         # part of a larger package
@@ -195,7 +195,7 @@ let
           dontUseCmakeBuildDir = true;
           doCheck = true;
           packageRequires = [ self.emacs ];
-          nativeBuildInputs = [ pkgs.cmake pkgs.llvmPackages.llvm pkgs.llvmPackages.clang ];
+          nativeBuildInputs = [ pkgs.cmake pkgs.llvmPackages.llvm pkgs.llvmPackages.libclang ];
         });
 
         # tries to write a log file to $HOME


### PR DESCRIPTION
###### Motivation for this change

The emacs `irony` package stopped building for me, presumably because of https://github.com/NixOS/nixpkgs/commit/7869d1654517c028aa76fc1dedc9b5ac301a867a .

This change seems to fix the build for me and the executable still runs - the auto-complete-clang-async change is a 'blind' fix similar to other changes I've seen, but I'm not familiar with the package myself.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
