### PR TITLE
compcert: 3.8 → 3.9

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper
 , coqPackages, ocamlPackages, coq2html
 , tools ? stdenv.cc
-, version ? "3.8"
+, version ? "3.9"
 }:
 
 let
@@ -56,6 +56,10 @@ let param = {
     ];
     useExternalFlocq = true;
   };
+  "3.9" = {
+    sha256 = "1srcz2dqrvmbvv5cl66r34zqkm0hsbryk7gd3i9xx4slahc9zvdb";
+    useExternalFlocq = true;
+  };
 }."${version}"; in
 
 stdenv.mkDerivation rec {
@@ -78,6 +82,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./configure \
+      --replace \$\{toolprefix\}ar 'ar' \
       --replace '{toolprefix}gcc' '{toolprefix}cc'
   '';
 

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -80,7 +80,7 @@ let
       VST = callPackage ../development/coq-modules/VST (with lib.versions;
         lib.switch coq.coq-version [
           { case = "8.11"; out = { compcert = compcert.override { coqPackages = self; version = "3.7"; }; }; }
-          { case = range "8.12" "8.13"; out = { compcert = compcert.override { coqPackages = self; }; }; }
+          { case = range "8.12" "8.13"; out = { compcert = compcert.override { coqPackages = self; version = "3.8"; }; }; }
         ] {});
       zorns-lemma = callPackage ../development/coq-modules/zorns-lemma {};
       filterPackages = doesFilter: if doesFilter then filterCoqPackages self else self;


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/AbsInt/CompCert/releases/tag/v3.9

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
