### PR TITLE
yara: 4.0.5 -> 4.1.1

### DIFF
--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv
-, fetchpatch
 , fetchFromGitHub
 , autoreconfHook
 , pcre
@@ -14,14 +13,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.5";
+  version = "4.1.1";
   pname = "yara";
 
   src = fetchFromGitHub {
     owner = "VirusTotal";
     repo = "yara";
     rev = "v${version}";
-    sha256 = "1gkdll2ygdlqy1f27a5b84gw2bq75ss7acsx06yhiss90qwdaalq";
+    sha256 = "185j7firn7i5506rcp0va7sxdbminwrm06jsm4c70jf98qxmv522";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -33,19 +32,6 @@ stdenv.mkDerivation rec {
   ;
 
   preConfigure = "./bootstrap.sh";
-
-  # If static builds are disabled, `make all-am` will fail to find libyara.a and
-  # cause a build failure. It appears that somewhere between yara 4.0.1 and
-  # 4.0.5, linking the yara binaries dynamically against libyara.so was broken.
-  #
-  # This was already fixed in yara master. Backport the patch to yara 4.0.5.
-  patches = [
-    (fetchpatch {
-      name = "fix-build-with-no-static.patch";
-      url = "https://github.com/VirusTotal/yara/commit/52e6866023b9aca26571c78fb8759bc3a51ba6dc.diff";
-      sha256 = "074cf99j0rqiyacp60j1hkvjqxia7qwd11xjqgcr8jmfwihb38nr";
-    })
-  ];
 
   configureFlags = [
     (lib.withFeature withCrypto "crypto")

--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -10,6 +10,7 @@
 , enableDotNet ? true
 , enableMacho ? true
 , enableMagic ? true, file
+, enableStatic ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +41,10 @@ stdenv.mkDerivation rec {
     (lib.enableFeature enableDotNet "dotnet")
     (lib.enableFeature enableMacho "macho")
     (lib.enableFeature enableMagic "magic")
+    (lib.enableFeature enableStatic "static")
   ];
+
+  doCheck = enableStatic;
 
   meta = with lib; {
     description = "The pattern matching swiss knife for malware researchers";


### PR DESCRIPTION
###### Motivation for this change
When putting #124885 together I noticed the release notes of 4.1.1 mentioned it fixing _another_ buffer overrun in the mach-o code. So I fully expect a CVE for that coming through sooner or later. Hence marked "security".

At the same time I added an `enableStatic` mode, mainly because it allows the tests to be enabled easily. I didn't make it the default however, because it doubles the size of the output with little benefit for non-devs. But it does mean people will need to deliberately do a build with it enabled to ensure the tests pass :S

In theory I could do a thing where the static library was _always_ built, but a `postInstall` would delete the static lib from the output. Would probably be quite annoying if static building were broken for some reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
