### PR TITLE
python3Packages.pytest-cov: 2.11.1 -> 2.12.1

### DIFF
--- a/pkgs/development/python-modules/pytest-cov/default.nix
+++ b/pkgs/development/python-modules/pytest-cov/default.nix
@@ -1,16 +1,21 @@
-{ lib, buildPythonPackage, fetchPypi
-, pytest, coverage }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, coverage
+}:
 
 buildPythonPackage rec {
   pname = "pytest-cov";
-  version = "2.11.1";
+  version = "2.12.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7";
+    sha256 = "sha256-JhzuuMIntyYkmzdrhSa2APOGZ+4xT5EDU/oxjKoB9Nc=";
   };
 
   buildInputs = [ pytest ];
+
   propagatedBuildInputs = [ coverage ];
 
   # xdist related tests fail with the following error
@@ -21,6 +26,8 @@ buildPythonPackage rec {
     export PYTHONPATH=$PYTHONPATH:$PWD/tests
     py.test tests
   '';
+
+  pythonImportsCheck = [ "pytest_cov" ];
 
   meta = with lib; {
     description = "Plugin for coverage reporting with support for both centralised and distributed testing, including subprocesses and multiprocessing";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.12.1

Change log:

- https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst#2121-2021-06-01
- https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst#2120-2021-05-14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
