### PR TITLE
treesitter: include CXX headers compiling with clang Darwin

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -1,5 +1,7 @@
 { stdenv
 , tree-sitter
+, libcxx
+, lib
 }:
 
 # Build a parser grammar and put the resulting shared object in `$out/parser`
@@ -27,6 +29,7 @@ stdenv.mkDerivation {
       "${source}/${location}"
   ;
 
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
   buildInputs = [ tree-sitter ];
 
   dontUnpack = true;


### PR DESCRIPTION
clang needs to find headers + libraries for compiling with libc++.
On Darwin we will include CXX headers when compiling C.

This closes #124396

Tested compiles on macOS

###### Motivation for this change

Fix an issue

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
