### PR TITLE
wine: gecko 2.47.1 -> 2.47.2 and add tests

### DIFF
--- a/nixos/tests/wine.nix
+++ b/nixos/tests/wine.nix
@@ -1,0 +1,14 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "wine";
+  meta = with pkgs.lib.maintainers; { maintainers = [ chkno ]; };
+
+  machine = { pkgs, ... }: { environment.systemPackages = [ pkgs.wine ]; };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    greeting = machine.succeed(
+        'wine ${pkgs.pkgsCross.mingw32.hello}/bin/hello.exe'
+    )
+    assert 'Hello, world!' in greeting
+  '';
+})

--- a/nixos/tests/wine.nix
+++ b/nixos/tests/wine.nix
@@ -1,14 +1,27 @@
-import ./make-test-python.nix ({ pkgs, ... }: {
-  name = "wine";
-  meta = with pkgs.lib.maintainers; { maintainers = [ chkno ]; };
+{ system ? builtins.currentSystem, pkgs ? import ../.. {
+  inherit system;
+  config = { };
+}, }:
 
-  machine = { pkgs, ... }: { environment.systemPackages = [ pkgs.wine ]; };
+let
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
 
-  testScript = ''
-    machine.wait_for_unit("multi-user.target")
-    greeting = machine.succeed(
-        'wine ${pkgs.pkgsCross.mingw32.hello}/bin/hello.exe'
-    )
-    assert 'Hello, world!' in greeting
-  '';
-})
+  makeWineTest = variant:
+    makeTest {
+      name = "wine-${variant}";
+      meta = with pkgs.lib.maintainers; { maintainers = [ chkno ]; };
+
+      machine = { pkgs, ... }: {
+        environment.systemPackages = [ pkgs.winePackages."${variant}" ];
+      };
+
+      testScript = ''
+        machine.wait_for_unit("multi-user.target")
+        greeting = machine.succeed(
+            'wine ${pkgs.pkgsCross.mingw32.hello}/bin/hello.exe'
+        )
+        assert 'Hello, world!' in greeting
+      '';
+    };
+in pkgs.lib.genAttrs [ "base" "full" "minimal" "staging" "unstable" ]
+makeWineTest

--- a/nixos/tests/wine.nix
+++ b/nixos/tests/wine.nix
@@ -25,9 +25,12 @@ let
         machine.wait_for_unit("multi-user.target")
         ${concatMapStrings (exe: ''
           greeting = machine.succeed(
-              'wine ${exe}'
+              "bash -c 'wine ${exe} 2> >(tee wine-stderr >&2)'"
           )
           assert 'Hello, world!' in greeting
+          machine.fail(
+              "fgrep 'Could not find Wine Gecko. HTML rendering will be disabled.' wine-stderr"
+          )
         '') exes}
       '';
     };

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -19,14 +19,14 @@ in rec {
 
     ## see http://wiki.winehq.org/Gecko
     gecko32 = fetchurl rec {
-      version = "2.47.1";
+      version = "2.47.2";
       url = "https://dl.winehq.org/wine/wine-gecko/${version}/wine-gecko-${version}-x86.msi";
-      sha256 = "0ld03pjm65xkpgqkvfsmk6h9krjsqbgxw4b8rvl2fj20j8l0w2zh";
+      sha256 = "07d6nrk2g0614kvwdjym1wq21d2bwy3pscwikk80qhnd6rrww875";
     };
     gecko64 = fetchurl rec {
-      version = "2.47.1";
+      version = "2.47.2";
       url = "https://dl.winehq.org/wine/wine-gecko/${version}/wine-gecko-${version}-x86_64.msi";
-      sha256 = "0jj7azmpy07319238g52a8m4nkdwj9g010i355ykxnl8m5wjwcb9";
+      sha256 = "0iffhvdawc499nbn4k99k33cr7g8sdfcvq8k3z1g6gw24h87d5h5";
     };
 
     ## see http://wiki.winehq.org/Mono


### PR DESCRIPTION
###### Motivation for this change
Wine complains about not having gecko & tries to fetch it over the internet because nixpkgs is providing the wrong version of gecko.  Fix this, and add a test so it's easy to notice in the future if the required & provided gecko versions come apart again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FYI: @SFrijters