### PR TITLE
nixos/atop: Don't break backwards-compatibility by rendering atoprc in any case

### DIFF
--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -102,7 +102,8 @@ in
     };
   };
 
-  config = mkIf cfg.enable (
+  config = mkMerge [
+    (mkIf cfg.enable (
     let
       atop =
         if cfg.atopgpu.enable then
@@ -111,14 +112,6 @@ in
           cfg.package;
     in
     {
-      environment.etc = mkIf (cfg.settings != { }) {
-        atoprc.text = concatStrings
-          (mapAttrsToList
-            (n: v: ''
-              ${n} ${toString v}
-            '')
-            cfg.settings);
-      };
       environment.systemPackages = [ atop (lib.mkIf cfg.netatop.enable cfg.netatop.package) ];
       boot.extraModulePackages = [ (lib.mkIf cfg.netatop.enable cfg.netatop.package) ];
       systemd =
@@ -143,6 +136,16 @@ in
         };
       security.wrappers =
         lib.mkIf cfg.setuidWrapper.enable { atop = { source = "${atop}/bin/atop"; }; };
+    }))
+    {
+      environment.etc = mkIf (cfg.settings != { }) {
+        atoprc.text = concatStrings
+          (mapAttrsToList
+            (n: v: ''
+              ${n} ${toString v}
+            '')
+            cfg.settings);
+      };
     }
-  );
+  ];
 }

--- a/nixos/tests/atop.nix
+++ b/nixos/tests/atop.nix
@@ -19,6 +19,10 @@ let assertions = rec {
         else:
             machine.require_unit_state("${name}", "${state}")
   '';
+  absent = ''
+    with subtest("atop should be absent"):
+        machine.fail("atop -V")
+  '';
   version = ''
     import re
 
@@ -232,5 +236,29 @@ in
       (netatop true)
       (atopgpu true)
     ];
+  };
+
+  # If the user only specified programs.atop.settings, the module should just render
+  # atoprc.
+  backwardsCompat = makeTest {
+    name = "atop-backwardsCompat";
+    machine = {
+      programs.atop = {
+        settings = {
+          flags = "faf1";
+          interval = 2;
+        };
+      };
+    };
+    testScript = with assertions;
+      builtins.concatStringsSep "\n" [
+        absent
+        (atoprc "flags faf1\\ninterval 2\\n")
+        (atopService false)
+        (atopRotateTimer false)
+        (atopacctService false)
+        (netatop false)
+        (atopgpu false)
+      ];
   };
 }


### PR DESCRIPTION
If a user had `atop.settings` previously, they would not render to a `/etc/atoprc` because the code was behind `atop.enable` since #123053.
This commit restores the old behaviour: When `atop.settings` is present, `/etc/atoprc` is rendered, regardless of `atop.enable` and the other new options.


see: https://github.com/NixOS/nixpkgs/pull/123053#issuecomment-851521286


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
