### PR TITLE
s2n-tls: split dev output to reduce Nix closure

### DIFF
--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ aws-c-cal aws-c-common s2n-tls];
+  buildInputs = [ aws-c-cal aws-c-common s2n-tls ];
   propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/s2n-tls/default.nix
+++ b/pkgs/development/libraries/s2n-tls/default.nix
@@ -13,11 +13,21 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  propagatedBuildInputs = [ openssl ]; # s2n-config has find_dependency(LibCrypto).
+  outputs = [ "out" "dev"];
+
+  buildInputs = [ openssl ]; # s2n-config has find_dependency(LibCrypto).
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ];
+
+  propagatedBuildInputs = [ openssl ]; # s2n-config has find_dependency(LibCrypto).
+
+  postInstall = ''
+    substituteInPlace $out/lib/s2n/cmake/shared/s2n-targets.cmake \
+      --replace 'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' 'INTERFACE_INCLUDE_DIRECTORIES ""'
+  '';
 
   meta = with lib; {
     description = "C99 implementation of the TLS/SSL protocols";


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/120948

Before:

```
$ du -shc $(nix-store -qR $(nix-build -A nixUnstable)) | tail -n1
141M	total
```

After:

```
$ du -shc $(nix-store -qR $(nix-build -A nixUnstable)) | tail -n1
81M	total
```