### PR TITLE
skytemple: init at 1.2.3

### DIFF
--- a/pkgs/applications/misc/skytemple/default.nix
+++ b/pkgs/applications/misc/skytemple/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, gobject-introspection, gtk3, gtksourceview3, wrapGAppsHook, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "skytemple";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "0l2c4qngv58j6zkp0va6m96zksx8gqn3mjc3isqybfnhjr6nd3v9";
+  };
+
+  buildInputs = [ gobject-introspection gtk3 gtksourceview3 ];
+  nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+  propagatedBuildInputs = with python3Packages; [
+    natsort
+    packaging
+    pycairo
+    pygal
+    pypresence
+    setuptools
+    skytemple-dtef
+    skytemple-eventserver
+    skytemple-files
+    skytemple-icons
+    skytemple-ssb-debugger
+  ];
+
+  doCheck = false; # there are no tests
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple";
+    description = "ROM hacking tool for Pokémon Mystery Dungeon Explorers of Sky";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/explorerscript/default.nix
+++ b/pkgs/development/python-modules/explorerscript/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub, antlr4-python3-runtime, pygments, python-igraph }:
+
+buildPythonPackage rec {
+  pname = "explorerscript";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "1vzyliiyrxx8l9sfbqcyr4xn5swd7znkxy69kn0vb5rban8hm9c1";
+  };
+
+  propagatedBuildInputs = [ antlr4-python3-runtime python-igraph ];
+  checkInputs = [ pygments ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/explorerscript";
+    description = "A programming language + compiler/decompiler for creating scripts for Pokémon Mystery Dungeon Explorers of Sky";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/ndspy/default.nix
+++ b/pkgs/development/python-modules/ndspy/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, crcmod }:
+
+buildPythonPackage rec {
+  pname = "ndspy";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1s0i81gspas22bjwk9vhy3x5sw1svyybk7c2j1ixc77drr9ym20a";
+  };
+
+  propagatedBuildInputs = [ crcmod ];
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "ndspy" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/RoadrunnerWMC/ndspy";
+    description = "A Python library for many Nintendo DS file formats";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/py-desmume/default.nix
+++ b/pkgs/development/python-modules/py-desmume/default.nix
@@ -1,0 +1,44 @@
+{ lib, buildPythonPackage, fetchFromGitHub, GitPython
+, libpcap, meson, ninja, pillow, pkg-config, pygobject3, SDL2
+, alsaLib, soundtouch, openal
+}:
+
+let
+  desmume = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = "desmume";
+    rev = "8e7af8ada883b7e91344985236f7c7c04ee795d7";
+    sha256 = "0svmv2rch9q347gbpbws4agymas8n014gh1ssaf91wx7jwn53842";
+  };
+in
+buildPythonPackage rec {
+  pname = "py-desmume";
+  version = "0.0.3.post2";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "1chsg70k8kqnlasn88b04ww3yl0lay1bjxvz6lhp6s2cvsxv03x1";
+  };
+
+  postPatch = ''
+    cp -R --no-preserve=mode ${desmume} __build_desmume
+  '';
+
+  buildInputs = [ GitPython libpcap SDL2 alsaLib soundtouch openal ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  propagatedBuildInputs = [ pillow pygobject3 ];
+
+  hardeningDisable = [ "format" ];
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "desmume" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/py-desmume";
+    description = "Python library to interface with DeSmuME, the Nintendo DS emulator";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/pygtkspellcheck/default.nix
+++ b/pkgs/development/python-modules/pygtkspellcheck/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, gobject-introspection, gtk3, pyenchant, pygobject3 }:
+
+buildPythonPackage rec {
+  pname = "pygtkspellcheck";
+  version = "4.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pc3xmv1q775hn4kc1kspvpdn4gm7ix3aw6hz9iy3brfcw6ddcl4";
+  };
+
+  nativeBuildInputs = [ gobject-introspection gtk3 ];
+  propagatedBuildInputs = [ pyenchant pygobject3 ];
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "gtkspellcheck" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/koehlma/pygtkspellcheck";
+    description = "A Python spell-checking library for GtkTextViews based on Enchant";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/pypresence/default.nix
+++ b/pkgs/development/python-modules/pypresence/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pypresence";
+  version = "4.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c8r7yxih5zp46qb9anq5s91pw2wr7d9d0nzcfh4l42x10c8lqal";
+  };
+
+  doCheck = false; # tests require internet connection
+  pythonImportsCheck = [ "pypresence" ];
+
+  meta = with lib; {
+    homepage = "https://qwertyquerty.github.io/pypresence/html/index.html";
+    description = "Discord RPC client written in Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-dtef/default.nix
+++ b/pkgs/development/python-modules/skytemple-dtef/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub, skytemple-files }:
+
+buildPythonPackage rec {
+  pname = "skytemple-dtef";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "177ydif01fai6z5yhgpa27pzfgabblzhl8nsczczcmw74vxqwzyc";
+  };
+
+  propagatedBuildInputs = [ skytemple-files ];
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "skytemple_dtef" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple-dtef";
+    description = "A format for standardized rule-based tilesets with 256 adjacency combinations";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-eventserver/default.nix
+++ b/pkgs/development/python-modules/skytemple-eventserver/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "skytemple-eventserver";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "1xcf7ljvi5ixhwx9rkg3hnwcyv4wsgd2yb6is11jffbrdp00j2bq";
+  };
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "skytemple_eventserver" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple-eventserver";
+    description = "Websocket server that emits SkyTemple UI events";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-files/default.nix
+++ b/pkgs/development/python-modules/skytemple-files/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub, appdirs, explorerscript, ndspy, pillow, setuptools, skytemple-rust, tilequant }:
+
+buildPythonPackage rec {
+  pname = "skytemple-files";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "1vklg4kcj3kb9ryrzrcmywn131b2bp3vy94cd4x4y4s7hkhgwg74";
+  };
+
+  propagatedBuildInputs = [ appdirs explorerscript ndspy pillow setuptools skytemple-rust tilequant ];
+
+  doCheck = false; # requires Pokémon Mystery Dungeon ROM
+  pythonImportsCheck = [ "skytemple_files" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple-files";
+    description = "Python library to edit the ROM of Pokémon Mystery Dungeon Explorers of Sky";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-icons/default.nix
+++ b/pkgs/development/python-modules/skytemple-icons/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "skytemple-icons";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "036bxy0n3p0ivcdaymj11z0nw555xjxxj15ja0rpjsvq1mqamd80";
+  };
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "skytemple_icons" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple-icons";
+    description = "Icons for SkyTemple";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, rustPlatform, setuptools-rust }:
+
+buildPythonPackage rec {
+  pname = "skytemple-rust";
+  version = "unstable-2021-05-30"; # Contains build bug fixes, but is otherwise identical to 0.0.1.post0
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = "cff8b2930af6d25d41331fab8c04f56a4fd75e95";
+    sha256 = "18y6wwvzyw062zlv3gcirr1hgld9d97ffyrvy0jvw8nr3b9h9x0i";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "1ypcsf9gbq1bz29kfn7g4kg8741mxg1lfcbb14a0vfhjq4d6pnx9";
+  };
+
+  nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [ cargoSetupHook rust.cargo rust.rustc ]);
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "skytemple_rust" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple-rust";
+    description = "Binary Rust extensions for SkyTemple";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchFromGitHub, gobject-introspection, gtk3, gtksourceview3
+, wrapGAppsHook, nest-asyncio, pycairo, py-desmume, pygtkspellcheck, setuptools
+, skytemple-files, skytemple-icons
+}:
+
+buildPythonPackage rec {
+  pname = "skytemple-ssb-debugger";
+  version = "1.2.4";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "0jmsli3wg386y0lxwddpwp1xqxsn2bsy4d1f7dyh0jjz8lqiz03i";
+  };
+
+  buildInputs = [ gobject-introspection gtk3 gtksourceview3 ];
+  nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+  propagatedBuildInputs = [
+    nest-asyncio
+    pycairo
+    py-desmume
+    pygtkspellcheck
+    setuptools
+    skytemple-files
+    skytemple-icons
+  ];
+
+  doCheck = false; # requires Pokémon Mystery Dungeon ROM
+  pythonImportsCheck = [ "skytemple_ssb_debugger" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/skytemple-ssb-debugger";
+    description = "Script Engine Debugger for Pokémon Mystery Dungeon Explorers of Sky";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/development/python-modules/tilequant/default.nix
+++ b/pkgs/development/python-modules/tilequant/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchFromGitHub, GitPython, click, ordered-set, pillow, sortedcollections }:
+
+let
+  aikku93-tilequant = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = "aikku93-tilequant";
+    rev = "6604e0906edff384b6c8d4cde03e6601731f66fd";
+    sha256 = "0w19h3n2i0xriqsy0b0rifjgbv4hqd7gl78fw0cappkrdykij5r1";
+  };
+in
+buildPythonPackage rec {
+  pname = "tilequant";
+  version = "0.4.0.post0";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "189af203iay3inj1bbgm3hh1fshn879bcm28ypbvfp27fy7j5b25";
+  };
+
+  postPatch = ''
+    cp -R --no-preserve=mode ${aikku93-tilequant} __aikku93_tilequant
+  '';
+
+  buildInputs = [ GitPython ];
+  propagatedBuildInputs = [ click ordered-set pillow sortedcollections ];
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "skytemple_tilequant" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/tilequant";
+    description = "Tool for quantizing image colors using tile-based palette restrictions";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xfix ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8598,6 +8598,8 @@ in
     tex = texlive.combined.scheme-small;
   };
 
