### PR TITLE
qdigidoc: 4.2.3 -> 4.2.8

### DIFF
--- a/pkgs/tools/security/qdigidoc/default.nix
+++ b/pkgs/tools/security/qdigidoc/default.nix
@@ -3,19 +3,22 @@
 
 mkDerivation rec {
   pname = "qdigidoc";
-  version = "4.2.3";
+  version = "4.2.8";
 
   src = fetchgit {
     url = "https://github.com/open-eid/DigiDoc4-Client";
     rev = "v${version}";
-    sha256 = "1hj49vvg8vrayr9kpz73fafa7k298hmiamkyd8c3ipy6s51xh6q4";
+    sha256 = "02k2s6l79ssvrksa0midm7bq856llrmq0n40yxwm3j011nvc8vsm";
     fetchSubmodules = true;
   };
 
   tsl = fetchurl {
     url = "https://ec.europa.eu/information_society/policy/esignature/trusted-list/tl-mp.xml";
-    sha256 = "0llr2fj8vd097hcr1d0xmzdy4jydv0b5j5qlksbjffs22rqgal14";
+    sha256 = "0klz9blrp0jjhlr9k1i266afp44pqmii1x0y8prk0417ia3fxpli";
   };
+
+  # Adds explicit imports for QPainterPath, fixed in upstream (https://github.com/open-eid/DigiDoc4-Client/pull/914)
+  patches = [ ./qt5.15.patch ];
 
   nativeBuildInputs = [ cmake darkhttpd gettext makeWrapper pkg-config ];
 

--- a/pkgs/tools/security/qdigidoc/qt5.15.patch
+++ b/pkgs/tools/security/qdigidoc/qt5.15.patch
@@ -1,0 +1,39 @@
+From 1aa314f5433b9b3e89a1c05b5c465fb477435e23 Mon Sep 17 00:00:00 2001
+From: Dmitri Smirnov <dmitri@smirnov.ee>
+Date: Mon, 8 Mar 2021 14:15:27 +0100
+Subject: [PATCH] =?UTF-8?q?Added=20explicit=20imports=20for=20QPainterPath?=
+ =?UTF-8?q?=20to=20fix=20builds=20with=20Qt=20=E2=89=A5=205.15?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Dmitri Smirnov <dmitri@smirnov.ee>
+---
+ client/widgets/CheckBox.cpp   | 1 +
+ client/widgets/MainAction.cpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/client/widgets/CheckBox.cpp b/client/widgets/CheckBox.cpp
+index a03b56e5d..725d585b7 100644
+--- a/client/widgets/CheckBox.cpp
++++ b/client/widgets/CheckBox.cpp
+@@ -22,6 +22,7 @@
+ #include <QBrush>
+ #include <QPaintEvent>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QStyleOptionButton>
+ 
+ CheckBox::CheckBox(QWidget *parent)
+diff --git a/client/widgets/MainAction.cpp b/client/widgets/MainAction.cpp
+index 4cf4bb1cf..a46c193e3 100644
+--- a/client/widgets/MainAction.cpp
++++ b/client/widgets/MainAction.cpp
+@@ -24,6 +24,7 @@
+ 
+ #include <QtCore/QSettings>
+ #include <QtGui/QPainter>
++#include <QtGui/QPainterPath>
+ #include <QtGui/QPaintEvent>
+ 
+ using namespace ria::qdigidoc4;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
