### PR TITLE
Add Plasma Mobile Gear 21.05

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -174,6 +174,7 @@ let
       ksquares = callPackage ./ksquares.nix {};
       kqtquickcharts = callPackage ./kqtquickcharts.nix {};
       kpkpass = callPackage ./kpkpass.nix {};
+      kpublictransport = callPackage ./kpublictransport.nix {};
       kreversi = callPackage ./kreversi.nix {};
       krdc = callPackage ./krdc.nix {};
       krfb = callPackage ./krfb.nix {};

--- a/pkgs/applications/kde/kpublictransport.nix
+++ b/pkgs/applications/kde/kpublictransport.nix
@@ -1,0 +1,13 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+}:
+
+mkDerivation {
+  pname = "kpublictransport";
+  meta = with lib; {
+    license = [ licenses.cc0 ];
+    maintainers = [ maintainers.samueldr ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules ];
+}

--- a/pkgs/applications/plasma-mobile/alligator.nix
+++ b/pkgs/applications/plasma-mobile/alligator.nix
@@ -1,0 +1,40 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kconfig
+, kcoreaddons
+, ki18n
+, kirigami2
+, qtquickcontrols2
+, syndication
+}:
+
+mkDerivation rec {
+  pname = "alligator";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    kcoreaddons
+    ki18n
+    kirigami2
+    qtquickcontrols2
+    syndication
+  ];
+
+  meta = with lib; {
+    description = "RSS reader made with kirigami";
+    homepage = "https://invent.kde.org/plasma-mobile/alligator";
+    # https://invent.kde.org/plasma-mobile/alligator/-/commit/db30f159c4700244532b17a260deb95551045b7a
+    #  * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+    license = with licenses; [ gpl2Only gpl3Only ];
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/calindori.nix
+++ b/pkgs/applications/plasma-mobile/calindori.nix
@@ -1,0 +1,46 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kcalendarcore
+, kconfig
+, kcoreaddons
+, kdbusaddons
+, ki18n
+, kirigami2
+, knotifications
+, kpeople
+, kservice
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "calindori";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcalendarcore
+    kconfig
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kirigami2
+    knotifications
+    kpeople
+    kservice
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Calendar for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/calindori";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -61,6 +61,7 @@ let
         inherit mkDerivation;
       };
     in {
+      alligator = callPackage ./alligator.nix {};
       kalk = callPackage ./kalk.nix {};
       kclock = callPackage ./kclock.nix {};
     };

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -65,6 +65,7 @@ let
       calindori = callPackage ./calindori.nix {};
       kalk = callPackage ./kalk.nix {};
       kclock = callPackage ./kclock.nix {};
+      krecorder = callPackage ./krecorder.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -65,6 +65,7 @@ let
       calindori = callPackage ./calindori.nix {};
       kalk = callPackage ./kalk.nix {};
       kclock = callPackage ./kclock.nix {};
+      koko = callPackage ./koko.nix {};
       krecorder = callPackage ./krecorder.nix {};
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -67,6 +67,7 @@ let
       kclock = callPackage ./kclock.nix {};
       koko = callPackage ./koko.nix {};
       krecorder = callPackage ./krecorder.nix {};
+      ktrip = callPackage ./ktrip.nix {};
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       spacebar = callPackage ./spacebar.nix {};

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -66,6 +66,7 @@ let
       kalk = callPackage ./kalk.nix {};
       kclock = callPackage ./kclock.nix {};
       krecorder = callPackage ./krecorder.nix {};
+      plasma-dialer = callPackage ./plasma-dialer.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -68,6 +68,7 @@ let
       krecorder = callPackage ./krecorder.nix {};
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
+      spacebar = callPackage ./spacebar.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -67,6 +67,7 @@ let
       kclock = callPackage ./kclock.nix {};
       krecorder = callPackage ./krecorder.nix {};
       plasma-dialer = callPackage ./plasma-dialer.nix {};
