### PR TITLE
cinnamon bulky

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -198,6 +198,7 @@ in
 
       environment.systemPackages = (with pkgs // pkgs.gnome // pkgs.cinnamon; pkgs.gnome.removePackagesByName [
         # cinnamon team apps
+        bulky
         blueberry
         warpinator
 

--- a/pkgs/data/misc/common-licenses/default.nix
+++ b/pkgs/data/misc/common-licenses/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, fetchurl
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "common-licenses";
+  version = "11.1";
+
+  src = fetchurl {
+    url = "http://deb.debian.org/debian/pool/main/b/base-files/base-files_${version}.tar.xz";
+    sha256 = "1i3hgd9vs14k819k441iibcgmi2zavnpqbnppyn2cz70kd830nbm";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -r licenses $out/share/common-licenses
+    cat debian/base-files.links | grep common-licenses | sed -e "s|usr|$out|g" -e "s|^|ln -s |g" | bash -x
+  '';
+
+  meta = with lib; {
+    description = "common-licenses extracted from debian base-files package";
+    homepage = "https://tracker.debian.org/pkg/base-files";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/bulky/default.nix
+++ b/pkgs/desktops/cinnamon/bulky/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, wrapGAppsHook
+, python3
+, gsettings-desktop-schemas
+, gettext
+, gtk3
+, glib
+, common-licenses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bulky";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "bulky";
+    rev = version;
+    sha256 = "NBlP10IM/+u8IRds4bdFyGWg3pJLRmlSLsdlndMVQqg=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gsettings-desktop-schemas
+    gettext
+  ];
+
+  buildInputs = [
+    (python3.withPackages(p: with p; [ pygobject3 magic setproctitle ]))
+    gsettings-desktop-schemas
+    gtk3
+    glib
+  ];
+
+  postPatch = ''
+    substituteInPlace usr/lib/bulky/bulky.py \
+                     --replace "/usr/share/locale" "$out/share/locale" \
+                     --replace /usr/share/bulky "$out/share/bulky" \
+                     --replace /usr/share/common-licenses "${common-licenses}/share/common-licenses" \
+                     --replace __DEB_VERSION__  "${version}"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    chmod +x usr/share/applications/*
+    cp -ra usr $out
+    ln -sf $out/lib/bulky/bulky.py $out/bin/bulky
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Bulk rename app";
+    homepage = "https://github.com/linuxmint/bulky";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
@@ -15,6 +15,7 @@
 , cinnamon-session
 , cinnamon-settings-daemon
 , cinnamon-common
+, bulky
 }:
 
 let
@@ -24,6 +25,7 @@ let
     mint-artwork
 
     # on
+    bulky
     muffin
     nemo
     xapps

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -13,6 +13,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   });
 
   # blueberry -> pkgs/tools/bluetooth/blueberry/default.nix
+  bulky = callPackage ./bulky {};
   cinnamon-common = callPackage ./cinnamon-common { };
   cinnamon-control-center = callPackage ./cinnamon-control-center { };
   cinnamon-desktop = callPackage ./cinnamon-desktop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2228,6 +2228,8 @@ in
 
   commitizen = callPackage ../applications/version-management/commitizen {};
 
+  common-licenses = callPackage ../data/misc/common-licenses {};
+
   compactor = callPackage ../applications/networking/compactor { };
 
   consul = callPackage ../servers/consul { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add bulky app for cinnamon desktop

~~Note: Currently fails to start with~~ On the cinnamon test vm everything works as it should

```
(.bulky-wrapped:3361228): GLib-GIO-CRITICAL **: 08:24:39.243: g_application_run: assertion 'G_IS_APPLICATION (application)' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
