### PR TITLE
python3Pacakges.awscrt: only pull in GCC on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/awscrt/default.nix
+++ b/pkgs/development/python-modules/awscrt/default.nix
@@ -11,7 +11,9 @@ buildPythonPackage rec {
   # https://github.com/NixOS/nixpkgs/issues/39687
   hardeningDisable = lib.optional stdenv.cc.isClang "strictoverflow";
 
-  nativeBuildInputs = [ cmake ] ++ lib.optionals stdenv.isAarch64 ([ gcc10 perl ]);
+  nativeBuildInputs = [ cmake ] ++
+    # gcc <10 is not supported, LLVM on darwin is just fine
+    lib.optionals (!stdenv.isDarwin && stdenv.isAarch64) [ gcc10 perl ];
 
   dontUseCmakeConfigure = true;
 


### PR DESCRIPTION
###### Motivation for this change

On aarch64-darwin we can't build GCC10 (yet) and the LLVM version in the stdenv is good enough for this package anyway. This PR restricts that optional package dependency further.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] tested on aarch64-darwin
- [x] tested on aarch64-linux  
