### PR TITLE
php: Simplify generic.nix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -199,9 +199,9 @@
 /doc/languages-frameworks/php.section.md @NixOS/php
 /nixos/tests/php                         @NixOS/php
 /pkgs/build-support/build-pecl.nix       @NixOS/php
-/pkgs/development/interpreters/php       @NixOS/php
+/pkgs/development/interpreters/php       @NixOS/php @jtojnar
 /pkgs/development/php-packages           @NixOS/php
-/pkgs/top-level/php-packages.nix         @NixOS/php
+/pkgs/top-level/php-packages.nix         @NixOS/php @jtojnar
 
 # Podman, CRI-O modules and related
 /nixos/modules/virtualisation/containers.nix @NixOS/podman @zowoq

--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -1,9 +1,7 @@
-{ callPackage, lib, stdenv, nixosTests, ... }@_args:
+{ callPackage, lib, stdenv, ... }@_args:
 
 let
-  generic = (import ./generic.nix) _args;
-
-  base = callPackage generic (_args // {
+  base = callPackage ./generic.nix (_args // {
     version = "7.4.20";
     sha256 = "0d5ncz97y0271dsmz269wl4721vhq2fn6pmm9rxglc756p36pnha";
   });

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -1,9 +1,7 @@
-{ callPackage, lib, stdenv, nixosTests, ... }@_args:
+{ callPackage, lib, stdenv, ... }@_args:
 
 let
-  generic = (import ./generic.nix) _args;
-
-  base = callPackage generic (_args // {
+  base = callPackage ./generic.nix (_args // {
     version = "8.0.7";
     sha256 = "0yazcc9x66xg1gmi3rpgk891g6s3mm7aywcadqfqnx1mdz4z5ckj";
   });

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -1,8 +1,6 @@
 # We have tests for PCRE and PHP-FPM in nixos/tests/php/ or
 # both in the same attribute named nixosTests.php
 
-{ callPackage, lib, stdenv, nixosTests, ... }:
-
 let
   generic =
     { callPackage, lib, stdenv, nixosTests, fetchurl, makeWrapper
@@ -33,250 +31,251 @@ let
     , valgrindSupport ? !stdenv.isDarwin
     , ztsSupport ? apxs2Support
     }@args:
