### PR TITLE
virtualization: Add enable options for amazon modules.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -107,6 +107,7 @@
   ./misc/passthru.nix
   ./misc/version.nix
   ./misc/nixops-autoluks.nix
+  ./profiles/headless-config.nix
   ./programs/adb.nix
   ./programs/appgate-sdp.nix
   ./programs/atop.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1098,6 +1098,7 @@
   ./virtualisation/container-config.nix
   ./virtualisation/containerd.nix
   ./virtualisation/containers.nix
+  ./virtualisation/ec2-data.nix
   ./virtualisation/nixos-containers.nix
   ./virtualisation/oci-containers.nix
   ./virtualisation/cri-o.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1108,6 +1108,8 @@
   ./virtualisation/lxc.nix
   ./virtualisation/lxcfs.nix
   ./virtualisation/lxd.nix
+  ./virtualisation/amazon-config.nix
+  ./virtualisation/amazon-init.nix
   ./virtualisation/amazon-options.nix
   ./virtualisation/hyperv-guest.nix
   ./virtualisation/kvmgt.nix

--- a/nixos/modules/profiles/headless-config.nix
+++ b/nixos/modules/profiles/headless-config.nix
@@ -1,23 +1,37 @@
 # Common configuration for headless machines (e.g., Amazon EC2
 # instances).
 
-{ lib, ... }:
+{ config, lib, ... }:
 
+let
+  cfg = config.profiles.headless;
+in
 {
-  boot.vesa = false;
+  options.profiles.headless = {
+    enable = lib.mkEnableOption "the headless profile";
 
-  # Don't start a tty on the serial consoles.
-  systemd.services."serial-getty@ttyS0".enable = false;
-  systemd.services."serial-getty@hvc0".enable = false;
-  systemd.services."getty@tty1".enable = false;
-  systemd.services."autovt@".enable = false;
+    serial.enable = lib.mkEnableOption "starting a tty on the serial consoles";
+  };
 
-  # Since we can't manually respond to a panic, just reboot.
-  boot.kernelParams = [ "panic=1" "boot.panic_on_fail" ];
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      boot.vesa = false;
 
-  # Don't allow emergency mode, because we don't have a console.
-  systemd.enableEmergencyMode = false;
+      # Since we can't manually respond to a panic, just reboot.
+      boot.kernelParams = [ "panic=1" "boot.panic_on_fail" ];
 
-  # Being headless, we don't need a GRUB splash image.
-  boot.loader.grub.splashImage = null;
+      # Don't allow emergency mode, because we don't have a console.
+      systemd.enableEmergencyMode = false;
+
+      # Being headless, we don't need a GRUB splash image.
+      boot.loader.grub.splashImage = null;
+    }
+
+    (lib.mkIf (!cfg.serial.enable) {
+      systemd.services."serial-getty@ttyS0".enable = false;
+      systemd.services."serial-getty@hvc0".enable = false;
+      systemd.services."getty@tty1".enable = false;
+      systemd.services."autovt@".enable = false;
+    })
+  ]);
 }

--- a/nixos/modules/profiles/headless-config.nix
+++ b/nixos/modules/profiles/headless-config.nix
@@ -3,8 +3,6 @@
 
 { lib, ... }:
 
