### PR TITLE
[20.09] radare2: add patch for CVE-2021-32613

### DIFF
--- a/pkgs/development/tools/analysis/radare2/4.5.1-CVE-2021-32613.patch
+++ b/pkgs/development/tools/analysis/radare2/4.5.1-CVE-2021-32613.patch
@@ -1,0 +1,63 @@
+Based on a combination of upstream 049de62730f4954ef9a642f2eeebbca30a8eccdc
+and 5e16e2d1c9fe245e4c17005d779fde91ec0b9c05, irrelevant hunks trimmed out by ris
+to allow it to apply to 4.5.1.
+
+diff --git a/libr/bin/format/pyc/marshal.c b/libr/bin/format/pyc/marshal.c
+index d9b1b4b2f64..9897e34a1d9 100644
+--- a/libr/bin/format/pyc/marshal.c
++++ b/libr/bin/format/pyc/marshal.c
+@@ -1137,7 +1135,9 @@ static pyc_object *get_object(RBuffer *buffer) {
+ 	}
+ 
+-	if (flag) {
+-		free_object (ref_idx->data);
++	if (flag && ref_idx) {
++		if (ref_idx->data != ret) {
++			free_object (ref_idx->data);
++		}
+ 		ref_idx->data = copy_object (ret);
+ 	}
+ 	return ret;
+
+@@ -1190,10 +1190,10 @@ static bool extract_sections_symbols(pyc_object *obj, RList *sections, RList *sy
+ 	symbol->paddr = cobj->start_offset;
+ 	symbol->ordinal = symbols_ordinal++;
+ 	if (cobj->consts->type != TYPE_TUPLE && cobj->consts->type != TYPE_SMALL_TUPLE) {
+-		goto fail;
++		goto fail2;
+ 	}
+ 	if (!r_list_append (symbols, symbol)) {
+-		goto fail;
++		goto fail2;
+ 	}
+ 	r_list_foreach (((RList *)(cobj->consts->data)), i, obj) {
+ 		extract_sections_symbols (obj, sections, symbols, cobjs, prefix);
+@@ -1201,11 +1201,14 @@ static bool extract_sections_symbols(pyc_object *obj, RList *sections, RList *sy
+ 	free (prefix);
+ 	return true;
+ fail:
+-
+ 	free (section);
+ 	free (prefix);
+ 	free (symbol);
+ 	return false;
++fail2:
++	free (prefix);
++	free (symbol);
++	return false;
+ }
+ 
+ bool get_sections_symbols_from_code_objects(RBuffer *buffer, RList *sections, RList *symbols, RList *cobjs, ut32 magic) {
+diff --git a/libr/bin/p/bin_pyc.c b/libr/bin/p/bin_pyc.c
+index 556fec88d45..068dd9f1011 100644
+--- a/libr/bin/p/bin_pyc.c
++++ b/libr/bin/p/bin_pyc.c
+@@ -106,7 +106,7 @@ static RList *symbols(RBinFile *arch) {
+ 	r_list_append (shared, cobjs);
+ 	r_list_append (shared, interned_table);
+ 	arch->o->bin_obj = shared;
+-	RList *sections = r_list_newf ((RListFree)free);
++	RList *sections = r_list_newf (NULL); // (RListFree)free);
+ 	if (!sections) {
+ 		r_list_free (shared);
+ 		arch->o->bin_obj = NULL;

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -41,6 +41,10 @@ let
         inherit rev sha256;
       };
 
+      patches = [
+        ./4.5.1-CVE-2021-32613.patch
+      ];
+
       postPatch = let
         capstone = fetchFromGitHub {
           owner = "aquynh";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-32613

Notionally a backport of #125066

In the end the adjustments needed were mostly removal of irrelevant hunks in the patch. Included 5e16e2d1c9fe245e4c17005d779fde91ec0b9c05's fix while I was at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
