### PR TITLE
[21.05] python3Packages.websockets: add patch for CVE-2021-33880

### DIFF
--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
 , pythonOlder
 , pytest
@@ -16,6 +17,15 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "05jbqcbjg50ydwl0fijhdlqcq7fl6v99kjva66kmmzzza7vwa872";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-33880.patch";
+      url = "https://github.com/aaugustin/websockets/commit/547a26b685d08cac0aa64e5e65f7867ac0ea9bc0.patch";
+      excludes = [ "docs/changelog.rst" ];
+      sha256 = "1wgsvza53ga8ldrylb3rqc17yxcrchwsihbq6i6ldpycq83q5akq";
+    })
+  ];
 
   disabled = pythonOlder "3.3";
 


### PR DESCRIPTION
###### Motivation for this change
This is a bit of an odd one because it's actually a _forward_ port of #125098 to 21.05. Why? Because I fully expected #123283 to make it in to 21.05, but now that doesn't look like it's going to happen.

So here's the patch from 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
