### PR TITLE
python3Packages.textacy: 0.10.1 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -1,34 +1,39 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
+{ lib
+, buildPythonPackage
 , cachetools
 , cytoolz
+, fetchPypi
 , jellyfish
+, joblib
 , matplotlib
 , networkx
 , numpy
 , pyemd
 , pyphen
-, pytest
+, pytestCheckHook
+, pythonOlder
 , requests
 , scikit-learn
 , scipy
 , spacy
-, srsly
+, tqdm
 }:
 
 buildPythonPackage rec {
   pname = "textacy";
-  version = "0.10.1";
-  disabled = isPy27;
+  version = "0.11.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ff72adc6dbb85db6981324e226fff77830da57d7fe7e4adb2cafd9dc2a8bfa7d";
+    sha256 = "sha256-d/tyTCewoERA15iBv4H2LORFzgco15fnnN1sneeGuF4=";
   };
 
   propagatedBuildInputs = [
     cachetools
     cytoolz
     jellyfish
+    joblib
     matplotlib
     networkx
     numpy
@@ -38,22 +43,25 @@ buildPythonPackage rec {
     scikit-learn
     scipy
     spacy
-    srsly
+    tqdm
   ];
 
-  checkInputs = [ pytest ];
-  # almost all tests have to deal with downloading a dataset, only test pure tests
-  checkPhase = ''
-    pytest tests/test_text_utils.py \
-      tests/test_utils.py \
-      tests/preprocessing \
-      tests/datasets/test_base_dataset.py
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # Almost all tests have to deal with downloading a dataset, only test pure tests
+    "tests/test_constants.py"
+    "tests/preprocessing/test_normalize.py"
+    "tests/similarity/test_edits.py"
+    "tests/preprocessing/test_resources.py"
+    "tests/preprocessing/test_replace.py"
+  ];
+
+  pythonImportsCheck = [ "textacy" ];
 
   meta = with lib; {
-    # scikit-learn in pythonPackages is too new for textacy
-    # remove as soon as textacy support scikit-learn >= 0.24
-    broken = true;
     description = "Higher-level text processing, built on spaCy";
     homepage = "https://textacy.readthedocs.io/";
     license = licenses.asl20;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.11.0

Change log: https://github.com/chartbeat-labs/textacy/releases/tag/0.11.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
