### PR TITLE
vector: 0.13.1 -> 0.14.0

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -2,41 +2,57 @@
 , lib
 , fetchFromGitHub
 , rustPlatform
-, openssl
 , pkg-config
+, llvmPackages
+, openssl
 , protobuf
+, rdkafka
+, oniguruma
+, zstd
 , Security
 , libiconv
-, rdkafka
-, tzdata
 , coreutils
 , CoreServices
-, features ? ([ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
-    ++ (lib.optional stdenv.targetPlatform.isUnix "unix")
-    ++ [ "sinks" "sources" "transforms" ])
+, tzdata
+  # kafka is optional but one of the most used features
+, enableKafka ? true
+  # TODO investigate adding "api" "api-client" "vrl-cli" and various "vendor-*"
+  # "disk-buffer" is using leveldb TODO: investigate how useful
+  # it would be, perhaps only for massive scale?
+, features ? ([ "sinks" "sources" "transforms" ]
+    # the second feature flag is passed to the rdkafka dependency
+    # building on linux fails without this feature flag (both x86_64 and AArch64)
+    ++ (lib.optionals enableKafka [ "rdkafka-plain" "rdkafka/dynamic_linking" ])
+    ++ (lib.optional stdenv.targetPlatform.isUnix "unix"))
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.13.1";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "timberio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ige0138alZ0KAmPakPVmDVydz5qco6m0xK7AEzScyXc=";
+    sha256 = "sha256-wtihrR19jMJ7Kgvy6XBzOUrC/WKNVl2MVx4lWgXYlvg=";
   };
 
-  cargoSha256 = "sha256-oK4M6zTfI0QVW9kQTgpP/vSxFt2VlRABmKvQ4aAqC74=";
+  cargoSha256 = "sha256-VYIzAqh5Xxmn1koxhh+UDb2G3WS2UVXffuBY7h5Kr7A=";
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl protobuf rdkafka ]
+  buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
 
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
+  RUSTONIG_SYSTEM_LIBONIG = true;
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   cargoBuildFlags = [ "--no-default-features" "--features" (lib.concatStringsSep "," features) ];
+  # TODO investigate compilation failure for tests
+  # dev dependency includes httpmock which depends on iashc which depends on curl-sys with http2 feature enabled
+  # compilation fails because of a missing http2 include
+  doCheck = !stdenv.isDarwin;
   checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} -- --test-threads 1";
 
   # recent overhauls of DNS support in 0.9 mean that we try to resolve


### PR DESCRIPTION
###### Motivation for this change

https://github.com/timberio/vector/releases/tag/v0.14.0
https://vector.dev/releases/0.14.0/ 

Here is what I did
- add TODO on investigating additional feature flags to enable
- remove obsolete feature flags (jemalloc was dropped and rdkafka has a different flag)
- add missing buildInputs (oniguruma for onig-sys and zstd for zstd-sys)

Here is what is left to do
- the latest version of curl-sys depends on libnghttp2-sys (when http2 feature is enabled). This dependency is only required in the checkPhase. Looking at the underlying library it seems that it needs the following environment variable
[DEP_NGHTTP2_ROOT](https://github.com/alexcrichton/nghttp2-rs/blob/master/systest/build.rs#L8) I'm not sure exactly how to set this variable for tests only. I've added it to the checkPhase but it doesn't seem to be passed to the dependency compilation process. I still have the following failure.
```
libnghttp2-sys-67ea4c7b35af0690/build-script-build` (exit code: 1)
  --- stdout
  TARGET = Some("x86_64-apple-darwin")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-apple-darwin")
  CC_x86_64-apple-darwin = None
  CC_x86_64_apple_darwin = None
  HOST_CC = None
  CC = Some("clang")
  CFLAGS_x86_64-apple-darwin = None
  CFLAGS_x86_64_apple_darwin = None
  HOST_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  running: "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=x86_64-apple-darwin" "-I" "nghttp2/lib/includes" "-I" "/private/tmp/nix-build-vector-0.14.0.drv-0/source/target/debug/build/libnghttp2-sys-a9070bd53e651889/out/i/include" "-DNGHTTP2_STATICLIB" "-DHAVE_NETINET_IN" "-DHAVE_ARPA_INET_H" "-o" "/private/tmp/nix-build-vector-0.14.0.drv-0/source/target/debug/build/libnghttp2-sys-a9070bd53e651889/out/i/lib/nghttp2/lib/nghttp2_buf.o" "-c" "nghttp2/lib/nghttp2_buf.c"
  cargo:warning=In file included from nghttp2/lib/nghttp2_buf.c:25:
  cargo:warning=In file included from nghttp2/lib/nghttp2_buf.h:32:
  cargo:warning=nghttp2/lib/includes/nghttp2/nghttp2.h:55:10: fatal error: 'nghttp2/nghttp2ver.h' file not found
  cargo:warning=#include <nghttp2/nghttp2ver.h>
  cargo:warning=         ^~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=1 error generated.
  exit code: 1
  running: "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=x86_64-apple-darwin" "-I" "nghttp2/lib/includes" "-I" "/private/tmp/nix-build-vector-0.14.0.drv-0/source/target/debug/build/libnghttp2-sys-a9070bd53e651889/out/i/include" "-DNGHTTP2_STATICLIB" "-DHAVE_NETINET_IN" "-DHAVE_ARPA_INET_H" "-o" "/private/tmp/nix-build-vector-0.14.0.drv-0/source/target/debug/build/libnghttp2-sys-a9070bd53e651889/out/i/lib/nghttp2/lib/nghttp2_callbacks.o" "-c" "nghttp2/lib/nghttp2_callbacks.c"
  cargo:warning=In file included from nghttp2/lib/nghttp2_callbacks.c:25:
  cargo:warning=In file included from nghttp2/lib/nghttp2_callbacks.h:32:
  cargo:warning=nghttp2/lib/includes/nghttp2/nghttp2.h:55:10: fatal error: 'nghttp2/nghttp2ver.h' file not found
  cargo:warning=#include <nghttp2/nghttp2ver.h>
  cargo:warning=         ^~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=1 error generated.
  exit code: 1

  --- stderr


  error occurred: Command "clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=x86_64-apple-darwin" "-I" "nghttp2/lib/includes" "-I" "/private/tmp/nix-build-vector-0.14.0.drv-0/source/target/debug/build/libnghttp2-sys-a9070bd53e651889/out/i/include" "-DNGHTTP2_STATICLIB" "-DHAVE_NETINET_IN" "-DHAVE_ARPA_INET_H" "-o" "/private/tmp/nix-build-vector-0.14.0.drv-0/source/target/debug/build/libnghttp2-sys-a9070bd53e651889/out/i/lib/nghttp2/lib/nghttp2_buf.o" "-c" "nghttp2/lib/nghttp2_buf.c" with args "clang" did not execute successfully (status code exit code: 1).
```
Not sure where to override some of these flags.

Here are some questions I still have but that can be ignored for now.
- The rdkafka thing is basically some feature to enable kafka. Should we have a flag to mark it as optional and drop it by default. I personally don't use kafka but I don't know what the majority of users does.
- if we leave rdkafka in and don't care that much about closure size, should be not enable the disk-buffer feature based on leveldb. I'm not even sure what that feature exactly is, but I'm guessing it's a performance improvement. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
