### PR TITLE
python3Packages.MechanicalSoup: fix alias

### DIFF
--- a/pkgs/development/python-modules/mechanicalsoup/default.nix
+++ b/pkgs/development/python-modules/mechanicalsoup/default.nix
@@ -1,6 +1,7 @@
 { lib
 , beautifulsoup4
 , buildPythonPackage
+, pythonAtLeast
 , fetchFromGitHub
 , lxml
 , pytest-httpbin
@@ -13,6 +14,8 @@
 buildPythonPackage rec {
   pname = "mechanicalsoup";
   version = "1.1.0";
+
+  disabled = ! pythonAtLeast "3.6";
 
   src = fetchFromGitHub {
     owner = "MechanicalSoup";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -36,5 +36,5 @@ mapAliases ({
   smart_open = smart-open; # added 2021-03-14
   google_api_python_client = google-api-python-client; # added 2021-03-19
   googleapis_common_protos = googleapis-common-protos; # added 2021-03-19
-  mechanicalsoup = MechanicalSoup;  # added 2021-06-01
+  MechanicalSoup = mechanicalsoup;  # added 2021-06-01
 })


### PR DESCRIPTION
###### Motivation for this change

Alias was backwards and would shadow the actual module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
