### PR TITLE
jdk8: fix sprintf patch

### DIFF
--- a/pkgs/development/compilers/openjdk/fix-library-path-jdk8.patch
+++ b/pkgs/development/compilers/openjdk/fix-library-path-jdk8.patch
@@ -24,7 +24,7 @@ index c477851c1b..ff5e28d95b 100644
                                                       sizeof(SYS_EXT_DIR) + sizeof("/lib/") + strlen(cpu_arch) + sizeof(DEFAULT_LIBPATH) + 1,
                                                       mtInternal);
 -    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib/%s:" DEFAULT_LIBPATH, v, v_colon, cpu_arch);
-+    sprintf(ld_library_path, "%s%s", v);
++    sprintf(ld_library_path, "%s", v);
      Arguments::set_library_path(ld_library_path);
      FREE_C_HEAP_ARRAY(char, ld_library_path, mtInternal);
    }


### PR DESCRIPTION
###### Motivation for this change

This fixes a recent commit via #123708
The patch itself had an additional '%s' in the sprintf which is unsafe depending on the surrounding memory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @lheckemann 