+      plasma-phonebook = callPackage ./plasma-phonebook.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -62,6 +62,7 @@ let
       };
     in {
       kalk = callPackage ./kalk.nix {};
+      kclock = callPackage ./kclock.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -1,0 +1,66 @@
+/*
+
+# New packages
+
+READ THIS FIRST
+
+This module is for official packages in the Plasma Mobile Gear. All
+available packages are listed in `./srcs.nix`, although some are not yet
+packaged in Nixpkgs.
+
+IF YOUR PACKAGE IS NOT LISTED IN `./srcs.nix`, IT DOES NOT GO HERE.
+
+See also `pkgs/applications/kde` as this is what this is based on.
+
+# Updates
+
+1. Update the URL in `./fetch.sh`.
+2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/applications/plasma-mobile`
+   from the top of the Nixpkgs tree.
+3. Use `nox-review wip` to check that everything builds.
+4. Commit the changes and open a pull request.
+
+*/
+
+{ lib
+, libsForQt5
+, fetchurl
+}:
+
+let
+  minQtVersion = "5.15";
+  broken = lib.versionOlder libsForQt5.qtbase.version minQtVersion;
+
+  mirror = "mirror://kde";
+  srcs = import ./srcs.nix { inherit fetchurl mirror; };
+
+  mkDerivation = args:
+    let
+      inherit (args) pname;
+      inherit (srcs.${pname}) src version;
+      mkDerivation =
+        libsForQt5.callPackage ({ mkDerivation }: mkDerivation) {};
+    in
+      mkDerivation (args // {
+        inherit pname version src;
+
+        outputs = args.outputs or [ "out" ];
+
+        meta =
+          let meta = args.meta or {}; in
+          meta // {
+            homepage = meta.homepage or "https://www.plasma-mobile.org/";
+            platforms = meta.platforms or lib.platforms.linux;
+            broken = meta.broken or broken;
+          };
+      });
+
+  packages = self: with self;
+    let
+      callPackage = self.newScope {
+        inherit mkDerivation;
+      };
+    in {
+    };
+
+in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -62,6 +62,7 @@ let
       };
     in {
       alligator = callPackage ./alligator.nix {};
+      calindori = callPackage ./calindori.nix {};
       kalk = callPackage ./kalk.nix {};
       kclock = callPackage ./kclock.nix {};
     };

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -61,6 +61,7 @@ let
         inherit mkDerivation;
       };
     in {
+      kalk = callPackage ./kalk.nix {};
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/fetch.sh
+++ b/pkgs/applications/plasma-mobile/fetch.sh
@@ -1,0 +1,1 @@
+WGET_ARGS=( http://download.kde.org/stable/plasma-mobile/21.05 -A '*.tar.xz' )

--- a/pkgs/applications/plasma-mobile/kalk.nix
+++ b/pkgs/applications/plasma-mobile/kalk.nix
@@ -1,0 +1,50 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+, bison
+, flex
+
+, gmp
+, mpfr
+
+, kconfig
+, kcoreaddons
+, ki18n
+, kirigami2
+, kunitconversion
+, qtfeedback
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "kalk";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    gmp
+    mpfr
+
+    kconfig
+    kcoreaddons
+    ki18n
+    kirigami2
+    kunitconversion
+    qtfeedback
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Calculator built with kirigami";
+    homepage = "https://invent.kde.org/plasma-mobile/kalk";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/kclock.nix
+++ b/pkgs/applications/plasma-mobile/kclock.nix
@@ -1,0 +1,44 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kconfig
+, kcoreaddons
+, kdbusaddons
+, ki18n
+, kirigami2
+, knotifications
+, plasma-framework
+, qtmultimedia
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "kclock";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kirigami2
+    knotifications
+    plasma-framework
+    qtmultimedia
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Clock app for plasma mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/kclock";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/koko.nix
+++ b/pkgs/applications/plasma-mobile/koko.nix
@@ -1,0 +1,81 @@
+{ lib
+, mkDerivation
+
+, fetchurl
+, cmake
+, extra-cmake-modules
+
+, exiv2
+, kconfig
+, kcoreaddons
+, kdeclarative
+, kfilemetadata
+, kguiaddons
+, ki18n
+, kio
+, kirigami2
+, knotifications
+, kpurpose
+, kquickimageedit
+, qtgraphicaleffects
+, qtlocation
+, qtquickcontrols2
+}:
+
+let
+  # URLs snapshotted through
+  # https://web.archive.org/save/$url
+  # Update when stale enough I guess?
+  admin1 = fetchurl {
+    url = "https://web.archive.org/web/20210714035424if_/http://download.geonames.org/export/dump/admin1CodesASCII.txt";
+    sha256 = "0r783yzajs26hvccdy4jv2v06xfgadx2g90fz3yn7lx8flz4nhwm";
+  };
+  admin2 = fetchurl {
+    url = "https://web.archive.org/web/20210714035427if_/http://download.geonames.org/export/dump/admin2Codes.txt";
+    sha256 = "1n5nzp3xblhr93rb1sadi5vfbw29slv5lc6cxq21h3x3cg0mwqh3";
+  };
+  cities1000 = fetchurl {
+    url = "https://web.archive.org/web/20210714035406if_/http://download.geonames.org/export/dump/cities1000.zip";
+    sha256 = "0cwbfff8gzci5zrahh6d53b9b3bfv1cbwlv0k6076531i1c7md9p";
+  };
+in
+mkDerivation rec {
+  pname = "koko";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    exiv2
+    kconfig
+    kcoreaddons
+    kdeclarative
+    kfilemetadata
+    kguiaddons
+    ki18n
+    kio
+    kirigami2
+    knotifications
+    kpurpose
+    kquickimageedit
+    qtgraphicaleffects
+    qtlocation
+    qtquickcontrols2
+  ];
+
+  prePatch = ''
+    ln -s ${admin1}     src/admin1CodesASCII.txt
+    ln -s ${admin2}     src/admin2Codes.txt
+    ln -s ${cities1000} src/cities1000.zip
+  '';
+
+  meta = with lib; {
+    description = "Image gallery mobile application";
+    homepage = "https://apps.kde.org/koko/";
+    # LGPL-2.1-only OR LGPL-3.0-only OR LicenseRef-KDE-Accepted-LGPL
+    license = [ licenses.lgpl3Only licenses.lgpl21Only ];
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/krecorder.nix
+++ b/pkgs/applications/plasma-mobile/krecorder.nix
@@ -1,0 +1,36 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kconfig
+, ki18n
+, kirigami2
+, qtmultimedia
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "krecorder";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    ki18n
+    kirigami2
+    qtmultimedia
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Audio recorder for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/krecorder";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/ktrip.nix
+++ b/pkgs/applications/plasma-mobile/ktrip.nix
@@ -1,0 +1,45 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kconfig
+, kcontacts
+, kcoreaddons
+, ki18n
+, kirigami-addons
+, kirigami2
+, kitemmodels
+, kpublictransport
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "ktrip";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    kcontacts
+    kcoreaddons
+    ki18n
+    kirigami-addons
+    kirigami2
+    kitemmodels
+    kpublictransport
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Public transport trip planner";
+    homepage = "https://apps.kde.org/ktrip/";
+    # GPL-2.0-or-later
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/plasma-dialer.nix
+++ b/pkgs/applications/plasma-mobile/plasma-dialer.nix
@@ -1,0 +1,54 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kcontacts
+, kcoreaddons
+, kdbusaddons
+, ki18n
+, kirigami2
+, knotifications
+, kpeople
+, libphonenumber
+, libpulseaudio
+, libqofono
+, protobuf
+, pulseaudio-qt
+, qtquickcontrols2
+, telepathy
+}:
+
+mkDerivation rec {
+  pname = "plasma-dialer";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcontacts
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kirigami2
+    knotifications
+    kpeople
+    libphonenumber
+    libpulseaudio
+    libqofono
+    protobuf # Needed by libphonenumber
+    pulseaudio-qt
+    qtquickcontrols2
+    telepathy
+  ];
+
+  meta = with lib; {
+    description = "Dialer for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/plasma-dialer";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/plasma-phonebook.nix
+++ b/pkgs/applications/plasma-mobile/plasma-phonebook.nix
@@ -1,0 +1,41 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kcontacts
+, kcoreaddons
+, kirigami2
+, kirigami-addons
+, kpeople
+, kpeoplevcard
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "plasma-phonebook";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcontacts
+    kcoreaddons
+    kirigami2
+    kirigami-addons
+    kpeople
+    kpeoplevcard
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Phone book for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/plasma-phonebook";
+    # https://invent.kde.org/plasma-mobile/plasma-phonebook/-/commit/3ac27760417e51c051c5dd44155c3f42dd000e4f
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/spacebar.nix
+++ b/pkgs/applications/plasma-mobile/spacebar.nix
@@ -1,0 +1,40 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kcontacts
+, ki18n
+, kirigami2
+, knotifications
+, kpeople
+, libqofono
+, telepathy
+}:
+
+mkDerivation rec {
+  pname = "spacebar";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcontacts
+    ki18n
+    kirigami2
+    knotifications
+    kpeople
+    libqofono
+    telepathy
+  ];
+
+  meta = with lib; {
+    description = "SMS application for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/spacebar";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/plasma-mobile/srcs.nix
+++ b/pkgs/applications/plasma-mobile/srcs.nix
@@ -1,0 +1,118 @@
+# DO NOT EDIT! This file is generated automatically.
+# Command: ./maintainers/scripts/fetch-kde-qt.sh pkgs/applications/plasma-mobile/
+{ fetchurl, mirror }:
+
+{
+  alligator = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/alligator-21.05.tar.xz";
+      sha256 = "04zgxfx2zmn1p2ap08i5sfsnrly3smip4ylr07ghkhkiyjzbv9w6";
+      name = "alligator-21.05.tar.xz";
+    };
+  };
+  angelfish = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/angelfish-21.05.tar.xz";
+      sha256 = "11jd5dwy0xa7kh5z5rc29xy3wfn20hm31908zjax4x83qqjrm075";
+      name = "angelfish-21.05.tar.xz";
+    };
+  };
+  calindori = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/calindori-21.05.tar.xz";
+      sha256 = "110f9ri9r1nb6q1ybhkfxljl4q5gqxikh9z0xkzjjbxjjqfscqcj";
+      name = "calindori-21.05.tar.xz";
+    };
+  };
+  kalk = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/kalk-21.05.tar.xz";
+      sha256 = "04n65hx0j9rx6b3jq69zgypi8qjd4ig3rfw7d44c3q7dgh4k451l";
+      name = "kalk-21.05.tar.xz";
+    };
+  };
+  kclock = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/kclock-21.05.tar.xz";
+      sha256 = "0pa5hvax0y80l8yrqczh9mcknfm3z0vdq3xc35cxdiz1vc6fwqmd";
+      name = "kclock-21.05.tar.xz";
+    };
+  };
+  koko = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/koko-21.05.tar.xz";
+      sha256 = "00hnzkl8dvf15psrcfh96b8wfb3pbggd2f7xnadzcb87sbaml035";
+      name = "koko-21.05.tar.xz";
+    };
+  };
+  kongress = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/kongress-21.05.tar.xz";
+      sha256 = "0qxgpi04ra9crc6drgbdm9arjbvcx52pprjr1dj8acch07f6i2gs";
+      name = "kongress-21.05.tar.xz";
+    };
+  };
+  krecorder = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/krecorder-21.05.tar.xz";
+      sha256 = "0ydaidxx2616bixihyaagvyym1r5s9rjkgg04vq9k4608d4vnn5c";
+      name = "krecorder-21.05.tar.xz";
+    };
+  };
+  ktrip = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/ktrip-21.05.tar.xz";
+      sha256 = "0hxgnncyc2ir6i9p6s9fy1r4mhxgm643pxvp8lj3j5y0c5wk2kp9";
+      name = "ktrip-21.05.tar.xz";
+    };
+  };
+  plasma-dialer = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/plasma-dialer-21.05.tar.xz";
+      sha256 = "0kwkjn7ry6snc86qi1j7kcq5qa6rbyk5i7v6gqf7a7wywkk9n045";
+      name = "plasma-dialer-21.05.tar.xz";
+    };
+  };
+  plasma-phonebook = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/plasma-phonebook-21.05.tar.xz";
+      sha256 = "0aqqi3gvcsh4zg41zf8y0c626lwrabjchhr8pxj4n9la7y0wdvca";
+      name = "plasma-phonebook-21.05.tar.xz";
+    };
+  };
+  plasma-settings = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/plasma-settings-21.05.tar.xz";
+      sha256 = "16bhx0i8gvi9ina4jxzx02xyzypyjic9646lahxvzvzmd9hn9ipi";
+      name = "plasma-settings-21.05.tar.xz";
+    };
+  };
+  qmlkonsole = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/qmlkonsole-21.05.tar.xz";
+      sha256 = "1ga48n09zlgvf5vvk2m26ak3ih5gjf361xxnyfprimmd7yj23han";
+      name = "qmlkonsole-21.05.tar.xz";
+    };
+  };
+  spacebar = {
+    version = "21.05";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma-mobile/21.05/spacebar-21.05.tar.xz";
+      sha256 = "16lvi5yzmvk6gb5m7csk44y2jbkk7psn1lkljmj1938p2475b94c";
+      name = "spacebar-21.05.tar.xz";
+    };
+  };
+}

