### PR TITLE
libserdes: init at 6.2.0

### DIFF
--- a/pkgs/development/libraries/libserdes/default.nix
+++ b/pkgs/development/libraries/libserdes/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, perl
+, boost
+, rdkafka
+, jansson
+, curl
+, avro-c
+, avro-cpp }:
+
+stdenv.mkDerivation rec {
+  pname = "libserdes";
+  version = "6.2.0";
+
+  src = fetchFromGitHub {
+    owner = "confluentinc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "194ras18xw5fcnjgg1isnb24ydx9040ndciniwcbdb7w7wd901gc";
+  };
+
+  outputs = [ "dev" "out" ];
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = [ boost rdkafka jansson curl avro-c avro-cpp ];
+
+  makeFlags = [ "GEN_PKG_CONFIG=y" ];
+
+  postPatch = ''
+    patchShebangs configure lds-gen.pl
+  '';
+
+  # Has a configure script but it’s not Autoconf so steal some bits from multiple-outputs.sh:
+  setOutputFlags = false;
+
+  preConfigure = ''
+    configureFlagsArray+=(
+      "--libdir=''${!outputLib}/lib"
+      "--includedir=''${!outputInclude}/include"
+    )
+  '';
+
+  preInstall = ''
+    installFlagsArray+=("pkgconfigdir=''${!outputDev}/lib/pkgconfig")
+  '';
+
+  # Header files get installed with executable bit for some reason; get rid of it.
+  postInstall = ''
+    chmod -x ''${!outputInclude}/include/libserdes/*.h
+  '';
+
+  meta = with lib; {
+    description = "A schema-based serializer/deserializer C/C++ library with support for Avro and the Confluent Platform Schema Registry";
+    homepage = "https://github.com/confluentinc/libserdes";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ liff ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16187,6 +16187,8 @@ in
 
   libsecret = callPackage ../development/libraries/libsecret { };
 
+  libserdes = callPackage ../development/libraries/libserdes { };
+
   libserialport = callPackage ../development/libraries/libserialport { };
 
   libsignal-protocol-c = callPackage ../development/libraries/libsignal-protocol-c { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [libserdes](https://github.com/confluentinc/libserdes/) library, which provides [Avro and Schema Registry support](https://docs.confluent.io/platform/current/app-development/index.html#c-c) for C and C++ applications.

Kafkacat can [use this for deserializing Avro messages](https://github.com/edenhill/kafkacat#requirements) and I intend to submit a PR adding this and Avro libraries as a dependency to the kafkacat derivation, should this one be accepted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
