### PR TITLE
josm: 17833 → 17919

### DIFF
--- a/pkgs/applications/misc/josm/default.nix
+++ b/pkgs/applications/misc/josm/default.nix
@@ -3,15 +3,15 @@
 }:
 let
   pname = "josm";
-  version = "17833";
+  version = "17919";
   srcs = {
     jar = fetchurl {
       url = "https://josm.openstreetmap.de/download/josm-snapshot-${version}.jar";
-      sha256 = "sha256-i3seRVfCLXNvUkWAAPZK0XloRHuXWCNp1tqnVr7CQ7Y=";
+      sha256 = "sha256-Bj1s3vFSHPiZNTjp7hQhu1X2v8nlynC37Cm6sMNOi3g=";
     };
     macosx = fetchurl {
       url = "https://josm.openstreetmap.de/download/macosx/josm-macos-${version}-java16.zip";
-      sha256 = "sha256-PM/wNXqtEwalhorWHqVHWsaiGv60SFrHXZrb1Mw/QqQ=";
+      sha256 = "sha256-W+s6ARA5lyRwTuRD89wm4HChb2Up5AXQwh5uk0U7pQk=";
     };
     pkg = fetchsvn {
       url = "https://josm.openstreetmap.de/svn/trunk/native/linux/tested";


### PR DESCRIPTION
###### Motivation for this change
[2021-06-02: Stable release 17919](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.05)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
