### PR TITLE
nixos/test-driver: Run commands with pipefail set

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -274,8 +274,29 @@ start_all()
     </term>
     <listitem>
      <para>
-      Execute a shell command, raising an exception if the exit status is not
-      zero, otherwise returning the standard output.
+      Execute a shell command, raising an exception if the exit status
+      is not zero, otherwise returning the standard output. Commands
+      are run with <literal>set -euo pipefail</literal> set:
+      <itemizedlist>
+        <listitem>
+          <para>
+            If several commands are separated by <literal>;</literal>
+            and one fails, the command as a whole will fail.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            For pipelines, the last non-zero exit status will be
+            returned (if there is one, zero will be returned
+            otherwise).
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Dereferencing unset variables fail the command.
+          </para>
+        </listitem>
+      </itemizedlist>
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -441,7 +441,7 @@ class Machine:
     def execute(self, command: str) -> Tuple[int, str]:
         self.connect()
 
-        out_command = "( {} ); echo '|!=EOF' $?\n".format(command)
+        out_command = "( set -euo pipefail; {} ); echo '|!=EOF' $?\n".format(command)
         self.shell.send(out_command.encode())
 
         output = ""

--- a/nixos/tests/calibre-web.nix
+++ b/nixos/tests/calibre-web.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix (
           default.wait_for_unit("calibre-web.service")
           default.wait_for_open_port(${toString defaultPort})
           default.succeed(
-              "curl --fail 'http://localhost:${toString defaultPort}/basicconfig' | grep -q 'Basic Configuration'"
+              "curl --fail 'http://localhost:${toString defaultPort}/basicconfig' | grep 'Basic Configuration'"
           )
 
           customized.succeed(
@@ -46,7 +46,7 @@ import ./make-test-python.nix (
           customized.wait_for_unit("calibre-web.service")
           customized.wait_for_open_port(${toString port})
           customized.succeed(
-              "curl --fail -H X-User:admin 'http://localhost:${toString port}' | grep -q test-book"
+              "curl --fail -H X-User:admin 'http://localhost:${toString port}' | grep test-book"
           )
         '';
       }

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -23,15 +23,15 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     with subtest("includeStorePath"):
         with subtest("assumption"):
             docker.succeed("${examples.helloOnRoot} | docker load")
-            docker.succeed("set -euo pipefail; docker run --rm hello | grep -i hello")
+            docker.succeed("docker run --rm hello | grep -i hello")
             docker.succeed("docker image rm hello:latest")
         with subtest("includeStorePath = false; breaks example"):
             docker.succeed("${examples.helloOnRootNoStore} | docker load")
-            docker.fail("set -euo pipefail; docker run --rm hello | grep -i hello")
+            docker.fail("docker run --rm hello | grep -i hello")
             docker.succeed("docker image rm hello:latest")
         with subtest("includeStorePath = false; works with mounted store"):
             docker.succeed("${examples.helloOnRootNoStore} | docker load")
-            docker.succeed("set -euo pipefail; docker run --rm --volume ${builtins.storeDir}:${builtins.storeDir}:ro hello | grep -i hello")
+            docker.succeed("docker run --rm --volume ${builtins.storeDir}:${builtins.storeDir}:ro hello | grep -i hello")
             docker.succeed("docker image rm hello:latest")
 
     with subtest("Ensure Docker images use a stable date by default"):

--- a/nixos/tests/doh-proxy-rust.nix
+++ b/nixos/tests/doh-proxy-rust.nix
@@ -38,6 +38,6 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     machine.wait_for_unit("doh-proxy-rust.service")
     machine.wait_for_open_port(53)
     machine.wait_for_open_port(3000)
-    machine.succeed(f"curl --fail '{url}?dns={query}' | grep -qF {bin_ip}")
+    machine.succeed(f"curl --fail '{url}?dns={query}' | grep -F {bin_ip}")
   '';
 })

