### PR TITLE
quartus: version bump and allow overrides of unwrapped package

### DIFF
--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, lib, buildFHSUserEnv, callPackage, makeDesktopItem, writeScript,
-  supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ] ,
-  unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; } }:
+{ stdenv, lib, buildFHSUserEnv, callPackage, makeDesktopItem, writeScript
+, supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
+, unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; }
+}:
 
 let
   desktopItem = makeDesktopItem {

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,99 +1,8 @@
-{ buildFHSUserEnv, makeDesktopItem, writeScript, stdenv, lib, requireFile, unstick,
-  supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ] }:
+{ stdenv, lib, buildFHSUserEnv, callPackage, makeDesktopItem, writeScript,
+  supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ] ,
+  unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; } }:
 
 let
-  deviceIds = {
-    "Arria II" = "arria_lite";
-    "Cyclone V" = "cyclonev";
-    "Cyclone IV" = "cyclone";
-    "Cyclone 10 LP" = "cyclone10lp";
-    "MAX II/V" = "max";
-    "MAX 10 FPGA" = "max10";
-  };
-
-  supportedDeviceIds =
-    assert lib.assertMsg (lib.all (name: lib.hasAttr name deviceIds) supportedDevices)
-      "Supported devices are: ${lib.concatStringsSep ", " (lib.attrNames deviceIds)}";
-    lib.listToAttrs (map (name: {
-      inherit name;
-      value = deviceIds.${name};
-    }) supportedDevices);
-
-  unsupportedDeviceIds = lib.filterAttrs (name: value:
-    !(lib.hasAttr name supportedDeviceIds)
-  ) deviceIds;
-
-  quartus = stdenv.mkDerivation rec {
-    version = "20.1.0.711";
-    pname = "quartus-prime-lite-unwrapped";
-
-    src = let
-      require = {name, sha256}: requireFile {
-        inherit name sha256;
-        url = "${meta.homepage}/${lib.versions.majorMinor version}/?edition=lite&platform=linux";
-      };
-
-      hashes = {
-        "arria_lite" = "09g2knq23h3vj0s5y7hsdnqbbkr3pnv53dzpqcw2lq9mb5zfs9r0";
-        "cyclonev" = "05hrpysasyfb7xhxg68spdffxyvxcx0iagibd5jz643b7n6aalpa";
-        "cyclone" = "1x3rnwsvzrb5kwdz35sbcabxmcvj8xxpnjlpcjwfc69ybiyr6sgz";
-        "cyclone10lp" = "1x6d4hm697mjgzaxixrw5va8anr6ihhx96x2524r6axpwqf6wcja";
-        "max" = "060b7v0xh86kkjyiix7akfkzhx2kl1b3q117kp7xibnz6yrzwmy3";
-        "max10" = "05840l9pmqa4i1b3ajfaxkqz1hppls556vbq16a42acz2qs2g578";
-      };
-
-      devicePackages = map (id: {
-        name = "${id}-${version}.qdz";
-        sha256 = lib.getAttr id hashes;
-      }) (lib.attrValues supportedDeviceIds);
-    in map require ([{
-      name = "QuartusLiteSetup-${version}-linux.run";
-      sha256 = "07ssrv8p8kacal6xd80n4h7l5xz13aw1m1gfqqaxig0ivsj971z5";
-    } {
-      name = "ModelSimSetup-${version}-linux.run";
-      sha256 = "0smxasrmr1c8k6hy378knskpjmz4cgpgb35v5jclns0kx68y3c42";
-    }] ++ devicePackages);
-
-    nativeBuildInputs = [ unstick ];
-
-    buildCommand = let
-      installers = lib.sublist 0 2 src;
-      components = lib.sublist 2 ((lib.length src) - 2) src;
-      copyInstaller = installer: ''
-        # `$(cat $NIX_CC/nix-support/dynamic-linker) $src[0]` often segfaults, so cp + patchelf
-        cp ${installer} $TEMP/${installer.name}
-        chmod u+w,+x $TEMP/${installer.name}
-        patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $TEMP/${installer.name}
-      '';
-      copyComponent = component: "cp ${component} $TEMP/${component.name}";
-      # leaves enabled: quartus, modelsim_ase, devinfo
-      disabledComponents = [
-        "quartus_help"
-        "quartus_update"
-        # not modelsim_ase
-        "modelsim_ae"
-      ] ++ (lib.attrValues unsupportedDeviceIds);
-    in ''
-      ${lib.concatMapStringsSep "\n" copyInstaller installers}
-      ${lib.concatMapStringsSep "\n" copyComponent components}
-
-      unstick $TEMP/${(builtins.head installers).name} \
-        --disable-components ${lib.concatStringsSep "," disabledComponents} \
-        --mode unattended --installdir $out --accept_eula 1
-
-      rm -r $out/uninstall $out/logs
-    '';
-
-    meta = {
-      homepage = "https://fpgasoftware.intel.com";
-      description = "FPGA design and simulation software";
-      license = lib.licenses.unfree;
-      platforms = lib.platforms.linux;
-      hydraPlatforms = [ ]; # requireFile srcs cannot be fetched by hydra, ignore
-      maintainers = with lib.maintainers; [ kwohlfahrt ];
-    };
-  };
-
   desktopItem = makeDesktopItem {
     name = "quartus-prime-lite";
     exec = "quartus";
@@ -102,7 +11,6 @@ let
     genericName = "Quartus Prime";
     categories = "Development;";
   };
