### PR TITLE
[20.09] yara: 4.0.1 -> 4.0.5

### DIFF
--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib, stdenv
+, fetchpatch
 , fetchFromGitHub
 , autoreconfHook
 , pcre
@@ -10,14 +11,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.1";
+  version = "4.0.5";
   pname = "yara";
 
   src = fetchFromGitHub {
     owner = "VirusTotal";
     repo = "yara";
     rev = "v${version}";
-    sha256 = "0dy8jf0pdn0wilxy1pj6pqjxg7icxkwax09w54np87gl9p00f5rk";
+    sha256 = "1gkdll2ygdlqy1f27a5b84gw2bq75ss7acsx06yhiss90qwdaalq";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -29,6 +30,19 @@ stdenv.mkDerivation rec {
   ;
 
   preConfigure = "./bootstrap.sh";
+
+  # If static builds are disabled, `make all-am` will fail to find libyara.a and
+  # cause a build failure. It appears that somewhere between yara 4.0.1 and
+  # 4.0.5, linking the yara binaries dynamically against libyara.so was broken.
+  #
+  # This was already fixed in yara master. Backport the patch to yara 4.0.5.
+  patches = [
+    (fetchpatch {
+      name = "fix-build-with-no-static.patch";
+      url = "https://github.com/VirusTotal/yara/commit/52e6866023b9aca26571c78fb8759bc3a51ba6dc.diff";
+      sha256 = "074cf99j0rqiyacp60j1hkvjqxia7qwd11xjqgcr8jmfwihb38nr";
+    })
+  ];
 
   configureFlags = [
     (stdenv.lib.withFeature withCrypto "crypto")


### PR DESCRIPTION
###### Motivation for this change
Backport of #114562, resolving at least https://nvd.nist.gov/vuln/detail/CVE-2021-3402 (#124684), and from the looks of the release notes, a couple more security issues without CVEs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
