### PR TITLE
ocaml: update meta.description

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -81,37 +81,33 @@ stdenv.mkDerivation (args // {
   };
 
   meta = with lib; {
-    homepage = "http://caml.inria.fr/ocaml";
+    homepage = "https://ocaml.org/";
     branch = versionNoPatch;
     license = with licenses; [
       qpl /* compiler */
       lgpl2 /* library */
     ];
-    description = "Most popular variant of the Caml language";
+    description = "OCaml is an industrial-strength programming language supporting functional, imperative and object-oriented styles";
 
-    longDescription =
-      ''
-        OCaml is the most popular variant of the Caml language.  From a
-        language standpoint, it extends the core Caml language with a
-        fully-fledged object-oriented layer, as well as a powerful module
-        system, all connected by a sound, polymorphic type system featuring
-        type inference.
+    longDescription = ''
+      OCaml is a general purpose programming language with an emphasis on expressiveness and safety. Developed for more than 20 years at Inria by a group of leading researchers, it has an advanced type system that helps catch your mistakes without getting in your way. It's used in environments where a single mistake can cost millions and speed matters, is supported by an active community, and has a rich set of libraries and development tools. It's widely used in teaching for its power and simplicity.
 
-        The OCaml system is an industrial-strength implementation of this
-        language, featuring a high-performance native-code compiler (ocamlopt)
-        for 9 processor architectures (IA32, PowerPC, AMD64, Alpha, Sparc,
-        Mips, IA64, HPPA, StrongArm), as well as a bytecode compiler (ocamlc)
-        and an interactive read-eval-print loop (ocaml) for quick development
-        and portability.  The OCaml distribution includes a comprehensive
-        standard library, a replay debugger (ocamldebug), lexer (ocamllex) and
-        parser (ocamlyacc) generators, a pre-processor pretty-printer (camlp4)
-        and a documentation generator (ocamldoc).
-      '';
+      Strengths:
+      * A powerful type system, equipped with parametric polymorphism and type inference. For instance, the type of a collection can be parameterized by the type of its elements. This allows defining some operations over a collection independently of the type of its elements: sorting an array is one example. Furthermore, type inference allows defining such operations without having to explicitly provide the type of their parameters and result.
+      * User-definable algebraic data types and pattern-matching. New algebraic data types can be defined as combinations of records and sums. Functions that operate over such data structures can then be defined by pattern matching, a generalized form of the well-known switch statement, which offers a clean and elegant way of simultaneously examining and naming data.
+      * Automatic memory management, thanks to a fast, unobtrusive, incremental garbage collector.
+      * Separate compilation of standalone applications. Portable bytecode compilers allow creating stand-alone applications out of Caml Light or OCaml programs. A foreign function interface allows OCaml code to interoperate with C code when necessary. Interactive use of OCaml is also supported via a “read-evaluate-print” loop.
+
+      In addition, OCaml features:
+      * A sophisticated module system, which allows organizing modules hierarchically and parameterizing a module over a number of other modules.
+      * An expressive object-oriented layer, featuring multiple inheritance, parametric and virtual classes.
+      * Efficient native code compilers. In addition to its bytecode compiler, OCaml offers a compiler that produces efficient machine code for many architectures.
+
+      Learn more at: https://ocaml.org/learn/description.html
+    '';
 
     platforms = with platforms; linux ++ darwin;
     broken = stdenv.isAarch64 && !lib.versionAtLeast version "4.06";
   };
 
 })
-
-


### PR DESCRIPTION
Updates links and description for OCaml project.

`https://caml.inria.fr/ocaml/` is outdated and the link itself points to `https://ocaml.org/`.