### PR TITLE
pythonPackages.wit: init at 6.0.0

### DIFF
--- a/pkgs/development/python-modules/wit/default.nix
+++ b/pkgs/development/python-modules/wit/default.nix
@@ -1,0 +1,15 @@
+{ lib, buildPythonPackage, fetchPypi
+, requests, prompt_toolkit
+}:
+
+buildPythonPackage rec {
+  pname = "wit";
+  version = "6.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y1m33anfsfd1aq4w2zz8s7c8ifhhxnvyxl75apaq37f8z0qlfqm";
+  };
+
+  propagatedBuildInputs =  [ requests prompt_toolkit ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8560,6 +8560,8 @@ in {
 
   winsspi = callPackage ../development/python-modules/winsspi { };
 
+  wit = callPackage ../development/python-modules/wit { };
+
   wled = callPackage ../development/python-modules/wled { };
 
   woob = callPackage ../development/python-modules/woob { };


### PR DESCRIPTION
###### Motivation for this change

Initialise github.com/wit-ai/pywit package

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
