### PR TITLE
vim-utils: load plug / pathogen plugins before customRC

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -341,10 +341,10 @@ let
         beforePlugins
         vamImpl
         (nativeImpl packages)
-        customRC
       ]
       ++ lib.optional (pathogen != null) pathogenImpl
-      ++ lib.optional (plug != null) plugImpl;
+      ++ lib.optional (plug != null) plugImpl
+      ++ [ customRC ];
 
     in
       lib.concatStringsSep "\n" (lib.filter (x: x != null && x != "") entries);


### PR DESCRIPTION
###### Motivation for this change

My vim's `customRC` contains `color NeoSolarized`, and my `plug.plugins` includes `vimPlugins.NeoSolarized` to provide this scheme.

Unfortunately, this doesn't work because that attempts to set the colorscheme before it's defined, so vim errors on startup.

This seems like a low-risk change since this is already how VAM works (it comes before customRC), and there's also `beforePlugins` if you really need to inject something prior to plugin loading.

/cc @teto because it looks like this is restoring the original ordering which you changed in 7836469dbe40783c640e2c0fafd2e55248ffea31. I don't want to revert it if that was intentional, but I can't see any rationale for it in [the PR](https://github.com/NixOS/nixpkgs/pull/120445/files) and what I'm doing here matches [your comment](https://github.com/NixOS/nixpkgs/pull/124577#issuecomment-849470378) in a separate issue.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
