### PR TITLE
graphene: fix nixos test

### DIFF
--- a/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
+++ b/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
@@ -23,7 +23,7 @@ index b9a2fb5..4b8629f 100644
 +       value: '',
 +       description: 'Installation directory for binary files in tests')
 diff --git a/tests/meson.build b/tests/meson.build
-index 77281f5..c4c7fac 100644
+index 77281f5..7522456 100644
 --- a/tests/meson.build
 +++ b/tests/meson.build
 @@ -21,8 +21,17 @@ unit_tests = [
@@ -71,7 +71,12 @@ index 77281f5..c4c7fac 100644
        ),
        env: ['MUTEST_OUTPUT=tap'],
        protocol: 'tap',
-@@ -70,13 +79,13 @@ if build_gir and host_system == 'linux' and not meson.is_cross_build()
+@@ -66,17 +75,18 @@ endif
+ if build_gir and host_system == 'linux' and not meson.is_cross_build()
+   foreach unit: ['introspection.py']
+     wrapper = '@0@.test'.format(unit)
++    install_data(unit, install_dir: test_bindir)
+     custom_target(wrapper,
        output: wrapper,
        command: [
          gen_installed_test,

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -12,6 +12,7 @@
 , docbook_xsl
 , docbook_xml_dtd_43
 , gobject-introspection
+, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gobject-introspection
     python3
+    makeWrapper
   ];
 
   buildInputs = [
@@ -62,6 +64,12 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs tests/gen-installed-test.py
+    PATH=${python3.withPackages (pp: [ pp.pygobject3 pp.tappy ])}/bin:$PATH patchShebangs tests/introspection.py
+  '';
+
+  postFixup = ''
+    wrapProgram "${placeholder "installedTests"}/libexec/installed-tests/graphene-1.0/introspection.py" \
+      --prefix GI_TYPELIB_PATH : "$out/lib/girepository-1.0"
   '';
 
   passthru = {


### PR DESCRIPTION
The file introspection.py was missing in the installed-tests files and
it requires python3 to run.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix failing nixos test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (gnome-todo fails, it seems it was broken before)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
