### PR TITLE
gnupg module: build custom pinentry for specified flavor only

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -91,12 +91,16 @@ in
     };
   };
 
-  config = mkIf cfg.agent.enable {
+  config = let
+    pinentry = pkgs.pinentry.override {
+      enabledFlavors = [ cfg.agent.pinentryFlavor ];
+    };
+  in mkIf cfg.agent.enable {
     # This overrides the systemd user unit shipped with the gnupg package
     systemd.user.services.gpg-agent = mkIf (cfg.agent.pinentryFlavor != null) {
       serviceConfig.ExecStart = [ "" ''
         ${cfg.package}/bin/gpg-agent --supervised \
-          --pinentry-program ${pkgs.pinentry.${cfg.agent.pinentryFlavor}}/bin/pinentry
+          --pinentry-program ${pinentry.${cfg.agent.pinentryFlavor}}/bin/pinentry
       '' ];
     };
 


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/124753

###### Things done
option `programs.gnupg.agent.pinentryFlavor` will build a custom pinentry with only the needed flavor available as I think this was intented (and pinentry is quite quick to build anyway).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change cf the linked issue above
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

## Pinging maintainers : 

@fpletz @bkchr @shosti 
