### PR TITLE
python3Packages.backports-zoneinfo: patch in zoneinfo and enable tests

### DIFF
--- a/pkgs/development/python-modules/backports-zoneinfo/zoneinfo.patch
+++ b/pkgs/development/python-modules/backports-zoneinfo/zoneinfo.patch
@@ -1,0 +1,17 @@
+diff --git a/src/backports/zoneinfo/_tzpath.py b/src/backports/zoneinfo/_tzpath.py
+index 9baaf6b..3f842af 100644
+--- a/src/backports/zoneinfo/_tzpath.py
++++ b/src/backports/zoneinfo/_tzpath.py
+@@ -24,10 +24,7 @@ def reset_tzpath(to=None):
+             base_tzpath = _parse_python_tzpath(env_var)
+         elif sys.platform != "win32":
+             base_tzpath = [
+-                "/usr/share/zoneinfo",
+-                "/usr/lib/zoneinfo",
+-                "/usr/share/lib/zoneinfo",
+-                "/etc/zoneinfo",
++                "@zoneinfo@"
+             ]
+ 
+             base_tzpath.sort(key=lambda x: not os.path.exists(x))
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Extracted from #125440, as it could be useful for #125445.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
