### PR TITLE
libiio: fix build with wrong libxml2 find_package

### DIFF
--- a/pkgs/development/libraries/libiio/cmake-fix-libxml2-find-package.patch
+++ b/pkgs/development/libraries/libiio/cmake-fix-libxml2-find-package.patch
@@ -1,0 +1,13 @@
+diff --color -ur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2021-05-30 13:46:22.256040282 +0200
++++ b/CMakeLists.txt	2021-05-30 14:15:42.530181216 +0200
+@@ -333,7 +333,7 @@
+ # So, try first to find the CMake module provided by libxml2 package, then fallback
+ # on the CMake's FindLibXml2.cmake module (which can lack some definition, especially
+ # in static build case).
+-find_package(LibXml2 QUIET NO_MODULE)
++find_package(LibXml2 QUIET MODULE)
+ if(DEFINED LIBXML2_VERSION_STRING)
+ 	set(LIBXML2_FOUND ON)
+ 	set(LIBXML2_INCLUDE_DIR ${LIBXML2_INCLUDE_DIRS})
+Seulement dans b: good.patch

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     sha256 = "0psw67mzysdb8fkh8xpcwicm7z94k8plkcc8ymxyvl6inshq0mc7";
   };
 
+  # Revert after https://github.com/NixOS/nixpkgs/issues/125008 is
+  # fixed properly
+  patches = [ ./cmake-fix-libxml2-find-package.patch ];
+
   nativeBuildInputs = [
     cmake
     flex


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Workaround for: #125008
Closes: #124951
Fixes: #124948

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
