### PR TITLE
matrix-appservice-discord: increase test timeout

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -155,7 +155,6 @@ with lib.maintainers; {
   matrix = {
     members = [
       ma27
-      pacien
       fadenb
       mguentner
       ekleog

--- a/pkgs/servers/matrix-appservice-discord/default.nix
+++ b/pkgs/servers/matrix-appservice-discord/default.nix
@@ -43,7 +43,8 @@ in mkYarnPackage rec {
 
   doCheck = true;
   checkPhase = ''
-    yarn --offline test
+    # the default 2000ms timeout is sometimes too short on our busy builders
+    yarn --offline test --timeout 10000
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

*   matrix-appservice-discord: increase test timeout
    Hydra and my local machine are sometimes hitting the default timeout.
    See https://hydra.nixos.org/build/138032455/nixlog/8/tail

*   maintainers/teams: remove pacien from the matrix team
    I prefer to focus only on the individual packages which I know.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
