### PR TITLE
moonlight-qt: add wayland to enable hardware accelerated video decode

### DIFF
--- a/pkgs/applications/misc/moonlight-qt/default.nix
+++ b/pkgs/applications/misc/moonlight-qt/default.nix
@@ -15,6 +15,7 @@
 , openssl
 , libopus
 , ffmpeg
+, wayland
 }:
 
 stdenv.mkDerivation rec {
@@ -47,6 +48,7 @@ stdenv.mkDerivation rec {
     openssl
     libopus
     ffmpeg
+    wayland
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wanted to try out moonlight under sway and was greeted with:

![image](https://user-images.githubusercontent.com/327488/120352121-c0620e00-c300-11eb-9b66-1f8e8f0bbf10.png)

Before:

```
00:00:00 - SDL Info (0): Compiled with SDL 2.0.14
00:00:00 - SDL Info (0): Running with SDL 2.0.14
00:00:00 - Qt Info: No translation available for  "en_US"
00:00:00 - SDL Info (0): Detected Wayland
00:00:00 - Qt Warning: qrc:/gui/main.qml:12:1: QML ApplicationWindow: ToolTip must be attached to an Item
00:00:00 - Qt Info: Found "gamecontrollerdb.txt" at "/home/johannes/.cache/Moonlight Game Streaming Project/Moonlight/gamecontrollerdb.txt"
00:00:00 - SDL Info (0): Loaded 128 new gamepad mappings
00:00:00 - SDL Info (0): V-sync enabled
00:00:00 - SDL Error (0): Moonlight not compiled with VAAPI Wayland support!
00:00:00 - SDL Error (0): Moonlight not compiled with VAAPI Wayland support!
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb1409ac80] VDPAU device creation on X11 display :0 failed.
00:00:00 - SDL Info (0): Trying fallback VDPAU driver paths
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140957c0] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140995c0] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb1400cc80] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140abbc0] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb1409ad40] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb14092f80] VDPAU device creation on X11 display :0 failed.
00:00:00 - SDL Error (0): Failed to create VDPAU context: -1313558101
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140ac440] VDPAU device creation on X11 display :0 failed.
00:00:00 - SDL Info (0): Trying fallback VDPAU driver paths
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140d1c80] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140b3bc0] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140af300] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140af340] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb1400ca80] VDPAU device creation on X11 display :0 failed.
Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7ffb140ac580] VDPAU device creation on X11 display :0 failed.
00:00:00 - SDL Error (0): Failed to create VDPAU context: -1313558101
00:00:00 - SDL Info (0): Using SDL renderer
```

After:

```
00:00:00 - SDL Info (0): Compiled with SDL 2.0.14
00:00:00 - SDL Info (0): Running with SDL 2.0.14
00:00:00 - Qt Info: No translation available for  "en_US"
00:00:00 - SDL Info (0): Detected Wayland
00:00:00 - Qt Warning: qrc:/gui/main.qml:12:1: QML ApplicationWindow: ToolTip must be attached to an Item
00:00:00 - Qt Info: Found "gamecontrollerdb.txt" at "/home/johannes/.cache/Moonlight Game Streaming Project/Moonlight/gamecontrollerdb.txt"
00:00:00 - SDL Info (0): Loaded 128 new gamepad mappings
00:00:00 - SDL Info (0): V-sync enabled
libva info: VA-API version 1.11.0
libva info: Trying to open /run/opengl-driver/lib/dri/radeonsi_drv_video.so
libva info: Found init function __vaDriverInit_1_11
libva info: va_openDriver() returns 0
00:00:00 - SDL Info (0): Initialized VAAPI 1.11
00:00:00 - SDL Info (0): Driver: Mesa Gallium driver 21.0.1 for AMD RENOIR (DRM 3.40.0, 5.11.22, LLVM 11.1.0)
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x3231564e -> nv12.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x30313050 -> p010le.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x36313050 -> unknown.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x30323449 -> yuv420p.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x32315659 -> yuv420p.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x56595559 -> unknown.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x32595559 -> yuyv422.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x59565955 -> uyvy422.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x41524742 -> bgra.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x41424752 -> rgba.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x58524742 -> bgr0.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Format 0x58424752 -> rgb0.
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] VAAPI driver: Mesa Gallium driver 21.0.1 for AMD RENOIR (DRM 3.40.0, 5.11.22, LLVM 11.1.0).
00:00:00 - FFmpeg: [AVHWDeviceContext @ 0x7f43b80d1dc0] Driver not found in known nonstandard list, using standard behaviour.
00:00:00 - SDL Info (0): VAAPI driver supports exporting DRM PRIME surface handles
00:00:00 - SDL Info (0): Using VAAPI accelerated renderer on wayland
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
