### PR TITLE
[21.05] mediatomb: use ffmpeg instead of ffmpeg_3

### DIFF
--- a/pkgs/servers/mediatomb/default.nix
+++ b/pkgs/servers/mediatomb/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchgit
-, sqlite, expat, mp4v2, flac, spidermonkey_68, taglib, libexif, curl, ffmpeg_3, file
+, sqlite, expat, mp4v2, flac, spidermonkey_68, taglib, libexif, curl, ffmpeg, file
 , pkg-config, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mimslr4q6mky865y6561rr64cbn4gf0qc2dhgb31hxp4rc1kmzd";
   };
 
-  buildInputs = [ sqlite expat spidermonkey_68 taglib libexif curl ffmpeg_3 file mp4v2 flac
+  buildInputs = [ sqlite expat spidermonkey_68 taglib libexif curl ffmpeg file mp4v2 flac
                   pkg-config autoreconfHook ];
 
   meta = with lib; {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
backport https://github.com/NixOS/nixpkgs/pull/123487

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
