### PR TITLE
[21.05] graphviz: patch CVE-2020-18032

### DIFF
--- a/pkgs/tools/graphics/graphviz/base.nix
+++ b/pkgs/tools/graphics/graphviz/base.nix
@@ -21,7 +21,14 @@ let
     buildCommand = "sed s/dot_root/agroot/g ${raw_patch} > $out";
   };
   # 2.42 has the patch included
-  patches = optional (lib.versionOlder version "2.42") patchToUse;
+  patches = optional (lib.versionOlder version "2.42") patchToUse
+  ++ optionals (lib.versionOlder version "2.46.0") [
+    (fetchpatch {
+      name = "CVE-2020-18032.patch";
+      url = "https://gitlab.com/graphviz/graphviz/-/commit/784411ca3655c80da0f6025ab20634b2a6ff696b.patch";
+      sha256 = "1nkw9ism8lkfvxsp5fh95i2l5s5cbjsidbb3g1kjfv10rxkyb41m";
+    })
+  ];
 in
 
 stdenv.mkDerivation {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
backport https://github.com/NixOS/nixpkgs/pull/124737

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
