### PR TITLE
gnome-flashback: add module support to gnome-panel for installing applets

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -261,6 +261,17 @@ in
           default = [];
           description = "Other GNOME Flashback sessions to enable.";
         };
+
+        panelModulePackages = mkOption {
+          default = [ pkgs.gnome.gnome-applets ];
+          type = types.listOf types.path;
+          description = ''
+            Packages containing modules that should be made available to <literal>gnome-panel</literal> (usually for applets).
+
+            If you're packaging something to use here, please install the modules in <literal>$out/lib/gnome-panel/modules</literal>.
+          '';
+          example = literalExample "[ pkgs.gnome.gnome-applets ]";
+        };
       };
     };
 
@@ -323,6 +334,7 @@ in
             (wm:
               pkgs.gnome.gnome-flashback.mkSessionForWm {
                 inherit (wm) wmName wmLabel wmCommand enableGnomePanel;
+                inherit (cfg.flashback) panelModulePackages;
               }
             ) flashbackWms;
 

--- a/pkgs/desktops/gnome/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-panel/default.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-nxNQde3GZs8rnKkd41xnA+KxdxwQp3B0FPtlbCilmzs=";
   };
 
+  patches = [
+    # Load modules from path in `NIX_GNOME_PANEL_MODULESDIR` environment variable
+    # instead of gnome-panel’s libdir so that the NixOS module can make gnome-panel
+    # load modules from other packages as well.
+    ./modulesdir-env-var.patch
+  ];
+
   # make .desktop Exec absolute
   postPatch = ''
     patch -p0 <<END_PATCH

--- a/pkgs/desktops/gnome/misc/gnome-panel/modulesdir-env-var.patch
+++ b/pkgs/desktops/gnome/misc/gnome-panel/modulesdir-env-var.patch
@@ -1,0 +1,31 @@
+diff --git a/gnome-panel/gp-module-manager.c b/gnome-panel/gp-module-manager.c
+index 58447fd84..7af99de7d 100644
+--- a/gnome-panel/gp-module-manager.c
++++ b/gnome-panel/gp-module-manager.c
+@@ -49,8 +49,16 @@ load_modules (GpModuleManager *self)
+ {
+   GDir *dir;
+   const gchar *name;
++  const gchar *modules_dir;
+ 
+-  dir = g_dir_open (MODULESDIR, 0, NULL);
++  modules_dir = g_getenv ("NIX_GNOME_PANEL_MODULESDIR");
++
++  if (!modules_dir) {
++    g_warning ("The NIX_GNOME_PANEL_MODULESDIR environment variable was not set, modules will not be loaded.");
++    return;
++  }
++
++  dir = g_dir_open (modules_dir, 0, NULL);
+   if (!dir)
+     return;
+ 
+@@ -63,7 +71,7 @@ load_modules (GpModuleManager *self)
+       if (!g_str_has_suffix (name, ".so"))
+         continue;
+ 
+-      path = g_build_filename (MODULESDIR, name, NULL);
++      path = g_build_filename (modules_dir, name, NULL);
+       module = gp_module_new_from_path (path);
+       g_free (path);
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes: https://github.com/NixOS/nixpkgs/issues/67545

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
