### PR TITLE
win-spice: say yes to all 7z dialogs

### DIFF
--- a/pkgs/applications/virtualization/driver/win-spice/default.nix
+++ b/pkgs/applications/virtualization/driver/win-spice/default.nix
@@ -36,15 +36,15 @@ stdenv.mkDerivation  {
 
   buildPhase = ''
     mkdir -p usbdk/x86 usbdk/amd64
-    (cd usbdk/x86; ${p7zip}/bin/7z x ${src_usbdk_x86})
-    (cd usbdk/amd64; ${p7zip}/bin/7z x ${src_usbdk_amd64})
+    (cd usbdk/x86; ${p7zip}/bin/7z x -y ${src_usbdk_x86})
+    (cd usbdk/amd64; ${p7zip}/bin/7z x -y ${src_usbdk_amd64})
 
     mkdir -p vdagent/x86 vdagent/amd64
-    (cd vdagent/x86; ${p7zip}/bin/7z x ${src_vdagent_x86}; mv vdagent_0_7_3_x86/* .; rm -r vdagent_0_7_3_x86)
-    (cd vdagent/amd64; ${p7zip}/bin/7z x ${src_vdagent_amd64}; mv vdagent_0_7_3_x64/* .; rm -r vdagent_0_7_3_x64)
+    (cd vdagent/x86; ${p7zip}/bin/7z x -y ${src_vdagent_x86}; mv vdagent_0_7_3_x86/* .; rm -r vdagent_0_7_3_x86)
+    (cd vdagent/amd64; ${p7zip}/bin/7z x -y ${src_vdagent_amd64}; mv vdagent_0_7_3_x64/* .; rm -r vdagent_0_7_3_x64)
 
     mkdir -p qxlwddm
-    (cd qxlwddm; ${p7zip}/bin/7z x ${src_qxlwddm}; mv Win8 w8.1; cd w8.1; mv x64 amd64)
+    (cd qxlwddm; ${p7zip}/bin/7z x -y ${src_qxlwddm}; mv Win8 w8.1; cd w8.1; mv x64 amd64)
     '';
 
   installPhase =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/build/143761095

relevant log:
```
Would you like to replace the existing file:
  Path:     ./vdagent_0_7_3_x86/vdagent.exe
  Size:     0 bytes
  Modified: 2021-05-24 22:39:03
with the file from archive:
  Path:     vdagent_0_7_3_x86/vdagent.exe
  Size:     649216 bytes (634 KiB)
  Modified: 2015-03-29 12:22:57
? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit? 
ERROR:
Unexpected end of input stream
builder for '/nix/store/i0fa7cwp6vhfvdz8gcjpja39403ajxfb-win-spice-0.11.drv' failed with exit code 2
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
