### PR TITLE
factorio: 1.1.32 → 1.1.34

### DIFF
--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -58,7 +58,7 @@ RELEASE_TYPES = [
 ]
 
 RELEASE_CHANNELS = [
-    ReleaseChannel("experimental"),
+    #ReleaseChannel("experimental"),
     ReleaseChannel("stable"),
 ]
 

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -1,57 +1,33 @@
 {
   "x86_64-linux": {
     "alpha": {
-      "experimental": {
-        "name": "factorio_alpha_x64-1.1.33.tar.xz",
-        "needsAuth": true,
-        "sha256": "0qgr609w8pgjpmh8ycf0b846v0i019b393x71i790lb7vcygl2aa",
-        "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.33/alpha/linux64",
-        "version": "1.1.33"
-      },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.32.tar.xz",
+        "name": "factorio_alpha_x64-1.1.34.tar.xz",
         "needsAuth": true,
-        "sha256": "0ciz7y8xqlk9vg3akvflq1aabzgbqpazfnihyk4gsadk12b6a490",
+        "sha256": "1gba6ivxdhj8khk6kfja2nzvqbbjlq1gzk8vlb23mkzqcmf4gnqc",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.32/alpha/linux64",
-        "version": "1.1.32"
+        "url": "https://factorio.com/get-download/1.1.34/alpha/linux64",
+        "version": "1.1.34"
       }
     },
     "demo": {
-      "experimental": {
-        "name": "factorio_demo_x64-1.1.30.tar.xz",
-        "needsAuth": false,
-        "sha256": "1b3na8xn9lhlvrsd6hxr130nf9p81s26n25a4qdgkczz6waysgjv",
-        "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.30/demo/linux64",
-        "version": "1.1.30"
-      },
       "stable": {
-        "name": "factorio_demo_x64-1.1.32.tar.xz",
+        "name": "factorio_demo_x64-1.1.34.tar.xz",
         "needsAuth": false,
-        "sha256": "19zwl20hn8hh942avqri1kslf7dcqi9nim50vh4w5d0493srybfw",
+        "sha256": "1ld373lxfx1xbaqq394az8sxfxpjwkyqwwr77wbmg4sm2g9dinxm",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.32/demo/linux64",
-        "version": "1.1.32"
+        "url": "https://factorio.com/get-download/1.1.34/demo/linux64",
+        "version": "1.1.34"
       }
     },
     "headless": {
-      "experimental": {
-        "name": "factorio_headless_x64-1.1.33.tar.xz",
-        "needsAuth": false,
-        "sha256": "0iv667l25aaij3g9v3mqxhkpphfbc6dhdghsg5qdw4l59vh6fpd4",
-        "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.33/headless/linux64",
-        "version": "1.1.33"
-      },
       "stable": {
-        "name": "factorio_headless_x64-1.1.32.tar.xz",
+        "name": "factorio_headless_x64-1.1.34.tar.xz",
         "needsAuth": false,
-        "sha256": "0dg98ycs7m8rm996pk0p1iajalpmiy30p0pwr9dw2chf1d887kvz",
+        "sha256": "0sfafdvfhhvxnhf7q23xnvckx8nihg5xzzc6dw39a3iprwhr75i1",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.32/headless/linux64",
-        "version": "1.1.32"
+        "url": "https://factorio.com/get-download/1.1.34/headless/linux64",
+        "version": "1.1.34"
       }
     }
   }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the current stable release of Factorio, drop the experimental releases
(no release currently exists for that channel).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~  N/A
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Ping maintainers

@Baughn @elitak @erictapen @priegger @lukegb
