### PR TITLE
pipewire: 0.3.27 -> 0.3.30

### DIFF
--- a/nixos/modules/services/desktops/pipewire/pipewire.conf.json
+++ b/nixos/modules/services/desktops/pipewire/pipewire.conf.json
@@ -74,7 +74,18 @@
       "args": {
         "factory.name": "support.node.driver",
         "node.name": "Dummy-Driver",
-        "priority.driver": 8000
+        "node.group": "pipewire.dummy",
+        "priority.driver": 20000
+      }
+    },
+    {
+      "factory": "spa-node-factory",
+      "args": {
+        "factory.name": "support.node.driver",
+        "node.name": "Freewheel-Driver",
+        "priority.driver": 19000,
+        "node.group": "pipewire.freewheel",
+        "node.freewheel": true
       }
     }
   ],

--- a/pkgs/development/libraries/pipewire/0080-pipewire-config-dir.patch
+++ b/pkgs/development/libraries/pipewire/0080-pipewire-config-dir.patch
@@ -1,30 +1,30 @@
 diff --git a/meson.build b/meson.build
-index a27569bd..fcf18344 100644
+index b6b4553b..f21c29d8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -36,7 +36,10 @@ pipewire_libexecdir = prefix / get_option('libexecdir')
- pipewire_localedir = prefix / get_option('localedir')
+@@ -37,7 +37,10 @@ pipewire_localedir = prefix / get_option('localedir')
  pipewire_sysconfdir = prefix / get_option('sysconfdir')
  
--pipewire_configdir = pipewire_sysconfdir / 'pipewire'
-+pipewire_configdir = get_option('pipewire_config_dir')
-+if pipewire_configdir == ''
-+  pipewire_configdir = pipewire_sysconfdir / 'pipewire'
+ pipewire_configdir = pipewire_sysconfdir / 'pipewire'
+-pipewire_confdatadir = pipewire_datadir / 'pipewire'
++pipewire_confdatadir = get_option('pipewire_confdata_dir')
++if pipewire_confdatadir == ''
++  pipewire_confdatadir = pipewire_datadir / 'pipewire'
 +endif
  modules_install_dir = pipewire_libdir / pipewire_name
  
  if host_machine.system() == 'linux'
 diff --git a/meson_options.txt b/meson_options.txt
