### PR TITLE
f2c: init at 20200916

### DIFF
--- a/pkgs/development/tools/f2c/default.nix
+++ b/pkgs/development/tools/f2c/default.nix
@@ -12,10 +12,14 @@ stdenv.mkDerivation {
   makeFlags = [ "-f" "makefile.u" ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/man/man1
     install -m755 f2c $out/bin
     install -m755 xsum $out/bin
     install f2c.1t $out/share/man/man1
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/f2c/default.nix
+++ b/pkgs/development/tools/f2c/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  pname = "f2c";
+  version = "20200916";
+
+  src = fetchurl {
+    url = "https://www.netlib.org/f2c/src.tgz";
+    sha256 = "0d8xfbv6dk4dz95qds7sd44b5hvara07f2g2c5g4xiwim9b7916l";
+  };
+
+  makeFlags = [ "-f" "makefile.u" ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    install -m755 f2c $out/bin
+    install -m755 xsum $out/bin
+    install f2c.1t $out/share/man/man1
+  '';
+
+  meta = with lib; {
+    description = "Convert Fortran 77 source code to C";
+    homepage = "https://www.netlib.org/f2c/";
+    license = licenses.mit;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14832,6 +14832,8 @@ in
       inherit fontconfig fontDirectories;
     };
 
+  f2c = callPackage ../development/tools/f2c { };
+
   freealut = callPackage ../development/libraries/freealut { };
 
   freeglut = callPackage ../development/libraries/freeglut { };


### PR DESCRIPTION
###### Motivation for this change
Convert F77 code to C. Old but sometimes useful, when dealing with scientific codes. See also `libf2c`, wich is already packaged. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
