### PR TITLE
chia: 1.1.5 -> 1.1.7

### DIFF
--- a/pkgs/applications/blockchains/chia/default.nix
+++ b/pkgs/applications/blockchains/chia/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "chia";
-  version = "1.1.5";
+  version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "Chia-Network";
     repo = "chia-blockchain";
     rev = version;
-    sha256 = "ZUxWOlJGQpeQCtWt0PSdcbMackHdeuNFkxHvYDPcU8Y=";
+    sha256 = "05hcckkv3vhz172w9kp5lh4srakizx1l383dijs50vgx2bj30m8v";
   };
 
   patches = [
@@ -38,6 +38,7 @@ python3Packages.buildPythonApplication rec {
     colorlog
     concurrent-log-handler
     cryptography
+    dnspython
     keyrings-cryptfile
     pyyaml
     setproctitle

--- a/pkgs/development/python-modules/chiapos/default.nix
+++ b/pkgs/development/python-modules/chiapos/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "chiapos";
-  version = "1.0.1";
+  version = "1.0.2";
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kJx57EtwPBrGMpjnSzeYYhWqc/g1N1Bg8slW5oZKjg8=";
+    sha256 = "09mwj9m9rcvcb3zn6v2xykgd4a9lpwl6c86nwl8d1iqr82gb5hb5";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Chia 1.1.6 promises significant improvements over 1.1.5 in finding peers to sync to as per the [changelog](https://github.com/Chia-Network/chia-blockchain/releases/tag/1.1.6)

###### Things done
- update chia to 1.1.7
- update chiapos to 1.0.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
