### PR TITLE
dotnetPackages.FSharpData: 2.2.3 -> 4.1.1

### DIFF
--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -81,6 +81,20 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "*" ];
   };
 
+  FSharpData = fetchNuGet {
+    baseName = "FSharp.Data";
+    version = "4.1.1";
+    sha256 = "0ytjiQi8vQQU51JYexnC13Bi7NqVmLRzM75SOZ+hhQU=";
+    outputFiles = [ "lib/*" ];
+
+    meta = with lib; {
+      description = "F# Data: Library for Data Access";
+      homepage = "https://fsprojects.github.io/FSharp.Data/";
+      license = licenses.asl20;
+      maintainers = [ maintainers.ratsclub ];
+    };
+  };
+
   FSharpData225 = fetchNuGet {
     baseName = "FSharp.Data";
     version = "2.2.5";
@@ -610,50 +624,6 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "The F# compiler services package is a component derived from the F# compiler source code that exposes additional functionality for implementing F# language bindings";
       homepage = "https://fsharp.github.io/FSharp.Compiler.Service/";
-      license = lib.licenses.asl20;
-      maintainers = with lib.maintainers; [ obadz ];
-      platforms = with lib.platforms; linux;
-    };
-  };
-
-  FSharpData = buildDotnetPackage rec {
-    baseName = "FSharp.Data";
-    version = "2.2.3";
-
-    src = fetchFromGitHub {
-      owner = "fsharp";
-      repo = baseName;
-      rev = version;
-      sha256 = "1h3v9rc8k0khp61cv5n01larqbxd3xcx3q52sw5zf9l0661vw7qr";
-    };
-
-    buildInputs = [ fsharp ];
-
-    fileProvidedTypes = fetchurl {
-      name = "ProvidedTypes.fs";
-      url = "https://raw.githubusercontent.com/fsprojects/FSharp.TypeProviders.StarterPack/877014bfa6244ac382642e113d7cd6c9bc27bc6d/src/ProvidedTypes.fs";
-      sha256 = "1lb056v1xld1rfx6a8p8i2jz8i6qa2r2823n5izsf1qg1qgf2980";
-    };
-
-    fileDebugProvidedTypes = fetchurl {
-      name = "DebugProvidedTypes.fs";
-      url = "https://raw.githubusercontent.com/fsprojects/FSharp.TypeProviders.StarterPack/877014bfa6244ac382642e113d7cd6c9bc27bc6d/src/DebugProvidedTypes.fs";
-      sha256 = "1whyrf2jv6fs7kgysn2086v15ggjsd54g1xfs398mp46m0nxp91f";
-    };
-
-    preConfigure = ''
-       # Copy single-files-in-git-repos
-       mkdir -p "paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src"
-       cp -v "${fileProvidedTypes}" "paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/ProvidedTypes.fs"
-       cp -v "${fileDebugProvidedTypes}" "paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/DebugProvidedTypes.fs"
-    '';
-
-    xBuildFiles = [ "src/FSharp.Data.fsproj" "src/FSharp.Data.DesignTime.fsproj" ];
-    outputFiles = [ "bin/*.dll" "bin/*.xml" ];
-
-    meta = {
-      description = "F# Data: Library for Data Access";
-      homepage = "https://fsharp.github.io/FSharp.Data/";
       license = lib.licenses.asl20;
       maintainers = with lib.maintainers; [ obadz ];
       platforms = with lib.platforms; linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
