### PR TITLE
nvfancontrol: init at 0.5.1

### DIFF
--- a/pkgs/tools/misc/nvfancontrol/default.nix
+++ b/pkgs/tools/misc/nvfancontrol/default.nix
@@ -20,7 +20,6 @@ rustPlatform.buildRustPackage rec {
     export LIBRARY_PATH=${libXNVCtrl}/lib:${libX11}/lib:${libXext}/lib
   '';
 
-
   meta = with lib; {
     description = "NVidia dynamic fan control for Linux";
     homepage = "https://github.com/foucault/nvfancontrol";

--- a/pkgs/tools/misc/nvfancontrol/default.nix
+++ b/pkgs/tools/misc/nvfancontrol/default.nix
@@ -1,0 +1,32 @@
+{ lib, rustPlatform, fetchFromGitHub, libXNVCtrl, libX11, libXext }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nvfancontrol";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "foucault";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-0WBQSnTYVc3sNmZf/KFzznMg9AVsyaBgdx/IvG1dZAw=";
+  };
+
+  cargoSha256 = "sha256-fEzdghGQSSeyeyiHjw1ggQ38gsETJFl9bq/tizGxIis=";
+
+  nativeBuildInputs = [ libXNVCtrl libX11 libXext ];
+
+  # Needed for static linking
+  preConfigure = ''
+    export LIBRARY_PATH=${libXNVCtrl}/lib:${libX11}/lib:${libXext}/lib
+  '';
+
+
+  meta = with lib; {
+    description = "NVidia dynamic fan control for Linux";
+    homepage = "https://github.com/foucault/nvfancontrol";
+    changelog = "https://github.com/foucault/nvfancontrol/releases/tag/${version}";
+    license = with licenses; [ gpl3Only ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ devins2518 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7266,6 +7266,10 @@ in
 
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
+  nvfancontrol = callPackage ../tools/misc/nvfancontrol {
+    libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
+  };
+
   nvimpager = callPackage ../tools/misc/nvimpager { };
 
   nwdiag = with python3Packages; toPythonApplication nwdiag;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done
Added nvfancontrol

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
