### PR TITLE
pam_u2f: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/os-specific/linux/pam_u2f/default.nix
+++ b/pkgs/os-specific/linux/pam_u2f/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pam_u2f";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src     = fetchurl {
     url = "https://developers.yubico.com/pam-u2f/Releases/${pname}-${version}.tar.gz";
-    sha256 = "01fwbrfnjkv93vvqm54jywdcxa1p7d4r32azicwnx75nxfbbzhqd";
+    sha256 = "12p3pkrp32vzpg7707cgx8zgvgj8iqwhy39sm761k7plqi027mmp";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     configureFlagsArray+=("--with-pam-dir=$out/lib/security")
+  '';
+
+  # a no-op makefile to prevent building the fuzz targets
+  postConfigure = ''
+    cat > fuzz/Makefile <<EOF
+    all:
+    install:
+    EOF
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-31924
https://www.yubico.com/support/security-advisories/ysa-2021-03/

Changelog: https://github.com/Yubico/pam-u2f/blob/pam_u2f-1.1.1/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>pam_u2f</li>
  </ul>
</details>