### PR TITLE
fetchutils: remove DESTDIR, use PREFIX, change owner

### DIFF
--- a/pkgs/tools/misc/fetchutils/default.nix
+++ b/pkgs/tools/misc/fetchutils/default.nix
@@ -5,7 +5,7 @@ stdenvNoCC.mkDerivation rec {
   version = "unstable-2021-03-16";
 
   src = fetchFromGitHub {
-    owner = "lptstr";
+    owner = "kiedtl";
     repo = pname;
     rev = "882781a297e86f4ad4eaf143e0777fb3e7c69526";
     sha256 = "sha256-ONrVZC6GBV5v3TeBekW9ybZjDHF3FNyXw1rYknqKRbk=";
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation rec {
 
   buildInputs = [ bash scdoc ];
 
-  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+  installFlags = [ "PREFIX=$(out)/" ];
 
   postPatch = ''
     patchShebangs --host src/*


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
for some reason the Makefile is ignoring DESTDIR, as a result nothing is in the output

change the github repo owners name as they seemed to have changed it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
