### PR TITLE
amdvlk: 2021.Q2.2 -> 2021.Q2.4

### DIFF
--- a/nixos/doc/manual/configuration/gpu-accel.xml
+++ b/nixos/doc/manual/configuration/gpu-accel.xml
@@ -178,9 +178,9 @@ GPU1:
        Core Next</link> (GCN) GPUs are supported through either radv, which is
        part of <package>mesa</package>, or the <package>amdvlk</package> package.
        Adding the <package>amdvlk</package> package to
-       <xref linkend="opt-hardware.opengl.extraPackages"/> makes both drivers
-       available for applications and lets them choose. A specific driver can
-       be forced as follows:
+       <xref linkend="opt-hardware.opengl.extraPackages"/> makes amdvlk the
+       default driver and hides radv and lavapipe from the device list. A
+       specific driver can be forced as follows:
 
        <programlisting><xref linkend="opt-hardware.opengl.extraPackages"/> = [
          pkgs.<package>amdvlk</package>
@@ -191,10 +191,9 @@ GPU1:
          pkgs.driversi686Linux.<package>amdvlk</package>
        ];
 
-       # For amdvlk
-       <xref linkend="opt-environment.variables"/>.VK_ICD_FILENAMES =
-          "/run/opengl-driver/share/vulkan/icd.d/amd_icd64.json";
-       # For radv
+       # Force radv
+       <xref linkend="opt-environment.variables"/>.AMD_VULKAN_ICD = "RADV";
+       # Or
        <xref linkend="opt-environment.variables"/>.VK_ICD_FILENAMES =
          "/run/opengl-driver/share/vulkan/icd.d/radeon_icd.x86_64.json";
        </programlisting>

--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -21,13 +21,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "amdvlk";
-  version = "2021.Q2.2";
+  version = "2021.Q2.4";
 
   src = fetchRepoProject {
     name = "${pname}-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${version}";
-    sha256 = "4k9ZkBxJGuNUO44F9D+u54eUREl5/8zxjxhaShhzGv0=";
+    sha256 = "KPWkwbD55BoztF6DPmvau9i1AMhR+5ad5VrrD8I2YyI=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
2021.Q2.4 was released (and [.3](https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2021.Q2.3) before that): https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2021.Q2.4

Also update the documentation as requested in #121010.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested vkcube
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
