### PR TITLE
i3lock-color: 2.13.c.2 -> 2.13.c.3

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.13.c.2";
+  version = "2.13.c.3";
   pname = "i3lock-color";
 
   src = fetchFromGitHub {
     owner = "PandorasFox";
     repo = "i3lock-color";
     rev = version;
-    sha256 = "sha256-cMj1uB2Hf7v5Rukw9c5YeUmwbdTn1+PV13bUaOWzBp0=";
+    sha256 = "0spldmis8fvnclwwi9xvnq2rq3hmpbiv3ck5p9pjf40ismvsi16k";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
Needed changes to parameter-style

###### Things done
Update version, hash

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking - Where to do?
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
