### PR TITLE
Revert "element-desktop: set dbus default for firefox"

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -45,8 +45,7 @@ in mkYarnPackage rec {
 
     # executable wrapper
     makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
-      --add-flags "$out/share/element/electron" \
-      --set-default MOZ_DBUS_REMOTE 1
+      --add-flags "$out/share/element/electron"
   '';
 
   # Do not attempt generating a tarball for element-web again.


### PR DESCRIPTION
This reverts commit becc715b8978f9fdf973da30637bbc5fc871fcf4.

###### Motivation for this change
#123777 broke opening links for an X11 user (and presumably all of them)
https://github.com/NixOS/nixpkgs/issues/120228#issuecomment-849019126

this will break opening links for at least sway users, but they can set `MOZ_DBUS_REMOTE` before running `element-desktop`
and i'm not aware of an inverse approach for X11 users (and since there's probably more of those, they should be preferred for the default working solution)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes

@buckley310 suggested setting MOZ_DBUS_REMOTE for firefox, which as i understand it would make firefox on X11 also use dbus as well
but i'm guessing that would bring unintended consequences and seems a bit of a big change for a quick fix for the current breakage

ping @symphorien who merged my original PR
ping @primeos (sway maintainer), @lovesegfault and @mweinelt (firefox maintainers) in case they can suggest a better approach


this breakage got into 21.05 so i'll open a backport PR in a few days if no other solution is found by then