### PR TITLE
glmark2: 2017-09-01 -> 2021.02

### DIFF
--- a/pkgs/tools/graphics/glmark2/default.nix
+++ b/pkgs/tools/graphics/glmark2/default.nix
@@ -1,23 +1,55 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, libjpeg, libpng, xorg, libX11, libGL, libdrm,
-  python27, wayland, udev, mesa, wafHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, makeWrapper
+, libjpeg
+, libpng
+, xorg
+, libX11
+, libGL
+, libdrm
+, udev
+, python3
+, wayland
+, wayland-protocols
+, mesa
+, wafHook
+}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "glmark2";
-  version = "2017-09-01";
+  version = "2021.02";
 
   src = fetchFromGitHub {
     owner = "glmark2";
     repo = "glmark2";
-    rev = "7265e8e6c77c4f60302507eca0e18560b1117a86";
-    sha256 = "076l75rfl6pnp1wgiwlaihy1vg2advg1z8bi0x84kk259kldgvwn";
+    rev = version;
+    sha256 = "1a75gg1dn03d3jq7n74wsw7kc14ildbb8azzbj4k28xik1m6khr9";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook ];
+  nativeBuildInputs = [ pkg-config wafHook makeWrapper ];
   buildInputs = [
-    libjpeg libpng xorg.libxcb libX11 libGL libdrm python27 wayland udev mesa
+    libjpeg
+    libpng
+    xorg.libxcb
+    libX11
+    libdrm
+    python3
+    udev
+    wayland
+    wayland-protocols
+    mesa
   ];
 
-  wafConfigureFlags = ["--with-flavors=x11-gl,x11-glesv2,drm-gl,drm-glesv2,wayland-gl,wayland-glesv2"];
+  wafConfigureFlags = [ "--with-flavors=x11-gl,x11-glesv2,drm-gl,drm-glesv2,wayland-gl,wayland-glesv2" ];
+
+  postInstall = ''
+    for binary in $out/bin/glmark2*; do
+      wrapProgram $binary \
+        --set LD_LIBRARY_PATH ${libGL}/lib
+    done
+  '';
 
   meta = with lib; {
     description = "OpenGL (ES) 2.0 benchmark";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).





Wrapped `libGL`, switched to python3 and ran nixpkgs-fmt