### PR TITLE
stdenv/darwin: add sigtool to extraNativeBuildInputs, tidy

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -145,14 +145,14 @@ in rec {
 
         inherit config shell extraBuildInputs;
 
-        extraNativeBuildInputs = extraNativeBuildInputs ++ lib.optionals doUpdateAutoTools [
-          last.pkgs.updateAutotoolsGnuConfigScriptsHook last.pkgs.gnu-config
-        ];
+        extraNativeBuildInputs = extraNativeBuildInputs
+          ++ lib.optionals doUpdateAutoTools [ last.pkgs.updateAutotoolsGnuConfigScriptsHook ];
 
         allowedRequisites = if allowedRequisites == null then null else allowedRequisites ++ [
           cc.expand-response-params cc.bintools
         ] ++ lib.optionals doUpdateAutoTools [
-          last.pkgs.updateAutotoolsGnuConfigScriptsHook last.pkgs.gnu-config
+          last.pkgs.updateAutotoolsGnuConfigScriptsHook
+          last.pkgs.gnu-config
         ] ++ lib.optionals doSign [
           last.pkgs.darwin.postLinkSignHook
           last.pkgs.darwin.sigtool

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -146,7 +146,8 @@ in rec {
         inherit config shell extraBuildInputs;
 
         extraNativeBuildInputs = extraNativeBuildInputs
-          ++ lib.optionals doUpdateAutoTools [ last.pkgs.updateAutotoolsGnuConfigScriptsHook ];
+          ++ lib.optionals doUpdateAutoTools [ last.pkgs.updateAutotoolsGnuConfigScriptsHook ]
+          ++ lib.optionals doSign [ last.pkgs.darwin.sigtool ];
 
         allowedRequisites = if allowedRequisites == null then null else allowedRequisites ++ [
           cc.expand-response-params cc.bintools
@@ -641,6 +642,7 @@ in rec {
 
     extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
       pkgs.updateAutotoolsGnuConfigScriptsHook
+      pkgs.darwin.sigtool
     ];
 
     extraBuildInputs = [ pkgs.darwin.CF ];


### PR DESCRIPTION
###### Motivation for this change

Building emacs on aarch64-darwin without explicitly adding "sigtool" to the emacs package.

**Untested**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
