### PR TITLE
[staging] alsaLib: 1.2.4 -> 1.2.5

### DIFF
--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,24 +1,21 @@
-{ lib, stdenv, fetchurl, fetchpatch, alsa-ucm-conf, alsa-topology-conf }:
+{ lib
+, stdenv
+, fetchurl
+, alsa-topology-conf
+, alsa-ucm-conf
+}:
 
 stdenv.mkDerivation rec {
   pname = "alsa-lib";
-  version = "1.2.4";
+  version = "1.2.5";
 
   src = fetchurl {
     url = "mirror://alsa/lib/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-91VL4aVs3/RotY/BwpuVtkhkxZADjdMJx6l4xxFpCPc=";
+    sha256 = "067ga0l6zr782kw8jdsqvbb20pcgnl0vkpnnz2n36fq8ii58k4lh";
   };
 
   patches = [
     ./alsa-plugin-conf-multilib.patch
-    (fetchpatch {
-      # plucked from upstream master, delete in next release
-      # without this patch alsa 1.2.4 fails to compile against musl-libc
-      # due to an overly conservative ifdef gate in a new feature
-      name = "fix-dlo.patch";
-      url = "https://github.com/alsa-project/alsa-lib/commit/ad8c8e5503980295dd8e5e54a6285d2d7e32eb1e.patch";
-      sha256 = "QQP4C1dSnJP1MNKt2el7Wn3KmtwtYzvyIHWdrHs+Jw4=";
-    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
I plan to also bump alsaUtils to 1.2.5 after this lands in master via staging-next. This needs to be bumped first though; alsaUtils 1.2.5 doesn't appear to build with alsaLib < 1.2.5.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
