### PR TITLE
(darwin) openjdk: update to latest versions, add aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -1,5 +1,23 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
 let
+  # Details from https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "11.48.21";
+      jdkVersion = "11.0.11";
+      sha256 = "0v0n7h7i04pvna41wpdq2k9qiy70sbbqzqzvazfdvgm3gb22asw6";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "11.48.21";
+      jdkVersion = "11.0.11";
+      sha256 = "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
+    };
+  }."${stdenv.hostPlatform.system}";
+
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
     url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
@@ -7,16 +25,16 @@ let
   };
 
   jdk = stdenv.mkDerivation rec {
-    name = "zulu11.43.21-ca-jdk11.0.9";
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/${name}-macosx_x64.tar.gz";
-      sha256 = "1j19fb5mwdkfn6y8wfsnvxsz6wfpcab4xv439fqssxy520n6q4zs";
-      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-mac/";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -40,8 +58,6 @@ let
       # properly.
       mkdir -p $out/nix-support
       printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
-
-      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -1,25 +1,43 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
 let
+  # Details from https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "8.54.0.21";
+      jdkVersion = "8.0.292";
+      sha256 = "1pgl0bir4r5v349gkxk54k6v62w241q7vw4gjxhv2g6pfq6hv7in";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "8.54.0.21";
+      jdkVersion = "8.0.292";
+      sha256 = "05w89wfjlfbpqfjnv6wisxmaf13qb28b2223f9264jyx30qszw1c";
+    };
+  }."${stdenv.hostPlatform.system}";
+
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
     url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 
-  jdk = stdenv.mkDerivation {
+  jdk = stdenv.mkDerivation rec {
     # @hlolli: Later version than 1.8.0_202 throws error when building jvmci.
     # dyld: lazy symbol binding failed: Symbol not found: _JVM_BeforeHalt
     # Referenced from: ../libjava.dylib Expected in: .../libjvm.dylib
-    name = "zulu1.8.0_202-8.36.0.1";
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-macosx_x64.zip";
-      sha256 = "0s92l1wlf02vjx8dvrsla2kq7qwxnmgh325b38mgqy872016jm9p";
-      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -43,8 +61,6 @@ let
       # properly.
       mkdir -p $out/nix-support
       printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
-
-      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/openjdk/darwin/default.nix
+++ b/pkgs/development/compilers/openjdk/darwin/default.nix
@@ -1,5 +1,23 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
 let
+  # Details from https://www.azul.com/downloads/?version=java-16-sts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "16.30.15";
+      jdkVersion = "16.0.1";
+      sha256 = "1jihn125dmxr9y5h9jq89zywm3z6rbwv5q7msfzsf2wzrr13jh0z";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "16.30.19";
+      jdkVersion = "16.0.1";
+      sha256 = "1i0bcjx3acb5dhslf6cabdcnd6mrz9728vxw9hb4al5y3f5fll4w";
+    };
+  }."${stdenv.hostPlatform.system}";
+
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
     url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
@@ -7,17 +25,16 @@ let
   };
 
   jdk = stdenv.mkDerivation rec {
-    pname = "zulu16.28.11-ca-jdk";
-    version = "16.0.0";
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/${pname}${version}-macosx_x64.tar.gz";
-      sha256 = "6d47ef22dc56ce1f5a102ed39e21d9a97320f0bb786818e2c686393109d79bc5";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -41,8 +58,6 @@ let
       # properly.
       mkdir -p $out/nix-support
       printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
-
-      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook


### PR DESCRIPTION
###### Motivation for this change

aarch64-darwin support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
