### PR TITLE
lowdown: fix aarch64-darwin by removing deprecated sandbox

### DIFF
--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
     echo 'HAVE_SANDBOX_INIT=0' > configure.local
-  ''
-    "echo 'HAVE_SANDBOX_INIT=0' > configure.local";
+  '';
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Fix lib extension so that fixDarwinDylibNames detects it
-  postInstall = lib.optionalString (stdenv.isDarwin) ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     mv $lib/lib/liblowdown.{so,dylib}
   '';
 

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
     echo 'HAVE_SANDBOX_INIT=0' > configure.local
-  ''
-    "echo 'HAVE_SANDBOX_INIT=0' > configure.local";
+  '';
 
   configurePhase = ''
     runHook preConfigure
@@ -39,7 +38,7 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     runHook preInstallCheck
     echo '# TEST' > test.md
-    lowdown test.md
+    $out/bin/lowdown test.md
     runHook postInstallCheck
   '';
 

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -34,7 +34,12 @@ stdenv.mkDerivation rec {
   patches = lib.optional (!stdenv.hostPlatform.isStatic) ./shared.patch;
 
   doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
-  installCheckPhase = "echo '# TEST' > test.md; $out/bin/lowdown test.md";
+  installCheckPhase = ''
+    runHook preInstallCheck
+    echo '# TEST' > test.md
+    lowdown test.md
+    runHook postInstallCheck
+  '';
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
   checkTarget = "regress";

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ]
     ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
-  preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64)
+  preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    echo 'HAVE_SANDBOX_INIT=0' > configure.local
+  ''
     "echo 'HAVE_SANDBOX_INIT=0' > configure.local";
 
   configurePhase = ''


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently latest nix doesn't build on aarch64 due to failure from lowdown.
The current regression test provided from lowdown falsly pass.
So I wrote one very basic install-check.

Some interesting discussions about the (bad and deprecated) sandbox.h
https://developer.apple.com/forums/thread/661939

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
