### PR TITLE
python3Packages.hap-python: 3.4.1 -> 3.5.0

### DIFF
--- a/pkgs/development/python-modules/hap-python/default.nix
+++ b/pkgs/development/python-modules/hap-python/default.nix
@@ -16,16 +16,16 @@
 }:
 
 buildPythonPackage rec {
-  pname = "HAP-python";
-  version = "3.4.1";
+  pname = "hap-python";
+  version = "3.5.0";
   disabled = pythonOlder "3.5";
 
   # pypi package does not include tests
   src = fetchFromGitHub {
     owner = "ikalchev";
-    repo = pname;
+    repo = "HAP-python";
     rev = "v${version}";
-    sha256 = "sha256-tZ6Zwlx5J62Xqpxxmt8Phdd9ngtKYhP/p3uor1dRfK8=";
+    sha256 = "1vzlfx0gpidl0rzv4z94pziwm6rj4lrilly5pykgq984y708pcqf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -36,4 +36,5 @@ mapAliases ({
   smart_open = smart-open; # added 2021-03-14
   google_api_python_client = google-api-python-client; # added 2021-03-19
   googleapis_common_protos = googleapis-common-protos; # added 2021-03-19
+  HAP-python = hap-python; # added 2021-06-01
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3075,7 +3075,7 @@ in {
 
   handout = callPackage ../development/python-modules/handout { };
 
-  HAP-python = callPackage ../development/python-modules/HAP-python { };
+  hap-python = callPackage ../development/python-modules/hap-python { };
 
   hass-nabucasa = callPackage ../development/python-modules/hass-nabucasa { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.5.0

Change log: https://github.com/ikalchev/HAP-python/compare/v3.4.1...v3.5.0

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51261
- Target Home Assistant release: 2021.6.0

Package was renamed acc. PEP-508.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
