### PR TITLE
rambox: unmaintain & mark as insecure

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -21,8 +21,11 @@ in mkRambox rec {
     description = "Free and Open Source messaging and emailing app that combines common web applications into one";
     homepage = "https://rambox.pro";
     license = licenses.mit;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
     platforms = ["i686-linux" "x86_64-linux"];
     hydraPlatforms = [];
+    knownVulnerabilities = [
+      "Electron 7.2.4 is EOL and contains at least the following vulnerabilities: CVE-2020-6458, CVE-2020-6460 and more (https://www.electronjs.org/releases/stable?version=7). Consider using an alternative such as `ferdi'."
+    ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Rambox hasn't had a stable release in a while and an increasing number
of issues which is why I don't intend to use this anymore.

While taking a closer look at the source I also realized that it uses
Electron 7.2.4[1]. This is not only EOLed[2], it also contains a few
security vulnerabilities which is why I decided to mark it as insecure.

A few (most likely not all) vulnerabilities can be found by looking at
the Electron 7 changelog[3]: after 7.2.4 there were a few more releases
with security backports - mostly from Chromium. Security issues that
were found later on (and are probably exploitable on the dependency
chain of rambox) aren't listed here. I only added two issues that seemed
applicable to `rambox`, but I haven't researched enough to check the
other ones.

[1] https://github.com/ramboxapp/community-edition/blob/0.7.7/package.json#L70
[2] https://www.electronjs.org/docs/tutorial/support#currently-supported-versions
[3] https://www.electronjs.org/releases/stable?version=7


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
