### PR TITLE
newsflash: fix build

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-qq8cZplt5YWUwsXUShMDhQm3RGH2kCEBk64x6bOa50E=";
   };
 
+  # https://github.com/CasualX/obfstr/blob/v0.2.4/build.rs#L5
+  # obfstr 0.2.4 fails to set RUSTC_BOOTSTRAP in its build script because cargo
+  # build scripts are forbidden from setting RUSTC_BOOTSTRAP since rustc 1.52.0
+  # https://github.com/rust-lang/rust/blob/1.52.0/RELEASES.md#compatibility-notes
+  RUSTC_BOOTSTRAP = 1;
+
   patches = [
     # Post install tries to generate an icon cache & update the
     # desktop database. The gtk setup hook drop-icon-theme-cache.sh


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[obfstr 0.2.4](https://github.com/CasualX/obfstr/blob/v0.2.4/build.rs#L5) fails to set RUSTC_BOOTSTRAP in its build script because cargo build scripts are forbidden from setting RUSTC_BOOTSTRAP since [rustc 1.52.0](https://github.com/rust-lang/rust/blob/1.52.0/RELEASES.md#compatibility-notes)

~~Tested on nixos on nixos-unstable branch, but on master branch it hangs on webkitgtk build~~
ofborg builds, so I assume it should work on master too

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