-      let
-        # buildEnv wraps php to provide additional extensions and
-        # configuration. Its usage is documented in
-        # doc/languages-frameworks/php.section.md.
-        #
-        # Create a buildEnv with earlier overridden values and
-        # extensions functions in its closure. This is necessary for
-        # consecutive calls to buildEnv and overrides to work as
-        # expected.
-        mkBuildEnv = prevArgs: prevExtensionFunctions: lib.makeOverridable (
-          { extensions ? ({ enabled, ... }: enabled), extraConfig ? "", ... }@innerArgs:
-            let
-              allArgs = args // prevArgs // innerArgs;
-              filteredArgs = builtins.removeAttrs allArgs [ "extensions" "extraConfig" ];
-              php = generic filteredArgs;
 
-              php-packages = (callPackage ../../../top-level/php-packages.nix {
-                phpPackage = phpWithExtensions;
-              }).overrideScope' packageOverrides;
+    let
+      # buildEnv wraps php to provide additional extensions and
+      # configuration. Its usage is documented in
+      # doc/languages-frameworks/php.section.md.
+      #
+      # Create a buildEnv with earlier overridden values and
+      # extensions functions in its closure. This is necessary for
+      # consecutive calls to buildEnv and overrides to work as
+      # expected.
+      mkBuildEnv = prevArgs: prevExtensionFunctions: lib.makeOverridable (
+        { extensions ? ({ enabled, ... }: enabled), extraConfig ? "", ... }@innerArgs:
+          let
+            allArgs = args // prevArgs // innerArgs;
+            filteredArgs = builtins.removeAttrs allArgs [ "extensions" "extraConfig" ];
+            php = generic filteredArgs;
 
-              allExtensionFunctions = prevExtensionFunctions ++ [ extensions ];
-              enabledExtensions =
-                builtins.foldl'
-                  (enabled: f:
-                    f { inherit enabled; all = php-packages.extensions; })
-                  []
-                  allExtensionFunctions;
+            php-packages = (callPackage ../../../top-level/php-packages.nix {
+              phpPackage = phpWithExtensions;
+            }).overrideScope' packageOverrides;
 
-              getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
+            allExtensionFunctions = prevExtensionFunctions ++ [ extensions ];
+            enabledExtensions =
+              builtins.foldl'
+                (enabled: f:
+                  f { inherit enabled; all = php-packages.extensions; })
+                []
+                allExtensionFunctions;
 
-              # Recursively get a list of all internal dependencies
-              # for a list of extensions.
-              getDepsRecursively = extensions:
-                let
-                  deps = lib.concatMap
-                           (ext: (ext.internalDeps or []) ++ (ext.peclDeps or []))
-                           extensions;
-                in
-                  if ! (deps == []) then
-                    deps ++ (getDepsRecursively deps)
-                  else
-                    deps;
+            getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
 
-              # Generate extension load configuration snippets from the
-              # extension parameter. This is an attrset suitable for use
-              # with textClosureList, which is used to put the strings in
-              # the right order - if a plugin which is dependent on
-              # another plugin is placed before its dependency, it will
-              # fail to load.
-              extensionTexts =
-                lib.listToAttrs
-                  (map (ext:
-                    let
-                      extName = getExtName ext;
-                      phpDeps = (ext.internalDeps or []) ++ (ext.peclDeps or []);
-                      type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
-                    in
-                      lib.nameValuePair extName {
-                        text = "${type}=${ext}/lib/php/extensions/${extName}.so";
-                        deps = map getExtName phpDeps;
-                      })
-                    (enabledExtensions ++ (getDepsRecursively enabledExtensions)));
+            # Recursively get a list of all internal dependencies
+            # for a list of extensions.
+            getDepsRecursively = extensions:
+              let
+                deps = lib.concatMap
+                         (ext: (ext.internalDeps or []) ++ (ext.peclDeps or []))
+                         extensions;
+              in
+                if ! (deps == []) then
+                  deps ++ (getDepsRecursively deps)
+                else
+                  deps;
 
-              extNames = map getExtName enabledExtensions;
-              extraInit = writeText "php-extra-init-${version}.ini" ''
-                ${lib.concatStringsSep "\n"
-                  (lib.textClosureList extensionTexts extNames)}
-                ${extraConfig}
-              '';
+            # Generate extension load configuration snippets from the
+            # extension parameter. This is an attrset suitable for use
+            # with textClosureList, which is used to put the strings in
+            # the right order - if a plugin which is dependent on
+            # another plugin is placed before its dependency, it will
+            # fail to load.
+            extensionTexts =
+              lib.listToAttrs
+                (map (ext:
+                  let
+                    extName = getExtName ext;
+                    phpDeps = (ext.internalDeps or []) ++ (ext.peclDeps or []);
+                    type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
+                  in
+                    lib.nameValuePair extName {
+                      text = "${type}=${ext}/lib/php/extensions/${extName}.so";
+                      deps = map getExtName phpDeps;
+                    })
+                  (enabledExtensions ++ (getDepsRecursively enabledExtensions)));
 
-              phpWithExtensions = symlinkJoin {
-                name = "php-with-extensions-${version}";
-                inherit (php) version;
-                nativeBuildInputs = [ makeWrapper ];
-                passthru = php.passthru // {
-                  buildEnv = mkBuildEnv allArgs allExtensionFunctions;
-                  withExtensions = mkWithExtensions allArgs allExtensionFunctions;
-                  phpIni = "${phpWithExtensions}/lib/php.ini";
-                  unwrapped = php;
-                  # Select the right php tests for the php version
-                  tests = nixosTests."php${lib.strings.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor php.version)}";
-                  inherit (php-packages) extensions buildPecl;
-                  packages = php-packages.tools;
-                  meta = php.meta // {
-                    outputsToInstall = [ "out" ];
-                  };
+            extNames = map getExtName enabledExtensions;
+            extraInit = writeText "php-extra-init-${version}.ini" ''
+              ${lib.concatStringsSep "\n"
+                (lib.textClosureList extensionTexts extNames)}
+              ${extraConfig}
+            '';
+
+            phpWithExtensions = symlinkJoin {
+              name = "php-with-extensions-${version}";
+              inherit (php) version;
+              nativeBuildInputs = [ makeWrapper ];
+              passthru = php.passthru // {
+                buildEnv = mkBuildEnv allArgs allExtensionFunctions;
+                withExtensions = mkWithExtensions allArgs allExtensionFunctions;
+                phpIni = "${phpWithExtensions}/lib/php.ini";
+                unwrapped = php;
+                # Select the right php tests for the php version
+                tests = nixosTests."php${lib.strings.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor php.version)}";
+                inherit (php-packages) extensions buildPecl;
+                packages = php-packages.tools;
+                meta = php.meta // {
+                  outputsToInstall = [ "out" ];
                 };
-                paths = [ php ];
-                postBuild = ''
-                  ln -s ${extraInit} $out/lib/php.ini
-
-                  if test -e $out/bin/php; then
-                    wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
-                  fi
-
-                  if test -e $out/bin/php-fpm; then
-                    wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
-                  fi
-
-                  if test -e $out/bin/phpdbg; then
-                    wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
-                  fi
-                '';
               };
-            in
-              phpWithExtensions);
+              paths = [ php ];
+              postBuild = ''
+                ln -s ${extraInit} $out/lib/php.ini
 
