### PR TITLE
tk-8_6: fix hash after tcl-8_6 update

### DIFF
--- a/pkgs/development/interpreters/tcl/8.5.nix
+++ b/pkgs/development/interpreters/tcl/8.5.nix
@@ -4,6 +4,8 @@ callPackage ./generic.nix (args // rec {
   release = "8.5";
   version = "${release}.18";
 
+  # Note: when updating, the hash in pkgs/development/libraries/tk/8.5.nix must also be updated!
+
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
     sha256 = "1jfkqp2fr0xh6xvaqx134hkfa5kh7agaqbxm6lhjbpvvc1xfaaq3";

--- a/pkgs/development/interpreters/tcl/8.6.nix
+++ b/pkgs/development/interpreters/tcl/8.6.nix
@@ -4,6 +4,8 @@ callPackage ./generic.nix (args // rec {
   release = "8.6";
   version = "${release}.11";
 
+  # Note: when updating, the hash in pkgs/development/libraries/tk/8.6.nix must also be updated!
+
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
     sha256 = "0n4211j80mxr6ql0xx52rig8r885rcbminfpjdb2qrw6hmk8c14c";

--- a/pkgs/development/libraries/tk/8.6.nix
+++ b/pkgs/development/libraries/tk/8.6.nix
@@ -4,7 +4,7 @@ callPackage ./generic.nix (args // {
 
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tk${tcl.version}.1-src.tar.gz"; # TODO: remove '.1' for v8.6.10 or v8.7.x
-    sha256 = "1d7bfkxpacy33w5nahf73lkwxqpff44w1jplg7i2gmwgiaawvjwg";
+    sha256 = "1gh9k7l76qg9l0sb78ijw9xz4xl1af47aqbdifb6mjpf3cbsnv00";
   };
 
   patches = [ ./different-prefix-with-tcl.patch ] ++ lib.optionals stdenv.isDarwin [ ./Fix-bad-install_name-for-libtk8.6.dylib.patch ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

tcl-8_6 was updated in 4fb92ae60d68344254b2bb753c03fd72f3ffb35c from 8.6.9 -> 8.6.11 but tk's hash wasn't updated at the same time, which means the current hash was still from tk 8.6.9 rather than 8.6.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
