### PR TITLE
seaweedfs: 2.36 -> 2.50

### DIFF
--- a/pkgs/applications/networking/seaweedfs/default.nix
+++ b/pkgs/applications/networking/seaweedfs/default.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "seaweedfs";
-  version = "2.36";
+  version = "2.50";
 
   src = fetchFromGitHub {
     owner = "chrislusf";
     repo = "seaweedfs";
     rev = version;
-    sha256 = "sha256-BVn+mV5SjyODcT+O8LXfGA42/Si5+GrdkjP0tAPiuTM=";
+    sha256 = "sha256-ai8/XryFw/7GYuWAmLkqHzK97QgTBPyE6m3dflck94w=";
   };
 
-  vendorSha256 = "sha256-qdgnoh+53o3idCfpkEFGK88aUVb2F6oHlSRZncs2hyY=";
+  vendorSha256 = "sha256-gJQDcACMWZWS4CgS2NDALoBzxu7Hh4ZW3f0gUFUALCM=";
 
   subPackages = [ "weed" ];
 
@@ -26,7 +26,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Simple and highly scalable distributed file system";
     homepage = "https://github.com/chrislusf/seaweedfs";
-    maintainers = [ maintainers.raboof ];
+    maintainers = with maintainers; [ cmacrae raboof ];
     license = licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Just a simple upgrade :)