-
 # I think modelsim_ase/linux/vlm checksums itself, so use FHSUserEnv instead of `patchelf`
 in buildFHSUserEnv rec {
   name = "quartus-prime-lite"; # wrapped
@@ -136,9 +44,7 @@ in buildFHSUserEnv rec {
     xorg.libXrender
   ];
 
-  passthru = {
-    unwrapped = quartus;
-  };
+  passthru = { inherit unwrapped; };
 
   extraInstallCommands = let
     quartusExecutables = (map (c: "quartus/bin/quartus_${c}") [
@@ -156,14 +62,14 @@ in buildFHSUserEnv rec {
   in ''
     mkdir -p $out/share/applications $out/share/icons/128x128
     ln -s ${desktopItem}/share/applications/* $out/share/applications
-    ln -s ${quartus}/licenses/images/dc_quartus_panel_logo.png $out/share/icons/128x128/quartus.png
+    ln -s ${unwrapped}/licenses/images/dc_quartus_panel_logo.png $out/share/icons/128x128/quartus.png
 
     mkdir -p $out/quartus/bin $out/quartus/sopc_builder/bin $out/modelsim_ase/bin
     WRAPPER=$out/bin/${name}
     EXECUTABLES="${lib.concatStringsSep " " (quartusExecutables ++ qsysExecutables ++ modelsimExecutables)}"
     for executable in $EXECUTABLES; do
         echo "#!${stdenv.shell}" >> $out/$executable
-        echo "$WRAPPER ${quartus}/$executable \$@" >> $out/$executable
+        echo "$WRAPPER ${unwrapped}/$executable \$@" >> $out/$executable
     done
 
     cd $out

--- a/pkgs/applications/editors/quartus-prime/quartus.nix
+++ b/pkgs/applications/editors/quartus-prime/quartus.nix
@@ -1,5 +1,6 @@
-{ stdenv, lib, unstick, requireFile,
-  supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ] }:
+{ stdenv, lib, unstick, requireFile
+, supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
+}:
 
 let
   deviceIds = {
@@ -85,12 +86,12 @@ in stdenv.mkDerivation rec {
       rm -r $out/uninstall $out/logs
     '';
 
-  meta = {
+  meta = with lib; {
     inherit homepage;
     description = "FPGA design and simulation software";
-    license = lib.licenses.unfree;
-    platforms = lib.platforms.linux;
+    license = licenses.unfree;
+    platforms = platforms.linux;
     hydraPlatforms = [ ]; # requireFile srcs cannot be fetched by hydra, ignore
-    maintainers = with lib.maintainers; [ kwohlfahrt ];
+    maintainers = with maintainers; [ kwohlfahrt ];
   };
 }

--- a/pkgs/applications/editors/quartus-prime/quartus.nix
+++ b/pkgs/applications/editors/quartus-prime/quartus.nix
@@ -1,0 +1,96 @@
+{ stdenv, lib, unstick, requireFile,
+  supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ] }:
+
+let
+  deviceIds = {
+    "Arria II" = "arria_lite";
+    "Cyclone V" = "cyclonev";
+    "Cyclone IV" = "cyclone";
+    "Cyclone 10 LP" = "cyclone10lp";
+    "MAX II/V" = "max";
+    "MAX 10 FPGA" = "max10";
+  };
+
+  supportedDeviceIds =
+    assert lib.assertMsg (lib.all (name: lib.hasAttr name deviceIds) supportedDevices)
+      "Supported devices are: ${lib.concatStringsSep ", " (lib.attrNames deviceIds)}";
+    lib.listToAttrs (map (name: {
+      inherit name;
+      value = deviceIds.${name};
+    }) supportedDevices);
+
+  unsupportedDeviceIds = lib.filterAttrs (name: value:
+    !(lib.hasAttr name supportedDeviceIds)
+  ) deviceIds;
+
+  componentHashes = {
+    "arria_lite" = "09g2knq23h3vj0s5y7hsdnqbbkr3pnv53dzpqcw2lq9mb5zfs9r0";
+    "cyclonev" = "05hrpysasyfb7xhxg68spdffxyvxcx0iagibd5jz643b7n6aalpa";
+    "cyclone" = "1x3rnwsvzrb5kwdz35sbcabxmcvj8xxpnjlpcjwfc69ybiyr6sgz";
+    "cyclone10lp" = "1x6d4hm697mjgzaxixrw5va8anr6ihhx96x2524r6axpwqf6wcja";
+    "max" = "060b7v0xh86kkjyiix7akfkzhx2kl1b3q117kp7xibnz6yrzwmy3";
+    "max10" = "05840l9pmqa4i1b3ajfaxkqz1hppls556vbq16a42acz2qs2g578";
+  };
+
+  version = "20.1.0.711";
+  homepage = "https://fpgasoftware.intel.com";
+
+  require = {name, sha256}: requireFile {
+    inherit name sha256;
+    url = "${homepage}/${lib.versions.majorMinor version}/?edition=lite&platform=linux";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit version;
+  pname = "quartus-prime-lite-unwrapped";
+
+  src = map require ([{
+    name = "QuartusLiteSetup-${version}-linux.run";
+    sha256 = "07ssrv8p8kacal6xd80n4h7l5xz13aw1m1gfqqaxig0ivsj971z5";
+  } {
+    name = "ModelSimSetup-${version}-linux.run";
+    sha256 = "0smxasrmr1c8k6hy378knskpjmz4cgpgb35v5jclns0kx68y3c42";
+  }] ++ (map (id: {
+    name = "${id}-${version}.qdz";
+    sha256 = lib.getAttr id componentHashes;
+  }) (lib.attrValues supportedDeviceIds)));
+
+  nativeBuildInputs = [ unstick ];
+
+  buildCommand = let
+    installers = lib.sublist 0 2 src;
+    components = lib.sublist 2 ((lib.length src) - 2) src;
+    copyInstaller = installer: ''
+        # `$(cat $NIX_CC/nix-support/dynamic-linker) $src[0]` often segfaults, so cp + patchelf
+        cp ${installer} $TEMP/${installer.name}
+        chmod u+w,+x $TEMP/${installer.name}
+        patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $TEMP/${installer.name}
+      '';
+    copyComponent = component: "cp ${component} $TEMP/${component.name}";
+    # leaves enabled: quartus, modelsim_ase, devinfo
+    disabledComponents = [
+      "quartus_help"
+      "quartus_update"
+      # not modelsim_ase
+      "modelsim_ae"
+    ] ++ (lib.attrValues unsupportedDeviceIds);
+  in ''
+      ${lib.concatMapStringsSep "\n" copyInstaller installers}
+      ${lib.concatMapStringsSep "\n" copyComponent components}
+
+      unstick $TEMP/${(builtins.head installers).name} \
+        --disable-components ${lib.concatStringsSep "," disabledComponents} \
+        --mode unattended --installdir $out --accept_eula 1
+
+      rm -r $out/uninstall $out/logs
+    '';
+
+  meta = {
+    inherit homepage;
+    description = "FPGA design and simulation software";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    hydraPlatforms = [ ]; # requireFile srcs cannot be fetched by hydra, ignore
+    maintainers = with lib.maintainers; [ kwohlfahrt ];
+  };
+}

--- a/pkgs/applications/editors/quartus-prime/quartus.nix
+++ b/pkgs/applications/editors/quartus-prime/quartus.nix
@@ -24,15 +24,15 @@ let
   ) deviceIds;
 
   componentHashes = {
-    "arria_lite" = "09g2knq23h3vj0s5y7hsdnqbbkr3pnv53dzpqcw2lq9mb5zfs9r0";
-    "cyclonev" = "05hrpysasyfb7xhxg68spdffxyvxcx0iagibd5jz643b7n6aalpa";
-    "cyclone" = "1x3rnwsvzrb5kwdz35sbcabxmcvj8xxpnjlpcjwfc69ybiyr6sgz";
-    "cyclone10lp" = "1x6d4hm697mjgzaxixrw5va8anr6ihhx96x2524r6axpwqf6wcja";
-    "max" = "060b7v0xh86kkjyiix7akfkzhx2kl1b3q117kp7xibnz6yrzwmy3";
-    "max10" = "05840l9pmqa4i1b3ajfaxkqz1hppls556vbq16a42acz2qs2g578";
+    "arria_lite" = "140jqnb97vrxx6398cpgpw35zrrx3z5kv1x5gr9is1xdbnf4fqhy";
+    "cyclone" = "116kf69ryqcmlc2k8ra0v32jy7nrk7w4s5z3yll7h3c3r68xcsfr";
+    "cyclone10lp" = "07wpgx9bap6rlr5bcmr9lpsxi3cy4yar4n3pxfghazclzqfi2cyl";
+    "cyclonev" = "11baa9zpmmfkmyv33w1r57ipf490gnd3dpi2daripf38wld8lgak";
+    "max" = "1zy2d42dqmn97fwmv4x6pmihh4m23jypv3nd830m1mj7jkjx9kcq";
+    "max10" = "1hvi9cpcjgbih3l6nh8x1vsp0lky5ax85jb2yqmzla80n7dl9ahs";
   };
 
-  version = "20.1.0.711";
+  version = "20.1.1.720";
   homepage = "https://fpgasoftware.intel.com";
 
   require = {name, sha256}: requireFile {
@@ -46,10 +46,10 @@ in stdenv.mkDerivation rec {
 
   src = map require ([{
     name = "QuartusLiteSetup-${version}-linux.run";
-    sha256 = "07ssrv8p8kacal6xd80n4h7l5xz13aw1m1gfqqaxig0ivsj971z5";
+    sha256 = "0mjp1rg312dipr7q95pb4nf4b8fwvxgflnd1vafi3g9cshbb1c3k";
   } {
     name = "ModelSimSetup-${version}-linux.run";
-    sha256 = "0smxasrmr1c8k6hy378knskpjmz4cgpgb35v5jclns0kx68y3c42";
+    sha256 = "1cqgv8x6vqga8s4v19yhmgrr886rb6p7sbx80528df5n4rpr2k4i";
   }] ++ (map (id: {
     name = "${id}-${version}.qdz";
     sha256 = lib.getAttr id componentHashes;


### PR DESCRIPTION
###### Motivation for this change

This PR does two things. The first is a simple version bump (20.1 to 20.1.1). The second is reorganizing the FHS environment and quartus package, so the quartus package can be overridden easily in an overlay, for example the suggestion to reduce closure size in #123469 could be implemented as:

```
self: super: {
  quartus-prime-lite = super.quartus-prime-lite.override {
    unwrapped = super.quartus-prime-lite.unwrapped.overrideAttrs (o: {
      buildCommand = o.buildCommand + ''
        rm -r $out/nios2eds/bin/gnu
        find $out/modelsim_ase/altera/{verilog,vhdl}/* ! -name src ! -path '*twentynm*' -delete
      '';
    });
  };
}
```

This is a more flexible approach than the `postBuild` parameter suggested in that PR.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).