### PR TITLE
nixos/prometheus: init partial kubernetes SD config

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -378,6 +378,10 @@ let
         relevant Prometheus configuration docs</link> for more detail.
       '';
 
+      kubernetes_sd_configs = mkOpt (types.listOf promTypes.kubernetes_sd_config) ''
+        List of Kubernetes service discovery configurations.
+      '';
+
       static_configs = mkOpt (types.listOf promTypes.static_config) ''
         List of labeled target groups for this job.
       '';
@@ -609,6 +613,25 @@ let
         See the GCP documentation on network tags for more information: <link
         xlink:href="https://cloud.google.com/vpc/docs/add-remove-network-tags"
         />
+      '';
+    };
+  };
+
+  promTypes.kubernetes_sd_config = types.submodule {
+    options = {
+      api_server = mkOpt types.str ''
+        The API server address.
+      '';
+
+      role = mkOption {
+        type = types.enum [ "node" "service" "pod" "endpoints" "ingress" ];
+        description = ''
+          The Kubernetes role of entities that should be discovered.
+        '';
+      };
+
+      tls_config = mkOpt promTypes.tls_config ''
+        Configures TLS settings.
       '';
     };
   };

--- a/nixos/tests/prometheus.nix
+++ b/nixos/tests/prometheus.nix
@@ -60,6 +60,15 @@ in import ./make-test-python.nix {
               }
             ];
           }
+          # This is only here to test the resulting configuration.
+          # No Kubernetes clusters are spun up.
+          {
+            job_name = "kubernetes-sd";
+            kubernetes_sd_configs = [{
+              role = "node";
+              api_server = "http://127.0.0.1:8001";
+            }];
+          }
         ];
         rules = [
           ''


### PR DESCRIPTION
###### Motivation for this change

Adds basic support for Kubernetes self-discovery to Prometheus.

Only a few fields are supported:

- `api_server`
- `role`
- `tls_config`

Other fields, like those dealing with authentication, require some work, since prometheus [has moved](https://github.com/prometheus/prometheus/pull/8512) from the `bearer` field to `authorization.credentials`.

The `bearer`/`bearer_file` options, used throughout this module, are not supported anymore. Switching to the new options will be done in a follow-up PR.

Additionally, a block testing the configuration is added to the relevant NixOS test. This is there to validate the config only, i.e. no functional testing is performed on the Kubernetes SD funcionality at this time. I think testing the config is useful, since it would've caught that the `bearer` key mentioned above is no longer valid.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
