### PR TITLE
rss2email test: fix name

### DIFF
--- a/nixos/tests/rss2email.nix
+++ b/nixos/tests/rss2email.nix
@@ -1,5 +1,5 @@
 import ./make-test-python.nix {
-  name = "opensmtpd";
+  name = "rss2email";
 
   nodes = {
     server = { pkgs, ... }: {


### PR DESCRIPTION
### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 21.05, sandbox = "true"
**packages declared changed:** {"rss2email"}
**manual tests declared performed:**
 * 😢 not built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions

**complies with contributing.md:** ✔ yes
**package rss2email:** ✔ continued building
**closure size for rss2email:** ✔ stayed constant, at 99.0 MB
**tests of rss2email:**
  * *updated tests:*
    * ✔ smoke-test continued running successfully


**binaries of rss2email:**
  * *updated binaries:*
    * ✔ r2e continued running successfully