### PR TITLE
pferd: init at 3.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -64,6 +64,16 @@
       fingerprint = "F466 A548 AD3F C1F1 8C88  4576 8702 7528 B006 D66D";
     }];
   };
+  _0xbe7a = {
+    email = "nix@be7a.de";
+    name = "Bela Stoyan";
+    github = "0xbe7a";
+    githubId = 6232980;
+    keys = [{
+      longkeyid = "rsa4096/0x6510870A77F49A99";
+      fingerprint = "2536 9E86 1AA5 9EB7 4C47  B138 6510 870A 77F4 9A99";
+    }];
+  };
   _1000101 = {
     email = "b1000101@pm.me";
     github = "1000101";

--- a/pkgs/tools/misc/pferd/default.nix
+++ b/pkgs/tools/misc/pferd/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pferd";
+  version = "3.0.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "Garmelon";
+    repo = "PFERD";
+    rev = "v${version}";
+    sha256 = "1s0z8yajy3n194pnlqb48hy2n5qvhkzwbpksrdyds79vfq0b9rdl";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    aiohttp
+    beautifulsoup4
+    rich
+    keyring
+    certifi
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Garmelon/PFERD";
+    description = "Tool for downloading course-related files from ILIAS";
+    license = licenses.mit;
+    maintainers = with maintainers; [ _0xbe7a ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -860,6 +860,8 @@ in
 
   metapixel = callPackage ../tools/graphics/metapixel { };
 
+  pferd = callPackage ../tools/misc/pferd {};
+
   quich = callPackage ../tools/misc/quich { } ;
 
   tfk8s = callPackage ../tools/misc/tfk8s { };


### PR DESCRIPTION
###### Motivation for this change

A tool for downloading course-related files from ILIAS, a widely used e-learning platform at German universities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
