### PR TITLE
nixos/jenkins: test declarative jobs

### DIFF
--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -2,6 +2,7 @@
 #   1. jenkins service starts on master node
 #   2. jenkins user can be extended on both master and slave
 #   3. jenkins service not started on slave node
+#   4. declarative jobs can be added and removed
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "jenkins";
@@ -13,7 +14,45 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     master =
       { ... }:
-      { services.jenkins.enable = true;
+      { services.jenkins = {
+          enable = true;
+          jobBuilder = {
+            enable = true;
+            nixJobs = [
+              { job = {
+                  name = "job-1";
+                  builders = [
+                    { shell = ''
+                        echo "Running job-1"
+                      '';
+                    }
+                  ];
+                };
+              }
+
+              { job = {
+                  name = "folder-1";
+                  project-type = "folder";
+                };
+              }
+
+              { job = {
+                  name = "folder-1/job-2";
+                  builders = [
+                    { shell = ''
+                        echo "Running job-2"
+                      '';
+                    }
+                  ];
+                };
+              }
+            ];
+          };
+        };
+
+        specialisation.noJenkinsJobs.configuration = {
+          services.jenkins.jobBuilder.nixJobs = pkgs.lib.mkForce [];
+        };
 
         # should have no effect
         services.jenkinsSlave.enable = true;
@@ -32,7 +71,12 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
   };
 
-  testScript = ''
+  testScript = { nodes, ... }:
+    let
+      configWithoutJobs = "${nodes.master.config.system.build.toplevel}/specialisation/noJenkinsJobs";
+      jenkinsPort = nodes.master.config.services.jenkins.port;
+      jenkinsUrl = "http://localhost:${toString jenkinsPort}";
+    in ''
     start_all()
 
     master.wait_for_unit("jenkins")
@@ -45,5 +89,42 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         assert "users" in groups
 
     slave.fail("systemctl is-enabled jenkins.service")
+
+    with subtest("jobs are declarative"):
+        # Check that jobs are created on disk.
+        master.wait_for_unit("jenkins-job-builder")
+        master.wait_until_fails("systemctl is-active jenkins-job-builder")
+        master.wait_until_succeeds("test -f /var/lib/jenkins/jobs/job-1/config.xml")
+        master.wait_until_succeeds("test -f /var/lib/jenkins/jobs/folder-1/config.xml")
+        master.wait_until_succeeds("test -f /var/lib/jenkins/jobs/folder-1/jobs/job-2/config.xml")
+
+        # Wait until jenkins is ready, reload configuration and verify it also
+        # sees the jobs.
+        master.succeed("curl --fail ${jenkinsUrl}/cli")
+        master.succeed("curl ${jenkinsUrl}/jnlpJars/jenkins-cli.jar -O")
+        master.succeed("${pkgs.jre}/bin/java -jar jenkins-cli.jar -s ${jenkinsUrl} -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword) reload-configuration")
+        out = master.succeed("${pkgs.jre}/bin/java -jar jenkins-cli.jar -s ${jenkinsUrl} -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword) list-jobs")
+        jobs = [x.strip() for x in out.splitlines()]
+        # Seeing jobs inside folders requires the Folders plugin
+        # (https://plugins.jenkins.io/cloudbees-folder/), which we don't have
+        # in this vanilla jenkins install, so limit ourself to non-folder jobs.
+        assert jobs == ['job-1'], f"jobs != ['job-1']: {jobs}"
+
+        master.succeed(
+            "${configWithoutJobs}/bin/switch-to-configuration test >&2"
+        )
+
+        # Check that jobs are removed from disk.
+        master.wait_for_unit("jenkins-job-builder")
+        master.wait_until_fails("systemctl is-active jenkins-job-builder")
+        master.wait_until_fails("test -f /var/lib/jenkins/jobs/job-1/config.xml")
+        master.wait_until_fails("test -f /var/lib/jenkins/jobs/folder-1/config.xml")
+        master.wait_until_fails("test -f /var/lib/jenkins/jobs/folder-1/jobs/job-2/config.xml")
+
+        # Reload jenkins' configuration and verify it also sees the jobs as removed.
+        master.succeed("${pkgs.jre}/bin/java -jar jenkins-cli.jar -s ${jenkinsUrl} -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword) reload-configuration")
+        out = master.succeed("${pkgs.jre}/bin/java -jar jenkins-cli.jar -s ${jenkinsUrl} -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword) list-jobs")
+        jobs = [x.strip() for x in out.splitlines()]
+        assert jobs == [], f"jobs != []: {jobs}"
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
Ensure that the nixos declarative jenkins jobs work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
