### PR TITLE
python3Packages.evohome-async: 0.3.8 -> 0.3.15

### DIFF
--- a/pkgs/development/python-modules/evohome-async/default.nix
+++ b/pkgs/development/python-modules/evohome-async/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "evohome-async";
-  version = "0.3.8";
+  version = "0.3.15";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "zxdavb";
     repo = pname;
     rev = version;
-    sha256 = "04xy72k79cnb8pc19v5jzkc0djazfm6pbm10ysphx06ndwvxr9mn";
+    sha256 = "sha256-/dZRlcTcea26FEpw/XDItKh4ncr/eEFQcdfIE2KIMo8=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.15

Change log: https://github.com/zxdavb/evohome-async/compare/0.3.8...0.3.15

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50803
- Target Home Assistant release: 2021.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
