### PR TITLE
zfsUnstable: 2.1.0-rc5 -> 2.1.0-rc6

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -206,9 +206,9 @@ in {
     kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.13";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2.1.0-rc5";
+    version = "2.1.0-rc6";
 
-    sha256 = "sha256-cj0P2bw6sTO+Y74pYn/WEpBuVGMMYCreJQjUdC3DMTE=";
+    sha256 = "0q3vl9rid6a84pb85v38hnf17vws65jjb4slw8bhm8dq8fna2a86";
 
     isUnstable = true;
   };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/openzfs/zfs/releases/tag/zfs-2.1.0-rc6

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).