### PR TITLE
bmake.passthru.setupHook: set some defaults

### DIFF
--- a/pkgs/development/tools/build-managers/bmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/bmake/setup-hook.sh
@@ -1,3 +1,13 @@
+addMakeFlags() {
+    export prefix="$out"
+    export MANDIR="${!outputMan}/share/man"
+    export MANTARGET=man
+    export BINOWN=
+    export STRIP_FLAG=
+}
+
+preConfigureHooks+=(addMakeFlags)
+
 bmakeBuildPhase() {
     runHook preBuild
 

--- a/pkgs/servers/http/bozohttpd/default.nix
+++ b/pkgs/servers/http/bozohttpd/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     ++ optional (stdenv.hostPlatform.libc != "libSystem") "-lcrypt"
     ++ optional (luaSupport) "-llua"
     ++ optionals (sslSupport) [ "-lssl" "-lcrypto" ];
-  makeFlags = [ "LDADD=$(_LDADD)" "prefix=$(out)" "MANDIR=$(out)/share/man" "BINOWN=" ];
+  makeFlags = [ "LDADD=$(_LDADD)" ];
 
   doCheck = true;
   checkInputs = [ inetutils wget ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These are all read from the environment by the default bmake
stdlib (e.g. <bsd.prog.mk>, <bsd.own.mk>).  Some of the default
values (like building cat pages instead of man pages, or stripping
binaries when installing) don't really make sense for Nixpkgs, so we
override them here for every build using bmake.

Eventually I'd like to unify the bmake setupHook and the NetBSD make
setupHook, but not today.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
