### PR TITLE
nixos/fcitx5: autostart with xserver

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -6,28 +6,33 @@ let
   im = config.i18n.inputMethod;
   cfg = im.fcitx5;
   fcitx5Package = pkgs.fcitx5-with-addons.override { inherit (cfg) addons; };
-in
-  {
-    options = {
-      i18n.inputMethod.fcitx5 = {
-        addons = mkOption {
-          type = with types; listOf package;
-          default = [];
-          example = with pkgs; [ fcitx5-rime ];
-          description = ''
-            Enabled Fcitx5 addons.
-          '';
-        };
+in {
+  options = {
+    i18n.inputMethod.fcitx5 = {
+      addons = mkOption {
+        type = with types; listOf package;
+        default = [];
+        example = with pkgs; [ fcitx5-rime ];
+        description = ''
+          Enabled Fcitx5 addons.
+        '';
       };
     };
+  };
 
-    config = mkIf (im.enabled == "fcitx5") {
-      i18n.inputMethod.package = fcitx5Package;
+  config = mkIf (im.enabled == "fcitx5") {
+    i18n.inputMethod.package = fcitx5Package;
 
-      environment.variables = {
-        GTK_IM_MODULE = "fcitx";
-        QT_IM_MODULE = "fcitx";
-        XMODIFIERS = "@im=fcitx";
-      };
+    environment.variables = {
+      GTK_IM_MODULE = "fcitx";
+      QT_IM_MODULE = "fcitx";
+      XMODIFIERS = "@im=fcitx";
     };
-  }
+
+    systemd.user.services.fcitx5-daemon = {
+      enable = true;
+      script = "${fcitx5Package}/bin/fcitx5";
+      wantedBy = [ "graphical-session.target" ];
+    };
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently, fcitx5 cannot autostart like fcitx on nixos.  This update is like to [fcitx module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/i18n/input-method/fcitx.nix#L41).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
