### PR TITLE
editline: 1.17.0 -> 1.17.1 and add patch to fix Home and End key in tmux

### DIFF
--- a/pkgs/development/libraries/editline/default.nix
+++ b/pkgs/development/libraries/editline/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://troglobit.com/editline.html";
+    homepage = "https://troglobit.com/projects/editline/";
     description = "A readline() replacement for UNIX without termcap (ncurses)";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ dtzWill oxalica ];

--- a/pkgs/development/libraries/editline/default.nix
+++ b/pkgs/development/libraries/editline/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    (fetchpatch {
+      name = "fix-for-home-end-in-tmux.patch";
+      url = "https://github.com/troglobit/editline/commit/265c1fb6a0b99bedb157dc7c320f2c9629136518.patch";
+      sha256 = "sha256-9fhQH0hT8BcykGzOUoT18HBtWjjoXnePSGDJQp8GH30=";
+    })
   ];
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/libraries/editline/default.nix
+++ b/pkgs/development/libraries/editline/default.nix
@@ -1,32 +1,31 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, nix-update-script, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "editline";
-  version = "1.17.0";
+  version = "1.17.1";
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "editline";
     rev = version;
-    sha256 = "0vjm42y6zjmi6hdcng0l7wkksw7s50agbmk5dxsc3292q8mvq8v6";
+    sha256 = "sha256-0FeDUVCUahbweH24nfaZwa7j7lSfZh1TnQK7KYqO+3g=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "fix-for-multiline-as-one-line.patch";
-      url = "https://github.com/troglobit/editline/commit/ceee039cfc819c8e09eebbfca192091b0cf8df75.patch";
-      sha256 = "149fmfva05ghzwkd0bq1sahdbkys3qyyky28ssqb5jq7q9hw3ddm";
-    })
   ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
   outputs = [ "out" "dev" "man" "doc" ];
 
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
   meta = with lib; {
     homepage = "https://troglobit.com/editline.html";
     description = "A readline() replacement for UNIX without termcap (ncurses)";
     license = licenses.bsdOriginal;
-    maintainers = with maintainers; [ dtzWill ];
+    maintainers = with maintainers; [ dtzWill oxalica ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`nix repl` uses editline, and is affected by this usability issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
1 package marked as broken and skipped:
nix-exec

55 packages built:
bundix cabal2nix cachix common-updater-scripts crate2nix crystal2nix dep2nix dydisnix editline fusionInventory go2nix hci hercules-ci-agent hydra-unstable jush libnixxml lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info nix nix-binary-cache nix-bundle nix-direnv nix-doc nix-du nix-index nix-pin nix-plugins nix-prefetch nix-prefetch-bzr nix-prefetch-cvs nix-prefetch-docker nix-prefetch-git nix-prefetch-hg nix-prefetch-scripts nix-prefetch-svn nix-review nix-serve nix-update nix-update-source nixFlakes nixStatic nixos-generators nixos-install-tools nixos-rebuild nixos-shell nixui python38Packages.nix-kernel python38Packages.nixpkgs python38Packages.pythonix python39Packages.nix-kernel python39Packages.nixpkgs python39Packages.pythonix update-nix-fetchgit vgo2nix vulnix
```
- Tested execution of all binary files (usually in `./result/bin/`)
  - It's a library.
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
