### PR TITLE
fcitx5*: bump fcitx5 packages

### DIFF
--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -18,21 +18,21 @@ let
     url = "https://download.fcitx-im.org/data/lm_sc.3gm.arpa-${arpaVer}.tar.bz2";
     sha256 = "0bqy3l7mif0yygjrcm65qallszgn17mvgyxhvz7a54zaamyan6vm";
   };
-  dictVer = "20200715";
+  dictVer = "20210402";
   dict = fetchurl {
     url = "https://download.fcitx-im.org/data/dict.utf8-${dictVer}.tar.xz";
-    sha256 = "1ln7r64j8mc7wz4j0q4v8wd68wy7qqz4bz1dpxk7zqbdvza6rhr3";
+    sha256 = "sha256-gYz7tama5bQMJwe2FYc09KEBlkRIU0AMvWsUUFWS2A0=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "1.0.3";
+  version = "1.0.7";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     rev = version;
-    sha256 = "sha256-Ykj4/3yKUqK0BRqW1E2zFYNgeUOXQ1DsotmKU6c8vEg=";
+    sha256 = "sha256-q/SXS6pT4vBkCkCTarPVHrZPXijYnc2t51YGRvzQ0FY=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/libraries/xcb-imdkit/default.nix
+++ b/pkgs/development/libraries/xcb-imdkit/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xcb-imdkit";
-  version = "1.0.2";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "xcb-imdkit";
     rev = version;
-    sha256 = "sha256-ISaVsMtDsyfhbhsAwDSWkQ7ZcpNtvC7M9NFQsWA5ju8=";
+    sha256 = "sha256-IPuTRSgmrnCJRgGWcE4JRaxd0sGCcHrKRnn2B1OdDMU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -31,13 +31,13 @@ in
 
 mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.0.3";
+  version = "5.0.6";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-chinese-addons";
     rev = version;
-    sha256 = "sha256-kCihpRUtUXrqqf7FPQp8ZRexiygOuDVOdQwVx7tSn+c=";
+    sha256 = "sha256-+DhXFqUxECGZYHAmEw5cZJQnRHHgvT0nVVqY9DXgWBU=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python3 -p nix-prefetch-github python3Packages.requests
+#!nix-shell -i python3 -p nix-update nix-prefetch-github python3Packages.requests
 
 from nix_prefetch_github import *
 import json
@@ -12,8 +12,7 @@ REPOS = [ "libime", "xcb-imdkit", "fcitx5", "fcitx5-gtk", "fcitx5-qt", "fcitx5-c
 OWNER = "fcitx"
 
 def get_latest_tag(repo, owner=OWNER):
-    r = requests.get( 'https://api.github.com/repos/{}/{}/tags'.format(owner,repo)
-                    , auth=('poscat', 'db5e6fd16d0eb8c36385d3d944e058a1178b4265'))
+    r = requests.get('https://api.github.com/repos/{}/{}/tags'.format(owner,repo))
     return r.json()[0].get("name")
 
 def main():


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump.

This update contains a bug fix of an input issue with alacritty/xterm, see https://github.com/fcitx/fcitx5/issues/254

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
1 package marked as broken and skipped:
libsForQt512.fcitx5-qt

15 packages built:
fcitx5 fcitx5-chinese-addons fcitx5-configtool fcitx5-gtk fcitx5-lua fcitx5-m17n fcitx5-mozc fcitx5-rime fcitx5-table-extra fcitx5-table-other fcitx5-with-addons libime libsForQt5.fcitx5-qt libsForQt514.fcitx5-qt xcb-imdkit
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
