### PR TITLE
release-combined.tested: Add the Sway test

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -147,6 +147,7 @@ in rec {
         (onFullSupported "nixos.tests.sddm.default")
         (onFullSupported "nixos.tests.shadow")
         (onFullSupported "nixos.tests.simple")
+        (onFullSupported "nixos.tests.sway")
         (onFullSupported "nixos.tests.switchTest")
         (onFullSupported "nixos.tests.udisks2")
         (onFullSupported "nixos.tests.xfce")


### PR DESCRIPTION
Sway is a Wayland compositor. It should have a smaller userbase than
Gnome and KDE but Sway plays an important role in the Wayland ecosystem
(it is e.g. maintained by Simon Ser who also maintains wlroots, Wayland,
and Weston (the reference compositor) and contributes to a lot of
important packages in the Wayland ecosystem). Sway also comes with much
fewer dependencies than large desktop environments.
This should make the Sway VM test an ideal choice for testing updates to
core packages (e.g. wayland, wayland-protocols, wlroots, libdrm, mesa,
and xwayland - I maintain all but XWayland in Nixpkgs) and test failures
should be much easier to debug.

The test is fairly new but so far all 18 Hydra builds on x86_64-linux
have succeeded [0]. I'm actively maintaining the test and can look into
build failures if I'm pinged.

[0]: https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.sway.x86_64-linux/all

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
