### PR TITLE
dotnetPackages.FSharpFormatting: 2.9.8 -> 11.2.0

### DIFF
--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -174,9 +174,23 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
   FSharpFormatting = fetchNuGet {
     baseName = "FSharp.Formatting";
-    version = "2.9.8";
-    sha256 = "1bswcpa68i2lqds4kkl2qxgkfrppbpxa4jkyja48azljajh0df3m";
-    outputFiles = [ "lib/net40/*" ];
+    version = "11.2.0";
+    sha256 = "4IMrd+jpRZw+vBXx4X89/B/Fdpiuy2hwtmQNGWQp0wM=";
+    outputFiles = [ "lib/*" ];
+    postUnpack = ''
+      chmod -R a+r $sourceRoot
+    '';
+
+    meta = with lib; {
+      description = "F# tools for generating documentation (Markdown processor and F# code formatter)";
+      homepage = "https://fsprojects.github.io/FSharp.Formatting/";
+      longDescription = ''
+        The FSharp.Formatting package includes libraries and tools for processing F# script files,
+        markdown and components for documentation generation.
+      '';
+      license = licenses.asl20;
+      maintainers = [ maintainers.ratsclub ];
+    };
   };
 
   NUnit3 = fetchNuGet {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
