### PR TITLE
rust: Bootstrap riscv64

### DIFF
--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -177,7 +177,7 @@ in stdenv.mkDerivation (rec {
     cp NATIVE/bin/llvm-config $dev/bin/llvm-config-native
   '';
 
-  doCheck = stdenv.isLinux && (!stdenv.isx86_32) && (!stdenv.hostPlatform.isMusl);
+  doCheck = stdenv.isLinux && (!stdenv.isx86_32) && (!stdenv.hostPlatform.isMusl) && (!stdenv.hostPlatform.isRiscV);
 
   checkTarget = "check-all";
 

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -177,7 +177,7 @@ in stdenv.mkDerivation (rec {
     cp NATIVE/bin/llvm-config $dev/bin/llvm-config-native
   '';
 
-  doCheck = stdenv.isLinux && (!stdenv.isx86_32);
+  doCheck = stdenv.isLinux && (!stdenv.isx86_32) && (!stdenv.hostPlatform.isRiscV);
 
   checkTarget = "check-all";
 

--- a/pkgs/development/compilers/rust/1_52.nix
+++ b/pkgs/development/compilers/rust/1_52.nix
@@ -47,6 +47,7 @@ import ./default.nix {
     x86_64-apple-darwin = "765212098a415996b767d1e372ce266caf94027402b269fec33291fffc085ca4";
     aarch64-apple-darwin = "95d0410bbd20b05f8b7d5adf70e8737873995bc86611a90e643d7081ca35147f";
     powerpc64le-unknown-linux-gnu = "7362f561104d7be4836507d3a53cd39444efcdf065813d559beb1f54ce9f7680";
+    riscv64gc-unknown-linux-gnu = "9d0c2c4ab2397e78758de8b6b57051482bcf20b6748e0e16d9d5bd23ce73d72a";
   };
 
   selectRustPackage = pkgs: pkgs.rust_1_52;

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -36,6 +36,7 @@
       "armv7l" = "armv7";
       "armv6l" = "arm";
       "armv5tel" = "armv5te";
+      "riscv64" = "riscv64gc";
     }.${cpu.name} or cpu.name;
   in platform.rustc.config
     or "${cpu_}-${vendor.name}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -18,6 +18,7 @@ PLATFORMS=(
   x86_64-apple-darwin
   aarch64-apple-darwin
   powerpc64le-unknown-linux-gnu
+  riscv64gc-unknown-linux-gnu
 )
 BASEURL=https://static.rust-lang.org/dist
 VERSION=${1:-}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11376,7 +11376,7 @@ in
       /**/ if platform.isDarwin then (if platform.isAarch64 then 11 else 7)
       else if platform.isFreeBSD then 7
       else if platform.isAndroid then 12
-      else if platform.isLinux then 7
+      else if platform.isLinux then (if platform.isRiscV then 9 else 7)
       else if platform.isWasm then 8
       else 11; # latest
     # We take the "max of the mins". Why? Since those are lower bounds of the


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bootstraps Rust native compilation on riscv64. The LLVM test suite needs to be disabled on RISC-V due to several failing tests (see commit message).

This depends on #115406 to actually work but can probably be merged now as it doesn't affect other platforms. Tested by building `rustc` and `cargo` on native riscv64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
