### PR TITLE
zstd: patch test flakiness on i686

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, bash, gnugrep
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, bash, gnugrep
 , fixDarwinDylibNames
 , file
 , legacySupport ? false
@@ -24,7 +24,13 @@ stdenv.mkDerivation rec {
     # This patches makes sure we do not attempt to use the MD5 implementation
     # of the host platform when running the tests
     ./playtests-darwin.patch
-  ];
+  ] ++ lib.optional stdenv.is32bit
+    (fetchpatch { # https://github.com/facebook/zstd/pull/2606
+      name = "test-memory-usage.diff";
+      url = "https://github.com/facebook/zstd/commit/6f40571a.diff";
+      sha256 = "1484k5b99wplv9vjvvxjn88l13hlay6bynhq3zh1nd34whyi1kd0";
+    });
+
 
   postPatch = lib.optionalString (!static) ''
     substituteInPlace build/cmake/CMakeLists.txt \


### PR DESCRIPTION
https://hydra.nixos.org/build/143933617/nixlog/246/tail
The last attempt I see on 21.05 has failed:
https://hydra.nixos.org/build/144447049#tabs-buildsteps

- - -
NixPkgs master is going for the major update that contains the patch already (1.5.0).

This is a channel blocker, though trying multiple attempts should work around it, as not every machine is configured with so many --cores.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] N/A macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