--- a/nixos/tests/elk.nix
+++ b/nixos/tests/elk.nix
@@ -178,7 +178,7 @@ let
           one.systemctl("stop logstash")
           one.systemctl("start elasticsearch-curator")
           one.wait_until_succeeds(
-              '! curl --silent --show-error "${esUrl}/_cat/indices" | grep logstash | grep -q ^'
+              '! curl --silent --show-error "${esUrl}/_cat/indices" | grep logstash | grep ^'
           )
     '';
   }) {};

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -102,7 +102,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : with lib; {
       # `doSetup` is is true.
       test = doSetup: ''
         gitlab.succeed(
-            "curl -isSf http://gitlab | grep -i location | grep -q http://gitlab/users/sign_in"
+            "curl -isSf http://gitlab | grep -i location | grep http://gitlab/users/sign_in"
         )
         gitlab.succeed(
             "${pkgs.sudo}/bin/sudo -u gitlab -H gitlab-rake gitlab:check 1>&2"

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -42,7 +42,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         "curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].uuid"
     )
     agent.succeed(
-        "curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].agent_state | grep -q Idle"
+        "curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].agent_state | grep Idle"
     )
   '';
 })

--- a/nixos/tests/grafana.nix
+++ b/nixos/tests/grafana.nix
@@ -74,7 +74,7 @@ in {
         declarativePlugins.wait_for_unit("grafana.service")
         declarativePlugins.wait_for_open_port(3000)
         declarativePlugins.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/plugins | grep -q grafana-clock-panel"
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/plugins | grep grafana-clock-panel"
         )
         declarativePlugins.shutdown()
 
@@ -82,7 +82,7 @@ in {
         sqlite.wait_for_unit("grafana.service")
         sqlite.wait_for_open_port(3000)
         sqlite.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep testadmin\@localhost"
         )
         sqlite.shutdown()
 
@@ -92,7 +92,7 @@ in {
         postgresql.wait_for_open_port(3000)
         postgresql.wait_for_open_port(5432)
         postgresql.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep testadmin\@localhost"
         )
         postgresql.shutdown()
 
@@ -102,7 +102,7 @@ in {
         mysql.wait_for_open_port(3000)
         mysql.wait_for_open_port(3306)
         mysql.succeed(
-            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost"
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep testadmin\@localhost"
         )
         mysql.shutdown()
   '';

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -48,23 +48,23 @@ with lib;
 
     default.wait_for_unit("miniflux.service")
     default.wait_for_open_port(${toString defaultPort})
-    default.succeed("curl --fail 'http://localhost:${toString defaultPort}/healthcheck' | grep -q OK")
+    default.succeed("curl --fail 'http://localhost:${toString defaultPort}/healthcheck' | grep OK")
     default.succeed(
-        "curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep -q '\"is_admin\":true'"
+        "curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep '\"is_admin\":true'"
     )
 
     withoutSudo.wait_for_unit("miniflux.service")
     withoutSudo.wait_for_open_port(${toString defaultPort})
-    withoutSudo.succeed("curl --fail 'http://localhost:${toString defaultPort}/healthcheck' | grep -q OK")
+    withoutSudo.succeed("curl --fail 'http://localhost:${toString defaultPort}/healthcheck' | grep OK")
     withoutSudo.succeed(
-        "curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep -q '\"is_admin\":true'"
+        "curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep '\"is_admin\":true'"
     )
 
     customized.wait_for_unit("miniflux.service")
     customized.wait_for_open_port(${toString port})
-    customized.succeed("curl --fail 'http://localhost:${toString port}/healthcheck' | grep -q OK")
+    customized.succeed("curl --fail 'http://localhost:${toString port}/healthcheck' | grep OK")
     customized.succeed(
-        "curl 'http://localhost:${toString port}/v1/me' -u '${username}:${password}' -H Content-Type:application/json | grep -q '\"is_admin\":true'"
+        "curl 'http://localhost:${toString port}/v1/me' -u '${username}:${password}' -H Content-Type:application/json | grep '\"is_admin\":true'"
     )
   '';
 })

--- a/nixos/tests/nginx-variants.nix
+++ b/nixos/tests/nginx-variants.nix
@@ -29,5 +29,5 @@ builtins.listToAttrs (
         };
       }
     )