-index 85beb86a..372e8faa 100644
+index 9bc33fcd..e4bd2dc1 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -67,6 +67,9 @@ option('jack-devel',
+@@ -61,6 +61,9 @@ option('jack-devel',
  option('libjack-path',
         description: 'Where to install the libjack.so library',
         type: 'string')
-+option('pipewire_config_dir',
-+       type : 'string',
-+       description : 'Directory for pipewire configuration (defaults to /etc/pipewire)')
++option('pipewire_confdata_dir',
++       type: 'string',
++       description: 'Directory for pipewire default configuration (defaults to /usr/share/pipewire)')
  option('spa-plugins',
         description: 'Enable spa plugins integration',
         type: 'feature',

--- a/pkgs/development/libraries/pipewire/0090-pipewire-config-template-paths.patch
+++ b/pkgs/development/libraries/pipewire/0090-pipewire-config-template-paths.patch
@@ -1,0 +1,28 @@
+diff --git a/src/daemon/pipewire.conf.in b/src/daemon/pipewire.conf.in
+index bbafa134..227d3e06 100644
+--- a/src/daemon/pipewire.conf.in
++++ b/src/daemon/pipewire.conf.in
+@@ -116,7 +116,7 @@ context.modules = [
+             # access.allowed to list an array of paths of allowed
+             # apps.
+             #access.allowed = [
+-            #    @media_session_path@
++            #    <media_session_path>
+             #]
+ 
+             # An array of rejected paths.
+@@ -220,12 +220,12 @@ context.exec = [
+     # but it is better to start it as a systemd service.
+     # Run the session manager with -h for options.
+     #
+-    @comment@{ path = "@media_session_path@"  args = "" }
++    @comment@{ path = "<media_session_path>"  args = "" }
+     #
+     # You can optionally start the pulseaudio-server here as well
+     # but it is better to start it as a systemd service.
+     # It can be interesting to start another daemon here that listens
+     # on another address with the -a option (eg. -a tcp:4713).
+     #
+-    @comment@{ path = "@pipewire_path@" args = "-c pipewire-pulse.conf" }
++    @comment@{ path = "<pipewire_path>" args = "-c pipewire-pulse.conf" }
+ ]

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitLab
 , removeReferencesTo
+, python3
 , meson
 , ninja
 , systemd
@@ -19,6 +20,7 @@
 , SDL2
 , vulkan-headers
 , vulkan-loader
+, webrtc-audio-processing
 , ncurses
 , makeFontsConf
 , callPackage
@@ -31,6 +33,8 @@
 , nativeHfpSupport ? true
 , ofonoSupport ? true
 , hsphfpdSupport ? true
+, pulseTunnelSupport ? true, libpulseaudio ? null
+, zeroconfSupport ? true, avahi ? null
 }:
 
 let
@@ -42,7 +46,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.27";
+    version = "0.3.30";
 
     outputs = [
       "out"
@@ -60,7 +64,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-GfcMODQWtcahBvXnZ98/PKIm4pkqLaz09oOy7zQR4IA=";
+      sha256 = "sha256-DnaPvZoDaegjtJNKBmCJEAZe5FQBnSER79FPnxiWQUE=";
     };
 
     patches = [
@@ -72,8 +76,10 @@ let
       ./0055-pipewire-media-session-path.patch
       # Move installed tests into their own output.
       ./0070-installed-tests-path.patch
-      # Add flag to specify configuration directory (different from the installation directory).
+      # Add option for changing the config install directory
       ./0080-pipewire-config-dir.patch
+      # Remove output paths from the comments in the config templates to break dependency cycles
+      ./0090-pipewire-config-template-paths.patch
     ];
 
     nativeBuildInputs = [
@@ -82,6 +88,7 @@ let
       meson
       ninja
       pkg-config
+      python3
     ];
 
     buildInputs = [
@@ -94,12 +101,15 @@ let
       udev
       vulkan-headers
       vulkan-loader
+      webrtc-audio-processing
       valgrind
       SDL2
       systemd
     ] ++ lib.optionals gstreamerSupport [ gst_all_1.gst-plugins-base gst_all_1.gstreamer ]
     ++ lib.optional ffmpegSupport ffmpeg
-    ++ lib.optionals bluezSupport [ bluez libopenaptx ldacbt sbc fdk_aac ];
+    ++ lib.optionals bluezSupport [ bluez libopenaptx ldacbt sbc fdk_aac ]
+    ++ lib.optional pulseTunnelSupport libpulseaudio
+    ++ lib.optional zeroconfSupport avahi;
 
     mesonFlags = [
       "-Ddocs=enabled"
@@ -112,6 +122,8 @@ let
       "-Dmedia-session-prefix=${placeholder "mediaSession"}"
       "-Dlibjack-path=${placeholder "jack"}/lib"
       "-Dlibcamera=disabled"
+      "-Dlibpulse=${mesonEnable pulseTunnelSupport}"
+      "-Davahi=${mesonEnable zeroconfSupport}"
       "-Dgstreamer=${mesonEnable gstreamerSupport}"
       "-Dffmpeg=${mesonEnable ffmpegSupport}"
       "-Dbluez5=${mesonEnable bluezSupport}"
@@ -119,24 +131,35 @@ let
       "-Dbluez5-backend-hfp-native=${mesonEnable nativeHfpSupport}"
       "-Dbluez5-backend-ofono=${mesonEnable ofonoSupport}"
       "-Dbluez5-backend-hsphfpd=${mesonEnable hsphfpdSupport}"
-      "-Dpipewire_config_dir=/etc/pipewire"
+      "-Dsysconfdir=/etc"
+      "-Dpipewire_confdata_dir=${placeholder "lib"}/share/pipewire"
     ];
 
     FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
 
     doCheck = true;
 
+    postUnpack = ''
+      patchShebangs source/doc/strip-static.sh
+      patchShebangs source/spa/tests/gen-cpp-test.py
+    '';
+
     postInstall = ''
-      pushd .
-      cd $out
+      pushd $lib/share
       mkdir -p $out/nix-support/etc/pipewire
-      for f in etc/pipewire/*.conf; do bin/spa-json-dump "$f" > "$out/nix-support/$f.json"; done
+      for f in pipewire/*.conf; do
+        echo "Generating JSON from $f"
+        $out/bin/spa-json-dump "$f" > "$out/nix-support/etc/$f.json"
+      done
 
       mkdir -p $mediaSession/nix-support/etc/pipewire/media-session.d
-      for f in etc/pipewire/media-session.d/*.conf; do bin/spa-json-dump "$f" > "$mediaSession/nix-support/$f.json"; done
+      for f in pipewire/media-session.d/*.conf; do
+        echo "Generating JSON from $f"
+        $out/bin/spa-json-dump "$f" > "$mediaSession/nix-support/etc/$f.json"
+      done
       popd
 
-      moveToOutput "etc/pipewire/media-session.d/*.conf" "$mediaSession"
+      moveToOutput "share/pipewire/media-session.d/*.conf" "$mediaSession"
       moveToOutput "share/systemd/user/pipewire-media-session.*" "$mediaSession"
       moveToOutput "lib/systemd/user/pipewire-media-session.*" "$mediaSession"
       moveToOutput "bin/pipewire-media-session" "$mediaSession"
@@ -155,6 +178,7 @@ let
         test-paths = callPackage ./test-paths.nix {
           paths-out = [
             "share/alsa/alsa.conf.d/50-pipewire.conf"
+            "nix-support/etc/pipewire/client-rt.conf.json"
             "nix-support/etc/pipewire/client.conf.json"
             "nix-support/etc/pipewire/jack.conf.json"
             "nix-support/etc/pipewire/pipewire.conf.json"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.30
* Fixes to Ardour compatibility and notification sounds

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.29
* Latency reporting
* Webrtc echo cancel module

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.28
* Freewheeling support in the JACK emulation so exporting projects from Ardour works
* Network sinks and sources (pulseaudio-compatible) including discovery via avahi
* filter-chain module for a convenient way to drop in LADSPA plugins (and some others) to your audio graph

Sadly this isn't usable yet: pipewire now installs the default config in `/usr/share/pipewire` now, and adjusting for that seems to have introduced some circular dependencies between `$out` and `$lib` that I haven't been able to pinpoint nor figure out how to avoid.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
