### PR TITLE
[20.09] cacert: 3.56 -> 3.66

### DIFF
--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -18,7 +18,7 @@ let
     sha256 = "1d4q27j1gss0186a5m8bs5dk786w07ccyq0qi6xmd2zr1a8q16wy";
   };
 
-  version = "3.57";
+  version = "3.60";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
-    sha256 = "55a86c01be860381d64bb4e5b94eb198df9b0f098a8af0e58c014df398bdc382";
+    sha256 = "hKvVV1q4dMU65RG9Rh5dCGjRobOE7kB1MVTN0dWQ/j0=";
   };
 
   outputs = [ "out" "unbundled" ];

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -18,7 +18,7 @@ let
     sha256 = "1d4q27j1gss0186a5m8bs5dk786w07ccyq0qi6xmd2zr1a8q16wy";
   };
 
-  version = "3.63";
+  version = "3.66";
 
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
-    sha256 = "0892xbjcaw6g4rd2rs4qa37nbda248cjrgxa4faaw0licbpjyb8q";
+    sha256 = "1jfdnh5l4k57r2vb07s06hqi7m2qzk0d9x25lsdsrw3cflx9x9w9";
   };
 
   outputs = [ "out" "unbundled" ];

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, nss, python3
 , blacklist ? []
+, includeEmail ? false
 
 # Used for tests only
 , runCommand
@@ -41,6 +42,10 @@ stdenv.mkDerivation {
     EOF
 
     cat ${certdata2pem} > certdata2pem.py
+    ${optionalString includeEmail ''
+      # Disable CAs used for mail signing
+      substituteInPlace certdata2pem.py --replace \[\'CKA_TRUST_EMAIL_PROTECTION\'\] '''
+    ''}
   '';
 
   buildPhase = ''

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -17,12 +17,17 @@ let
     sha256 = "1d4q27j1gss0186a5m8bs5dk786w07ccyq0qi6xmd2zr1a8q16wy";
   };
 
+  version = "3.57";
+  underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
 
 stdenv.mkDerivation {
-  name = "nss-cacert-${nss.version}";
+  name = "nss-cacert-${version}";
 
-  src = nss.src;
+  src = fetchurl {
+    url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
+    sha256 = "55a86c01be860381d64bb4e5b94eb198df9b0f098a8af0e58c014df398bdc382";
+  };
 
   outputs = [ "out" "unbundled" ];
 
@@ -59,6 +64,7 @@ stdenv.mkDerivation {
 
   setupHook = ./setup-hook.sh;
 
+  passthru.updateScript = ./update.sh;
   passthru.tests = {
     # Test that building this derivation with a blacklist works, and that UTF-8 is supported.
     blacklist-utf8 = let

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -18,7 +18,8 @@ let
     sha256 = "1d4q27j1gss0186a5m8bs5dk786w07ccyq0qi6xmd2zr1a8q16wy";
   };
 
-  version = "3.60";
+  version = "3.63";
+
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
 
@@ -27,7 +28,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
-    sha256 = "hKvVV1q4dMU65RG9Rh5dCGjRobOE7kB1MVTN0dWQ/j0=";
+    sha256 = "0892xbjcaw6g4rd2rs4qa37nbda248cjrgxa4faaw0licbpjyb8q";
   };
 
   outputs = [ "out" "unbundled" ];

--- a/pkgs/data/misc/cacert/update.sh
+++ b/pkgs/data/misc/cacert/update.sh
@@ -12,6 +12,14 @@
 #
 # As of this writing there are a few magnitudes more packages depending on
 # cacert than on nss.
+#
+# If the current nixpkgs revision contains the attribute `nss_latest` that will
+# be used instead of `nss`. This is done to help the stable branch maintenance
+# where (usually) after branch-off during the first Firefox upgrade that
+# requries a new NSS version that attribute is introduced.
+# By having this change in the unstable branch we can safely carry it from
+# release to release without requiring more backport churn on those doing the
+# stable maintenance.
 
 
 set -ex
@@ -20,7 +28,7 @@ BASEDIR="$(dirname "$0")/../../../.."
 
 
 CURRENT_PATH=$(nix-build --no-out-link -A cacert.out)
-PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; (cacert.overrideAttrs (_: { inherit (nss) src version; })).out")
+PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; let nss_pkg = pkgs.nss_latest or pkgs.nss; in (cacert.overrideAttrs (_: { inherit (nss_pkg) src version; })).out")
 
 # Check the hash of the etc subfolder
 # We can't check the entire output as that contains the nix-support folder

--- a/pkgs/data/misc/cacert/update.sh
+++ b/pkgs/data/misc/cacert/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix common-updater-scripts jq
+
+# Build both the cacert package and an overriden version where we use the source attribute of NSS.
+# Cacert and NSS are both from the same upstream sources. They are decoupled as
+# the cacert output only cares about a few infrequently changing files in the
+# sources while the NSS source code changes frequently.
+#
+# By having cacert on a older source revision that produces the same
+# certificate output as a newer version we can avoid large amounts of
+# unnecessary rebuilds.
+#
+# As of this writing there are a few magnitudes more packages depending on
+# cacert than on nss.
+
+
+set -ex
+
+BASEDIR="$(dirname "$0")/../../../.."
+
+
+CURRENT_PATH=$(nix-build --no-out-link -A cacert.out)
+PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; (cacert.overrideAttrs (_: { inherit (nss) src version; })).out")
+
+# Check the hash of the etc subfolder
+# We can't check the entire output as that contains the nix-support folder
+# which contains the output path itself.
+CURRENT_HASH=$(nix-hash "$CURRENT_PATH/etc")
+PATCHED_HASH=$(nix-hash "$PATCHED_PATH/etc")
+
+if [[ "$CURRENT_HASH" !=  "$PATCHED_HASH" ]]; then
+    NSS_VERSION=$(nix-instantiate --json --eval -E "with import $BASEDIR {}; nss.version" | jq -r .)
+    update-source-version cacert "$NSS_VERSION"
+fi


### PR DESCRIPTION
###### Motivation for this change

Partial backport #123048 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
