### PR TITLE
php.packages.deployer: install shell completions

### DIFF
--- a/pkgs/development/php-packages/deployer/default.nix
+++ b/pkgs/development/php-packages/deployer/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchurl, makeWrapper, lib, php }:
+{ mkDerivation, fetchurl, makeWrapper, installShellFiles, lib, php }:
 
 mkDerivation rec {
   pname = "deployer";
@@ -11,12 +11,17 @@ mkDerivation rec {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase = ''
     mkdir -p $out/bin
     install -D $src $out/libexec/deployer/deployer.phar
     makeWrapper ${php}/bin/php $out/bin/dep --add-flags "$out/libexec/deployer/deployer.phar"
+
+    # fish support currently broken: https://github.com/deployphp/deployer/issues/2527
+    installShellCompletion --cmd dep \
+      --bash <($out/bin/dep autocomplete --install) \
+      --zsh <($out/bin/dep autocomplete --install)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I thought shell completions would be helpful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
