### PR TITLE
depotdownloader: init at 2.4.1

### DIFF
--- a/pkgs/tools/misc/depotdownloader/default.nix
+++ b/pkgs/tools/misc/depotdownloader/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, fetchFromGitHub, fetchurl, linkFarmFromDrvs, makeWrapper
+,  dotnet-sdk_5, dotnetPackages
+}:
+
+let
+  fetchNuGet = {name, version, sha256}: fetchurl {
+    name = "nuget-${name}-${version}.nupkg";
+    url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+    inherit sha256;
+  };
+  deps = import ./deps.nix fetchNuGet;
+in
+stdenv.mkDerivation rec {
+  pname = "depotdownloader";
+  version = "2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "SteamRE";
+    repo = "DepotDownloader";
+    rev = "DepotDownloader_${version}";
+    sha256 = "1ldwda7wyvzqvqv1wshvqvqaimlm0rcdzhy9yn5hvxyswc0jxirr";
+  };
+
+  nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget makeWrapper ];
+
+  buildPhase = ''
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_NOLOGO=1
+    export HOME=$TMP/home
+
+    nuget sources Add -Name tmpsrc -Source $TMP/nuget
+    nuget init ${linkFarmFromDrvs "deps" deps} $TMP/nuget
+
+    dotnet restore --source $TMP/nuget DepotDownloader/DepotDownloader.csproj
+    dotnet publish --no-restore -c Release --output $out
+  '';
+
+  installPhase = ''
+    makeWrapper ${dotnet-sdk_5}/bin/dotnet $out/bin/$pname \
+      --add-flags $out/DepotDownloader.dll
+  '';
+
+  meta = with lib; {
+    description = "Steam depot downloader utilizing the SteamKit2 library.";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.babbaj ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/tools/misc/depotdownloader/deps.nix
+++ b/pkgs/tools/misc/depotdownloader/deps.nix
@@ -1,0 +1,88 @@
+fetchNuGet:
+[
+  (fetchNuGet {
+    name = "protobuf-net";
+    version = "3.0.101";
+    sha256 = "0594qckbc0lh61sw74ihaq4qmvf1lf133vfa88n443mh7lxm2fwf";
+  })
+  (fetchNuGet {
+    name = "SteamKit2";
+    version = "2.4.0-Alpha.2";
+    sha256 = "1r6chqdp912pr8f8d7px2vp4y1ydx0kida7d5a1hbf6b7acnsg7d";
+  })
+  (fetchNuGet {
+    name = "protobuf-net.Core";
+    version = "3.0.101";
+    sha256 = "1kvn9rnm6f0jxs0s9scyyx2f2p8rk03qzc1f6ijv1g6xgkpxkq1m";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App";
+    version = "2.0.0";
+    sha256 = "0j8xkssrashyxrmdraci6kmj2gdrdxb0z61jwnzf1r9r2kqrd7d2";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.DotNetAppHost";
+    version = "2.0.0";
+    sha256 = "0yixdk1rslbznrl50d6pyhg50xxr6jbfb1qpy2yd8xv44s4shgwd";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.DotNetHostPolicy";
+    version = "2.0.0";
+    sha256 = "1zz9yfzcvcai4il78s3phjp1hryib2zk3w2r16v3fxm2yllssyaf";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.DotNetHostResolver";
+    version = "2.0.0";
+    sha256 = "0xy45xqmdqz7r6v0g8m7c1rp761ghavjl8nzxiyrpbp0wccxl3xb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "5.0.0";
+    sha256 = "0mwpwdflidzgzfx2dlpkvvnkgkr2ayaf0s80737h4wa35gaj11rc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "5.0.0";
+    sha256 = "102hvhq2gmlcbq8y2cb7hdr2dnmjzfp2k3asr1ycwrfacwyaak7n";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "2.0.0";
+    sha256 = "1bc4ba8ahgk15m8k4nd7x406nhi0kwqzbgjk2dmw52ss553xz7iy";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.7.1";
+    sha256 = "1nh4nlxfc7lbnbl86wwk1a3jwl6myz5j6hvgh5sp4krim9901hsq";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.4";
+    sha256 = "14gbbs22mcxwggn0fcfs1b062521azb9fbb7c113x0mq6dzq9h6y";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.7.0";
+    sha256 = "121l1z2ypwg02yz84dy6gr82phpys0njk7yask3sihgy214w43qp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.7.0";
+    sha256 = "0mbjfajmafkca47zr8v36brvknzks5a7pgb49kfq2d188pyv6iap";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.3";
+    sha256 = "1afi6s2r1mh1kygbjmfba6l4f87pi5sg13p4a48idqafli94qxln";
+  })
+  (fetchNuGet {
+    name = "System.Security.AccessControl";
+    version = "5.0.0";
+    sha256 = "17n3lrrl6vahkqmhlpn3w20afgz09n7i6rv0r3qypngwi7wqdr5r";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "5.0.0";
+    sha256 = "1mpk7xj76lxgz97a5yg93wi8lj0l8p157a5d50mmjy3gbz1904q8";
+  })
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30326,6 +30326,8 @@ in
 
   darling-dmg = callPackage ../tools/filesystems/darling-dmg { };
 
+  depotdownloader = callPackage ../tools/misc/depotdownloader { };
+
   desmume = callPackage ../misc/emulators/desmume { inherit (pkgs.gnome2) gtkglext libglade; };
 
   dbacl = callPackage ../tools/misc/dbacl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A cli tool for downloading game files from steam servers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
