### PR TITLE
mbuffer: Clarify gpl3 license

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = "http://www.maier-komor.de/mbuffer.html";
+    homepage = "https://www.maier-komor.de/mbuffer.html";
     description  = "A tool for buffering data streams with a large set of unique features";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ tokudan ];

--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.maier-komor.de/mbuffer.html";
     description  = "A tool for buffering data streams with a large set of unique features";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ tokudan ];
     platforms = lib.platforms.linux; # Maybe other non-darwin Unix
   };


### PR DESCRIPTION
###### Motivation for this change

Clarification of the license

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