-    [ "nginxStable" "nginxUnstable" "nginxShibboleth" "openresty" "tengine" ]
+    [ "nginxStable" "nginxMainline" "nginxShibboleth" "openresty" "tengine" ]
 )

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -56,11 +56,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       };
 
       specialisation.reloadRestartSystem.configuration = {
-        services.nginx.package = pkgs.nginxUnstable;
+        services.nginx.package = pkgs.nginxMainline;
       };
 
       specialisation.reloadWithErrorsSystem.configuration = {
-        services.nginx.package = pkgs.nginxUnstable;
+        services.nginx.package = pkgs.nginxMainline;
         services.nginx.virtualHosts."!@$$(#*%".locations."~@#*$*!)".proxyPass = ";;;";
       };
     };

--- a/nixos/tests/pomerium.nix
+++ b/nixos/tests/pomerium.nix
@@ -88,15 +88,15 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     with subtest("no authentication required"):
         pomerium.succeed(
-            "curl --resolve my.website:80:127.0.0.1 http://my.website | grep -q 'hello world'"
+            "curl --resolve my.website:80:127.0.0.1 http://my.website | grep 'hello world'"
         )
 
     with subtest("login required"):
         pomerium.succeed(
-            "curl -I --resolve login.required:80:127.0.0.1 http://login.required | grep -q pom-auth"
+            "curl -I --resolve login.required:80:127.0.0.1 http://login.required | grep pom-auth"
         )
         pomerium.succeed(
-            "curl -L --resolve login.required:80:127.0.0.1 http://login.required | grep -q 'hello I am login page'"
+            "curl -L --resolve login.required:80:127.0.0.1 http://login.required | grep 'hello I am login page'"
         )
   '';
 })

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -71,7 +71,7 @@ let
         wait_for_open_port(3551)
         wait_for_unit("prometheus-apcupsd-exporter.service")
         wait_for_open_port(9162)
-        succeed("curl -sSf http://localhost:9162/metrics | grep -q 'apcupsd_info'")
+        succeed("curl -sSf http://localhost:9162/metrics | grep 'apcupsd_info'")
       '';
     };
 
@@ -85,7 +85,7 @@ let
         wait_for_unit("prometheus-artifactory-exporter.service")
         wait_for_open_port(9531)
         succeed(
-            "curl -sSf http://localhost:9531/metrics | grep -q 'artifactory_up'"
+            "curl -sSf http://localhost:9531/metrics | grep 'artifactory_up'"
         )
       '';
     };
@@ -106,7 +106,7 @@ let
         wait_for_unit("prometheus-bind-exporter.service")
         wait_for_open_port(9119)
         succeed(
-            "curl -sSf http://localhost:9119/metrics | grep -q 'bind_query_recursions_total 0'"
+            "curl -sSf http://localhost:9119/metrics | grep 'bind_query_recursions_total 0'"
         )
       '';
     };
@@ -135,7 +135,7 @@ let
         wait_for_unit("prometheus-bird-exporter.service")
         wait_for_open_port(9324)
         wait_until_succeeds(
-            "curl -sSf http://localhost:9324/metrics | grep -q 'MyObviousTestString'"
+            "curl -sSf http://localhost:9324/metrics | grep 'MyObviousTestString'"
         )
       '';
     };
@@ -154,7 +154,7 @@ let
         wait_for_unit("prometheus-bitcoin-exporter.service")
         wait_for_unit("bitcoind-default.service")
         wait_for_open_port(9332)
-        succeed("curl -sSf http://localhost:9332/metrics | grep -q '^bitcoin_blocks '")
+        succeed("curl -sSf http://localhost:9332/metrics | grep '^bitcoin_blocks '")
       '';
     };
 
@@ -172,7 +172,7 @@ let
         wait_for_unit("prometheus-blackbox-exporter.service")
         wait_for_open_port(9115)
         succeed(
-            "curl -sSf 'http://localhost:9115/probe?target=localhost&module=icmp_v6' | grep -q 'probe_success 1'"
+            "curl -sSf 'http://localhost:9115/probe?target=localhost&module=icmp_v6' | grep 'probe_success 1'"
         )
       '';
     };
