### PR TITLE
nixos: fix installer profile

### DIFF
--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -70,7 +70,9 @@ with lib;
     };
 
     # Enable wpa_supplicant, but don't start it by default.
+    networking.usePredictableInterfaceNames = mkDefault false;
     networking.wireless.enable = mkDefault true;
+    networking.wireless.interfaces = mkDefault [ "wlan0" ];
     systemd.services.wpa_supplicant.wantedBy = mkOverride 50 [];
 
     # Tell the Nix evaluator to garbage collect more aggressively.


### PR DESCRIPTION
###### Motivation for this change

Fix the assertion error introduced by https://github.com/NixOS/nixpkgs/pull/125288, hopefully without causing more trouble.

###### Things done

- [x] Tested via `installer.simple nixos-generate-config`
- [x] Tested on real hardware
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @dasJ 