--- a/pkgs/development/libraries/kirigami-addons/default.nix
+++ b/pkgs/development/libraries/kirigami-addons/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+
+, cmake
+, extra-cmake-modules
+
+, ki18n
+, kirigami2
+, qtquickcontrols2
+}:
+
+mkDerivation rec {
+  pname = "kirigami-addons";
+  version = "21.05";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "libraries";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0pwkpag15mvzhd3hvdwx0a8ajwq9j30r6069vsx85bagnag3zanh";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    ki18n
+    kirigami2
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Add-ons for the Kirigami framework";
+    homepage = "https://invent.kde.org/libraries/kirigami-addons";
+    # https://invent.kde.org/libraries/kirigami-addons/-/blob/b197d98fdd079b6fc651949bd198363872d1be23/src/treeview/treeviewplugin.cpp#L1-5
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}
+

--- a/pkgs/development/libraries/libqofono/0001-NixOS-Skip-tests-they-re-shock-full-of-hardcoded-FHS.patch
+++ b/pkgs/development/libraries/libqofono/0001-NixOS-Skip-tests-they-re-shock-full-of-hardcoded-FHS.patch
@@ -1,0 +1,29 @@
+From 8b508d427c4fd472639ba8d4a0d3b8ab69e3f2e3 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Tue, 30 Mar 2021 16:37:52 -0400
+Subject: [PATCH] [NixOS] Skip tests, they're shock-full of hardcoded FHS paths
+
+---
+ libqofono.pro | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/libqofono.pro b/libqofono.pro
+index 60d0b89..638a4a8 100644
+--- a/libqofono.pro
++++ b/libqofono.pro
+@@ -1,5 +1,5 @@
+ TEMPLATE = subdirs
+-SUBDIRS += src plugin test ofonotest
++SUBDIRS += src plugin
+ OTHER_FILES += \
+   rpm/libqofono-qt5.spec \
+   TODO \
+@@ -7,5 +7,3 @@ OTHER_FILES += \
+ 
+ src.target = src-target
+ plugin.depends = src-target
+-test.depends = src-target
+-ofonotest.depends = src-target
+-- 
+2.28.0
+

