### PR TITLE
gnomeExtensions: allowAliases should default to true if unset

### DIFF
--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -62,7 +62,7 @@ in rec {
   gnomeExtensions = lib.recurseIntoAttrs (
     (mapReadableNames (produceExtensionsList "40"))
     // (callPackage ./manuallyPackaged.nix {})
-    // lib.optionalAttrs (config.allowAliases or false) {
+    // lib.optionalAttrs (config.allowAliases or true) {
       unite-shell = gnomeExtensions.unite; # added 2021-01-19
       arc-menu = gnomeExtensions.arcmenu; # added 2021-02-14
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make this use of `config.allowAliases` consistent with every other use in the tree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
