### PR TITLE
vapoursynth: load default VapourSynth plugins

### DIFF
--- a/pkgs/development/libraries/vapoursynth/plugin-interface.nix
+++ b/pkgs/development/libraries/vapoursynth/plugin-interface.nix
@@ -22,7 +22,7 @@ plugins: let
   pluginLoader = let
     source = writeText "vapoursynth-nix-plugins.c" ''
       void VSLoadPluginsNix(void (*load)(void *data, const char *path), void *data) {
-      ${lib.concatMapStringsSep "" (path: "load(data, \"${path}/lib/vapoursynth\");") deepPlugins}
+      ${lib.concatMapStringsSep "" (path: "load(data, \"${path}/lib/vapoursynth\");") ([ vapoursynth ] ++ deepPlugins)}
       }
     '';
   in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

VapourSynth ships with a few default plugins, like `eedi3`, `misc`, and `removegrain`. This PR loads these included plugins with `VSLoadPluginsNix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Maintainer pings

cc @tadeokondrak 