### PR TITLE
jetbrains: add mainPrograms

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -3,7 +3,7 @@
 , vmopts ? null
 }:
 
-{ name, product, version, src, wmClass, jdk, meta, extraLdPath ? [] }:
+{ name, product, version, src, wmClass, jdk, meta, extraLdPath ? [] }@args:
 
 with lib;
 
@@ -18,7 +18,9 @@ let loName = toLower product;
 in
 
 with stdenv; lib.makeOverridable mkDerivation rec {
-  inherit name src meta;
+  inherit name src;
+  meta = args.meta // { mainProgram = execName; };
+
   desktopItem = makeDesktopItem {
     name = execName;
     exec = execName;

--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -9,7 +9,7 @@ with lib;
 
 let loName = toLower product;
     hiName = toUpper product;
-    execName = concatStringsSep "-" (init (splitString "-" name));
+    mainProgram = concatStringsSep "-" (init (splitString "-" name));
     vmoptsName = loName
                + ( if (with stdenv.hostPlatform; (is32bit || isDarwin))
                    then ""
@@ -19,16 +19,16 @@ in
 
 with stdenv; lib.makeOverridable mkDerivation rec {
   inherit name src;
-  meta = args.meta // { mainProgram = execName; };
+  meta = args.meta // { inherit mainProgram; };
 
   desktopItem = makeDesktopItem {
-    name = execName;
-    exec = execName;
+    name = mainProgram;
+    exec = mainProgram;
     comment = lib.replaceChars ["\n"] [" "] meta.longDescription;
     desktopName = product;
     genericName = meta.description;
     categories = "Development;";
-    icon = execName;
+    icon = mainProgram;
     extraEntries = ''
       StartupWMClass=${wmClass}
     '';
@@ -66,13 +66,13 @@ with stdenv; lib.makeOverridable mkDerivation rec {
   installPhase = ''
     mkdir -p $out/{bin,$name,share/pixmaps,libexec/${name}}
     cp -a . $out/$name
-    ln -s $out/$name/bin/${loName}.png $out/share/pixmaps/${execName}.png
+    ln -s $out/$name/bin/${loName}.png $out/share/pixmaps/${mainProgram}.png
     mv bin/fsnotifier* $out/libexec/${name}/.
 
     jdk=${jdk.home}
     item=${desktopItem}
 
-    makeWrapper "$out/$name/bin/${loName}.sh" "$out/bin/${execName}" \
+    makeWrapper "$out/$name/bin/${loName}.sh" "$out/bin/${mainProgram}" \
       --prefix PATH : "$out/libexec/${name}:${lib.optionalString (stdenv.isDarwin) "${jdk}/jdk/Contents/Home/bin:"}${lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath ([
         # Some internals want libstdc++.so.6

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -24,9 +24,8 @@ openjdk11.overrideAttrs (oldAttrs: rec {
      your own risk.
     '';
     homepage = "https://bintray.com/jetbrains/intellij-jdk/";
-    license = licenses.gpl2;
+    inherit (openjdk11.meta) license platforms;
     maintainers = with maintainers; [ edwtjo petabyteboy ];
-    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
   };
   passthru = oldAttrs.passthru // {
     home = "${jetbrains.jdk}/lib/openjdk";

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -24,7 +24,7 @@ openjdk11.overrideAttrs (oldAttrs: rec {
      your own risk.
     '';
     homepage = "https://bintray.com/jetbrains/intellij-jdk/";
-    inherit (openjdk11.meta) license platforms;
+    inherit (openjdk11.meta) license platforms mainProgram;
     maintainers = with maintainers; [ edwtjo petabyteboy ];
   };
   passthru = oldAttrs.passthru // {

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -136,14 +136,7 @@ let
 
     disallowedReferences = [ openjdk11-bootstrap ];
 
-    meta = with lib; {
-      homepage = "http://openjdk.java.net/";
-      license = licenses.gpl2;
-      description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo asbachb ];
-      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
-      mainProgram = "java";
-    };
+    meta = import ./meta.nix lib;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -145,14 +145,7 @@ let
 
     disallowedReferences = [ openjdk11 ];
 
-    meta = with lib; {
-      homepage = "http://openjdk.java.net/";
-      license = licenses.gpl2;
-      description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo ];
-      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
-      mainProgram = "java";
-    };
+    meta = import ./meta.nix lib;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -145,14 +145,7 @@ let
 
     disallowedReferences = [ openjdk13-bootstrap ];
 
-    meta = with lib; {
-      homepage = "http://openjdk.java.net/";
-      license = licenses.gpl2;
-      description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo ];
-      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
-      mainProgram = "java";
-    };
+    meta = import ./meta.nix lib;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -141,14 +141,7 @@ let
 
     disallowedReferences = [ openjdk14-bootstrap ];
 
-    meta = with lib; {
-      homepage = "https://openjdk.java.net/";
-      license = licenses.gpl2;
-      description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo ];
-      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
-      mainProgram = "java";
-    };
+    meta = import ./meta.nix lib;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/15.nix
+++ b/pkgs/development/compilers/openjdk/15.nix
@@ -141,14 +141,7 @@ let
 
     disallowedReferences = [ openjdk15-bootstrap ];
 
-    meta = with lib; {
-      homepage = "https://openjdk.java.net/";
-      license = licenses.gpl2;
-      description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo ];
-      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
-      mainProgram = "java";
-    };
+    meta = import ./meta.nix lib;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/16.nix
+++ b/pkgs/development/compilers/openjdk/16.nix
@@ -147,14 +147,7 @@ let
 
     disallowedReferences = [ openjdk16-bootstrap ];
 
-    meta = with lib; {
-      homepage = "https://openjdk.java.net/";
-      license = licenses.gpl2;
-      description = "The open-source Java Development Kit";
-      maintainers = with maintainers; [ edwtjo ];
-      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
-      mainProgram = "java";
-    };
+    meta = import ./meta.nix lib;
 
     passthru = {
       architecture = "";

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -53,10 +53,6 @@ let
       home = jdk;
     };
 
-    meta = with lib; {
-      license = licenses.gpl2;
-      platforms = platforms.darwin;
-    };
-
+    meta = import ./meta.nix lib;
   };
 in jdk

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -57,10 +57,6 @@ let
       home = jdk;
     };
 
-    meta = with lib; {
-      license = licenses.gpl2;
-      platforms = platforms.darwin;
-    };
-
+    meta = import ./meta.nix lib;
   };
 in jdk

