### PR TITLE
haskell: add erictapen as maintainer

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -143,6 +143,10 @@ package-maintainers:
     - vector-sized
     - vulkan
     - vulkan-utils
+  erictapen:
+    - hakyll
+    - hakyll-contrib-hyphenation
+    - webify
   Gabriel439:
     - annah
     - bench


### PR DESCRIPTION
###### Motivation for this change

@sternenseemann proposed in https://github.com/NixOS/nixpkgs/pull/125190#issuecomment-852016748 that I could become a maintainer for hakyll. So I added the packages I'm usually fixing the most.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
