### PR TITLE
natural-docs: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7297,9 +7297,9 @@
     githubId = 3159451;
     name = "Nicolas Schneider";
   };
-  nipav = {
+  nkpvk = {
     email = "niko.pavlinek@gmail.com";
-    github = "nipav";
+    github = "nkpvk";
     githubId = 16385648;
     name = "Niko Pavlinek";
   };

--- a/pkgs/applications/misc/natural-docs/default.nix
+++ b/pkgs/applications/misc/natural-docs/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchzip, makeWrapper, mono, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "natural-docs";
+  version = "2.1.1";
+
+  src = fetchzip {
+    url = "https://naturaldocs.org/download/natural_docs/${version}/Natural_Docs_${version}.zip";
+    sha256 = "03fizjgvhiw3lqyykqw1whdh97xyiy3f226c1348ll61ryjxamqw";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r . $out/
+    makeWrapper ${mono}/bin/mono $out/bin/NaturalDocs --add-flags "$out/NaturalDocs.exe"
+  '';
+
+  meta = with lib; {
+    description = "Documentation generator for multiple programming languages.";
+    longDescription = ''
+      Natural Docs is an open source documentation generator for multiple
+      programming languages. You document your code in a natural syntax that
+      reads like plain English. Natural Docs then scans your code and builds
+      high-quality HTML documentation from it.
+    '';
+    homepage = "https://naturaldocs.org";
+    license = licenses.agpl3Only;
+    maintainers = [ maintainers.nkpvk ];
+  };
+}

--- a/pkgs/applications/misc/yokadi/default.nix
+++ b/pkgs/applications/misc/yokadi/default.nix
@@ -24,6 +24,6 @@ buildPythonApplication rec {
     description = "A command line oriented, sqlite powered, todo-list";
     homepage = "https://yokadi.github.io/index.html";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.nipav ];
+    maintainers = [ maintainers.nkpvk ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25369,6 +25369,8 @@ in
 
   natron = callPackage ../applications/video/natron { };
 
+  natural-docs = callPackage ../applications/misc/natural-docs { };
+
   neocomp  = callPackage ../applications/window-managers/neocomp { };
 
   newsflash = callPackage ../applications/networking/feedreaders/newsflash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

NaturalDocs isn't available in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
