### PR TITLE
sundials: fix download URL and hash

### DIFF
--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "examples" ];
 
   src = fetchurl {
-    url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
-    sha256 = "jW3QlP7Mu41uzEE0DsFqZfq6yC7UQVAj9tfBwjkOovM=";
+    url = "https://github.com/LLNL/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-SNp7qoFS3bIq7RsC2C0du0+/6iKs9nY0ARqgMDoQCkM=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "examples" ];
 
   src = fetchurl {
-    url = "https://github.com/LLNL/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/LLNL/sundials/releases/download/v${version}/sundials-${version}.tar.gz";
     hash = "sha256-SNp7qoFS3bIq7RsC2C0du0+/6iKs9nY0ARqgMDoQCkM=";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The old URL doesn't seem to be available anymore (fails with 403 Forbidden error).

The tarball in the new URL contains a few changes from the old one, so the hash has changed.

Specifically, only the following files have changed:

* sundials-5.7.0/doc/arkode/ark_examples.pdf
* sundials-5.7.0/doc/arkode/ark_guide.pdf
* sundials-5.7.0/doc/cvode/cv_examples.pdf
* sundials-5.7.0/doc/cvode/cv_guide.pdf
* sundials-5.7.0/doc/cvodes/cvs_examples.pdf
* sundials-5.7.0/doc/cvodes/cvs_guide.pdf
* sundials-5.7.0/doc/ida/ida_examples.pdf
* sundials-5.7.0/doc/ida/ida_guide.pdf
* sundials-5.7.0/doc/idas/idas_examples.pdf
* sundials-5.7.0/doc/idas/idas_guide.pdf
* sundials-5.7.0/doc/kinsol/kin_examples.pdf
* sundials-5.7.0/doc/kinsol/kin_guide.pdf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
