### PR TITLE
nixos/acme: don't use --reuse-key

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -804,6 +804,16 @@ environment.systemPackages = [
      the deprecated <option>services.radicale.config</option> is used.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     In the <option>security.acme</option> module, use of <literal>--reuse-key</literal>
+     parameter  for Lego has been removed. It was introduced for HKPK, but this security
+     feature is now deprecated. It is a better security practice to rotate key pairs
+     instead of always keeping the same. If you need to keep this parameter, you can add
+     it back using <literal>extraLegoRenewFlags</literal> as an option for the
+     appropriate certificate.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -152,7 +152,7 @@ let
     );
     renewOpts = escapeShellArgs (
       commonOpts
-      ++ [ "renew" "--reuse-key" ]
+      ++ [ "renew" ]
       ++ optionals data.ocspMustStaple [ "--must-staple" ]
       ++ data.extraLegoRenewFlags
     );


### PR DESCRIPTION
###### Motivation for this change

Reusing the same private/public key on renewal has two issues:

 - some providers don't accept to sign the same public key
   again (Buypass Go SSL)

 - keeping the same private key forever partly defeats the purpose of
   renewing the certificate often

Therefore, let's remove this option. People wanting to keep the same
key can set extraLegoRenewFlags to `[ --reuse-key ]` to keep the
previous behavior. Alternatively, we could put this as an option whose
default value is true.

cc @m1cr0man

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
