### PR TITLE
darwin.xattr: init at 61.60.1

### DIFF
--- a/pkgs/os-specific/darwin/xattr/default.nix
+++ b/pkgs/os-specific/darwin/xattr/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchzip
+, buildPythonPackage
+, python
+, ed
+, unifdef
+}:
+
+buildPythonPackage rec {
+  pname = "xattr";
+  version = "61.60.1";
+
+  src = fetchzip rec {
+    url = "https://opensource.apple.com/tarballs/python_modules/python_modules-${version}.tar.gz";
+    sha256 = "19kydl7w4vpdi7zmfd5z9vjkq24jfk2cv4j0pppw69j06czhdwwi";
+  };
+
+  sourceRoot = "${src.name}/Modules/xattr-0.6.4";
+  format = "other";
+
+  nativeBuildInputs = [
+    ed
+    unifdef
+  ];
+
+  makeFlags = [
+    "OBJROOT=$(PWD)"
+    "DSTROOT=${placeholder "out"}"
+    "OSL=${placeholder "doc"}/share/xattr/OpenSourceLicenses"
+    "OSV=${placeholder "doc"}/share/xattr/OpenSourceVersions"
+  ];
+
+  # need to use `out` instead of `bin` since buildPythonPackage ignores the latter
+  outputs = [ "out" "doc" "python" ];
+
+  # We need to patch a reference to gnutar in an included Makefile
+  postUnpack = ''
+    chmod u+w $sourceRoot/..
+  '';
+
+  postPatch = ''
+    substituteInPlace ../Makefile.inc --replace gnutar tar
+    substituteInPlace Makefile --replace "/usr" ""
+  '';
+
+  preInstall = ''
+    # prevent setup.py from trying to download setuptools
+    sed -i xattr-*/setup.py -e '/ez_setup/d'
+
+    # create our custom target dirs we patch in
+    mkdir -p "$doc/share/xattr/"OpenSource{Licenses,Versions}
+    mkdir -p "$python/lib/${python.libPrefix}"
+  '';
+
+  # move python package to its own output to reduce clutter
+  postInstall = ''
+    mv "$out/lib/python" "$python/${python.sitePackages}"
+    rmdir "$out/lib"
+  '';
+
+  makeWrapperArgs = [
+    "--prefix" "PYTHONPATH" ":" "${placeholder "python"}/${python.sitePackages}"
+  ];
+
+  meta = with lib; {
+    description = "Display and manipulate extended attributes";
+    license = [ licenses.psfl licenses.mit ]; # see $doc/share/xattr/OpenSourceLicenses
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://opensource.apple.com/source/python_modules/";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -156,6 +156,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   usr-include = callPackage ../os-specific/darwin/usr-include { };
 
+  xattr = pkgs.python3Packages.callPackage ../os-specific/darwin/xattr { };
+
   inherit (pkgs.callPackages ../os-specific/darwin/xcode { })
     xcode_8_1 xcode_8_2
     xcode_9_1 xcode_9_2 xcode_9_4 xcode_9_4_1


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package Apple's `xattr` “fork” which is required for building GHC 8.10.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
