### PR TITLE
poco: propagate buildInputs

### DIFF
--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ zlib pcre expat sqlite openssl unixODBC libmysqlclient ];
+  buildInputs = [ expat sqlite openssl unixODBC libmysqlclient ];
+  propagatedBuildInputs = [ zlib pcre ];
 
   MYSQL_DIR = libmysqlclient;
   MYSQL_INCLUDE_DIR = "${MYSQL_DIR}/include/mysql";


### PR DESCRIPTION
Should more of the dependencies be passed through? The ones in `PocoFoundationConfig.cmake` seem to be the main common deps, but the other components may need their dependencies available for cmake to find as well. 

###### Motivation for this change

poco's cmake scripts require these, so make sure it can find them!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
