### PR TITLE
nebula: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/tools/networking/nebula/default.nix
+++ b/pkgs/tools/networking/nebula/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "nebula";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "slackhq";
     repo = pname;
     rev = "v${version}";
-    sha256 = "08pjzlqck9524phsmqjwg6237vj1mmwsynkxivnahv1vhwyy9awz";
+    sha256 = "lu2/rSB9cFD7VUiK+niuqCX9CI2x+k4Pi+U5yksETSU=";
   };
 
-  vendorSha256 = "1g6wk5sydxbzpx62k4bdq4qnyk98mn1pljgi5hbffj01ipd82kq8";
+  vendorSha256 = "p1inJ9+NAb2d81cn+y+ofhxFz9ObUiLgj+9cACa6Jqg=";
 
   doCheck = false;
 


### PR DESCRIPTION
Tested on x86_64-linux and aarch64-linux. I did not find any other packages dependent on this change using nixpkgs-review.
Given that the build works, I assume I updated the sha256 and vendorSha256 correctly. (Using prefetch for the Git SHA and then building the package once to get the correct vendorSha256).

###### Motivation for this change
https://github.com/slackhq/nebula/releases/tag/v1.4.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
