### PR TITLE
vimPlugins.vim-colorschemes: Fix source hash

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -5805,7 +5805,7 @@ final: prev:
       owner = "flazz";
       repo = "vim-colorschemes";
       rev = "fd8f122cef604330c96a6a6e434682dbdfb878c9";
-      sha256 = "0kpsf6j20fgblc8vhqn7ymr52v2d1h52vc7rbxmxfwdm80nvv3g5";
+      sha256 = "1cg8q7w0vgl73aw1b9zz0zh5vw5d2pm8pm54fhfzva4azg56f416";
     };
     meta.homepage = "https://github.com/flazz/vim-colorschemes/";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In #124694 the hash for this plugin was [changed](https://github.com/NixOS/nixpkgs/commit/d4de973c917d4bdc74dd2eff3ac027c03a3b3b72#diff-b7a49d194ede1147f14a19a5be0875f0a7d9807db98d49602ec270e5ae44395cR5784) despite the fact that there was no update to the commit.

@RonanMacF It would be great if you can provide the tarball that you got (should still be in your Nix store) when performing this update.

```
these derivations will be built:
  /nix/store/z5r3msby1x9336al1h5ds2vhqyjygmkj-source.drv
  /nix/store/r3x8qwk715kpw0pql2s0v2d650xx29nl-vimplugin-vim-colorschemes-2020-05-15.drv
building '/nix/store/z5r3msby1x9336al1h5ds2vhqyjygmkj-source.drv'...

trying https://github.com/flazz/vim-colorschemes/archive/fd8f122cef604330c96a6a6e434682dbdfb878c9.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   164  100   164    0     0    742      0 --:--:-- --:--:-- --:--:--   742
100 1216k  100 1216k    0     0  1778k      0 --:--:-- --:--:-- --:--:-- 1778k
unpacking source archive /build/fd8f122cef604330c96a6a6e434682dbdfb878c9.tar.gz
hash mismatch in fixed-output derivation '/nix/store/2r0hrjgnhb8nyf5zh0gn8xwyqxazrg9f-source':
  wanted: sha256:0kpsf6j20fgblc8vhqn7ymr52v2d1h52vc7rbxmxfwdm80nvv3g5
  got:    sha256:1cg8q7w0vgl73aw1b9zz0zh5vw5d2pm8pm54fhfzva4azg56f416
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