@@ -204,7 +204,7 @@ let
               "curl -sSfH 'Content-Type: application/json' -X POST --data @/tmp/data.json localhost:9103/collectd"
           )
           succeed(
-              "curl -sSf localhost:9103/metrics | grep -q 'collectd_testplugin_gauge{instance=\"testhost\"} 23'"
+              "curl -sSf localhost:9103/metrics | grep 'collectd_testplugin_gauge{instance=\"testhost\"} 23'"
           )
         '';
     };
@@ -220,7 +220,7 @@ let
       exporterTest = ''
         wait_for_unit("prometheus-dnsmasq-exporter.service")
         wait_for_open_port(9153)
-        succeed("curl -sSf http://localhost:9153/metrics | grep -q 'dnsmasq_leases 0'")
+        succeed("curl -sSf http://localhost:9153/metrics | grep 'dnsmasq_leases 0'")
       '';
     };
 
@@ -235,7 +235,7 @@ let
         wait_for_unit("prometheus-domain-exporter.service")
         wait_for_open_port(9222)
         succeed(
-            "curl -sSf 'http://localhost:9222/probe?target=nixos.org' | grep -q 'domain_probe_success 0'"
+            "curl -sSf 'http://localhost:9222/probe?target=nixos.org' | grep 'domain_probe_success 0'"
         )
       '';
     };
@@ -254,7 +254,7 @@ let
         wait_for_unit("prometheus-dovecot-exporter.service")
         wait_for_open_port(9166)
         succeed(
-            "curl -sSf http://localhost:9166/metrics | grep -q 'dovecot_up{scope=\"global\"} 1'"
+            "curl -sSf http://localhost:9166/metrics | grep 'dovecot_up{scope=\"global\"} 1'"
         )
       '';
     };
@@ -268,7 +268,7 @@ let
         wait_for_unit("prometheus-fritzbox-exporter.service")
         wait_for_open_port(9133)
         succeed(
-            "curl -sSf http://localhost:9133/metrics | grep -q 'fritzbox_exporter_collect_errors 0'"
+            "curl -sSf http://localhost:9133/metrics | grep 'fritzbox_exporter_collect_errors 0'"
         )
       '';
     };
@@ -290,9 +290,9 @@ let
         wait_for_unit("prometheus-jitsi-exporter.service")
         wait_for_open_port(9700)
         wait_until_succeeds(
-            'journalctl -eu prometheus-jitsi-exporter.service -o cat | grep -q "key=participants"'
+            'journalctl -eu prometheus-jitsi-exporter.service -o cat | grep "key=participants"'
         )
-        succeed("curl -sSf 'localhost:9700/metrics' | grep -q 'jitsi_participants 0'")
+        succeed("curl -sSf 'localhost:9700/metrics' | grep 'jitsi_participants 0'")
       '';
     };
 
@@ -321,7 +321,7 @@ let
         wait_for_unit("prometheus-json-exporter.service")
         wait_for_open_port(7979)
         succeed(
-            "curl -sSf 'localhost:7979/probe?target=http://localhost' | grep -q 'json_test_metric 1'"
+            "curl -sSf 'localhost:7979/probe?target=http://localhost' | grep 'json_test_metric 1'"
         )
       '';
     };
@@ -426,7 +426,7 @@ let
         wait_for_unit("knot.service")
         wait_for_unit("prometheus-knot-exporter.service")
         wait_for_open_port(9433)
-        succeed("curl -sSf 'localhost:9433' | grep -q 'knot_server_zone_count 1.0'")
+        succeed("curl -sSf 'localhost:9433' | grep 'knot_server_zone_count 1.0'")
       '';
     };
 
@@ -441,10 +441,10 @@ let
         wait_for_unit("prometheus-keylight-exporter.service")
         wait_for_open_port(9288)
         succeed(
-            "curl -sS --write-out '%{http_code}' -o /dev/null http://localhost:9288/metrics | grep -q '400'"
+            "curl -sS --write-out '%{http_code}' -o /dev/null http://localhost:9288/metrics | grep '400'"
         )
         succeed(
-            "curl -sS --write-out '%{http_code}' -o /dev/null http://localhost:9288/metrics?target=nosuchdevice | grep -q '500'"
+            "curl -sS --write-out '%{http_code}' -o /dev/null http://localhost:9288/metrics?target=nosuchdevice | grep '500'"
         )
       '';
     };
