### PR TITLE
Any way to support an attr that provides viable paths at build-time to a suitable run-time `sudo`?

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8750,7 +8750,12 @@ in
 
   subsurface = libsForQt514.callPackage ../applications/misc/subsurface { };
 
-  sudo = callPackage ../tools/security/sudo { };
+  sudo = if stdenv.isDarwin
+    then runCommand "impure-native-darwin-sudo" { } ''
+      mkdir -p $out/bin
+      ln -s /usr/bin/sudo $out/bin/sudo
+      ln -s /usr/sbin/visudo $out/bin/visudo
+    '' else callPackage ../tools/security/sudo { };
 
   suidChroot = callPackage ../tools/system/suid-chroot { };
 


### PR DESCRIPTION
Edit: Erg. :) @LnL7 promptly pointed out a misunderstanding in chat ([summary](https://github.com/NixOS/nixpkgs/pull/124536#issuecomment-849097368)) that makes it clear the problem is a little bigger / more complicated than this. I do still have the problem/need here, and would still like to discuss whether there's any fix for it.

I tucked the original text in a details section at the end of the post, and am extracting what's still relevant to the top.

---

I have a specific (personal + community) use-case for an attr that, at build-time, contains a reference to a working run-time `sudo`. Ideally, it'd also be intuitive/discoverable, but I guess that's secondary.

`resholve` ([nixpkg](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/misc/resholve), [repo](https://github.com/abathur/resholve) provides CLI + Nix APIs for resolving bare command references in shell scripts and blocking if it finds commands that aren't supplied by an input. 

resholve's Nix API improves shell packaging in Nixpkgs, but it also makes it easier for end Nix/NixOS users (and developers of shell projects) to maintain shell-idiomatic scripts that they can readily use in non-Nix contexts. Their scripts can be separate shell files that use generic commands without absolute paths, instead of either having to port them to Nix files to use interpolation, or pepper them with `@varName@` to use `substituteAll*`. 

`sudo` is common enough (poor measure, but GH code searches by `language:shell` report `9,498,395` results for grep, `2,087,379` for curl, `1,712,215` for sudo, `997,732` for xargs) that poor ergonomics/workarounds will cause ongoing friction.

---

<details>
<summary>original post text</summary>
I stumbled into an implementation that ~cheats a little (lot?) to fix a problem/need I have, so I want to open for discussion. There's a bit of context/history here. I've tried to outline ~enough, but don't hesitate to ask for clarification.

## Status quo

There is no top-level `sudo` attr that works across platforms (and specifically here, on macOS).
- The current top-level sudo attr is not marked with darwin support. It will actually build if I force it, but it isn't useful.
- `darwin.sudo` was added in #109626. 
    - The initial PR intent was to also use it as the top-level sudo for Darwin, but this was reverted in #112006. 
    - There is an ergonomics issue with meeting this need by re-mapping `darwin.sudo` to top-level sudo. It throws errors like `error: derivation ... requested impure path '/usr/bin/sudo', but it was not in allowed-impure-host-deps`. (see also: https://github.com/NixOS/nixpkgs/pull/109003#issuecomment-757782436)
        - I don't think making every darwin user individually set this is ideal.
        - The other fix might be adding it to the [default darwin `allowedImpureHostPrefixes `](https://github.com/NixOS/nix/blob/4638bcfb2cfb74cb5029c0da0af38bb7ca4b4a6f/src/libstore/globals.cc#L74), but I have no perspective on the consequences (and it seems like a leakier fix)?
- Before I realized #109626 tried and failed to update the top-level sudo attr, I stumbled into the approach in the present PR. 

## Motivation
I have a specific (personal + community) use-case for a top-level sudo attr that actually builds and contains a reference to a working `sudo` executable.

`resholve` ([nixpkg](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/misc/resholve), [repo](https://github.com/abathur/resholve) provides CLI + Nix APIs for resolving bare command references in shell scripts and blocking if it finds commands that aren't supplied by an input. 

resholve's Nix API improves shell packaging in Nixpkgs, but it also makes it easier for end Nix/NixOS users (and developers of shell projects) to maintain shell-idiomatic scripts that they can readily use in non-Nix contexts. Their scripts can be separate shell files that use generic commands without absolute paths, instead of either having to port them to Nix files to use interpolation, or pepper them with `@varName@` to use `substituteAll*`. 

`sudo` is common enough (poor measure, but GH code searches by `language:shell` report `9,498,395` results for grep, `2,087,379` for curl, `1,712,215` for sudo, `997,732` for xargs) that poor ergonomics will cause ongoing friction:
- A top-level `sudo` attr that works only on linux makes it very easy for packagers working on linux to author packages that they don't realize will not build on macOS.
    - This is probably just annoying if they are packaging it for Nixpkgs, where the testing/review process should notice the break.
    - It's a footgun if they're doing something outside of Nixpkgs are tricked into thinking they have a working package that'll blow up on macOS. 
- For macOS users, discovering any workable way to package something that needs sudo will be pretty rough (for the reasons in the status quo section)
- The straightforward ways to special-case a fallback hardcoded darwin system path in resholve will cause their own cross-platform issues that I suspect will only be tractable by adding Nix-specific logic and sudo semantics that run contra to how all other inputs are specified. (This wouldn't be a _disaster_--I am building resholve for Nix/Nixpkgs--but I am trying hard to keep the core program generic, and it would add to the already-significant conceptual complexity.)

</details>

@veprbl @grahamc @matthewbauer @holymonson (probably others...)