###### Notes
I tried building on macOS, but weirdly it seems to fail with no indication of what's wrong 🤔 
<details>
<summary>nix-build -I . -A seaweedfs</summary>

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/9aaz2hfhij4sdwcvmcyci2j5af7w1rbm-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 1622794970 of file source/weed/weed.go
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Building subPackage ./weed
internal/unsafeheader
internal/cpu
internal/bytealg
runtime/internal/atomic
runtime/internal/sys
runtime/internal/math
runtime
internal/reflectlite
errors
internal/race
sync/atomic
sync
io
internal/oserror
unicode/utf8
path
sort
syscall
time
io/fs
embed
math/bits
math
strconv
unicode
reflect
internal/fmtsort
internal/poll
internal/syscall/execenv
internal/syscall/unix
internal/testlog
os
fmt
bytes
strings
runtime/cgo
os/user
archive/tar
bufio
context
encoding
encoding/binary
encoding/base64
unicode/utf16
encoding/json
compress/flate
hash
hash/crc32
compress/gzip
hash/fnv
google.golang.org/protobuf/internal/detrand
google.golang.org/protobuf/internal/errors
google.golang.org/protobuf/encoding/protowire
google.golang.org/protobuf/internal/pragma
regexp/syntax
regexp
google.golang.org/protobuf/reflect/protoreflect
log
google.golang.org/protobuf/reflect/protoregistry
google.golang.org/protobuf/internal/encoding/messageset
google.golang.org/protobuf/internal/flags
go/token
google.golang.org/protobuf/internal/strs
google.golang.org/protobuf/internal/encoding/text
google.golang.org/protobuf/internal/fieldnum
google.golang.org/protobuf/internal/mapsort
google.golang.org/protobuf/internal/set
google.golang.org/protobuf/internal/fieldsort
google.golang.org/protobuf/runtime/protoiface
google.golang.org/protobuf/proto
google.golang.org/protobuf/encoding/prototext
google.golang.org/protobuf/internal/descfmt
google.golang.org/protobuf/internal/descopts
google.golang.org/protobuf/internal/encoding/defval
google.golang.org/protobuf/internal/filedesc
google.golang.org/protobuf/internal/encoding/tag
google.golang.org/protobuf/internal/genname
path/filepath
io/ioutil
google.golang.org/protobuf/internal/impl
google.golang.org/protobuf/internal/filetype
google.golang.org/protobuf/internal/version
google.golang.org/protobuf/runtime/protoimpl
github.com/golang/protobuf/proto
golang.org/x/net/internal/timeseries
html
net/url
text/template/parse
text/template
html/template
vendor/golang.org/x/net/dns/dnsmessage
vendor/golang.org/x/net/route
internal/nettrace
internal/singleflight
net
container/list
crypto/internal/subtle
crypto/subtle
crypto/cipher
crypto/aes
math/rand
math/big
crypto/rand
crypto
crypto/des
crypto/elliptic
crypto/internal/randutil
crypto/sha512
encoding/asn1
vendor/golang.org/x/crypto/cryptobyte/asn1
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
crypto/ed25519/internal/edwards25519
crypto/ed25519
crypto/hmac
crypto/md5
crypto/rc4
crypto/rsa
crypto/sha1
crypto/sha256
crypto/dsa
crypto/x509/internal/macos
encoding/hex
crypto/x509/pkix
encoding/pem
crypto/x509
vendor/golang.org/x/crypto/internal/subtle
vendor/golang.org/x/crypto/chacha20
vendor/golang.org/x/crypto/poly1305
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/crypto/chacha20poly1305
vendor/golang.org/x/crypto/curve25519
vendor/golang.org/x/crypto/hkdf
crypto/tls
vendor/golang.org/x/text/transform
vendor/golang.org/x/text/unicode/bidi
vendor/golang.org/x/text/secure/bidirule
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/net/idna
net/textproto
vendor/golang.org/x/net/http/httpguts
vendor/golang.org/x/net/http/httpproxy
vendor/golang.org/x/net/http2/hpack
mime
mime/quotedprintable
mime/multipart
net/http/httptrace
net/http/internal
net/http
text/tabwriter
golang.org/x/net/trace
google.golang.org/grpc/backoff
google.golang.org/grpc/internal/grpclog
google.golang.org/grpc/grpclog
google.golang.org/grpc/connectivity
google.golang.org/grpc/credentials/internal
google.golang.org/grpc/internal
google.golang.org/grpc/credentials
google.golang.org/grpc/metadata
google.golang.org/grpc/attributes
google.golang.org/grpc/serviceconfig
google.golang.org/grpc/resolver
google.golang.org/grpc/balancer
google.golang.org/grpc/balancer/base
google.golang.org/grpc/internal/grpcrand
google.golang.org/grpc/balancer/roundrobin
google.golang.org/grpc/codes
google.golang.org/grpc/encoding
google.golang.org/grpc/encoding/proto
google.golang.org/grpc/internal/backoff
google.golang.org/grpc/internal/balancerload
google.golang.org/protobuf/types/known/anypb
github.com/golang/protobuf/ptypes/any
google.golang.org/protobuf/types/known/durationpb
github.com/golang/protobuf/ptypes/duration
google.golang.org/protobuf/types/known/timestamppb
github.com/golang/protobuf/ptypes/timestamp
github.com/golang/protobuf/ptypes
google.golang.org/grpc/binarylog/grpc_binarylog_v1
google.golang.org/genproto/googleapis/rpc/status
google.golang.org/grpc/internal/status
google.golang.org/grpc/status
google.golang.org/grpc/internal/binarylog
google.golang.org/grpc/internal/buffer
google.golang.org/grpc/internal/channelz
google.golang.org/grpc/internal/envconfig
google.golang.org/grpc/internal/grpcsync
google.golang.org/grpc/internal/grpcutil
google.golang.org/grpc/internal/resolver/dns
google.golang.org/grpc/internal/resolver/passthrough
golang.org/x/text/transform
golang.org/x/text/unicode/bidi
golang.org/x/text/secure/bidirule
golang.org/x/text/unicode/norm
golang.org/x/net/idna
golang.org/x/net/http/httpguts
golang.org/x/net/http2/hpack
golang.org/x/net/http2
google.golang.org/grpc/internal/syscall
google.golang.org/grpc/keepalive
google.golang.org/grpc/peer
google.golang.org/grpc/stats
google.golang.org/grpc/tap
google.golang.org/grpc/internal/transport
google.golang.org/grpc/naming
net/http/httputil
google.golang.org/grpc
github.com/chrislusf/raft/protobuf
github.com/chrislusf/seaweedfs/weed/util/fla9
github.com/chrislusf/seaweedfs/weed/glog
github.com/chrislusf/seaweedfs/weed/pb/volume_server_pb
expvar
github.com/beorn7/perks/quantile
github.com/cespare/xxhash/v2
github.com/prometheus/client_model/go
github.com/prometheus/client_golang/prometheus/internal
github.com/matttproud/golang_protobuf_extensions/pbutil
github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
github.com/prometheus/common/model
github.com/prometheus/common/expfmt
github.com/prometheus/procfs/internal/fs
github.com/prometheus/procfs/internal/util
github.com/prometheus/procfs
runtime/debug
github.com/prometheus/client_golang/prometheus
github.com/prometheus/client_golang/prometheus/promhttp
github.com/prometheus/client_golang/prometheus/push
github.com/chrislusf/seaweedfs/weed/stats
encoding/csv
golang.org/x/sys/internal/unsafeheader
golang.org/x/sys/unix
github.com/fsnotify/fsnotify
github.com/hashicorp/hcl/hcl/strconv
github.com/hashicorp/hcl/hcl/token
github.com/hashicorp/hcl/hcl/ast
github.com/hashicorp/hcl/hcl/scanner
github.com/hashicorp/hcl/hcl/parser
github.com/hashicorp/hcl/json/token
github.com/hashicorp/hcl/json/scanner
github.com/hashicorp/hcl/json/parser
github.com/hashicorp/hcl
github.com/hashicorp/hcl/hcl/printer
flag
github.com/magiconair/properties
github.com/mitchellh/mapstructure
github.com/pelletier/go-toml
github.com/spf13/afero/mem
github.com/spf13/afero
github.com/spf13/cast
github.com/spf13/jwalterweatherman
github.com/spf13/pflag
gopkg.in/yaml.v2
github.com/spf13/viper
github.com/chrislusf/seaweedfs/weed/util
github.com/chrislusf/seaweedfs/weed/notification
image/color
image
golang.org/x/image/bmp
hash/adler32
compress/zlib
golang.org/x/image/ccitt
golang.org/x/image/tiff/lzw
golang.org/x/image/tiff
image/internal/imageutil
image/draw
compress/lzw
image/color/palette
image/gif
image/jpeg
image/png
github.com/disintegration/imaging
github.com/seaweedfs/goexif/tiff
github.com/seaweedfs/goexif/exif
github.com/chrislusf/seaweedfs/weed/images
github.com/chrislusf/seaweedfs/weed/pb/master_pb
github.com/chrislusf/seaweedfs/weed/storage/types
github.com/chrislusf/seaweedfs/weed/storage/backend
github.com/klauspost/crc32
github.com/chrislusf/seaweedfs/weed/storage/needle
github.com/go-errors/errors
github.com/pkg/errors
go/scanner
go/ast
go/parser
container/heap
go/constant
go/types
os/signal
github.com/viant/toolbox
github.com/viant/ptrie
github.com/chrislusf/seaweedfs/weed/pb/filer_pb
github.com/chrislusf/seaweedfs/weed/pb/messaging_pb
github.com/aws/aws-sdk-go/aws/awserr
github.com/aws/aws-sdk-go/internal/ini
github.com/aws/aws-sdk-go/internal/shareddefaults
github.com/aws/aws-sdk-go/internal/sync/singleflight
github.com/aws/aws-sdk-go/aws/credentials
github.com/aws/aws-sdk-go/aws/endpoints
github.com/aws/aws-sdk-go/internal/sdkio
github.com/aws/aws-sdk-go/aws
github.com/aws/aws-sdk-go/aws/client/metadata
github.com/jmespath/go-jmespath
github.com/aws/aws-sdk-go/aws/awsutil
github.com/aws/aws-sdk-go/aws/request
github.com/aws/aws-sdk-go/internal/sdkrand
github.com/aws/aws-sdk-go/aws/client
github.com/aws/aws-sdk-go/aws/corehandlers
os/exec
github.com/aws/aws-sdk-go/aws/credentials/processcreds
github.com/aws/aws-sdk-go/internal/strings
github.com/aws/aws-sdk-go/internal/sdkmath
github.com/aws/aws-sdk-go/private/protocol
github.com/aws/aws-sdk-go/private/protocol/rest
github.com/aws/aws-sdk-go/aws/signer/v4
encoding/xml
github.com/aws/aws-sdk-go/private/protocol/query/queryutil
github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
github.com/aws/aws-sdk-go/private/protocol/query
github.com/aws/aws-sdk-go/service/sts
github.com/aws/aws-sdk-go/service/sts/stsiface
github.com/aws/aws-sdk-go/aws/credentials/stscreds
github.com/aws/aws-sdk-go/aws/csm
github.com/aws/aws-sdk-go/internal/sdkuri
github.com/aws/aws-sdk-go/aws/ec2metadata
github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
github.com/aws/aws-sdk-go/aws/defaults
github.com/aws/aws-sdk-go/aws/session
github.com/aws/aws-sdk-go/aws/arn
github.com/aws/aws-sdk-go/internal/s3err
github.com/aws/aws-sdk-go/private/checksum
github.com/aws/aws-sdk-go/private/protocol/eventstream
github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi
github.com/aws/aws-sdk-go/private/protocol/restxml
github.com/aws/aws-sdk-go/service/s3/internal/arn
github.com/aws/aws-sdk-go/service/s3
github.com/aws/aws-sdk-go/service/s3/s3iface
github.com/aws/aws-sdk-go/service/s3/s3manager
database/sql/driver
github.com/google/uuid
github.com/chrislusf/seaweedfs/weed/storage/backend/s3_backend
google.golang.org/protobuf/internal/detectknown
google.golang.org/protobuf/internal/encoding/json
google.golang.org/protobuf/encoding/protojson
github.com/golang/protobuf/jsonpb
github.com/chrislusf/seaweedfs/weed/pb
github.com/dgrijalva/jwt-go
golang.org/x/net/context
github.com/grpc-ecosystem/go-grpc-middleware
github.com/grpc-ecosystem/go-grpc-middleware/util/metautils
github.com/grpc-ecosystem/go-grpc-middleware/auth
github.com/chrislusf/seaweedfs/weed/security
github.com/valyala/bytebufferpool
github.com/chrislusf/seaweedfs/weed/operation
github.com/chrislusf/seaweedfs/weed/pb/iam_pb
github.com/chrislusf/seaweedfs/weed/storage/idx
github.com/google/btree
github.com/syndtr/goleveldb/leveldb/util
github.com/syndtr/goleveldb/leveldb/cache
github.com/syndtr/goleveldb/leveldb/comparer
github.com/syndtr/goleveldb/leveldb/storage
github.com/syndtr/goleveldb/leveldb/errors
github.com/syndtr/goleveldb/leveldb/filter
github.com/syndtr/goleveldb/leveldb/iterator
github.com/syndtr/goleveldb/leveldb/journal
github.com/syndtr/goleveldb/leveldb/memdb
github.com/syndtr/goleveldb/leveldb/opt
github.com/golang/snappy
github.com/syndtr/goleveldb/leveldb/table
github.com/syndtr/goleveldb/leveldb
github.com/chrislusf/seaweedfs/weed/storage/needle_map
github.com/chrislusf/seaweedfs/weed/storage/super_block
github.com/klauspost/cpuid
github.com/klauspost/reedsolomon
github.com/chrislusf/seaweedfs/weed/storage/erasure_coding
github.com/spaolacci/murmur3
github.com/willf/bitset
github.com/willf/bloom
github.com/chrislusf/seaweedfs/weed/storage
github.com/karlseguin/ccache/v2
github.com/chrislusf/seaweedfs/weed/util/chunk_cache
github.com/chrislusf/seaweedfs/weed/util/log_buffer
github.com/chrislusf/seaweedfs/weed/wdclient/resource_pool
github.com/chrislusf/seaweedfs/weed/wdclient/net2
github.com/chrislusf/seaweedfs/weed/wdclient
github.com/golang/groupcache/singleflight
github.com/chrislusf/seaweedfs/weed/filer
github.com/chrislusf/seaweedfs/weed/filer/leveldb
github.com/chrislusf/seaweedfs/weed/util/bounded_tree
github.com/chrislusf/seaweedfs/weed/filesys/meta_cache
runtime/pprof
github.com/chrislusf/seaweedfs/weed/util/grace
github.com/seaweedfs/fuse
github.com/seaweedfs/fuse/fuseutil
github.com/seaweedfs/fuse/fs
github.com/chrislusf/seaweedfs/weed/filesys
github.com/aws/aws-sdk-go/service/iam
github.com/chrislusf/seaweedfs/weed/s3api/http
github.com/chrislusf/seaweedfs/weed/s3api/s3err
github.com/chrislusf/seaweedfs/weed/s3api/policy
github.com/chrislusf/seaweedfs/weed/s3api/s3_constants
github.com/chrislusf/raft
github.com/gocql/gocql/internal/lru
github.com/gocql/gocql/internal/murmur
github.com/gocql/gocql/internal/streams
github.com/hailocab/go-hostpool
gopkg.in/inf.v0
github.com/gocql/gocql
github.com/chrislusf/seaweedfs/weed/filer/cassandra
github.com/modern-go/concurrent
github.com/modern-go/reflect2
github.com/json-iterator/go
github.com/mailru/easyjson/jlexer
github.com/mailru/easyjson/buffer
github.com/mailru/easyjson/jwriter
github.com/mailru/easyjson
github.com/olivere/elastic/v7/config
github.com/olivere/elastic/v7/uritemplates
github.com/olivere/elastic/v7
github.com/chrislusf/seaweedfs/weed/filer/elastic/v7
github.com/gogo/protobuf/proto
github.com/gogo/protobuf/protoc-gen-gogo/descriptor
github.com/gogo/protobuf/gogoproto
go.etcd.io/etcd/auth/authpb
go.uber.org/atomic
go.uber.org/multierr
go.uber.org/zap/buffer
go.uber.org/zap/internal/bufferpool
go.uber.org/zap/internal/color
go.uber.org/zap/internal/exit
go.uber.org/zap/zapcore
go.uber.org/zap
go.etcd.io/etcd/clientv3/balancer/connectivity
go.etcd.io/etcd/clientv3/balancer/picker
google.golang.org/grpc/resolver/dns
google.golang.org/grpc/resolver/passthrough
go.etcd.io/etcd/clientv3/balancer
go.etcd.io/etcd/clientv3/balancer/resolver/endpoint
go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes
go.etcd.io/etcd/clientv3/credentials
go.etcd.io/etcd/etcdserver/api/membership/membershippb
go.etcd.io/etcd/mvcc/mvccpb
go.etcd.io/etcd/etcdserver/etcdserverpb
github.com/coreos/go-systemd/v22/journal
go.etcd.io/etcd/pkg/systemd
go.etcd.io/etcd/raft/quorum
go.etcd.io/etcd/raft/raftpb
go.etcd.io/etcd/raft/tracker
go.etcd.io/etcd/raft/confchange
go.etcd.io/etcd/raft
go.etcd.io/etcd/pkg/logutil
go.etcd.io/etcd/pkg/types
github.com/coreos/go-semver/semver
go.etcd.io/etcd/version
go.etcd.io/etcd/clientv3
github.com/chrislusf/seaweedfs/weed/filer/etcd
github.com/sirupsen/logrus
github.com/tsuna/gohbase/compression/snappy
github.com/tsuna/gohbase/compression
github.com/tsuna/gohbase/pb
github.com/tsuna/gohbase/filter
github.com/tsuna/gohbase/hrpc
github.com/tsuna/gohbase/region
github.com/go-zookeeper/zk
github.com/tsuna/gohbase/zk
modernc.org/b
github.com/tsuna/gohbase
github.com/chrislusf/seaweedfs/weed/filer/hbase
github.com/chrislusf/seaweedfs/weed/filer/leveldb2
github.com/chrislusf/seaweedfs/weed/filer/leveldb3
go.mongodb.org/mongo-driver/bson/bsonoptions
go.mongodb.org/mongo-driver/bson/bsontype
go.mongodb.org/mongo-driver/bson/primitive
github.com/go-stack/stack
go.mongodb.org/mongo-driver/x/bsonx/bsoncore
go.mongodb.org/mongo-driver/bson/bsonrw
go.mongodb.org/mongo-driver/bson/bsoncodec
go.mongodb.org/mongo-driver/bson
go.mongodb.org/mongo-driver/event
go.mongodb.org/mongo-driver/mongo/readconcern
go.mongodb.org/mongo-driver/tag
go.mongodb.org/mongo-driver/mongo/readpref
go.mongodb.org/mongo-driver/mongo/writeconcern
github.com/klauspost/compress/fse
github.com/klauspost/compress/huff0
github.com/klauspost/compress/snappy
github.com/klauspost/compress/zstd/internal/xxhash
github.com/klauspost/compress/zstd
go.mongodb.org/mongo-driver/x/mongo/driver/address
go.mongodb.org/mongo-driver/x/mongo/driver/description
go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options
go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt
go.mongodb.org/mongo-driver/x/bsonx
go.mongodb.org/mongo-driver/x/mongo/driver/uuid
go.mongodb.org/mongo-driver/x/mongo/driver/session
go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage
go.mongodb.org/mongo-driver/x/mongo/driver
go.mongodb.org/mongo-driver/internal
go.mongodb.org/mongo-driver/x/mongo/driver/dns
go.mongodb.org/mongo-driver/x/mongo/driver/connstring
go.mongodb.org/mongo-driver/mongo/options
github.com/xdg/stringprep
golang.org/x/crypto/pbkdf2
github.com/xdg/scram
go.mongodb.org/mongo-driver/version
go.mongodb.org/mongo-driver/x/mongo/driver/operation
go.mongodb.org/mongo-driver/x/mongo/driver/auth
golang.org/x/sync/semaphore
go.mongodb.org/mongo-driver/x/mongo/driver/topology
go.mongodb.org/mongo-driver/mongo
github.com/chrislusf/seaweedfs/weed/filer/mongodb
database/sql
github.com/chrislusf/seaweedfs/weed/filer/abstract_sql
github.com/go-sql-driver/mysql
github.com/chrislusf/seaweedfs/weed/filer/mysql
github.com/chrislusf/seaweedfs/weed/filer/mysql2
github.com/lib/pq/oid
github.com/lib/pq/scram
github.com/lib/pq
github.com/chrislusf/seaweedfs/weed/filer/postgres
github.com/chrislusf/seaweedfs/weed/filer/postgres2
github.com/dgryski/go-rendezvous
github.com/go-redis/redis/v8/internal/util
github.com/go-redis/redis/v8/internal/proto
github.com/go-redis/redis/v8/internal/rand
go.opentelemetry.io/otel/codes
go.opentelemetry.io/otel/internal
go.opentelemetry.io/otel/label
go.opentelemetry.io/otel/trace
go.opentelemetry.io/otel/internal/trace/noop
go.opentelemetry.io/otel/metric/number
go.opentelemetry.io/otel/unit
go.opentelemetry.io/otel/metric
go.opentelemetry.io/otel/metric/registry
go.opentelemetry.io/otel/internal/baggage
go.opentelemetry.io/otel/propagation
go.opentelemetry.io/otel/internal/global
go.opentelemetry.io/otel
github.com/go-redis/redis/v8/internal
github.com/go-redis/redis/v8/internal/hashtag
github.com/go-redis/redis/v8/internal/pool
github.com/go-redis/redis/v8
github.com/chrislusf/seaweedfs/weed/filer/redis
github.com/chrislusf/seaweedfs/weed/filer/redis2
github.com/mattn/go-isatty
modernc.org/libc/errno
modernc.org/libc/fcntl
modernc.org/libc/fts
modernc.org/libc/honnef.co/go/netdb
modernc.org/libc/langinfo
modernc.org/libc/limits
modernc.org/libc/netdb
modernc.org/libc/netinet/in
modernc.org/libc/poll
modernc.org/libc/pwd
modernc.org/libc/signal
modernc.org/libc/stdio
modernc.org/libc/sys/socket
modernc.org/libc/sys/stat
modernc.org/libc/sys/types
modernc.org/libc/termios
modernc.org/libc/time
modernc.org/libc/unistd
modernc.org/libc/utime
github.com/remyoudompheng/bigfft
modernc.org/mathutil
modernc.org/memory
modernc.org/libc
modernc.org/sqlite/lib
modernc.org/sqlite
github.com/chrislusf/seaweedfs/weed/filer/sqlite
github.com/aws/aws-sdk-go/service/sqs
github.com/chrislusf/seaweedfs/weed/notification/aws_sqs
github.com/streadway/amqp
github.com/googleapis/gax-go
gocloud.dev/internal/retry
golang.org/x/xerrors/internal
golang.org/x/xerrors
gocloud.dev/internal/gcerr
gocloud.dev/gcerrors
go.opencensus.io/resource
go.opencensus.io/metric/metricdata
go.opencensus.io/tag
go.opencensus.io/stats/internal
go.opencensus.io/stats
go.opencensus.io/internal/tagencoding
go.opencensus.io/metric/metricproducer
go.opencensus.io/stats/view
github.com/golang/groupcache/lru
go.opencensus.io
go.opencensus.io/internal
go.opencensus.io/trace/internal
go.opencensus.io/trace/tracestate
runtime/trace
go.opencensus.io/trace
go.opencensus.io/trace/propagation
go.opencensus.io/plugin/ocgrpc
gocloud.dev/internal/oc
gocloud.dev/internal/openurl
gocloud.dev/pubsub/batcher
gocloud.dev/pubsub/driver
golang.org/x/sync/errgroup
gocloud.dev/pubsub
github.com/aws/aws-sdk-go/service/sns
github.com/google/wire
gocloud.dev/aws
gocloud.dev/internal/escape
gocloud.dev/pubsub/awssnssqs
github.com/googleapis/gax-go/v2
google.golang.org/protobuf/types/descriptorpb
github.com/golang/protobuf/protoc-gen-go/descriptor
google.golang.org/genproto/googleapis/api/annotations
google.golang.org/genproto/googleapis/type/expr
google.golang.org/genproto/googleapis/iam/v1
cloud.google.com/go/iam
google.golang.org/api/iterator
golang.org/x/net/context/ctxhttp
golang.org/x/oauth2/internal
golang.org/x/oauth2
cloud.google.com/go/compute/metadata
golang.org/x/oauth2/jws
golang.org/x/oauth2/jwt
golang.org/x/oauth2/google
google.golang.org/api/internal
google.golang.org/api/option
github.com/google/go-cmp/cmp/internal/flags
github.com/google/go-cmp/cmp/internal/diff
github.com/google/go-cmp/cmp/internal/function
github.com/google/go-cmp/cmp/internal/value
github.com/google/go-cmp/cmp
google.golang.org/grpc/balancer/grpclb/grpc_lb_v1
google.golang.org/grpc/balancer/grpclb
google.golang.org/grpc/credentials/alts/internal
google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp
google.golang.org/grpc/credentials/alts/internal/authinfo
google.golang.org/grpc/credentials/alts/internal/conn
google.golang.org/grpc/credentials/alts/internal/handshaker
google.golang.org/grpc/credentials/alts/internal/handshaker/service
google.golang.org/grpc/credentials/alts
google.golang.org/grpc/credentials/oauth
google.golang.org/grpc/credentials/google
google.golang.org/api/transport/grpc
google.golang.org/protobuf/types/known/emptypb
github.com/golang/protobuf/ptypes/empty
google.golang.org/protobuf/types/known/fieldmaskpb
google.golang.org/genproto/protobuf/field_mask
google.golang.org/genproto/googleapis/pubsub/v1
cloud.google.com/go/pubsub/apiv1
gocloud.dev/gcp
gocloud.dev/internal/useragent
gocloud.dev/pubsub/gcppubsub
encoding/gob
encoding/base32
golang.org/x/crypto/ed25519
github.com/nats-io/nkeys
github.com/nats-io/jwt
github.com/nats-io/nats.go/encoders/builtin
github.com/nats-io/nats.go/util
github.com/nats-io/nuid
github.com/nats-io/nats.go
gocloud.dev/pubsub/natspubsub
gocloud.dev/pubsub/rabbitpubsub
github.com/chrislusf/seaweedfs/weed/notification/gocdk_pub_sub
cloud.google.com/go/internal/optional
cloud.google.com/go/internal/version
cloud.google.com/go/pubsub/internal/distribution
google.golang.org/api/support/bundler
cloud.google.com/go/pubsub
github.com/chrislusf/seaweedfs/weed/notification/google_pub_sub
github.com/DataDog/zstd
# github.com/DataDog/zstd
vendor/github.com/DataDog/zstd/errors.go:5:10: fatal error: 'zstd.h' file not found
github.com/davecgh/go-spew/spew
github.com/eapache/go-resiliency/breaker
github.com/eapache/go-xerial-snappy
github.com/eapache/queue
github.com/jcmturner/gofork/encoding/asn1
github.com/pierrec/lz4/internal/xxh32
github.com/pierrec/lz4
log/syslog
github.com/rcrowley/go-metrics
golang.org/x/net/internal/socks
golang.org/x/net/proxy
gopkg.in/jcmturner/gokrb5.v7/asn1tools
gopkg.in/jcmturner/dnsutils.v1
gopkg.in/jcmturner/gokrb5.v7/iana/etypeID
gopkg.in/jcmturner/gokrb5.v7/config
github.com/hashicorp/go-uuid
gopkg.in/jcmturner/gokrb5.v7/iana/nametype
gopkg.in/jcmturner/gokrb5.v7/iana
gopkg.in/jcmturner/gokrb5.v7/iana/addrtype
gopkg.in/jcmturner/gokrb5.v7/iana/asnAppTag
gopkg.in/jcmturner/gokrb5.v7/iana/patype
gopkg.in/jcmturner/gokrb5.v7/types
gopkg.in/jcmturner/gokrb5.v7/keytab
gopkg.in/jcmturner/gokrb5.v7/credentials
golang.org/x/crypto/md4
gopkg.in/jcmturner/gokrb5.v7/crypto/etype
gopkg.in/jcmturner/gokrb5.v7/crypto/common
gopkg.in/jcmturner/gokrb5.v7/crypto/rfc3961
github.com/jcmturner/gofork/x/crypto/pbkdf2
gopkg.in/jcmturner/aescts.v1
gopkg.in/jcmturner/gokrb5.v7/crypto/rfc3962
gopkg.in/jcmturner/gokrb5.v7/crypto/rfc4757
gopkg.in/jcmturner/gokrb5.v7/crypto/rfc8009
gopkg.in/jcmturner/gokrb5.v7/iana/chksumtype
gopkg.in/jcmturner/gokrb5.v7/crypto
gopkg.in/jcmturner/gokrb5.v7/iana/errorcode
gopkg.in/jcmturner/gokrb5.v7/iana/flags
gopkg.in/jcmturner/gokrb5.v7/iana/keyusage
gopkg.in/jcmturner/gokrb5.v7/krberror
gopkg.in/jcmturner/gokrb5.v7/iana/adtype
gopkg.in/jcmturner/gokrb5.v7/iana/msgtype
gopkg.in/jcmturner/rpc.v1/ndr
gopkg.in/jcmturner/rpc.v1/mstypes
gopkg.in/jcmturner/gokrb5.v7/pac
gopkg.in/jcmturner/gokrb5.v7/messages
gopkg.in/jcmturner/gokrb5.v7/kadmin
gopkg.in/jcmturner/gokrb5.v7/client
gopkg.in/jcmturner/gokrb5.v7/gssapi
github.com/chrislusf/seaweedfs/weed/notification/log
github.com/chrislusf/seaweedfs/weed/query/sqltypes
github.com/tidwall/match
github.com/tidwall/pretty
github.com/tidwall/gjson
github.com/chrislusf/seaweedfs/weed/query/json
github.com/bwmarrin/snowflake
go.etcd.io/etcd/pkg/pathutil
go.etcd.io/etcd/pkg/srv
go.etcd.io/etcd/client
github.com/chrislusf/seaweedfs/weed/sequence
github.com/dustin/go-humanize
github.com/chrislusf/seaweedfs/weed/server/filer_ui
github.com/chrislusf/seaweedfs/weed/server/master_ui
github.com/chrislusf/seaweedfs/weed/server/volume_server_ui
github.com/chrislusf/seaweedfs/weed/wdclient/exclusive_locks
container/ring
github.com/mattn/go-runewidth
github.com/peterh/liner
github.com/chrislusf/seaweedfs/weed/shell
github.com/chrislusf/seaweedfs/weed/storage/backend/memory_map
github.com/chrislusf/seaweedfs/weed/topology
github.com/chrislusf/seaweedfs/weed/util/buffered_writer
github.com/gorilla/mux
github.com/skip2/go-qrcode/bitset
github.com/skip2/go-qrcode/reedsolomon
github.com/skip2/go-qrcode
golang.org/x/net/webdav/internal/xml
golang.org/x/net/webdav
github.com/pquerna/cachecontrol/cacheobject
github.com/buraksezer/consistent
github.com/cespare/xxhash
github.com/chrislusf/seaweedfs/weed/messaging/broker
github.com/chrislusf/seaweedfs/weed/replication/source
github.com/chrislusf/seaweedfs/weed/replication/sink
github.com/chrislusf/seaweedfs/weed/replication
github.com/mattn/go-ieproxy
github.com/Azure/azure-pipeline-go/pipeline
github.com/Azure/azure-storage-blob-go/azblob
github.com/chrislusf/seaweedfs/weed/replication/repl_util
github.com/chrislusf/seaweedfs/weed/replication/sink/azuresink
github.com/kurin/blazer/internal/b2types
github.com/kurin/blazer/internal/blog
github.com/kurin/blazer/base
github.com/kurin/blazer/internal/b2assets
github.com/kurin/blazer/x/window
github.com/kurin/blazer/b2
github.com/chrislusf/seaweedfs/weed/replication/sink/b2sink
github.com/chrislusf/seaweedfs/weed/replication/sink/filersink
google.golang.org/api/internal/third_party/uritemplates
google.golang.org/api/googleapi
cloud.google.com/go/internal
google.golang.org/genproto/googleapis/rpc/code
cloud.google.com/go/internal/trace
google.golang.org/api/internal/gensupport
google.golang.org/api/option/internaloption
go.opencensus.io/plugin/ochttp/propagation/b3
go.opencensus.io/plugin/ochttp
google.golang.org/api/googleapi/transport
google.golang.org/api/transport/cert
google.golang.org/api/transport/http/internal/propagation
google.golang.org/api/transport/http
google.golang.org/api/storage/v1
cloud.google.com/go/storage
github.com/chrislusf/seaweedfs/weed/replication/sink/gcssink
github.com/chrislusf/seaweedfs/weed/replication/sink/localsink
github.com/chrislusf/seaweedfs/weed/replication/sink/s3sink
github.com/facebookgo/clock
github.com/facebookgo/stats
github.com/chrislusf/seaweedfs/weed/util/httpdown
google.golang.org/grpc/reflection/grpc_reflection_v1alpha
google.golang.org/grpc/reflection
internal/profile
net/http/pprof
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
