### PR TITLE
bsp-layout: init at unstable-2021-05-10

### DIFF
--- a/pkgs/tools/misc/bsp-layout/default.nix
+++ b/pkgs/tools/misc/bsp-layout/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, lib, bspwm, makeWrapper, git, bc }:
+
+stdenv.mkDerivation rec {
+  pname = "bsp-layout";
+  version = "unstable-2021-05-10";
+
+  src = fetchFromGitHub {
+    owner = "phenax";
+    repo = pname;
+    rev = "726b850b79eabdc6f4d236cff52e434848cb55e3";
+    sha256 = "1wqlzbz7l9vz37gin2zckrnxkkabnd7x5mi9pb0x96w4yhld5mx6";
+  };
+
+  nativeBuildInputs = [ makeWrapper git bc ];
+  buildInputs = [ bspwm ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/bsp-layout --replace 'bc ' '${bc}/bin/bc '
+  '';
+
+  meta = with lib; {
+    description = "Manage layouts in bspwm";
+    homepage = "https://github.com/phenax/bsp-layout";
+    license = licenses.mit;
+    maintainers = with maintainers; [ devins2518 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2008,6 +2008,8 @@ in
 
   bottom-rs = callPackage ../tools/misc/bottom-rs { };
 
+  bsp-layout = callPackage ../tools/misc/bsp-layout {};
+
   buildtorrent = callPackage ../tools/misc/buildtorrent { };
 
   bustle = haskellPackages.bustle;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done
Adds bsp-layout

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
