### PR TITLE
openrgb: Fix udev rules with hardcoded /bin/chmod

### DIFF
--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitLab, qmake, libusb1, hidapi, pkg-config }:
+{ lib, mkDerivation, fetchFromGitLab, qmake, libusb1, hidapi, pkg-config, coreutils }:
 
 mkDerivation rec {
   pname = "openrgb";
@@ -15,11 +15,18 @@ mkDerivation rec {
   buildInputs = [ libusb1 hidapi ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp openrgb $out/bin
 
+    substituteInPlace 60-openrgb.rules \
+      --replace /bin/chmod "${coreutils}/bin/chmod"
+
     mkdir -p $out/etc/udev/rules.d
     cp 60-openrgb.rules $out/etc/udev/rules.d
+
+    runHook postInstall
   '';
 
   doInstallCheck = true;
@@ -27,13 +34,11 @@ mkDerivation rec {
     HOME=$TMPDIR $out/bin/openrgb --help > /dev/null
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Open source RGB lighting control";
     homepage = "https://gitlab.com/CalcProgrammer1/OpenRGB";
     maintainers = with maintainers; [ jonringer ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New rules introduced in 0.6 have this hardcoded /bin/chmod path and udev refuses to install them.

@jonringer does this seem correct?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
