### PR TITLE
qemu, runInLinuxVM: fix KVM availability check

### DIFF
--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -22,7 +22,7 @@ rec {
         else throw "Unknown QEMU serial device for system '${pkgs.stdenv.hostPlatform.system}'";
 
   qemuBinary = qemuPkg: {
-    x86_64-linux = "${qemuPkg}/bin/qemu-kvm -cpu max";
+    x86_64-linux = "${qemuPkg}/bin/qemu-kvm -cpu qemu64";
     armv7l-linux = "${qemuPkg}/bin/qemu-system-arm -enable-kvm -machine virt -cpu host";
     aarch64-linux = "${qemuPkg}/bin/qemu-system-aarch64 -enable-kvm -machine virt,gic-version=host -cpu host";
     powerpc64le-linux = "${qemuPkg}/bin/qemu-system-ppc64 -machine powernv";

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -222,7 +222,7 @@ stdenv.mkDerivation rec {
     if [ -x $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
       makeWrapper $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} \
                   $out/bin/qemu-kvm \
-                  --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"
+                  --add-flags "\$([ -r /dev/kvm -a -w /dev/kvm ] && echo -enable-kvm)"
     fi
   '';
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, python, zlib, pkg-config, glib
 , perl, pixman, vde2, alsa-lib, texinfo, flex
 , bison, lzo, snappy, libaio, libtasn1, gnutls, nettle, curl, ninja, meson, sigtool
-, makeWrapper, autoPatchelfHook
+, makeWrapper, autoPatchelfHook, runtimeShell
 , attr, libcap, libcap_ng
 , CoreServices, Cocoa, Hypervisor, rez, setfile
 , numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
@@ -219,9 +219,12 @@ stdenv.mkDerivation rec {
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = ''
+    cp -- $emitKvmWarningsPath $out/libexec/emit-kvm-warnings
+    chmod a+x -- $out/libexec/emit-kvm-warnings
     if [ -x $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
       makeWrapper $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} \
                   $out/bin/qemu-kvm \
+                  --run $out/libexec/emit-kvm-warnings \
                   --add-flags "\$([ -r /dev/kvm -a -w /dev/kvm ] && echo -enable-kvm)"
     fi
   '';
@@ -232,6 +235,26 @@ stdenv.mkDerivation rec {
 
   # Builds in ~3h with 2 cores, and ~20m with a big-parallel builder.
   requiredSystemFeatures = [ "big-parallel" ];
+
+  emitKvmWarnings = ''
+    #!${runtimeShell}
+    WARNCOL='\033[1;35m'
+    NEUTRALCOL='\033[0m'
+    WARNING="''${WARNCOL}warning:''${NEUTRALCOL}"
+    if [ ! -e /dev/kvm ]; then
+      echo -e "''${WARNING} KVM is not available - execution will be slow" >&2
+      echo "Consider installing KVM for hardware-accelerated execution." >&2
+      echo "If KVM is already installed make sure the kernel module is loaded." >&2
+    elif [ ! -r /dev/kvm -o ! -w /dev/kvm ]; then
+      echo -e "''${WARNING} /dev/kvm is not read-/writable - execution will be slow" >&2
+      echo "/dev/kvm needs to be read-/writable by the user executing QEMU." >&2
+      echo "" >&2
+      echo "For hardware-acceleration inside the nix build sandbox /dev/kvm" >&2
+      echo "must be world-read-/writable (rw-rw-rw-)." >&2
+    fi
+  '';
+
+  passAsFile = [ "emitKvmWarnings" ];
 
   meta = with lib; {
     homepage = "http://www.qemu.org/";


### PR DESCRIPTION
KVM should only be considered abailable if /dev/kvm exists and
is read-writable by the user that is trying to launch it.

The previous check for existance only had the consequence that
on some Linux distributions running VMs with Nix's QEMU only worked
if KVM was NOT installed.

See issue: https://github.com/NixOS/nixpkgs/issues/124371

---

To test this change I
1. built some NixOS Test driver on `x86_64` NixOS.
2. changed the permissions for /dev/kvm `chmod o-rw /dev/kvm`
3. ran `result/bin/nixos-run-vms`

Without this change that test failed right away with a log like this:
```
./nixos-run-vms
starting VDE switch for network 1
deleting VM state directory /tmp/vm-state-pia
if you want to keep the VM state, pass --keep-vm-state
deleting VM state directory /tmp/vm-state-satellite
if you want to keep the VM state, pass --keep-vm-state
deleting VM state directory /tmp/vm-state-sensor
if you want to keep the VM state, pass --keep-vm-state
running the VM test script
starting all VMs
pia: starting vm
pia # Formatting '/tmp/vm-state-pia/pia.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=536870912 lazy_refcounts=off refcount_bits=16
pia # Could not access KVM kernel module: Permission denied
pia # qemu-system-x86_64: failed to initialize kvm: Permission denied
pia: QEMU running (pid 2926214)
satellite: starting vm
satellite # Formatting '/tmp/vm-state-satellite/satellite.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=536870912 lazy_refcounts=off refcount_bits=16
satellite # Could not access KVM kernel module: Permission denied
satellite # qemu-system-x86_64: failed to initialize kvm: Permission denied
satellite: QEMU running (pid 2926260)
sensor: starting vm
sensor # Formatting '/tmp/vm-state-sensor/sensor.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=536870912 lazy_refcounts=off refcount_bits=16
sensor # Could not access KVM kernel module: Permission denied
sensor # qemu-system-x86_64: failed to initialize kvm: Permission denied
sensor: QEMU running (pid 2926271)
(1.33 seconds)
waiting for all VMs to finish
pia: waiting for the VM to power off
(0.00 seconds)
satellite: waiting for the VM to power off
(0.00 seconds)
sensor: waiting for the VM to power off
(0.00 seconds)
(0.00 seconds)
(1.33 seconds)
test script finished in 1.33s
cleaning up
(0.00 seconds)
```
while with the change the test proceeded without hardware acceleration via KVM.

I have also tested that this fixes the same issue when running QEMU inside the build sandbox as part of a NixOS Test. The NixOS Test checkbox is unchecked though, because there there is automatic NixOS Tests for the new behavior.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
