### PR TITLE
sfm: init at 0.1

### DIFF
--- a/pkgs/applications/misc/sfm/default.nix
+++ b/pkgs/applications/misc/sfm/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, conf ? null }:
+
+stdenv.mkDerivation rec {
+  pname = "sfm";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "afify";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-i4WzYaJKityIt+LPWCbd6UsPBaYoaS397l5BInOXQQA=";
+  };
+
+  configFile = lib.optionalString (conf!=null) (lib.writeText "config.def.h" conf);
+
+  postPatch = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Simple file manager";
+    homepage = "https://github.com/afify/sfm";
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7223,6 +7223,8 @@ in
 
   nnn = callPackage ../applications/misc/nnn { };
 
+  sfm = callPackage ../applications/misc/sfm { };
+
   shfm = callPackage ../applications/misc/shfm { };
 
   noise-repellent = callPackage ../applications/audio/noise-repellent { };


### PR DESCRIPTION
###### Motivation for this change
[**sfm**](https://github.com/afify/sfm) is a simple file manager for unix-like systems.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
