### PR TITLE
python3Packages.solo-python: 0.0.27 -> 0.0.30

### DIFF
--- a/pkgs/development/python-modules/solo-python/default.nix
+++ b/pkgs/development/python-modules/solo-python/default.nix
@@ -14,7 +14,7 @@
 
  buildPythonPackage rec {
   pname = "solo-python";
-  version = "0.0.27";
+  version = "0.0.30";
   format = "flit";
   disabled = pythonOlder "3.6"; # only python>=3.6 is supported
 
@@ -22,7 +22,7 @@
     owner = "solokeys";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OCiKa6mnqJGoNCC4KqI+hMw22tzhdN63x9/KujNJqcE=";
+    sha256 = "1i9kybp08qfcdx6m4wl7ij40y1v17mvvhcdg7zglwfakblf69w41";
   };
 
   # replaced pinned fido, with unrestricted fido version
@@ -60,8 +60,5 @@
     homepage = "https://github.com/solokeys/solo-python";
     maintainers = with maintainers; [ wucke13 ];
     license = with licenses; [ asl20 mit ];
-    # solo-python v0.0.27 does not support fido2 >= v0.9
-    # https://github.com/solokeys/solo-python/issues/110
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update package and un-mark as broken

solo-python since version 0.0.28 supports fido2 >= v0.9 therefore no longer broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
