### PR TITLE
[21.05] gitRepo: Add import to ssl module to avoid runtime error (#125373)

### DIFF
--- a/pkgs/applications/version-management/git-repo/default.nix
+++ b/pkgs/applications/version-management/git-repo/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, nix-update-script
-, python3, git, gnupg, less
+, python3, git, gnupg, less, openssh
 }:
 
 stdenv.mkDerivation rec {
@@ -10,8 +10,11 @@ stdenv.mkDerivation rec {
     owner = "android";
     repo = "tools_repo";
     rev = "v${version}";
-    sha256 = "sha256-3FSkWpHda1jVhy/633B+ippWcbKd83IlQcJYS9Qx5wQ=";
+    sha256 = "sha256-SuHp6C5ueUErvRiWDQNEmCybFIa7Iu7C/FtnHys9XqU=";
   };
+
+  # Fix 'NameError: name 'ssl' is not defined'
+  patches = [ ./import-ssl-module.patch ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ python3 ];
@@ -34,7 +37,7 @@ stdenv.mkDerivation rec {
   # Important runtime dependencies
   postFixup = ''
     wrapProgram $out/bin/repo --prefix PATH ":" \
-      "${lib.makeBinPath [ git gnupg less ]}"
+      "${lib.makeBinPath [ git gnupg less openssh ]}"
   '';
 
   passthru = {

--- a/pkgs/applications/version-management/git-repo/import-ssl-module.patch
+++ b/pkgs/applications/version-management/git-repo/import-ssl-module.patch
@@ -1,0 +1,28 @@
+Fix runtime error due missing import
+
+Traceback (most recent call last):
+  File "/nix/store/4qqhr7g9ri3n7v6ik9ahlpvyp18wcn4p-git-repo-2.15.3/bin/.repo-wrapped", line 1339, in <module>
+    main(sys.argv[1:])
+  File "/nix/store/4qqhr7g9ri3n7v6ik9ahlpvyp18wcn4p-git-repo-2.15.3/bin/.repo-wrapped", line 1304, in main
+    _Init(args, gitc_init=(cmd == 'gitc-init'))
+  File "/nix/store/4qqhr7g9ri3n7v6ik9ahlpvyp18wcn4p-git-repo-2.15.3/bin/.repo-wrapped", line 607, in _Init
+    _Clone(url, dst, opt.clone_bundle, opt.quiet, opt.verbose)
+  File "/nix/store/4qqhr7g9ri3n7v6ik9ahlpvyp18wcn4p-git-repo-2.15.3/bin/.repo-wrapped", line 912, in _Clone
+    if clone_bundle and _DownloadBundle(url, cwd, quiet, verbose):
+  File "/nix/store/4qqhr7g9ri3n7v6ik9ahlpvyp18wcn4p-git-repo-2.15.3/bin/.repo-wrapped", line 860, in _DownloadBundle
+    r = urllib.request.urlopen(url, context=ssl.create_default_context())
+NameError: name 'ssl' is not defined
+builder for '/nix/store/4hvds8fv8xmzlm86yg9cf1lj6hrya7sg-amdvlk-src.drv' failed with exit code 1
+
+diff --git a/repo b/repo
+index 8b05def..f394b3e 100755
+--- a/repo
++++ b/repo
+@@ -236,6 +236,7 @@ import optparse
+ import re
+ import shutil
+ import stat
++import ssl
+ 
+ if sys.version_info[0] == 3:
+   import urllib.request


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of #125373 to release-21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
