### PR TITLE
wezterm: Add terminfo output

### DIFF
--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , lib
 , fetchFromGitHub
+, ncurses
 , pkg-config
 , fontconfig
 , python3
@@ -68,6 +69,8 @@ rustPlatform.buildRustPackage rec {
     fetchSubmodules = true;
   };
 
+  outputs = [ "out" "terminfo" ];
+
   postPatch = ''
     echo ${version} > .tag
   '';
@@ -78,9 +81,17 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     python3
     perl
+    ncurses
   ];
 
   buildInputs = runtimeDeps;
+
+  postInstall = ''
+    mkdir -p $terminfo/share/terminfo/w
+    tic -x -o $terminfo/share/terminfo termwiz/data/wezterm.terminfo
+    mkdir -p $out/nix-support
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+  '';
 
   preFixup = lib.optionalString stdenv.isLinux ''
     for artifact in wezterm wezterm-gui wezterm-mux-server strip-ansi-escapes; do

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -87,9 +87,8 @@ rustPlatform.buildRustPackage rec {
   buildInputs = runtimeDeps;
 
   postInstall = ''
-    mkdir -p $terminfo/share/terminfo/w
+    mkdir -p $terminfo/share/terminfo/w $out/nix-support
     tic -x -o $terminfo/share/terminfo termwiz/data/wezterm.terminfo
-    mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As part of wezterm's documentation, the usage of terminfo to enable specific features (curly and coloured underlines) for it is mentioned [here](https://wezfurlong.org/wezterm/faq.html#how-do-i-enable-undercurl-curly-underlines). To use this terminfo, in configuration a user must have (at least as a minimal config, potentially placed at `$XDG_CONFIG_HOME/wezterm/wezterm.lua`):

```lua
local wezterm = require 'wezterm';

return {
	term = "wezterm",
}
```

Alternatively, the TERM variable may be overrode as specified in the documentation.

This change installs that terminfo automatically and provides it as an output.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
