### PR TITLE
nixos/mbpfan: set aggressive default values

### DIFF
--- a/nixos/modules/services/misc/mbpfan.nix
+++ b/nixos/modules/services/misc/mbpfan.nix
@@ -29,7 +29,7 @@ in {
 
     maxFanSpeed = mkOption {
       type = types.int;
-      default = 6200;
+      default = 6199;
       description = ''
         The maximum fan speed.
       '';
@@ -37,7 +37,7 @@ in {
 
     lowTemp = mkOption {
       type = types.int;
-      default = 63;
+      default = 55;
       description = ''
         The low temperature.
       '';
@@ -45,7 +45,7 @@ in {
 
     highTemp = mkOption {
       type = types.int;
-      default = 66;
+      default = 58;
       description = ''
         The high temperature.
       '';
@@ -61,7 +61,7 @@ in {
 
     pollingInterval = mkOption {
       type = types.int;
-      default = 7;
+      default = 1;
       description = ''
         The polling interval.
       '';
@@ -82,8 +82,8 @@ in {
     environment = {
       etc."mbpfan.conf".text = ''
         [general]
-        min_fan_speed = ${toString cfg.minFanSpeed}
-        max_fan_speed = ${toString cfg.maxFanSpeed}
+        min_fan1_speed = ${toString cfg.minFanSpeed}
+        max_fan1_speed = ${toString cfg.maxFanSpeed}
         low_temp = ${toString cfg.lowTemp}
         high_temp = ${toString cfg.highTemp}
         max_temp = ${toString cfg.maxTemp}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR changes default values for `mbpfan` module. When current defaults are used, the fan does not kick in because of CPU frequency scaling. Even with high stress (`stress -c 4`), CPU slows down a lot, but the fan remains inactive.

Documentation about the temps is [here](https://github.com/linux-on-mac/mbpfan/blob/dd2c305593e43778f072f48e3f6331ba151548c9/mbpfan.conf). It is from an old revision as comments are removed now. Default polling interval has been changed and documented on the same page.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
