### PR TITLE
kubebuilder: init at 3.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1907,6 +1907,16 @@
     githubId = 3392199;
     name = "Calum MacRae";
   };
+  cmars = {
+    email = "nix@cmars.tech";
+    github = "cmars";
+    githubId = 23741;
+    name = "Casey Marshall";
+    keys = [{
+      longkeyid = "rsa3072/0x6DEC2758ACD5A973";
+      fingerprint = "6B78 7E5F B493 FA4F D009  5D10 6DEC 2758 ACD5 A973";
+    }];
+  };
   cmcdragonkai = {
     email = "roger.qiu@matrix.ai";
     github = "cmcdragonkai";

--- a/pkgs/applications/networking/cluster/kubebuilder/default.nix
+++ b/pkgs/applications/networking/cluster/kubebuilder/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, git
+, go
+}:
+
+buildGoModule rec {
+  pname = "kubebuilder";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "kubebuilder";
+    rev = "v${version}";
+    sha256 = "1726j2b5jyvllvnk60g6px3g2jyyphd9pc4vgid45mis9b60sh8a";
+  };
+  vendorSha256 = "0zxyd950ksjswja64rfri5v2yaalfg6qmq8215ildgrcavl9974n";
+
+  subPackages = ["cmd" "pkg/..."];
+
+  preBuild = ''
+    export buildFlagsArray+=("-ldflags=-X main.kubeBuilderVersion=v${version} \
+        -X main.goos=$GOOS \
+        -X main.goarch=$GOARCH \
+        -X main.gitCommit=v${version} \
+        -X main.buildDate=v${version}")
+  '';
+
+  doCheck = true;
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/kubebuilder
+    wrapProgram $out/bin/kubebuilder \
+      --prefix PATH : ${lib.makeBinPath [ go ]}
+  '';
+
+  allowGoReference = true;
+  nativeBuildInputs = [ makeWrapper git ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kubernetes-sigs/kubebuilder";
+    description = "SDK for building Kubernetes APIs using CRDs";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cmars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24780,6 +24780,8 @@ in
 
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
+  kubebuilder = callPackage ../applications/networking/cluster/kubebuilder { };
+
   kuttl = callPackage ../applications/networking/cluster/kuttl {
     buildGoModule = buildGo115Module;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
kubebuilder is a common tool used for developing Kubernetes controllers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
