### PR TITLE
libimobiledevice: 1.3.0 ->  unstable-2021-06-02

### DIFF
--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -1,25 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, automake, autoconf, libtool, pkg-config, gnutls
-, libgcrypt, libtasn1, glib, libplist, libusbmuxd }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, libtool
+, pkg-config
+, gnutls
+, libgcrypt
+, libtasn1
+, glib
+, libplist
+, libusbmuxd
+}:
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "1.3.0";
+  version = "unstable-2021-06-02";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = version;
-    sha256 = "1jkq3hpg4n5a6s1k618ib0s80pwf00nlfcby7xckysq8mnd2pp39";
+    rev = "ca324155f8b33babf907704828c7903608db0aa2";
+    sha256 = "sha256-Q7THwld1+elMJQ14kRnlIJDohFt7MW7JeyIUGC0k52I=";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     libtool
     pkg-config
   ];
+
   propagatedBuildInputs = [
     glib
     gnutls
@@ -29,12 +40,7 @@ stdenv.mkDerivation rec {
     libusbmuxd
   ];
 
-  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
-
-  configureFlags = [
-    "--disable-openssl"
-    "--without-cython"
-  ];
+  configureFlags = [ "--disable-openssl" "--without-cython" ];
 
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/libimobiledevice";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
one of libimobiledevice's tools `ideviceenterrecovery` doesn't work right with iOS 14

```
~ ^ ideviceenterrecovery 00008020-001A58582283002E
Telling device with udid 00008020-001A58582283002E to enter recovery mode.
Failed to enter recovery mode.
Device is successfully switching to recovery mode.
```

tested with an iPhone Xs running iOS 14.5.1

```
nixpkgs on  libimobiledevice ^ /nix/store/xhpzbwh6q4bvjdg23vywzrvbpn6r8hsz-libimobiledevice-unstable-2021-06-02/bin/ideviceenterrecovery 00008020-001A58582283002E
Telling device with udid 00008020-001A58582283002E to enter recovery mode.
Device is successfully switching to recovery mode
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
