### PR TITLE
radare2: add patch for CVE-2021-32613

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -20,6 +20,7 @@
 , ruby
 , lua
 , capstone
+, fetchpatch
 , useX11 ? false
 , rubyBindings ? false
 , pythonBindings ? false
@@ -36,6 +37,19 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0n3k190qjhdlj10fjqijx6ismz0g7fk28i83j0480cxdqgmmlbxc";
   };
+
+  patches = [
+    # fix for CVE-2021-32613
+    (fetchpatch {
+      url = "https://github.com/radareorg/radare2/commit/5e16e2d1c9fe245e4c17005d779fde91ec0b9c05.patch";
+      sha256 = "sha256-zCFNn968buLuSqfUT5E+72qz0l1tA3fEUQIxJl2nd3I=";
+    })
+    (fetchpatch {
+      name = "CVE-2021-32613.patch";
+      url = "https://github.com/radareorg/radare2/commit/049de62730f4954ef9a642f2eeebbca30a8eccdc.patch";
+      sha256 = "sha256-s8SWGuSQ6fxDCybtjO2ZW8w7H6mr+AuzVLL6dw+XKDw=";
+    })
+  ];
 
   postInstall = ''
     install -D -m755 $src/binr/r2pm/r2pm $out/bin/r2pm


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #124670
See also https://nvd.nist.gov/vuln/detail/CVE-2021-32613

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
