### PR TITLE
morph: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -1,18 +1,17 @@
-{ buildGoPackage, fetchFromGitHub, go-bindata, openssh, makeWrapper, lib }:
+{ buildGoModule, fetchFromGitHub, go-bindata, openssh, makeWrapper, lib }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "morph";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "dbcdk";
     repo = "morph";
     rev = "v${version}";
-    sha256 = "064ccvvq4yk17jy5jvi1nxfp5ajvnvn2k4zvh9v0n3ragcl3rd20";
+    sha256 = "0aibs4gsb9pl21nd93bf963kdzf0661qn0liaw8v8ak2xbz7nbs8";
   };
 
-  goPackagePath = "github.com/dbcdk/morph";
-  goDeps = ./deps.nix;
+  vendorSha256 = "08zzp0h4c4i5hk4whz06a3da7qjms6lr36596vxz0d8q0n7rspr9";
 
   nativeBuildInputs = [ makeWrapper go-bindata ];
 
@@ -28,7 +27,7 @@ buildGoPackage rec {
 
   postInstall = ''
     mkdir -p $lib
-    cp -v go/src/$goPackagePath/data/*.nix $lib
+    cp -v ./data/*.nix $lib
     wrapProgram $out/bin/morph --prefix PATH : ${lib.makeBinPath [ openssh ]};
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/DBCDK/morph/releases/tag/v1.6.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>morph</li>
  </ul>
</details>