### PR TITLE
Add a package for SoftMaker Office 2018

### DIFF
--- a/pkgs/applications/office/softmaker/softmaker_office_2018.nix
+++ b/pkgs/applications/office/softmaker/softmaker_office_2018.nix
@@ -1,0 +1,28 @@
+{ callPackage
+, fetchurl
+
+  # This is a bit unusual, but makes version and hash easily
+  # overridable. This is useful when people have an older version of
+  # Softmaker Office or when the upstream archive was replaced and
+  # nixpkgs is not in sync yet.
+, officeVersion ? {
+  version = "982";
+  edition = "2018";
+  hash = "sha256-A45q/irWxKTLszyd7Rv56WeqkwHtWg4zY9YVxqA/KmQ=";
+}
+
+, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  inherit (officeVersion) version edition;
+
+  pname = "softmaker-office-2018";
+  suiteName = "SoftMaker Office 2018";
+
+  src = fetchurl {
+    inherit (officeVersion) hash;
+    url = "https://www.softmaker.net/down/softmaker-office-${edition}-${version}-amd64.tgz";
+  };
+
+  archive = "office${edition}.tar.lzma";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25421,6 +25421,8 @@ in
 
   softmaker-office = callPackage ../applications/office/softmaker/softmaker_office.nix {};
 
+  softmaker-office-2018 = callPackage ../applications/office/softmaker/softmaker_office_2018.nix {};
+
   spacegun = callPackage ../applications/networking/cluster/spacegun {};
 
   stride = callPackage ../applications/networking/instant-messengers/stride { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
SoftMaker Office is available in different versions (2012, 2016, 2018, 2021), and users who own a license for an older version need to be able to install the older version. Here, I have added a package for the latest (and probably final) version SoftMaker Office 2018, which is differentiated from the latest version by containing the reference to the version '2018' in the package name.
The .nix script for the new package is the same as for the latest version, just with changed version numbers and sha256 hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have tested the three applications on nixos 20.09, everything seems to be working fine.