### PR TITLE
mwprocapture: 1.2.4177 -> 1.3.0.4236

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "4236";
 
   src = fetchurl {
-    url = "http://www.magewell.com/files/drivers/ProCaptureForLinux_${version}.tar.gz";
+    url = "https://www.magewell.com/files/drivers/ProCaptureForLinux_${version}.tar.gz";
     sha256 = "1mfgj84km276sq5i8dny1vqp2ycqpvgplrmpbqwnk230d0w3qs74";
   };
 

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -2,9 +2,6 @@
 
 with lib;
 
-# The Magewell Pro Capture drivers are not supported for kernels older than 3.2
-assert versionAtLeast kernel.version "3.2.0";
-
 let
   bits =
   if stdenv.is64bit then "64"
@@ -14,15 +11,15 @@ let
 
 in
 stdenv.mkDerivation rec {
-  name = "mwprocapture-1.2.${version}-${kernel.version}";
-  version = "4177";
+  name = "mwprocapture-1.3.0.${version}-${kernel.version}";
+  version = "4236";
 
   src = fetchurl {
     url = "http://www.magewell.com/files/drivers/ProCaptureForLinux_${version}.tar.gz";
-    sha256 = "1nf51w9yixpvr767k49sfdb9n9rv5qc72f5yki1mkghbmabw7vys";
+    sha256 = "1mfgj84km276sq5i8dny1vqp2ycqpvgplrmpbqwnk230d0w3qs74";
   };
 
-  nativeBuildInputs = [ kernel.moduleBuildDependencies ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   preConfigure =
   ''
@@ -63,5 +60,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ MP2E ];
     platforms = platforms.linux;
+    broken = kernel.kernelOlder "3.2.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Driver version bump, needed for compatibility with kernel versions 5.8 and later. Fixes #122999.

This is needed by 21.05 also, if the committer is willing to cherry pick instead of waiting for my follow-up PR.
ZHF: #122042

Tested on MW ProCapture HDMI card.

###### Things done
- [x] Tested using sandboxing](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
