### PR TITLE
deltachat-cursed: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/deltachat-cursed/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-cursed/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, python3
+, fetchFromGitHub
+, wrapGAppsHook
+, gobject-introspection
+, libnotify
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "deltachat-cursed";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "adbenitez";
+    repo = "deltachat-cursed";
+    rev = "v${version}";
+    sha256 = "0kbb7lh17dbkd85mcqf438qwk5masz2fxsy8ljdh23kis55nksh8";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    libnotify
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    deltachat
+    pygobject3
+    urwid-readline
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  doCheck = false; # no tests implemented
+
+  meta = with lib; {
+    description = "Lightweight Delta Chat client";
+    homepage = "https://github.com/adbenitez/deltachat-cursed";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1398,6 +1398,8 @@ in
 
   cyclonedx-python = callPackage ../tools/misc/cyclonedx-python { };
 
+  deltachat-cursed = callPackage ../applications/networking/instant-messengers/deltachat-cursed { };
+
   deltachat-electron = callPackage
     ../applications/networking/instant-messengers/deltachat-electron { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @adbenitez