### PR TITLE
hydra: init at 1.10.2

### DIFF
--- a/pkgs/applications/misc/hydra/default.nix
+++ b/pkgs/applications/misc/hydra/default.nix
@@ -1,0 +1,33 @@
+{ fetchFromGitHub, buildGoModule, lib, stdenv }:
+
+buildGoModule rec {
+  pname = "hydra";
+  version = "1.10.2";
+
+  src = fetchFromGitHub {
+    owner = "ory";
+    repo = "hydra";
+    rev = "v${version}";
+    sha256 = "01q4ihhf06iyk84ssnz9r479zg5n9bnj58pv8fcfjm9ai1mvb1il";
+  };
+
+  vendorSha256 = "1ba2g2fzhpml5b8kz2y15ng83l7884mzn6rl1qj4dlwz6vhhx6qq";
+
+  subPackages = [ "." ];
+
+  buildFlags = [ "-tags sqlite" ];
+
+  doCheck = false;
+
+  preBuild = ''
+    # patchShebangs doesn't work for this Makefile, do it manually
+    substituteInPlace Makefile --replace '/bin/bash' '${stdenv.shell}'
+  '';
+
+  meta = with lib; {
+    maintainers = with maintainers; [ cmcdragonkai ];
+    homepage = "https://www.ory.sh/hydra/";
+    license = licenses.asl20;
+    description = "OpenID Certified OAuth 2.0 Server and OpenID Connect Provider optimized for low-latency, high throughput, and low resource consumption";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15477,6 +15477,8 @@ in
 
   hydra-check = with python3.pkgs; toPythonApplication hydra-check;
 
+  hydra = callPackage ../applications/misc/hydra { };
+
   hyena = callPackage ../development/libraries/hyena { };
 
   hyperscan = callPackage ../development/libraries/hyperscan { };


### PR DESCRIPTION
###### Motivation for this change

This adds Ory Hydra which is an OpenID and OAuth2 server.

Related to Ory Kratos: https://github.com/NixOS/nixpkgs/pull/121706

@MrMebelMan 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).