### PR TITLE
git: fix pkgsStatic build

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
     ++ lib.optionals withLibsecret [ pkg-config glib libsecret ];
 
   # required to support pthread_cancel()
-  NIX_LDFLAGS = lib.optionalString (!stdenv.cc.isClang) "-lgcc_s"
+  NIX_LDFLAGS = lib.optionalString (stdenv.cc.isGNU && stdenv.hostPlatform.libc == "glibc") "-lgcc_s"
               + lib.optionalString (stdenv.isFreeBSD) "-lthr";
 
   configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Building `pkgsStatic.git` succeed instead of failing with:

```
configuring
configure flags: --prefix=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1 --bindir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/bin --sbindir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/sbin --includedir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/include --oldincludedir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/include --mandir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/share/man --infodir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/share/info --docdir=/nix/store/m36w1ql3nl3awplf2b58nl5sg2gpss3w-git-static-x86_64-unknown-linux-musl-2.31.1-doc/share/doc/git --libdir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/lib --libexecdir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/libexec --localedir=/nix/store/377zww64ys8phf974q4g4phncqxcyh81-git-static-x86_64-unknown-linux-musl-2.31.1/share/locale ac_cv_fread_reads_directories=yes ac_cv_snprintf_returns_bogus=no ac_cv_iconv_omits_bom=no ac_cv_prog_CURL_CONFIG=/nix/store/jb0kv6pniz4hj883x6nb9xcs7c6kswhn-curl-static-x86_64-unknown-linux-musl-7.76.1-dev/bin/curl-config --disable-shared --enable-static --disable-shared --build=x86_64-unknown-linux-gnu --host=x86_64-unknown-linux-musl
configure: WARNING: unrecognized options: --disable-shared, --enable-static, --disable-shared
configure: Setting lib to 'lib' (the default)
configure: Will try -pthread then -lpthread to enable POSIX Threads.
configure: CHECKS for site configuration
checking for x86_64-unknown-linux-musl-gcc... x86_64-unknown-linux-musl-gcc
checking whether the C compiler works... no
configure: error: in `/build/git-2.31.1':
configure: error: C compiler cannot create executables
See `config.log' for more details
builder for '/nix/store/ar9j0fdrlq8j9bcxwwmw8l3sm2i9hhr0-git-static-x86_64-unknown-linux-musl-2.31.1.drv' failed with exit code 77
error: build of '/nix/store/ar9j0fdrlq8j9bcxwwmw8l3sm2i9hhr0-git-static-x86_64-unknown-linux-musl-2.31.1.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
