### PR TITLE
bmake: 20200902 -> 20210420

### DIFF
--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -1,21 +1,45 @@
-{ lib, stdenv, fetchurl
-, getopt
+{ lib, stdenv, fetchurl, fetchpatch
+, getopt, tzdata
 }:
 
 stdenv.mkDerivation rec {
   pname = "bmake";
-  version = "20200902";
+  version = "20210420";
 
   src = fetchurl {
     url    = "http://www.crufty.net/ftp/pub/sjg/${pname}-${version}.tar.gz";
-    sha256 = "1v1v81llsiy8qbpy38nml1x08dhrihwh040pqgwbwb9zy1108b08";
+    sha256 = "1ajq8v5rq3pl5y9h1hlscs83007fsyk3lhcp87z09ma370lm3ra7";
   };
+
+  # Make tests work with musl
+  # * Disable deptgt-delete_on_error test (alpine does this too)
+  # * Fix test failing due to different strerror(3) output for musl and glibc
+  postPatch = lib.optionalString (stdenv.hostPlatform.libc == "musl") ''
+    sed -i unit-tests/Makefile -e '/deptgt-delete_on_error/d'
+    substituteInPlace unit-tests/opt-chdir.exp --replace "File name" "Filename"
+  '';
 
   nativeBuildInputs = [ getopt ];
 
   patches = [
+    # make bootstrap script aware of the prefix in /nix/store
     ./bootstrap-fix.patch
+    # preserve PATH from build env in unit tests
     ./fix-unexport-env-test.patch
+    # Fix localtime tests without global /etc/zoneinfo directory
+    ./fix-localtime-test.patch
+    # decouple tests from build phase
+    (fetchpatch {
+      name = "separate-tests.patch";
+      url = "https://raw.githubusercontent.com/alpinelinux/aports/2a36f7b79df44136c4d2b8e9512f908af65adfee/community/bmake/separate-tests.patch";
+      sha256 = "00s76jwyr83c6rkvq67b1lxs8jhm0gj2rjgy77xazqr5400slj9a";
+    })
+    # add a shebang to bmake's install(1) replacement
+    (fetchpatch {
+      name = "install-sh.patch";
+      url = "https://raw.githubusercontent.com/alpinelinux/aports/34cd8c45397c63c041cf3cbe1ba5232fd9331196/community/bmake/install-sh.patch";
+      sha256 = "0z8icd6akb96r4cksqnhynkn591vbxlmrrs4w6wil3r6ggk6mwa6";
+    })
   ];
 
   # The generated makefile is a small wrapper for calling ./boot-strap
@@ -41,6 +65,16 @@ stdenv.mkDerivation rec {
     ./boot-strap --prefix=$out -o . op=install
 
     runHook postInstall
+  '';
+
+  doCheck = true;
+  checkInputs = [ tzdata ];
+  checkPhase = ''
+    runHook preCheck
+
+    ./boot-strap -o . op=test
+
+    runHook postCheck
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/tools/build-managers/bmake/fix-localtime-test.patch
+++ b/pkgs/development/tools/build-managers/bmake/fix-localtime-test.patch
@@ -1,0 +1,23 @@
+--- bmake/unit-tests/Makefile.orig	2021-05-30 14:24:38.822484317 +0200
++++ bmake/unit-tests/Makefile	2021-05-31 13:25:21.645751428 +0200
+@@ -455,7 +455,8 @@
+ ENV.varmisc=		FROM_ENV=env
+ ENV.varmisc+=		FROM_ENV_BEFORE=env
+ ENV.varmisc+=		FROM_ENV_AFTER=env
+-ENV.varmod-localtime+=	TZ=Europe/Berlin
++# Set absolute path to tz file since musl doesn't support TZDIR
++ENV.varmod-localtime+=	TZDIR=${TZDIR} TZ=:${TZDIR}/Europe/Berlin
+ ENV.varname-vpath+=	VPATH=varname-vpath.dir:varname-vpath.dir2
+ 
+ # Override make flags for some of the tests; default is -k.
+--- bmake/unit-tests/varmod-localtime.mk.orig	2021-05-30 14:30:34.397986246 +0200
++++ bmake/unit-tests/varmod-localtime.mk	2021-05-31 13:24:41.430906606 +0200
+@@ -3,7 +3,7 @@
+ # Tests for the :localtime variable modifier, which formats a timestamp
+ # using strftime(3) in local time.
+ 
+-.if ${TZ} != "Europe/Berlin"	# see unit-tests/Makefile
++.if ${TZ} != ":${TZDIR}/Europe/Berlin"	# see unit-tests/Makefile
+ .  error
+ .endif
+ 

--- a/pkgs/development/tools/build-managers/bmake/fix-unexport-env-test.patch
+++ b/pkgs/development/tools/build-managers/bmake/fix-unexport-env-test.patch
@@ -1,13 +1,13 @@
---- bmake/unit-tests/unexport-env.mk.orig       2019-02-19 10:24:14.356713136 -0800
-+++ bmake/unit-tests/unexport-env.mk    2019-02-19 10:25:43.838775388 -0800
-@@ -3,8 +3,8 @@
- # pick up a bunch of exported vars
+--- bmake/unit-tests/unexport-env.mk.orig	2021-05-27 14:44:45.263392298 +0200
++++ bmake/unit-tests/unexport-env.mk	2021-05-27 14:46:46.188881996 +0200
+@@ -4,8 +4,8 @@
+ FILTER_CMD=	grep ^UT_
  .include "export.mk"
  
 -# an example of setting up a minimal environment.
--PATH = /bin:/usr/bin:/sbin:/usr/sbin
+-PATH=	/bin:/usr/bin:/sbin:/usr/sbin
 +# preserve PATH so commands used in the "all" target are still available
-+PATH := ${PATH}
++PATH :=	${PATH}
  
  # now clobber the environment to just PATH and UT_TEST
- UT_TEST = unexport-env
+ UT_TEST=	unexport-env


### PR DESCRIPTION
* Fix varmod-localtime test by setting TZ to an absolute path to the
  appropriate file in TZDIR. This avoids having an extra patch for musl
  which doesn't support TZDIR at all.
* Move tests into checkPhase by applying patch from alpine
* Fix build with musl by disabling deptgt-delete_on_error test (which I
  haven't debugged myself, just copied this from alpine) and fixing a
  test which fails due to differing output from strerror(3) between musl
  and glibc. Also we need to add a shebang to install-sh, otherwise it
  won't be executed in pkgsMusl.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
