### PR TITLE
fritzing: 0.9.4-498 -> 0.9.6

### DIFF
--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -1,86 +1,75 @@
-{ mkDerivation, lib, fetchpatch, fetchFromGitHub, qmake, pkg-config
-, qtbase, qtsvg, qttools, qtserialport, boost, libgit2
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, qmake
+, pkg-config
+, qtbase
+, qtsvg
+, qttools
+, qtserialport
+, boost
+, libgit2
 }:
 
 let
   # build number corresponding to a release, has no further relation
   # see https://github.com/fritzing/fritzing-app/releases/tag/CD-498
-  fritzingBuild = "498";
+  # fritzingBuild = "498";
+  # version 0.9.6 is properly tagged, hope it continues
+
   # SHA256 of the fritzing-parts HEAD on the master branch,
   # which contains the latest stable parts definitions
-  partsSha = "e79a69765026f3fda8aab1b3e7a4952c28047a62";
+  partsSha = "6f04697be286768bc9e4d64f8707e8e40cbcafcb";
 in
 
 mkDerivation rec {
   pname = "fritzing";
-  version = "0.9.4-${fritzingBuild}";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
-    owner = "fritzing";
+    owner = pname;
     repo = "fritzing-app";
-    rev = "CD-${fritzingBuild}";
-    sha256 = "0aljj2wbmm1vd64nhj6lh9qy856pd5avlgydsznya2vylyz20p34";
+    rev = version;
+    sha256 = "083nz7vj7a334575smjry6257535h68gglh8a381xxa36dw96aqs";
   };
 
   parts = fetchFromGitHub {
-    owner = "fritzing";
+    owner = pname;
     repo = "fritzing-parts";
     name = "fritzing-parts";
     rev = partsSha;
-    sha256 = "0spka33a5qq34aq79j01arw1aly4vh0hzv7mahryhdlcdk22qqvc";
+    sha256 = "1f4w0hz44n4iw1rc5vhcgzvlji54rf4yr8bvzkqv99hn2xf5pjgs";
   };
 
   buildInputs = [ qtbase qtsvg qtserialport boost libgit2 ];
-
   nativeBuildInputs = [ qmake pkg-config qttools ];
-
-  patches = [(fetchpatch {
-    name = "fix-libgit2-version.patch";
-    url = "https://github.com/fritzing/fritzing-app/commit/472951243d70eeb40a53b1f7e16e6eab0588d079.patch";
-    sha256 = "0v1zi609cjnqac80xgnk23n54z08g1lia37hbzfl8jcq9sn9adak";
-  })];
 
   postPatch = ''
     substituteInPlace phoenix.pro \
       --replace 'LIBGIT_STATIC = true' 'LIBGIT_STATIC = false'
 
-    substituteInPlace tools/linux_release_script/release.sh \
-      --replace 'git status' 'echo >/dev/null' \
-      --replace 'git clean' 'echo >/dev/null' \
-      --replace 'git clone' 'echo >/dev/null' \
-      --replace 'release_folder="' 'release_folder="$out" #' \
-      --replace './Fritzing -db' '# run after fixup'
-
     substituteInPlace src/fapplication.cpp \
       --replace 'PartsChecker::getSha(dir.absolutePath());' '"${partsSha}";'
-  '';
 
-  buildPhase = ''
-    bash tools/linux_release_script/release.sh ${version}
-  '';
-
-  installPhase = ''
-    rm "$out/Fritzing" # remove script file
-    mkdir "$out/bin"
-    mv "$out/lib/Fritzing" "$out/bin/Fritzing"
-    mkdir --parents "$out/share/applications" "$out/share/metainfo"
-    mv --target-directory="$out/share/applications" "$out/org.fritzing.Fritzing.desktop"
-    mv --target-directory="$out/share/metainfo" "$out/org.fritzing.Fritzing.appdata.xml"
-    cp --recursive --no-target-directory "$parts" "$out/fritzing-parts"
+    mkdir parts
+    cp -a ${parts}/* parts/
   '';
 
   postFixup = ''
     # generate the parts.db file
-    QT_QPA_PLATFORM=offscreen "$out/bin/Fritzing" -db "$out/fritzing-parts/parts.db" -pp "$out/fritzing-parts" -folder "$out"
+    QT_QPA_PLATFORM=offscreen "$out/bin/Fritzing" \
+      -db "$out/share/fritzing/parts/parts.db" \
+      -pp "$out/fritzing/parts" \
+      -folder "$out/share/fritzing"
   '';
 
   qmakeFlags = [ "phoenix.pro" ];
 
-  meta = {
+  meta = with lib; {
     description = "An open source prototyping tool for Arduino-based projects";
     homepage = "https://fritzing.org/";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.robberer ];
-    platforms = lib.platforms.linux;
+    license = with licenses; [ gpl3 cc-by-sa-30 ];
+    maintainers = with maintainers; [ robberer ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change
A new version of Fritzing is released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This version of fritzing is properly tagged (not CD-XXX). Removed a merged patch and updated parts to latest commit.