### PR TITLE
ocamlPackages.cooltt: init at unstable-2021-05-25

### DIFF
--- a/pkgs/development/ocaml-modules/cooltt/default.nix
+++ b/pkgs/development/ocaml-modules/cooltt/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, cmdliner
+, menhir
+, menhirLib
+, ppx_deriving
+, ppxlib
+, uuseg
+, uutf
+}:
+
+buildDunePackage {
+  pname = "cooltt";
+  version = "unstable-2021-05-25";
+
+  minimumOCamlVersion = "4.10";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "RedPRL";
+    repo = "cooltt";
+    rev = "8ac06cbf7e05417d777f3ac6a471fe3576249f79";
+    sha256 = "sha256-JBLNJaRuP/gwlg8RS3cpOpzxChOVKfmFulf5HKhhHh4=";
+  };
+
+  nativeBuildInputs = [
+    cmdliner
+    menhir
+    ppxlib
+  ];
+
+  propagatedBuildInputs = [
+    menhirLib
+    ppx_deriving
+    uuseg
+    uutf
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/RedPRL/cooltt";
+    description = "A cool implementation of normalization by evaluation (nbe) & elaboration for Cartesian cubical type theory";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -191,6 +191,8 @@ let
 
     containers-data = callPackage ../development/ocaml-modules/containers/data.nix { };
 
+    cooltt = callPackage ../development/ocaml-modules/cooltt { };
+
     cow = callPackage ../development/ocaml-modules/cow { };
 
     cpdf = callPackage ../development/ocaml-modules/cpdf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
