### PR TITLE
nixos/prometheus-exporters: improve docs & fix rspamd exporter

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
@@ -35,13 +35,28 @@ in
         {
           <xref linkend="opt-services.prometheus.exporters.dovecot.enable" /> = true;
           <xref linkend="opt-services.prometheus.exporters.dovecot.socketPath" /> = "/var/run/dovecot2/old-stats";
+          <xref linkend="opt-services.dovecot2.mailPlugins.globally.enable" /> = [ "old_stats" ];
           <xref linkend="opt-services.dovecot2.extraConfig" /> = '''
-            mail_plugins = $mail_plugins old_stats
             service old-stats {
               unix_listener old-stats {
                 user = dovecot-exporter
                 group = dovecot-exporter
+                mode = 0660
               }
+              fifo_listener old-stats-mail {
+                mode = 0660
+                user = dovecot
+                group = dovecot
+              }
+              fifo_listener old-stats-user {
+                mode = 0660
+                user = dovecot
+                group = dovecot
+              }
+            }
+            plugin {
+              old_stats_refresh = 30 secs
+              old_stats_track_cmds = yes
             }
           ''';
         }

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
@@ -112,6 +112,24 @@ let
       '';
       description = ''
         List of servers that should be probed.
+
+        <emphasis>Note:</emphasis> if your mailserver has <citerefentry>
+        <refentrytitle>rspamd</refentrytitle><manvolnum>8</manvolnum></citerefentry> configured,
+        it can happen that emails from this exporter are marked as spam.
+
+        It's possible to work around the issue with a config like this:
+        <programlisting>
+        {
+          <link linkend="opt-services.rspamd.locals._name_.text">services.rspamd.locals."multimap.conf".text</link> = '''
+            ALLOWLIST_PROMETHEUS {
+              filter = "email:domain:tld";
+              type = "from";
+              map = "''${pkgs.writeText "allowmap" "domain.tld"}";
+              score = -100.0;
+            }
+          ''';
+        }
+        </programlisting>
       '';
     };
   };

--- a/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix
@@ -5,21 +5,19 @@ with lib;
 let
   cfg = config.services.prometheus.exporters.rspamd;
 
-  prettyJSON = conf:
-    pkgs.runCommand "rspamd-exporter-config.yml" { } ''
-      echo '${builtins.toJSON conf}' | ${pkgs.buildPackages.jq}/bin/jq '.' > $out
-    '';
+  mkFile = conf:
+    pkgs.writeText "rspamd-exporter-config.yml" (builtins.toJSON conf);
 
   generateConfig = extraLabels: {
     metrics = (map (path: {
-      name = "rspamd_${replaceStrings [ "." " " ] [ "_" "_" ] path}";
+      name = "rspamd_${replaceStrings [ "[" "." " " "]" "\\" "'" ] [ "_" "_" "_" "" "" "" ] path}";
       path = "{ .${path} }";
       labels = extraLabels;
     }) [
-      "actions.'add header'"
-      "actions.'no action'"
-      "actions.'rewrite subject'"
-      "actions.'soft reject'"
+      "actions['add\\ header']"
+      "actions['no\\ action']"
+      "actions['rewrite\\ subject']"
+      "actions['soft\\ reject']"
       "actions.greylist"
       "actions.reject"
       "bytes_allocated"
@@ -40,18 +38,18 @@ let
     ]) ++ [{
       name = "rspamd_statfiles";
       type = "object";
-      path = "$.statfiles[*]";
+      path = "{.statfiles[*]}";
       labels = recursiveUpdate {
-        symbol = "$.symbol";
-        type = "$.type";
+        symbol = "{.symbol}";
+        type = "{.type}";
       } extraLabels;
       values = {
-        revision = "$.revision";
-        size = "$.size";
-        total = "$.total";
-        used = "$.used";
-        languages = "$.languages";
-        users = "$.users";
+        revision = "{.revision}";
+        size = "{.size}";
+        total = "{.total}";
+        used = "{.used}";
+        languages = "{.languages}";
+        users = "{.users}";
       };
     }];
   };
@@ -76,7 +74,7 @@ in
   };
   serviceOpts.serviceConfig.ExecStart = ''
     ${pkgs.prometheus-json-exporter}/bin/json_exporter \
-      --config.file ${prettyJSON (generateConfig cfg.extraLabels)} \
+      --config.file ${mkFile (generateConfig cfg.extraLabels)} \
       --web.listen-address "${cfg.listenAddress}:${toString cfg.port}" \
       ${concatStringsSep " \\\n  " cfg.extraFlags}
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While improving the monitoring of my self-hosted mailserver a bit, I found a few issues with the current prometheus exporters here. The `rspamd` exporter needed further adjustment to work with the json-exporter 0.3.0, for the dovecot & mail exporters I decided to improve the documentation a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
