### PR TITLE
docs: acme: Fix typo

### DIFF
--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -194,7 +194,7 @@ services.httpd = {
   <para>
    This is useful if you want to generate a wildcard certificate, since
    ACME servers will only hand out wildcard certs over DNS validation.
-   There a number of supported DNS providers and servers you can utilise,
+   There are a number of supported DNS providers and servers you can utilise,
    see the <link xlink:href="https://go-acme.github.io/lego/dns/">lego docs</link>
    for provider/server specific configuration values. For the sake of these
    docs, we will provide a fully self-hosted example using bind.


### PR DESCRIPTION
###### Motivation for this change

Mini typo doc fix