### PR TITLE
update URL of apple-sdk-11

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -6,10 +6,10 @@ let
     pname = "MacOSX-SDK";
     version = "11.0.0";
 
-    # https://swscan.apple.com/content/catalogs/others/index-10.16.merged-1.sucatalog
+    # https://swscan.apple.com/content/catalogs/others/index-11-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog
     src = fetchurl {
-      url = "http://swcdn.apple.com/content/downloads/58/37/001-75138-A_59RXKDS8YM/12ksm19hgzscfc7cau3yhecz4vpkps7wbq/CLTools_macOSNMOS_SDK.pkg";
-      sha256 = "0n51ba926ckwm62w5c8lk3w5hj4ihk0p5j02321qi75wh824hl8m";
+      url = "http://swcdn.apple.com/content/downloads/46/21/001-89745-A_56FM390IW5/v1um2qppgfdnam2e9cdqcqu2r6k8aa3lis/CLTools_macOSNMOS_SDK.pkg";
+      sha256 = "0n425smj4q1vxbza8fzwnk323fyzbbq866q32w288c44hl5yhwsf";
     };
 
     dontBuild = true;
@@ -24,7 +24,7 @@ let
     '';
 
     installPhase = ''
-      cd Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+      cd Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 
       mkdir $out
       cp -r System usr $out/


### PR DESCRIPTION
The previous one is outdated, this updates it to 11.1.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
