### PR TITLE
terraform-providers.acme: 1.5.0-patched -> 2.5.2

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -2,6 +2,7 @@
 , buildGoModule
 , buildGoPackage
 , fetchFromGitHub
+, fetchpatch
 , callPackage
 }:
 let
@@ -46,10 +47,12 @@ let
   # These are the providers that don't fall in line with the default model
   special-providers = {
     acme = automated-providers.acme.overrideAttrs (attrs: {
-      prePatch = attrs.prePatch or "" + ''
-        substituteInPlace go.mod --replace terraform-providers/terraform-provider-acme getstackhead/terraform-provider-acme
-        substituteInPlace main.go --replace terraform-providers/terraform-provider-acme getstackhead/terraform-provider-acme
-      '';
+      patches = attrs.patches or [ ] ++ [
+        (fetchpatch {
+          url = "https://github.com/vancluever/terraform-provider-acme/commit/a5834747aebc3677225c68a08ef784cfd7b35e6c.patch";
+          sha256 = "091484whrpq6ykpgpndc8kc9cbvd9wwr0b51m1yxp31750lydp8m";
+        })
+      ];
     });
 
     # Packages that don't fit the default model

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -2,7 +2,6 @@
 , buildGoModule
 , buildGoPackage
 , fetchFromGitHub
-, fetchpatch
 , callPackage
 }:
 let
@@ -46,15 +45,6 @@ let
 
   # These are the providers that don't fall in line with the default model
   special-providers = {
-    acme = automated-providers.acme.overrideAttrs (attrs: {
-      patches = attrs.patches or [ ] ++ [
-        (fetchpatch {
-          url = "https://github.com/vancluever/terraform-provider-acme/commit/a5834747aebc3677225c68a08ef784cfd7b35e6c.patch";
-          sha256 = "091484whrpq6ykpgpndc8kc9cbvd9wwr0b51m1yxp31750lydp8m";
-        })
-      ];
-    });
-
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
     cloudfoundry = callPackage ./cloudfoundry {};

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -7,12 +7,13 @@
     "version": "0.2.3"
   },
   "acme": {
-    "owner": "getstackhead",
-    "provider-source-address": "registry.terraform.io/getstackhead/acme",
+    "owner": "vancluever",
+    "provider-source-address": "registry.terraform.io/vancluever/acme",
     "repo": "terraform-provider-acme",
-    "rev": "v1.5.0-patched",
-    "sha256": "1wdrjpd3l0xadsa3lqhsc9c57g8x2qkwb76q824sk8za1a7lapii",
-    "version": "1.5.0-patched"
+    "rev": "v2.4.0",
+    "sha256": "0r7i55gdscw94b954nfkvgfsrw7piq63gp06vh9smrwax9i2xc2f",
+    "vendorSha256": "09zmw2xm5fwwsa9bqwscq0s67hlxjk2kd3j02ayr4mxzhaagh1z9",
+    "version": "2.4.0"
   },
   "akamai": {
     "owner": "terraform-providers",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -10,10 +10,10 @@
     "owner": "vancluever",
     "provider-source-address": "registry.terraform.io/vancluever/acme",
     "repo": "terraform-provider-acme",
-    "rev": "v2.4.0",
-    "sha256": "0r7i55gdscw94b954nfkvgfsrw7piq63gp06vh9smrwax9i2xc2f",
-    "vendorSha256": "09zmw2xm5fwwsa9bqwscq0s67hlxjk2kd3j02ayr4mxzhaagh1z9",
-    "version": "2.4.0"
+    "rev": "v2.5.2",
+    "sha256": "0yk5yxx8vdfymxggydpzsb2a0iw4n8010wlprz23qg37gb2p26yf",
+    "vendorSha256": "04zrrn67w30ib0n5s4f31x3nl3h3xz2r522ldkbbx20jy5iabrkk",
+    "version": "2.5.2"
   },
   "akamai": {
     "owner": "terraform-providers",


### PR DESCRIPTION
Updated and moving to upstream source because [the README claims the fork is inactive and tells you to avoid using it](https://github.com/getstackhead/terraform-provider-acme/blob/feature/http01-challenge/README.md). If the fork is still needed, it might make sense to add the patched version under another attr such as `acme-http01`?

###### Motivation for this change

`1.5.0` is outdated and [doesn't seem to work anymore](https://github.com/vancluever/terraform-provider-acme/issues/154).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