-        mkWithExtensions = prevArgs: prevExtensionFunctions: extensions:
-          mkBuildEnv prevArgs prevExtensionFunctions { inherit extensions; };
-      in
-        stdenv.mkDerivation {
-          pname = "php";
+                if test -e $out/bin/php; then
+                  wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
+                fi
 
-          inherit version;
+                if test -e $out/bin/php-fpm; then
+                  wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
+                fi
 
-          enableParallelBuilding = true;
+                if test -e $out/bin/phpdbg; then
+                  wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
+                fi
+              '';
+            };
+          in
+            phpWithExtensions);
 
-          nativeBuildInputs = [ autoconf automake bison flex libtool pkg-config re2c ]
-            ++ lib.optional stdenv.isDarwin xcbuild;
+      mkWithExtensions = prevArgs: prevExtensionFunctions: extensions:
+        mkBuildEnv prevArgs prevExtensionFunctions { inherit extensions; };
+    in
+    stdenv.mkDerivation {
+      pname = "php";
 
-          buildInputs =
-            # PCRE extension
-            [ pcre2 ]
+      inherit version;
 
-            # Enable sapis
-            ++ lib.optional pearSupport [ libxml2.dev ]
+      enableParallelBuilding = true;
 
-            # Misc deps
-            ++ lib.optional apxs2Support apacheHttpd
-            ++ lib.optional argon2Support libargon2
-            ++ lib.optional systemdSupport systemd
-            ++ lib.optional valgrindSupport valgrind
-          ;
+      nativeBuildInputs = [ autoconf automake bison flex libtool pkg-config re2c ]
+        ++ lib.optional stdenv.isDarwin xcbuild;
 
-          CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
+      buildInputs =
+        # PCRE extension
+        [ pcre2 ]
 
-          configureFlags =
-            # Disable all extensions
-            [ "--disable-all" ]
+        # Enable sapis
+        ++ lib.optional pearSupport [ libxml2.dev ]
 
-            # PCRE
-            ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre2.dev}" ]
-            ++ lib.optionals (lib.versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre2.dev}" ]
-            ++ lib.optionals (lib.versionOlder version "7.3") [ "--with-pcre-regex=${pcre2.dev}" ]
-            ++ [ "PCRE_LIBDIR=${pcre2}" ]
+        # Misc deps
+        ++ lib.optional apxs2Support apacheHttpd
+        ++ lib.optional argon2Support libargon2
+        ++ lib.optional systemdSupport systemd
+        ++ lib.optional valgrindSupport valgrind
+      ;
 
