### PR TITLE
[20.09] postgresqlPackages.pg_partman: add patch for CVE-2021-33204

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, postgresql }:
+{ stdenv, fetchFromGitHub, fetchpatch, postgresql }:
 
 stdenv.mkDerivation rec {
   pname = "pg_partman";
@@ -12,6 +12,18 @@ stdenv.mkDerivation rec {
     rev    = "refs/tags/v${version}";
     sha256 = "0wr2nivp0b8vk355rnv4bygiashq98q9zhfgdbxzhm7bgxd01rk2";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-33204.patch";
+      url = "https://github.com/pgpartman/pg_partman/commit/0b6565ad378c358f8a6cd1d48ddc482eb7f854d3.patch";
+      includes = [
+        "sql/functions/check_name_length.sql"
+        "sql/tables/tables.sql"
+      ];
+      sha256 = "002zbbabianagqpck4kdnj0db1pq5v69v08q7kd5vnks2qy31c8f";
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/{lib,share/postgresql/extension}


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-33204

Upstream squashes entire releases. Joy. `fetchpatch` to the rescue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
