### PR TITLE
emacs: fix for darwin's aarch64 codesigning issue

### DIFF
--- a/pkgs/applications/editors/emacs/27.nix
+++ b/pkgs/applications/editors/emacs/27.nix
@@ -1,7 +1,12 @@
 import ./generic.nix (rec {
   version = "27.2";
   sha256 = "sha256-tKfMTnjmPzeGJOCRkhW5EK9bsqCvyBn60pgnLp9Awbk=";
-  patches = [
+  patches = fetchpatch: [
     ./tramp-detect-wrapped-gvfsd.patch
+    (fetchpatch {
+      name = "fix-aarch64-darwin-triplet.patch";
+      url = "https://git.savannah.gnu.org/cgit/emacs.git/patch/?id=a88f63500e475f842e5fbdd9abba4ce122cdb082";
+      sha256 = "sha256-RF9b5PojFUAjh2TDUW4+HaWveV30Spy1iAXhaWf1ZVg=";
+    })
   ];
 })

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -10,7 +10,7 @@
 , Xaw3d, libXcursor,  pkg-config, gettext, libXft, dbus, libpng, libjpeg, giflib
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
 , alsa-lib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf
-, jansson, harfbuzz
+, sigtool, jansson, harfbuzz
 , dontRecurseIntoAttrs ,emacsPackagesFor
 , libgccjit, targetPlatform, makeWrapper # native-comp params
 , systemd ? null
@@ -46,10 +46,10 @@ assert withXwidgets -> withGTK3 && webkitgtk != null;
 let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
   NATIVE_FULL_AOT = "1";
   LIBRARY_PATH = "${lib.getLib stdenv.cc.libc}/lib";
-} // lib.optionalAttrs stdenv.isDarwin {
-  CFLAGS = "-DMAC_OS_X_VERSION_MAX_ALLOWED=101200";
 } // {
-  inherit pname version patches;
+  inherit pname version;
+
+  patches = patches fetchpatch;
 
   src = fetchurl {
     url = "mirror://gnu/emacs/${name}.tar.xz";
@@ -118,8 +118,8 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optional (withX && withMotif) motif
     ++ lib.optionals (withX && withXwidgets) [ webkitgtk glib-networking ]
     ++ lib.optionals withNS [ AppKit GSS ImageIO ]
-    ++ lib.optionals nativeComp [ libgccjit ]
-    ;
+    ++ lib.optionals stdenv.isDarwin [ sigtool ]
+    ++ lib.optionals nativeComp [ libgccjit ];
 
   hardeningDisable = [ "format" ];
 
@@ -138,7 +138,7 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optional withXwidgets "--with-xwidgets"
     ++ lib.optional nativeComp "--with-native-compilation"
     ++ lib.optional withImageMagick "--with-imagemagick"
-    ;
+  ;
 
   installTargets = [ "tags" "install" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23411,6 +23411,7 @@ in
     acl = null;
     gpm = null;
     inherit (darwin.apple_sdk.frameworks) AppKit GSS ImageIO;
+    inherit (darwin) sigtool;
   };
 
   emacs27-nox = lowPrio (appendToName "nox" (emacs27.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Excited to get started with aarch64 but Emacs doesn't compile
as well does https://github.com/NixOS/nixpkgs/pull/124571 not fix the issue I have for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Felt lucky to have bumped into this commit https://github.com/emacs-mirror/emacs/commit/868f51324ac96bc3af49a826e1db443548c9d6cc so the work has been done for us.

As well I remove the osx upper limit, I think it's fair to say that we are ok making assumtions about recency of aarch64 apple m1 computers. But please correct me if I'm wrong.

Screen:
built with `nix-build -E 'with import <nixpkgs> { localSystem = "aarch64-darwin"; }; (import ./default.nix { localSystem = "aarch64-darwin"; }).emacs' -o result`
<img width="299" alt="2021-05-29 20 38 55" src="https://user-images.githubusercontent.com/6074754/120081794-a4235e80-c0bf-11eb-82aa-ff0bb11979e5.png">

built with `nix-build -E 'with import <nixpkgs> { localSystem = "x86_64-darwin"; }; (import ./default.nix { localSystem = "x86_64-darwin"; }).emacs' -o result`
<img width="297" alt="2021-05-29 20 54 43" src="https://user-images.githubusercontent.com/6074754/120081895-2ad83b80-c0c0-11eb-9910-37d91fe8da30.png">


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
