### PR TITLE
clapper: init at 0.4.0

### DIFF
--- a/pkgs/applications/video/clapper/default.nix
+++ b/pkgs/applications/video/clapper/default.nix
@@ -1,0 +1,85 @@
+{ config
+, lib
+, stdenv
+, fetchFromGitHub
+, glib
+, gobject-introspection
+, python3
+, pkg-config
+, ninja
+, wayland
+, wayland-protocols
+, desktop-file-utils
+, makeWrapper
+, shared-mime-info
+, wrapGAppsHook
+, meson
+, gjs
+, gtk4
+, gst_all_1
+, libadwaita
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clapper";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner  = "Rafostar";
+    repo   = pname;
+    rev    = version;
+    sha256 = "1gf4z9lib5rxi1xilkxxyywakm9zlq5915w2wib09jyh0if82ahr";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils # for update-desktop-database
+    glib
+    gobject-introspection
+    meson
+    ninja
+    makeWrapper
+    pkg-config
+    python3
+    shared-mime-info # for update-mime-database
+    wrapGAppsHook # for gsettings
+  ];
+
+  buildInputs = [
+    gjs
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gtk4
+    libadwaita
+    wayland
+    wayland-protocols
+  ];
+
+  postPatch = ''
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  mesonFlags = [
+    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+  ];
+
+  postInstall = ''
+    cp ${src}/data/icons/*.svg $out/share/icons/hicolor/scalable/apps/
+    cp ${src}/data/icons/*.svg $out/share/icons/hicolor/symbolic/apps/
+  '';
+
+  meta = with lib; {
+    description = "A GNOME media player built using GJS with GTK4 toolkit and powered by GStreamer with OpenGL rendering. ";
+    longDescription = ''
+      Clapper is a GNOME media player build using GJS with GTK4 toolkit.
+      The media player is using GStreamer as a media backend and renders everything via OpenGL.
+    '';
+    homepage = "https://github.com/Rafostar/clapper";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23922,6 +23922,8 @@ with pkgs;
 
   cipher = callPackage ../applications/misc/cipher { };
 
+  clapper = callPackage ../applications/video/clapper { };
+
   claws-mail-gtk2 = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;
     useGtk3 = false;


### PR DESCRIPTION
###### Motivation for this change
A GNOME media player build using GJS with GTK4 toolkit. The media player is using GStreamer as a media backend and renders everything via OpenGL.

https://github.com/Rafostar/clapper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
