### PR TITLE
nixos/tests/test-driver: cleanup "dead" code

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -907,7 +907,6 @@ class Machine:
 def create_machine(args: Dict[str, Any]) -> Machine:
     global log
     args["log"] = log
-    args["redirectSerial"] = os.environ.get("USE_SERIAL", "0") == "1"
     return Machine(args)
 
 

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -196,8 +196,7 @@ rec {
               --add-flags "''${vms[*]}" \
               ${lib.optionalString enableOCR "--prefix PATH : '${ocrProg}/bin'"} \
               --set tests 'start_all(); join_all();' \
-              --set VLANS '${toString vlans}' \
-              ${lib.optionalString (builtins.length vms == 1) "--set USE_SERIAL 1"}
+              --set VLANS '${toString vlans}'
           ''); # "
 
       passMeta = drv: drv // lib.optionalAttrs (t ? meta) {


### PR DESCRIPTION
There is no real existing code path that runs 
the `create_startcommand` method.