@@ -489,7 +489,7 @@ let
         wait_for_open_port(10009)
         wait_for_unit("prometheus-lnd-exporter.service")
         wait_for_open_port(9092)
-        succeed("curl -sSf localhost:9092/metrics | grep -q '^promhttp_metric_handler'")
+        succeed("curl -sSf localhost:9092/metrics | grep '^promhttp_metric_handler'")
       '';
     };
 
@@ -531,7 +531,7 @@ let
         wait_for_unit("prometheus-mail-exporter.service")
         wait_for_open_port(9225)
         wait_until_succeeds(
-            "curl -sSf http://localhost:9225/metrics | grep -q 'mail_deliver_success{configname=\"testserver\"} 1'"
+            "curl -sSf http://localhost:9225/metrics | grep 'mail_deliver_success{configname=\"testserver\"} 1'"
         )
       '';
     };
@@ -571,7 +571,7 @@ let
         wait_for_unit("prometheus-mikrotik-exporter.service")
         wait_for_open_port(9436)
         succeed(
-            "curl -sSf http://localhost:9436/metrics | grep -q 'mikrotik_scrape_collector_success{device=\"router\"} 0'"
+            "curl -sSf http://localhost:9436/metrics | grep 'mikrotik_scrape_collector_success{device=\"router\"} 0'"
         )
       '';
     };
@@ -596,7 +596,7 @@ let
         wait_for_unit("prometheus-modemmanager-exporter.service")
         wait_for_open_port(9539)
         succeed(
-            "curl -sSf http://localhost:9539/metrics | grep -q 'modemmanager_info'"
+            "curl -sSf http://localhost:9539/metrics | grep 'modemmanager_info'"
         )
       '';
     };
@@ -634,7 +634,7 @@ let
         wait_for_unit("nginx.service")
         wait_for_unit("prometheus-nextcloud-exporter.service")
         wait_for_open_port(9205)
-        succeed("curl -sSf http://localhost:9205/metrics | grep -q 'nextcloud_up 1'")
+        succeed("curl -sSf http://localhost:9205/metrics | grep 'nextcloud_up 1'")
       '';
     };
 
@@ -653,7 +653,7 @@ let
         wait_for_unit("nginx.service")
         wait_for_unit("prometheus-nginx-exporter.service")
         wait_for_open_port(9113)
-        succeed("curl -sSf http://localhost:9113/metrics | grep -q 'nginx_up 1'")
+        succeed("curl -sSf http://localhost:9113/metrics | grep 'nginx_up 1'")
       '';
     };
 
@@ -708,12 +708,12 @@ let
         succeed("curl http://localhost")
         execute("sleep 1")
         succeed(
-            "curl -sSf http://localhost:9117/metrics | grep 'filelogger_http_response_count_total' | grep -q 1"
+            "curl -sSf http://localhost:9117/metrics | grep 'filelogger_http_response_count_total' | grep 1"
         )
         succeed("curl http://localhost:81")
         execute("sleep 1")
         succeed(
-            "curl -sSf http://localhost:9117/metrics | grep 'syslogger_http_response_count_total' | grep -q 1"
+            "curl -sSf http://localhost:9117/metrics | grep 'syslogger_http_response_count_total' | grep 1"
         )
       '';
     };
@@ -726,7 +726,7 @@ let
         wait_for_unit("prometheus-node-exporter.service")
         wait_for_open_port(9100)
         succeed(
-            "curl -sSf http://localhost:9100/metrics | grep -q 'node_exporter_build_info{.\\+} 1'"
+            "curl -sSf http://localhost:9100/metrics | grep 'node_exporter_build_info{.\\+} 1'"
         )
       '';
     };
@@ -786,7 +786,7 @@ let
         wait_for_open_port(389)
         wait_for_open_port(9330)
         wait_until_succeeds(
-            "curl -sSf http://localhost:9330/metrics | grep -q 'openldap_scrape{result=\"ok\"} 1'"
+            "curl -sSf http://localhost:9330/metrics | grep 'openldap_scrape{result=\"ok\"} 1'"
         )
       '';
     };
