### PR TITLE
unpackerr: 0.9.4 -> 0.9.6

### DIFF
--- a/pkgs/servers/unpackerr/default.nix
+++ b/pkgs/servers/unpackerr/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "unpackerr";
-  version = "0.9.4";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "davidnewhall";
     repo = "unpackerr";
     rev = "v${version}";
-    sha256 = "0ss12i8bclz1q9jgr54shvs8zgcs6jrwdm1vj9gvycyd5sx4717s";
+    sha256 = "1jyqrfik6fy7d4lr1y0ryp4iz8yn898ksyxwaryvrhykznqivp0y";
   };
 
-  vendorSha256 = "1j79vmf0mkwkqrg5j6fm2b8y3a23y039kbiqkiwb56724bmd27dd";
+  vendorSha256 = "0ilpg7xfll0c5lsv8zf4h3i72yabddkddih4d292hczyz9wi3j4z";
 
   buildInputs = lib.optionals stdenv.isDarwin [ Cocoa WebKit ];
 


### PR DESCRIPTION
###### Motivation for this change
* https://github.com/davidnewhall/unpackerr/releases/tag/v0.9.5
* https://github.com/davidnewhall/unpackerr/releases/tag/v0.9.6

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
