### PR TITLE
fdr: 4.2.3 -> 4.2.7

### DIFF
--- a/pkgs/applications/science/programming/fdr/default.nix
+++ b/pkgs/applications/science/programming/fdr/default.nix
@@ -1,9 +1,10 @@
-{lib, stdenv, fetchurl, qtbase, qtx11extras, ncurses5, xorg, zlib, python27Packages}:
+{ lib, stdenv, fetchurl, qtbase, qtx11extras, ncurses5, xorg, zlib, python27Packages }:
 stdenv.mkDerivation {
-  name = "fdr-4.2.3";
+  pname = "fdr";
+  version = "4.2.7";
   src = fetchurl {
-    url = "https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-3789-linux-x86_64.tar.gz";
-    sha256 = "0n2yqichym5xdawlgk3r7yha88k7ycnx6585jfrcm7043sls1i88";
+    url = "https://dl.cocotec.io/fdr/fdr-3814-linux-x86_64.tar.gz";
+    sha256 = "0cajz1gz4slq9nfhm8dqdgxl0kc950838n0lrf8jw4vl54gv6chh";
   };
 
   libPath = lib.makeLibraryPath [
@@ -59,7 +60,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "https://www.cs.ox.ac.uk/projects/fdr/";
+    homepage = "https://cocotec.io/fdr/";
     description = "The CSP refinement checker";
     license = licenses.unfreeRedistributable;
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

FDR has been updated but the derivation hasn't since 2017. This change bumps the version, uses `pname` and `version` instead of `name`, and updates the homepage, since FDR is now hosted on [Cocotec's website](https://cocotec.io/fdr/) instead of the [University of Oxford's website](https://www.cs.ox.ac.uk/projects/fdr/). (In fact you can click to see that the latter now redirects to the former.)

This doesn't fix the bug where `:graph` hangs while laying out after evaluating, but this was present prior to the change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
