### PR TITLE
nixos/release-notes: Improve 21.11 stub

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -12,8 +12,18 @@
       </para>
     </listitem>
   </itemizedlist>
+  <section xml:id="highlights">
+    <title>Highlights</title>
+    <para>
+    </para>
+  </section>
+  <section xml:id="new-services">
+    <title>New Services</title>
+    <para>
+    </para>
+  </section>
   <section xml:id="backward-incompatibilities">
-    <title>Backward incompatibilities</title>
+    <title>Backward Incompatibilities</title>
     <itemizedlist spacing="compact">
       <listitem>
         <para>
@@ -22,5 +32,10 @@
         </para>
       </listitem>
     </itemizedlist>
+  </section>
+  <section xml:id="other-notable-changes">
+    <title>Other Notable Changes</title>
+    <para>
+    </para>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -4,6 +4,12 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 * Support is planned until the end of April 2022, handing over to 22.05.
 
-## Backward incompatibilities
+## Highlights
+
+## New Services
+
+## Backward Incompatibilities
 
 * The `staticjinja` package has been upgraded from 1.0.4 to 2.0.0
+
+## Other Notable Changes


### PR DESCRIPTION
###### Motivation for this change
Not all of the usual sections were present.

cc @ryantm 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
