### PR TITLE
python2Packages.ipdb: Fix build

### DIFF
--- a/pkgs/development/python-modules/ipdb/default.nix
+++ b/pkgs/development/python-modules/ipdb/default.nix
@@ -3,21 +3,21 @@
 , fetchPypi
 , ipython
 , isPyPy
-, isPy27
 , mock
+, toml
 }:
 
 buildPythonPackage rec {
   pname = "ipdb";
   version = "0.13.7";
-  disabled = isPyPy || isPy27;  # setupterm: could not find terminfo database
+  disabled = isPyPy;  # setupterm: could not find terminfo database
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "178c367a61c1039e44e17c56fcc4a6e7dc11b33561261382d419b6ddb4401810";
   };
 
-  propagatedBuildInputs = [ ipython ];
+  propagatedBuildInputs = [ ipython toml ];
   checkInputs = [ mock ];
 
   preCheck = ''


### PR DESCRIPTION
###### Motivation for this change
Fixes python 2 build of ipdb

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