+  skytemple = callPackage ../applications/misc/skytemple {};
+
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 
   # Not updated upstream since 2018, doesn't support qt newer than 5.12

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7699,6 +7699,8 @@ in {
 
   skytemple-rust = callPackage ../development/python-modules/skytemple-rust { };
 
+  skytemple-ssb-debugger = callPackage ../development/python-modules/skytemple-ssb-debugger { };
+
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
   slackclient = callPackage ../development/python-modules/slackclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7691,6 +7691,8 @@ in {
 
   skybellpy = callPackage ../development/python-modules/skybellpy { };
 
+  skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };
+
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
   slackclient = callPackage ../development/python-modules/slackclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4527,6 +4527,8 @@ in {
 
   ndjson = callPackage ../development/python-modules/ndjson { };
 
+  ndspy = callPackage ../development/python-modules/ndspy { };
+
   ndtypes = callPackage ../development/python-modules/ndtypes { };
 
   neo = callPackage ../development/python-modules/neo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5767,6 +5767,8 @@ in {
 
   pygtail = callPackage ../development/python-modules/pygtail { };
 
+  pygtkspellcheck = callPackage ../development/python-modules/pygtkspellcheck { };
+
   pygtrie = callPackage ../development/python-modules/pygtrie { };
 
   pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7693,6 +7693,8 @@ in {
 
   skytemple-dtef = callPackage ../development/python-modules/skytemple-dtef { };
 
+  skytemple-eventserver = callPackage ../development/python-modules/skytemple-eventserver { };
+
   skytemple-files = callPackage ../development/python-modules/skytemple-files { };
 
   skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2295,6 +2295,8 @@ in {
 
   expiringdict = callPackage ../development/python-modules/expiringdict { };
 
+  explorerscript = callPackage ../development/python-modules/explorerscript { };
+
   exrex = callPackage ../development/python-modules/exrex { };
 
   extractcode = callPackage ../development/python-modules/extractcode { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6102,6 +6102,8 @@ in {
 
   pyppeteer = callPackage ../development/python-modules/pyppeteer { };
 
+  pypresence = callPackage ../development/python-modules/pypresence { };
+
   pyprind = callPackage ../development/python-modules/pyprind { };
 
   pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5603,6 +5603,8 @@ in {
 
   pydenticon = callPackage ../development/python-modules/pydenticon { };
 
+  py-desmume = callPackage ../development/python-modules/py-desmume { };
+
   pydexcom = callPackage ../development/python-modules/pydexcom { };
 
   pydicom = callPackage ../development/python-modules/pydicom { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8284,6 +8284,8 @@ in {
     inherit (pkgs) tiledb;
   };
 
+  tilequant = callPackage ../development/python-modules/tilequant { };
+
   tilestache = callPackage ../development/python-modules/tilestache { };
 
   timeago = callPackage ../development/python-modules/timeago { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7693,6 +7693,8 @@ in {
 
   skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };
 
+  skytemple-rust = callPackage ../development/python-modules/skytemple-rust { };
+
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
   slackclient = callPackage ../development/python-modules/slackclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7691,6 +7691,8 @@ in {
 
   skybellpy = callPackage ../development/python-modules/skybellpy { };
 
+  skytemple-files = callPackage ../development/python-modules/skytemple-files { };
+
   skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };
 
   skytemple-rust = callPackage ../development/python-modules/skytemple-rust { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7691,6 +7691,8 @@ in {
 
   skybellpy = callPackage ../development/python-modules/skybellpy { };
 
+  skytemple-dtef = callPackage ../development/python-modules/skytemple-dtef { };
+
   skytemple-files = callPackage ../development/python-modules/skytemple-files { };
 
   skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Mostly, the fact that running the program without packaging it is awkward. I tried using `pip install --upgrade skytemple[eventserver,discord]` as mentioned in program's readme, but that doesn't work all that well on NixOS.

Two of the packages have a custom `patchPhase` because the build scripts try to clone a git repository which is obviously disallowed, however this can be avoided by cloning the repository in advance. I'm using an unstable version for `skytemple-rust` as it contains various improvements to the build process, in particular it includes `Cargo.lock` file.

I think @marius851000 may be interested in maintaining this package, if they are fine with that I can add them to maintainer list.

If preferred, I could split this into multiple commits, it's just a single commit because it's more convenient to develop this way, but once it's code reviewed I'm fine with splitting this into multiple parts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

  `skytemple-ssb-debugger` crashes when executed directly, and I have no idea whether that's intended or not. However, when the debugger is executed from `skytemple` executable it works correctly. I'm assuming this program wasn't intended to be called directly.
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
