### PR TITLE
nixos/wireless: make wireless.interfaces mandatory

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -194,6 +194,15 @@
   <itemizedlist>
    <listitem>
     <para>
+     Enabling wireless networking now requires specifying at least one network
+     interface using <xref linkend="opt-networking.wireless.interfaces"/>.
+     This is to avoid a race condition with the card initialisation (see
+     <link xlink:href="https://github.com/NixOS/nixpkgs/issues/101963">issue
+     #101963</link> for more information).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      If you are using <option>services.udev.extraRules</option> to assign
      custom names to network interfaces, this may stop working due to a change
      in the initialisation of dhcpcd and systemd networkd. To avoid this, either


### PR DESCRIPTION
###### Motivation for this change

This is the only way to solve issue #101963, for now.

###### Things done

- [x] Tested in 21.05
- [x] Built manual 
- [x] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
