### PR TITLE
kbd: patch paths to decompressors

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -201,6 +201,7 @@ in
   jitsi-meet = handleTest ./jitsi-meet.nix {};
   k3s = handleTest ./k3s.nix {};
   kafka = handleTest ./kafka.nix {};
+  kbd-setfont-decompress = handleTest ./kbd-setfont-decompress.nix {};
   keepalived = handleTest ./keepalived.nix {};
   keepassxc = handleTest ./keepassxc.nix {};
   kerberos = handleTest ./kerberos/default.nix {};

--- a/nixos/tests/kbd-setfont-decompress.nix
+++ b/nixos/tests/kbd-setfont-decompress.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+{
+  name = "kbd-setfont-decompress";
+
+  meta.maintainers = with lib.maintainers; [ oxalica ];
+
+  machine = { ... }: {};
+
+  testScript = ''
+    machine.succeed("gzip -cd ${pkgs.terminus_font}/share/consolefonts/ter-v16b.psf.gz >font.psf")
+    machine.succeed("gzip <font.psf >font.psf.gz")
+    machine.succeed("bzip2 <font.psf >font.psf.bz2")
+    machine.succeed("xz <font.psf >font.psf.xz")
+    machine.succeed("zstd <font.psf >font.psf.zst")
+    # setfont returns 0 even on error.
+    assert machine.succeed("PATH= ${pkgs.kbd}/bin/setfont font.psf.gz  2>&1") == ""
+    assert machine.succeed("PATH= ${pkgs.kbd}/bin/setfont font.psf.bz2 2>&1") == ""
+    assert machine.succeed("PATH= ${pkgs.kbd}/bin/setfont font.psf.xz  2>&1") == ""
+    assert machine.succeed("PATH= ${pkgs.kbd}/bin/setfont font.psf.zst 2>&1") == ""
+  '';
+})

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -61,7 +61,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ check pam ];
   nativeBuildInputs = [ autoreconfHook pkg-config flex ];
 
-  passthru.tests = nixosTests.keymap;
+  passthru.tests = {
+    inherit (nixosTests) keymap kbd-setfont-decompress;
+  };
 
   meta = with lib; {
     homepage = "https://kbd-project.org/";

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -8,6 +8,10 @@
 , check
 , pam
 , coreutils
+, gzip
+, bzip2
+, xz
+, zstd
 }:
 
 stdenv.mkDerivation rec {
@@ -38,6 +42,13 @@ stdenv.mkDerivation rec {
       mv fgGIod/trf{,-fgGIod}.map
       mv colemak/{en-latin9,colemak}.map
       popd
+
+      # Fix paths to decompressors. Trailing space to avoid replacing `xz` in `".xz"`.
+      substituteInPlace src/libkbdfile/kbdfile.c \
+        --replace 'gzip '  '${gzip}/bin/gzip ' \
+        --replace 'bzip2 ' '${bzip2.bin}/bin/bzip2 ' \
+        --replace 'xz '    '${xz.bin}/bin/xz ' \
+        --replace 'zstd '  '${zstd.bin}/bin/zstd '
     '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Use absolute paths to de-compressors in `kbd`. Fix #124170.

Tested `setfont some-gz-font.psf.gz` with empty `PATH`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  `nix build -f . kbd.tests`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
