### PR TITLE
tumiki-fighters: init at 0.21

### DIFF
--- a/pkgs/games/tumiki-fighters/default.nix
+++ b/pkgs/games/tumiki-fighters/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchpatch
+, fetchurl
+, unzip
+, gdc
+, SDL
+, SDL_mixer
+, bulletml
+}:
+
+let
+debianPatch = patchname: hash: fetchpatch {
+  name = "${patchname}.patch";
+  url = "https://sources.debian.org/data/main/t/tumiki-fighters/0.2.dfsg1-9/debian/patches/${patchname}.patch";
+  sha256 = hash;
+};
+
+in stdenv.mkDerivation {
+  pname = "tumiki-fighters";
+  version = "0.21";
+
+  src = fetchurl {
+    url = "http://abagames.sakura.ne.jp/windows/tf0_21.zip";
+    sha256 = "0djykfc1r8ysapklm621h89ana1c4qzc1m5nr9bqw4iccnmvwk3p";
+  };
+
+  patches = [
+    (debianPatch
+      "imports"
+      "1l3kc67b43gdi139cpz5cka1nkn0pjp9mrgrrxlmr0liwx2aryhn")
+    (debianPatch
+      "fixes"
+      "1iy1a5vii6yz9zdlk2bcj6gkj4y25hn9y2fczz15jpqd9r2zm603")
+    (debianPatch
+      "directories"
+      "0kmv0s7jgr693fzrkjsmz4dnicc4w7njanxm2la3cf4vmgdyipmm")
+    (debianPatch
+      "windowed"
+      "1wp74l0bi8wq85pcxnmkwrlfmlf09im95n27pxgz082lhwf2ksy1")
+    (debianPatch
+      "dotfile"
+      "0d8x519bclh41j992qn6ijzfcrgacb79px6zjd1awypkwyc0j2p6")
+    (debianPatch
+      "makefile"
+      "11xf2b31kjyps53jfryv82dv0g6q0smc9xgp8imrbr93mzi51vf0")
+    (debianPatch
+      "window-resizing"
+      "1dm79d0yisa8zs5fr89y3wq2kzd3khcaxs0la8lhncvkqbd4smx8")
+    (debianPatch
+      "dlang_v2"
+      "1isnvbl3bjnpyphji8k3fl0yd1z4869h0lai143vpwgj6518lpg4")
+    (debianPatch
+      "gdc-8"
+      "1md0zwmv50jnak5g9d93bglv9v4z41blinjii6kv3vmgjnajapzj")
+  ];
+
+  postPatch = ''
+    for f in \
+      src/abagames/tf/barragemanager.d \
+      src/abagames/util/sdl/sound.d \
+      src/abagames/util/sdl/texture.d \
+      src/abagames/tf/enemyspec.d \
+      src/abagames/tf/field.d \
+      src/abagames/tf/stagemanager.d \
+      src/abagames/tf/tumikiset.d
+    do
+      substituteInPlace $f \
+        --replace "/usr/" "$out/"
+    done
+  '';
+
+  nativeBuildInputs = [
+    unzip
+    gdc
+  ];
+
+  buildInputs = [
+    SDL
+    SDL_mixer
+    bulletml
+  ];
+
+  installPhase = ''
+    install -Dm755 tumiki-fighters $out/bin/tumiki-fighters
+    mkdir -p $out/share/games/tumiki-fighters
+    cp -r barrage sounds enemy field stage tumiki $out/share/games/tumiki-fighters/
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.asahi-net.or.jp/~cs8k-cyu/windows/tf_e.html";
+    description = "Sticky 2D shooter";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28923,6 +28923,8 @@ in
 
   tts = callPackage ../tools/audio/tts { };
 
+  tumiki-fighters = callPackage ../games/tumiki-fighters { };
+
   tuxpaint = callPackage ../games/tuxpaint { };
 
   tuxtype = callPackage ../games/tuxtype { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#125691

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
