### PR TITLE
python3Packages.boost-histogram: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchPypi, buildPythonPackage, isPy3k, boost, numpy, pytestCheckHook, pytest-benchmark }:
+
+buildPythonPackage rec {
+  pname = "boost-histogram";
+  version = "1.0.2";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    pname = "boost_histogram";
+    inherit version;
+    sha256 = "b79cb9a00c5b8e44ff24ffcbec0ce5d3048dd1570c8592066344b6d2f2369fa2";
+  };
+
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [ pytestCheckHook pytest-benchmark ];
+
+  meta = with lib; {
+    description = "Python bindings for the C++14 Boost::Histogram library";
+    homepage = "https://github.com/scikit-hep/boost-histogram";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -57,8 +57,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";
     homepage = "https://arrow.apache.org/";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with lib.maintainers; [ veprbl ];
+    maintainers = with maintainers; [ veprbl ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1126,6 +1126,10 @@ in {
 
   boschshcpy = callPackage ../development/python-modules/boschshcpy { };
 
+  boost-histogram = callPackage ../development/python-modules/boost-histogram {
+    inherit (pkgs) boost;
+  };
+
   boto3 = callPackage ../development/python-modules/boto3 { };
 
   boto = callPackage ../development/python-modules/boto { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
