### PR TITLE
rox-filer: Use wrapGAppsHook

### DIFF
--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -1,17 +1,27 @@
-{ lib, stdenv, fetchurl, pkg-config, libxml2, gtk, libSM, shared-mime-info }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, wrapGAppsHook
+, libxml2
+, gtk
+, libSM
+, shared-mime-info
+}:
 
-let
+stdenv.mkDerivation rec {
+  pname = "rox-filer";
   version = "2.11";
-  name = "rox-filer-${version}";
-in stdenv.mkDerivation {
-  inherit name;
 
   src = fetchurl {
     url = "mirror://sourceforge/rox/rox-filer-${version}.tar.bz2";
     sha256 = "a929bd32ee18ef7a2ed48b971574574592c42e34ae09f36604bf663d7c101ba8";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+  ];
   buildInputs = [ libxml2 gtk shared-mime-info libSM ];
   NIX_LDFLAGS = "-ldl -lm";
 


### PR DESCRIPTION
I also updated the derivation slightly to use `pname` + `version`.

###### Motivation for this change

Fixes ROX-Filer being unable to use SVG icons when the environment is not already being polluted by another wrapper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
