### PR TITLE
gocryptfs: 1.8.0 -> 2.0

### DIFF
--- a/pkgs/tools/filesystems/gocryptfs/default.nix
+++ b/pkgs/tools/filesystems/gocryptfs/default.nix
@@ -1,27 +1,41 @@
 { lib
+, stdenv
 , buildGoModule
 , fetchFromGitHub
 , openssl
 , pandoc
 , pkg-config
+, libfido2
 }:
+
+let
+  # pandoc is currently broken on aarch64-darwin
+  # because of missing ghc
+  brokenPandoc = stdenv.isDarwin && stdenv.isAarch64;
+in
 
 buildGoModule rec {
   pname = "gocryptfs";
-  version = "1.8.0";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "rfjakob";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1acalwrr5xqhpqca3gypj0s68w6vpckxmg5z5gfgh8wx6nqx4aw9";
+    sha256 = "1wpdzi1qfpab76v0ki74qkk82m3ykr4iqb8r6a8k11l4fn42fjk0";
   };
 
-  runVend = true;
-  vendorSha256 = "0z3y51sgr1rmr23jpc5h5d5lw14p3qzv48rc7zj7qa4rd5cfhsgi";
+  vendorSha256 = "10az8n7z4rhsk1af2x6v3pmxg4zp7c9cal35ily8bdzzcb9cpgs0";
 
-  nativeBuildInputs = [ pandoc pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals (!brokenPandoc) [
+    pandoc
+  ];
+
   buildInputs = [ openssl ];
+
+  propagatedBuildInputs = [ libfido2 ];
 
   buildFlagsArray = ''
     -ldflags=
@@ -32,9 +46,10 @@ buildGoModule rec {
 
   subPackages = [ "." "gocryptfs-xray" "contrib/statfs" ];
 
-  postBuild = ''
+  postBuild = lib.optionalString (!brokenPandoc) ''
     pushd Documentation/
     mkdir -p $out/share/man/man1
+    # taken from Documentation/MANPAGE-render.bash
     pandoc MANPAGE.md -s -t man -o $out/share/man/man1/gocryptfs.1
     pandoc MANPAGE-XRAY.md -s -t man -o $out/share/man/man1/gocryptfs-xray.1
     pandoc MANPAGE-STATFS.md -s -t man -o $out/share/man/man1/statfs.1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update (supersedes https://github.com/NixOS/nixpkgs/pull/125872)
- add libfido2 to propagatedBuildInputs to enable fido2 features (gocryptfs uses command-line tools contained in the package)
- skip documentation on aarch64-darwin (pandoc is broken because of the missing ghc)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
