### PR TITLE
ocamlPackages.ansiterminal: 0.7 -> 0.8.2

### DIFF
--- a/pkgs/development/ocaml-modules/ansiterminal/default.nix
+++ b/pkgs/development/ocaml-modules/ansiterminal/default.nix
@@ -1,36 +1,29 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
+{ lib, buildDunePackage, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "ANSITerminal";
+  version = "0.8.2";
 
-  version = "0.7";
+  useDune2 = true;
 
-  name = "ocaml${ocaml.version}-ansiterminal-${version}";
-
-  src = fetchurl {
-    url = "https://github.com/Chris00/ANSITerminal/releases/download/${version}/ANSITerminal-${version}.tar.gz";
-    sha256 = "03pqfxvw9pa9720l8i5fgxky1qx70kw6wxbczd5i50xi668lh0i9";
+  src = fetchFromGitHub {
+    owner = "Chris00";
+    repo = pname;
+    rev = version;
+    sha256 = "0dyjischrgwlxqz1p5zbqq76jvk6pl1qj75i7ydhijssr9pj278d";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-
-  buildPhase = "ocaml setup.ml -build";
-
-  installPhase = "ocaml setup.ml -install";
-
-  createFindlibDestdir = true;
+  doCheck = true;
 
   meta = with lib; {
-    homepage = "https://github.com/Chris00/ANSITerminal";
     description = "A module allowing to use the colors and cursor movements on ANSI terminals";
     longDescription = ''
       ANSITerminal is a module allowing to use the colors and cursor
       movements on ANSI terminals. It also works on the windows shell (but
       this part is currently work in progress).
     '';
+    inherit (src.meta) homepage;
     license = licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.jirkamarsik ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version update. Build system changed to Dune.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
