### PR TITLE
gmnisrv: fix security vulnerability

### DIFF
--- a/pkgs/servers/gemini/gmnisrv/default.nix
+++ b/pkgs/servers/gemini/gmnisrv/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   pname = "gmnisrv";
-  version = "unstable-2021-03-26";
+  version = "unstable-2021-05-16";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "gmnisrv";
-    rev = "f23ec10a6d66c574bbf718c4b10f2cf91ea8daef";
-    sha256 = "1d9rjx0s092yfzjxd2yvzixhqgg883nlnmsysgp21w75n2as354n";
+    rev = "b9a92193e96bbe621ebc8430d8308d45a5b86cef";
+    sha256 = "sha256-eMKsoq3Y+eS20nxI7EoDLbdwdoB6shbGt6p8wS+uoPc=";
   };
 
   MIMEDB = "${mime-types}/etc/mime.types";
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl mime-types scdoc ];
+  nativeBuildInputs = [ pkg-config scdoc ];
+  buildInputs = [ openssl mime-types ];
 
   meta = with lib; {
     description = "A simple Gemini protocol server";
     homepage = "https://git.sr.ht/~sircmpwn/gmnisrv";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ bsima jb55 ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[[gmnisrv] Notice of security vulnerability](https://lists.orbitalfox.eu/archives/gemini/2021/006490.html)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
