### PR TITLE
ptags: Add `ctags` to the PATH

### DIFF
--- a/pkgs/development/tools/misc/ptags/default.nix
+++ b/pkgs/development/tools/misc/ptags/default.nix
@@ -1,8 +1,9 @@
 { fetchFromGitHub
 , cargo
+, ctags
 , lib
+, makeWrapper
 , rustPlatform
-
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -17,6 +18,14 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "1pz5hvn1iq26i8c2cmqavhnri8h0sn40khrxvcdkj9q47nsj5wcx";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    # `ctags` must be accessible in `PATH` for `ptags` to work.
+    wrapProgram "$out/bin/ptags" \
+      --prefix PATH : "${lib.makeBinPath [ ctags ]}"
+  '';
 
   # Sanity check.
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

`ptags` fails to run;
Probably it was tested it with `ctags` in the `PATH` before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
