### PR TITLE
mutt: patch for CVE-2021-32055

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -45,6 +45,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/muttmua/mutt/-/commit/4a2becbdb4422aaffe3ce314991b9d670b7adf17.patch";
       sha256 = "1dcfv1pfxchw3bjlcggjmy9fmldpzhmb1bffy03l25pjglbc4n95";
     })
+    # CVE-2021-32055
+    (fetchpatch {
+      url = "https://gitlab.com/muttmua/mutt/-/commit/7c4779ac24d2fb68a2a47b58c7904118f40965d5.patch";
+      sha256 = "11fwy05rrr8akyxic2y37r8kq3l0rqjhfmbn1ilq7055205pmlca";
+    })
   ] ++ optional smimeSupport [
     (fetchpatch {
       url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";


### PR DESCRIPTION
###### Motivation for this change

Fix #124652

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS (i686-linux, x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
