### PR TITLE
unit: 1.22.0 -> 1.24.0

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -30,14 +30,14 @@ let
   php74-unit = php74.override phpConfig;
 
 in stdenv.mkDerivation rec {
-  version = "1.22.0";
+  version = "1.24.0";
   pname = "unit";
 
   src = fetchFromGitHub {
     owner = "nginx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-M5Q8sxI1nZi8+ixO1PHuQpQ81EwyLAsnBI5PTtm+bKA=";
+    sha256 = "0214dvwz31hxjxnqk3fkqhn2xznaqdrb96m5s2k8ll8rldmk1gd6";
   };
 
   nativeBuildInputs = [ which ];


### PR DESCRIPTION
###### Motivation for this change
Update unit to version 1.24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
