### PR TITLE
nixos/tests/test-driver: add shell_interact

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -444,6 +444,7 @@ machine.systemctl("list-jobs --no-pager", "any-user") # spawns a shell for `any-
      <para>
       Allows you to directly interact with the guest shell.
       This should only be used during test development, not in production tests.
+      Killing the interactive session with <literal>Ctrl-d</literal> or <literal>Ctrl-c</literal> also ends the guest session.
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -436,6 +436,17 @@ machine.systemctl("list-jobs --no-pager", "any-user") # spawns a shell for `any-
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term>
+     <methodname>shell_interact</methodname>
+    </term>
+    <listitem>
+     <para>
+      Allows you to directly interact with the guest shell.
+      This should only be used during test development, not in production tests.
+     </para>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </para>
 

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -461,6 +461,7 @@ class Machine:
 
         Should only be used during test development, not in the production test."""
         self.connect()
+        self.log("Terminal is ready (there is no prompt):")
         telnet = telnetlib.Telnet()
         telnet.sock = self.shell  # type: ignore
         telnet.interact()

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -21,6 +21,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import telnetlib
 import tempfile
 import time
 import traceback
@@ -454,6 +455,15 @@ class Machine:
                 status_code = int(match[2])
                 return (status_code, output)
             output += chunk
+
+    def shell_interact(self) -> None:
+        """Allows you to interact with the guest shell
+
+        Should only be used during testing, not in the production test."""
+        self.connect()
+        telnet = telnetlib.Telnet()
+        telnet.sock = self.shell  # type: ignore
+        telnet.interact()
 
     def succeed(self, *commands: str) -> str:
         """Execute each command and check that it succeeds."""

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -459,7 +459,7 @@ class Machine:
     def shell_interact(self) -> None:
         """Allows you to interact with the guest shell
 
-        Should only be used during testing, not in the production test."""
+        Should only be used during test development, not in the production test."""
         self.connect()
         telnet = telnetlib.Telnet()
         telnet.sock = self.shell  # type: ignore


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, there was no easy way to drop into a guest shell from the test driver. This PR adds the method `machine.shell_interact()`, which drops you into the "main" guest shell. 
A few notes:
* This isn't super polished, you get a very bare-bones shell without anything pretty like tab completion.
* Killing the interactive session with `ctrl-d` or `ctrl-c` also ends the guest session.

A better implementation might be to set up a real ssh session, which would aleviate the above two issues. However, that would also be a lot more work than these 4 lines of code.

However, I think this is still worth adding since this is not very discoverable (even though it is pretty much built-in to python).

Open questions:

- [x] Should this be backported to 20.05?
- [ ] Is this important enough for a release note?

cc @domenkozar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
