### PR TITLE
liquidwar: fix build

### DIFF
--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -4,7 +4,7 @@
 , SDL, SDL_image, SDL_mixer, SDL_ttf
 , curl, sqlite, libtool, readline
 , libogg, libvorbis, libcaca, csound, cunit
-, pkg-config } :
+, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "liquidwar6";

--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -3,7 +3,8 @@
 , expat, gettext, perl, guile
 , SDL, SDL_image, SDL_mixer, SDL_ttf
 , curl, sqlite, libtool, readline
-, libogg, libvorbis, libcaca, csound, cunit } :
+, libogg, libvorbis, libcaca, csound, cunit
+, pkg-config } :
 
 stdenv.mkDerivation rec {
   pname = "liquidwar6";
@@ -24,6 +25,8 @@ stdenv.mkDerivation rec {
     libXrender libcaca cunit
     libtool readline
   ];
+
+  nativeBuildInputs = [ pkg-config ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change

Configure script would try to use guile-config to determine guile configuration which in turn would attempt to use pkg-config.

Since pkg-config was not available in the build, guile-config would fail and some default options would be used causing guile config to not be properly picked up.

Fixed by adding pkg-config to dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
