### PR TITLE
nixos/release-notes: Fix link to GNOME 40 release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -56,7 +56,7 @@
     <itemizedlist>
      <listitem>
       <para>
-        Gnome: 3.36 -> 3.40, see its <link xlink:href="https://help.gnome.org/misc/release-notes/3.40/">release notes</link>
+        GNOME: 3.36 -> 40, see its <link xlink:href="https://help.gnome.org/misc/release-notes/40.0/">release notes</link>
       </para>
      </listitem>
      <listitem>


### PR DESCRIPTION
Fix a broken link to the GNOME 40 release notes.