### PR TITLE
root: 6.22.08 -> 6.24.00 

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,20 +1,20 @@
-{ stdenv, lib, fetchurl, makeWrapper, cmake, ftgl, gl2ps, glew, gsl, llvm_5
-, libX11, libXpm, libXft, libXext, libGLU, libGL, libxml2, lz4, xz, pcre
+{ stdenv, lib, fetchurl, makeWrapper, cmake, git, ftgl, gl2ps, glew, gsl
+, libX11, libXpm, libXft, libXext, libGLU, libGL, libxml2, lz4, xz, pcre, nlohmann_json
 , pkg-config, python, xxHash, zlib, zstd
 , libAfterImage, giflib, libjpeg, libtiff, libpng
 , Cocoa, OpenGL, noSplash ? false }:
 
 stdenv.mkDerivation rec {
   pname = "root";
-  version = "6.22.08";
+  version = "6.24.00";
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    sha256 = "0vrgi83hrw4n9zgx873fn4ba3vk54slrwk1cl4cc4plgxzv1y1kg";
+    sha256 = "12crjzd7pzx5qpk2pb3z0rhmxlw5gsqaqzfl48qiq8c9l940b8wx";
   };
 
-  nativeBuildInputs = [ makeWrapper cmake pkg-config llvm_5.dev ];
-  buildInputs = [ ftgl gl2ps glew pcre zlib zstd llvm_5 libxml2 lz4 xz gsl xxHash libAfterImage giflib libjpeg libtiff libpng python.pkgs.numpy ]
+  nativeBuildInputs = [ makeWrapper cmake pkg-config git ];
+  buildInputs = [ ftgl gl2ps glew pcre zlib zstd libxml2 lz4 xz gsl xxHash libAfterImage giflib libjpeg libtiff libpng nlohmann_json python.pkgs.numpy ]
     ++ lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext libGLU libGL ]
     ++ lib.optionals (stdenv.isDarwin) [ Cocoa OpenGL ]
     ;
@@ -28,6 +28,13 @@ stdenv.mkDerivation rec {
     substituteInPlace cmake/modules/SearchInstalledSoftware.cmake \
       --replace 'set(lcgpackages ' '#set(lcgpackages '
 
+    # Don't require textutil on macOS
+    : > cmake/modules/RootCPack.cmake
+
+    # Hardcode path to fix use with cmake
+    sed -i cmake/scripts/ROOTConfig.cmake.in \
+      -e 'iset(nlohmann_json_DIR "${nlohmann_json}/lib/cmake/nlohmann_json/")'
+
     patchShebangs build/unix/
   '' + lib.optionalString noSplash ''
     substituteInPlace rootx/src/rootx.cxx --replace "gNoLogo = false" "gNoLogo = true"
@@ -35,11 +42,13 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-Drpath=ON"
+    "-DCMAKE_CXX_STANDARD=17"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-Dbuiltin_nlohmannjson=OFF"
+    "-Dbuiltin_openui5=OFF"
     "-Dalien=OFF"
     "-Dbonjour=OFF"
-    "-Dbuiltin_llvm=OFF"
     "-Dcastor=OFF"
     "-Dchirp=OFF"
     "-Dclad=OFF"
@@ -53,6 +62,7 @@ stdenv.mkDerivation rec {
     "-Dgfal=OFF"
     "-Dgviz=OFF"
     "-Dhdfs=OFF"
+    "-Dhttp=ON"
     "-Dkrb5=OFF"
     "-Dldap=OFF"
     "-Dmonalisa=OFF"
@@ -64,9 +74,11 @@ stdenv.mkDerivation rec {
     "-Dpythia6=OFF"
     "-Dpythia8=OFF"
     "-Drfio=OFF"
+    "-Droot7=OFF"
     "-Dsqlite=OFF"
     "-Dssl=OFF"
     "-Dvdt=OFF"
+    "-Dwebgui=OFF"
     "-Dxml=ON"
     "-Dxrootd=OFF"
   ]

--- a/pkgs/applications/science/misc/root/sw_vers.patch
+++ b/pkgs/applications/science/misc/root/sw_vers.patch
@@ -1,8 +1,8 @@
 diff a/cmake/modules/SetUpMacOS.cmake b/cmake/modules/SetUpMacOS.cmake
 --- a/cmake/modules/SetUpMacOS.cmake
 +++ b/cmake/modules/SetUpMacOS.cmake
-@@ -8,17 +8,10 @@ set(ROOT_ARCHITECTURE macosx)
- set(ROOT_PLATFORM macosx)
+@@ -28,17 +28,10 @@ if(CMAKE_VERSION VERSION_LESS 3.14.4)
+ endif()
  
  if (CMAKE_SYSTEM_NAME MATCHES Darwin)
 -  EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
@@ -19,16 +19,15 @@ diff a/cmake/modules/SetUpMacOS.cmake b/cmake/modules/SetUpMacOS.cmake
      #TODO: check haveconfig and rpath -> set rpath true
      #TODO: check Thread, define link command
      #TODO: more stuff check configure script
-@@ -37,23 +30,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+@@ -57,22 +50,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+        SET(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -m64")
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
-        SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m64")
 -    else()
--       MESSAGE(STATUS "Found a 32bit system")
 -       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
 -       SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
 -       SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m32")
--    endif()
+     endif()
 -  endif()
 -
 -  if(MACOSX_VERSION VERSION_GREATER 10.6)
@@ -40,11 +39,10 @@ diff a/cmake/modules/SetUpMacOS.cmake b/cmake/modules/SetUpMacOS.cmake
 -  if(MACOSX_VERSION VERSION_GREATER 10.8)
 -    set(MACOSX_GLU_DEPRECATED ON)
 -  endif()
-+     endif()
  
    if (CMAKE_COMPILER_IS_GNUCXX)
-      message(STATUS "Found GNU compiler collection")
-@@ -115,7 +92,6 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wshadow -Wall -Woverloaded-virtual -fsigned-char -fno-common")
+@@ -130,7 +108,6 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
    endif()
  
    #---Set Linker flags----------------------------------------------------------------------


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ROOT 6.24 introduces some interesting changes, like seeding of `GetRandom` for `TH1` classes, and many performance improvements on `RooFit`. This version also introduces Apple silicon support (at least from the `cmake` files).

However, upstream has bumped the `llvm` to `llvm_9`. I first tried to just change the input from `llvm_5` to `llvm_9`, but I got the following compilation error:

```
-- Using LLVM external library - 9.0.1
-- Clang version: 9.0.1
CMake Error at /nix/store/i2als7skhvbyjw9i79p9mfqkjypd56ck-llvm-9.0.1-dev/lib/cmake/llvm/AddLLVM.cmake:637 (add_custom_target):
  add_custom_target cannot create target "install-clang-cpp" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory
  "/build/root-6.24.00/interpreter/llvm/src/tools/clang/tools/driver".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  interpreter/llvm/src/tools/clang/cmake/modules/AddClang.cmake:117 (add_llvm_install_targets)
  interpreter/llvm/src/tools/clang/tools/clang-shlib/CMakeLists.txt:18 (add_clang_library)


CMake Error at interpreter/CMakeLists.txt:452 (get_directory_property):
  get_directory_property DIRECTORY argument provided but requested directory
  not found.  This could be because the directory argument was invalid or, it
  is valid but has not been processed yet.
```

So I switched to the bundled `llvm` instead. Unfortunately this will make compilation slower. I also [asked about this](https://root-forum.cern.ch/t/compiling-root-6-24-with-external-llvm-but-built-in-clang/45258) on the official forum.

I'd like to hear the opinion of the maintainer @veprbl before proceed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
