### PR TITLE
rpg-cli: unstable-2021-05-27 -> 0.3.0

### DIFF
--- a/pkgs/games/rpg-cli/default.nix
+++ b/pkgs/games/rpg-cli/default.nix
@@ -2,17 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rpg-cli";
-  version = "unstable-2021-05-27";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "facundoolano";
     repo = pname;
-    # certain revision because the Cargo.lock was checked-in in that commit
-    rev = "4d8a1dac79a1d29d79c0c874475037769dcef5a1";
-    sha256 = "sha256-qfj1uij9lYyfyHFUnVi9I0ELOoObjFG2NS9UreC/xio=";
+    rev = version;
+    sha256 = "sha256-pcVxUX6CPIE5GJniXbAiwZQjwv2eer8LevFl6gASKmM=";
   };
 
-  cargoSha256 = "sha256-I+rSfuiGFdzA5zqPfvMPcERaQfiX92LW2NKjazWh9c4=";
+  cargoSha256 = "sha256-4DB3Zj9awmKX5t1zCgWxetz/+tl6ojpCEKxWpZFlMcw=";
 
   # tests assume the authors macbook, and thus fail
   doCheck = false;
@@ -22,6 +21,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/facundoolano/rpg-cli";
     license = licenses.mit;
     maintainers = with maintainers; [ legendofmiracles ];
-    mainProgram = "rpg-cli";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
