### PR TITLE
heisenbridge: unstable-2021-05-23 -> unstable-2021-05-29

### DIFF
--- a/pkgs/servers/heisenbridge/default.nix
+++ b/pkgs/servers/heisenbridge/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "heisenbridge";
-  version = "unstable-2021-05-23";
+  version = "unstable-2021-05-29";
 
   src = fetchFromGitHub {
     owner = "hifi";
     repo = "heisenbridge";
-    rev = "1f8df49b7e89aaeb2cbb5fee68bd29cf3eda079a";
-    sha256 = "sha256-ta6n9hXRdIjfxsLy9jrzZkz6TS50/TYpFOb/BLrRWK4=";
+    rev = "980755226b0cb46ad9c7f40e0e940f354212a8b7";
+    sha256 = "sha256-jO1Dqtv3IbV4FLI3C82pxssgrCf43hAEcPLYszX2GNI=";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
Closes #124889 because it includes the changes from hifi/heisenbridge#78 which adds an entrypoint so that the executable works.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
    ```
    sumner@coruscant /nix/store/07dxvixf7znkinrgdw53p137r9dajza3-python3.8-heisenbridge-unstable-2021-05-29 % ./bin/heisenbridge
    usage: python3.8 -m heisenbridge [-h] [-v] -c CONFIG [-l LISTEN_ADDRESS] [-p LISTEN_PORT] [-u UID] [-g GID] [-i]
                                     [--generate] [--reset] [-o OWNER]
                                     [homeserver]
    python3.8 -m heisenbridge: error: the following arguments are required: -c/--config
    ```
    (error is due to not having a config file, but the executable itself works)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
