### PR TITLE
onlyoffice-bin: 6.1.0 -> 6.2.0 and fix runHook typo

### DIFF
--- a/pkgs/applications/office/onlyoffice-bin/default.nix
+++ b/pkgs/applications/office/onlyoffice-bin/default.nix
@@ -72,11 +72,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "onlyoffice-desktopeditors";
-  version = "6.1.0";
-  minor = "90";
+  version = "6.2.0";
+  minor = null;
   src = fetchurl {
-    url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_${version}-${minor}_amd64.deb";
-    sha256 = "sha256-TUaECChM3GxtB54/zNIKjRIocnAxpBVK7XsX3z7aq8o=";
+    url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
+    sha256 = "sha256-nKmWxaVVul/rGDIh3u9zCpKu7U0nmrntFFf96xQyzdg=";
   };
 
   nativeBuildInputs = [
@@ -153,7 +153,7 @@ in stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/onlyoffice-desktopeditors.desktop \
       --replace "/usr/bin/onlyoffice-desktopeditor" "$out/bin/DesktopEditor"
 
-    runHook preInstall
+    runHook postInstall
   '';
 
   preFixup = ''
@@ -163,6 +163,8 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Office suite that combines text, spreadsheet and presentation editors allowing to create, view and edit local documents";
     homepage = "https://www.onlyoffice.com/";
+    downloadPage = "https://github.com/ONLYOFFICE/DesktopEditors/releases";
+    changelog = "https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md";
     platforms = [ "x86_64-linux" ];
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ nh2 gtrunsec ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
