### PR TITLE
all Jetbrains products: update to latest version

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -307,12 +307,12 @@ in
 
   mps = buildMps rec {
     name = "mps-${version}";
-    version = "2020.3.3"; /* updated by script */
+    version = "2021.1"; /* updated by script */
     description = "Create your own domain-specific language";
     license = lib.licenses.asl20;
     src = fetchurl {
-      url = "https://download.jetbrains.com/mps/2020.3/MPS-${version}.tar.gz";
-      sha256 = "0sb50f7d4272dzx84njc326xvhbqn3xwrphvdq4zl3pk3wl8f4nz"; /* updated by script */
+      url = "https://download.jetbrains.com/mps/${version}/MPS-${version}.tar.gz";
+      sha256 = "0fdh8lzsi2zryi0xs961vrf3l8kqk5imlj56dhifywi7xkhs3vwn"; /* updated by script */
     };
     wmClass = "jetbrains-mps";
     update-channel = "MPS RELEASE";
@@ -320,12 +320,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2021.1.2"; /* updated by script */
+    version = "2021.1.3"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "02s75fqd9hfh302zha4jw6qynpgm9nkrlq7s78nk3fc3d3hw8v5y"; /* updated by script */
+      sha256 = "05hjv1nz1b82bkakadjvsy23v0qv8fyni6h31lcg9198h1890f7v"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PhpStorm RELEASE";
@@ -333,12 +333,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2021.1.1"; /* updated by script */
+    version = "2021.1.2"; /* updated by script */
     description = "PyCharm Community Edition";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "04bs9sz872b0h1zzax23irvj6q5wxnzp6fl4f177j94kh4116cqh"; /* updated by script */
+      sha256 = "0sp7w1xrl0y36dai08kqfd0jk06yr7jdbaf1a9f3fgxp5pmspxp1"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm RELEASE";
@@ -346,12 +346,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2021.1.1"; /* updated by script */
+    version = "2021.1.2"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "0wc9j7nilakmm7scf7a71zb3k9vixgih05ni3n3pp4iznvwb3nxg"; /* updated by script */
+      sha256 = "0ny7rbl8g5azpqnlcq8l6bwh6hrp8rgp06lf4a8gdr9rpvw9xsqb"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm RELEASE";
@@ -372,12 +372,12 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2021.1.1"; /* updated by script */
+    version = "2021.1.2"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "05sfjf5523idsl7byc7400r4xqv1d65gpmkh5x0lbgf1k3bx2wlm"; /* updated by script */
+      sha256 = "0r80y8y38rdxgc9sim0q2p7bmgxlp4pdxydr0w9gjikwnjxnvz51"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
     update-channel = "RubyMine RELEASE";

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -61,8 +61,9 @@ sub update_nix_block {
         # try to interpret some nix
         my ($name) = $block =~ /name\s*=\s*"([^"]+)"/;
         $name =~ s/\$\{version\}/$latest_versions{$channel}/;
-        $url =~ s/\$\{name\}/$name/;
-        $url =~ s/\$\{version\}/$latest_versions{$channel}/;
+        # Some url paattern contain variables more than once
+        $url =~ s/\$\{name\}/$name/g;
+        $url =~ s/\$\{version\}/$latest_versions{$channel}/g;
         die "$url still has some interpolation" if $url =~ /\$/;
         my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
         my $version_string = $latest_versions{$channel};


### PR DESCRIPTION
clion: 2020.2.1 -> 2021.1.2
datagrip: 2020.2.2 -> 2021.1.2
goland: 2020.2.2 -> 2021.1.2
idea-community: 2020.2.1 -> 2021.1.2
idea-ultimate: 2020.2.1 -> 2021.1.2
mps: 2020.1.4 -> 2021.1
phpstorm: 2020.2.1 -> 2021.1.3
pycharm-community: 2020.2.1 -> 2021.1.2
pycharm-professional: 2020.2.1 -> 2021.1.2
rider: 2020.2.1 -> 2021.1.3
ruby-mine: 2020.2.1 -> 2021.1.2
webstorm: 2020.2.1 -> 2021.1.2

These updates have all been generated with the newly fixed update.pl
script.

The script update.pl, which gets the latest versions from upstream
web server, has been failing for roughly half a year. It failed to
handle the new url pattern of MPS. The script and the url pattern
is updated to work with the latest version.

The clion specific postFixup hook had to be adapted, because names
of shared libraries changed.

(cherry picked from commit 8593496928ebacc8d0779ff5706b8d511dbc0177)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

IntelliJ updates haven't found their way into Nixos lately. They used to come regularly as long as the update.pl script 
was working. That started fialing last year when MPS changed its download url pattern. A straightforward change to
it didn't work, because then update.pl was failing differently. 

This commit restores the ability to just run update.pl in nixpkgs/pkgs/applications/editors/jebrains and have current packages
for all Jetbrains products.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
