### PR TITLE
warzone2100: fix build

### DIFF
--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , cmake
 , ninja
-, zip
+, p7zip
 , pkg-config
 , asciidoctor
 , gettext
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     pkg-config
     cmake
     ninja
-    zip
+    p7zip
     asciidoctor
     gettext
     shaderc


### PR DESCRIPTION
###### Motivation for this change

I'm not sure how the build broke[1] or how it worked before, but
the problem is zip is being used in place of p7zip, which obviously
fail as the flags have different meanings.

[1]: https://hydra.nixos.org/build/143354937

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (just this one)
- [x] Tested execution of all binary files
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
