### PR TITLE
[21.05] pgsync: 0.6.6 → 0.6.7

### DIFF
--- a/pkgs/development/tools/database/pgsync/Gemfile.lock
+++ b/pkgs/development/tools/database/pgsync/Gemfile.lock
@@ -3,12 +3,12 @@ GEM
   specs:
     parallel (1.20.1)
     pg (1.2.3)
-    pgsync (0.6.6)
+    pgsync (0.6.7)
       parallel
       pg (>= 0.18.2)
       slop (>= 4.8.2)
       tty-spinner
-    slop (4.8.2)
+    slop (4.9.0)
     tty-cursor (0.7.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)

--- a/pkgs/development/tools/database/pgsync/gemset.nix
+++ b/pkgs/development/tools/database/pgsync/gemset.nix
@@ -25,20 +25,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0wjvcfsgm7xxhb2lxil19qjxvvihqxbjd2ykmm5d43p0h2l9wvxr";
+      sha256 = "0kn7cf048zwbap0mifdpzz8if1ah803vgzbx09dfgjwgvfx5w5w6";
       type = "gem";
     };
-    version = "0.6.6";
+    version = "0.6.7";
   };
   slop = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "05d1xv8r9cmd0mmlqpa853yzd7xhcyha063w1g8dpf84scxbxmd3";
+      sha256 = "09n6sj4p3b43qq6jmghr9zhgny6719bpca8j6rxnlbq9bsnrd8rj";
       type = "gem";
     };
-    version = "4.8.2";
+    version = "4.9.0";
   };
   tty-cursor = {
     groups = ["default"];


### PR DESCRIPTION
###### Motivation for this change
backport https://github.com/NixOS/nixpkgs/pull/124686

(cherry picked from commit cc855b133100a956d4587079e27c5704cbc8342b)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
