### PR TITLE
qbittorrent: 4.3.3 -> 4.3.5

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -12,14 +12,16 @@ assert trackerSearch -> (python3 != null);
 with lib;
 mkDerivation rec {
   pname = "qbittorrent";
-  version = "4.3.3";
+  version = "4.3.5";
 
   src = fetchFromGitHub {
     owner = "qbittorrent";
-    repo = "qbittorrent";
+    repo = "qBittorrent";
     rev = "release-${version}";
-    sha256 = "0y8vrvfv8n6zg6pgg5a9hmvxi2z9rrfd9k8zv04nv5js91b99ncq";
+    sha256 = "1vdk42f8rxffyfydjk5cgzg5gl88ng2pynlyxw5ajh08wvkkjzgy";
   };
+
+  enableParallelBuilding = true;
 
   # NOTE: 2018-05-31: CMake is working but it is not officially supported
   nativeBuildInputs = [ makeWrapper pkg-config ];
@@ -47,7 +49,8 @@ mkDerivation rec {
   meta = {
     description = "Featureful free software BitTorrent client";
     homepage    = "https://www.qbittorrent.org/";
-    license     = licenses.gpl2;
+    changelog   = "https://github.com/qbittorrent/qBittorrent/blob/release-${version}/Changelog";
+    license     = licenses.gpl2Plus;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ Anton-Latukha ];
   };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/qbittorrent/qBittorrent/blob/release-4.3.5/Changelog

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).