### PR TITLE
nixos/solanum: implement reload and allow config changes

### DIFF
--- a/nixos/modules/services/networking/solanum.nix
+++ b/nixos/modules/services/networking/solanum.nix
@@ -2,7 +2,7 @@
 
 let
   inherit (lib) mkEnableOption mkIf mkOption types;
-  inherit (pkgs) solanum;
+  inherit (pkgs) solanum util-linux;
   cfg = config.services.solanum;
 
   configFile = pkgs.writeText "solanum.conf" cfg.config;
@@ -78,12 +78,20 @@ in
 
   config = mkIf cfg.enable (lib.mkMerge [
     {
+
+      environment.etc."solanum/ircd.conf".source = configFile;
+
       systemd.services.solanum = {
         description = "Solanum IRC daemon";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
+        reloadIfChanged = true;
+        restartTriggers = [
+          configFile
+        ];
         serviceConfig = {
-          ExecStart   = "${solanum}/bin/solanum -foreground -logfile /dev/stdout -configfile ${configFile} -pidfile /run/solanum/ircd.pid";
+          ExecStart = "${solanum}/bin/solanum -foreground -logfile /dev/stdout -configfile /etc/solanum/ircd.conf -pidfile /run/solanum/ircd.pid";
+          ExecReload = "${util-linux}/bin/kill -HUP $MAINPID";
           DynamicUser = true;
           User = "solanum";
           StateDirectory = "solanum";

--- a/pkgs/servers/irc/solanum/default.nix
+++ b/pkgs/servers/irc/solanum/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An IRCd for unified networks";
     homepage = "https://github.com/solanum-ircd/solanum";
-    license = licenses.gpl2Only;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ hexa ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Reload only works with a static configuration path as there is no way to
pass the dynamically generated config path to a running solanum
instance, therefore we symlink the configuration to
/etc/solanum/ircd.conf.

But that will prevent reloads of the ircd, because the systemd unit
wouldn't change when the configuration changes. That is why we add the
actual location of the config file to restartTriggers and enable
reloadIfChanged, so changes will not restart, but reload on changes.

cc @Xe @andir 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
