### PR TITLE
apple_sdk_11: alias JavaVM

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -151,6 +151,9 @@ in rec {
     # This framework doesn't exist in newer SDKs (somewhere around 10.13), but
     # there are references to it in nixpkgs.
     QuickTime = throw "QuickTime framework not available";
+
+    # Seems to be appropriate given https://developer.apple.com/forums/thread/666686
+    JavaVM = super.JavaNativeFoundation;
   };
 
   bareFrameworks = (


### PR DESCRIPTION
##### Motivation for this change

Apple removed JavaVM but JavaNativeFoundation seems to be
the replacement. Should be safe to substitute usage of
JavaVM with JavaNativeFoundation.

related: https://github.com/NixOS/nixpkgs/pull/124095
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
