### PR TITLE
usbutils: 012 -> 013

### DIFF
--- a/pkgs/os-specific/linux/usbutils/default.nix
+++ b/pkgs/os-specific/linux/usbutils/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, substituteAll, autoreconfHook, pkg-config, libusb1, hwdata , python3 }:
 
 stdenv.mkDerivation rec {
-  name = "usbutils-012";
+  name = "usbutils-013";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/usb/usbutils/${name}.tar.xz";
-    sha256 = "0iiy0q7fzikavmdsjsb0sl9kp3gfh701qwyjjccvqh0qz4jlcqw8";
+    sha256 = "0f0klk6d3hmbpf6p4dcwa1qjzblmkhbxs1wsw87aidvqri7lj8wy";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/usbutils/fix-paths.patch
+++ b/pkgs/os-specific/linux/usbutils/fix-paths.patch
@@ -1,7 +1,7 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -51,11 +51,11 @@
- 	usbreset.c
+@@ -61,7 +61,7 @@ EXTRA_DIST = \
+ 	LICENSES/GPL-3.0-only.txt
  
  lsusb.py: $(srcdir)/lsusb.py.in
 -	sed 's|VERSION|$(VERSION)|g;s|@usbids@|$(datadir)/usb.ids|g' $< >$@
@@ -9,8 +9,3 @@
  	chmod 755 $@
  
  lsusb.8: $(srcdir)/lsusb.8.in
--	sed 's|VERSION|$(VERSION)|g;s|@usbids@|$(datadir)/usb.ids|g' $< >$@
-+	sed 's|VERSION|$(VERSION)|g;s|@usbids@|@hwdata@/share/hwdata/usb.ids|g' $< >$@
- 
- usb-devices.1: $(srcdir)/usb-devices.1.in
- 	sed 's|VERSION|$(VERSION)|g' $< >$@


### PR DESCRIPTION
###### Motivation for this change
Update to latest version

###### Things done
Update version, hash, removed patches as breaking build and seems unnecessary (https://github.com/gregkh/usbutils/blob/master/Makefile.am#L63 until Line 74)

ping @jtojnar (who implemented the patching)

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
