### PR TITLE
[20.09] python3Packages.starlette: fix build

### DIFF
--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , aiofiles
 , graphene
 , itsdangerous
@@ -30,6 +31,16 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "11i0yd8cqwscixajl734g11vf8pghki11c81chzfh8ifmj6mf9jk";
   };
+
+  patches = [
+    # a fix for https://github.com/encode/starlette/issues/1131 exposed
+    # by newer python 3.8+ versions
+    (fetchpatch {
+      name = "dont-use-undocumented-tracebackexception-attr.patch";
+      url = "https://github.com/encode/starlette/pull/1132/commits/aa97f30c73e1c830e0952f7a97d08bc5fad03dea.patch";
+      sha256 = "0clf8l4606y1g585dg4gvx250s2djskji8jaim4s90l9xzjag8sb";
+    })
+  ];
 
   propagatedBuildInputs = [
     aiofiles


### PR DESCRIPTION
###### Motivation for this change
Our switch to python 3.8.8+ broke this, because it exposes some breakage and causes a test to fail. Documented https://github.com/encode/starlette/issues/1131 and fixed https://github.com/encode/starlette/pull/1132. Cherry pick that patch to get 20.09's `starlette` building again.

Apologies to 20.09 users for leaving this broken so long.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
