### PR TITLE
python3Packages.homematicip: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "homematicip";
-  version = "1.0.0";
+  version = "1.0.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "coreGreenberet";
     repo = "homematicip-rest-api";
     rev = version;
-    sha256 = "0bgvrjcf10kiqqkbl56sxx3jydd722b08q2j9c8sxpk0qdrmrinv";
+    sha256 = "sha256-AvZfcFvtn90FXJ8iRpNE2qNMYLYrXNSnDPfuh7IK3ck=";
   };
 
   propagatedBuildInputs = [
@@ -53,6 +53,7 @@ buildPythonPackage rec {
     "test_pluggable_switch_measuring"
     "test_rotary_handle_sensor"
     "test_security_group"
+    "test_security_zone"
     "test_shutter_device"
     "test_smoke_detector"
     "test_switching_group"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.1

Change log: https://github.com/coreGreenberet/homematicip-rest-api/releases/tag/1.0.1

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51407
- Target Home Assistant release: 2021.8.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
