### PR TITLE
Mix release closure size

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -29,9 +29,6 @@ let
     MIX_DEBUG = if enableDebugInfo then 1 else 0;
     HEX_OFFLINE = 1;
 
-    # stripping does not have any effect on beam files
-    dontStrip = true;
-
     # add to ERL_LIBS so other modules can find at runtime.
     # http://erlang.org/doc/man/code.html#code-path
     # Mix also searches the code path when compiling with the --no-deps-check flag
@@ -71,6 +68,10 @@ let
 
       runHook postInstall
     '';
+
+    # stripping does not have any effect on beam files
+    # it is however needed for dependencies with NIFs like bcrypt for example
+    dontStrip = false;
 
     passthru = {
       packageName = name;

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -23,8 +23,7 @@ let
 
   pkg = self: stdenv.mkDerivation (attrs // {
     name = "${name}-${version}";
-    inherit version;
-    inherit src;
+    inherit version src buildInputs;
 
     MIX_ENV = mixEnv;
     MIX_DEBUG = if enableDebugInfo then 1 else 0;
@@ -41,7 +40,7 @@ let
       addToSearchPath ERL_LIBS "$1/lib/erlang/lib"
     '';
 
-    buildInputs = buildInputs ++ [ elixir hex ];
+    nativeBuildInputs = [ elixir hex ];
     propagatedBuildInputs = propagatedBuildInputs ++ beamDeps;
 
     buildPhase = attrs.buildPhase or ''

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -42,8 +42,12 @@ let
     buildInputs = buildInputs ++ [ erlang rebar3 openssl libyaml ];
     propagatedBuildInputs = unique beamDeps;
 
-    dontStrip = true;
     inherit src;
+
+    # stripping does not have any effect on beam files
+    # it is however needed for dependencies with NIFs
+    # false is the default but we keep this for readability
+    dontStrip = false;
 
     setupHook = writeText "setupHook.sh" ''
       addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -82,8 +82,7 @@ stdenv.mkDerivation (overridable // {
     runHook postInstall
   '';
 
-  fixupPhase = ''
-    runHook preFixup
+  postFixup = ''
     if [ -e "$out/bin/${pname}.bat" ]; then # absent in special cases, i.e. elixir-ls
       rm "$out/bin/${pname}.bat" # windows file
     fi
@@ -102,9 +101,6 @@ stdenv.mkDerivation (overridable // {
         substituteInPlace "$file" --replace "${erlang}/lib/erlang" "$out"
       done
     fi
-
-    patchShebangs $out
-    runHook postFixup
   '';
 
   # TODO investigate why the resulting closure still has

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -82,6 +82,9 @@ stdenv.mkDerivation (overridable // {
     runHook postInstall
   '';
 
+  # Stripping of the binary is intentional
+  # even though it does not affect beam files
+  # it is necessary for NIFs binaries
   postFixup = ''
     if [ -e "$out/bin/${pname}.bat" ]; then # absent in special cases, i.e. elixir-ls
       rm "$out/bin/${pname}.bat" # windows file
@@ -97,6 +100,8 @@ stdenv.mkDerivation (overridable // {
     # closure size
     if [ -e $out/erts-* ]; then
       echo "ERTS found in $out - removing references to erlang to reduce closure size"
+      # there is a link in $out/erts-*/bin/start always
+      # sometimes there are links in dependencies like bcrypt compiled binaries
       for file in $(rg "${erlang}/lib/erlang" "$out" --text --files-with-matches); do
         substituteInPlace "$file" --replace "${erlang}/lib/erlang" "$out"
       done

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, elixir, erlang, findutils, hex, rebar, rebar3, fetchMixDeps, makeWrapper, git }:
+{ stdenv, lib, elixir, erlang, findutils, hex, rebar3, fetchMixDeps, makeWrapper, git }:
 
 { pname
 , version
@@ -31,7 +31,6 @@ stdenv.mkDerivation (overridable // {
   HEX_OFFLINE = 1;
   DEBUG = if enableDebugInfo then 1 else 0; # for Rebar3 compilation
   # the api with `mix local.rebar rebar path` makes a copy of the binary
-  MIX_REBAR = "${rebar}/bin/rebar";
   MIX_REBAR3 = "${rebar3}/bin/rebar3";
 
   postUnpack = ''

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -142,8 +142,6 @@ stdenv.mkDerivation ({
     wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${lib.makeBinPath [ gnused gawk ]}"
   '';
 
-  setupHook = ./setup-hook.sh;
-
   passthru = {
     updateScript =
       let major = builtins.head (builtins.splitVersion version);

--- a/pkgs/development/interpreters/erlang/setup-hook.sh
+++ b/pkgs/development/interpreters/erlang/setup-hook.sh
@@ -1,5 +1,0 @@
-addErlangLibPath() {
-    addToSearchPath ERL_LIBS $1/lib/erlang/lib
-}
-
-addEnvHooks "$hostOffset" addErlangLibPath


### PR DESCRIPTION
###### Motivation for this change

@dlesl started the work of removing the reference to erlang in rebarRelx resulting closure in https://github.com/NixOS/nixpkgs/pull/124779

This PR aims at starting the work for mix-release. @NobbZ you noticed in the initial PR that the resulting closure built by mix-release contained reference to erlang.
This PR does the following.
- Removing the setup hook from the generic builder of erlang. It seems it has no effect. Also from a reference found by @dlesl , it seems not needed https://erlang.org/doc/man/code.html
- Switches some dependencies from buildInputs to nativeBuildInputs. This is more a semantic difference, but just to make the intent clearer to future contributors.
- Remove reference to rebar into mix release. There is likely no need anymore for the old rebar.
- Remove the explicit reference of erlang into closure built by mix-release.

Please note however that the resulting closure built by mix-release still reference erlang somehow, even though I can't find any explicit reference by grepping. This is still a work in progress.

Since removing the erlang setup hook might be impactful, I'm curious to have people test this and give feedback

@NixOS/beam 

@ydlr @petabyteboy @cw789 you might be interested in this as well.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
