### PR TITLE
Use LLVM's libunwind on RISC-V

### DIFF
--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation rec {
     description = "A portable and efficient API to determine the call-chain of a program";
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.linux;
+    badPlatforms = [ "riscv32-linux" "riscv64-linux" ];
     license = licenses.mit;
   };
-
-  passthru.supportsHost = !stdenv.hostPlatform.isRiscV;
 }

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -1,9 +1,5 @@
 { lib, stdenv, fetchurl, perl, libunwind, buildPackages }:
 
-# libunwind does not have the supportsHost attribute on darwin, thus
-# when this package is evaluated it causes an evaluation error
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   pname = "strace";
   version = "5.12";
@@ -16,7 +12,9 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ perl.out ] ++ lib.optional libunwind.supportsHost libunwind; # support -k
+  # On RISC-V platforms, LLVM's libunwind implementation is unsupported by strace.
+  # The build will silently fall back and -k will not work on RISC-V.
+  buildInputs = [ perl.out libunwind ]; # support -k
 
   postPatch = "patchShebangs --host strace-graph";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16823,8 +16823,9 @@ in
 
   libutempter = callPackage ../development/libraries/libutempter { };
 
-  libunwind = if stdenv.isDarwin
-    then darwin.libunwind
+  libunwind =
+    if stdenv.isDarwin then darwin.libunwind
+    else if stdenv.hostPlatform.isRiscV then llvmPackages_latest.libunwind
     else callPackage ../development/libraries/libunwind { };
 
   libuv = callPackage ../development/libraries/libuv {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The author of the nongnu libunwind has [stated](https://github.com/libunwind/libunwind/issues/99) that he has no intention to implement support for RISC-V, so for RISC-V platforms let's switch to LLVM's implementation like [what Gentoo did](https://github.com/gentoo/gentoo/commit/c15afd7cd060d8f46ab636befd20086dc9fd9aeb).

strace does not support LLVM's implementation which lacks `libunwind-ptrace`, but there's no actual feature degradation since the nongnu libunwind doesn't work on RISC-V anyways.

Tested:
- `xorg.xorgserver` builds on riscv64
- The nongnu `libunwind` does *not* build on riscv64 :broken_heart: 

More information:
- https://github.com/JuliaLang/julia/issues/30154
- http://clang-developers.42468.n3.nabble.com/libunwind-relation-between-llvm-libunwind-and-nongnu-libunwind-td4053288.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
