### PR TITLE
[staging-next] ngrok-2: fix aarch64-darwin logic

### DIFF
--- a/pkgs/tools/networking/ngrok-2/default.nix
+++ b/pkgs/tools/networking/ngrok-2/default.nix
@@ -9,7 +9,8 @@ let versions = builtins.fromJSON (builtins.readFile ./versions.json);
            else if stdenv.isAarch64 then "arm64"
            else throw "Unsupported architecture";
     os = if stdenv.isLinux then "linux"
-         else if stdenv.isDarwin then "darwin"
+         else if (stdenv.isDarwin && stdenv.isx86_64) then "darwin"
+         else if stdenv.isDarwin then throw "Unsupported architecture"
          else throw "Unsupported os";
     versionInfo = versions."${os}-${arch}";
     inherit (versionInfo) version sha256 url;


### PR DESCRIPTION
###### Motivation for this change
fix https://hydra.nixos.org/build/144759321/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
