### PR TITLE
nixos/wordpress: regenerate secret keys if misspelled key name is found

### DIFF
--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -61,8 +61,10 @@ let
     ?>
   '';
 
-  secretsVars = [ "AUTH_KEY" "SECURE_AUTH_KEY" "LOOGGED_IN_KEY" "NONCE_KEY" "AUTH_SALT" "SECURE_AUTH_SALT" "LOGGED_IN_SALT" "NONCE_SALT" ];
+  secretsVars = [ "AUTH_KEY" "SECURE_AUTH_KEY" "LOGGED_IN_KEY" "NONCE_KEY" "AUTH_SALT" "SECURE_AUTH_SALT" "LOGGED_IN_SALT" "NONCE_SALT" ];
   secretsScript = hostStateDir: ''
+    # The match in this line is not a typo, see https://github.com/NixOS/nixpkgs/pull/124839
+    grep -q "LOOGGED_IN_KEY" "${hostStateDir}/secret-keys.php" && rm "${hostStateDir}/secret-keys.php"
     if ! test -e "${hostStateDir}/secret-keys.php"; then
       umask 0177
       echo "<?php" >> "${hostStateDir}/secret-keys.php"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A secret key generated by the nixos module was misspelled, which could
possibly impact the security of session cookies.

To recover from this situation we will wipe all security keys that were
previously generated by the NixOS module, when the misspelled one is
found. This will result in all session cookies being invalidated. This
is confirmed by the wordpress documentation:

> You can change these at any point in time to invalidate all existing
> cookies. This does mean that all users will have to login again.

https://wordpress.org/support/article/editing-wp-config-php/#security-keys

Meanwhile this issue shouldn't be too grave, since the salting function
of wordpress will rely on the concatenation of both the user-provided
and automatically generated values, that are stored in the database.

> Secret keys are located in two places: in the database and in the
> wp-config.php file. The secret key in the database is randomly
> generated and will be appended to the secret keys in wp-config.php.

https://developer.wordpress.org/reference/functions/wp_salt/

Fixes: 2adb03fdaea6186299c6ff578bb6814d8f3bb30b ("nixos/wordpress:
generate secrets locally")

Reported-by: Moritz Hedtke <Moritz.Hedtke@t-online.de>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  ```diff
  diff --git a/nixos/tests/wordpress.nix b/nixos/tests/wordpress.nix
  index a5c10c2de74..81e1028e1ec 100644
  --- a/nixos/tests/wordpress.nix
  +++ b/nixos/tests/wordpress.nix
  @@ -53,5 +53,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
               assert pattern.search(
                   machine.succeed(f"cat /var/lib/wordpress/{site_name}/secret-keys.php")
               )
  +
  +    machine.log(machine.succeed(f"cat /var/lib/wordpress/{site_name}/secret-keys.php"))
  +
     '';
   })
  ```
  ```php
  <?php
  define('AUTH_KEY', 'hTLoNHA1MJR3m14ToF2HB0HnPmsJAv10l3w1XDeIzWakGKcAFOi1lSDh24PAc6Ip');
  define('SECURE_AUTH_KEY', 'cINLqwcEPzAqGDtZunKjWBAhGtgfo9ixBCy5TDSG2vwtqatWaPn70sTUWTFzFNHy');
  define('LOGGED_IN_KEY', 'IBeK4dDtBJFoBdNoeat3Sne06msILminxYrHRyZGFt5l6plP8scmKJhvwEXLInR5');
  define('NONCE_KEY', 'urPJS77M2Gp0Kuh4ouz3FM4GQGBAZtYW3toyWouHX0YRxFMqytCKNQxSyJAelkOi');
  define('AUTH_SALT', 'TizXbfy0kWfKVuwIpOYingscroa8o5iGp968ckkGRfflkOa2JfoWVhmTGVDDYhGH');
  define('SECURE_AUTH_SALT', 'k77QSODAAL0EihsuS7CMMfDRhGpkt49fLZU7csMjfQjjmh3TpaaUVtujv49quNAg');
  define('LOGGED_IN_SALT', 'zYOvj5xxEsRWRVJhWJ7YrsvFofRbbfvMpIp1qY5RIjhPNp5TxynQgX2Ze8m4Yfg8');
  define('NONCE_SALT', 'TJSDbo4Fs1YkhJl74lo1Hs8JtXZHZfOwXBcIUZhpVrkXYjHrbl2aBEl7dZwtyXfy');
  ?>
  ```
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
