### PR TITLE
ocamlPackages.csexp: 1.4.0 -> 1.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/csexp/default.nix
+++ b/pkgs/development/ocaml-modules/csexp/default.nix
@@ -2,23 +2,24 @@
 
 buildDunePackage rec {
   pname = "csexp";
-  version = "1.4.0";
-
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.02.3";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "https://github.com/ocaml-dune/csexp/releases/download/${version}/csexp-${version}.tbz";
-    sha256 = "sha256-jj1vyofxAqEm3ui3KioNFG8QQ5xHIY38FJ1Rvz7fNk4=";
+    sha256 = "sha256-1gXkBl+pCliABEDvLzOi2TE5i/LCIGGorLffhFwKrAI=";
   };
 
-  propagatedBuildInputs = [ result ];
+  minimumOCamlVersion = "4.03";
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    result
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/ocaml-dune/csexp";
+    homepage = "https://github.com/ocaml-dune/csexp/";
     description = "Minimal support for Canonical S-expressions";
     license = licenses.mit;
-    maintainers = [ maintainers.marsam ];
+    maintainers = with maintainers; [ marsam ];
   };
 }


### PR DESCRIPTION
ocamlPackages.csexp: 1.4.0 -> 1.5.1
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
