### PR TITLE
borgmatic: 1.5.12 -> 1.5.13

### DIFF
--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -2,23 +2,19 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "borgmatic";
-  version = "1.5.12";
+  version = "1.5.13";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-XLbBJvNRmH8W9SnOjF7zUbazRYFCMW6SEO2wKN/2VTY=";
+    sha256 = "12390ffdg30ncc5k92pvagwbvnsh42xl35a3nagbskznyfd23mw3";
   };
 
   checkInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ];
 
   # - test_borgmatic_version_matches_news_version
   # The file NEWS not available on the pypi source, and this test is useless
-  # - test_collect_configuration_run_summary_logs_outputs_merged_json_results
-  # Upstream fixed in the next version, see
-  # https://github.com/witten/borgmatic/commit/ea6cd53067435365a96786b006aec391714501c4
   disabledTests = [
     "test_borgmatic_version_matches_news_version"
-    "test_collect_configuration_run_summary_logs_outputs_merged_json_results"
   ];
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New version https://github.com/witten/borgmatic/releases/tag/1.5.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