+      CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
-            # Enable sapis
-            ++ lib.optional (!cgiSupport) "--disable-cgi"
-            ++ lib.optional (!cliSupport) "--disable-cli"
-            ++ lib.optional fpmSupport    "--enable-fpm"
-            ++ lib.optional pearSupport [ "--with-pear" "--enable-xml" "--with-libxml" ]
-            ++ lib.optionals (pearSupport && (lib.versionOlder version "7.4")) [
-              "--enable-libxml"
-              "--with-libxml-dir=${libxml2.dev}"
-            ]
-            ++ lib.optional pharSupport   "--enable-phar"
-            ++ lib.optional (!phpdbgSupport) "--disable-phpdbg"
+      configureFlags =
+        # Disable all extensions
+        [ "--disable-all" ]
 
-
-            # Misc flags
-            ++ lib.optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
-            ++ lib.optional argon2Support "--with-password-argon2=${libargon2}"
-            ++ lib.optional cgotoSupport "--enable-re2c-cgoto"
-            ++ lib.optional embedSupport "--enable-embed"
-            ++ lib.optional (!ipv6Support) "--disable-ipv6"
-            ++ lib.optional systemdSupport "--with-fpm-systemd"
-            ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
-            ++ lib.optional (ztsSupport && (lib.versionOlder version "8.0")) "--enable-maintainer-zts"
-            ++ lib.optional (ztsSupport && (lib.versionAtLeast version "8.0")) "--enable-zts"
+        # PCRE
+        ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre2.dev}" ]
+        ++ lib.optionals (lib.versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre2.dev}" ]
+        ++ lib.optionals (lib.versionOlder version "7.3") [ "--with-pcre-regex=${pcre2.dev}" ]
+        ++ [ "PCRE_LIBDIR=${pcre2}" ]
 
 
-            # Sendmail
-            ++ [ "PROG_SENDMAIL=${system-sendmail}/bin/sendmail" ]
-          ;
+        # Enable sapis
+        ++ lib.optional (!cgiSupport) "--disable-cgi"
+        ++ lib.optional (!cliSupport) "--disable-cli"
+        ++ lib.optional fpmSupport    "--enable-fpm"
+        ++ lib.optional pearSupport [ "--with-pear" "--enable-xml" "--with-libxml" ]
+        ++ lib.optionals (pearSupport && (lib.versionOlder version "7.4")) [
+          "--enable-libxml"
+          "--with-libxml-dir=${libxml2.dev}"
+        ]
+        ++ lib.optional pharSupport   "--enable-phar"
+        ++ lib.optional (!phpdbgSupport) "--disable-phpdbg"
 
-          hardeningDisable = [ "bindnow" ];
 
-          preConfigure =
-          # Don't record the configure flags since this causes unnecessary
-          # runtime dependencies
-          ''
-            for i in main/build-defs.h.in scripts/php-config.in; do
-              substituteInPlace $i \
-                --replace '@CONFIGURE_COMMAND@' '(omitted)' \
-                --replace '@CONFIGURE_OPTIONS@' "" \
-                --replace '@PHP_LDFLAGS@' ""
-            done
+        # Misc flags
+        ++ lib.optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+        ++ lib.optional argon2Support "--with-password-argon2=${libargon2}"
+        ++ lib.optional cgotoSupport "--enable-re2c-cgoto"
+        ++ lib.optional embedSupport "--enable-embed"
+        ++ lib.optional (!ipv6Support) "--disable-ipv6"
+        ++ lib.optional systemdSupport "--with-fpm-systemd"
+        ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
+        ++ lib.optional (ztsSupport && (lib.versionOlder version "8.0")) "--enable-maintainer-zts"
+        ++ lib.optional (ztsSupport && (lib.versionAtLeast version "8.0")) "--enable-zts"
 
-            export EXTENSION_DIR=$out/lib/php/extensions
-          ''
-          # PKG_CONFIG need not be a relative path
-          + lib.optionalString (! lib.versionAtLeast version "7.4") ''
-            for i in $(find . -type f -name "*.m4"); do
-              substituteInPlace $i \
-                --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
-            done
-          '' + ''
-            ./buildconf --copy --force
 
