### PR TITLE
cudatext: 1.131.0 → 1.133.5

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.131.0";
+  version = "1.133.5";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "1zq17yi5zn4hdgrrn3c3cdk6s38fv36r66dl0dqz2z8jjd6vy4p3";
+    sha256 = "sha256-0QWYitlOS3x7BQpFTYDAjIgkw83IkRFfA/slyEvQUnw=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -11,33 +11,33 @@
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2021.04.01",
-    "sha256": "12sncivsv6pvwflzzy12rpn1fjiq64n2n3bcj7630xxlrbygkhxb"
+    "rev": "2021.05.16",
+    "sha256": "sha256-oQW0M8Sx1bC+keOWivXwlD5SDKJuO5Sk/3HiO9HvJtY="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.04.09",
-    "sha256": "1ldr2z88zywn0ccgs17vfhq55ibihjcmfjjxcqsjifrbm0y6wipp"
+    "rev": "2021.05.31",
+    "sha256": "sha256-4B6/I0CH9gfslwUbCTTI4kycgTHUjLGtVrCctfO6gRo="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.04.01",
-    "sha256": "1g6zp9d7vwjisad3y1mfnk1jcbjqxp3yimm0sh1655al6qwn886m"
+    "rev": "2021.05.03",
+    "sha256": "sha256-zns83XA2SslHRGqa3iro0phIBlz5/neJ34TTYAKhX5Q="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.03.16",
-    "sha256": "159s1rpl829bmaa4bllqhjm8z0vji1ncsd6hw2s8z8hz28n905k8"
+    "rev": "2021.05.27",
+    "sha256": "sha256-D0UBK69V28Izs9FgevtvX6vyDU7KpfIGJqcqpWaxU9E="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2021.04.01",
-    "sha256": "1hq9hbv81mcymjcms97wcwcfqfpxis6h6v5m0syyih4r53khv0az"
+    "rev": "2021.05.27",
+    "sha256": "sha256-1zhSB6bgeW5G6RAZvhznNTpRk0uEDZnLXsk+cgElKLw="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
-    "rev": "2021.02.18",
-    "sha256": "0fy6bmpdcl2aa8pb7zban6midkfwdj99x14hdghrv7cp8l4gcsg5"
+    "rev": "2021.04.16",
+    "sha256": "sha256-HN3Lr3uDCyNk+8+J09ivyC0LZxQ6x6SaUH4swZJBFkM="
   },
   "Emmet-Pascal": {
     "owner": "Alexey-T",


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://cudatext.github.io/history.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
