### PR TITLE
Aarch64 darwin eval

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -6,6 +6,8 @@
 , setJavaClassPath
 }:
 
+assert (stdenv.isDarwin && stdenv.isx86_64);
+
 let cpuName = stdenv.hostPlatform.parsed.cpu.name;
     result = stdenv.mkDerivation {
   name = if sourcePerArch.packageType == "jdk"

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -2,6 +2,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, enablePolly ? false
 }:
 
 let
@@ -39,7 +40,11 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals enablePolly [
+      "-DWITH_POLLY=ON"
+      "-DLINK_POLLY_INTO_TOOLS=ON"
     ];
+
 
     patches = [
       ./purity.patch

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -68,16 +68,30 @@ let
     # we need to reintroduce `outputUnspecified` to get the expected behavior e.g. of lib.get*
     llvm = tools.libllvm.out // { outputUnspecified = true; };
 
+    libllvm-polly = callPackage ./llvm {
+      inherit llvm_meta;
+      enablePolly = true;
+    };
+
+    llvm-polly = tools.libllvm-polly.lib // { outputUnspecified = true; };
+
     libclang = callPackage ./clang {
       inherit clang-tools-extra_src llvm_meta;
     };
 
     clang-unwrapped = tools.libclang.out // { outputUnspecified = true; };
-    # disabled until recommonmark supports sphinx 3
-    #Llvm-manpages = lowPrio (tools.libllvm.override {
-    #  enableManpages = true;
-    #  python3 = pkgs.python3;  # don't use python-boot
-    #});
+
+    clang-polly-unwrapped = callPackage ./clang {
+      inherit llvm_meta;
+      inherit clang-tools-extra_src;
+      libllvm = tools.libllvm-polly;
+      enablePolly = true;
+    };
+
+    llvm-manpages = lowPrio (tools.libllvm.override {
+      enableManpages = true;
+      python3 = pkgs.python3;  # don't use python-boot
+    });
 
     clang-manpages = lowPrio (tools.libclang.override {
       enableManpages = true;

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -1,5 +1,23 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
 let
+  # Details from https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "11.48.21";
+      jdkVersion = "11.0.11";
+      sha256 = "0v0n7h7i04pvna41wpdq2k9qiy70sbbqzqzvazfdvgm3gb22asw6";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "11.48.21";
+      jdkVersion = "11.0.11";
+      sha256 = "066whglrxx81c95grv2kxdbvyh32728ixhml2v44ildh549n4lhc";
+    };
+  }."${stdenv.hostPlatform.system}";
+
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
     url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
@@ -7,16 +25,16 @@ let
   };
 
   jdk = stdenv.mkDerivation rec {
-    name = "zulu11.43.21-ca-jdk11.0.9";
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/${name}-macosx_x64.tar.gz";
-      sha256 = "1j19fb5mwdkfn6y8wfsnvxsz6wfpcab4xv439fqssxy520n6q4zs";
-      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-mac/";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -40,8 +58,6 @@ let
       # properly.
       mkdir -p $out/nix-support
       printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
-
-      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -1,25 +1,43 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
 let
+  # Details from https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "8.54.0.21";
+      jdkVersion = "8.0.292";
+      sha256 = "1pgl0bir4r5v349gkxk54k6v62w241q7vw4gjxhv2g6pfq6hv7in";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "8.54.0.21";
+      jdkVersion = "8.0.292";
+      sha256 = "05w89wfjlfbpqfjnv6wisxmaf13qb28b2223f9264jyx30qszw1c";
+    };
+  }."${stdenv.hostPlatform.system}";
+
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
     url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 
