### PR TITLE
botamusique: unstable-2021-05-19 -> unstable-2021-06-01

### DIFF
--- a/pkgs/tools/audio/botamusique/node-packages.nix
+++ b/pkgs/tools/audio/botamusique/node-packages.nix
@@ -4527,7 +4527,7 @@ let
     name = "botamusique";
     packageName = "botamusique";
     version = "0.0.0";
-    src = ../../../../../../../../../tmp/tmp.hWY9btrx5g;
+    src = ../../../../../../../../../tmp/tmp.UAoivnXH3n;
     dependencies = [
       sources."@babel/code-frame-7.10.4"
       sources."@babel/compat-data-7.12.7"

--- a/pkgs/tools/audio/botamusique/src.json
+++ b/pkgs/tools/audio/botamusique/src.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/azlux/botamusique",
-  "rev": "33a9e75ba9d0a382f7a76d23a0ceb626924a8b49",
-  "date": "2021-05-19T22:37:39+08:00",
-  "path": "/nix/store/dqc2vjd43cixm49w8g66wvi9zmdfwsdd-botamusique",
-  "sha256": "18lbgslx9vdwd5nrbkqfjvzaikp2swvv375v9gql7cg8p46w7i11",
+  "rev": "ba02cdebf2e175dc371995361eafcb88ad2c1b52",
+  "date": "2021-06-01T23:39:44+02:00",
+  "path": "/nix/store/dp5vnj7zqv1sp1ab5xycvvqdpia9xb71-botamusique",
+  "sha256": "01d51y6h38hs4ynjgz050ryy14sp5y2c3n7f80mcv0a4ls8413qp",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes
- streaming from mpd http streams
- race conditions while editing the playlist

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
