### PR TITLE
getdata: add security patch from Debian

### DIFF
--- a/pkgs/development/libraries/getdata/default.nix
+++ b/pkgs/development/libraries/getdata/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libtool }:
+{ lib, stdenv, fetchurl, fetchpatch, libtool }:
 stdenv.mkDerivation rec {
   pname = "getdata";
   version = "0.10.0";
@@ -6,6 +6,11 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/getdata/${pname}-${version}.tar.xz";
     sha256 = "18xbb32vygav9x6yz0gdklif4chjskmkgp06rwnjdf9myhia0iym";
   };
+
+  patches = [ (fetchpatch {
+    url = "https://sources.debian.org/data/main/libg/libgetdata/0.10.0-10/debian/patches/CVE-2021-20204.patch";
+    sha256 = "1lvp1c2pkk9kxniwlvax6d8fsmjrkpxawf71c7j4rfjm6dgvivzm";
+  })];
 
   buildInputs = [ libtool ];
 

--- a/pkgs/development/libraries/getdata/default.nix
+++ b/pkgs/development/libraries/getdata/default.nix
@@ -7,10 +7,12 @@ stdenv.mkDerivation rec {
     sha256 = "18xbb32vygav9x6yz0gdklif4chjskmkgp06rwnjdf9myhia0iym";
   };
 
-  patches = [ (fetchpatch {
-    url = "https://sources.debian.org/data/main/libg/libgetdata/0.10.0-10/debian/patches/CVE-2021-20204.patch";
-    sha256 = "1lvp1c2pkk9kxniwlvax6d8fsmjrkpxawf71c7j4rfjm6dgvivzm";
-  })];
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/libg/libgetdata/0.10.0-10/debian/patches/CVE-2021-20204.patch";
+      sha256 = "1lvp1c2pkk9kxniwlvax6d8fsmjrkpxawf71c7j4rfjm6dgvivzm";
+    })
+  ];
 
   buildInputs = [ libtool ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #124626

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
