### PR TITLE
python3Packages.pymeteoclimatic: init at 0.0.6

### DIFF
--- a/pkgs/development/python-modules/pymeteoclimatic/default.nix
+++ b/pkgs/development/python-modules/pymeteoclimatic/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pymeteoclimatic";
+  version = "0.0.6";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "adrianmo";
+    repo = pname;
+    rev = version;
+    sha256 = "0ys0d6jy7416gbsd0pqgvm5ygzn36pjdaklqi4q56vsb13zn7y0h";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    lxml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "meteoclimatic" ];
+
+  meta = with lib; {
+    description = "Python wrapper around the Meteoclimatic service";
+    homepage = "https://github.com/adrianmo/pymeteoclimatic";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -500,7 +500,7 @@
     "met_eireann" = ps: with ps; [ pymeteireann ];
     "meteo_france" = ps: with ps; [ ]; # missing inputs: meteofrance-api
     "meteoalarm" = ps: with ps; [ meteoalertapi ];
-    "meteoclimatic" = ps: with ps; [ ]; # missing inputs: pymeteoclimatic
+    "meteoclimatic" = ps: with ps; [ pymeteoclimatic ];
     "metoffice" = ps: with ps; [ ]; # missing inputs: datapoint
     "mfi" = ps: with ps; [ ]; # missing inputs: mficlient
     "mhz19" = ps: with ps; [ ]; # missing inputs: pmsensor

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -471,6 +471,7 @@ in with py.pkgs; buildPythonApplication rec {
     "meraki"
     "met"
     "met_eireann"
+    "meteoclimatic"
     "microsoft_face"
     "microsoft_face_detect"
     "microsoft_face_identify"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5996,6 +5996,8 @@ in {
 
   pymeteireann = callPackage ../development/python-modules/pymeteireann { };
 
+  pymeteoclimatic = callPackage ../development/python-modules/pymeteoclimatic { };
+
   pymetno = callPackage ../development/python-modules/pymetno { };
 
   pymitv = callPackage ../development/python-modules/pymitv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper around the Meteoclimatic service

https://github.com/adrianmo/pymeteoclimatic

This is a Home Assistant dependency.

- Target Home Assistant release: 2021.6.0

ToDo:

- [x] Update `component-packages`
- [x] Enable tests in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
