### PR TITLE
rebar3Relx: link executables to bin dir and remove unnecessary dependency

### DIFF
--- a/pkgs/development/beam-modules/rebar3-release.nix
+++ b/pkgs/development/beam-modules/rebar3-release.nix
@@ -80,10 +80,10 @@ let
       dir=${if releaseType == "escript"
             then "bin"
             else "rel"}
-      mkdir -p "$out/$dir"
+      mkdir -p "$out/$dir" "$out/bin"
       cp -R --preserve=mode "_build/${profile}/$dir" "$out"
       ${lib.optionalString (releaseType == "release")
-      "mkdir -p $out/bin && ln -s -t $out/bin $out/rel/*/bin/*"}
+        "find $out/rel/*/bin -type f -executable -exec ln -s -t $out/bin {} \\;"}
       runHook postInstall
     '';
 

--- a/pkgs/development/beam-modules/rebar3-release.nix
+++ b/pkgs/development/beam-modules/rebar3-release.nix
@@ -82,7 +82,18 @@ let
             else "rel"}
       mkdir -p "$out/$dir"
       cp -R --preserve=mode "_build/${profile}/$dir" "$out"
+      ${lib.optionalString (releaseType == "release")
+      "mkdir -p $out/bin && ln -s -t $out/bin $out/rel/*/bin/*"}
       runHook postInstall
+    '';
+
+    postInstall = ''
+      for dir in $out/rel/*/erts-*; do
+        echo "ERTS found in $dir - removing references to erlang to reduce closure size"
+        for f in $dir/bin/{erl,start}; do
+          substituteInPlace "$f" --replace "${erlang}/lib/erlang" "''${dir/\/erts-*/}"
+        done
+      done
     '';
 
     meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Small improvements to `rebar3Relx`: Put executables into /bin, ensure that `erlang` is not pulled in as a dependency for self contained releases (useful for `dockerTools.buildImage` for example)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
