### PR TITLE
duplicati: 2.0.5.1 -> 2.0.6.1, fix nixos module

### DIFF
--- a/nixos/modules/services/backup/duplicati.nix
+++ b/nixos/modules/services/backup/duplicati.nix
@@ -54,11 +54,13 @@ in
       };
     };
 
-    users.users.duplicati = lib.optionalAttrs (cfg.user == "duplicati") {
-      uid = config.ids.uids.duplicati;
-      home = "/var/lib/duplicati";
-      createHome = true;
-      group = "duplicati";
+    users.users = lib.optionalAttrs (cfg.user == "duplicati") {
+      duplicati = {
+        uid = config.ids.uids.duplicati;
+        home = "/var/lib/duplicati";
+        createHome = true;
+        group = "duplicati";
+      };
     };
     users.groups.duplicati.gid = config.ids.gids.duplicati;
 

--- a/pkgs/tools/backup/duplicati/default.nix
+++ b/pkgs/tools/backup/duplicati/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "duplicati";
-  version = "2.0.5.1";
+  version = "2.0.6.1";
   channel = "beta";
-  build_date = "2020-01-18";
+  build_date = "2021-05-03";
 
   src = fetchzip {
     url = "https://github.com/duplicati/duplicati/releases/download/v${version}-${version}_${channel}_${build_date}/duplicati-${version}_${channel}_${build_date}.zip";
-    sha256 = "1k3gfwcw7snxkqn4lf9rx1vzradpyq5vc48pwvaa8wwqnlykiimw";
+    sha256 = "09537hswpicsx47vfdm78j3h7vvjd7nqjd2461jrln57nl7v7dac";
     stripRoot = false;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
