### PR TITLE
box2d: fix hash

### DIFF
--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "2.3.1";
 
   src = fetchurl {
-    url = "https://github.com/erincatto/Box2D/archive/v${version}.tar.gz";
+    url = "https://github.com/erincatto/box2d/archive/v${version}.tar.gz";
     sha256 = "0p03ngsmyz0r5kbpiaq10ns4fxwkjvvawi8k6pfall46b93wizsq";
   };
 

--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -7,10 +7,10 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/erincatto/Box2D/archive/v${version}.tar.gz";
-    sha256 = "0llpcifl8zbjbpxdwz87drd01m3lwnv82xb4av6kca1xn4w2gmkm";
+    sha256 = "0p03ngsmyz0r5kbpiaq10ns4fxwkjvvawi8k6pfall46b93wizsq";
   };
 
-  sourceRoot = "Box2D-${version}/Box2D";
+  sourceRoot = "box2d-${version}/Box2D";
 
   nativeBuildInputs = [ cmake unzip pkg-config ];
   buildInputs = [ libGLU libGL freeglut libX11 xorgproto libXi ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The upstream tarball changed. Specifically, files now extract onto a
`box2d-2.3.1/` directory rather than `Box2D-2.3.1/`. The files themselves
(and their contents) seem to remain the same.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
