### PR TITLE
ocamlPackages.ocplib-endian: 1.0 -> 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocplib-endian/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-endian/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, cppo }:
+{ lib, buildDunePackage, fetchzip, cppo }:
 
-let version = "1.0"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-ocplib-endian-${version}";
+buildDunePackage rec {
+  version = "1.1";
+  pname = "ocplib-endian";
 
   src = fetchzip {
     url = "https://github.com/OCamlPro/ocplib-endian/archive/${version}.tar.gz";
-    sha256 = "0s1ld3kavz892b8awyxyg1mr98h2g61gy9ci5v6yb49bsii6wicw";
+    sha256 = "sha256-zKsSkhlZBXSqPtw+/WN3pwo9plM9rDZfMbGVfosqb10=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cppo ];
+  useDune2 = true;
 
-  createFindlibDestdir = true;
+  buildInputs = [ cppo ];
 
-  meta = {
+  meta = with lib; {
     description = "Optimised functions to read and write int16/32/64";
     homepage = "https://github.com/OCamlPro/ocplib-endian";
-    license = lib.licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [];
-    maintainers = with lib.maintainers; [ vbgl ];
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ vbgl ];
   };
 }


### PR DESCRIPTION
ocamlPackages.ocplib-endian: 1.0 -> 1.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
