### PR TITLE
ocamlPackages.fix: 20130611 -> 20201120

### DIFF
--- a/pkgs/development/ocaml-modules/fix/default.nix
+++ b/pkgs/development/ocaml-modules/fix/default.nix
@@ -1,25 +1,24 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
+{ lib, fetchFromGitLab, buildDunePackage }:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "3.12";
+buildDunePackage rec {
+  pname = "fix";
+  version = "20201120";
 
-stdenv.mkDerivation {
-
-  name = "ocaml-fix-20130611";
-
-  src = fetchurl {
-    url = "http://gallium.inria.fr/~fpottier/fix/fix-20130611.tar.gz";
-    sha256 = "1phlqcs1nb93x9cf0w0hnq2ck4dmn71zm4mxf60w96vb9yb9qzp0";
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "fpottier";
+    repo = "fix";
+    rev = "${version}";
+    sha256 = "sha256-RO+JCG6R2i5uZfwTYEnQBCVq963fjv5lA2wA/8KrgMg=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-
-  createFindlibDestdir = true;
+  minimumOCamlVersion = "4.03";
+  useDune2 = true;
 
   meta = with lib; {
-    homepage = "http://gallium.inria.fr/~fpottier/fix/";
+    homepage = "https://gitlab.inria.fr/fpottier/fix/";
     description = "A simple OCaml module for computing the least solution of a system of monotone equations";
     license = licenses.cecill-c;
-    maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    maintainers = with maintainers; [ vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
ocamlPackages.fix: 20130611 -> 20201120

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](./CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
