### PR TITLE
mfc9140cdn{lpr,cupswrapper}: init

### DIFF
--- a/pkgs/misc/cups/drivers/mfc9140cdncupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9140cdncupswrapper/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, gnugrep
+, gnused
+, mfc9140cdnlpr
+, pkgsi686Linux
+, psutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfc9140cdncupswrapper";
+  version = "1.1.4-0";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf100407/${pname}-${version}.i386.deb";
+    sha256 = "18aramgqgra1shdhsa75i0090hk9i267gvabildwsk52kq2b96c6";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    lpr=${mfc9140cdnlpr}/opt/brother/Printers/mfc9140cdn
+    dir=$out/opt/brother/Printers/mfc9140cdn
+
+    interpreter=${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2
+    patchelf --set-interpreter "$interpreter" "$dir/cupswrapper/brcupsconfpt1"
+
+    substituteInPlace $dir/cupswrapper/cupswrappermfc9140cdn \
+      --replace "mkdir -p /usr" ": # mkdir -p /usr" \
+      --replace '/opt/brother/''${device_model}/''${printer_model}/lpd/filter''${printer_model}' "$lpr/lpd/filtermfc9140cdn" \
+      --replace '/usr/share/ppd/Brother/brother_''${printer_model}_printer_en.ppd' "$dir/cupswrapper/brother_mfc9140cdn_printer_en.ppd" \
+      --replace '/usr/share/cups/model/Brother/brother_''${printer_model}_printer_en.ppd' "$dir/cupswrapper/brother_mfc9140cdn_printer_en.ppd" \
+      --replace '/opt/brother/Printers/''${printer_model}/' "$lpr/" \
+      --replace 'nup="psnup' "nup=\"${psutils}/bin/psnup" \
+      --replace '/usr/bin/psnup' "${psutils}/bin/psnup"
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln $dir/cupswrapper/cupswrappermfc9140cdn $out/lib/cups/filter
+    ln $dir/cupswrapper/brother_mfc9140cdn_printer_en.ppd $out/share/cups/model
+
+    sed -n '/!ENDOFWFILTER!/,/!ENDOFWFILTER!/p' "$dir/cupswrapper/cupswrappermfc9140cdn" | sed '1 br; b; :r s/.*/printer_model=mfc9140cdn; cat <<!ENDOFWFILTER!/'  | bash > $out/lib/cups/filter/brother_lpdwrapper_mfc9140cdn
+    sed -i "/#! \/bin\/sh/a PATH=${lib.makeBinPath [ coreutils gnused gnugrep ]}:\$PATH" $out/lib/cups/filter/brother_lpdwrapper_mfc9140cdn
+    chmod +x $out/lib/cups/filter/brother_lpdwrapper_mfc9140cdn
+    '';
+
+  meta = with lib; {
+    description = "Brother MFC-9140CDN CUPS wrapper driver";
+    homepage = "http://www.brother.com/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfc9140cdnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9140cdnlpr/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, file
+, gawk
+, ghostscript
+, gnused
+, pkgsi686Linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfc9140cdnlpr";
+  version = "1.1.2-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf100405/${pname}-${version}.i386.deb";
+    sha256 = "1wqx8njrv078fc3vlq90qyrfg3cw9kr9m6f3qvfnkhq1f95fbslh";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    dir=$out/opt/brother/Printers/mfc9140cdn
+
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $dir/lpd/brmfc9140cdnfilter
+
+    wrapProgram $dir/inf/setupPrintcapij \
+      --prefix PATH : ${lib.makeBinPath [
+        coreutils
+      ]}
+
+    substituteInPlace $dir/lpd/filtermfc9140cdn \
+      --replace "BR_CFG_PATH=" "BR_CFG_PATH=\"$dir/\" #" \
+      --replace "BR_LPD_PATH=" "BR_LPD_PATH=\"$dir/\" #"
+
+    wrapProgram $dir/lpd/filtermfc9140cdn \
+      --prefix PATH : ${lib.makeBinPath [
+        coreutils
+        file
+        ghostscript
+        gnused
+      ]}
+
+    substituteInPlace $dir/lpd/psconvertij2 \
+      --replace '`which gs`' "${ghostscript}/bin/gs"
+
+    wrapProgram $dir/lpd/psconvertij2 \
+      --prefix PATH : ${lib.makeBinPath [
+        gnused
+        gawk
+      ]}
+  '';
+
+  meta = with lib; {
+    description = "Brother MFC-9140CDN LPR printer driver";
+    homepage = "http://www.brother.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ hexa ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31132,6 +31132,8 @@ in
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 
+  mfc9140cdnlpr = callPackage ../misc/cups/drivers/mfc9140cdnlpr { };
+
   samsung-unified-linux-driver_1_00_36 = callPackage ../misc/cups/drivers/samsung/1.00.36/default.nix { };
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung/1.00.37.nix { };
   samsung-unified-linux-driver_4_00_39 = callPackage ../misc/cups/drivers/samsung/4.00.39 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31132,6 +31132,7 @@ in
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 
+  mfc9140cdncupswrapper = callPackage ../misc/cups/drivers/mfc9140cdncupswrapper { };
   mfc9140cdnlpr = callPackage ../misc/cups/drivers/mfc9140cdnlpr { };
 
   samsung-unified-linux-driver_1_00_36 = callPackage ../misc/cups/drivers/samsung/1.00.36/default.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There is a printer in a house in which I maintain workstations that people seem to want to print from.
They know nothing of the pains I've gone through to get this working.
But I don't mind too much, they're my family after all.

It's not pretty, and probably not worth it making it more pretty than this.
It works for me, it is probably good enough for the consumption of others.

![image](https://user-images.githubusercontent.com/131599/120909677-b67d3980-c677-11eb-9d3b-3d2b50515633.png)

My motivation to change anything is low. Bite me
Oh and I need this ported to 21.05, can't well run my parents on unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Wasted hours of my life on printers and cups debug logs
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested on the actual model this driver is for
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
