### PR TITLE
vgmstream: init at r1050-3738-g7cfa1f29

### DIFF
--- a/pkgs/applications/audio/vgmstream/default.nix
+++ b/pkgs/applications/audio/vgmstream/default.nix
@@ -16,10 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ mpg123 ffmpeg libvorbis libao jansson ];
 
-  ##
-  # There's no nice way to build the audacious plugin without
-  # a circular dependency.
-  ##
+  # There's no nice way to build the audacious plugin without a circular dependency
   cmakeFlags = [ "-DBUILD_AUDACIOUS=OFF" ];
 
   preConfigure = ''

--- a/pkgs/applications/audio/vgmstream/default.nix
+++ b/pkgs/applications/audio/vgmstream/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config
+, mpg123, ffmpeg, libvorbis, libao, jansson
+}:
+stdenv.mkDerivation rec {
+  pname   = "vgmstream";
+  version = "r1050-3448-g77cc431b";
+
+  src = fetchFromGitHub {
+    owner  = "vgmstream";
+    repo   = "vgmstream";
+    rev    = version;
+    sha256 = "030q02c9li14by7vm00gn6v3m4dxxmfwiy9iyz3xsgzq1i7pqc1d";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ mpg123 ffmpeg libvorbis libao jansson ];
+
+  ##
+  # There's no nice way to build the audacious plugin without
+  # a circular dependency.
+  ##
+  cmakeFlags = [ "-DBUILD_AUDACIOUS=OFF" ];
+
+  preConfigure = ''
+    echo "#define VERSION \"${version}\"" > cli/version.h
+  '';
+
+  meta = with lib; {
+    description = "A library for playback of various streamed audio formats used in video games";
+    homepage    = "https://vgmstream.org";
+    maintainers = with maintainers; [ zane ];
+    license     = with licenses; isc;
+    platforms   = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30888,6 +30888,8 @@ in
 
   vbam = callPackage ../misc/emulators/vbam { };
 
+  vgmstream = callPackage ../applications/audio/vgmstream { };
+
   vice = callPackage ../misc/emulators/vice { };
 
   ViennaRNA = callPackage ../applications/science/molecular-dynamics/viennarna { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add vgmstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).