@@ -812,7 +812,7 @@ let
       exporterTest = ''
         wait_for_unit("openvpn-test.service")
         wait_for_unit("prometheus-openvpn-exporter.service")
-        succeed("curl -sSf http://localhost:9176/metrics | grep -q 'openvpn_up{.*} 1'")
+        succeed("curl -sSf http://localhost:9176/metrics | grep 'openvpn_up{.*} 1'")
       '';
     };
 
@@ -828,9 +828,9 @@ let
         wait_for_file("/var/lib/postfix/queue/public/showq")
         wait_for_open_port(9154)
         succeed(
-            "curl -sSf http://localhost:9154/metrics | grep -q 'postfix_smtpd_connects_total 0'"
+            "curl -sSf http://localhost:9154/metrics | grep 'postfix_smtpd_connects_total 0'"
         )
-        succeed("curl -sSf http://localhost:9154/metrics | grep -q 'postfix_up{.*} 1'")
+        succeed("curl -sSf http://localhost:9154/metrics | grep 'postfix_up{.*} 1'")
       '';
     };
 
@@ -847,20 +847,20 @@ let
         wait_for_open_port(9187)
         wait_for_unit("postgresql.service")
         succeed(
-            "curl -sSf http://localhost:9187/metrics | grep -q 'pg_exporter_last_scrape_error 0'"
+            "curl -sSf http://localhost:9187/metrics | grep 'pg_exporter_last_scrape_error 0'"
         )
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 1'")
+        succeed("curl -sSf http://localhost:9187/metrics | grep 'pg_up 1'")
         systemctl("stop postgresql.service")
         succeed(
-            "curl -sSf http://localhost:9187/metrics | grep -qv 'pg_exporter_last_scrape_error 0'"
+            "curl -sSf http://localhost:9187/metrics | grep -v 'pg_exporter_last_scrape_error 0'"
         )
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 0'")
+        succeed("curl -sSf http://localhost:9187/metrics | grep 'pg_up 0'")
         systemctl("start postgresql.service")
         wait_for_unit("postgresql.service")
         succeed(
-            "curl -sSf http://localhost:9187/metrics | grep -q 'pg_exporter_last_scrape_error 0'"
+            "curl -sSf http://localhost:9187/metrics | grep 'pg_exporter_last_scrape_error 0'"
         )
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 1'")
+        succeed("curl -sSf http://localhost:9187/metrics | grep 'pg_up 1'")
       '';
     };
 
@@ -874,7 +874,7 @@ let
         wait_for_unit("prometheus-py-air-control-exporter.service")
         wait_for_open_port(9896)
         succeed(
-            "curl -sSf http://localhost:9896/metrics | grep -q 'py_air_control_sampling_error_total'"
+            "curl -sSf http://localhost:9896/metrics | grep 'py_air_control_sampling_error_total'"
         )
       '';
     };
@@ -889,7 +889,7 @@ let
         wait_for_unit("prometheus-redis-exporter.service")
         wait_for_open_port(6379)
         wait_for_open_port(9121)
-        wait_until_succeeds("curl -sSf localhost:9121/metrics | grep -q 'redis_up 1'")
+        wait_until_succeeds("curl -sSf localhost:9121/metrics | grep 'redis_up 1'")
       '';
     };
 
@@ -907,7 +907,7 @@ let
         wait_for_open_port(11334)
         wait_for_open_port(7980)
         wait_until_succeeds(
-            "curl -sSf 'localhost:7980/probe?target=http://localhost:11334/stat' | grep -q 'rspamd_scanned{host=\"rspamd\"} 0'"
+            "curl -sSf 'localhost:7980/probe?target=http://localhost:11334/stat' | grep 'rspamd_scanned{host=\"rspamd\"} 0'"
         )
       '';
     };
