### PR TITLE
python3Packages.pyflic: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/pyflic/default.nix
+++ b/pkgs/development/python-modules/pyflic/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyflic";
+  version = "2.0.3";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "soldag";
+    repo = pname;
+    rev = version;
+    sha256 = "0adf4k191138jmbsfhkhhbgaxcq97d1hr5w48ryxr1fig64sjqy2";
+  };
+
+  # Projec thas no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyflic" ];
+
+  meta = with lib; {
+    description = "Python module to interact with Flic buttons";
+    homepage = "https://github.com/soldag/pyflic";
+    license = with licenses; [ cc0 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5699,6 +5699,8 @@ in {
 
   pyflakes = callPackage ../development/python-modules/pyflakes { };
 
+  pyflic = callPackage ../development/python-modules/pyflic { };
+
   pyflume = callPackage ../development/python-modules/pyflume { };
 
   pyflunearyou = callPackage ../development/python-modules/pyflunearyou { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to interact with Flic buttons

https://github.com/soldag/pyflic

This is a Home Assistant dependency.

- Target Home Assistant release: 2021.6.0
- [ ] Update `component-packages`
- [ ] Enable tests in Home Assistant

Best would be to hold back with this one for a little as the update of Home Assistant 2021.6.0 is in process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
