### PR TITLE
flips: unstable-2020-10-02 -> unstable-2021-05-18

### DIFF
--- a/pkgs/tools/compression/flips/default.nix
+++ b/pkgs/tools/compression/flips/default.nix
@@ -2,20 +2,24 @@
 
 stdenv.mkDerivation {
   pname = "flips";
-  version = "unstable-2020-10-02";
+  version = "unstable-2021-05-18";
 
   src = fetchFromGitHub {
     owner = "Alcaro";
     repo = "Flips";
-    rev = "5a3d2012b8ea53ae777c24b8ac4edb9a6bdb9761";
-    sha256 = "1ksh9j1n5z8b78yd7gjxswndsqnb1azp84xk4rc0p7zq127l0fyy";
+    rev = "3476e5e46fc6f10df475f0cad1714358ba04c756";
+    sha256 = "0s13qrmqfmlb2vy0smpgw39vjkl8vzsmpzk52jnc9r7b4hisii39";
   };
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
   buildInputs = [ gtk3 libdivsufsort ];
   patches = [ ./use-system-libdivsufsort.patch ];
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
-  buildPhase = "./make.sh";
+  buildPhase = ''
+    runHook preBuild
+    ./make.sh
+    runHook postBuild
+  '';
 
   meta = with lib; {
     description = "A patcher for IPS and BPS files";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
