### PR TITLE
[21.05] cacert: 3.63 -> 3.66

### DIFF
--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -10,7 +10,7 @@
 with lib;
 
 let
-  version = "3.63";
+  version = "3.66";
 
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
-    sha256 = "0892xbjcaw6g4rd2rs4qa37nbda248cjrgxa4faaw0licbpjyb8q";
+    sha256 = "1jfdnh5l4k57r2vb07s06hqi7m2qzk0d9x25lsdsrw3cflx9x9w9";
   };
 
   certdata2pem = fetchurl {

--- a/pkgs/data/misc/cacert/update.sh
+++ b/pkgs/data/misc/cacert/update.sh
@@ -12,6 +12,14 @@
 #
 # As of this writing there are a few magnitudes more packages depending on
 # cacert than on nss.
+#
+# If the current nixpkgs revision contains the attribute `nss_latest` that will
+# be used instead of `nss`. This is done to help the stable branch maintenance
+# where (usually) after branch-off during the first Firefox upgrade that
+# requries a new NSS version that attribute is introduced.
+# By having this change in the unstable branch we can safely carry it from
+# release to release without requiring more backport churn on those doing the
+# stable maintenance.
 
 
 set -ex
@@ -20,7 +28,7 @@ BASEDIR="$(dirname "$0")/../../../.."
 
 
 CURRENT_PATH=$(nix-build --no-out-link -A cacert.out)
-PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; (cacert.overrideAttrs (_: { inherit (nss) src version; })).out")
+PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; let nss_pkg = pkgs.nss_latest or pkgs.nss; in (cacert.overrideAttrs (_: { inherit (nss_pkg) src version; })).out")
 
 # Check the hash of the etc subfolder
 # We can't check the entire output as that contains the nix-support folder


### PR DESCRIPTION
###### Motivation for this change
mozilla says this is CA version 2.50, up from 2.48 in nss 3.63

(cherry picked from commit e579e93b6517c29af8b84641d2ec16a064d34c8b)

Partial backport of #123048

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
