### PR TITLE
nq: fix tq

### DIFF
--- a/pkgs/tools/system/nq/default.nix
+++ b/pkgs/tools/system/nq/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
   postPatch = ''
     sed -i tq \
-      -e 's|\bfq\b|'$out'/bin/fq|g' \
-      -e 's|\bnq\b|'$out'/bin/nq|g'
+      -e 's|\bnq\b|'$out'/bin/nq|g' \
+      -e 's|\bfq\b|'$out'/bin/fq|g'
   '';
   meta = with lib; {
     description = "Unix command line queue utility";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
occurrences of `fq` in `tq`'s code was previously replaced with `/nix/store/xkcifwgsf2glhwha2zbjca295b07v8br-/nix/store/xkcifwgsf2glhwha2zbjca295b07v8br-nq-0.4/bin/nq-0.4/bin/fq` due to `fq` first being replaced by the store path for `fq` and then the `nq` in the store path being replaced by the store path again. This PR fixes the issue by changing the substitution order.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
