### PR TITLE
[21.05] sageWithDoc: fix documentation symlinks

### DIFF
--- a/pkgs/applications/science/math/sage/sagedoc.nix
+++ b/pkgs/applications/science/math/sage/sagedoc.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     mv html/en/_static{,.tmp}
     for _dir in `find -name _static` ; do
           rm -r $_dir
-          ln -s html/en/_static $_dir
+          ln -rs html/en/_static $_dir
     done
     mv html/en/_static{.tmp,}
   '';


### PR DESCRIPTION
###### Motivation for this change

In #123698, I tried fixing our documentation static resource symlinks but made a mistake while doing so. This PR is the same as #124980 but for the 21.05 branch.

(Beware that sagedoc always times out on ofBorg.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
