### PR TITLE
dnsdist: 1.5.2 -> 1.7.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -104,6 +104,7 @@ in
   discourse = handleTest ./discourse.nix {};
   dnscrypt-proxy2 = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy2.nix {};
   dnscrypt-wrapper = handleTestOn ["x86_64-linux"] ./dnscrypt-wrapper {};
+  dnsdist = handleTest ./dnsdist.nix {};
   doas = handleTest ./doas.nix {};
   docker = handleTestOn ["x86_64-linux"] ./docker.nix {};
   docker-rootless = handleTestOn ["x86_64-linux"] ./docker-rootless.nix {};

--- a/nixos/tests/dnsdist.nix
+++ b/nixos/tests/dnsdist.nix
@@ -1,0 +1,48 @@
+import ./make-test-python.nix (
+  { pkgs, ... }: {
+    name = "dnsdist";
+    meta = with pkgs.lib; {
+      maintainers = with maintainers; [ jojosch ];
+    };
+
+    machine = { pkgs, lib, ... }: {
+      services.bind = {
+        enable = true;
+        extraOptions = "empty-zones-enable no;";
+        zones = lib.singleton {
+          name = ".";
+          master = true;
+          file = pkgs.writeText "root.zone" ''
+            $TTL 3600
+            . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+            . IN NS ns.example.org.
+
+            ns.example.org. IN A    192.168.0.1
+            ns.example.org. IN AAAA abcd::1
+
+            1.0.168.192.in-addr.arpa IN PTR ns.example.org.
+          '';
+        };
+      };
+      services.dnsdist = {
+        enable = true;
+        listenPort = 5353;
+        extraConfig = ''
+          newServer({address="127.0.0.1:53", name="local-bind"})
+        '';
+      };
+
+      environment.systemPackages = with pkgs; [ dig ];
+    };
+
+    testScript = ''
+      machine.wait_for_unit("bind.service")
+      machine.wait_for_open_port(53)
+      machine.succeed("dig @127.0.0.1 +short -x 192.168.0.1 | grep -qF ns.example.org")
+
+      machine.wait_for_unit("dnsdist.service")
+      machine.wait_for_open_port(5353)
+      machine.succeed("dig @127.0.0.1 -p 5353 +short -x 192.168.0.1 | grep -qF ns.example.org")
+    '';
+  }
+)

--- a/pkgs/servers/dns/dnsdist/default.nix
+++ b/pkgs/servers/dns/dnsdist/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, pkg-config, systemd
 , boost, libsodium, libedit, re2
 , net-snmp, lua, protobuf, openssl, zlib, h2o
