### PR TITLE
ryzenadj: init at 0.8.2

### DIFF
--- a/pkgs/os-specific/linux/ryzenadj/default.nix
+++ b/pkgs/os-specific/linux/ryzenadj/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, pciutils, cmake }:
+stdenv.mkDerivation rec {
+  pname = "ryzenadj";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "FlyGoat";
+    repo = "RyzenAdj";
+    rev = "v${version}";
+    sha256 = "182l9nchlpl4yr568n86086glkr607rif92wnwc7v3aym62ch6ld";
+  };
+
+  nativeBuildInputs = [ pciutils cmake ];
+
+  installPhase = ''
+    install -D libryzenadj.so $out/lib/libryzenadj.so
+    install -D ryzenadj $out/bin/ryzenadj
+  '';
+
+  meta = with lib; {
+    description = "Adjust power management settings for Ryzen Mobile Processors.";
+    homepage = "https://github.com/FlyGoat/RyzenAdj";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ asbachb ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31748,6 +31748,8 @@ in
 
   zenstates = callPackage ../os-specific/linux/zenstates {};
 
+  ryzenadj = callPackage ../os-specific/linux/ryzenadj {};
+
   vpsfree-client = callPackage ../tools/virtualization/vpsfree-client {};
 
   gpio-utils = callPackage ../os-specific/linux/kernel/gpio-utils.nix { };


### PR DESCRIPTION
###### Motivation for this change
see #125689 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
