### PR TITLE
saml2aws: 2.28.0 -> 2.30.0

### DIFF
--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   };
 
   runVend = true;
-  vendorSha256 = lib.fakeSha256;
+  vendorSha256 = "06d2lsjniw1w4r6ccr48ylrggqw5k0hkd4m6ipspv7yai711wvga";
 
   doCheck = false;
 
@@ -21,7 +21,7 @@ buildGoModule rec {
   buildFlagsArray = ''
     -v
     -trimpath
-    -ldflags=-s -w -X main.Version=${version} -X main.commit=${src.sha256}
+    -ldflags=-s -w -X main.Version=${version}
   '';
 
   meta = with lib; {

--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -2,24 +2,26 @@
 
 buildGoModule rec {
   pname = "saml2aws";
-  version = "2.28.0";
+  version = "2.30.0";
 
   src = fetchFromGitHub {
     owner = "Versent";
     repo = "saml2aws";
     rev = "v${version}";
-    sha256 = "sha256-2t1MytLjAxhVVsWyMYcQZ9c+ox+X2OszG5mLAv8c7xE=";
+    sha256 = "0plwh7dswf756xy048dqycc2nlpnzk3d1s9m6ypgi77vydryzhj3";
   };
 
   runVend = true;
-  vendorSha256 = "sha256-8Kox01iyWhv/Fp7jHPeNXxc/K2TT1WPyWFieHZkqLho=";
+  vendorSha256 = lib.fakeSha256;
 
   doCheck = false;
 
   subPackages = [ "." "cmd/saml2aws" ];
 
   buildFlagsArray = ''
-    -ldflags=-X main.Version=${version}
+    -v
+    -trimpath
+    -ldflags=-s -w -X main.Version=${version} -X main.commit=${src.sha256}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upstream moved to goreleaser, with some flag changes: https://github.com/Versent/saml2aws/blob/beaaece5fe57049eaa20ed227e9a966e24f268c1/.goreleaser.yml

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
