### PR TITLE
songrec: init at 0.1.8

### DIFF
--- a/pkgs/applications/audio/songrec/default.nix
+++ b/pkgs/applications/audio/songrec/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, gtk3
+, openssl
+, alsaLib
+, pkg-config
+, ffmpeg
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "songrec";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "marin-m";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-6siGLegNgvLdP7engwpKmhzWYqBXcMsfaXhJJ1tIqJg=";
+  };
+
+  cargoSha256 = "sha256-H4qJYcFjip71EVTGw50goj0HjKN9fmjQZqQDhaSKlaQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ alsaLib gtk3 openssl ffmpeg ];
+
+  meta = with lib; {
+    description = "An open-source Shazam client for Linux, written in Rust";
+    homepage = "https://github.com/marin-m/SongRec";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tcbravo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25486,6 +25486,8 @@ in
 
   softmaker-office = callPackage ../applications/office/softmaker/softmaker_office.nix {};
 
+  songrec = callPackage ../applications/audio/songrec {};
+
   spacegun = callPackage ../applications/networking/cluster/spacegun {};
 
   stride = callPackage ../applications/networking/instant-messengers/stride { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [SongRec](https://github.com/marin-m/SongRec). This is a GTK+ client for [Shazam](https://www.shazam.com/) (music identification service).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
