### PR TITLE
[21.05] dr14_tmeter: use ffmpeg 4

### DIFF
--- a/pkgs/applications/audio/dr14_tmeter/default.nix
+++ b/pkgs/applications/audio/dr14_tmeter/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with pkgs; [
-    python3Packages.numpy flac vorbis-tools ffmpeg_3 faad2 lame
+    python3Packages.numpy flac vorbis-tools ffmpeg faad2 lame
   ];
 
   # There are no tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

migrate away from ffmpeg_3 (https://github.com/NixOS/nixpkgs/issues/120705)

(cherry picked from commit 0b32978596d24542e6561a31b5f134ddcc6b811c)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
