### PR TITLE
oneko: 1.2.sakura.5 -> 1.2.hanami.6, and change upstream

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4323,6 +4323,16 @@
     githubId = 54999;
     name = "Ariel Nunez";
   };
+  irenes = {
+    name = "Irene Knapp";
+    email = "ireneista@gmail.com";
+    github = "IreneKnapp";
+    githubId = 157678;
+    keys = [{
+      longkeyid = "rsa4096/0xDBF252AFFB2619FD";
+      fingerprint = "E864 BDFA AB55 36FD C905  5195 DBF2 52AF FB26 19FD";
+    }];
+  };
   ironpinguin = {
     email = "michele@catalano.de";
     github = "ironpinguin";

--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, imake, gccmakedep, xlibsWrapper }:
+{ lib, stdenv, fetchFromGitHub, imake, gccmakedep, xlibsWrapper }:
 
 stdenv.mkDerivation rec {
-  version_name = "1.2.sakura.5";
-  version = "1.2.5";
+  version_name = "1.2.hanami.6";
+  version = "1.2.6";
   pname = "oneko";
-  src = fetchurl {
-    url = "http://www.daidouji.com/oneko/distfiles/oneko-${version_name}.tar.gz";
-    sha256 = "2c2e05f1241e9b76f54475b5577cd4fb6670de058218d04a741a04ebd4a2b22f";
+  src = fetchFromGitHub {
+    owner = "IreneKnapp";
+    repo = "oneko";
+    rev = version_name;
+    sha256 = "0vx12v5fm8ar3f1g6jbpmd3b1q652d32nc67ahkf28djbqjgcbnc";
   };
   nativeBuildInputs = [ imake gccmakedep ];
   buildInputs = [ xlibsWrapper ];
@@ -22,9 +24,9 @@ stdenv.mkDerivation rec {
     chasing around your mouse cursor.
     When the cat is done catching the mouse, it starts sleeping.
     '';
-    homepage = "http://www.daidouji.com/oneko/";
-    license = licenses.publicDomain;
-    maintainers = [ maintainers.xaverdh ];
+    homepage = "https://github.com/IreneKnapp/oneko";
+    license = with licenses; [ publicDomain ];
+    maintainers = with maintainers; [ xaverdh irenes ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
As of approximately a year ago, I am the upstream maintainer of Oneko. The previous version was released in 1999. Per the README, every version has been by a different maintainer. I did attempt to contact the previous one, but since there was no response, I think it's entirely in the spirit of the project to consider my version the latest. I like to think of it as similar to those piles of stones, where each hiker who passes adds one more.

###### Things done
Update Oneko to version 1.2.hanami.6. Add myself as a second nixpkgs maintainer for it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
