### PR TITLE
xtensor: init at 0.23.10

### DIFF
--- a/pkgs/development/libraries/xtensor/default.nix
+++ b/pkgs/development/libraries/xtensor/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, xsimd
+, xtl
+}:
+stdenv.mkDerivation rec {
+  pname = "xtensor";
+  version = "0.23.10";
+
+  src = fetchFromGitHub {
+    owner = "xtensor-stack";
+    repo = "xtensor";
+    rev = version;
+    sha256 = "1ayrhyh9x33b87ic01b4jzxc8x27yxpxzya5x54ikazvz8p71n14";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ xtl xsimd ];
+
+  cmakeFlags = [ "-DBUILD_TESTS=ON" ];
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+  checkTarget = "xtest";
+
+  meta = with lib; {
+    description = "Multi-dimensional arrays with broadcasting and lazy computing.";
+    homepage = "https://github.com/xtensor-stack/xtensor";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cpcloud ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18604,6 +18604,8 @@ in
 
   xsimd = callPackage ../development/libraries/xsimd { };
 
+  xtensor = callPackage ../development/libraries/xtensor { };
+
   xtl = callPackage ../development/libraries/xtl { };
 
   xvidcore = callPackage ../development/libraries/xvidcore { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the `xtensor` header-only C++ array library to `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
