### PR TITLE
python3Packages.pykulersky: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/pykulersky/default.nix
+++ b/pkgs/development/python-modules/pykulersky/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, bleak
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pykulersky";
+  version = "0.5.2";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "emlove";
+    repo = pname;
+    rev = version;
+    sha256 = "1fzfixnl28rny7c3wr6gcdpqhyrz7z2aqq6qfwkxnkq2kqdbpmmg";
+  };
+
+  propagatedBuildInputs = [
+    bleak
+    click
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pykulersky" ];
+
+  meta = with lib; {
+    description = "Python module to control Brightech Kuler Sky Bluetooth LED devices";
+    homepage = "https://github.com/emlove/pykulersky";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -433,7 +433,7 @@
     "konnected" = ps: with ps; [ aiohttp-cors ]; # missing inputs: konnected
     "kostal_plenticore" = ps: with ps; [ ]; # missing inputs: kostal_plenticore
     "kraken" = ps: with ps; [ ]; # missing inputs: krakenex pykrakenapi
-    "kulersky" = ps: with ps; [ ]; # missing inputs: pykulersky
+    "kulersky" = ps: with ps; [ pykulersky ];
     "kwb" = ps: with ps; [ ]; # missing inputs: pykwb
     "lacrosse" = ps: with ps; [ pylacrosse ];
     "lametric" = ps: with ps; [ ]; # missing inputs: lmnotify

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -446,6 +446,7 @@ in with py.pkgs; buildPythonApplication rec {
     "kmtronic"
     "knx"
     "kodi"
+    "kulersky"
     "lastfm"
     "lcn"
     "light"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5894,6 +5894,8 @@ in {
 
   pykoplenti = callPackage ../development/python-modules/pykoplenti { };
 
+  pykulersky = callPackage ../development/python-modules/pykulersky { };
+
   pykwalify = callPackage ../development/python-modules/pykwalify { };
 
   pylacrosse = callPackage ../development/python-modules/pylacrosse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to control Brightech Kuler Sky Bluetooth LED devices

https://github.com/emlove/pykulersky

This is a Home Assistant dependency.

- Target Home Assistant release: 2021.6.0

ToDo:

- [x] Update `component-packages`
- [x] Enable tests in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
