### PR TITLE
xfitter: remove `hardeningDisable = [ "format" ];`

### DIFF
--- a/pkgs/applications/science/physics/xfitter/default.nix
+++ b/pkgs/applications/science/physics/xfitter/default.nix
@@ -16,9 +16,6 @@ stdenv.mkDerivation rec {
     ./undefined_behavior.patch
   ];
 
-  # patch needs to updated due to version bump
-  #CXXFLAGS = "-Werror=return-type";
-
   preConfigure =
   # Fix F77LD to workaround for a following build error:
   #
@@ -47,8 +44,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ lynx ];
 
   enableParallelBuilding = true;
-
-  hardeningDisable = [ "format" ];
 
   NIX_CFLAGS_COMPILE = lib.optional (stdenv.hostPlatform.libc == "glibc") "-I${libtirpc.dev}/include/tirpc";
   NIX_LDFLAGS = lib.optional (stdenv.hostPlatform.libc == "glibc") "-ltirpc";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Not needed after f42aa7e1 ('cc-wrapper: set FC when langFortran is on')

cc #27218

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
