### PR TITLE
pr-tracker: 1.0.0 -> 1.1.0; adopt; add changelog

### DIFF
--- a/pkgs/servers/pr-tracker/default.nix
+++ b/pkgs/servers/pr-tracker/default.nix
@@ -1,6 +1,6 @@
 { rustPlatform
 , lib
-, fetchgit
+, fetchurl
 , openssl
 , pkg-config
 , systemd
@@ -8,20 +8,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pr-tracker";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src = fetchgit {
-    url = "https://git.qyliss.net/pr-tracker";
-    rev = version;
-    sha256 = "sha256-NHtY05Llrvfvcb3uyagLd6kaVW630TIP3IreFrY3wl0=";
+  src = fetchurl {
+    url = "https://git.qyliss.net/pr-tracker/snapshot/pr-tracker-${version}.tar.xz";
+    sha256 = "0881ckb4y762isisf9d6xk6fh9207xi1i04kays298zx2dq6gh6h";
   };
 
-  cargoSha256 = "sha256-SgSASfIanADV31pVy+VIwozTLxq7P3oMDIiAAQ8s+k0=";
+  cargoSha256 = "0r8pxg65s5jv95a0g8pzr693za7jfb4rv0wc739lkbpf0dssw8sr";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl systemd ];
 
   meta = with lib; {
+    changelog = "https://git.qyliss.net/pr-tracker/plain/NEWS?h=${version}";
     description = "Nixpkgs pull request channel tracker";
     longDescription = ''
       A web server that displays the path a Nixpkgs pull request will take
@@ -30,6 +30,6 @@ rustPlatform.buildRustPackage rec {
     platforms = platforms.linux;
     homepage = "https://git.qyliss.net/pr-tracker";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ sumnerevans ];
+    maintainers = with maintainers; [ qyliss sumnerevans ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I released a new version to handle 21.05's staging-next-21.05 branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
