### PR TITLE
pcl: fix convex hull support

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , wrapQtAppsHook
 , cmake
 , qhull
@@ -29,6 +30,15 @@ stdenv.mkDerivation rec {
     rev = "${pname}-${version}";
     sha256 = "1cli2rxqsk6nxp36p5mgvvahjz8hm4fb68yi8cf9nw4ygbcvcwb1";
   };
+
+  patches = [
+    # Support newer QHull versions (2020.2)
+    # Backport of https://github.com/PointCloudLibrary/pcl/pull/4540
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/conda-forge/pcl-feedstock/0b1eff402994a3fb891b44659c261e7e85c8d915/recipe/4540.patch";
+      sha256 = "0hhvw6ajigzrarn95aicni73zd3sdgnb8rc3wgjrrg19xs84z138";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config cmake wrapQtAppsHook ];
   buildInputs = [


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
PCL requires a patch to be compatible with QHull 2020.2. The patch has been accepted upstream, but this commit uses a version of the patch from Conda which has been backported to 1.11.

Without this patch, the build still succeeds, but convex hull support is disabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @viric