### PR TITLE
treewide: Fix mysql alias deprecation breakage

### DIFF
--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  inherit (pkgs) mysql gzip;
+  inherit (pkgs) mariadb gzip;
 
   cfg = config.services.mysqlBackup;
   defaultUser = "mysqlbackup";
@@ -20,7 +20,7 @@ let
   '';
   backupDatabaseScript = db: ''
     dest="${cfg.location}/${db}.gz"
-    if ${mysql}/bin/mysqldump ${if cfg.singleTransaction then "--single-transaction" else ""} ${db} | ${gzip}/bin/gzip -c > $dest.tmp; then
+    if ${mariadb}/bin/mysqldump ${if cfg.singleTransaction then "--single-transaction" else ""} ${db} | ${gzip}/bin/gzip -c > $dest.tmp; then
       mv $dest.tmp $dest
       echo "Backed up to $dest"
     else

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -34,7 +34,7 @@ in
 
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.mysql";
+        example = literalExample "pkgs.mariadb";
         description = "
           Which MySQL derivation to use. MariaDB packages are supported too.
         ";

--- a/nixos/modules/services/video/epgstation/default.nix
+++ b/nixos/modules/services/video/epgstation/default.nix
@@ -27,7 +27,7 @@ let
 
     # NOTE: Use password authentication, since mysqljs does not yet support auth_socket
     if [ ! -e /var/lib/epgstation/db-created ]; then
-      ${pkgs.mysql}/bin/mysql -e \
+      ${pkgs.mariadb}/bin/mysql -e \
         "GRANT ALL ON \`${cfg.database.name}\`.* TO '${username}'@'localhost' IDENTIFIED by '$DB_PASSWORD';"
       touch /var/lib/epgstation/db-created
     fi
@@ -224,7 +224,7 @@ in
 
     services.mysql = {
       enable = mkDefault true;
-      package = mkDefault pkgs.mysql;
+      package = mkDefault pkgs.mariadb;
       ensureDatabases = [ cfg.database.name ];
       # FIXME: enable once mysqljs supports auth_socket
       # ensureUsers = [ {

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -728,7 +728,7 @@ in
 
         services.postgresql.enable = lib.mkDefault createLocalPostgreSQL;
         services.mysql.enable = lib.mkDefault createLocalMySQL;
-        services.mysql.package = lib.mkIf createLocalMySQL pkgs.mysql;
+        services.mysql.package = lib.mkIf createLocalMySQL pkgs.mariadb;
       };
 
   meta.doc = ./keycloak.xml;

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -644,7 +644,7 @@ let
 
     services.mysql = mkIf mysqlLocal {
       enable = true;
-      package = mkDefault pkgs.mysql;
+      package = mkDefault pkgs.mariadb;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
         {

--- a/nixos/tests/bitwarden.nix
+++ b/nixos/tests/bitwarden.nix
@@ -42,7 +42,7 @@ let
                 GRANT ALL ON `bitwarden`.* TO 'bitwardenuser'@'localhost';
                 FLUSH PRIVILEGES;
               '';
-              package = pkgs.mysql;
+              package = pkgs.mariadb;
             };
 
             services.bitwarden_rs.config.databaseUrl = "mysql://bitwardenuser:${dbPassword}@localhost/bitwarden";

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -18,7 +18,7 @@ let
       };
       services.mysql = {
         enable = true;
-        package = pkgs.mysql;
+        package = pkgs.mariadb;
       };
       services.nginx.enable = true;
     };

--- a/nixos/tests/mysql/mysql-autobackup.nix
+++ b/nixos/tests/mysql/mysql-autobackup.nix
@@ -8,7 +8,7 @@ import ./../make-test-python.nix ({ pkgs, lib, ... }:
     { pkgs, ... }:
     {
       services.mysql.enable = true;
-      services.mysql.package = pkgs.mysql;
+      services.mysql.package = pkgs.mariadb;
       services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
 
       services.automysqlbackup.enable = true;

--- a/nixos/tests/mysql/mysql-backup.nix
+++ b/nixos/tests/mysql/mysql-backup.nix
@@ -10,7 +10,7 @@ import ./../make-test-python.nix ({ pkgs, ... } : {
       services.mysql = {
         enable = true;
         initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
-        package = pkgs.mysql;
+        package = pkgs.mariadb;
       };
 
       services.mysqlBackup = {

--- a/nixos/tests/mysql/mysql-replication.nix
+++ b/nixos/tests/mysql/mysql-replication.nix
@@ -17,7 +17,7 @@ in
 
       {
         services.mysql.enable = true;
-        services.mysql.package = pkgs.mysql;
+        services.mysql.package = pkgs.mariadb;
         services.mysql.replication.role = "master";
         services.mysql.replication.slaveHost = "%";
         services.mysql.replication.masterUser = replicateUser;
@@ -31,7 +31,7 @@ in
 
       {
         services.mysql.enable = true;
-        services.mysql.package = pkgs.mysql;
+        services.mysql.package = pkgs.mariadb;
         services.mysql.replication.role = "slave";
         services.mysql.replication.serverId = 2;
         services.mysql.replication.masterHost = nodes.master.config.networking.hostName;
@@ -44,7 +44,7 @@ in
 
       {
         services.mysql.enable = true;
-        services.mysql.package = pkgs.mysql;
+        services.mysql.package = pkgs.mariadb;
         services.mysql.replication.role = "slave";
         services.mysql.replication.serverId = 3;
         services.mysql.replication.masterHost = nodes.master.config.networking.hostName;

--- a/nixos/tests/sogo.nix
+++ b/nixos/tests/sogo.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
       services.mysql = {
         enable = true;
-        package = pkgs.mysql;
+        package = pkgs.mariadb;
         ensureDatabases = [ "sogo" ];
         ensureUsers = [{
           name = "sogo";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -173,7 +173,7 @@ with super;
       MYSQL_LIBDIR="${pkgs.libmysqlclient}/lib/mysql";
     };
     buildInputs = [
-      pkgs.mysql.client
+      pkgs.mariadb.client
       pkgs.libmysqlclient
     ];
   });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
62733b37b4a866cabafe1fc8bb7415240126eb0b broke evaluation in all places `pkgs.mysql` was used when `allowAliases = false`, which is true for tests since 3edde6562e19698da69a499881e0a2e4f5a497a2. Fix this by changing all occurrences to `pkgs.mariadb`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