--- a/pkgs/development/compilers/openjdk/darwin/default.nix
+++ b/pkgs/development/compilers/openjdk/darwin/default.nix
@@ -54,10 +54,6 @@ let
       home = jdk;
     };
 
-    meta = with lib; {
-      license = licenses.gpl2;
-      platforms = platforms.darwin;
-    };
-
+    meta = import ./meta.nix lib;
   };
 in jdk

--- a/pkgs/development/compilers/openjdk/darwin/meta.nix
+++ b/pkgs/development/compilers/openjdk/darwin/meta.nix
@@ -1,0 +1,4 @@
+lib: (removeAttrs (import ../meta.nix lib) [ "maintainers" ]) // {
+  platforms = lib.platforms.darwin;
+  homepage = "https://www.azul.com/";
+}

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -1,5 +1,5 @@
 lib: with lib; {
-  homepage = "http://openjdk.java.net/";
+  homepage = "https://openjdk.java.net/";
   license = licenses.gpl2Only;
   description = "The open-source Java Development Kit";
   maintainers = with maintainers; [ edwtjo asbachb ];

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -1,6 +1,6 @@
 lib: with lib; {
   homepage = "http://openjdk.java.net/";
-  license = licenses.gpl2;
+  license = licenses.gpl2Only;
   description = "The open-source Java Development Kit";
   maintainers = with maintainers; [ edwtjo asbachb ];
   platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -1,0 +1,8 @@
+lib: with lib; {
+  homepage = "http://openjdk.java.net/";
+  license = licenses.gpl2;
+  description = "The open-source Java Development Kit";
+  maintainers = with maintainers; [ edwtjo asbachb ];
+  platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
+  mainProgram = "java";
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I need to unset DESKTOP_STARTUP_ID on jetbrain IDE startup to make @fctorial's https://github.com/fctorial/enter_nix_shell work to its full potential. In order to [do the wrapping in overrides generically](https://github.com/Atemu/nixos-config/blob/06be43876e0a81d4a283b287bbe1f2098d5f129e/overlays.nix#L23-L31), I needed the IDEs' executable names.

Also, did some cleanup. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
