### PR TITLE
ponyc: 0.38.3 -> 0.41.1

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.38.3";
+  version = "0.41.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "14kivmyphi7gbd7mgd4cnsiwl4cl7wih8kwzh7n79s2s4c5hj4ak";
+    sha256 = "02wx070cy1193xzv58vh79yzwgpqiayqlwd3i285698fppbcg69a";
 
 # Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
 # LLVM.  (The submodule is a specific tag in the LLVM source tree).
@@ -23,34 +23,33 @@ stdenv.mkDerivation (rec {
     fetchSubmodules = true;
   };
 
-  ponygbenchmark = fetchurl {
-    url = "https://github.com/google/benchmark/archive/v1.5.0.tar.gz";
-    sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";
-    name = "v1.5.0.tar.gz";
+  ponygbenchmark = fetchFromGitHub {
+    owner = "google";
+    repo = "benchmark";
+    rev = "v1.5.2";
+    sha256 = "13rxagpzw6bal6ajlmrxlh9kgfvcixn6j734b2bvfqz7lch8n0pa";
   };
 
   nativeBuildInputs = [ cmake makeWrapper which ];
   buildInputs = [ libxml2 z3 ];
-  propagatedBuildInputs = [ cc ];
 
   # Sandbox disallows network access, so disabling problematic networking tests
   patches = [
     ./disable-tests.patch
+    ./fix-libstdcpp-path.patch
     (substituteAll {
       src = ./make-safe-for-sandbox.patch;
       googletest = fetchurl {
         url = "https://github.com/google/googletest/archive/release-1.8.1.tar.gz";
         sha256 = "17147961i01fl099ygxjx4asvjanwdd446nwbq9v8156h98zxwcv";
-        name = "release-1.8.1.tar.gz";
       };
     })
   ];
 
   postUnpack = ''
     mkdir -p source/build/build_libs/gbenchmark-prefix/src
-    tar -C source/build/build_libs/gbenchmark-prefix/src -zxvf "$ponygbenchmark"
-    mv source/build/build_libs/gbenchmark-prefix/src/benchmark-1.5.0 \
-       source/build/build_libs/gbenchmark-prefix/src/benchmark
+    cp -r "$ponygbenchmark"/ source/build/build_libs/gbenchmark-prefix/src/benchmark
+    chmod -R u+w source/build/build_libs/gbenchmark-prefix/src/benchmark
   '';
 
   dontConfigure = true;
@@ -61,7 +60,6 @@ stdenv.mkDerivation (rec {
     patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-09-01-is-trivially-copyable.diff
     patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-01-07-01-c-exports.diff
     patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2019-12-23-01-jit-eh-frames.diff
-
     substituteInPlace packages/process/_test.pony \
         --replace '"/bin/' '"${coreutils}/bin/' \
         --replace '=/bin' "${coreutils}/bin"
@@ -91,7 +89,6 @@ stdenv.mkDerivation (rec {
     + lib.optionalString stdenv.isDarwin "bits=64 "
     + lib.optionalString (stdenv.isDarwin && (!lto)) "lto=no "
     + '' install
-
     wrapProgram $out/bin/ponyc \
       --prefix PATH ":" "${stdenv.cc}/bin" \
       --set-default CC "$CC" \

--- a/pkgs/development/compilers/ponyc/fix-libstdcpp-path.patch
+++ b/pkgs/development/compilers/ponyc/fix-libstdcpp-path.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libponyc/CMakeLists.txt b/src/libponyc/CMakeLists.txt
+index bf2c385e..11d0d619 100644
+--- a/src/libponyc/CMakeLists.txt
++++ b/src/libponyc/CMakeLists.txt
+@@ -136,7 +136,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
+ else()
+     # add a rule to generate the standalone library if needed
+     add_custom_command(OUTPUT libponyc-standalone.a
+-        COMMAND cp `find /usr/lib/ -name 'libstdc++.a' -print -quit` libstdcpp.a
++        COMMAND cp `${CMAKE_CXX_COMPILER} --print-file-name='libstdc++.a'` libstdcpp.a
+         COMMAND echo "create libponyc-standalone.a" > standalone.mri
+         COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
+         COMMAND echo "addlib libstdcpp.a" >> standalone.mri
+

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,10 +1,10 @@
---- a/lib/CMakeLists.txt	2020-09-27 02:39:12.862940179 +0000
-+++ b/lib/CMakeLists.txt	2020-09-27 02:39:16.451957865 +0000
+--- a/lib/CMakeLists.txt	2021-05-27 15:58:36.819331229 -0400
++++ b/lib/CMakeLists.txt	2021-05-27 16:00:19.768268649 -0400
 @@ -10,12 +10,12 @@
  endif()
  
  ExternalProject_Add(gbenchmark
--    URL https://github.com/google/benchmark/archive/v1.5.0.tar.gz
+-    URL https://github.com/google/benchmark/archive/v1.5.2.tar.gz
 +    SOURCE_DIR gbenchmark-prefix/src/benchmark
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
  )
@@ -30,12 +30,12 @@
 -        option(GIT_SUBMODULE "Check submodules during build" ON)
 -        if(GIT_SUBMODULE)
 -            message(STATUS "Updating submodules...")
--            execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+-            execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --depth 1
 -                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 -                            RESULT_VARIABLE git_submod_result)
 -            #message("git_submod_result ${git_submod_result}")
 -            if(NOT git_submod_result EQUAL "0")
--                message(FATAL_ERROR "git submodule update --init --recursive failed with ${git_submod_result}, please checkout submodules")
+-                message(FATAL_ERROR "git submodule update --init --recursive --depth 1 failed with ${git_submod_result}, please checkout submodules")
 -            endif()
 -
 -            # we check to make sure the submodule hash matches

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11572,7 +11572,7 @@ in
 
   ponyc = callPackage ../development/compilers/ponyc {
     # Upstream pony has dropped support for versions compiled with gcc.
-    stdenv = clangStdenv;
+    stdenv = llvmPackages_9.stdenv;
   };
 
   pony-corral = callPackage ../development/compilers/ponyc/pony-corral.nix { };


### PR DESCRIPTION
###### Motivation for this change

* Fix NullablePointer type constraint check being omitted in FFI declarations
* Change to Steed's model of subtyping
* Fix memory corruption with Array.chop and String.chop
* Improve error message for match on structs
* RFC 68: Mandatory FFI declarations
* Change return type of String.add to String iso^
* Improve error message on destructuring of non-tuple types
* Use built-in offset argument to cpointer
* Add IsPrime checker to math package
* Fix compiler crash related to type parameter references
* Fix literal inference through partial function
* Fix partial FFI declarations ignoring partial annotation
* Fix symbol table patching for overriding default methods
* Fix tuple related compiler segfaults
* Create a standalone libponyc on Linux

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
