### PR TITLE
Revert "release.nix: add aarch64-darwin as a supportedSystem"

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -11,7 +11,7 @@
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
 , officialRelease ? false
   # The platforms for which we build Nixpkgs.
-, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
+, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]
 , limitedSupportedSystems ? [ "i686-linux" ]
   # Strip most of attributes when evaluating to spare memory usage
 , scrubJobs ? true


### PR DESCRIPTION
Reverts NixOS/nixpkgs#124887

https://github.com/NixOS/nixpkgs/pull/124887#issuecomment-851448998

>I am quite unhappy that this merged without a ping, and despite my objections in another PR. I think my concerns are valid, and I feel you have ignored them.
>
> Throwing this many jobs to that architecture with such little experience of building at that scale is, I feel, a bit rude and puts me in a hard position. Doing it without ofborg evaluation time support is also quite concerning, as demonstrated by the immediate problems this PR has caused.
>
> I feel a disrespected and devalued. I would like this PR reverted for now, and I propose a separate jobset to build aarch64-darwin in the supportedSystems argument for now.