### PR TITLE
handbrake: fix audio when linking with ffmpeg-4.4

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -7,7 +7,7 @@
 # be nice to add the native GUI (and/or the GTK GUI) as an option too, but that
 # requires invoking the Xcode build system, which is non-trivial for now.
 
-{ stdenv, lib, fetchFromGitHub,
+{ stdenv, lib, fetchFromGitHub, fetchpatch,
   # Main build tools
   pkg-config, autoconf, automake, libtool, m4, xz, python3,
   numactl,
@@ -57,6 +57,15 @@ stdenv.mkDerivation rec {
       echo "DATE=$(date +"%F %T %z" -r $out/NEWS.markdown)" > $out/version.txt
     '';
   };
+
+  # Remove with a release after 1.3.3
+  patches = [
+    (fetchpatch {
+      name = "audio-fix-ffmpeg-4_4";
+      url = "https://github.com/HandBrake/HandBrake/commit/f28289fb06ab461ea082b4be56d6d1504c0c31c2.patch";
+      sha256 = "sha256:1zcwa4h97d8wjspb8kbd8b1jg0a9vvmv9zaphzry4m9q0bj3h3kz";
+    })
+  ];
 
   # we put as little as possible in src.extraPostFetch as it's much easier to
   # add to it here without having to fiddle with src.sha256


### PR DESCRIPTION
Handbrake rips do not include working audio without this upstream patch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix an issue preventing handbrake from producing videos with working audio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
