### PR TITLE
python3Packages.ismartgate: init at 4.0.1

### DIFF
--- a/pkgs/development/python-modules/ismartgate/default.nix
+++ b/pkgs/development/python-modules/ismartgate/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, asynctest
+, buildPythonPackage
+, click
+, defusedxml
+, dicttoxml
+, fetchFromGitHub
+, httpx
+, pycryptodome
+, pytest-asyncio
+, pytest-raises
+, pytestCheckHook
+, pythonOlder
+, respx
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "ismartgate";
+  version = "4.0.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kxlcjnppsk8m93gfcpy3asig1frhp1k5rfqx3rszhkcxmni95m2";
+  };
+
+  propagatedBuildInputs = [
+    click
+    defusedxml
+    dicttoxml
+    httpx
+    pycryptodome
+    typing-extensions
+  ];
+
+  checkInputs = [
+    asynctest
+    pytest-asyncio
+    pytest-raises
+    pytestCheckHook
+    respx
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"pytest-runner>=5.2",' ""
+  '';
+
+  pythonImportsCheck = [ "ismartgate" ];
+
+  meta = with lib; {
+    description = "Python module to work with the ismartgate and gogogate2 API";
+    homepage = "https://github.com/bdraco/ismartgate";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3441,6 +3441,8 @@ in {
 
   iso3166 = callPackage ../development/python-modules/iso3166 { };
 
+  ismartgate = callPackage ../development/python-modules/ismartgate { };
+
   iso-639 = callPackage ../development/python-modules/iso-639 { };
 
   iso8601 = callPackage ../development/python-modules/iso8601 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to work with the ismartgate and gogogate2 API

https://github.com/bdraco/ismartgate

This is a Home Assistant dependency.

- Target Home Assistant release: 2021.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
