### PR TITLE
go_1_15: 1.15.12 -> 1.15.13, go_1_16: 1.16.4 -> 1.16.5

### DIFF
--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -11,7 +11,7 @@ let
 
   inherit (lib) optionals optionalString;
 
-  version = "1.15.12";
+  version = "1.15.13";
 
   go_bootstrap = buildPackages.callPackage ./bootstrap.nix { };
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "sha256-HGkRk330onf6dOe378PQhZRJjExK3AtsSuNWYTdSgJE=";
+    sha256 = "sha256-mQaeciNHnM5FU/hPh0uTRfb0BF8nz1CJSJtUbaYZokQ=";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -268,5 +268,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = teams.golang.members;
     platforms = platforms.linux ++ platforms.darwin;
+    badPlatforms = [ "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -11,7 +11,7 @@ let
 
   inherit (lib) optionals optionalString;
 
-  version = "1.16.4";
+  version = "1.16.5";
 
   go_bootstrap = buildPackages.callPackage ./bootstrap.nix { };
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "sha256-rk9rbioWd9MYF5hGVadiB0tTVtpQ+1hyK5kQSHDUNQM=";
+    sha256 = "sha256-e/p+WQjHzJ512l3fMGbXy88/2fpRlFhRMl7rwX9QuoA=";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   dontStrip = stdenv.hostPlatform.isDarwin;
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/share/go $out/bin
     mv bin/* $out/bin
     cp -r . $out/share/go
@@ -37,5 +38,6 @@ stdenv.mkDerivation rec {
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
       $out/bin/go
     '')}
-  '' ;
+    runHook postInstall
+  '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Might try to land this at the same time as the `ldflags` PR to save on rebuilds.