### PR TITLE
[docs] Define backport criteria

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,14 @@ Follow these steps to backport a change into a release branch in compliance with
 5. Push to GitHub and open a backport pull request. Make sure to select the release branch (e.g. `release-20.09`) as the target branch of the pull request, and link to the pull request in which the original change was comitted to `master`. The pull request title should be the commit title with the release version as prefix, e.g. `[20.09]`.
 6. When the backport pull request is merged and you have the necessary privileges you can also replace the label `9.needs: port to stable` with `8.has: port to stable` on the original pull request. This way maintainers can keep track of missing backports easier.
 
+## Criteria for Backporting changes
+
+Anything that does not cause user or downstream dependency regressions can be backported. This includes:
+- New Packages / Modules
+- Security / Patch updates
+- Version updates which include new functionality (but no breaking changes)
+- Software which is always meant to be at it's latest. (E.g. `spotify`, `steam`, or `discord`)
+
 ## Generating 21.11 Release Notes
 
 Documentation in nixpkgs is transitioning to a markdown-centric workflow. Release notes now require a translation step to convert from markdown to a compatible docbook document.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,7 +65,8 @@ Anything that does not cause user or downstream dependency regressions can be ba
 - New Packages / Modules
 - Security / Patch updates
 - Version updates which include new functionality (but no breaking changes)
-- Software which is always meant to be at it's latest. (E.g. `spotify`, `steam`, or `discord`)
+- Services which require a client to be up-to-date regardless. (E.g. `spotify`, `steam`, or `discord`)
+- Security critical applications (E.g. `firefox`)
 
 ## Generating 21.11 Release Notes
 

--- a/doc/contributing/submitting-changes.chapter.md
+++ b/doc/contributing/submitting-changes.chapter.md
@@ -267,3 +267,14 @@ Other examples of reasons are:
 - Previously the build would fail due to, e.g., `getaddrinfo` not being defined
 - The previous download links were all broken
 - Crash when starting on some X11 systems
+
+#### Acceptable backport criteria
+
+The stable branch does have some changes which cannot be backported. Most notable are breaking changes. The desire is to have stable users be uninterrupted when updating packages.
+
+However, many changes are able to be backported, including:
+- New Packages / Modules
+- Security / Patch updates
+- Version updates which include new functionality (but no breaking changes)
+- Services which require a client to be up-to-date regardless. (E.g. `spotify`, `steam`, or `discord`)
+- Security critical applications (E.g. `firefox`)


### PR DESCRIPTION
###### Motivation for this change
Make it more definitive on what can be backported.

cc @alyssais

"retired", but active RMs: @domenkozar @vcunat 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
