### PR TITLE
fakecam-cli: init at 0.0 (sic)

### DIFF
--- a/pkgs/applications/video/fakecam-cli/default.nix
+++ b/pkgs/applications/video/fakecam-cli/default.nix
@@ -1,0 +1,24 @@
+#Copied from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fakecam-cli
+{ buildGoModule, fetchFromGitHub, lib }:
+buildGoModule rec{
+  pname = "fakecam-cli";
+  version = "0.0"; #not a typo
+  src = fetchFromGitHub {
+    owner = "UQuark0";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "pBsjjomQEoqL8tXgh981A/fnlu/TYW/LrDBSzbxAm5Q=";
+  };
+  vendorSha256 = "ZQqvEsd2sRaAFo1lGVMJZ49CjQj4HLeLPbDCLY8yj8o=";
+  GOFLAGS = "-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw -v";
+  meta = with lib;{
+    description = ''
+      A fake webcam provider to stream custom video (CLI)
+      You need to add
+      boot.extraModprobeConfig = "options v4l2loopback exclusive_caps=1 video_nr=2";
+    '';
+    license = licenses.mit;
+    platform = platforms.linux;
+    maintainer = with maintainers;[];
+  };
+}

--- a/pkgs/applications/video/fakecam-gui/default.nix
+++ b/pkgs/applications/video/fakecam-gui/default.nix
@@ -1,0 +1,26 @@
+#Copied from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fakecam-gui
+{ buildGoModule, fetchFromGitHub, lib, wrapGAppsHook, gtk3, polkit, ffmpeg, pkg-config }:
+buildGoModule rec{
+  pname = "fakecam-gui";
+  version = "0.0"; #not a typo
+  src = fetchFromGitHub {
+    owner = "UQuark0";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "SY2/Lx2dFXgY+Nr1Pj8owz41HPVxSx3LmGE8Hi9eTsk=";
+  };
+  vendorSha256 = "stISOOuaXZGYKaTU7JBpVsk+EZjKFjvjik5Nr3q9nxw=";
+  GOFLAGS = "-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw -v";
+  nativeBuildInputs = [ wrapGAppsHook pkg-config ];
+  buildInputs = [ gtk3 polkit ffmpeg ];
+  meta = with lib;{
+    description = ''
+      A fake webcam provider to stream custom video (CLI)
+      You need to add
+      boot.extraModprobeConfig = "options v4l2loopback exclusive_caps=1 video_nr=2";
+    '';
+    license = licenses.mit;
+    platform = platforms.linux;
+    maintainer = with maintainers;[];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -413,6 +413,8 @@ in
 
   fakecam-cli = callPackage ../applications/video/fakecam-cli { };
 
+  fakecam-gui = callPackage ../applications/video/fakecam-gui { };
+
   fetchutils = callPackage ../tools/misc/fetchutils { };
 
   fet-sh = callPackage ../tools/misc/fet-sh { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -411,6 +411,8 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
+  fakecam-cli = callPackage ../applications/video/fakecam-cli { };
+
   fetchutils = callPackage ../tools/misc/fetchutils { };
 
   fet-sh = callPackage ../tools/misc/fet-sh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A simple program to create a webcam with virtual background on linux.

Note that fakecam-gui does not build it errors with
```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/3f7xad9j695mqniz0cy71gg1lgp0f6cj-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 1622411780 of file source/main.go
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Building subPackage .
internal/unsafeheader
internal/cpu
internal/bytealg
runtime/internal/atomic
runtime/internal/sys
runtime/internal/math
runtime
internal/reflectlite
errors
internal/race
sync/atomic
sync
io
unicode
unicode/utf8
bytes
strings
bufio
math/bits
math
strconv
reflect
sort
internal/fmtsort
internal/oserror
syscall
internal/syscall/unix
time
internal/poll
internal/syscall/execenv
internal/testlog
path
io/fs
os
fmt
compress/flate
encoding/binary
hash
hash/crc32
compress/gzip
context
path/filepath
os/exec
github.com/UQuark0/fcbe
runtime/cgo
github.com/gotk3/gotk3/glib
# github.com/gotk3/gotk3/glib
cgo-gcc-prolog: In function '_cgo_313852ae111a_Cfunc_g_binding_get_source':
cgo-gcc-prolog:71:2: warning: 'g_binding_get_source' is deprecated: Use 'g_binding_dup_source' instead [-Wdeprecated-declarations]
In file included from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/glib-object.h:22,
                 from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gio/gioenums.h:28,
                 from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gio/giotypes.h:28,
                 from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gio/gio.h:26,
                 from vendor/github.com/gotk3/gotk3/glib/gbinding.go:3:
/nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gobject/gbinding.h:112:23: note: declared here
  112 | GObject *             g_binding_get_source          (GBinding *binding);
      |                       ^~~~~~~~~~~~~~~~~~~~
cgo-gcc-prolog: In function '_cgo_313852ae111a_Cfunc_g_binding_get_target':
cgo-gcc-prolog:107:2: warning: 'g_binding_get_target' is deprecated: Use 'g_binding_dup_target' instead [-Wdeprecated-declarations]
In file included from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/glib-object.h:22,
                 from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gio/gioenums.h:28,
                 from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gio/giotypes.h:28,
                 from /nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gio/gio.h:26,
                 from vendor/github.com/gotk3/gotk3/glib/gbinding.go:3:
/nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0/gobject/gbinding.h:116:23: note: declared here
  116 | GObject *             g_binding_get_target          (GBinding *binding);
      |                       ^~~~~~~~~~~~~~~~~~~~
github.com/gotk3/gotk3/cairo
github.com/gotk3/gotk3/gdk
github.com/gotk3/gotk3/pango
github.com/gotk3/gotk3/gtk
# github.com/gotk3/gotk3/gtk
vendor/github.com/gotk3/gotk3/gtk/accel.go:261:5: val.accel_flags undefined (type _Ctype_struct__GtkAccelKey has no field or method accel_flags)
vendor/github.com/gotk3/gotk3/gtk/accel.go:270:22: obj.accel_flags undefined (type *_Ctype_struct__GtkAccelKey has no field or method accel_flags)
io/ioutil
```
So should we merge those, merge only the first commit
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
