### PR TITLE
nixos/stage1-init: Add multi-device btrfs wait (closes #32588)

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -389,10 +389,12 @@ mountFS() {
 
     mkdir -p "/mnt-root$mountPoint"
 
+    # For BTFS, wait for all associated devices to show up (nixpkgs#32588)
     # For ZFS and CIFS mounts, retry a few times before giving up.
     # We do this for ZFS as a workaround for issue NixOS/nixpkgs#25383.
     local n=0
     while true; do
+        if [ "$fsType" == btrfs ]; then btrfs device ready "$device"; fi
         mount "/mnt-root$mountPoint" && break
         if [ \( "$fsType" != cifs -a "$fsType" != zfs \) -o "$n" -ge 10 ]; then fail; break; fi
         echo "retrying..."


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As noted in #32588, there is a race condition due to the `btrfs device scan` in the stage-1 init script is sometimes running before all the devices are available because udevadm settle does not guarantee this (whether by error or design I do not know) as the stage-1 init writer expected.

There is a `btrfs device ready` command that
> wait[s] until all devices of a multiple-device filesystem are scanned and registered within the kernel module ... to provide a way for automatic filesystem mounting tools to wait before the mount.

Presumably using this is the correct thing to do.

###### Things done

I build this on my machine and rebooted. It came up okay. I don't know for sure though if this is correct way to use this, nor, as it is a race condition, if it actually solved it or the timing just worked out okay.

I am also not 100% clear on how `btrfs device scan` interplays with `btrfs device ready`. From the man page, I get the feeling that we should maybe drop the `btrfs device scan` call (which this patch does not do) in favour of just using `btrfs device ready`.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
