### PR TITLE
ferdi: 5.6.0-beta.5 -> 5.6.0-beta.6, improve XWayland support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ferdi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ferdi/default.nix
@@ -1,18 +1,33 @@
-{ lib, mkFranzDerivation, fetchurl }:
+{ lib, mkFranzDerivation, fetchurl, xorg, xdg-utils, buildEnv, writeShellScriptBin }:
 
-mkFranzDerivation rec {
+let
+  mkFranzDerivation' = mkFranzDerivation.override {
+    xdg-utils = buildEnv {
+      name = "xdg-utils-for-ferdi";
+      paths = [
+        xdg-utils
+        (lib.hiPrio (writeShellScriptBin "xdg-open" ''
+          unset GDK_BACKEND
+          exec ${xdg-utils}/bin/xdg-open "$@"
+        ''))
+      ];
+    };
+  };
+in
+mkFranzDerivation' rec {
   pname = "ferdi";
   name = "Ferdi";
-  version = "5.6.0-beta.5";
+  version = "5.6.0-beta.6";
   src = fetchurl {
     url = "https://github.com/getferdi/ferdi/releases/download/v${version}/ferdi_${version}_amd64.deb";
-    sha256 = "sha256-fDUzYir53OQ3O4o9eG70sGD+FJ0/4SDNsTfh97WFRnQ=";
+    sha256 = "sha256-Q1HSAEVcaxFyOq7oWqa6AJJpsBKRxbsKb9ydyK/gH/A=";
   };
+  extraBuildInputs = [ xorg.libxshmfence ];
   meta = with lib; {
     description = "Combine your favorite messaging services into one application";
     homepage = "https://getferdi.com/";
     license = licenses.asl20;
-    maintainers = [ maintainers.davidtwco ];
+    maintainers = with maintainers; [ davidtwco ma27 ];
     platforms = [ "x86_64-linux" ];
     hydraPlatforms = [ ];
   };

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -28,7 +28,8 @@
 
 # Helper function for building a derivation for Franz and forks.
 
-{ pname, name, version, src, meta }:
+{ pname, name, version, src, meta, extraBuildInputs ? [] }:
+
 stdenv.mkDerivation rec {
   inherit pname version src meta;
 
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapGAppsHook dpkg ];
-  buildInputs = (with xorg; [
+  buildInputs = extraBuildInputs ++ (with xorg; [
     libXi
     libXcursor
     libXdamage


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLog: https://github.com/getferdi/ferdi/blob/1886c8abed32e33f0f547c069c674b79279cf931/CHANGELOG.md#560-beta6-2021-05-31

Even though this isn't explicitly noted in the Changelog, this seems to
have fixed the Element integration for me.

Additionally, I added a (hacky) `xdg-open` wrapper which removes the
`GDK_BACKEND` variable to fix the XWayland integration[1]. The problem
is that if a Firefox is running with Wayland (`ferdi` is running under
X11) and `GDK_BACKEND=x11` is passed to the `xdg-open` (and thus
`firefox`) process, Firefox refuses to start since another instance of
it is running under Wayland (but attempts to start in X11 mode because of
`GDK_BACKEND=x11`).

[1] https://github.com/electron/electron/issues/28436


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