-, nghttp2
+, nghttp2, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -38,6 +38,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   enableParallelBuilding = true;
+
+  passthru.tests = {
+    inherit (nixosTests) dnsdist;
+  };
 
   meta = with lib; {
     description = "DNS Loadbalancer";

--- a/pkgs/servers/dns/dnsdist/default.nix
+++ b/pkgs/servers/dns/dnsdist/default.nix
@@ -1,19 +1,26 @@
 { lib, stdenv, fetchurl, pkg-config, systemd
 , boost, libsodium, libedit, re2
 , net-snmp, lua, protobuf, openssl, zlib, h2o
+, nghttp2
 }:
 
 stdenv.mkDerivation rec {
   pname = "dnsdist";
-  version = "1.5.2";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/dnsdist-${version}.tar.bz2";
-    sha256 = "sha256-K9e1M9Lae7RWY8amLkftDS8Zigd/WNxzDEY7eXNjZ0k=";
+    sha256 = "sha256-eMxyywzPf7Xz8vrgnHntplpSVjdNoJu1Qbc16mho/GQ=";
   };
 
+  patches = [
+    # Disable tests requiring networking:
+    # "Error connecting to new server with address 192.0.2.1:53: connecting socket to 192.0.2.1:53: Network is unreachable"
+    ./disable-network-tests.patch
+  ];
+
   nativeBuildInputs = [ pkg-config protobuf ];
-  buildInputs = [ systemd boost libsodium libedit re2 net-snmp lua openssl zlib h2o ];
+  buildInputs = [ systemd boost libsodium libedit re2 net-snmp lua openssl zlib h2o nghttp2 ];
 
   configureFlags = [
     "--with-libsodium"

--- a/pkgs/servers/dns/dnsdist/default.nix
+++ b/pkgs/servers/dns/dnsdist/default.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation rec {
     description = "DNS Loadbalancer";
     homepage = "https://dnsdist.org";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    maintainers = with maintainers; [ jojosch ];
   };
 }

--- a/pkgs/servers/dns/dnsdist/disable-network-tests.patch
+++ b/pkgs/servers/dns/dnsdist/disable-network-tests.patch
@@ -1,0 +1,28 @@
+diff --git a/test-dnsdisttcp_cc.cc b/test-dnsdisttcp_cc.cc
+index 1fbb00e..dc04137 100644
+--- a/test-dnsdisttcp_cc.cc
++++ b/test-dnsdisttcp_cc.cc
+@@ -848,6 +848,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionWithProxyProtocol_SelfAnswered)
+ 
+ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
+ {
++  return;
+   auto local = getBackendAddress("1", 80);
+   ClientState localCS(local, true, false, false, "", {});
+   auto tlsCtx = std::make_shared<MockupTLSCtx>();
+@@ -1711,6 +1712,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnection_BackendNoOOOR)
+ 
+ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
+ {
++  return;
+   auto local = getBackendAddress("1", 80);
+   ClientState localCS(local, true, false, false, "", {});
+   /* enable out-of-order on the front side */
+@@ -3677,6 +3679,7 @@ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendOOOR)
+ 
+ BOOST_AUTO_TEST_CASE(test_IncomingConnectionOOOR_BackendNotOOOR)
+ {
++  return;
+   auto local = getBackendAddress("1", 80);
+   ClientState localCS(local, true, false, false, "", {});
+   /* enable out-of-order on the front side */


### PR DESCRIPTION
###### Motivation for this change
Update to latest release https://dnsdist.org/changelog.html#change-1.7.0. Been using 1.6 and 1.7 it since the `1.6.0-alpha2` on my personal resolvers.

1.7 needs `nghttp2` for outgoing DoH Support (https://dnsdist.org/guides/dns-over-https.html#dns-over-https-doh):

without:
```
$ ./result/bin/dnsdist --version
dnsdist 1.7.0 (Lua 5.2.4)
Enabled features: dns-over-tls(openssl) dns-over-https(DOH) dnscrypt ebpf ipcipher libsodium protobuf re2 recvmmsg/sendmmsg snmp systemd
```

with (note the `outgoing-dns-over-https(nghttp2)`):
```
$ ./result/bin/dnsdist --version
dnsdist 1.7.0 (Lua 5.2.4)
Enabled features: dns-over-tls(openssl) dns-over-https(DOH) dnscrypt ebpf ipcipher libsodium outgoing-dns-over-https(nghttp2) protobuf re2 recvmmsg/sendmmsg snmp systemd
```

----------------------------

Also added a simple NixOS-test and needed to disable 3 tests which require networking:

```
dnsdist> FAIL: testrunner
dnsdist> ================
dnsdist> Running 104 test cases...
dnsdist> Error connecting to new server with address 192.0.2.1:53: connecting socket to 192.0.2.1:53: Network is unreachable
dnsdist> Error connecting to new server with address 192.0.2.2:53: connecting socket to 192.0.2.2:53: Network is unreachable
[...]
dnsdist> Error connecting to new server with address 192.0.2.10:53: connecting socket to 192.0.2.10:53: Network is unreachable
dnsdist> test-dnsdisttcp_cc.cc(213): fatal error: in "test_dnsdisttcp_cc/test_IncomingConnection_BackendNoOOOR": critical check step.request == !d_client ? ExpectedStep::ExpectedRequest::closeClient : ExpectedStep::ExpectedRequest::closeBackend has failed [connect to the backend != close connection to backend]
dnsdist> terminate called after throwing an instance of 'boost::execution_aborted'
dnsdist> unknown location(0): fatal error: in "test_dnsdisttcp_cc/test_IncomingConnection_BackendNoOOOR": signal: SIGABRT (application abort requested)
dnsdist> test-dnsdisttcp_cc.cc(213): last checkpoint
dnsdist> test-dnsdisttcp_cc.cc(213): fatal error: in "test_dnsdisttcp_cc/test_IncomingConnectionOOOR_BackendOOOR": critical check step.request == !d_client ? ExpectedStep::ExpectedRequest::closeClient : ExpectedStep::ExpectedRequest::closeBackend has failed [connect to the backend != close connection to backend]
dnsdist> terminate called recursively
dnsdist> unknown location(0): fatal error: in "test_dnsdisttcp_cc/test_IncomingConnectionOOOR_BackendOOOR": signal: SIGABRT (application abort requested)
dnsdist> test-dnsdisttcp_cc.cc(213): last checkpoint
dnsdist> test-dnsdisttcp_cc.cc(213): fatal error: in "test_dnsdisttcp_cc/test_IncomingConnectionOOOR_BackendNotOOOR": critical check step.request == !d_client ? ExpectedStep::ExpectedRequest::closeClient : ExpectedStep::ExpectedRequest::closeBackend has failed [connect to the backend != close connection to backend]
dnsdist> terminate called recursively
dnsdist> unknown location(0): fatal error: in "test_dnsdisttcp_cc/test_IncomingConnectionOOOR_BackendNotOOOR": signal: SIGABRT (application abort requested)
dnsdist> test-dnsdisttcp_cc.cc(213): last checkpoint
dnsdist> *** 6 failures are detected in the test module "unit"
dnsdist> FAIL testrunner (exit status: 201)
dnsdist> ============================================================================
dnsdist> Testsuite summary for dnsdist 1.6.0
dnsdist> ============================================================================
dnsdist> # TOTAL: 1
dnsdist> # PASS:  0
dnsdist> # SKIP:  0
dnsdist> # XFAIL: 0
dnsdist> # FAIL:  1
dnsdist> # XPASS: 0
dnsdist> # ERROR: 0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