-  jdk = stdenv.mkDerivation {
+  jdk = stdenv.mkDerivation rec {
     # @hlolli: Later version than 1.8.0_202 throws error when building jvmci.
     # dyld: lazy symbol binding failed: Symbol not found: _JVM_BeforeHalt
     # Referenced from: ../libjava.dylib Expected in: .../libjvm.dylib
-    name = "zulu1.8.0_202-8.36.0.1";
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-macosx_x64.zip";
-      sha256 = "0s92l1wlf02vjx8dvrsla2kq7qwxnmgh325b38mgqy872016jm9p";
-      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -43,8 +61,6 @@ let
       # properly.
       mkdir -p $out/nix-support
       printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
-
-      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/openjdk/darwin/default.nix
+++ b/pkgs/development/compilers/openjdk/darwin/default.nix
@@ -1,5 +1,23 @@
-{ lib, stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
 let
+  # Details from https://www.azul.com/downloads/?version=java-16-sts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "16.30.15";
+      jdkVersion = "16.0.1";
+      sha256 = "1jihn125dmxr9y5h9jq89zywm3z6rbwv5q7msfzsf2wzrr13jh0z";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "16.30.19";
+      jdkVersion = "16.0.1";
+      sha256 = "1i0bcjx3acb5dhslf6cabdcnd6mrz9728vxw9hb4al5y3f5fll4w";
+    };
+  }."${stdenv.hostPlatform.system}";
+
   jce-policies = fetchurl {
     # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
     url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
@@ -7,17 +25,16 @@ let
   };
 
   jdk = stdenv.mkDerivation rec {
-    pname = "zulu16.28.11-ca-jdk";
-    version = "16.0.0";
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/${pname}${version}-macosx_x64.tar.gz";
-      sha256 = "6d47ef22dc56ce1f5a102ed39e21d9a97320f0bb786818e2c686393109d79bc5";
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -41,8 +58,6 @@ let
       # properly.
       mkdir -p $out/nix-support
       printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
-
-      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -119,6 +119,20 @@ in rec {
       '';
     };
 
+    sandbox = stdenv.mkDerivation {
+      name = "apple-lib-sandbox";
+
+      dontUnpack = true;
+      dontBuild = true;
+
+      installPhase = ''
+        mkdir -p $out/include $out/lib
+        ln -s "${MacOSX-SDK}/usr/include/sandbox.h" $out/include/sandbox.h
+        cp "${MacOSX-SDK}/usr/lib/libsandbox.1.tbd" $out/lib
+        ln -s libsandbox.1.tbd $out/lib/libsandbox.tbd
+      '';
+    };
+
     libDER = stdenv.mkDerivation {
       name = "apple-lib-libDER";
       dontUnpack = true;
@@ -133,6 +147,10 @@ in rec {
     CoreFoundation = lib.overrideDerivation super.CoreFoundation (drv: {
       setupHook = ./cf-setup-hook.sh;
     });
+
+    # This framework doesn't exist in newer SDKs (somewhere around 10.13), but
+    # there are references to it in nixpkgs.
+    QuickTime = throw "QuickTime framework not available";
   };
 
   bareFrameworks = (

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/private-frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/private-frameworks.nix
@@ -14,4 +14,5 @@
   URLFormatting = {};
   SignpostMetrics = {};
   PassKitCore = {};
+  SkyLight = {};
 }

--- a/pkgs/servers/irc/inspircd/default.nix
+++ b/pkgs/servers/irc/inspircd/default.nix
@@ -23,7 +23,7 @@ let
   # checking, only whitelist licenses used by notable
   # libcs in nixpkgs (musl and glibc).
   compatible = lib: drv:
-    lib.any (lic: lic == drv.meta.license) [
+    lib.any (lic: lic == (drv.meta.license or {})) [
       lib.licenses.mit        # musl
       lib.licenses.lgpl2Plus  # glibc
     ];

--- a/pkgs/tools/networking/acme-client/default.nix
+++ b/pkgs/tools/networking/acme-client/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchurl
-, apple_sdk ? null
 , libbsd
 , libressl
 , pkg-config
@@ -18,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libbsd libressl ] ++ optional stdenv.isDarwin apple_sdk.sdk;
+  buildInputs = [ libbsd libressl ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -786,7 +786,7 @@ in
 
   aescrypt = callPackage ../tools/misc/aescrypt { };
 
-  acme-client = callPackage ../tools/networking/acme-client { inherit (darwin) apple_sdk; stdenv = gccStdenv; };
+  acme-client = callPackage ../tools/networking/acme-client { stdenv = gccStdenv; };
 
   amass = callPackage ../tools/networking/amass { };
 


### PR DESCRIPTION
Fixes required for `nix-build pkgs/top-level/release.nix -A tarball` to pass when using aarch64-darwin as supported platform.