### PR TITLE
i-pi: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/i-pi/default.nix
+++ b/pkgs/development/python-modules/i-pi/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage, lib, fetchFromGitHub, gfortran
+, makeWrapper, numpy, pytest, mock, pytest-mock
+} :
+
+buildPythonPackage rec {
+  name = "i-pi";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "i-pi";
+    repo = "i-pi";
+    rev = "v${version}";
+    sha256 = "0d0ag57aa0fsqjwya27fyj8alimjvlxzgh6hxjqy1k4ap9h3n1cy";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [
+    pytest
+    mock
+    pytest-mock
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/i-pi \
+      --set IPI_ROOT $out
+  '';
+
+  meta = with lib; {
+    description = "A universal force engine for ab initio and force field driven (path integral) molecular dynamics";
+    license = with licenses; [ gpl3Only mit ];
+    homepage = "http://ipi-code.org/";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5842,6 +5842,8 @@ in
 
   ipget = callPackage ../applications/networking/ipget { };
 
+  i-pi = with python3Packages; toPythonApplication i-pi;
+
   iptsd = callPackage ../applications/misc/iptsd { };
 
   ipmitool = callPackage ../tools/system/ipmitool {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3406,6 +3406,8 @@ in {
 
   ipfshttpclient = callPackage ../development/python-modules/ipfshttpclient { };
 
+  i-pi = callPackage ../development/python-modules/i-pi { };
+
   iptools = callPackage ../development/python-modules/iptools { };
 
   ipy = callPackage ../development/python-modules/IPy { };


### PR DESCRIPTION
###### Motivation for this change
Adds i-PI. This is a molecular dynamics engine for quantum chemistry written python. Part of the packages @markuskowa and me want to merge from markuskowa/NixOS-QChem#56.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
