### PR TITLE
picotool: init at 1.0.1

### DIFF
--- a/pkgs/development/libraries/pico-sdk/default.nix
+++ b/pkgs/development/libraries/pico-sdk/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "pico-sdk";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = pname;
+    rev = version;
+    sha256 = "00z160f7ypws5pzp1ql7xrs3gmjcbw6gywnnq2fiwl47940balns";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  # SDK contains libraries and build-system to develop projects for RP2040 chip
+  # We only need to compile pioasm binary
+  sourceRoot = "source/tools/pioasm";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/pico-sdk
+    cp -a ../../../* $out/lib/pico-sdk/
+    chmod 755 $out/lib/pico-sdk/tools/pioasm/build/pioasm
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/raspberrypi/picotool";
+    description = "SDK provides the headers, libraries and build system necessary to write programs for the RP2040-based devices";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ musfay ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/picotool/default.nix
+++ b/pkgs/development/tools/picotool/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libusb1, pico-sdk }:
+
+stdenv.mkDerivation rec {
+  pname = "picotool";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = pname;
+    rev = version;
+    sha256 = "1k5j742sj91akdrgnd3wa5csqb638dgaz0c09zsr22fcqz0qhzig";
+  };
+
+  buildInputs = [ libusb1 pico-sdk ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  cmakeFlags = [ "-DPICO_SDK_PATH=${pico-sdk}/lib/pico-sdk" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ./picotool -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/raspberrypi/picotool";
+    description = "Tool for interacting with a RP2040 device in BOOTSEL mode, or with a RP2040 binary";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ musfay ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13695,6 +13695,8 @@ in
 
   phantomjs2 = libsForQt514.callPackage ../development/tools/phantomjs2 { };
 
+  picotool = callPackage ../development/tools/picotool { };
+
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
   pkgconf-unwrapped = callPackage ../development/tools/misc/pkgconf {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17460,6 +17460,8 @@ in
     physfs_2
     physfs;
 
+  pico-sdk = callPackage ../development/libraries/pico-sdk { };
+
   pipelight = callPackage ../tools/misc/pipelight {
     stdenv = stdenv_32bit;
     wine-staging = pkgsi686Linux.wine-staging;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change
Tool for interacting with a RP2040 device in BOOTSEL mode, or with a RP2040 binary. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
