### PR TITLE
postgresql: 9.6.21 -> 9.6.22, 10.16 -> 10.17, 11.11 -> 11.12, 12.6 -> 12.7, 13.2 -> 13.3

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -224,9 +224,9 @@ in self: {
   };
 
   postgresql_12 = self.callPackage generic {
-    version = "12.6";
+    version = "12.7";
     psqlSchema = "12";
-    sha256 = "028asz92mi3706zabfs8w9z03mzyx62d1l71qy9zdwfabj6xjzfz";
+    sha256 = "15frsmsl1n2i4p76ji0wng4lvnlzw6f01br4cs5xr3n88wgp9444";
     this = self.postgresql_12;
     thisAttr = "postgresql_12";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -233,9 +233,9 @@ in self: {
   };
 
   postgresql_13 = self.callPackage generic {
-    version = "13.2";
+    version = "13.3";
     psqlSchema = "13";
-    sha256 = "1z5d847jnajcfr3wa6jn52a8xjhamvwzmz18xlm5nvxqip8grmsz";
+    sha256 = "18dliq7h2l8irffhyyhdmfwx3si515q6gds3cxdjb9n7m17lbn9w";
     this = self.postgresql_13;
     thisAttr = "postgresql_13";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -205,9 +205,9 @@ in self: {
   };
 
   postgresql_10 = self.callPackage generic {
-    version = "10.16";
+    version = "10.17";
     psqlSchema = "10.0"; # should be 10, but changing it is invasive
-    sha256 = "1cvv8qw0gkkczqhiwx6ns7w88dwkvdz4cvb2d4ff14363f5p2p53";
+    sha256 = "0v5jahkqm6gkq67s4bac3h7297bscn2ab6y128idi73cc1qq1wjs";
     this = self.postgresql_10;
     thisAttr = "postgresql_10";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -215,9 +215,9 @@ in self: {
   };
 
   postgresql_11 = self.callPackage generic {
-    version = "11.11";
+    version = "11.12";
     psqlSchema = "11.1"; # should be 11, but changing it is invasive
-    sha256 = "0v0qk298nxmpzpgsxcsxma328hdkyzd7fwjs0zsn6zavl5zpnq20";
+    sha256 = "016bacpmqxc676ipzc1l8zv1jj44mjz7dv7jhqazg3ibdfqxiyc7";
     this = self.postgresql_11;
     thisAttr = "postgresql_11";
     inherit self;

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -196,9 +196,9 @@ let
 in self: {
 
   postgresql_9_6 = self.callPackage generic {
-    version = "9.6.21";
+    version = "9.6.22";
     psqlSchema = "9.6";
-    sha256 = "0d0ngpadf1i7c0i2psaxcbmiwx8334ibcsn283n9fp4853pyl3wk";
+    sha256 = "0c19kzrj5ib5ygmavf5d6qvxdwrxzzz6jz1r2dl5b815208cscix";
     this = self.postgresql_9_6;
     thisAttr = "postgresql_9_6";
     inherit self;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.postgresql.org/support/security/CVE-2021-32027/
https://www.postgresql.org/support/security/CVE-2021-32028/
https://www.postgresql.org/support/security/CVE-2021-32029/

https://www.postgresql.org/docs/13/release-13-3.html
https://www.postgresql.org/docs/12/release-12-7.html
https://www.postgresql.org/docs/11/release-11-12.html
https://www.postgresql.org/docs/10/release-10-17.html
https://www.postgresql.org/docs/9.6/release-9-6-22.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
