### PR TITLE
nixos-install: ask which admin account to set password for

### DIFF
--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -502,19 +502,24 @@ OK
         </para>
         <para>
           As the last step, <literal>nixos-install</literal> will ask
-          you to set the password for the <literal>root</literal> user,
-          e.g.
+          you to set the password for an admin user or the
+          <literal>root</literal> user, e.g.
         </para>
         <programlisting>
-setting root password...
+Please supply the username of an admin user and a new password.
+Supplying no username will cause no password to be set.
+
+Valid admin users are: jane root
+Username: jane
+setting jane password...
 New password: ***
 Retype new password: ***
 </programlisting>
         <note>
           <para>
             For unattended installations, it is possible to use
-            <literal>nixos-install --no-root-passwd</literal> in order
-            to disable the password prompt entirely.
+            <literal>nixos-install &lt; /dev/null</literal> in order to
+            disable the password prompt entirely.
           </para>
         </note>
       </listitem>
@@ -538,17 +543,17 @@ Retype new password: ***
           something goes wrong.
         </para>
         <para>
-          You should log in and change the <literal>root</literal>
-          password with <literal>passwd</literal>.
+          Use your declared user account to log in. If you didn’t
+          declare one, you should still be able to log in using
+          <literal>root</literal> user.
         </para>
         <para>
-          You’ll probably want to create some user accounts as well,
-          which can be done with <literal>useradd</literal>:
+          Note that some graphical display managers like SDDM do not
+          allow <literal>root</literal> login by default so you might
+          need to switch to TTY. Head to
+          <xref linkend="sec-user-management" /> for more info regarding
+          declaring user accounts.
         </para>
-        <programlisting>
-$ useradd -c 'Eelco Dolstra' -m eelco
-$ passwd eelco
-</programlisting>
         <para>
           You may also want to install some software. This will be
           covered in <xref linkend="sec-package-management" />.

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -92,6 +92,15 @@
       </listitem>
       <listitem>
         <para>
+          If you declared admin users in
+          <literal>configuration.nix</literal>, the
+          <literal>nixos-install</literal> will now allow you to choose
+          between these users and <literal>root</literal> when setting
+          password.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           PHP now defaults to PHP 8.1, updated from 8.0.
         </para>
       </listitem>

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -354,17 +354,22 @@ Use the following commands:
     fixing your `configuration.nix`.
 
     As the last step, `nixos-install` will ask you to set the password
-    for the `root` user, e.g.
+    for an admin user or the `root` user, e.g.
 
     ```plain
-    setting root password...
+    Please supply the username of an admin user and a new password.
+    Supplying no username will cause no password to be set.
+
+    Valid admin users are: jane root
+    Username: jane
+    setting jane password...
     New password: ***
     Retype new password: ***
     ```
 
     ::: {.note}
     For unattended installations, it is possible to use
-    `nixos-install --no-root-passwd` in order to disable the password
+    `nixos-install < /dev/null` in order to disable the password
     prompt entirely.
     :::
 
@@ -381,15 +386,13 @@ Use the following commands:
     menu. This allows you to easily roll back to a previous
     configuration if something goes wrong.
 
-    You should log in and change the `root` password with `passwd`.
+    Use your declared user account to log in. If you didn't declare one,
+    you should still be able to log in using `root` user.
 
-    You'll probably want to create some user accounts as well, which can
-    be done with `useradd`:
-
-    ```ShellSession
-    $ useradd -c 'Eelco Dolstra' -m eelco
-    $ passwd eelco
-    ```
+    Note that some graphical display managers like SDDM do not allow
+    `root` login by default so you might need to switch to TTY.
+    Head to [](#sec-user-management) for more info regarding
+    declaring user accounts.
 
     You may also want to install some software. This will be covered in
     [](#sec-package-management).

--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -71,6 +71,9 @@
    <arg>
     <group choice='req'>
      <arg choice='plain'>
+      <option>--no-password</option>
+     </arg>
+     <arg choice='plain'>
       <option>--no-root-password</option>
      </arg>
      <arg choice='plain'>
@@ -161,8 +164,8 @@
     </listitem>
     <listitem>
      <para>
-      It prompts you for a password for the root account (unless
-      <option>--no-root-password</option> is specified).
+      It prompts you for a password for an admin account (unless
+      <option>--no-password</option> is specified).
      </para>
     </listitem>
    </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -44,6 +44,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   Alternatively, you can remove the `hostPlatform` line and use NixOS like you
   would in NixOS 22.05 and earlier.
 
+- If you declared admin users in `configuration.nix`, the `nixos-install` will now allow you to choose between these users and `root` when setting password.
+
 - PHP now defaults to PHP 8.1, updated from 8.0.
 
 - `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes: https://github.com/NixOS/nixpkgs/issues/97422
Fixes: https://github.com/NixOS/nixpkgs/pull/104343

Tested with `jane` user uncommented in generated `configuration.nix`:
- [X] New `nixos-install` with new `nixpkgs` - promts for username, `jane` or `root`.
If `users.mutableUsers` is set to `false` or one of users have delared password in config, it doesn't asks any passwords.
- [X] New `nixos-install` with old `nixpkgs` - promts for username, only `root`.
- [X] Old `nixos-install` with new `nixpkgs` - asks for `root` password, just like before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
