### PR TITLE
bootiso: init at 4.2.0

### DIFF
--- a/pkgs/tools/cd-dvd/bootiso/default.nix
+++ b/pkgs/tools/cd-dvd/bootiso/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, bash
+, makeWrapper
+, bc
+, jq
+, wimlib
+, file
+, syslinux
+, busybox
+, gnugrep # We can't use busybox's 'grep' as it doesn't support perl '-P' expressions.
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "bootiso";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jsamr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1l09d543b73r0wbpsj5m6kski8nq48lbraq1myxhidkgl3mm3d5i";
+  };
+
+  strictDeps = true;
+  buildInputs = [ bash ];
+  nativeBuildInputs = [ makeWrapper ];
+  postPatch = ''
+    patchShebangs --host bootiso
+  '';
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/bootiso \
+      --prefix PATH : ${lib.makeBinPath [ bc jq wimlib file syslinux gnugrep busybox ]} \
+      --prefix BOOTISO_SYSLINUX_LIB_ROOT : ${syslinux}/share/syslinux
+  '';
+
+  meta = with lib; {
+    description = "Script for securely creating a bootable USB device from one image file";
+    homepage = "https://github.com/jsamr/bootiso";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ musfay ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1896,6 +1896,8 @@ in
 
   blur-effect = callPackage ../tools/graphics/blur-effect { };
 
+  bootiso = callPackage ../tools/cd-dvd/bootiso { };
+
   butane = callPackage ../development/tools/butane { };
 
   charles = charles4;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Motivation for this change
Script for securely creating a bootable USB device from one image file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
