### PR TITLE
rtorrent-jesec: 0.9.8-r13 -> 0.9.8-r14

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent-jesec/default.nix
@@ -1,21 +1,31 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gtest, openssl, zlib }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, gtest, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "libtorrent-jesec";
-  version = "0.13.8-r1";
+  version = "0.13.8-r2";
 
   src = fetchFromGitHub {
     owner = "jesec";
     repo = "libtorrent";
     rev = "v${version}";
-    sha256 = "sha256-Eh5pMkSe9uO0dPRWDg2BbbRxxuvX9FM2/OReq/61ojc=";
+    sha256 = "sha256-eIXVTbVOCRHcxSsLPvIm9F60t2upk5ORpDSOOYqTCJ4=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "test-fallback";
+      url = "https://github.com/jesec/libtorrent/commit/a38205ce06aadc9908478ec3a9c8aefd9be06344.patch";
+      sha256 = "sha256-2TyQ9zYWZw6bzAfVZzTOQSkfIZnDU8ykgpRAFXscEH0=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl zlib ];
 
-  # https://github.com/jesec/libtorrent/issues/1
-  doCheck = false;
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
+  '';
   checkInputs = [ gtest ];
 
   meta = with lib; {

--- a/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "rtorrent-jesec";
-  version = "0.9.8-r13";
+  version = "0.9.8-r14";
 
   src = fetchFromGitHub {
     owner = "jesec";
     repo = "rtorrent";
     rev = "v${version}";
-    sha256 = "1srn1ms7dvsn994zvb8i4m6gc144ygc7wc2a23bma79cqpl7drlw";
+    sha256 = "sha256-AbjzNIha3MkCZi6MuyUfPx9r3zeXeTUzkbD7uHB85lo=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bumps `rtorrent-jesec` and `libtorrent-jesec` to their latest versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).