### PR TITLE
kiterunner: init at 1.0.2

### DIFF
--- a/pkgs/tools/security/kiterunner/default.nix
+++ b/pkgs/tools/security/kiterunner/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "kiterunner";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "assetnote";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "084jywgqjj2hpaprdcb9a7i8hihphnfil0sx3wrlvjpa8sk0z1mw";
+  };
+
+  vendorSha256 = "1nczzzsnh38qi949ki5268y39ggkwncanc1pv7727qpwllzl62vy";
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X github.com/assetnote/kiterunner/cmd/kiterunner/cmd.Version=${version}")
+  '';
+
+  subPackages = [ "./cmd/kiterunner" ];
+
+  # Test data is missing in the repo
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Contextual content discovery tool";
+    longDescription = ''
+      Kiterunner is a tool that is capable of not only performing traditional
+      content discovery at lightning fast speeds, but also bruteforcing routes
+      and endpoints in modern applications.
+    '';
+    homepage = "https://github.com/assetnote/kiterunner";
+    license = with licenses; [ agpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6089,6 +6089,8 @@ in
 
   kismet = callPackage ../applications/networking/sniffers/kismet { };
 
+  kiterunner = callPackage ../tools/security/kiterunner { };
+
   klick = callPackage ../applications/audio/klick { };
 
   klystrack = callPackage ../applications/audio/klystrack { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Kiterunner is a tool that is capable of not only performing traditional content discovery at lightning fast speeds, but also bruteforcing routes/endpoints in modern applications.

https://github.com/assetnote/kiterunner

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
