### PR TITLE
postgresql: support JIT compilation for version >= 11

### DIFF
--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -21,6 +21,14 @@ let
     CREATE TABLE xmltest ( doc xml );
     INSERT INTO xmltest (doc) VALUES ('<test>ok</test>'); -- check if libxml2 enabled
   '';
+
+  jit-test-sql = pkgs.writeText "postgresql-jit-test" ''
+    SET jit_above_cost = 1;
+    SET jit = 1;
+    EXPLAIN ANALYZE SELECT CONCAT('jit result = ', SUM(id)) FROM sth;
+    SELECT CONCAT('jit result = ', SUM(id)) from sth;
+  '';
+
   make-postgresql-test = postgresql-name: postgresql-package: backup-all: makeTest {
     name = postgresql-name;
     meta = with pkgs.lib.maintainers; {
@@ -75,6 +83,16 @@ let
               "zcat /var/backup/postgresql/${backupName}.sql.gz | grep '<test>ok</test>'",
               "stat -c '%a' /var/backup/postgresql/${backupName}.sql.gz | grep 600",
           )
+
+      ${optionalString (versionAtLeast postgresql-package.version "11") ''
+      with subtest("Postgresql JIT should work on postgresql >= 11"):
+           output = machine.succeed(
+               "cat ${jit-test-sql} | sudo -u postgres psql"
+           )
+           assert "JIT:" in output
+           assert "jit result = 5" in output
+      ''}
+
 
       with subtest("Initdb works"):
           machine.succeed("sudo -u postgres initdb -D /tmp/testpostgres2")


### PR DESCRIPTION
###### Motivation for this change

PostgreSQL (from 11 onwards AFAICT) supports JIT compilation of
(frequently used) queries. This should provide a speedup to some queries
where operations such as comparing rows is a bottleneck.

For JIT support we have to build PostgreSQL with with the --with-llvm
config flag and pass both clang and llvm into the build environment.
PostPostgreSQL then calls llvm-config to obtain the required compiler
flags.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] compiled postgresl 11 with the feature
- [x] tested that JIT actually works
- [x] verify that all the postgresql version we provide still build
