### PR TITLE
signald: use jre_headless

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -52,20 +52,28 @@ in stdenv.mkDerivation rec {
   inherit pname src version postPatch patches;
 
   buildPhase = ''
+    runHook preBuild
+
     export GRADLE_USER_HOME=$(mktemp -d)
 
     # Use the local packages from -deps
     sed -i -e 's|mavenCentral()|mavenLocal(); maven { url uri("${deps}") }|' build.gradle
 
     gradle --offline --no-daemon distTar
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out
     tar xvf ./build/distributions/signald.tar --strip-components=1 --directory $out/
     wrapProgram $out/bin/signald \
       --prefix PATH : ${lib.makeBinPath [ coreutils ]} \
       --set JAVA_HOME "${jre_headless}"
+
+    runHook postInstall
   '';
 
   nativeBuildInputs = [ git gradle_6 makeWrapper ];

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchgit, jre, coreutils, gradle_6, git, perl
+{ lib, stdenv, fetchurl, fetchgit, jre_headless, coreutils, gradle_6, git, perl
 , makeWrapper }:
 
 let
@@ -65,7 +65,7 @@ in stdenv.mkDerivation rec {
     tar xvf ./build/distributions/signald.tar --strip-components=1 --directory $out/
     wrapProgram $out/bin/signald \
       --prefix PATH : ${lib.makeBinPath [ coreutils ]} \
-      --set JAVA_HOME "${jre}"
+      --set JAVA_HOME "${jre_headless}"
   '';
 
   nativeBuildInputs = [ git gradle_6 makeWrapper ];


### PR DESCRIPTION
There is no GUI component


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).