### PR TITLE
python3Packages.wallbox: init at 0.4.4

### DIFF
--- a/pkgs/development/python-modules/wallbox/default.nix
+++ b/pkgs/development/python-modules/wallbox/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, simplejson
+, requests
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "wallbox";
+  version = "0.4.4";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "cliviu74";
+    repo = pname;
+    rev = version;
+    sha256 = "1bj0aiszrszfrv897bhp9s7rdbjz2qqp881gc5yvzvwlmf903rvx";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    simplejson
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "wallbox" ];
+
+  meta = with lib; {
+    description = "Python Module interface for Wallbox EV chargers API";
+    homepage = "https://github.com/cliviu74/wallbox";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -939,7 +939,7 @@
     "vultr" = ps: with ps; [ vultr ];
     "w800rf32" = ps: with ps; [ ]; # missing inputs: pyW800rf32
     "wake_on_lan" = ps: with ps; [ wakeonlan ];
-    "wallbox" = ps: with ps; [ ]; # missing inputs: wallbox
+    "wallbox" = ps: with ps; [ wallbox ];
     "waqi" = ps: with ps; [ waqiasync ];
     "water_heater" = ps: with ps; [ ];
     "waterfurnace" = ps: with ps; [ waterfurnace ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -653,6 +653,7 @@ in with py.pkgs; buildPythonApplication rec {
     "volumio"
     "vultr"
     "wake_on_lan"
+    "wallbox"
     "water_heater"
     "waze_travel_time"
     "weather"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8854,6 +8854,8 @@ in {
 
   wakeonlan = callPackage ../development/python-modules/wakeonlan { };
 
+  wallbox = callPackage ../development/python-modules/wallbox { };
+
   Wand = callPackage ../development/python-modules/Wand { };
 
   warlock = callPackage ../development/python-modules/warlock { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Module interface for Wallbox EV chargers API

https://github.com/cliviu74/wallbox

This is a Home Assistant dependency.

- Target Home Assistant release: 2021.6.0

ToDo:
- [x] Update `component-packages`
- [x] Enable tests in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
