### PR TITLE
rhdf5: fix build (#125101)

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -310,7 +310,7 @@ let
     Rglpk = [ pkgs.glpk ];
     RGtk2 = [ pkgs.gtk2.dev ];
     rhdf5 = [ pkgs.zlib ];
-    Rhdf5lib = [ pkgs.zlib ];
+    Rhdf5lib = [ pkgs.zlib.dev ];
     Rhpc = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.xz.dev pkgs.mpi pkgs.pcre.dev ];
     Rhtslib = [ pkgs.zlib.dev pkgs.automake pkgs.autoconf pkgs.bzip2.dev pkgs.xz.dev pkgs.curl.dev ];
     rjags = [ pkgs.jags ];

--- a/pkgs/development/r-modules/patches/Rhdf5lib.patch
+++ b/pkgs/development/r-modules/patches/Rhdf5lib.patch
@@ -2,11 +2,11 @@ diff --git a/configure b/configure
 index e2d292e..b13c0db 100755
 --- a/configure
 +++ b/configure
-@@ -2880,6 +2880,7 @@ $MAKE
+@@ -3874,6 +3874,7 @@
+ 
  echo "building the hdf5 library...";
  cd ../;
- ## we add the '-w' flag to suppress all the warnings hdf5 prints
 +sed -i 's#/bin/mv#mv#' configure
- ./configure --with-pic --enable-shared=no --enable-cxx \
-     --with-szlib \
-     CXX="${CXX}" CXFLAGS="${CXXFLAGS} -w" \
+ ./configure --with-pic --enable-shared=no --enable-cxx --enable-hl \
+     --with-szlib=${SZIP_HOME} --with-zlib=${ZLIB_HOME} \
+     ${WITH_S3_VFD} \


### PR DESCRIPTION

###### Motivation for this change
Fixes build of rhdf5 R library. (#125101)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
