### PR TITLE
python3Packages.matplotlib: fix darwin qhull

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -10,6 +10,7 @@
 # required for headless detection
 , libX11, wayland
 , Cocoa
+, python
 }:
 
 let
@@ -79,6 +80,15 @@ buildPythonPackage rec {
   # Matplotlib needs to be built against a specific version of freetype in
   # order for all of the tests to pass.
   doCheck = false;
+
+  pythonImportsCheck = [ "matplotlib" "matplotlib.pyplot" "matplotlib._qhull" ];
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    # Fix paths to libqhull library. Its path is prefixed with "lib/"
+    install_name_tool -change lib/libqhull_r.8.0.dylib \
+      ${qhull}/lib/libqhull_r.8.0.dylib \
+      $out/${python.sitePackages}/matplotlib/_qhull.*.so
+  '';
 
   meta = with lib; {
     description = "Python plotting library, making publication quality plots";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


Matplotlib was not correctly linking against the qhull library, causing
failing builds in downstream packages like cartopy
(https://hydra.nixos.org/build/144122509). Here is an example of this error message

```

self = <matplotlib.tri.triangulation.Triangulation object at 0x1271530a0>
x = array([-5.78687373, -5.15662016, -3.95340879])
y = array([49.96191974, 50.59217331, 50.87865221])
triangles = array([[0, 1, 2]], dtype=int32), mask = None

    def __init__(self, x, y, triangles=None, mask=None):
>       from matplotlib import _qhull
E       ImportError: dlopen(/nix/store/swqaz9n5rxnykx5wl1mfmalcc17q4as6-python3.8-matplotlib-3.4.1/lib/python3.8/site-packages/matplotlib/_qhull.cpython-38-darwin.so, 2): Library not loaded: lib/libqhull_r.8.0.dylib
E         Referenced from: /nix/store/swqaz9n5rxnykx5wl1mfmalcc17q4as6-python3.8-matplotlib-3.4.1/lib/python3.8/site-packages/matplotlib/_qhull.cpython-38-darwin.so
E         Reason: image not found

```


ZHF: #122042 

This allow cartopy to build on Darwin.

cc @jonringer @veprbl @mredaelli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
