### PR TITLE
helvum: add desktop entry

### DIFF
--- a/pkgs/applications/audio/helvum/default.nix
+++ b/pkgs/applications/audio/helvum/default.nix
@@ -1,5 +1,7 @@
 { lib
 , fetchFromGitLab
+, makeDesktopItem
+, copyDesktopItems
 , rustPlatform
 , pkg-config
 , clang
@@ -23,10 +25,18 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-uNTSU06Fz/ud04K40e98rb7o/uAht0DsiJOXeHX72vw=";
 
-  nativeBuildInputs = [ clang pkg-config ];
+  nativeBuildInputs = [ clang copyDesktopItems pkg-config ];
   buildInputs = [ glib gtk4 pipewire ];
 
   LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  desktopItems = makeDesktopItem {
+    name = "Helvum";
+    exec = pname;
+    desktopName = "Helvum";
+    genericName = "Helvum";
+    categories = "AudioVideo;";
+  };
 
   meta = with lib; {
     description = "A GTK patchbay for pipewire";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add a .desktop entry to Helvum. Icon is not available yet though. This should probably be backported to 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