@@ -938,7 +938,7 @@ let
         wait_for_unit("prometheus-rtl_433-exporter.service")
         wait_for_open_port(9550)
         wait_until_succeeds(
-            "curl -sSf localhost:9550/metrics | grep -q '{}'".format(
+            "curl -sSf localhost:9550/metrics | grep '{}'".format(
                 'rtl_433_temperature_celsius{channel="3",id="55",location="",model="zopieux"} 18'
             )
         )
@@ -954,12 +954,12 @@ let
         wait_for_unit("prometheus-smokeping-exporter.service")
         wait_for_open_port(9374)
         wait_until_succeeds(
-            "curl -sSf localhost:9374/metrics | grep '{}' | grep -qv ' 0$'".format(
+            "curl -sSf localhost:9374/metrics | grep '{}' | grep -v ' 0$'".format(
                 'smokeping_requests_total{host="127.0.0.1",ip="127.0.0.1"} '
             )
         )
         wait_until_succeeds(
-            "curl -sSf localhost:9374/metrics | grep -q '{}'".format(
+            "curl -sSf localhost:9374/metrics | grep '{}'".format(
                 'smokeping_response_ttl{host="127.0.0.1",ip="127.0.0.1"}'
             )
         )
@@ -977,7 +977,7 @@ let
       exporterTest = ''
         wait_for_unit("prometheus-snmp-exporter.service")
         wait_for_open_port(9116)
-        succeed("curl -sSf localhost:9116/metrics | grep -q 'snmp_request_errors_total 0'")
+        succeed("curl -sSf localhost:9116/metrics | grep 'snmp_request_errors_total 0'")
       '';
     };
 
@@ -1021,7 +1021,7 @@ let
       exporterTest = ''
         wait_for_unit("prometheus-sql-exporter.service")
         wait_for_open_port(9237)
-        succeed("curl http://localhost:9237/metrics | grep -c 'sql_points{' | grep -q 2")
+        succeed("curl http://localhost:9237/metrics | grep -c 'sql_points{' | grep 2")
       '';
     };
 
@@ -1044,7 +1044,7 @@ let
         wait_for_open_port(80)
         wait_for_unit("prometheus-surfboard-exporter.service")
         wait_for_open_port(9239)
-        succeed("curl -sSf localhost:9239/metrics | grep -q 'surfboard_up 1'")
+        succeed("curl -sSf localhost:9239/metrics | grep 'surfboard_up 1'")
       '';
     };
 
@@ -1057,7 +1057,7 @@ let
         wait_for_unit("prometheus-systemd-exporter.service")
         wait_for_open_port(9558)
         succeed(
-            "curl -sSf localhost:9558/metrics | grep -q '{}'".format(
+            "curl -sSf localhost:9558/metrics | grep '{}'".format(
                 'systemd_unit_state{name="basic.target",state="active",type="target"} 1'
             )
         )
@@ -1079,7 +1079,7 @@ let
         wait_for_open_port(9051)
         wait_for_unit("prometheus-tor-exporter.service")
         wait_for_open_port(9130)
-        succeed("curl -sSf localhost:9130/metrics | grep -q 'tor_version{.\\+} 1'")
+        succeed("curl -sSf localhost:9130/metrics | grep 'tor_version{.\\+} 1'")
       '';
     };
 
@@ -1091,7 +1091,7 @@ let
         wait_for_unit("prometheus-unifi-poller-exporter.service")
         wait_for_open_port(9130)
         succeed(
-            "curl -sSf localhost:9130/metrics | grep -q 'unifipoller_build_info{.\\+} 1'"
+            "curl -sSf localhost:9130/metrics | grep 'unifipoller_build_info{.\\+} 1'"
         )
       '';
     };
@@ -1115,7 +1115,7 @@ let
         wait_for_unit("unbound.service")
         wait_for_unit("prometheus-unbound-exporter.service")
         wait_for_open_port(9167)
-        succeed("curl -sSf localhost:9167/metrics | grep -q 'unbound_up 1'")
+        succeed("curl -sSf localhost:9167/metrics | grep 'unbound_up 1'")
       '';
     };
 
@@ -1144,7 +1144,7 @@ let
         wait_for_unit("prometheus-varnish-exporter.service")
         wait_for_open_port(6081)
         wait_for_open_port(9131)