--- a/pkgs/development/libraries/libqofono/0001-NixOS-provide-mobile-broadband-provider-info-path.patch
+++ b/pkgs/development/libraries/libqofono/0001-NixOS-provide-mobile-broadband-provider-info-path.patch
@@ -1,0 +1,34 @@
+From 04106010ae2a13b3a2a93e210062998ee51778ca Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Tue, 30 Mar 2021 15:47:38 -0400
+Subject: [PATCH] [NixOS] provide mobile-broadband-provider-info path
+
+---
+ src/qofonoconnectioncontext.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/qofonoconnectioncontext.cpp b/src/qofonoconnectioncontext.cpp
+index b5877ed..455167c 100644
+--- a/src/qofonoconnectioncontext.cpp
++++ b/src/qofonoconnectioncontext.cpp
+@@ -346,7 +346,7 @@ bool QOfonoConnectionContext::validateProvisioning(const QString &providerString
+     QXmlQuery query;
+     QString provider = providerString;
+ 
+-    query.setFocus(QUrl("/usr/share/mobile-broadband-provider-info/serviceproviders.xml"));
++    query.setFocus(QUrl("@mobile-broadband-provider-info@/share/mobile-broadband-provider-info/serviceproviders.xml"));
+ 
+     if (provider.contains("\'")) {
+         provider = provider.replace("\'", "&apos;");
+@@ -457,7 +457,7 @@ void QOfonoConnectionContext::provision(const QString &provider, const QString &
+ {
+ #ifdef QOFONO_PROVISIONING
+     QXmlQuery query;
+-    query.setFocus(QUrl("/usr/share/mobile-broadband-provider-info/serviceproviders.xml"));
++    query.setFocus(QUrl("@mobile-broadband-provider-info@/share/mobile-broadband-provider-info/serviceproviders.xml"));
+ 
+     QString providerStr = provider;
+     if (providerStr.contains("\'")) {
+-- 
+2.28.0
+

--- a/pkgs/development/libraries/libqofono/default.nix
+++ b/pkgs/development/libraries/libqofono/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, substituteAll
+, mkDerivation
+, fetchFromGitLab
+, mobile-broadband-provider-info
+, qmake
+, qtbase
+, qtdeclarative
+}:
+
+mkDerivation rec {
+  pname = "libqofono";
+  version = "0.103";
+
+  src = fetchFromGitLab {
+    domain = "git.sailfishos.org";
+    owner = "mer-core";
+    repo = "libqofono";
+    rev = version;
+    sha256 = "1ly5aj412ljcjvhqyry6nhiglbzzhczsy1a6w4i4fja60b2m1z45";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./0001-NixOS-provide-mobile-broadband-provider-info-path.patch;
+      inherit mobile-broadband-provider-info;
+    })
+    ./0001-NixOS-Skip-tests-they-re-shock-full-of-hardcoded-FHS.patch
+  ];
+
+  # Replaces paths from the Qt store path to this library's store path.
+  postPatch = ''
+    substituteInPlace src/src.pro \
+      --replace /usr $out \
+      --replace '$$[QT_INSTALL_PREFIX]' "$out" \
+      --replace 'target.path = $$[QT_INSTALL_LIBS]' "target.path = $out/lib"
+
+    substituteInPlace plugin/plugin.pro \
+      --replace '$$[QT_INSTALL_QML]' $out'/${qtbase.qtQmlPrefix}'
+  '';
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+  ];
+
+  meta = with lib; {
+    description = "Library for accessing the ofono daemon, and declarative plugin for it";
+    homepage = "https://git.sailfishos.org/mer-core/libqofono/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ samueldr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -373,7 +373,6 @@ mapAliases ({
   jikes = throw "jikes was deprecated on 2019-10-07: abandoned by upstream";
   joseki = apache-jena-fuseki; # added 2016-02-28
   json_glib = json-glib; # added 2018-02-25
-  kalk = kalker; # added 2021-06-03
   kdecoration-viewer = throw "kdecoration-viewer has been removed from nixpkgs, as there is no upstream activity"; # 2020-06-16
   k9copy = throw "k9copy has been removed from nixpkgs, as there is no upstream activity"; # 2020-11-06
   kodiGBM = kodi-gbm;

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -43,9 +43,17 @@ let
     };
   in (lib.makeOverridable mkGear attrs);
 
-in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
+  plasmaMobileGear = let
+    mkPlamoGear = import ../applications/plasma-mobile;
+    attrs = {
+      inherit libsForQt5;
+      inherit (pkgs) lib fetchurl;
+    };
+  in (lib.makeOverridable mkPlamoGear attrs);
 
-  inherit kdeFrameworks plasma5 kdeGear qt5;
+in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
+
+  inherit kdeFrameworks plasmaMobileGear plasma5 kdeGear qt5;
 
   # Alias for backwards compatibility. Added 2021-05-07.
   kdeApplications = kdeGear;

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -88,6 +88,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
   kf5gpgmepp = callPackage ../development/libraries/kf5gpgmepp { };
 
+  kirigami-addons = libsForQt5.callPackage ../development/libraries/kirigami-addons { };
+
   kimageannotator = callPackage ../development/libraries/kimageannotator { };
 
   kproperty = callPackage ../development/libraries/kproperty { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -122,6 +122,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
     inherit (pkgs.darwin.apple_sdk.frameworks) AGL;
   };
 
+  libqofono = callPackage ../development/libraries/libqofono { };
+
   libqtav = callPackage ../development/libraries/libqtav { };
 
   kpmcore = callPackage ../development/libraries/kpmcore { };


### PR DESCRIPTION
## Motivation for this change

#121345 is a mess to review because it is just plain too big. I'll rebase #121345 on top of this PR, which will make it hold **only** the Plasma Mobile *shell*. (The "phone GUI environment".)

Those applications are independent from *actual* plasma mobile.

They can seemingly be used (with caveats) on e.g. Phosh.

*Only applications with a release tags are packaged.*

Note that these applications launch just right on my X11 desktop with Awesome WM. No real caveats there AFAICT.

:heavy_check_mark: This PR is **ready** for reviewing.

 - https://www.plasma-mobile.org/2021/05/10/plasma-mobile-gear-may-2021/
 - https://www.plasma-mobile.org/info/plasma-mobile-gear-21-05/

* * *

### Caveats

None of those caveats are bugs in the packaging of these applications.

<details><summary>(Long scary list, not actual packaging bugs)</summary>

#### Icons wont work as expected

 - https://bugs.kde.org/show_bug.cgi?id=435236
 - Workaround: https://github.com/samueldr/hack-merged-icons

```nix
{
  # Work around issues with plasma mobile apps on phosh
  #  - https://bugs.kde.org/show_bug.cgi?id=435236
  hacks.mergedIcons = {
    enable = true;

    # Helps with breeze fallback icons under gnome/phosh
    # Otherwise it might use Adwaita
    removeLegacyIcons = true;
    disabledThemes = [
      "Adwaita"
    ];

    # Options that aren't used
    #masqueradeAs = [
    #  "Adwaita" # Doesn't help really
    #];
    #iconThemes = [
    #];
  };
}
```

#### Will not start by default

By default the apps on Phosh (or GNOME too I suppose?) won't start:

> ```
> Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland ro tun on Wayland anyway.
> ```

They'll try to start using `xcb`/X11 and crash. How rude.

The workaround is to force Wayland... Rude...

```nix

{
  environment.variables = {
    QT_QPA_PLATFORM = "wayland";
  };
}
```

It is unclear why those apps are willfully ignoring starting as wayland apps in Phosh (and GNOME I suppose).

#### CSDs in Phosh

While not really an issue, one can *completely disable Qt CSDs* this way:

```nix

{
  environment.variables = {
    QT_WAYLAND_DISABLE_WINDOWDECORATION = "1";
  };
}
```

Seems to me there is a need for some coordination between "phone environments" to properly tell when CSDs are needed and when they're not for docked/undocked modes :/.

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Actual tests:

I ran applications on my X11 desktop **and** under Phosh. Apps were *also* ran in their previous releases under Plasma Mobile, but not this most up-to-date branch yet.

**Fully tested:**

 - alligator
 - calindori
 - kalk
 - kclock
 - koko
 - krecorder
 - ktrip
 - ~~kweather~~ (not part of 21.05)
 - ~~plasma-camera~~ (not part of 21.05)
 - plasma-phonebook

**Features untested:**

 - plasma-dialer (dialing/receiving a call... basically ofono integration)
 - spacebar (sms receiving/sending... basically ofono integration)

cc @NixOS/qt-kde 

#### TODO

 - [x] Use an update script for Plasma Mobile Gear