### PR TITLE
diffoscope: 175 -> 176

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -16,11 +16,11 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "diffoscope";
-  version = "175";
+  version = "176";
 
   src = fetchurl {
     url = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
-    sha256 = "sha256-ofRu5bD+kymdXdViPxfGD/2cf7lUvnEQfYAqog5GIIk=";
+    sha256 = "sha256-Hr3GNgpvKCLs+HA8QLOewh5nz9npZr5MZ65wRrat7l0=";
   };
 
   outputs = [ "out" "man" ];
@@ -35,10 +35,6 @@ python3Packages.buildPythonApplication rec {
 
     # When generating manpage, use the installed version
     substituteInPlace doc/Makefile --replace "../bin" "$out/bin"
-
-    # https://salsa.debian.org/reproducible-builds/diffoscope/-/issues/258
-    substituteInPlace tests/data/mp3_expected_diff \
-      --replace "  Stream" "Stream"
   '';
 
   nativeBuildInputs = [ docutils help2man installShellFiles ];


### PR DESCRIPTION
###### Motivation for this change

Diffoscope 176 released this morning

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