-        succeed("curl -sSf http://localhost:9131/metrics | grep -q 'varnish_up 1'")
+        succeed("curl -sSf http://localhost:9131/metrics | grep 'varnish_up 1'")
       '';
     };
 

--- a/nixos/tests/shiori.nix
+++ b/nixos/tests/shiori.nix
@@ -28,7 +28,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
     machine.wait_for_unit("shiori.service")
     machine.wait_for_open_port(8080)
     machine.succeed("curl --fail http://localhost:8080/")
-    machine.succeed("curl --fail --location http://localhost:8080/ | grep -qi shiori")
+    machine.succeed("curl --fail --location http://localhost:8080/ | grep -i shiori")
 
     with subtest("login"):
         auth_json = machine.succeed(

--- a/nixos/tests/wiki-js.nix
+++ b/nixos/tests/wiki-js.nix
@@ -119,7 +119,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
 
     with subtest("Setup"):
         result = machine.succeed(
-            "set -o pipefail; curl -sSf localhost:3000/finalize -X POST -d "
+            "curl -sSf localhost:3000/finalize -X POST -d "
             + "@${payloads.finalize} -H 'Content-Type: application/json' "
             + "| jq .ok | xargs echo"
         )
@@ -132,7 +132,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
 
     with subtest("Base functionality"):
         auth = machine.succeed(
-            "set -o pipefail; curl -sSf localhost:3000/graphql -X POST "
+            "curl -sSf localhost:3000/graphql -X POST "
             + "-d @${payloads.login} -H 'Content-Type: application/json' "
             + "| jq '.[0].data.authentication.login.jwt' | xargs echo"
         ).strip()
@@ -140,7 +140,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
         assert auth
 
         create = machine.succeed(
-            "set -o pipefail; curl -sSf localhost:3000/graphql -X POST "
+            "curl -sSf localhost:3000/graphql -X POST "
             + "-d @${payloads.content} -H 'Content-Type: application/json' "
             + f"-H 'Authorization: Bearer {auth}' "
             + "| jq '.[0].data.pages.create.responseResult.succeeded'|xargs echo"

--- a/nixos/tests/xandikos.nix
+++ b/nixos/tests/xandikos.nix
@@ -44,7 +44,7 @@ import ./make-test-python.nix (
             xandikos_default.wait_for_open_port(8080)
             xandikos_default.succeed("curl --fail http://localhost:8080/")
             xandikos_default.succeed(
-                "curl -s --fail --location http://localhost:8080/ | grep -qi Xandikos"
+                "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"
             )
             xandikos_client.wait_for_unit("network.target")
             xandikos_client.fail("curl --fail http://xandikos_default:8080/")
@@ -55,15 +55,15 @@ import ./make-test-python.nix (
             xandikos_proxy.wait_for_open_port(8080)
             xandikos_proxy.succeed("curl --fail http://localhost:8080/")
             xandikos_proxy.succeed(
-                "curl -s --fail --location http://localhost:8080/ | grep -qi Xandikos"
+                "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"
             )
             xandikos_client.wait_for_unit("network.target")
             xandikos_client.fail("curl --fail http://xandikos_proxy:8080/")
             xandikos_client.succeed(
-                "curl -s --fail -u xandikos:snakeOilPassword -H 'Host: xandikos.local' http://xandikos_proxy/xandikos/ | grep -qi Xandikos"
+                "curl -s --fail -u xandikos:snakeOilPassword -H 'Host: xandikos.local' http://xandikos_proxy/xandikos/ | grep -i Xandikos"
             )
             xandikos_client.succeed(
-                "curl -s --fail -u xandikos:snakeOilPassword -H 'Host: xandikos.local' http://xandikos_proxy/xandikos/user/ | grep -qi Xandikos"
+                "curl -s --fail -u xandikos:snakeOilPassword -H 'Host: xandikos.local' http://xandikos_proxy/xandikos/user/ | grep -i Xandikos"
             )
       '';
     }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bash's standard behavior of not propagating non-zero exit codes through a pipeline is unexpected and almost universally
unwanted. Default to setting `pipefail` for the command being run; it can still be turned off by prefixing the pipeline with
`set +o pipefail` if needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested by constructing a test with a failing command early in the pipeline
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
