### PR TITLE
python3packages.meteoalertapi: init at 0.1.8

### DIFF
--- a/pkgs/development/python-modules/meteoalertapi/default.nix
+++ b/pkgs/development/python-modules/meteoalertapi/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "meteoalertapi";
-  version = "0.1.8";
+  version = "0.2.0";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "rolfberkenbosch";
     repo = "meteoalert-api";
     rev = "v${version}";
-    sha256 = "1l66vsd77g5hqkp2c3qrrxz4mr7liwq96apg8km80qyqsjmma9yy";
+    sha256 = "sha256-EdHqWEkE/uUtz/xjV4k4NvNvtPPU4sJjHGwUM7J+HWs=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/meteoalertapi/default.nix
+++ b/pkgs/development/python-modules/meteoalertapi/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, requests
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "meteoalertapi";
+  version = "0.1.8";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rolfberkenbosch";
+    repo = "meteoalert-api";
+    rev = "v${version}";
+    sha256 = "1l66vsd77g5hqkp2c3qrrxz4mr7liwq96apg8km80qyqsjmma9yy";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    xmltodict
+  ];
+
+  # Tests require network access
+  doCheck = false;
+
+  pythonImportsCheck = [ "meteoalertapi" ];
+
+  meta = with lib; {
+    description = "Python wrapper for MeteoAlarm.org";
+    homepage = "https://github.com/rolfberkenbosch/meteoalert-api";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -499,7 +499,7 @@
     "met" = ps: with ps; [ pymetno ];
     "met_eireann" = ps: with ps; [ pymeteireann ];
     "meteo_france" = ps: with ps; [ ]; # missing inputs: meteofrance-api
-    "meteoalarm" = ps: with ps; [ ]; # missing inputs: meteoalertapi
+    "meteoalarm" = ps: with ps; [ meteoalertapi ];
     "meteoclimatic" = ps: with ps; [ ]; # missing inputs: pymeteoclimatic
     "metoffice" = ps: with ps; [ ]; # missing inputs: datapoint
     "mfi" = ps: with ps; [ ]; # missing inputs: mficlient

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4301,6 +4301,8 @@ in {
 
   metar = callPackage ../development/python-modules/metar { };
 
+  meteoalertapi = callPackage ../development/python-modules/meteoalertapi { };
+
   mezzanine = callPackage ../development/python-modules/mezzanine { };
 
   micawber = callPackage ../development/python-modules/micawber { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python wrapper for MeteoAlarm.org

https://github.com/rolfberkenbosch/meteoalert-api

This is a Home Assistant dependency.

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51383
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
