### PR TITLE
yafetch: unstable-2021-05-13 -> unstable-2021-06-01

### DIFF
--- a/pkgs/tools/misc/yafetch/default.nix
+++ b/pkgs/tools/misc/yafetch/default.nix
@@ -2,22 +2,23 @@
 
 stdenv.mkDerivation rec {
   pname = "yafetch";
-  version = "unstable-2021-05-13";
+  version = "unstable-2021-06-01";
 
   src = fetchFromGitLab {
     owner = "cyberkitty";
     repo = pname;
-    rev = "627465e6bf0192a9bc10f9c9385cde544766486f";
-    sha256 = "1r8jnzfyjs5ardq697crwysclfm3k8aiqvfbsyhsl251a08yls5c";
+    rev = "d9bbc1e4abca87028f898473c9a265161af3c287";
+    sha256 = "0hyb5k7drnm9li720z1fdvz7b15xgf7n6yajnz1j98day3k88bqk";
   };
 
   # Use the provided NixOS logo automatically
   prePatch = ''
-    echo "#include \"ascii/nixos.h\"" > config.h
+    substituteInPlace ./config.h --replace \
+      "#include \"ascii/tux.h\"" "#include \"ascii/nixos.h\""
   '';
 
   # Fixes installation path
-  DESTDIR = placeholder "out";
+  PREFIX = placeholder "out";
 
   meta = with lib; {
     homepage = "https://gitlab.com/cyberkitty/yafetch";


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
