### PR TITLE
[21.05] python3Packages.hdbscan: disable another flaky test

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -40,6 +40,8 @@ buildPythonPackage rec {
     "test_mem_vec_diff_clusters"
     "test_all_points_mem_vec_diff_clusters"
     "test_approx_predict_diff_clusters"
+    # another flaky test https://github.com/scikit-learn-contrib/hdbscan/issues/421
+    "test_hdbscan_boruvka_balltree_matches"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
ZHF #122042 

Backport of #124545

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
