### PR TITLE
neovim: always generate rplugin.vim

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -107,6 +107,7 @@ let
       '')
       + ''
         rm $out/bin/nvim
+        touch $out/rplugin.vim
         makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs} ${wrapperArgsStr}
       '';
 


### PR DESCRIPTION
###### Motivation for this change

`NVIM_SYSTEM_RPLUGIN_MANIFEST` would point to a file that did not exist if it failed to be created.

This patch creates an empty `rplugin.nvim` if it fails to be created.

Additional context on Home Manager:
<https://github.com/nix-community/home-manager/issues/1789>

```
Error detected while processing function <SNR>17_LoadRemotePlugins:
line    3:
E484: Can't open file /nix/store/r8iw2m8dy18r4gi7xpzxx21j2l243b6m-neovim-0.4.4/rplugin.vim
```

cc: @teto

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
