### PR TITLE
ocamlPackages.reason-native: init 2020-07-18-a33f152

### DIFF
--- a/pkgs/development/ocaml-modules/reason-native/cli.nix
+++ b/pkgs/development/ocaml-modules/reason-native/cli.nix
@@ -1,0 +1,11 @@
+{ re, reason, pastel, ... }:
+
+{
+  pname = "cli";
+
+  buildInputs = [
+    re
+    reason
+    pastel
+  ];
+}

--- a/pkgs/development/ocaml-modules/reason-native/console.nix
+++ b/pkgs/development/ocaml-modules/reason-native/console.nix
@@ -1,0 +1,21 @@
+{ buildDunePackage, callPackage, reason, console, ... }:
+
+{
+  pname = "console";
+
+  buildInputs = [
+    reason
+  ];
+
+  passthru.tests = {
+    console = callPackage ./tests/console {
+      inherit buildDunePackage reason console;
+    };
+  };
+
+  meta = {
+    description = "A library providing a web-influenced polymorphic console API for native Console.log(anything) with runtime printing";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/console";
+    homepage = "https://reason-native.com/docs/console/";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/default.nix
+++ b/pkgs/development/ocaml-modules/reason-native/default.nix
@@ -1,0 +1,43 @@
+{ newScope, lib, fetchFromGitHub, callPackage, buildDunePackage, atdgen, junit, qcheck-core, re, reason, reason-native }:
+
+let
+  generic = (somePath:
+    let
+      prepkg = import somePath {
+        inherit callPackage cli buildDunePackage atdgen junit qcheck-core re reason;
+        inherit (reason-native) console file-context-printer fp pastel rely;
+      };
+    in
+      buildDunePackage
+        ({
+          version = "2021-16-16-aec0ac6";
+          src = fetchFromGitHub {
+            owner = "reasonml";
+            repo = "reason-native";
+            rev = "aec0ac681be7211b4d092262281689c46deb63e1";
+            sha256 = "sha256-QoyI50MBY3RJBmM1y90n7oXrLmHe0CQxKojv+7YbegE=";
+          };
+          useDune2 = true;
+          meta = with lib; {
+            description = "Libraries for building and testing native Reason programs";
+            downloadPage = "https://github.com/reasonml/reason-native";
+            homepage = "https://reason-native.com/";
+            license = licenses.mit;
+            maintainers = with maintainers; [ superherointj ];
+          } // (prepkg.meta or {});
+        } // prepkg)
+  );
+  cli = generic ./cli.nix; # Used only by Rely.
+in
+  lib.makeScope newScope (self: with self; {
+    console = generic ./console.nix;
+    dir = generic ./dir.nix;
+    file-context-printer = generic ./file-context-printer.nix;
+    fp = generic ./fp.nix;
+    pastel = generic ./pastel.nix;
+    pastel-console = generic ./pastel-console.nix;
+    qcheck-rely = generic ./qcheck-rely.nix;
+    refmterr = generic ./refmterr.nix;
+    rely = generic ./rely.nix;
+    rely-junit-reporter = generic ./rely-junit-reporter.nix;
+  })

--- a/pkgs/development/ocaml-modules/reason-native/dir.nix
+++ b/pkgs/development/ocaml-modules/reason-native/dir.nix
@@ -1,0 +1,18 @@
+{ reason, fp, ... }:
+
+{
+  pname = "dir";
+
+  buildInputs = [
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    fp
+  ];
+
+  meta = {
+    description = "A library that provides a consistent API for common system, user and application directories consistently on all platforms";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/dir";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/file-context-printer.nix
+++ b/pkgs/development/ocaml-modules/reason-native/file-context-printer.nix
@@ -1,0 +1,20 @@
+{ reason, re, pastel, ... }:
+
+{
+  pname = "file-context-printer";
+
+  buildInputs = [
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    re
+    pastel
+  ];
+
+  meta = {
+    description = "Utility for displaying snippets of files on the command line";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/file-context-printer";
+    homepage = "https://reason-native.com/docs/file-context-printer/";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/fp.nix
+++ b/pkgs/development/ocaml-modules/reason-native/fp.nix
@@ -1,0 +1,14 @@
+{ reason, ... }:
+
+{
+  pname = "fp";
+
+  buildInputs = [
+    reason
+  ];
+
+  meta = {
+    description = "A library for creating and operating on file paths consistently on multiple platforms";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/fp";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/pastel-console.nix
+++ b/pkgs/development/ocaml-modules/reason-native/pastel-console.nix
@@ -1,0 +1,20 @@
+{ reason, console, pastel, ... }:
+
+{
+  pname = "pastel-console";
+
+  buildInputs = [
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    console
+    pastel
+  ];
+
+  meta = {
+    description = "Small library for pretty coloring to Console output";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/pastel-console";
+    homepage = "https://reason-native.com/docs/pastel/console";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/pastel.nix
+++ b/pkgs/development/ocaml-modules/reason-native/pastel.nix
@@ -1,0 +1,20 @@
+{ reason, re, ... }:
+
+{
+  pname = "pastel";
+
+  minimalOCamlVersion = "4.05";
+
+  buildInputs = [
+    reason
+  ];
+  propagatedBuildInputs = [
+    re
+  ];
+
+  meta = {
+    description = "A text formatting library that harnesses Reason JSX to provide intuitive terminal output. Like React but for CLI";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/pastel";
+    homepage = "https://reason-native.com/docs/pastel/";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
+++ b/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
@@ -1,0 +1,20 @@
+{ qcheck-core, reason, console, rely, ... }:
+
+{
+  pname = "qcheck-rely";
+
+  buildInputs = [
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    qcheck-core
+    console
+    rely
+  ];
+
+  meta = {
+    description = "A library containing custom Rely matchers allowing for easily using QCheck with Rely. QCheck is a 'QuickCheck inspired property-based testing for OCaml, and combinators to generate random values to run tests on'";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/qcheck-rely";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/refmterr.nix
+++ b/pkgs/development/ocaml-modules/reason-native/refmterr.nix
@@ -1,0 +1,21 @@
+{ atdgen, re, reason, pastel, ... }:
+
+{
+  pname = "refmterr";
+
+  buildInputs = [
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    atdgen
+    re
+    pastel
+  ];
+
+  meta = {
+    description = "An error formatter tool for Reason and OCaml. Takes raw error output from compiler and converts to pretty output";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/refmterr";
+    homepage = "https://reason-native.com/docs/refmterr/";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/rely-junit-reporter.nix
+++ b/pkgs/development/ocaml-modules/reason-native/rely-junit-reporter.nix
@@ -1,0 +1,23 @@
+{ atdgen, junit, re, reason, pastel, rely, ... }:
+
+{
+  pname = "rely-junit-reporter";
+
+  buildInputs = [
+    atdgen
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    junit
+    re
+    pastel
+    rely
+  ];
+
+  meta = {
+    description = "A tool providing JUnit Reporter for Rely Testing Framework";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/rely-junit-reporter";
+    homepage = "https://reason-native.com/docs/rely/";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/rely.nix
+++ b/pkgs/development/ocaml-modules/reason-native/rely.nix
@@ -1,0 +1,22 @@
+{ re, reason, cli, file-context-printer, pastel, ... }:
+
+{
+  pname = "rely";
+
+  buildInputs = [
+    reason
+  ];
+
+  propagatedBuildInputs = [
+    re
+    cli
+    file-context-printer
+    pastel
+  ];
+
+  meta = {
+    description = "A Jest-inspired testing framework for native OCaml/Reason";
+    downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/rely";
+    homepage = "https://reason-native.com/docs/rely/";
+  };
+}

--- a/pkgs/development/ocaml-modules/reason-native/tests/console/console-test.re
+++ b/pkgs/development/ocaml-modules/reason-native/tests/console/console-test.re
@@ -1,0 +1,1 @@
+Console.log(Some("Hello fellow Nixer!")); /* {"Hello fellow Nixer!"} */

--- a/pkgs/development/ocaml-modules/reason-native/tests/console/default.nix
+++ b/pkgs/development/ocaml-modules/reason-native/tests/console/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, reason, console }:
+
+buildDunePackage rec {
+  pname = "console-test";
+  version = "1";
+
+  src = ./.;
+
+  useDune2 = true;
+
+  buildInputs = [
+    reason
+    console
+  ];
+
+  doInstallCheck = true;
+  postInstallCheck = ''
+    $out/bin/console-test | grep -q "{\"Hello fellow Nixer!\"}" > /dev/null
+  '';
+}

--- a/pkgs/development/ocaml-modules/reason-native/tests/console/dune
+++ b/pkgs/development/ocaml-modules/reason-native/tests/console/dune
@@ -1,0 +1,4 @@
+(executable
+ (name console-test)
+ (public_name console-test)
+ (libraries reason console.lib))

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1143,6 +1143,8 @@ let
 
     reason = callPackage ../development/compilers/reason { };
 
+    reason-native = lib.recurseIntoAttrs (callPackage ../development/ocaml-modules/reason-native { });
+
     rope = callPackage ../development/ocaml-modules/rope { };
 
     rpclib = callPackage ../development/ocaml-modules/rpclib { };


### PR DESCRIPTION
Adds 10 Reason Native packages:
* reason-native-console
* reason-native-dir
* reason-native-file-context-printer
* reason-native-fp
* reason-native-pastel
* reason-native-pastel-console
* reason-native-qcheck-rely
* reason-native-refmterr
* reason-native-rely
* reason-native-rely-junit-reporter
