### PR TITLE
neovim: set packpath only if needed

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -184,7 +184,7 @@ let
 
   rtpPath = "share/vim-plugins";
 
-  nativeImpl = packages: lib.optionalString (packages != null)
+  nativeImpl = packages:
   (let
     link = (packageName: dir: pluginPath: "ln -sf ${pluginPath}/share/vim-plugins/* $out/pack/${packageName}/${dir}");
     packageLinks = (packageName: {start ? [], opt ? []}:
@@ -340,8 +340,8 @@ let
       entries = [
         beforePlugins
         vamImpl
-        (nativeImpl packages)
       ]
+      ++ lib.optional (packages != null && packages != []) (nativeImpl packages)
       ++ lib.optional (pathogen != null) pathogenImpl
       ++ lib.optional (plug != null) plugImpl
       ++ [ customRC ];


### PR DESCRIPTION
part of the work to automatically disable the generation of init.vim when unnecessary

to help with https://github.com/nix-community/home-manager/issues/1907

should probably be merged after https://github.com/NixOS/nixpkgs/pull/124903

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
