### PR TITLE
kubevirt: init at 0.41.0

### DIFF
--- a/pkgs/development/tools/kubevirt/default.nix
+++ b/pkgs/development/tools/kubevirt/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubevirt";
+  version = "0.41.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "033xh8clijxj93avi6qkwfx2756ac5aqrr4hsmh1pgnp9ihxk0wx";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/virtctl" ];
+
+  meta = with lib; {
+    description = "A virtual machine management add-on for Kubernetes";
+    homepage = "https://github.com/kubevirt/kubevirt";
+    maintainers = with maintainers; [ nshalman ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13533,6 +13533,8 @@ in
 
   kubicorn = callPackage ../development/tools/kubicorn {  };
 
+  kubevirt = callPackage ../development/tools/kubevirt { };
+
   kubie = callPackage ../development/tools/kubie {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

I want to be able to use this software. I imagine others might as well.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
