### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "5b6bfbdcdbdda7da4839d7163ce579ed98410282",
-  "date": "2021-05-21T15:22:56+02:00",
-  "path": "/nix/store/msyjbgxf3y3rj6m3w2apd65cvr9x523r-tree-sitter-c-sharp",
-  "sha256": "0ls2qic3jb20zv4m5pdrc3ikfb66afay3krvc6gsq1fi9hbxrmvv",
+  "rev": "aa429589525bb849189a0c5ddb52267ce578f988",
+  "date": "2021-06-07T18:47:38+02:00",
+  "path": "/nix/store/mclvpa5kfbl9g5ij3xjdhnqc6bqzqcj6-tree-sitter-c-sharp",
+  "sha256": "07alycp4bclr0ycn44dj2481xag0s10nwgyrdxar3j91hphd966s",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "f05e279aedde06a25801c3f2b2cc8ac17fac52ae",
-  "date": "2021-03-28T09:12:10-07:00",
-  "path": "/nix/store/4bcxsfrgrcpjy3f6dsmqli2xawjpyz44-tree-sitter-c",
-  "sha256": "1rismmgaqii1sdnri66h75sgw3mky4aha9hff6fan1qzll4f3hif",
+  "rev": "008008e30a81849fca0c79291e2b480855e0e02c",
+  "date": "2021-05-26T09:13:01-07:00",
+  "path": "/nix/store/vkps4991ip8dhgjqwfw7mamnmnizw31m-tree-sitter-c",
+  "sha256": "1mw4vma7kl504qn91f6janiqk9i05849rizqkqhyagb3glfbkrx2",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "2e33ffa3313830faa325fe25ebc3769896b3a68b",
-  "date": "2021-04-19T23:45:03+02:00",
-  "path": "/nix/store/75mc2mfs4sm21c871s5lm9djnjk90r7n-tree-sitter-haskell",
-  "sha256": "0np7mzi1na1qscdxsjpyw314iwcmpzzrx1v7fk3yxc70qwzjcpp1",
+  "rev": "237f4eb4417c28f643a29d795ed227246afb66f9",
+  "date": "2021-06-05T13:41:42+02:00",
+  "path": "/nix/store/wwi86c3ix0zq8czwljxxypw5w2mxnz5h-tree-sitter-haskell",
+  "sha256": "0gx6mr6yg053i5mif8i8qwkk9h57laf9riw5r24av1y7cal7sszd",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "6c8cfae935f67dd9e3a33982e5e06be0ece6399a",
-  "date": "2021-05-11T09:51:32-07:00",
-  "path": "/nix/store/dhh1gz45l3h3p31jfg5fgy1kns1lbw6d-tree-sitter-javascript",
-  "sha256": "1mw6miw4yp6s1i0b08hflamfvrjdim4fnnj6fy461n05jp1s1i78",
+  "rev": "45b9ce2a2588c0e6d616b0ee2a710b1fcb99c5b5",
+  "date": "2021-06-09T14:12:41-07:00",
+  "path": "/nix/store/j6r7z3m4wk6baz70qg2xn2mq3jlnyq6f-tree-sitter-javascript",
+  "sha256": "0rzpyxbh1j9l12jxyryc06f8jhbd5ci18lfb7bw2msc685b2ckcx",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
-  "url": "https://github.com/Azganoth/tree-sitter-lua",
-  "rev": "a943944ec09c5e96f455bb166079de4ef3534457",
-  "date": "2020-12-27T00:15:24-03:00",
-  "path": "/nix/store/6glr8p3x58pva0nn586dk5jwb3bpgqrj-tree-sitter-lua",
-  "sha256": "0pm6wwb3kv73bfvvshdmvazcb1is5x1z6jwr31gz0niln18nqvpb",
+  "url": "https://github.com/nvim-treesitter/tree-sitter-lua",
+  "rev": "b6d4e9e10ccb7b3afb45018fbc391b4439306b23",
+  "date": "2021-03-05T14:55:53+01:00",
+  "path": "/nix/store/mlvnfmm5q67810qdim11qs4ivq54jrmr-tree-sitter-lua",
+  "sha256": "17kf1m2qpflqv7xng6ls4v1qxfgdlpgxs4qjwb6rcc8nbcdsj4ms",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "6a271f4075e11815e787df9055a950fb844ee63b",
-  "date": "2021-05-13T12:41:22+02:00",
-  "path": "/nix/store/n6hycd1scxa990xchk5h09ilxi7w18f5-tree-sitter-php",
-  "sha256": "1ijxc6brd0d35hr89ic8k5ispc6sj4mxln7bznd9n6zrgjvfdjqb",
+  "rev": "b065fc4ded84c30aff14c07ec6e7cf449e222b04",
+  "date": "2021-06-01T20:33:20+02:00",
+  "path": "/nix/store/czdqn2nz8pgrd64w74yskx6vl233phxn-tree-sitter-php",
+  "sha256": "1qr2byy344haqybd0zz2hazncay7zndkp4p3317ck50xrs05z086",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql",
-  "rev": "965948cce9a94a710b1339851e0919471ad5ee2c",
-  "date": "2021-03-04T14:34:34-08:00",
-  "path": "/nix/store/4hi59c856ii2b79nv2wjib6qbp3hk24i-tree-sitter-ql",
-  "sha256": "01y1fzclwlaffx0rzg49h7kyvhhm25fba0w362n2y8hgjp3imgmg",
+  "rev": "8e7fd7e638d4a0ec7a792ee16b19dbc6407aa810",
+  "date": "2021-06-02T18:46:47+02:00",
+  "path": "/nix/store/yhyi9y09shv1fm87gka43vnv9clvyd92-tree-sitter-ql",
+  "sha256": "0x5f9989ymqvw3g8acckyk4j7zpmnc667qishbgly9icl9rkmv7w",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
-  "date": "2021-03-03T16:54:30-08:00",
-  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
-  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
+  "rev": "391269d74d20154bbd0ac9be20b35eced6920290",
+  "date": "2021-05-04T14:02:32-07:00",
+  "path": "/nix/store/hamsaml0yzi13qd61abypjwbv33rd824-tree-sitter-ruby",
+  "sha256": "0biyhydfzybz3g6hhdd0rk6yav7xsk61j8lnmpsi60vaxabdsaiv",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "c696a13a587b0595baf7998f1fb9e95c42750263",
-  "date": "2021-03-20T16:45:11+05:30",
-  "path": "/nix/store/8krdxqwpi95ljrb5jgalwgygz3aljqr8-tree-sitter-svelte",
-  "sha256": "0ckmss5gmvffm6danlsvgh6gwvrlznxsqf6i6ipkn7k5lxg1awg3",
+  "rev": "10c113001acf9852817150acb3031a5e68d2b4cf",
+  "date": "2021-05-02T10:05:14+05:30",
+  "path": "/nix/store/mpfr56mfiizhwr4hq7h422glmdc4hg48-tree-sitter-svelte",
+  "sha256": "1n7addsnin6czm5hrbhaaqqgf0c3nz3mpcdysm2z4icgn7fjq281",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -75,7 +75,7 @@ let
       repo = "tree-sitter-nix";
     };
     "tree-sitter-lua" = {
-      orga = "Azganoth";
+      orga = "nvim-treesitter";
       repo = "tree-sitter-lua";
     };
     "tree-sitter-fennel" = {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update tree-sitter grammars

Switch to nvim-treesitter/tree-sitter-lua for lua, since current lua grammar is broken for 0.19.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
