### PR TITLE
Fix neovim.override

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -54,15 +54,7 @@ let
 
 
       configurePatched = configure // {
-        packages.nix = {
-          start = lib.filter (f: f != null)
-            (map (x: if x.optional == false then x.plugin else null)
-              pluginsNormalized);
-          opt = lib.filter (f: f != null)
-            (map (x: if x.optional == true then x.plugin else null)
-              pluginsNormalized);
-        };
-        customRC = pluginRc + customRC;
+        customRC = pluginRc + customRC + (configure.customRC or "");
       };
 
       # A function to get the configuration string (if any) from an element of 'plugins'

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -165,11 +165,8 @@ let
     assert withPython -> throw "Python2 support has been removed from neovim, please remove withPython and extraPythonPackages.";
 
     wrapNeovimUnstable neovim (res // {
-      wrapperArgs = lib.escapeShellArgs (
-        res.wrapperArgs ++ lib.optionals (configure != {}) [
-          "--add-flags" "-u ${writeText "init.vim" res.neovimRcContent}"
-        ]) + " " + extraMakeWrapperArgs
-      ;
+      wrapperArgs = lib.escapeShellArgs res.wrapperArgs + extraMakeWrapperArgs;
+      wrapRc = (configure != {});
   });
 in
 {

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -36,6 +36,15 @@ in
   ##################
   nvim_with_plugins = wrapNeovim "-with-plugins" nvimConfNix;
 
+  nvim_via_override = neovim.override {
+    configure = {
+      packages.foo.start = [ vimPlugins.ale ];
+      customRC = ''
+        :help ale
+      '';
+    };
+  };
+
   ### vim tests
   ##################
   vim_with_vim2nix = vim_configurable.customize {


### PR DESCRIPTION

###### Motivation for this change

Follow up of  to fix people configuring neovim via `neovim.override`. 
It temporarily disables the `plugins` option introduced in https://github.com/NixOS/nixpkgs/pull/120445 until we have a better testing infra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
