### PR TITLE
haskellPackages.reactive-banana: specify dependency versions

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1949,5 +1949,7 @@ EOT
     testTarget = "libarchive-test --test-options='-j1'";
   };
 
-  reactive-banana = super.reactive-banana.override { hashable = self.hashable_1_2_7_0; semigroups = self.semigroups_0_18_5;};
+  # unrestrict bounds for hashable and semigroups
+  # https://github.com/NixOS/nixpkgs/pull/125893
+  reactive-banana = doJailbreak super.reactive-banana;
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1949,4 +1949,5 @@ EOT
     testTarget = "libarchive-test --test-options='-j1'";
   };
 
+  reactive-banana = super.reactive-banana.override { hashable = self.hashable_1_2_7_0; semigroups = self.semigroups_0_18_5;};
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3798,7 +3798,6 @@ broken-packages:
   - react-haskell
   - reaction-logic
   - reactive-bacon
-  - reactive-banana
   - reactive-thread
   - react-tutorial-haskell-server
   - readability

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -122,8 +122,6 @@ extra-packages:
   - gi-gtk < 4.0                        # 2021-05-07: For haskell-gi 0.25 without gtk4
   - gi-gdkx11 == 3.0.11                 # 2021-05-07: For haskell-gi 0.25 without gtk4
   - ShellCheck == 0.7.1                 # 2021-05-09: haskell-ci 0.12.1 pins this version
-  - hashable < 1.3                      # required by reactive-banana 1.2.1.0
-  - semigroups < 0.19			# required by reactive-banana 1.2.1.0
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -122,6 +122,8 @@ extra-packages:
   - gi-gtk < 4.0                        # 2021-05-07: For haskell-gi 0.25 without gtk4
   - gi-gdkx11 == 3.0.11                 # 2021-05-07: For haskell-gi 0.25 without gtk4
   - ShellCheck == 0.7.1                 # 2021-05-09: haskell-ci 0.12.1 pins this version
+  - hashable < 1.3                      # required by reactive-banana 1.2.1.0
+  - semigroups < 0.19			# required by reactive-banana 1.2.1.0
 
 package-maintainers:
   abbradar:


### PR DESCRIPTION
###### Motivation for this change
Fix `reactive-banana `dep versions


Hey, I'm very new to nix and contributing, when I tried to use `reactive-banana` it gave this error:
`error: Package ‘reactive-banana-1.2.1.0’ in /nix/store/b61rcazs8v85crr816filiaq6g9x4gdi-nixpkgs-src/pkgs/development/haskell-modules/hackage-packages.nix:211255 is marked as broken, refusing to evaluate.`

And then following [this tutorial](https://www.youtube.com/watch?v=KLhkAEk8I20) tried to compile the package and got this 
error: 
```
Setup: Encountered missing or private dependencies:
hashable >=1.1 && <1.3, semigroups >=0.13 && <0.19
```
And eventually figured out that I had to add in the versions in the config file for hackage2nix and followed this [tutorial](https://www.youtube.com/watch?v=qX0mgtSm360) (thanks again Peter).

But then couldn't figure out which `all-cabal-hashes` revision was needed and wasn't exactly sure how to run `hackage2nix` to get the desired output (when I ran it, it removed many if not all of `hydraPlatforms = lib.platforms.none;`)

But even with this output I thought I should at least be able to compile the `reactive-banana`, but got the following error:
```
.
.
.
setupCompileFlags: -package-db=/build/setup-package.conf.d -j16 +RTS -A64M -RTS -threaded -rtsopts
unpacking sources
unpacking source archive /nix/store/lwmkwfc64gznfd38q898y9fhy6v32lzf-hashable-1.2.7.0.tar.gz
source root is hashable-1.2.7.0
setting SOURCE_DATE_EPOCH to timestamp 1520460129 of file hashable-1.2.7.0/tests/Regress/Mmap.hsc
patching sources
Replace Cabal file with edited version from mirror://hackage/hashable-1.2.7.0/revision/1.cabal.
unpacking sources
compileBuildDriverPhase
unpacking source archive /nix/store/9w21njlyzvmnbwaa2kggnr83z14nxh7s-hashable-1.3.2.0.tar.gz
setupCompileFlags: -package-db=/build/setup-package.conf.d -j16 +RTS -A64M -RTS -threaded -rtsopts
source root is hashable-1.3.2.0
setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file hashable-1.3.2.0/tests/Regress/Mmap.hsc
patching sources
[1 of 1] Compiling Main             ( Setup.lhs, /build/Main.o )
dos2unix: converting file hashable.cabal to Unix format...
applying patch /nix/store/mn6mrn7f5qp9qrxl4yzxv7pq1s00w0av-78fa8fdb4f8bec5d221f34110d6afa0d0a00b5f9.patch
patching file hashable.cabal
Hunk #1 FAILED at 83.
1 out of 1 hunk FAILED -- saving rejects to file hashable.cabal.rej
error: builder for '/nix/store/hl0apz1xialy28hvcc7rqmmgg7i50ibn-hashable-1.3.2.0.drv' failed with exit code 1;
       last 10 log lines:
       > unpacking sources
       > unpacking source archive /nix/store/9w21njlyzvmnbwaa2kggnr83z14nxh7s-hashable-1.3.2.0.tar.gz
       > source root is hashable-1.3.2.0
       > setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file hashable-1.3.2.0/tests/Regress/Mmap.hsc
       > patching sources
       > dos2unix: converting file hashable.cabal to Unix format...
       > applying patch /nix/store/mn6mrn7f5qp9qrxl4yzxv7pq1s00w0av-78fa8fdb4f8bec5d221f34110d6afa0d0a00b5f9.patch
       > patching file hashable.cabal
       > Hunk #1 FAILED at 83.
       > 1 out of 1 hunk FAILED -- saving rejects to file hashable.cabal.rej
       For full logs, run 'nix log /nix/store/hl0apz1xialy28hvcc7rqmmgg7i50ibn-hashable-1.3.2.0.drv'.
error: 1 dependencies of derivation '/nix/store/862nhzqm96qhdb6i5rk158c01js4x3z1-psqueues-0.2.7.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1wmkd4ycihs590gxypjwd5vqgiqp31d3-reactive-banana-1.2.1.0.drv' failed to build
```

Not sure if I'm on the right track, hope someone can help me out.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).