### PR TITLE
kiln: init at 0.2.1

### DIFF
--- a/pkgs/applications/misc/kiln/default.nix
+++ b/pkgs/applications/misc/kiln/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromSourcehut, scdoc }:
+
+buildGoModule rec {
+  pname = "kiln";
+  version = "0.2.1";
+
+  src = fetchFromSourcehut {
+    owner = "~adnano";
+    repo = pname;
+    rev = version;
+    hash = "sha256-c6ed62Nn++qw+U/DCiYeGwF77YsBxexWKZ7UQ3LE4fI=";
+  };
+
+  nativeBuildInputs = [ scdoc ];
+
+  vendorSha256 = "sha256-bMpzebwbVHAbBtw0uuGyWd4wnM9z6tlsEQN4S/iucgk=";
+
+  installPhase = ''
+    runHook preInstall
+    make PREFIX=$out install
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple static site generator for Gemini";
+    homepage = "https://git.sr.ht/~adnano/kiln";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25077,6 +25077,8 @@ in
 
   kile-wl = callPackage ../applications/misc/kile-wl { };
 
+  kiln = callPackage ../applications/misc/kiln { };
+
   kubernetes-helm = callPackage ../applications/networking/cluster/helm { };
 
   wrapHelm = callPackage ../applications/networking/cluster/helm/wrapper.nix { };


### PR DESCRIPTION
###### Motivation for this change
[**kiln**](https://git.sr.ht/~adnano/kiln) is a simple static site generator for Gemini.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
