### PR TITLE
gns3-server: modified py-cpuinfo condition to >=

### DIFF
--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -22,7 +22,7 @@ in python.pkgs.buildPythonPackage {
     sha256 = sha256Hash;
   };
 
-  # postPatch replacements should be removed on the update.
+  # postPatch replacements should be removed on the release.
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "aiohttp==3.6.2" "aiohttp>=3.6.2" \

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -24,7 +24,8 @@ in python.pkgs.buildPythonPackage {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "aiohttp==3.6.2" "aiohttp>=3.6.2"
+      --replace "aiohttp==3.6.2" "aiohttp>=3.6.2" \
+      --replace "py-cpuinfo==7.0.0" "py-cpuinfo>=7.0.0"
   '';
 
   propagatedBuildInputs = with python.pkgs; [

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -22,6 +22,7 @@ in python.pkgs.buildPythonPackage {
     sha256 = sha256Hash;
   };
 
+  # postPatch replacements should be removed on the update.
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "aiohttp==3.6.2" "aiohttp>=3.6.2" \


### PR DESCRIPTION
###### Motivation for this change
I was unable to install gns3 change because of the different version requirements.
the permission for higher versions >= allows the server installation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).