### PR TITLE
xtl: init at 0.7.2

### DIFF
--- a/pkgs/development/libraries/xtl/default.nix
+++ b/pkgs/development/libraries/xtl/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+}:
+stdenv.mkDerivation rec {
+  pname = "xtl";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "xtensor-stack";
+    repo = "xtl";
+    rev = version;
+    sha256 = "177ym67sz544wdylksfkkpi6bqn34kagycfnb3cv0nkmpipqj9lg";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DBUILD_TESTS=ON" ];
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+  checkTarget = "xtest";
+
+  meta = with lib; {
+    description = "Basic tools (containers, algorithms) used by other quantstack packages";
+    homepage = "https://github.com/xtensor-stack/xtl";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cpcloud ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18561,6 +18561,8 @@ in
 
   xsimd = callPackage ../development/libraries/xsimd { };
 
+  xtl = callPackage ../development/libraries/xtl { };
+
   xvidcore = callPackage ../development/libraries/xvidcore { };
 
   xxHash = callPackage ../development/libraries/xxHash {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change adds the `xtl` package to nixpkgs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
