### PR TITLE
firefox-bin: Avoid including both the wrapped and unwrapped versions.

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -303,10 +303,6 @@ let
             ln -sLt $out/lib/mozilla/pkcs11-modules $ext/lib/mozilla/pkcs11-modules/*
         done
 
-        # For manpages, in case the program supplies them
-        mkdir -p $out/nix-support
-        echo ${browser} > $out/nix-support/propagated-user-env-packages
-
 
         #########################
         #                       #


### PR DESCRIPTION
###### Motivation for this change

When running `nix run nixpkgs.latest.firefox-nightly-bin`, using https://github.com/mozilla/nixpkgs-mozilla, the shell contains both versions of Firefox, the unwrapped Firefox and the wrapped Firefox. Due to the path order, the unwrapped firefox is the one which is started when typing `firefox`.

This problem cause the GTK environment variable to not be considered with any wrapped Firefox, except with the one which is built from source as it is compiled against a specific GTK version.

The problem is caused by the `propagated-user-env` which suggests to carry the path of the unwrapped browser, in order to fix the man pages (based on the comment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This is tested as working by running `which -a firefox` in a shell spawn with `nix run nixpkgs.firefox-bin`. Before, `which -a firefox` would list both the unwrapped and the wrapped Firefox, and after it would only list the wrapped Firefox.
