### PR TITLE
[21.05] Release Notes on mediatomb changes (actual backport)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -307,6 +307,24 @@
    </listitem>
    <listitem>
      <para>
+       The <literal>mediatomb</literal> service is
+       now using by default the new and maintained fork
+       <literal>gerbera</literal> package instead of the unmaintained
+       <literal>mediatomb</literal> package. If you want to keep the old
+       behavior, you must declare it with:
+       <programlisting>
+       services.mediatomb.package = pkgs.mediatomb;
+       </programlisting>
+       One new option <literal>openFirewall</literal> has been introduced which
+       defaults to false. If you relied on the service declaration to add the
+       firewall rules itself before, you should now declare it with:
+       <programlisting>
+       services.mediatomb.openFirewall = true;
+       </programlisting>
+     </para>
+   </listitem>
+   <listitem>
+     <para>
        xfsprogs was update from 4.19 to 5.11. It now enables reflink support by default on filesystem creation.
        Support for reflinks was added with an experimental status to kernel 4.9 and deemed stable in kernel 4.16.
        If you want to be able to mount XFS filesystems created with this release of xfsprogs on kernel releases older than those, you need to format them
@@ -834,6 +852,29 @@ environment.systemPackages = [
     <para>
      All services should use <xref linkend="opt-systemd.services._name_.startLimitIntervalSec" /> or <literal>StartLimitIntervalSec</literal> in <xref linkend="opt-systemd.services._name_.unitConfig" /> instead.
     </para>
+   </listitem>
+   <listitem>
+     <para>
+       The <literal>mediatomb</literal> service
+       declares new options. It also adapts existing options so the
+       configuration generation is now lazy. The existing option
+       <literal>customCfg</literal> (defaults to false), when enabled, stops
+       the service configuration generation completely. It then expects the
+       users to provide their own correct configuration at the right location
+       (whereas the configuration was generated and not used at all before).
+       The new option <literal>transcodingOption</literal> (defaults to no)
+       allows a generated configuration. It makes the mediatomb service pulls
+       the necessary runtime dependencies in the nix store (whereas it was
+       generated with hardcoded values before). The new option
+       <literal>mediaDirectories</literal> allows the users to declare autoscan
+       media directories from their nixos configuration:
+       <programlisting>
+       services.mediatomb.mediaDirectories = [
+         { path = "/var/lib/mediatomb/pictures"; recursive = false; hidden-files = false; }
+         { path = "/var/lib/mediatomb/audio"; recursive = true; hidden-files = false; }
+       ];
+       </programlisting>
+     </para>
    </listitem>
    <listitem>
     <para>


### PR DESCRIPTION
###### Motivation for this change

The changes to the `mediatomb` module are already in master and release-21.05, but the corresponding release notes are not.
Supersedes and closes #100348 by fixing the manual build.

Backport of #124768

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
