### PR TITLE
antimony: add desktop item

### DIFF
--- a/pkgs/applications/graphics/antimony/default.nix
+++ b/pkgs/applications/graphics/antimony/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub, libpng, python3
 , libGLU, libGL, qtbase, wrapQtAppsHook, ncurses
 , cmake, flex, lemon
+, makeDesktopItem, copyDesktopItems
 }:
 
 let
@@ -27,12 +28,35 @@ in
        sed -i "s,python3,${python3.executable}," CMakeLists.txt
     '';
 
+    postInstall = lib.optionalString stdenv.isLinux ''
+      install -Dm644 $src/deploy/icon.svg $out/share/icons/hicolor/scalable/apps/antimony.svg
+      install -Dm644 ${./mimetype.xml} $out/share/mime/packages/antimony.xml
+    '';
+
     buildInputs = [
       libpng python3 python3.pkgs.boost
       libGLU libGL qtbase ncurses
     ];
 
-    nativeBuildInputs = [ cmake flex lemon wrapQtAppsHook ];
+    nativeBuildInputs = [ cmake flex lemon wrapQtAppsHook copyDesktopItems ];
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "antimony";
+        desktopName = "Antimony";
+        comment="Tree-based Modeler";
+        genericName = "CAD Application";
+        exec = "antimony %f";
+        icon = "antimony";
+        terminal = "false";
+        categories = "Graphics;Science;Engineering";
+        mimeType = "application/x-extension-sb;application/x-antimony;";
+        extraEntries = ''
+          StartupWMClass=antimony
+          Version=1.0
+        '';
+      })
+    ];
 
     cmakeFlags= [
       "-DGITREV=${gitRev}"

--- a/pkgs/applications/graphics/antimony/mimetype.xml
+++ b/pkgs/applications/graphics/antimony/mimetype.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-antimony">
+    <comment xml:lang="en">Antimony model</comment>
+    <glob pattern="*.sb"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Modified `antimony` to include a desktop file, so that it can be launched by linux desktop managers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
