### PR TITLE
gstreamer: move executables to bin output

### DIFF
--- a/pkgs/applications/kde/kamoso.nix
+++ b/pkgs/applications/kde/kamoso.nix
@@ -34,7 +34,7 @@ mkDerivation {
   ];
 
   qtWrapperArgs = [
-    "--prefix GST_PLUGIN_PATH : ${lib.makeSearchPath "lib/gstreamer-1.0" gst}"
+    "--prefix GST_PLUGIN_PATH : ${lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gst}"
   ];
 
   meta.license = with lib.licenses; [ lgpl21Only gpl3Only ];

--- a/pkgs/applications/misc/qt-video-wlr/default.nix
+++ b/pkgs/applications/misc/qt-video-wlr/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, pkg-config, meson, ninja, wayland, pixman, cairo, librsvg, wayland-protocols, wlroots, libxkbcommon, gst_all_1, wrapQtAppsHook, qtbase, qtmultimedia }:
 let
- gstreamerPath = with gst_all_1; lib.makeSearchPath "lib/gstreamer-1.0" [
+ gstreamerPath = with gst_all_1; lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
      gstreamer
      gst-plugins-base
      gst-plugins-good

--- a/pkgs/applications/networking/browsers/nyxt/default.nix
+++ b/pkgs/applications/networking/browsers/nyxt/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     xclip notify-osd enchant
   ] ++ gstBuildInputs;
 
-  GST_PLUGIN_SYSTEM_PATH_1_0 = lib.concatMapStringsSep ":" (p: "${p}/lib/gstreamer-1.0") gstBuildInputs;
+  GST_PLUGIN_SYSTEM_PATH_1_0 = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gstBuildInputs;
 
   dontWrapGApps = true;
   installPhase = ''

--- a/pkgs/development/libraries/grilo-plugins/default.nix
+++ b/pkgs/development/libraries/grilo-plugins/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # * chromaprint (gst-plugins-bad)
     (substituteAll {
       src = ./chromaprint-gst-plugins.patch;
-      load_plugins = lib.concatMapStrings (plugin: ''gst_registry_scan_path(gst_registry_get(), "${plugin}/lib/gstreamer-1.0");'') (with gst_all_1; [
+      load_plugins = lib.concatMapStrings (plugin: ''gst_registry_scan_path(gst_registry_get(), "${lib.getLib plugin}/lib/gstreamer-1.0");'') (with gst_all_1; [
         gstreamer
         gst-plugins-base
         gst-plugins-bad

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -24,13 +24,13 @@ stdenv.mkDerivation rec {
   version = "1.18.4";
 
   outputs = [
+    "bin"
     "out"
     "dev"
     # "devdoc" # disabled until `hotdoc` is packaged in nixpkgs, see:
     # - https://github.com/NixOS/nixpkgs/pull/98767
     # - https://github.com/NixOS/nixpkgs/issues/98769#issuecomment-702296551
   ];
-  outputBin = "dev";
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/${pname}/${pname}-${version}.tar.xz";
@@ -92,14 +92,14 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    for prog in "$dev/bin/"*; do
+    for prog in "$bin/bin/"*; do
         # We can't use --suffix here due to quoting so we craft the export command by hand
         wrapProgram "$prog" --run 'export GST_PLUGIN_SYSTEM_PATH_1_0=$GST_PLUGIN_SYSTEM_PATH_1_0''${GST_PLUGIN_SYSTEM_PATH_1_0:+:}$(unset _tmp; for profile in $NIX_PROFILES; do _tmp="$profile/lib/gstreamer-1.0''${_tmp:+:}$_tmp"; done; printf '%s' "$_tmp")'
     done
   '';
 
   preFixup = ''
-    moveToOutput "share/bash-completion" "$dev"
+    moveToOutput "share/bash-completion" "$bin"
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./gst-hardcode-plugins.patch;
       load_gst_plugins = lib.concatMapStrings
-        (plugin: ''gst_registry_scan_path(gst_registry_get(), "${plugin}/lib/gstreamer-1.0");'')
+        (plugin: ''gst_registry_scan_path(gst_registry_get(), "${lib.getLib plugin}/lib/gstreamer-1.0");'')
         (gstPlugins gst_all_1);
     })
   ];

--- a/pkgs/tools/networking/gmrender-resurrect/default.nix
+++ b/pkgs/tools/networking/gmrender-resurrect/default.nix
@@ -4,9 +4,7 @@
 let
   version = "0.0.9";
 
-  makePluginPath = plugins: builtins.concatStringsSep ":" (map (p: p + "/lib/gstreamer-1.0") plugins);
-
-  pluginPath = makePluginPath [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ];
+  pluginPath = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ];
 in
   stdenv.mkDerivation {
     pname = "gmrender-resurrect";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Gstreamer should expose gst-launch-1.0 and gst-inspect-1.0 to users, not developers only.
I propose to just move binaries from "dev" to "out".

please read discussion here with @jtojnar: https://github.com/NixOS/nixpkgs/commit/e8043ce0ab44f449cc36f0d1edb6e61fe5b0e41b#r51706501

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
