### PR TITLE
btrfs-progs: build from source, not release tarball

### DIFF
--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -42,10 +42,6 @@ stdenv.mkDerivation rec {
   # for python cross-compiling
   _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config;
 
-  # gcc bug with -O1 on ARM with gcc 4.8
-  # This should be fine on all platforms so apply universally
-  postPatch = "sed -i s/-O1/-O2/ configure";
-
   postInstall = ''
     install -v -m 444 -D btrfs-completion $out/share/bash-completion/completions/btrfs
   '';

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -1,5 +1,20 @@
-{ lib, stdenv, fetchurl, pkg-config, attr, acl, zlib, libuuid, e2fsprogs, lzo
-, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt, zstd, python3
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, attr
+, acl
+, zlib
+, libuuid
+, e2fsprogs
+, lzo
+, asciidoc
+, xmlto
+, docbook_xml_dtd_45
+, docbook_xsl
+, libxslt
+, zstd
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -12,8 +27,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkg-config asciidoc xmlto docbook_xml_dtd_45 docbook_xsl libxslt
-    python3 python3.pkgs.setuptools
+    pkg-config
+    asciidoc
+    xmlto
+    docbook_xml_dtd_45
+    docbook_xsl
+    libxslt
+    python3
+    python3.pkgs.setuptools
   ];
 
   buildInputs = [ attr acl zlib libuuid e2fsprogs lzo zstd python3 ];

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -1,6 +1,8 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
+, autoconf
+, automake
 , pkg-config
 , attr
 , acl
@@ -21,12 +23,16 @@ stdenv.mkDerivation rec {
   pname = "btrfs-progs";
   version = "5.12.1";
 
-  src = fetchurl {
-    url = "mirror://kernel/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v${version}.tar.xz";
-    sha256 = "sha256-lQhG/qRU+0scOfD6RUmDZEVy35HfXAYEezNb8tVHN1k=";
+  src = fetchFromGitHub {
+    owner = "kdave";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-rC9X4XzmT6PUDCajLkhuG85nRjJTqQ4mvevF4HWgHNE=";
   };
 
   nativeBuildInputs = [
+    autoconf
+    automake
     pkg-config
     asciidoc
     xmlto
@@ -41,6 +47,10 @@ stdenv.mkDerivation rec {
 
   # for python cross-compiling
   _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config;
+
+  preConfigure = ''
+    sh autogen.sh
+  '';
 
   postInstall = ''
     install -v -m 444 -D btrfs-completion $out/share/bash-completion/completions/btrfs


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
