### PR TITLE
remove solson as maintainer

### DIFF
--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    maintainers = with maintainers; [ solson ];
+    maintainers = [];
     description = "MIDI libraries for Qt5/C++";
     homepage = "http://drumstick.sourceforge.net/";
     license = licenses.gpl2Plus;

--- a/pkgs/development/tools/cue/default.nix
+++ b/pkgs/development/tools/cue/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   meta = {
     description = "A data constraint language which aims to simplify tasks involving defining and using data";
     homepage = "https://cuelang.org/";
-    maintainers = with lib.maintainers; [ solson ];
+    maintainers = [];
     license = lib.licenses.asl20;
   };
 }


### PR DESCRIPTION
I don't actively use either of these packages. I kept myself in the maintainers list because I expect to maintain new packages in the future.