### PR TITLE
libelf: fix build on NetBSD

### DIFF
--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchurl, autoreconfHook, gettext
+, fetchurl, autoreconfHook, gettext, netbsd
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -32,7 +32,8 @@ stdenv.mkDerivation rec {
        # on Darwin, so disable NLS for now.
     ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-nls";
 
-  nativeBuildInputs = [ gettext ]
+  nativeBuildInputs =
+    if stdenv.hostPlatform.isNetBSD then [ netbsd.gencat ] else [ gettext ]
        # Need to regenerate configure script with newer version in order to pass
        # "mr_cv_target_elf=yes", but `autoreconfHook` brings in `makeWrapper`
        # which doesn't work with the bootstrapTools bash, so can only do this


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

libelf wants to use gencat on Darwin, but Darwin's gencat is [disabled](https://github.com/NixOS/nixpkgs/blob/611d718c464ee0d916284f725156c70663e78bb8/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix).  So until that's fixed, borrow NetBSD's gencat for Darwin as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