-            if test -f $src/genfiles; then
-              ./genfiles
-            fi
-          '' + lib.optionalString stdenv.isDarwin ''
-            substituteInPlace configure --replace "-lstdc++" "-lc++"
-          '';
+        # Sendmail
+        ++ [ "PROG_SENDMAIL=${system-sendmail}/bin/sendmail" ]
+      ;
 
-          postInstall = ''
-            test -d $out/etc || mkdir $out/etc
-            cp php.ini-production $out/etc/php.ini
-          '';
+      hardeningDisable = [ "bindnow" ];
 
-          postFixup = ''
-            mkdir -p $dev/bin $dev/share/man/man1
-            mv $out/bin/phpize $out/bin/php-config $dev/bin/
-            mv $out/share/man/man1/phpize.1.gz \
-               $out/share/man/man1/php-config.1.gz \
-               $dev/share/man/man1/
-          '';
+      preConfigure =
+      # Don't record the configure flags since this causes unnecessary
+      # runtime dependencies
+      ''
+        for i in main/build-defs.h.in scripts/php-config.in; do
+          substituteInPlace $i \
+            --replace '@CONFIGURE_COMMAND@' '(omitted)' \
+            --replace '@CONFIGURE_OPTIONS@' "" \
+            --replace '@PHP_LDFLAGS@' ""
+        done
 
-          src = fetchurl {
-            url = "https://www.php.net/distributions/php-${version}.tar.bz2";
-            inherit sha256;
-          };
+        export EXTENSION_DIR=$out/lib/php/extensions
+      ''
+      # PKG_CONFIG need not be a relative path
+      + lib.optionalString (! lib.versionAtLeast version "7.4") ''
+        for i in $(find . -type f -name "*.m4"); do
+          substituteInPlace $i \
+            --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
+        done
+      '' + ''
+        ./buildconf --copy --force
 
-          patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
+        if test -f $src/genfiles; then
+          ./genfiles
+        fi
+      '' + lib.optionalString stdenv.isDarwin ''
+        substituteInPlace configure --replace "-lstdc++" "-lc++"
+      '';
 
-          separateDebugInfo = true;
+      postInstall = ''
+        test -d $out/etc || mkdir $out/etc
+        cp php.ini-production $out/etc/php.ini
+      '';
 
-          outputs = [ "out" "dev" ];
+      postFixup = ''
+        mkdir -p $dev/bin $dev/share/man/man1
+        mv $out/bin/phpize $out/bin/php-config $dev/bin/
+        mv $out/share/man/man1/phpize.1.gz \
+           $out/share/man/man1/php-config.1.gz \
+           $dev/share/man/man1/
+      '';
 
-          passthru = {
-            buildEnv = mkBuildEnv {} [];
-            withExtensions = mkWithExtensions {} [];
-            inherit ztsSupport;
-          };
+      src = fetchurl {
+        url = "https://www.php.net/distributions/php-${version}.tar.bz2";
+        inherit sha256;
+      };
 
-          meta = with lib; {
-            description = "An HTML-embedded scripting language";
-            homepage = "https://www.php.net/";
-            license = licenses.php301;
-            maintainers = teams.php.members;
-            platforms = platforms.all;
-            outputsToInstall = [ "out" "dev" ];
-          };
-        };
+      patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
+
+      separateDebugInfo = true;
+
+      outputs = [ "out" "dev" ];
+
+      passthru = {
+        buildEnv = mkBuildEnv {} [];
+        withExtensions = mkWithExtensions {} [];
+        inherit ztsSupport;
+      };
+
+      meta = with lib; {
+        description = "An HTML-embedded scripting language";
+        homepage = "https://www.php.net/";
+        license = licenses.php301;
+        maintainers = teams.php.members;
+        platforms = platforms.all;
+        outputsToInstall = [ "out" "dev" ];
+      };
+    };
 in generic


### PR DESCRIPTION
###### Motivation for this change
There is no need for the outer function since all arguments are shadowed anyway.

Also add myself to codeowners.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
