### PR TITLE
lz4: patch CVE-2021-3520 and null pointer dereference

### DIFF
--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -14,6 +14,19 @@ stdenv.mkDerivation rec {
     owner = pname;
   };
 
+  patches = [
+    (fetchpatch { # https://github.com/lz4/lz4/pull/972
+      name = "CVE-2021-3520.patch";
+      url = "https://github.com/lz4/lz4/commit/8301a21773ef61656225e264f4f06ae14462bca7.patch";
+      sha256 = "0r1cwpqdkdc8im0pf2r5jp7mwwn69xcw405rrk7rc0mpjcp5ydfk";
+    })
+    (fetchpatch { # https://github.com/lz4/lz4/pull/973
+      name = "avoid-null-pointer-dereference.patch";
+      url = "https://github.com/lz4/lz4/commit/29a6a1f4941e7243241fe00d6c13b749fd6b60c2.patch";
+      sha256 = "0v5yl5hd3qrfm3xm7m06j4b21qwllb4cqkjn2az7x1vnzqgpf8y7";
+    })
+  ];
+
   # TODO(@Ericson2314): Separate binaries and libraries
   outputs = [ "bin" "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/lz4/lz4/pull/972
https://github.com/lz4/lz4/pull/973

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).