### PR TITLE
nixos/tests/{sway,cage,cagebreak}: Fix the tests on aarch64-linux

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -52,8 +52,8 @@ in
   buildkite-agents = handleTest ./buildkite-agents.nix {};
   caddy = handleTest ./caddy.nix {};
   cadvisor = handleTestOn ["x86_64-linux"] ./cadvisor.nix {};
-  cage = handleTestOn ["x86_64-linux"] ./cage.nix {};
-  cagebreak = handleTestOn ["x86_64-linux"] ./cagebreak.nix {};
+  cage = handleTest ./cage.nix {};
+  cagebreak = handleTest ./cagebreak.nix {};
   calibre-web = handleTest ./calibre-web.nix {};
   cassandra_2_1 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_2_1; };
   cassandra_2_2 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_2_2; };
@@ -395,7 +395,7 @@ in
   sssd-ldap = handleTestOn ["x86_64-linux"] ./sssd-ldap.nix {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
   sudo = handleTest ./sudo.nix {};
-  sway = handleTestOn ["x86_64-linux"] ./sway.nix {};
+  sway = handleTest ./sway.nix {};
   switchTest = handleTest ./switch-test.nix {};
   sympa = handleTest ./sympa.nix {};
   syncthing = handleTest ./syncthing.nix {};

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -18,10 +18,8 @@ import ./make-test-python.nix ({ pkgs, ...} :
     };
 
     virtualisation.memorySize = 1024;
-    # Need to switch to a different VGA card / GPU driver because Cage segfaults with the default one (std):
-    # machine # [   14.355893] .cage-wrapped[736]: segfault at 20 ip 00007f035fa0d8c7 sp 00007ffce9e4a2f0 error 4 in libwlroots.so.8[7f035fa07000+5a000]
-    # machine # [   14.358108] Code: 4f a8 ff ff eb aa 0f 1f 44 00 00 c3 0f 1f 80 00 00 00 00 41 54 49 89 f4 55 31 ed 53 48 89 fb 48 8d 7f 18 48 8d 83 b8 00 00 00 <80> 7f 08 00 75 0d 48 83 3f 00 0f 85 91 00 00 00 48 89 fd 48 83 c7
-    virtualisation.qemu.options = [ "-vga virtio" ];
+    # Need to switch to a different GPU driver than the default one (-vga std) so that Cage can launch:
+    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   enableOCR = true;

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -36,8 +36,8 @@ in
     environment.systemPackages = [ pkgs.cagebreak pkgs.wayland-utils ];
 
     virtualisation.memorySize = 1024;
-    # Need to switch to a different VGA card / GPU driver than the default one (std) so that Cagebreak can launch:
-    virtualisation.qemu.options = [ "-vga virtio" ];
+    # Need to switch to a different GPU driver than the default one (-vga std) so that Cagebreak can launch:
+    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   enableOCR = true;

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -42,8 +42,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
     programs.gnupg.agent.enable = true;
 
     virtualisation.memorySize = 1024;
-    # Need to switch to a different VGA card / GPU driver than the default one (std) so that Sway can launch:
-    virtualisation.qemu.options = [ "-vga virtio" ];
+    # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
+    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   enableOCR = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

    Since the update to wlroots 0.13 (e03dde82a74) the default VGA card
    isn't supported anymore and we needed to switch to virtio (qxl didn't
    work either). However, as it turned out "-vga virtio" (28b8cff301f)
    broke the test on AArch64. Luckily there's a third option that works on
    all three supported platforms: virtio-gpu-pci

    According to [0] "This device lacks VGA compatibility mode but is
    otherwise identical to the virtio vga device. UEFI firmware can handle
    this, and if your guests has drivers too you can use this instead of
    virtio-vga. This will reduce the attack surface (no complex VGA
    emulation support) and reduce the memory footprint by 8 MB (no pci
    memory bar for VGA compatibility). This device can be placed in a PCI
    Express slot."
    So in the end this seems like the ideal choice :)
    See also [1].

    [0]: https://www.kraxel.org/blog/2019/09/display-devices-in-qemu/#virtio-gpu-pci
    [1]: https://patches.openembedded.org/patch/164351/

###### Motivation for this change

~~WIP, not sure if this works but from what I found online it should.~~
Nice, it does work: https://github.com/NixOS/nixpkgs/pull/124688/checks?check_run_id=2687957185

~~TODOs in case it works: Cage, Cagebreak + proper commit message.~~

According to https://patches.openembedded.org/patch/164351/:
> If using qemu-system-aarch64 or qemu-system-arm with the options, an error
occured as follows:
>  qemu-system-aarch64: Virtio VGA not available
> this commit fixes the error to use -device virtio-gpu-pci instead of
-vga virtio.

And https://www.kraxel.org/blog/2019/09/display-devices-in-qemu/#virtio-gpu-pci also seems like a good source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
