### PR TITLE
[staging] graphicsmagic: reduce runtime closure bloat

### DIFF
--- a/pkgs/applications/graphics/graphicsmagick/default.nix
+++ b/pkgs/applications/graphics/graphicsmagick/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, bzip2, freetype, graphviz, ghostscript
 , libjpeg, libpng, libtiff, libxml2, zlib, libtool, xz, libX11
-, libwebp, quantumdepth ? 8, fixDarwinDylibNames }:
+, libwebp, quantumdepth ? 8, fixDarwinDylibNames, nukeReferences }:
 
 stdenv.mkDerivation rec {
   pname = "graphicsmagick";
@@ -27,8 +27,14 @@ stdenv.mkDerivation rec {
       zlib libtool libwebp
     ];
 
-  nativeBuildInputs = [ xz ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = [ xz nukeReferences ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+
+  # Remove CFLAGS from the binaries to avoid closure bloat.
+  # In the past we have had -dev packages in the closure of the binaries soley due to the string references.
+  postConfigure = ''
+    nuke-refs ./magick/magick_config.h
+  '';
 
   postInstall = ''
     sed -i 's/-ltiff.*'\'/\'/ $out/bin/*


### PR DESCRIPTION
###### Motivation for this change

Before this commit we had libxml and freetype development files as part
of the runtime closure of graphicsmagick. Both of these combined added
up to 2MiB. With this commit those references are now gone :-)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
