### PR TITLE
iptsd: init at 0.4

### DIFF
--- a/pkgs/applications/misc/iptsd/default.nix
+++ b/pkgs/applications/misc/iptsd/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, systemd, inih }:
+
+stdenv.mkDerivation rec {
+  pname = "iptsd";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "linux-surface";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-CoPgkt7n2kk7WlQHe0RjNlxfp2Nd8BbIE2gyf0bOBy4=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+
+  buildInputs = [ systemd inih ];
+
+  # Original installs udev rules and service config into global paths
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "install_dir: unitdir" "install_dir: datadir" \
+      --replace "install_dir: rulesdir" "install_dir: datadir" \
+  '';
+  mesonFlags = [
+    "-Dsystemd=true"
+    "-Dsample_config=false"
+    "-Ddebug_tool=false"
+  ];
+
+  meta = with lib; {
+    description = "Userspace daemon for Intel Precise Touch & Stylus";
+    homepage = "https://github.com/linux-surface/iptsd";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ tomberek ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5821,6 +5821,8 @@ in
 
   ipget = callPackage ../applications/networking/ipget { };
 
+  iptsd = callPackage ../applications/misc/iptsd { };
+
   ipmitool = callPackage ../tools/system/ipmitool {};
 
   ipmiutil = callPackage ../tools/system/ipmiutil {};


### PR DESCRIPTION
###### Motivation for this change
This is a nixos-hardware TODO item to support touchscreen on Microsoft Surface laptops in NixOS.

###### Things done

simple meson/ninja packaging. There are some options available to create more/less output.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
