### PR TITLE
zabbix.agent2: create a symlink which is compatible with the zabbixAg…

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -46,8 +46,13 @@ import ./versions.nix ({ version, sha256 }:
     '';
 
     installPhase = ''
+      mkdir -p $out/sbin
+
       install -Dm0644 src/go/conf/zabbix_agent2.conf $out/etc/zabbix_agent2.conf
       install -Dm0755 src/go/bin/zabbix_agent2 $out/bin/zabbix_agent2
+
+      # create a symlink which is compatible with the zabbixAgent module
+      ln -s $out/bin/zabbix_agent2 $out/sbin/zabbix_agentd
     '';
 
     meta = with lib; {


### PR DESCRIPTION
…ent module

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
After updating to `21.05` I noticed there was an issue with the `zabbix.agent2` package when combined with our `services.zabbixAgent` module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
