### PR TITLE
nixos/open-with: init

### DIFF
--- a/nixos/modules/programs/open-with/open-with.nix
+++ b/nixos/modules/programs/open-with/open-with.nix
@@ -175,7 +175,7 @@ in
 				example = { 
 					"application/pdf" = [ pkgs.zathura "${pkgs.evince}/share/applications/org.gnome.Evince.desktop" ];
 					"inode/directory" = [ "${pkgs.spaceFM}/share/applications/spacefm.desktop" pkgs.ranger pkgs.vifm ];
-					"video/mp4" = pkgs.vifm;
+					"video/mp4" = [ pkgs.vifm ];
 				} ;
 				description = ''
 					Set that defines default launcher programs. Attribute name is the mimetype, 

--- a/nixos/modules/programs/open-with/open-with.nix
+++ b/nixos/modules/programs/open-with/open-with.nix
@@ -1,0 +1,203 @@
+{ config, lib, utils, pkgs, ... }:
+# This module defines an option to set 
+# default programs and "Open with" associations.
+
+with lib;
+let
+	cfg = config.programs.defaults;
+	singleEntryType = types.either types.str types.package;
+
+	programDataType = lib.mkOptionType {
+		name = "program (.desktop) list";
+		merge = (
+			# [{notes/nix/module 1}]
+			_loc:
+			defs:
+				lib.mkMerge
+					(
+						map
+							(
+								def: 
+									mapAttrValues 
+										singleToList 
+										def.value
+							)
+
+							(lib.reverseList defs)
+					)
+		);
+};
+
+
+
+  doesEndInDesktop = 
+	  filePath: 
+	  (
+		  ( 
+			  builtins.substring  
+				  ( 
+					  builtins.stringLength filePath  - 8
+				  ) 
+				  ( 
+					  builtins.stringLength filePath - 1
+				  ) 
+				  filePath  
+		  ) 
+		  == 
+			  ".desktop"
+	)
+  ;
+
+  singleToList = 
+	  val:  
+		  if ( builtins.typeOf val != "list" ) 
+		  then 
+			  [ val ] 
+		  else 
+			  val 
+  ;
+  
+	mapAttrValues = 
+		f: set: 
+			builtins.listToAttrs (
+				 map 
+					 (
+						 attr: 
+						 { 
+							 name = attr; 
+							 value = f set.${attr};
+						 }
+					 )
+					 ( builtins.attrNames set ) 
+			 )
+	;
+
+	getSingleDesktopFileFromPackage = pkg: 
+	(
+		builtins.elemAt
+			( 
+				builtins.filter 
+					doesEndInDesktop
+					( 
+						builtins.attrNames( 
+							builtins.readDir "${pkg}/share/applications"
+						)
+					) 
+			) 
+			0
+	)
+	;
+
+	desktopFileNameFromPath = path:
+		(
+			let 
+				nodes = builtins.split "/" path;
+			in
+				builtins.elemAt nodes ( ( builtins.length nodes ) - 1 )
+		)
+	;
+	
+	
+	# list of mixed type, string and package
+	packageFilter = launcherAttrOfList: 
+		builtins.filter
+			(
+				p: ( builtins.typeOf p ) != "string"
+			)
+			( 
+				builtins.concatLists
+				( 
+					builtins.attrValues launcherAttrOfList 
+				)
+			)
+	;
+
+	mixedListToDesktopFileList = mixedList:
+		builtins.map
+			(
+				entry: 
+				(
+					if( builtins.typeOf entry == "string" )
+					then
+						desktopFileNameFromPath entry
+					else
+						( getSingleDesktopFileFromPackage entry )
+				)
+			)
+			mixedList
+	;
+
+	defaultLaunchers = cfg.defaults;
+	defaultLaunchersAttrOfList = 
+		mapAttrValues 
+			singleToList
+			defaultLaunchers 
+	;
+
+	allDirectPackages = packageFilter defaultLaunchersAttrOfList;
+
+	allCustomAssociations = mapAttrValues
+		(
+			mixedList: 
+				builtins.concatStringsSep
+					";"
+					( mixedListToDesktopFileList mixedList )
+		)
+		defaultLaunchersAttrOfList 
+	;
+
+
+	mimeappsDOTlist  = 
+		let
+			header = "[Default Applications]\n";
+
+			dictionary =
+				builtins.concatStringsSep
+					";\n"
+					( 
+						builtins.map
+							(
+								key: ''${key}=${allCustomAssociations.${key}}''
+							)
+							( builtins.attrNames allCustomAssociations ) 
+					)
+			;
+		in
+			header + dictionary
+	;
+
+in
+{
+	options.programs.defaults = {
+		defaults =
+			mkOption {
+				default = {};
+				example = { 
+					"application/pdf" = [ pkgs.zathura "${pkgs.evince}/share/applications/org.gnome.Evince.desktop" ];
+					"inode/directory" = [ "${pkgs.spaceFM}/share/applications/spacefm.desktop" pkgs.ranger pkgs.vifm ];
+					"video/mp4" = pkgs.vifm;
+				} ;
+				description = ''
+					Set that defines default launcher programs. Attribute name is the mimetype, 
+					and attribute values 
+					A set where mimetypes are keys and an array of .desktop files, or packages
+					are the values which would be used to open that file by default. 
+				'';
+
+
+				# Actually this could also be `either singleEntryType (types.listOf singleEntryType )`
+				# But merge function would need to be written manually
+				type = types.attrsOf (
+						types.listOf singleEntryType
+				) ;
+			};
+	};
+
+	config = {
+		environment.systemPackages = allDirectPackages ;
+
+		environment.etc."xdg/mimeapps.list" = { 
+			text = mimeappsDOTlist;
+		};
+	};
+}


### PR DESCRIPTION
(contd) https://github.com/NixOS/nixpkgs/pull/88025


Some discussion here- https://discourse.nixos.org/t/configure-how-xdg-open-opens-html-files/6419/22

# Motivation
On my computer currently- these are the liens in mimeinfo.cache

```
application/pdf=inkscape.desktop;org.gnome.Evince.desktop;pqiv.desktop;texworks.desktop;
inode/directory=code.desktop;pcmanfm.desktop;ranger.desktop;spacefm-find.desktop;spacefm-folder-handler.desktop;spacefm.desktop;vifm.desktop;
video/mp4=pqiv.desktop;vlc.desktop;
``` 

meaning that pdf is (not) opened in Inkscape, directory is (at a leisurely pace) opened in Visual Studio Code and mp4 (barely) opens in pqiv.

At this point one would refer to Arch wiki to figure out how to override these settings manually. However, two of the probably most popular programs around this- xdg-open and mimeopen do not concur on how to do so. It appears that they read different files. The obvious solution would be to link to another but that doesn't work because, in my recollection one of those files is such that it is deleted and recreated upon every edit.

So it seems that the only sane solution is to override the global (computer-wide) defaults because everybody seems to respect that at least.

This code adds an option programs.defaults.defaults to achieve that.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] **NA** macOS
   - [ ] **NA** other Linux distributions
- [] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] **NA** Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] **NA**  Tested execution of all binary files (usually in `./result/bin/`)
- [x] **NA** Added a release notes entry if the change is major or breaking 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


# NOTE TO REVIEWERS

I am doing this for free, and already using this module locally. I get emails for comments mentioned here so please read the following link for my review "philosophy". 

https://discourse.nixos.org/t/how-many-people-are-paid-to-work-on-nix-nixpkgs/8307/86  TLDR: Do not do nitpicks, if you're bothered about space at the end of line, please stay away. Look at the larger picture of the work and approve based on that if you'd like. 