### PR TITLE
frogatto: unstable-2018-12-18 -> unstable-2021-05-24, unbreak

### DIFF
--- a/pkgs/games/frogatto/data.nix
+++ b/pkgs/games/frogatto/data.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation {
   pname = "frogatto-data";
-  version = "unstable-2018-12-18";
+  version = "unstable-2021-05-24";
 
   src = fetchFromGitHub {
     owner = "frogatto";
     repo = "frogatto";
     # master branch as of 2020-12-17
-    rev = "c1d0813b3b755a4e232369b6791397ad058efc16";
-    sha256 = "1fhaidd35392zzavp93r6ihyansgkc3m1ilz71ia1zl4n3fbsxjg";
+    rev = "8b0f2bc8f9f172f6225b8e0d806552cb94f35e2a";
+    sha256 = "09nrna9l1zj2ma2bazdhdvphwy570kfz4br4xgpwq21rsjrvrqiy";
   };
 
   installPhase = ''

--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -34,7 +34,6 @@ in buildEnv {
   '';
 
   meta = with lib; {
-    broken = true;
     homepage = "https://frogatto.com";
     description = description;
     license = with licenses; [ cc-by-30 unfree ];

--- a/pkgs/games/frogatto/engine.nix
+++ b/pkgs/games/frogatto/engine.nix
@@ -4,16 +4,20 @@
 
 stdenv.mkDerivation {
   pname = "anura-engine";
-  version = "unstable-2018-11-28";
+  version = "unstable-2021-05-24";
 
   src = fetchFromGitHub {
     owner = "anura-engine";
     repo = "anura";
-    # trunk branch as of 2018-11-28
-    rev = "a05f413f255d2854019134be817c253a03da3d9f";
-    sha256 = "1hd57q8gbn1zdpibnqd3ma0z1ycayc2f4r9j4m2m9kc6yf4v7w7b";
+    rev = "ed50bbfa68a4aa09438d95d39103ec39156d438f";
+    sha256 = "0bk0qklk9wwx3jr2kbrmansccn1nj962v5n2vlb5hxsrcv96s3dg";
     fetchSubmodules = true;
   };
+
+  postPatch = ''
+    substituteInPlace src/sys.cpp \
+      --replace mallinfo2 mallinfo
+  '';
 
   nativeBuildInputs = [
     which pkg-config


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update. Unbreaks the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
