### PR TITLE
paperwork: 2.0.2 -> 2.0.3 and compile user manual

### DIFF
--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -13,10 +13,24 @@
 , gettext
 , gobject-introspection
 , gdk-pixbuf
+, texlive
+, imagemagick
+, perlPackages
 }:
 
+let
+  documentation_deps = [
+    (texlive.combine {
+      inherit (texlive) scheme-small wrapfig was;
+    })
+    xvfb-run
+    imagemagick
+    perlPackages.Po4a
+  ];
+in
+
 python3Packages.buildPythonApplication rec {
-  inherit (import ./src.nix { inherit fetchFromGitLab; }) version src;
+  inherit (import ./src.nix { inherit fetchFromGitLab; }) version src sample_documents;
   pname = "paperwork";
 
   sourceRoot = "source/paperwork-gtk";
@@ -52,9 +66,16 @@ python3Packages.buildPythonApplication rec {
     for i in $site/data/paperwork_*.png; do
       ln -s $i $site/icon/out;
     done
+
+    export XDG_DATA_DIRS=$XDG_DATA_DIRS:${gnome.adwaita-icon-theme}/share
+    # build the user manual
+    PATH=$out/bin:$PATH PAPERWORK_TEST_DOCUMENTS=${sample_documents} make data
+    for i in src/paperwork_gtk/model/help/out/*.pdf; do
+      install -Dt $site/model/help/out $i
+    done
   '';
 
-  checkInputs = [ xvfb-run dbus.daemon ];
+  checkInputs = [ dbus.daemon ];
 
   nativeBuildInputs = [
     wrapGAppsHook
@@ -62,7 +83,7 @@ python3Packages.buildPythonApplication rec {
     (lib.getBin gettext)
     which
     gdk-pixbuf # for the setup hook
-  ];
+  ] ++ documentation_deps;
 
   buildInputs = [
     gnome.adwaita-icon-theme
@@ -78,13 +99,20 @@ python3Packages.buildPythonApplication rec {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  # A few parts of chkdeps need to have a display and a dbus session, so we not
-  # only need to run a virtual X server + dbus but also have a large enough
-  # resolution, because the Cairo test tries to draw a 200x200 window.
-  preCheck = ''
+  checkPhase = ''
+    runHook preCheck
+
+    # A few parts of chkdeps need to have a display and a dbus session, so we not
+    # only need to run a virtual X server + dbus but also have a large enough
+    # resolution, because the Cairo test tries to draw a 200x200 window.
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       $out/bin/paperwork-gtk chkdeps
+
+    # content of make test, without the dep on make install
+    python -m unittest discover --verbose -s tests
+
+    runHook postCheck
   '';
 
   propagatedBuildInputs = with python3Packages; [
@@ -97,6 +125,8 @@ python3Packages.buildPythonApplication rec {
     dateutil
     setuptools
   ];
+
+  disallowedRequisites = documentation_deps;
 
   meta = {
     description = "A personal document manager for scanned documents";

--- a/pkgs/applications/office/paperwork/src.nix
+++ b/pkgs/applications/office/paperwork/src.nix
@@ -1,12 +1,22 @@
 {fetchFromGitLab}:
 rec {
-  version = "2.0.2";
+  version = "2.0.3";
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     repo = "paperwork";
     group = "World";
     owner = "OpenPaperwork";
     rev = version;
-    sha256 = "1di7nnl8ywyiwfpl5m1kvip1m0hvijbmqmkdpviwqw7ajizrr1ly";
+    sha256 = "02c2ysca75j59v87n1axqfncvs167kmdr40m0f05asdh2akwrbi9";
   };
+  sample_documents = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    repo = "paperwork-test-documents";
+    group = "World";
+    owner = "OpenPaperwork";
+    # https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/blob/master/paperwork-gtk/src/paperwork_gtk/model/help/screenshot.sh see TEST_DOCS_TAG
+    rev = "1.0";
+    sha256 = "155nhw2jmlgfi6c3wm241vrr3yma6lw85k9lxn844z96kyi7wbpr";
+  };
+
 }


### PR DESCRIPTION
The user manual button is broken because the help was not built. It is only possible to build the help inside the sanbox since 2.0.3. I intend to backport this to 21.05 as it is a bugfix.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
