### PR TITLE
nufraw: fix build

### DIFF
--- a/pkgs/applications/graphics/nufraw/default.nix
+++ b/pkgs/applications/graphics/nufraw/default.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
     substituteAll ${./nufraw.thumbnailer} $out/share/thumbnailers/${pname}.thumbnailer
   '';
 
+  # Fixes an upstream issue where headers with templates were included in an extern-C scope
+  # which caused the build to fail
+  patches = [ ./move-extern-c.patch ];
+
   meta = with lib; {
     homepage = "https://nufraw.sourceforge.io/";
     description = "Utility to read and manipulate raw images from digital cameras";

--- a/pkgs/applications/graphics/nufraw/move-extern-c.patch
+++ b/pkgs/applications/graphics/nufraw/move-extern-c.patch
@@ -1,0 +1,21 @@
+diff --git a/uf_glib.h b/uf_glib.h
+index c1a17bd..8a10800 100644
+--- a/uf_glib.h
++++ b/uf_glib.h
+@@ -13,13 +13,13 @@
+ #ifndef _UF_GLIB_H
+ #define _UF_GLIB_H
+ 
++#include <glib.h>
++#include <glib/gstdio.h>
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+ 
+-#include <glib.h>
+-#include <glib/gstdio.h>
+-
+ // g_win32_locale_filename_from_utf8 is needed only on win32
+ #ifdef _WIN32
+ #define uf_win32_locale_filename_from_utf8(__some_string__) \


### PR DESCRIPTION
###### Motivation for this change

Sources would include glib-headers from within an extern-C scope. Since glib-headers contained templates, this would fail. Add a patch to move the header includes outside of the extern-C scope.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
