### PR TITLE
ocamlPackages.ppx_gen_rec: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
@@ -1,22 +1,23 @@
-{ lib, fetchurl, buildDunePackage, ocaml-migrate-parsetree }:
+{ lib, fetchurl, buildDunePackage, ppxlib }:
 
 buildDunePackage rec {
   pname = "ppx_gen_rec";
-  version = "1.1.0";
-
-  useDune2 = true;
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0fwi4bknq8h9zgpsarjvnzdm9bm8qlyyw0lz30pihg02aiiljqbh";
+    sha256 = "sha256-/mMj5UT22KQGVy1sjgEoOgPzyCYyeDPtWJYNDvQ9nlk=";
   };
 
-  buildInputs = [ ocaml-migrate-parsetree ];
+  minimumOCamlVersion = "4.07";
+  useDune2 = true;
+
+  buildInputs = [ ppxlib ];
 
   meta = with lib; {
     homepage = "https://github.com/flowtype/ocaml-ppx_gen_rec";
-    description = "ocaml preprocessor that generates a recursive module";
+    description = "A ppx rewriter that transforms a recursive module expression into a struct.";
     license = licenses.mit;
-    maintainers = [ maintainers.frontsideair ];
+    maintainers = with maintainers; [ frontsideair ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
ocamlPackages.ppx_gen_rec: 1.1.0 -> 2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
