### PR TITLE
python3: set an explicit high priority

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12355,7 +12355,7 @@ in
   # When switching these sets, please update docs at ../../doc/languages-frameworks/python.md
   python = python2;
   python2 = python27;
-  python3 = python38;
+  python3 = python38.overrideAttrs lib.hiPrio;
   pypy = pypy2;
   pypy2 = pypy27;
   pypy3 = pypy36;


### PR DESCRIPTION
Currently there are multiple derivations named `python3`, none of which have an explicit `meta.priority`. This means that `nix-env -i python3` will give a different result than `nix-env -iA nixpkgs.python3`, and `nix-env -u` is not useful when you have `nixpkgs.python3` installed.

So we explicitly raise the priority of `nixpkgs.python3`, so that `nix-env -i python3` will no longer try to install an alpha version of python3 just because it has a higher version number.

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/126036

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I verified this change by using `nix-env -qa`:

```
$ nix-env -qa python3 --json -f . | jq '.[] |= .meta.priority'   {
  "python310": null,
  "python36": null,
  "python36Full": null,
  "python37Full": null,
  "python37": null,
  "gnuradio3_8Packages.python": -10,
  "python38": null,
  "python38Full": null,
  "python3Full": -10,
  "sourcehut.python": -10,
  "python39": null,
  "python39Full": null
}
```

Which does not include `python3` because it's identical to `sourcehut.python3`, but can be confirmed separately:

```
$ nix-env -qaA python3 --json -f . | jq '.[] |= .meta.priority'
{
  "python3": -10
}
```