### PR TITLE
wine{Unstable,Staging}: 6.7 -> 6.9

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.8";
+    version = "6.9";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "sha256-W0It3mfYQShxFSzjFYde+0lFB604oPTXEPE5OKdp69g=";
+    sha256 = "sha256-GFVOYB3vhqmiAXKwhcZoMpFPwh511VX25U/4nn6uW/4=";
     inherit (stable) gecko32 gecko64;
 
     ## see http://wiki.winehq.org/Mono
@@ -65,13 +65,17 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-cuJaODJ1jDxlUG9QTIQjg4IQqK5rOZGjgdpzjd4XAHc=";
+    sha256 = "sha256-g0NmiypafOAmKDRoRf4uz5NnhFo6uga0fKYNCF29jbE=";
     owner = "wine-staging";
     repo = "wine-staging";
-    rev = "v${version}";
+    #rev = "v${version}";
+    # FIXME: replace with line above with 6.10 release
+    # Fix https://bugs.winehq.org/show_bug.cgi?id=51172
+    rev = "5bbe3e47a559b3c04bc8791e0b398a271c772af7";
 
-    # Just keep list empty, if current release haven't broken patchsets
-    disabledPatchsets = [ ];
+    # Actually only "d3d11-Deferred_Context" cause problems, two others only dependencies
+    # see FIXME above
+    disabledPatchsets = [ "d3d11-Deferred_Context" "wined3d-CSMT_Main" "nvapi-Stub_DLL" "nvcuvid-CUDA_Video_Support" "nvencodeapi-Video_Encoder" ];
   };
 
   winetricks = fetchFromGitHub rec {

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.7";
+    version = "6.8";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "sha256-wwUUt3YdRhFRSuAhyx41QSjXfv9UooPxQB7nAid7vqQ=";
+    sha256 = "sha256-W0It3mfYQShxFSzjFYde+0lFB604oPTXEPE5OKdp69g=";
     inherit (stable) gecko32 gecko64;
 
     ## see http://wiki.winehq.org/Mono
@@ -65,7 +65,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-fWriizSk2+U7Mpn6w/Dlrevd4vc5MnlSWSGxQDf2p+M=";
+    sha256 = "sha256-cuJaODJ1jDxlUG9QTIQjg4IQqK5rOZGjgdpzjd4XAHc=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , meson
 , ninja
@@ -79,6 +80,13 @@ in stdenv.mkDerivation rec {
   )'';
 
   patches = [
+    # Fix for wine 6.8+ (remove patch in next release):
+    (fetchpatch {
+      url = "https://github.com/robbert-vdh/yabridge/commit/5577c4bfd842c60a8ae8ce2889bbfeb53a51c62b.patch";
+      sha256 = "sha256-bTT08iWwDBVqi2PZPa7oal7/MqVu8t2Bh1gpjFMqLvQ=";
+      excludes = [ "CHANGELOG.md" ];
+    })
+
     # Hard code wine path so wine version is correct in logs
     (substituteAll {
       src = ./hardcode-wine.patch;


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

This broke compatibility with yabridge, so I've bumped the version and added a modified upstream patch to fix the build @kira-bruneau 

It looks like it breaks the graphics in at least one of the programs I use though, so we may want to wait for a later version instead? @avnik 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
