### PR TITLE
mvapich: init at 2.3.6

### DIFF
--- a/pkgs/development/libraries/mvapich/default.nix
+++ b/pkgs/development/libraries/mvapich/default.nix
@@ -1,0 +1,73 @@
+{ lib, stdenv, fetchurl, pkg-config, bison, numactl, libxml2
+, perl, gfortran, slurm, openssh, hwloc, zlib, makeWrapper
+# InfiniBand dependencies
+, opensm, rdma-core
+# OmniPath dependencies
+, libpsm2, libfabric
+# Compile with slurm as a process manager
+, useSlurm ? false
+# Network type for MVAPICH2
+, network ? "ethernet"
+} :
+
+assert builtins.elem network [ "ethernet" "infiniband" "omnipath" ];
+
+stdenv.mkDerivation rec {
+  pname = "mvapich";
+  version = "2.3.6";
+
+  src = fetchurl {
+    url = "http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-${version}.tar.gz";
+    sha256 = "0jd28vy9ivl3rcpkxmhw73b6krzm0pd9jps8asw92wa00lm2z9mk";
+  };
+
+  nativeBuildInputs = [ pkg-config bison makeWrapper ];
+  propagatedBuildInputs = [ numactl rdma-core zlib opensm ];
+  buildInputs = with lib; [
+    numactl
+    libxml2
+    perl
+    gfortran
+    openssh
+    hwloc
+  ] ++ optionals (network == "infiniband") [ rdma-core opensm ]
+    ++ optionals (network == "omnipath") [ libpsm2 libfabric ]
+    ++ optional useSlurm slurm;
+
+  configureFlags = with lib; [
+    "--with-pm=hydra"
+    "--enable-fortran=all"
+    "--enable-cxx"
+    "--enable-threads=multiple"
+    "--enable-hybrid"
+    "--enable-shared"
+  ] ++ optional useSlurm "--with-pm=slurm"
+    ++ optional (network == "ethernet") "--with-device=ch3:sock"
+    ++ optionals (network == "infiniband") [ "--with-device=ch3:mrail" "--with-rdma=gen2" ]
+    ++ optionals (network == "omnipath") ["--with-device=ch3:psm" "--with-psm2=${libpsm2}"];
+
+  doCheck = true;
+
+  preFixup = ''
+    # /tmp/nix-build... ends up in the RPATH, fix it manually
+    for entry in $out/bin/mpichversion $out/bin/mpivars; do
+      echo "fix rpath: $entry"
+      patchelf --set-rpath "$out/lib" $entry
+    done
+
+    # Ensure the default compilers are the ones mvapich was built with
+    substituteInPlace $out/bin/mpicc --replace 'CC="gcc"' 'CC=${stdenv.cc}/bin/gcc'
+    substituteInPlace $out/bin/mpicxx --replace 'CXX="g++"' 'CC=${stdenv.cc}/bin/g++'
+    substituteInPlace $out/bin/mpifort --replace 'FC="gfortran"' 'CC=${gfortran}/bin/gfortran'
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "MPI-3.1 implementation optimized for Infiband transport";
+    homepage = "https://mvapich.cse.ohio-state.edu";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17135,6 +17135,8 @@ in
 
   mutest = callPackage ../development/libraries/mutest { };
 
+  mvapich = callPackage ../development/libraries/mvapich { };
+
   mygpoclient = pythonPackages.mygpoclient;
 
   mygui = callPackage ../development/libraries/mygui {


### PR DESCRIPTION
###### Motivation for this change
Another MPI implementation optimized for Infiniband networks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
