### PR TITLE
[20.09] python3Packages.websockets: add patch for CVE-2018-1000518-redux

### DIFF
--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
 , pythonOlder
 , pytest
@@ -16,6 +17,15 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "05jbqcbjg50ydwl0fijhdlqcq7fl6v99kjva66kmmzzza7vwa872";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-1000518-redux.patch";
+      url = "https://github.com/aaugustin/websockets/commit/547a26b685d08cac0aa64e5e65f7867ac0ea9bc0.patch";
+      excludes = [ "docs/changelog.rst" ];
+      sha256 = "1wgsvza53ga8ldrylb3rqc17yxcrchwsihbq6i6ldpycq83q5akq";
+    })
+  ];
 
   disabled = pythonOlder "3.3";
 


### PR DESCRIPTION
###### Motivation for this change
This is a reintroduction of https://nvd.nist.gov/vuln/detail/CVE-2018-1000518 which doesn't appear to have its own CVE assigned (yet?).

Patches cleanly, all existing tests pass & newly added test covering issue passes for me.

See #123283 for master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
