### PR TITLE
plantuml-server 1.2021.6 -> 1.2021.7

### DIFF
--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, maven, jdk8_headless }:
 
 let
-  version = "1.2021.6";
+  version = "1.2021.7";
 
   src = fetchFromGitHub {
     owner = "plantuml";
     repo = "plantuml-server";
     rev = "v${version}";
-    sha256 = "sha256:1v69vabdq9pv75wzb6n5s198iy5ijfcx6lgjqwxz7n5ns3blf6sz";
+    sha256 = "sha256-kY7b3ocm1zudGIf72MNMZDUG2t2FFqucRr3kRaFv7mo=";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
@@ -28,7 +28,7 @@ let
     installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256:1fvir7yvg4a4dc4kiv2d5q081cygj7s2lmxj90j8zzkggyq7v8zh";
+    outputHash = "sha256-HzT5rBycrd48KskWKAGtkMKdCDQ8NPYADVWZh8K0ll4=";
   };
 in
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://plantuml.com/changes

```
[nix-shell:~/.cache/nixpkgs-review/pr-125741]$ ls ./results/plantuml-server/webapps/
plantuml.war
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
