### PR TITLE
emacs: fix build on aarch64-darwin

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -47,7 +47,11 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
   NATIVE_FULL_AOT = "1";
   LIBRARY_PATH = "${lib.getLib stdenv.cc.libc}/lib";
 } // lib.optionalAttrs stdenv.isDarwin {
-  CFLAGS = "-DMAC_OS_X_VERSION_MAX_ALLOWED=101200";
+  CFLAGS =
+    let
+      version = lib.versions.splitVersion stdenv.hostPlatform.darwinMinVersion;
+      part = i: lib.fixedWidthNumber 2 (if i < builtins.length version then lib.elemAt version i else 0);
+    in "-DMAC_OS_X_VERSION_MAX_ALLOWED=${part 0}${part 1}${part 2}";
 } // {
   inherit pname version patches;
 
@@ -139,6 +143,12 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optional nativeComp "--with-native-compilation"
     ++ lib.optional withImageMagick "--with-imagemagick"
     ;
+
+  # Emacs checks for arm-apple-darwin, but our configuration is
+  # aarch64-apple-darwin. Force enable DO_CODESIGN.
+  preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    sed -i 's/^DO_CODESIGN=.*/DO_CODESIGN=yes/' src/Makefile.in
+  '';
 
   installTargets = [ "tags" "install" ];
 


### PR DESCRIPTION
###### Motivation for this change

Fix emacs build on aarch64-darwin. Requires "codesign", which will be provided by #124570 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
