### PR TITLE
[staging] unbound: remove references to compile-time dependencies in outputs

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -59,6 +59,13 @@ stdenv.mkDerivation rec {
     "--with-libnghttp2=${libnghttp2.dev}"
   ];
 
+  # Remove references to compile-time dependencies that are included in the configure flags
+  postConfigure = let
+    inherit (builtins) storeDir;
+  in ''
+    sed -E '/CONFCMDLINE/ s;${storeDir}/[a-z0-9]{32}-;${storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-;g' -i config.h
+  '';
+
   installFlags = [ "configfile=\${out}/etc/unbound/unbound.conf" ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Previously unbound dev dependencies would leak into the unbound binary
through the embedded configure flags string in the binary.

Before this commit `unbound -V` would list something like this:

> Version 1.13.1
> Configure line: --disable-static --prefix=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1 --bindir=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1/bin --sbindir=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1/sbin --includedir=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1/include --oldincludedir=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1/include --mandir=/nix/store/n4kgsi87dxjm2ifpllh31grfcg7q3n8x-unbound-1.13.1-man/share/man --infodir=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1/share/info --docdir=/nix/store/1892sms7ciiki99jra4qhmwysaipv1qz-unbound-1.13.1/share/doc/unbound --libdir=/nix/store/ncpggv4bmdh22y6108qrdvnid6rqamlz-unbound-1.13.1-lib/lib --libexecdir=/nix/store/ncpggv4bmdh22y6108qrdvnid6rqamlz-unbound-1.13.1-lib/libexec --localedir=/nix/store/ncpggv4bmdh22y6108qrdvnid6rqamlz-unbound-1.13.1-lib/share/locale --with-ssl=/nix/store/dndqy1r8h0kcnd55895czs8lrpv8xqf4-openssl-1.1.1k-dev --with-libexpat=/nix/store/x5kjng6iha7kcdm3p12fxfvzg09wizwc-expat-2.2.10-dev --with-libevent=/nix/store/89i6mpzp1n866i86y07pxka1a58v4s1a-libevent-2.1.12-dev --localstatedir=/var --sysconfdir=/etc --sbindir=${out}/bin --with-rootkey-file=/nix/store/gyz4nxg9s1faqkhaqbasdxzldm8zial8-dns-root-data-2019-01-11/root.key --enable-pie --enable-relro-now
> Linked libs: libevent 2.1.12-stable (it uses epoll), OpenSSL 1.1.1k  25 Mar 2021
> Linked modules: dns64 respip validator iterator

After this commit:

> Version 1.13.1
> Configure line: --disable-static --prefix=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1 --bindir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1/bin --sbindir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1/sbin --includedir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1/include --oldincludedir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1/include --mandir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1-man/share/man --infodir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1/share/info --docdir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1/share/doc/unbound --libdir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1-lib/lib --libexecdir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1-lib/libexec --localedir=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unbound-1.13.1-lib/share/locale --with-ssl=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-1.1.1k-dev --with-libexpat=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.2.10-dev --with-libevent=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libevent-2.1.12-dev --localstatedir=/var --sysconfdir=/etc --sbindir=${out}/bin --with-rootkey-file=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-dns-root-data-2019-01-11/root.key --enable-pie --enable-relro-now
> Linked libs: libevent 2.1.12-stable (it uses epoll), OpenSSL 1.1.1k  25 Mar 2021
> Linked modules: dns64 respip validator iterator

Notice: All the paths are now invalid and thus do not produce a
reference in the output binaries.

This removes a total of 2MiB from the closure of unbound.



###### Things done
- [x] looked at the closure differences of unbound and unbound-with-systemd