### PR TITLE
nixos/openrgb: init

### DIFF
--- a/nixos/modules/hardware/openrgb.nix
+++ b/nixos/modules/hardware/openrgb.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.openrgb;
+in
+
+{
+  options.programs.openrgb = {
+    enable = mkEnableOption ''
+      OpenRGB support. Will install udev rules to allow for more devices
+      to be shown, and optionally run OpenRGB as a server
+    '';
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.openrgb;
+      description = "OpenRGB package to use for both client and potentially server.";
+    };
+
+    server.enable = mkEnableOption ''
+      OpenRGB server. OpenRGB will start as a system process, and launching
+      the OpenRGB client will attempt to connect to this server. This is
+      advantageous as users do not need to run OpenRGB with superuser
+      privileges to edit RGB settings in this case
+    '';
+
+    server.port = mkOption {
+      type = types.port;
+      default = 6742;
+      example = 7575;
+      description = "The port the OpenRGB server will listen.";
+    };
+  };
+
+  config = mkIf (cfg.enable || cfg.server.enable) {
+
+    # enable more RGB devices to be found
+    services.udev.packages = [ cfg.package ];
+
+    environment.systemPackages = [ cfg.package ];
+
+  } // (mkIf cfg.server.enable) {
+    # should be ran as root, to have write access to hardware
+    systemd.services.openrgb = {
+      description = "OpenRGB server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/openrgb --server --server-port ${toString cfg.server.port}";
+        Restart = "always";
+      };
+    };
+  };
+
+  meta.maintainers = [ maintainers.jonringer ];
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -61,6 +61,7 @@
   ./hardware/nitrokey.nix
   ./hardware/opengl.nix
   ./hardware/openrazer.nix
+  ./hardware/openrgb.nix
   ./hardware/pcmcia.nix
   ./hardware/printers.nix
   ./hardware/raid/hpsa.nix


### PR DESCRIPTION
###### Motivation for this change
Add module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
