### PR TITLE
android-tools: init at 31.0.0p1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -760,6 +760,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     # channel and NixOS images.
   };
 
+  unicode-dfs-2015 = spdx {
+    spdxId = "Unicode-DFS-2015";
+    fullName = "Unicode License Agreement - Data Files and Software (2015)";
+  };
+
   unicode-dfs-2016 = spdx {
     spdxId = "Unicode-DFS-2016";
     fullName = "Unicode License Agreement - Data Files and Software (2016)";

--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchurl
+, cmake, perl, go
+, protobuf, zlib, gtest, brotli, lz4, zstd, libusb1, pcre2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "android-tools";
+  version = "31.0.0p1";
+
+  src = fetchurl {
+    url = "https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz";
+    sha256 = "1dn7v10gdx1pi0pkddznd5sdz941qz0x4jww8h2mk50nbyxc792i";
+  };
+
+  nativeBuildInputs = [ cmake perl go ];
+  buildInputs = [ protobuf zlib gtest brotli lz4 zstd libusb1 pcre2 ];
+
+  # Don't try to fetch any Go modules via the network:
+  GOFLAGS = [ "-mod=vendor" ];
+
+  preConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+  '';
+
+  meta = with lib; {
+    description = "Android SDK platform tools";
+    longDescription = ''
+      Android SDK Platform-Tools is a component for the Android SDK. It
+      includes tools that interface with the Android platform, such as adb and
+      fastboot. These tools are required for Android app development. They're
+      also needed if you want to unlock your device bootloader and flash it
+      with a new system image.
+      Currently the following tools are supported:
+      - adb
+      - fastboot
+      - mke2fs.android (required by fastboot)
+      - simg2img, img2simg, append2simg
+    '';
+    # https://developer.android.com/studio/command-line#tools-platform
+    # https://developer.android.com/studio/releases/platform-tools
+    homepage = "https://github.com/nmeum/android-tools";
+    license = with licenses; [ asl20 unicode-dfs-2015 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1039,6 +1039,10 @@ in
 
   analog = callPackage ../tools/admin/analog {};
 
+  android-tools = lowPrio (callPackage ../tools/misc/android-tools {
+    stdenv = if stdenv.targetPlatform.isAarch64 then gcc10Stdenv else stdenv;
+  });
+
   angle-grinder = callPackage ../tools/text/angle-grinder {};
 
   ansifilter = callPackage ../tools/text/ansifilter {};


### PR DESCRIPTION
~~TODO:
[ 52%] Built target fipsmodule
[ 52%] Generating chacha/chacha-x86_64.S
[ 52%] Generating test/trampoline-x86_64.S
[ 52%] Generating cipher_extra/aes128gcmsiv-x86_64.S
[ 52%] Generating cipher_extra/chacha20_poly1305_x86_64.S
[ 52%] Generating err_data.c
go: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9: Get "https://proxy.golang.org/golang.org/x/crypto/@v/v0.0.0-20200622213623-75b288015ac9.mod": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:56418->[::1]:53: read: connection refused
make[2]: *** [vendor/boringssl/crypto/CMakeFiles/crypto.dir/build.make:104: vendor/boringssl/crypto/err_data.c] Error 1
make[2]: *** Deleting file 'vendor/boringssl/crypto/err_data.c'
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1351: vendor/boringssl/crypto/CMakeFiles/crypto.dir/all] Error 2
make: *** [Makefile:171: all] Error 2
builder for '/nix/store/yib15nh8kzgrf94ijbgsjmbppcs59jij-android-tools-31.0.0p1.drv' failed with exit code 2
error: build of '/nix/store/yib15nh8kzgrf94ijbgsjmbppcs59jij-android-tools-31.0.0p1.drv' failed~~

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See #75603 and https://github.com/NixOS/nixpkgs/issues/75603#issuecomment-851010621. This let's us finally build the Android tools from source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
