### PR TITLE
solanum: fix MOTD

### DIFF
--- a/nixos/tests/solanum.nix
+++ b/nixos/tests/solanum.nix
@@ -16,6 +16,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       networking.firewall.allowedTCPPorts = [ ircPort ];
       services.solanum = {
         enable = true;
+        motd = ''
+          The default MOTD doesn't contain the word "nixos" in it.
+          This one does.
+        '';
       };
     };
   } // lib.listToAttrs (builtins.map (client: lib.nameValuePair client {
@@ -47,6 +51,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           ${client}.systemctl("start ii")
           ${client}.wait_for_unit("ii")
           ${client}.wait_for_file("${iiDir}/${server}/out")
+        ''
+        # look for the custom text in the MOTD.
+        ''
+          ${client}.wait_until_succeeds("grep 'nixos' ${iiDir}/${server}/out")
         ''
         # wait until first PING from server arrives before joining,
         # so we don't try it too early

--- a/pkgs/servers/irc/solanum/default.nix
+++ b/pkgs/servers/irc/solanum/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     ./dont-create-logdir.patch
   ];
 
+  postPatch = ''
+    substituteInPlace include/defaults.h --replace 'ETCPATH "' '"/etc/solanum'
+  '';
+
   configureFlags = [
     "--enable-epoll"
     "--enable-ipv6"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Previously this defaulted to the default MOTD in the solanum source
tree, and I don't want my friends to laugh at me. Includes a patch to
the tests to ensure that the MOTD is actually set.

This replicates the fix done in #109705 (solanum is a fork of charybdis,
so they share fundamental logic for this).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
