### PR TITLE
cppzmq: align drafts CMake flag with zeromq

### DIFF
--- a/pkgs/development/libraries/cppzmq/default.nix
+++ b/pkgs/development/libraries/cppzmq/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
     # Tests try to download googletest at compile time; there is no option
     # to use a system one and no simple way to download it beforehand.
     "-DCPPZMQ_BUILD_TESTS=OFF"
-  ];
+  ]
+  # enable drafts if zeromq has them
+  ++ builtins.filter (a: a == "-DENABLE_DRAFTS=ON") zeromq.cmakeFlags;
 
   meta = with lib; {
     homepage = "https://github.com/zeromq/cppzmq";


### PR DESCRIPTION
###### Motivation for this change

The `zeromq` pkg has an `enableDrafts` attribute which sets the CMake
flag `ENABLE_DRAFTS=ON`. This makes library functions under development
visible. This change aligns `cppzmq` to enable draft functions when they
are enabled in `zeromq`.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
