### PR TITLE
rpg-cli: init at 0.2.0

### DIFF
--- a/pkgs/games/rpg-cli/default.nix
+++ b/pkgs/games/rpg-cli/default.nix
@@ -1,0 +1,27 @@
+{ rustPlatform, fetchFromGitHub, lib }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rpg-cli";
+  version = "unstable-2021-05-27";
+
+  src = fetchFromGitHub {
+    owner = "facundoolano";
+    repo = pname;
+    # certain revision because the Cargo.lock was checked-in in that commit
+    rev = "4d8a1dac79a1d29d79c0c874475037769dcef5a1";
+    sha256 = "sha256-qfj1uij9lYyfyHFUnVi9I0ELOoObjFG2NS9UreC/xio=";
+  };
+
+  cargoSha256 = "sha256-I+rSfuiGFdzA5zqPfvMPcERaQfiX92LW2NKjazWh9c4=";
+
+  # tests assume the authors macbook, and thus fail
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Your filesystem as a dungeon";
+    homepage = "https://github.com/facundoolano/rpg-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ legendofmiracles ];
+    mainProgram = "rpg-cli";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8242,6 +8242,8 @@ in
 
   rowhammer-test = callPackage ../tools/system/rowhammer-test { };
 
+  rpg-cli = callPackage ../games/rpg-cli { };
+
   rpPPPoE = callPackage ../tools/networking/rp-pppoe { };
 
   rpi-imager = libsForQt5.callPackage ../tools/misc/rpi-imager { };


### PR DESCRIPTION
###### Motivation for this change
~~Cargo.lock isn't checked in, for now we patch it, but I opened a issue https://github.com/facundoolano/rpg-cli/issues/26~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
