### PR TITLE
python3Packages.adext: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/development/python-modules/adext/default.nix
+++ b/pkgs/development/python-modules/adext/default.nix
@@ -1,18 +1,23 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , setuptools-scm
 , alarmdecoder
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "adext";
   version = "0.4.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-Y9AvLgclNZdFnZJDoH6/pf8AqHr3WmwysgpJvWKicHo=";
+  src = fetchFromGitHub {
+    owner = "ajschmidt8";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0h5k9kzms2f0r48pdhsgv8pimk0vsxw8vs0k6880mank8ij914wr";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     setuptools-scm
@@ -22,8 +27,10 @@ buildPythonPackage rec {
     alarmdecoder
   ];
 
-  # Tests are not published yet
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [ "adext" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/adext/default.nix
+++ b/pkgs/development/python-modules/adext/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "adext";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1yz1rpfvhbf7kfjck5vadbj9rd3bkx5248whaa3impdrjh7vs03x";
+    sha256 = "sha256-Y9AvLgclNZdFnZJDoH6/pf8AqHr3WmwysgpJvWKicHo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/alarmdecoder/default.nix
+++ b/pkgs/development/python-modules/alarmdecoder/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "alarmdecoder";
-  version = "1.13.10";
+  version = "1.13.11";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "nutechsoftware";
     repo = "alarmdecoder";
     rev = version;
-    sha256 = "05581j78181p6mwbfpbkp5irnrzsvps1lslgqrh7xbdcmz5b2nxd";
+    sha256 = "sha256-q2s+wngDKtWm5mxGHNAc63Ed6tiQD9gLHVoQZNWFB0w=";
   };
 
   propagatedBuildInputs = [ pyserial pyftdi pyusb pyopenssl ];

--- a/pkgs/development/python-modules/alarmdecoder/default.nix
+++ b/pkgs/development/python-modules/alarmdecoder/default.nix
@@ -1,5 +1,14 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pyserial, pyftdi, pyusb
-, pyopenssl, nose, isPy3k, pythonOlder, mock }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pyftdi
+, pyopenssl
+, pyserial
+, pytestCheckHook
+, pythonOlder
+, pyusb
+}:
 
 buildPythonPackage rec {
   pname = "alarmdecoder";
@@ -13,16 +22,30 @@ buildPythonPackage rec {
     sha256 = "sha256-q2s+wngDKtWm5mxGHNAc63Ed6tiQD9gLHVoQZNWFB0w=";
   };
 
-  propagatedBuildInputs = [ pyserial pyftdi pyusb pyopenssl ];
+  propagatedBuildInputs = [
+    pyftdi
+    pyopenssl
+    pyserial
+    pyusb
+  ];
 
-  doCheck = !isPy3k;
-  checkInputs = [ nose mock ];
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Socket issue, https://github.com/nutechsoftware/alarmdecoder/issues/45
+    "test_ssl"
+    "test_ssl_exception"
+  ];
+
   pythonImportsCheck = [ "alarmdecoder" ];
 
   meta = with lib; {
+    description = "Python interface for the Alarm Decoder (AD2USB, AD2SERIAL and AD2PI) devices";
     homepage = "https://github.com/nutechsoftware/alarmdecoder";
-    description =
-      "Python interface for the Alarm Decoder (AD2) family of alarm devices. (AD2USB, AD2SERIAL and AD2PI)";
     license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releases

Change log:
- https://github.com/ajschmidt8/adext/releases/tag/v0.4.2
- https://github.com/nutechsoftware/alarmdecoder/releases/tag/1.13.11



- Related Home Assistant change: https://github.com/home-assistant/core/pull/51315
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
