### PR TITLE
mpvScripts.youtube-quality: init at unstable-2020-02-11

### DIFF
--- a/pkgs/applications/video/mpv/scripts/youtube-quality.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-quality.nix
@@ -21,13 +21,9 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/share/mpv/scripts
     cp youtube-quality.lua $out/share/mpv/scripts
-  ''
-  + lib.optionalString oscSupport
-    ''
-      cp youtube-quality-osc.lua $out/share/mpv/scripts
-    ''
-  +
-  ''
+  '' + lib.optionalString oscSupport ''
+    cp youtube-quality-osc.lua $out/share/mpv/scripts
+  '' + ''
     runHook postInstall
   '';
 

--- a/pkgs/applications/video/mpv/scripts/youtube-quality.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-quality.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, oscSupport ? false
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mpv-playlistmanager";
+  version = "unstable-2020-02-11";
+
+  src = fetchFromGitHub {
+    owner = "jgreco";
+    repo = "mpv-youtube-quality";
+    rev = "1f8c31457459ffc28cd1c3f3c2235a53efad7148";
+    sha256 = "voNP8tCwCv8QnAZOPC9gqHRV/7jgCAE63VKBd/1s5ic=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/mpv/scripts
+    cp youtube-quality.lua $out/share/mpv/scripts
+  ''
+  + lib.optionalString oscSupport
+    ''
+      cp youtube-quality-osc.lua $out/share/mpv/scripts
+    ''
+  +
+  ''
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "youtube-quality.lua";
+
+  meta = with lib; {
+    description = "A userscript for MPV that allows you to change youtube video quality (ytdl-format) on the fly";
+    homepage = "https://github.com/jgreco/mpv-youtube-quality";
+    license = licenses.unfree;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ lunik1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25193,6 +25193,7 @@ in
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
     thumbnail = callPackage ../applications/video/mpv/scripts/thumbnail.nix { };
+    youtube-quality = callPackage ../applications/video/mpv/scripts/youtube-quality.nix { };
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the youtube-quality mpv lua script.

License is set to unfree as there is no upstream license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).