### PR TITLE
Add the -a param to the docs

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -520,7 +520,7 @@ If you do need to do create this sort of patch file, one way to do so is with gi
 4. Use git to create a diff, and pipe the output to a patch file:
 
     ```ShellSession
-    $ git diff > nixpkgs/pkgs/the/package/0001-changes.patch
+    $ git diff -a > nixpkgs/pkgs/the/package/0001-changes.patch
     ```
 
 If a patch is available online but does not cleanly apply, it can be modified in some fixed ways by using additional optional arguments for `fetchpatch`:


### PR DESCRIPTION
The patch utility does not understand git formatted patches.
For text files, there is no problem, but binary files use a format patch doesn't understand.

The -a param makes git diff put binary files into the patch in
raw format that can be understood by the patch tool.