### PR TITLE
acoustics: fix

### DIFF
--- a/pkgs/development/python-modules/acoustics/default.nix
+++ b/pkgs/development/python-modules/acoustics/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     pushd tests
-    py.test ./.
+    py.test -Wignore::DeprecationWarning ./.
     popd
   '';
 


### PR DESCRIPTION
There's a bit of LaTeX math code in a comment in a test file:

```
    .. math:: L = 10 \cdot \\log_{10}{\\left(\\frac{MS}{p_r^2} \\right)}
```

which of course should be `\\cdot`.

I could patch it, but I think skipping deprecation warnings in tests is probably ok... (If nothing else it's easier.)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ZHF: #122042 @jonringer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Tested lightly with `nix-shell -I nixpkgs=/code/nixpkgs -p python37Packages.acoustics --run python`
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