-with lib;
-
 {
   boot.vesa = false;
 

--- a/nixos/modules/profiles/headless.nix
+++ b/nixos/modules/profiles/headless.nix
@@ -1,5 +1,5 @@
 { ... }:
 
 {
-  imports = [ ./headless-config.nix ];
+  config.profiles.headless.enable = true;
 }

--- a/nixos/modules/profiles/headless.nix
+++ b/nixos/modules/profiles/headless.nix
@@ -1,0 +1,5 @@
+{ ... }:
+
+{
+  imports = [ ./headless-config.nix ];
+}

--- a/nixos/modules/virtualisation/amazon-config.nix
+++ b/nixos/modules/virtualisation/amazon-config.nix
@@ -14,7 +14,7 @@ let
 in
 
 {
-  imports = [ ../profiles/headless.nix ./ec2-data.nix ./amazon-init.nix ];
+  imports = [ ../profiles/headless.nix ./amazon-init.nix ];
 
   config = {
 
@@ -26,6 +26,8 @@ in
         message = "EC2 instances using EFI must be HVM instances.";
       }
     ];
+
+    ec2.metadata.enable = true;
 
     boot.growPartition = cfg.hvm;
 

--- a/nixos/modules/virtualisation/amazon-config.nix
+++ b/nixos/modules/virtualisation/amazon-config.nix
@@ -1,8 +1,4 @@
-# Configuration for Amazon EC2 instances. (Note that this file is a
-# misnomer - it should be "amazon-config.nix" or so, not
-# "amazon-image.nix", since it's used not only to build images but
-# also to reconfigure instances. However, we can't rename it because
-# existing "configuration.nix" files on EC2 instances refer to it.)
+# Configuration for Amazon EC2 instances.
 
 { config, lib, pkgs, ... }:
 

--- a/nixos/modules/virtualisation/amazon-config.nix
+++ b/nixos/modules/virtualisation/amazon-config.nix
@@ -12,8 +12,6 @@ let
 in
 
 {
-  imports = [ ./amazon-init.nix ];
-
   config = lib.mkIf cfg.enable {
     assertions = [
       { assertion = cfg.hvm;
@@ -25,6 +23,7 @@ in
     ];
 
     ec2.metadata.enable = true;
+    virtualization.amazon-init.enable = true;
 
     profiles.headless.enable = true;
     profiles.headless.serial.enable = true;

--- a/nixos/modules/virtualisation/amazon-config.nix
+++ b/nixos/modules/virtualisation/amazon-config.nix
@@ -23,7 +23,7 @@ in
     ];
 
     ec2.metadata.enable = true;
-    virtualization.amazon-init.enable = true;
+    virtualisation.amazon-init.enable = true;
 
     profiles.headless.enable = true;
     profiles.headless.serial.enable = true;

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -5,4 +5,6 @@
 
 {
   imports = [ ./amazon-config.nix ];
+
+  config.ec2.enable = true;
 }

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -1,0 +1,8 @@
+# Import "amazon-config.nix" and enable it.
+# This supports existing "configuration.nix" files that reference this file.
+
+{ ... }:
+
+{
+  imports = [ ./amazon-config.nix ];
+}

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -4,7 +4,5 @@
 { ... }:
 
 {
-  imports = [ ./amazon-config.nix ];
-
   config.ec2.enable = true;
 }

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.virtualisation.amazon-init;
 
@@ -55,18 +53,11 @@ let
     nixos-rebuild switch
   '';
 in {
-
   options.virtualisation.amazon-init = {
-    enable = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Enable or disable the amazon-init service.
-      '';
-    };
+    enable = lib.mkEnableOption "the amazon-init service";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.amazon-init = {
       inherit script;
       description = "Reconfigure the system from EC2 userdata on startup";

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -2,6 +2,8 @@
 {
   options = {
     ec2 = {
+      enable = lib.mkEnableOption "EC2 instance configuration";
+
       hvm = lib.mkOption {
         default = lib.versionAtLeast config.system.stateVersion "17.03";
         internal = true;

--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -4,14 +4,15 @@
 
 { config, lib, pkgs, ... }:
 
-with lib;
-
+let
+  cfg = config.ec2.metadata;
+in
 {
-  imports = [
-    (mkRemovedOptionModule [ "ec2" "metadata" ] "")
-  ];
+  options.ec2.metadata = {
+    enable = lib.mkEnableOption "EC2 metadata";
+  };
 
-  config = {
+  config = lib.mkIf cfg.enable {
 
     systemd.services.apply-ec2-data =
       { description = "Apply EC2 Data";
@@ -23,7 +24,7 @@ with lib;
 
         script =
           ''
-            ${optionalString (config.networking.hostName == "") ''
+            ${lib.optionalString (config.networking.hostName == "") ''
               echo "setting host name..."
               if [ -s /etc/ec2-metadata/hostname ]; then
                   ${pkgs.nettools}/bin/hostname $(cat /etc/ec2-metadata/hostname)

--- a/nixos/modules/virtualisation/openstack-config.nix
+++ b/nixos/modules/virtualisation/openstack-config.nix
@@ -1,7 +1,5 @@
 { pkgs, lib, ... }:
 
-with lib;
-
 let
   metadataFetcher = import ./openstack-metadata-fetcher.nix {
     targetRoot = "/";
@@ -13,11 +11,13 @@ in
     ../profiles/qemu-guest.nix
     ../profiles/headless.nix
     # The Openstack Metadata service exposes data on an EC2 API also.
-    ./ec2-data.nix
     ./amazon-init.nix
   ];
 
   config = {
+    # The Openstack Metadata service exposes data on an EC2 API also.
+    ec2.metadata.enable = true;
+
     fileSystems."/" = {
       device = "/dev/disk/by-label/nixos";
       fsType = "ext4";
@@ -33,11 +33,11 @@ in
     services.openssh = {
       enable = true;
       permitRootLogin = "prohibit-password";
-      passwordAuthentication = mkDefault false;
+      passwordAuthentication = lib.mkDefault false;
     };
 
     # Force getting the hostname from Openstack metadata.
-    networking.hostName = mkDefault "";
+    networking.hostName = lib.mkDefault "";
 
     systemd.services.openstack-init = {
       path = [ pkgs.wget ];

--- a/nixos/modules/virtualisation/openstack-config.nix
+++ b/nixos/modules/virtualisation/openstack-config.nix
@@ -10,13 +10,12 @@ in
   imports = [
     ../profiles/qemu-guest.nix
     ../profiles/headless.nix
-    # The Openstack Metadata service exposes data on an EC2 API also.
-    ./amazon-init.nix
   ];
 
   config = {
     # The Openstack Metadata service exposes data on an EC2 API also.
     ec2.metadata.enable = true;
+    virtualisation.amazon-init.enable = true;
 
     fileSystems."/" = {
       device = "/dev/disk/by-label/nixos";

--- a/nixos/tests/amazon-init-shell.nix
+++ b/nixos/tests/amazon-init-shell.nix
@@ -20,7 +20,8 @@ makeTest {
   };
   machine = { ... }:
   {
-    imports = [ ../modules/profiles/headless.nix ../modules/virtualisation/amazon-init.nix ];
+    imports = [ ../modules/profiles/headless.nix ];
+    virtualisation.amazon-init.enable = true;
     services.openssh.enable = true;
     networking.hostName = "";
     environment.etc."ec2-metadata/user-data" = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change allows the amazon modules in the virtualization directory to be added to the main module list, and enabled like any other module, while preserving backwards compatibility. For new configuration, this allows the user to create configs which toggle the settings specific for EC2 instances -- for example, using a command-line option -- which provides greater flexibility.

This change also adds a toggle for enabling serial TTYs on ec2 instances, as EC2 allows admins to connect to their instances using serial tty for recovery purposes.

My main motivation for this change was that I wanted to be able to test my configuration.nix for an EC2 instance locally before deploying it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
