### PR TITLE
fheroes2: init at 0.9.4

### DIFF
--- a/pkgs/games/fheroes2/default.nix
+++ b/pkgs/games/fheroes2/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitHub
+, gettext, libpng, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fheroes2";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "ihhub";
+    repo = "fheroes2";
+    rev = version;
+    sha256 = "sha256-z+88tVsf4uyMFzNfZDKXo0cYqBCYn1ehX+A+e+aIfSg=";
+  };
+
+  buildInputs = [ gettext libpng SDL2 SDL2_image SDL2_mixer SDL2_ttf zlib ];
+
+  makeFlags = [
+    "FHEROES2_STRICT_COMPILATION=1"
+    "RELEASE=1"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $PWD/src/dist/fheroes2 $out/bin/fheroes2
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ihhub/fheroes2";
+    description = "Free implementation of Heroes of Might and Magic II game engine";
+    longDescription = ''
+        In order to play this game, an original game data is required.
+        Please refer to README of the project for instructions.
+        On linux, the data can be placed in ~/.local/share/fheroes2 folder.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.karolchmist ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28332,6 +28332,8 @@ in
 
   fava = callPackage ../applications/office/fava {};
 
+  fheroes2 = callPackage ../games/fheroes2 {};
+
   fish-fillets-ng = callPackage ../games/fish-fillets-ng {};
 
   flightgear = libsForQt5.callPackage ../games/flightgear { };


### PR DESCRIPTION
###### Motivation for this change

This is an open-source reimplementation of `Heroes of Might and Magic II`, a turn-based strategy game from 1996.

This script can be used to download data files from the demo version :
https://github.com/ihhub/fheroes2/blob/master/script/demo/demo_unix.sh

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
