### PR TITLE
luajit: fix stack corruption with pcall

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,10 +1,10 @@
 { self, callPackage, lib }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.0.5-2021-05-17";
-  rev = "44684fa71d8af6fa8b3051c7d763bbfdcf7915d7";
+  version = "2.0.5-2021-05-29";
+  rev = "c2cfa04231785116d9d198462830f41ef94147c0";
   isStable = true;
-  sha256 = "049d3l0miv4n0cnm35ml8flrb9vs12zvbda2743vypckymidliqp";
+  sha256 = "1fw64pv0dvzb9bgr2zwcv9q8gqgsmfnvrcrmrdfgj4ncamgdnilj";
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: p != "aarch64-linux")
       (platforms.linux ++ platforms.darwin);

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,8 +1,8 @@
 { self, callPackage }:
 callPackage ./default.nix {
   inherit self;
-  version = "2.1.0-2021-05-22";
-  rev = "5783ba1bf73c53ca56e64ed0c462c62224f0393c";
+  version = "2.1.0-2021-05-29";
+  rev = "839fb5bd72341d8e67b6cfc2053e2acffdb75567";
   isStable = false;
-  sha256 = "1j25xnbradks58lwsqnxcc7k29wsk2hnky0b1vjzpadrj0sxxc42";
+  sha256 = "1gyzq4n0fwah0245wazv4c43q9in1mwbk3dhh6cb1ijnjcxp2bb6";
 }


### PR DESCRIPTION
###### Motivation for this change

Fix stack corruption with pcalls introduced by #124110
Upstream issue: https://github.com/LuaJIT/LuaJIT/issues/704

I believe this will solve neovim issue: https://github.com/neovim/neovim/issues/14246

In luajit 2.0 issue is not triggered, but it is there, so I've updated it together with 2.1.

*luajit_2_0*

https://github.com/LuaJIT/LuaJIT/compare/44684fa71d8af6fa8b3051c7d763bbfdcf7915d7...c2cfa04231785116d9d198462830f41ef94147c0

*luajit_2_1*
https://github.com/LuaJIT/LuaJIT/compare/5783ba1bf73c53ca56e64ed0c462c62224f0393c...839fb5bd72341d8e67b6cfc2053e2acffdb75567

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
