### PR TITLE
openimageio2: add giflib dependency

### DIFF
--- a/pkgs/applications/graphics/openimageio/2.x.nix
+++ b/pkgs/applications/graphics/openimageio/2.x.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , boost
 , cmake
+, giflib
 , ilmbase
 , libjpeg
 , libpng
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost
+    giflib
     ilmbase
     libjpeg
     libpng


### PR DESCRIPTION
- openimageio2: add giflib dependency

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds a `giflib` dependency to OpenImageIO, to enable reading GIFs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
