### PR TITLE
Ustreamer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10013,6 +10013,12 @@
     githubId = 27386;
     name = "Milan Svoboda";
   };
+  tfc = {
+    email = "jacek@galowicz.de";
+    github = "tfc";
+    githubId = 29044;
+    name = "Jacek Galowicz";
+  };
   tg-x = {
     email = "*@tg-x.net";
     github = "tg-x";

--- a/pkgs/applications/video/ustreamer/default.nix
+++ b/pkgs/applications/video/ustreamer/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, libbsd, libevent, libjpeg }:
+
+stdenv.mkDerivation rec {
+  pname = "ustreamer";
+  version = "3.27";
+
+  src = fetchFromGitHub {
+    owner = "pikvm";
+    repo = "ustreamer";
+    rev = "v${version}";
+    sha256 = "1max2171abdpix0wq7mdkji5lvkfzisj166qfgmqkkwc2nh721iw";
+  };
+
+  buildInputs = [ libbsd libevent libjpeg ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ustreamer $out/bin/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/pikvm/ustreamer";
+    description = "Lightweight and fast MJPG-HTTP streamer";
+    longDescription = ''
+      µStreamer is a lightweight and very quick server to stream MJPG video from
+      any V4L2 device to the net. All new browsers have native support of this
+      video format, as well as most video players such as mplayer, VLC etc.
+      µStreamer is a part of the Pi-KVM project designed to stream VGA and HDMI
+      screencast hardware data with the highest resolution and FPS possible.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ tfc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9361,6 +9361,8 @@ in
 
   usbmuxd = callPackage ../tools/misc/usbmuxd {};
 
+  ustreamer = callPackage ../applications/video/ustreamer { };
+
   usync = callPackage ../applications/misc/usync { };
 
   uwc = callPackage ../tools/text/uwc { };


### PR DESCRIPTION


###### Motivation for this change

This package is useful (not only) on raspberry pi 4 devices in combination with a tc358743 HDMI-to-CSI-2 converter.

https://github.com/NixOS/nixos-hardware/pull/269

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
