### PR TITLE
xcp: init at 0.9.0

### DIFF
--- a/pkgs/tools/misc/xcp/default.nix
+++ b/pkgs/tools/misc/xcp/default.nix
@@ -1,0 +1,25 @@
+{ rustPlatform, fetchFromGitHub, lib }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "xcp";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "tarka";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Kwt1qLuP63bIn0VY3oFEcbKh1GGBdObfOmtPV4DMQUU=";
+  };
+
+  # no such file or directory errors
+  doCheck = false;
+
+  cargoSha256 = "sha256-wFOXRQSOfmGB6Zmkqn7KoK+vyHeFKyGNx7Zf2zzPcE4=";
+
+  meta = with lib; {
+    description = "An extended cp(1)";
+    homepage = "https://github.com/tarka/xcp";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ legendofmiracles ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31298,6 +31298,8 @@ in
 
   zsnes = pkgsi686Linux.callPackage ../misc/emulators/zsnes { };
 
+  xcp = callPackage ../tools/misc/xcp { };
+
   xcpc = callPackage ../misc/emulators/xcpc { };
 
   zxcvbn-c = callPackage ../development/libraries/zxcvbn-c { };


### PR DESCRIPTION
###### Motivation for this change
seems faster, and it's multithreaded

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
