### PR TITLE
[WIP] nyxt: fix on darwin

### DIFF
--- a/pkgs/applications/networking/browsers/nyxt/default.nix
+++ b/pkgs/applications/networking/browsers/nyxt/default.nix
@@ -1,9 +1,19 @@
-{ stdenv, lib, lispPackages
-, makeWrapper, wrapGAppsHook, gst_all_1
-, glib, gdk-pixbuf, cairo
-, mime-types, pango, gtk3
-, glib-networking, gsettings-desktop-schemas
-, xclip, notify-osd, enchant
+{ stdenv
+, lib
+, lispPackages
+, makeWrapper
+, wrapGAppsHook
+, gst_all_1
+, glib
+, gdk-pixbuf
+, cairo
+, mime-types
+, pango
+, gtk3
+, glib-networking
+, gsettings-desktop-schemas
+, xclip
+, enchant
 }:
 
 stdenv.mkDerivation rec {
@@ -14,17 +24,24 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
   gstBuildInputs = with gst_all_1; [
-    gstreamer gst-libav
+    gstreamer
+    gst-libav
     gst-plugins-base
     gst-plugins-good
     gst-plugins-bad
     gst-plugins-ugly
   ];
   buildInputs = [
-    glib gdk-pixbuf cairo
-    mime-types pango gtk3
-    glib-networking gsettings-desktop-schemas
-    xclip notify-osd enchant
+    glib
+    gdk-pixbuf
+    cairo
+    mime-types
+    pango
+    gtk3
+    glib-networking
+    gsettings-desktop-schemas
+    xclip
+    enchant
   ] ++ gstBuildInputs;
 
   GST_PLUGIN_SYSTEM_PATH_1_0 = lib.concatMapStringsSep ":" (p: "${p}/lib/gstreamer-1.0") gstBuildInputs;


### PR DESCRIPTION
###### Motivation for this change

Now that webkitgtk is fixed, trying to get nyxt to build on darwin.  Notify-osd is no longer a dependency of nyxt per the 2.0 [changelog](https://github.com/atlas-engineer/nyxt/blob/master/documents/CHANGELOG.org), so this can be removed from the buildinputs.

The makefile of nyxt includes install-app-bundle as a dependency of the install target, which is what is causing the remaining failure.  https://github.com/atlas-engineer/nyxt/blob/23858171e28e06f2841bd06ff22dd30c5e649fe8/Makefile#L53-L55

```
 nix build '.#nyxt'
error: builder for '/nix/store/qdv3dra27ys8wp40wfy50747vgdf4w98-lisp-nyxt-2.0.0.drv' failed with exit code 2;
       last 10 log lines:
       > writing 27410432 bytes from the immobile space at 0x52000000
       > done]
       > mkdir -p ./Nyxt.app/Contents/MacOS
       > mkdir -p ./Nyxt.app/Contents/Resources
       > mv ./nyxt ./Nyxt.app/Contents/MacOS
       > cp ./assets/Info.plist ./Nyxt.app/Contents
       > cp ./assets/nyxt.icns ./Nyxt.app/Contents/Resources
       > cp -r Nyxt.app /Applications
       > cp: cannot create directory '/Applications/Nyxt.app': Permission denied
       > make: *** [Makefile:55: install-app-bundle] Error 1
       For full logs, run 'nix log /nix/store/qdv3dra27ys8wp40wfy50747vgdf4w98-lisp-nyxt-2.0.0.drv'.
error: 1 dependencies of derivation '/nix/store/hlrplm1hrn2xq7f7zxfl3kakz9anlh58-nyxt-2.0.0.drv' failed to build
```

I don't actually know where make install is called in the darwin builder, so any advice on fixing this last hurdle is appreciated!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
