### PR TITLE
qdl: init at 20210506

### DIFF
--- a/pkgs/tools/misc/qdl/default.nix
+++ b/pkgs/tools/misc/qdl/default.nix
@@ -1,0 +1,31 @@
+{ lib 
+, stdenv 
+, fetchFromGitHub
+, libxml2
+, libudev
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "qdl";
+  version = "20210506";
+  src = fetchFromGitHub {
+    owner  = "andersson";
+    repo   = "qdl";
+    rev    = "2021b303a81ca1bcf21b7f1f23674b5c8747646f";
+    sha256 = "0akrdca4jjdkfdya36vy1y5vzimrc4pp5jm24rmlw8hbqxvj72ri";
+  };
+
+  buildInputs = [ libxml2 libudev ];
+
+  installPhase = ''
+    install -Dm755 ./qdl $out/bin/qdl
+  '';
+
+  meta = with lib; {
+    homepage    = "https://github.com/andersson/qdl";
+    description = "A tool to flash images to Qualcomm devices.";
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/qdl/default.nix
+++ b/pkgs/tools/misc/qdl/default.nix
@@ -1,5 +1,5 @@
-{ lib 
-, stdenv 
+{ lib
+, stdenv
 , fetchFromGitHub
 , libxml2
 , libudev

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30869,6 +30869,8 @@ in
 
   py-wmi-client = callPackage ../tools/networking/py-wmi-client { };
 
+  qdl = callPackage ../tools/misc/qdl { };
+
   rargs = callPackage ../tools/misc/rargs { };
 
   rauc = callPackage ../tools/misc/rauc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A great tool to flash system images to Qualcomm based devices which is in EDL mode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
