### PR TITLE
python3Packages.pymata-express: 1.19 -> 1.20

### DIFF
--- a/pkgs/development/python-modules/pymata-express/default.nix
+++ b/pkgs/development/python-modules/pymata-express/default.nix
@@ -2,20 +2,19 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pyserial
-, pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pymata-express";
-  version = "1.19";
+  version = "1.20";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "MrYsLab";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0gfjmqcxwsnfjgll6ql5xd1n3xp4klf4fcaajaivh053i02p0a79";
+    sha256 = "sha256-spYmd+Cb7Ej5FmniuJYAVVmq0mhOz5fu4+2UUXctRWs=";
   };
 
   propagatedBuildInputs = [ pyserial ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.20

Change log: https://github.com/MrYsLab/pymata-express/releases/tag/v1.20

- Related Home Assistant change: -
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
