### PR TITLE
[WIP] webkitgtk: Fix Darwin issues

### DIFF
--- a/pkgs/development/libraries/webkitgtk/0001-Prevent-WebKitWebProcess-from-being-in-the-dock-or-p.patch
+++ b/pkgs/development/libraries/webkitgtk/0001-Prevent-WebKitWebProcess-from-being-in-the-dock-or-p.patch
@@ -1,0 +1,51 @@
+--- a/Source/WebKit/PlatformGTK.cmake
++++ b/Source/WebKit/PlatformGTK.cmake
+@@ -32,6 +32,10 @@
+     "SourcesGTK.txt"
+ )
+ 
++find_library(APPKIT_FRAMEWORK NAMES AppKit)
++target_link_libraries(WebKit PRIVATE ${APPKIT_FRAMEWORK})
++list(APPEND WebKit_SOURCES WebProcess/gtk/NSApplicationActivationPolicy.mm)
++
+ if (NOT USE_GTK4)
+     list(APPEND WebKit_SOURCES
+         UIProcess/ViewGestureController.cpp
+--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
++++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+@@ -31,6 +31,7 @@
+ #include "WebProcess.h"
+ #include <WebCore/GtkVersioning.h>
+ #include <libintl.h>
++#include "NSApplicationActivationPolicy.h"
+ 
+ #if PLATFORM(X11)
+ #include <X11/Xlib.h>
+@@ -64,6 +65,7 @@
+ 
+         bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
+         bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
++        SetActivationPolicyProhibited ();
+ 
+         return true;
+     }
+--- /dev/null
++++ b/Source/WebKit/WebProcess/gtk/NSApplicationActivationPolicy.h
+@@ -0,0 +1,4 @@
++
++// This is the C "trampoline" function that will be used
++// to invoke a specific Objective-C method FROM C++
++void SetActivationPolicyProhibited ();
+--- /dev/null
++++ b/Source/WebKit/WebProcess/gtk/NSApplicationActivationPolicy.mm
+@@ -0,0 +1,10 @@
++#include "config.h"
++#import "NSApplicationActivationPolicy.h"
++#import <AppKit/AppKit.h>
++
++// C "trampoline" function to invoke Objective-C method
++void SetActivationPolicyProhibited ()
++{
++    [NSApp setActivationPolicy: NSApplicationActivationPolicyProhibited];
++    return;
++}

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -107,6 +107,10 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-78iP+T2vaIufO8TmIPO/tNDgmBgzlDzalklrOPrtUeo=";
       excludes = [ "Source/WebKit/ChangeLog" ];
     })
+
+    # hides webkit processes from the macOS Dock
+    # https://source.atlas.engineer/view/repository/macports-port
+    ./0001-Prevent-WebKitWebProcess-from-being-in-the-dock-or-p.patch
   ];
 
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -222,6 +222,8 @@ stdenv.mkDerivation rec {
     sed 43i'#include <CommonCrypto/CommonCryptor.h>' -i Source/WTF/wtf/RandomDevice.cpp
   '';
 
+  doCheck = true;
+
   requiredSystemFeatures = [ "big-parallel" ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -111,6 +111,14 @@ stdenv.mkDerivation rec {
       excludes = [ "Source/WebKit/ChangeLog" ];
     })
 
+    # keypresses are ignored with the GTK Quartz backend
+    # https://bugs.webkit.org/show_bug.cgi?id=227360
+    (fetchpatch {
+      url = "https://bug-227360-attachments.webkit.org/attachment.cgi?id=432180";
+      sha256 = "sha256-1JLJKu0G1hRTzqcHsZgbXIp9ZekwbYFWg/MtwB4jTjc=";
+      excludes = [ "Source/WebKit/ChangeLog" ];
+    })
+
     # hides webkit processes from the macOS Dock
     # https://source.atlas.engineer/view/repository/macports-port
     ./0001-Prevent-WebKitWebProcess-from-being-in-the-dock-or-p.patch

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -209,6 +209,8 @@ stdenv.mkDerivation rec {
     "-DUSE_WPE_RENDERER=OFF"
     "-DENABLE_MINIBROWSER=ON"
     "-DLIBEXEC_INSTALL_DIR=${placeholder "out"}/libexec/webkit2gtk"
+  ] ++ lib.optionals doCheck [
+    "-DENABLE_API_TESTS=ON"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DENABLE_GAMEPAD=OFF"
     "-DENABLE_GTKDOC=OFF"
@@ -237,7 +239,8 @@ stdenv.mkDerivation rec {
     wrapGApp $out/libexec/webkit2gtk/MiniBrowser --argv0 MiniBrowser
   '';
 
-  doCheck = true;
+  # tests are still failing
+  doCheck = false;
 
   # we only want to wrap the MiniBrowser
   dontWrapGApps = true;

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -229,6 +229,12 @@ stdenv.mkDerivation rec {
     "-DENABLE_X11_TARGET=OFF"
     "-DUSE_APPLE_ICU=OFF"
     "-DUSE_OPENGL_OR_ES=OFF"
+
+    # FIXME: Remove this option once the macOS SDK has been updated to 10.13.
+    # This option disables WebKit's bmalloc memory allocator, which includes
+    # various mitigations against heap exploits.
+    #
+    # https://blogs.gnome.org/mcatanzaro/2018/11/02/on-webkit-build-options-also-how-to-accidentally-disable-important-security-features/
     "-DUSE_SYSTEM_MALLOC=ON"
   ] ++ lib.optionals (!stdenv.isLinux) [
     "-DUSE_SYSTEMD=OFF"

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -250,6 +250,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
+    # needed for TLS and multimedia functionality
     wrapGApp $out/libexec/webkit2gtk/MiniBrowser --argv0 MiniBrowser
   '';
 

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -63,6 +63,7 @@
 
 assert enableGeoLocation -> geoclue2 != null;
 
+# NOTE: Run $out/libexec/MiniBrowser to test changes for this package
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
   version = "2.32.1";
@@ -203,9 +204,11 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DENABLE_INTROSPECTION=ON"
     "-DPORT=GTK"
+    "-DENABLE_MINIBROWSER=ON"
     "-DUSE_LIBHYPHEN=OFF"
     "-DUSE_WPE_RENDERER=OFF"
     "-DENABLE_MINIBROWSER=ON"
+    "-DLIBEXEC_INSTALL_DIR=${placeholder "out"}/libexec/webkit2gtk"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DENABLE_GAMEPAD=OFF"
     "-DENABLE_GTKDOC=OFF"
@@ -230,10 +233,8 @@ stdenv.mkDerivation rec {
     sed 43i'#include <CommonCrypto/CommonCryptor.h>' -i Source/WTF/wtf/RandomDevice.cpp
   '';
 
-  postInstall = ''
-    mv $out/libexec/MiniBrowser $out/bin/MiniBrowser
-    gappsWrapperArgsHook # FIXME: currently runs at preFixup
-    wrapGApp $out/bin/MiniBrowser --argv0 MiniBrowser
+  postFixup = ''
+    wrapGApp $out/libexec/webkit2gtk/MiniBrowser --argv0 MiniBrowser
   '';
 
   doCheck = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This attempts to fix WebkitGTK issues on Darwin uncovered in #125113 and #126082.

**The current fix:**

* Enables `checkPhase`.
* Builds the `MiniBrowser` binary. This is small and extremely useful for uncovering issues with the WebKitGTK build.
* Prevents `WebKitWebProcess` processes from appearing in the macOS Dock.

**The major remaining problems are:**

* Inability to process keypresses
* Crashes
* Possible performance issue (currently affects Nyxt, but not `MiniBrowser`)

**Additional info for the keypress problem:**

I've confirmed the behavior with the Nyxt package in #126082 and `MiniBrowser` in this PR, and is probably reproducible with any browser built against WebKitGTK. Special keys like Backspace and Cmd key combinations would work normally, but alphanumerical key input won't be passed to webpages.

After debugging `MiniBrowser`, I found that keypresses are being passed to [`webkitWebViewBaseKeyPressEvent`](https://github.com/WebKit/WebKit/blob/e0eccd4033bf1db191b187f5c7839e64337f9728/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp#L986), but [is ignored](https://github.com/WebKit/WebKit/blob/e0eccd4033bf1db191b187f5c7839e64337f9728/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp#L1030-L1031) after running [`WebKit::WebCore::InputMethodFilter::filterKeyEvent`](https://github.com/WebKit/WebKit/blob/e0eccd4033bf1db191b187f5c7839e64337f9728/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp#L99). My current theory is that this is an upstream issue with IME handling working incorrectly on Darwin.

**Additional info for the crashes:**
<details>
<summary>Crashlog for WebKitGTK  WebProcess obtained by running Nyxt</summary>

```
Process:               WebKitWebProcess [49581]
Path:                  /nix/*/WebKitWebProcess
Identifier:            WebKitWebProcess
Version:               0
Code Type:             X86-64 (Native)
Parent Process:        ??? [49528]
Responsible:           WebKitWebProcess [49581]
User ID:               501

Date/Time:             2021-06-08 02:02:45.418 +0900
OS Version:            Mac OS X 10.14.6 (18G9216)
Report Version:        12
Anonymous UUID:        B08AEC7B-A5C1-BD40-966B-893727C2BD8F

Sleep/Wake UUID:       B3DAD40A-A597-41FF-85FF-8F7D86D08DD2

Time Awake Since Boot: 110000 seconds
Time Since Wake:       16000 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BREAKPOINT (SIGTRAP)
Exception Codes:       0x0000000000000002, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Trace/BPT trap: 5
Termination Reason:    Namespace SIGNAL, Code 0x5
Terminating Process:   exc handler [49581]

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libwebkit2gtk-4.0.37.dylib    	0x0000000106d49970 WebKit::AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) + 32
1   libwebkit2gtk-4.0.37.dylib    	0x0000000106d3a173 IPC::Connection::dispatchMessage(std::__1::unique_ptr<IPC::Decoder, std::__1::default_delete<IPC::Decoder> >) + 291
2   libwebkit2gtk-4.0.37.dylib    	0x0000000106d3a508 IPC::Connection::dispatchOneIncomingMessage() + 264
3   libjavascriptcoregtk-4.0.18.dylib	0x000000010c12bc3e WTF::RunLoop::performWork() + 478
4   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1953b9 WTF::RunLoop::RunLoop()::$_1::__invoke(void*) + 9
5   libjavascriptcoregtk-4.0.18.dylib	0x000000010c19433d WTF::RunLoop::$_0::__invoke(_GSource*, int (*)(void*), void*) + 77
6   libglib-2.0.0.dylib           	0x000000010e897976 g_main_context_dispatch + 326
7   libglib-2.0.0.dylib           	0x000000010e897d32 g_main_context_iterate + 546
8   libglib-2.0.0.dylib           	0x000000010e89807f g_main_loop_run + 239
9   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1949f6 WTF::RunLoop::run() + 150
10  libwebkit2gtk-4.0.37.dylib    	0x0000000107101c1c int WebKit::AuxiliaryProcessMain<WebKit::WebProcessMainGtk>(int, char**) + 252
11  libdyld.dylib                 	0x00007fff76f223d5 start + 1

Thread 1:
0   libsystem_pthread.dylib       	0x00007fff771153f0 start_wqthread + 0

Thread 2:: com.apple.WebKit.EventDispatcher
0   libsystem_kernel.dylib        	0x00007fff7705f36a poll + 10
1   libglib-2.0.0.dylib           	0x000000010e897cd6 g_main_context_iterate + 454
2   libglib-2.0.0.dylib           	0x000000010e89807f g_main_loop_run + 239
3   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1949f6 WTF::RunLoop::run() + 150
4   libjavascriptcoregtk-4.0.18.dylib	0x000000010c12e08c WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) + 124
5   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1975a9 WTF::wtfThreadEntryPoint(void*) + 9
6   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
7   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
8   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 3:: com.apple.WebKit.WebInspectorInterruptDispatcher
0   libsystem_kernel.dylib        	0x00007fff7705f36a poll + 10
1   libglib-2.0.0.dylib           	0x000000010e897cd6 g_main_context_iterate + 454
2   libglib-2.0.0.dylib           	0x000000010e89807f g_main_loop_run + 239
3   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1949f6 WTF::RunLoop::run() + 150
4   libjavascriptcoregtk-4.0.18.dylib	0x000000010c12e08c WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) + 124
5   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1975a9 WTF::wtfThreadEntryPoint(void*) + 9
6   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
7   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
8   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 4:: com.apple.IPC.ReceiveQueue
0   libsystem_kernel.dylib        	0x00007fff7705f36a poll + 10
1   libglib-2.0.0.dylib           	0x000000010e897cd6 g_main_context_iterate + 454
2   libglib-2.0.0.dylib           	0x000000010e89807f g_main_loop_run + 239
3   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1949f6 WTF::RunLoop::run() + 150
4   libjavascriptcoregtk-4.0.18.dylib	0x000000010c12e08c WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) + 124
5   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1975a9 WTF::wtfThreadEntryPoint(void*) + 9
6   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
7   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
8   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 5:: com.apple.IPC.ReceiveQueue
0   libsystem_kernel.dylib        	0x00007fff7705f36a poll + 10
1   libglib-2.0.0.dylib           	0x000000010e897cd6 g_main_context_iterate + 454
2   libglib-2.0.0.dylib           	0x000000010e89807f g_main_loop_run + 239
3   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1949f6 WTF::RunLoop::run() + 150
4   libjavascriptcoregtk-4.0.18.dylib	0x000000010c12e08c WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) + 124
5   libjavascriptcoregtk-4.0.18.dylib	0x000000010c1975a9 WTF::wtfThreadEntryPoint(void*) + 9
6   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
7   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
8   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 6:: pool-spawner
0   libsystem_kernel.dylib        	0x00007fff7705a866 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff7711956e _pthread_cond_wait + 722
2   libglib-2.0.0.dylib           	0x000000010e8efe16 g_cond_wait + 38
3   libglib-2.0.0.dylib           	0x000000010e861715 g_async_queue_pop_intern_unlocked + 117
4   libglib-2.0.0.dylib           	0x000000010e8c46e8 g_thread_pool_spawn_thread + 72
5   libglib-2.0.0.dylib           	0x000000010e8c4072 g_thread_proxy + 66
6   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
7   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
8   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 7:: gmain
0   libsystem_kernel.dylib        	0x00007fff7705f36a poll + 10
1   libglib-2.0.0.dylib           	0x000000010e897cd6 g_main_context_iterate + 454
2   libglib-2.0.0.dylib           	0x000000010e897df6 g_main_context_iteration + 102
3   libglib-2.0.0.dylib           	0x000000010e899f96 glib_worker_main + 54
4   libglib-2.0.0.dylib           	0x000000010e8c4072 g_thread_proxy + 66
5   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
6   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
7   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 8:: pool-<unknown>
0   libsystem_kernel.dylib        	0x00007fff7705a866 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff771195a1 _pthread_cond_wait + 773
2   libglib-2.0.0.dylib           	0x000000010e8f000c g_cond_wait_until + 140
3   libglib-2.0.0.dylib           	0x000000010e861704 g_async_queue_pop_intern_unlocked + 100
4   libglib-2.0.0.dylib           	0x000000010e8618a8 g_async_queue_timeout_pop + 56
5   libglib-2.0.0.dylib           	0x000000010e8c5449 g_thread_pool_thread_proxy + 393
6   libglib-2.0.0.dylib           	0x000000010e8c4072 g_thread_proxy + 66
7   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
8   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
9   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 9:
0   libsystem_kernel.dylib        	0x00007fff7705a866 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff7711956e _pthread_cond_wait + 722
2   libgdk-3.0.dylib              	0x000000010a20bc63 select_thread_func + 67
3   libsystem_pthread.dylib       	0x00007fff771162eb _pthread_body + 126
4   libsystem_pthread.dylib       	0x00007fff77119249 _pthread_start + 66
5   libsystem_pthread.dylib       	0x00007fff7711540d thread_start + 13

Thread 10:
0   libsystem_pthread.dylib       	0x00007fff771153f0 start_wqthread + 0

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x9fb0a7b0ac83002a  rbx: 0x00007f8df9525a70  rcx: 0x0000000000000000  rdx: 0x0000000000107b20
  rdi: 0x000000010fee6080  rsi: 0x00007f8df9700000  rbp: 0x00007ffee91f00f0  rsp: 0x00007ffee91f00f0
   r8: 0x00007f8df97ef9b0   r9: 0x00007f8df97f5800  r10: 0x0000000000000190  r11: 0xc00007f8df97f97e
  r12: 0x0000000000000000  r13: 0x0000000000000021  r14: 0x00007ffee91f0130  r15: 0x00007f8df9525a00
  rip: 0x0000000106d49970  rfl: 0x0000000000000202  cr2: 0x0000000018962000
  
Logical CPU:     0
Error Code:      0x00000000
Trap Number:     3


Binary Images:
       0x106a0d000 -        0x106a14ff3 +WebKitWebProcess (0) /nix/*/WebKitWebProcess
       0x106a17000 -        0x108b76ff3 +libwebkit2gtk-4.0.37.dylib (0) /nix/*/libwebkit2gtk-4.0.37.dylib
       0x10a1c3000 -        0x10a238ff3 +libgdk-3.0.dylib (0) /nix/*/libgdk-3.0.dylib
       0x10a26c000 -        0x10a281ffb +libz.dylib (0) /nix/*/libz.dylib
       0x10a285000 -        0x10a294fff +libpangocairo-1.0.0.dylib (0) /nix/*/libpangocairo-1.0.0.dylib
       0x10a2a0000 -        0x10a2ddff7 +libpango-1.0.0.dylib (0) /nix/*/libpango-1.0.0.dylib
       0x10a2f1000 -        0x10a3beff3 +libharfbuzz.0.dylib (0) /nix/*/libharfbuzz.0.dylib
       0x10a3e5000 -        0x10a400ff3 +libatk-1.0.0.dylib (0) /nix/*/libatk-1.0.0.dylib
       0x10a40e000 -        0x10a411fff +libcairo-gobject.2.dylib (0) /nix/*/libcairo-gobject.2.dylib
       0x10a416000 -        0x10a4eaffb +libcairo.2.dylib (0) /nix/*/libcairo.2.dylib
       0x10a514000 -        0x10a534ff3 +libgdk_pixbuf-2.0.0.dylib (0) /nix/*/libgdk_pixbuf-2.0.0.dylib
       0x10a540000 -        0x10a6a0ff3 +libicuuc.69.1.dylib (0) /nix/*/libicuuc.69.1.dylib
       0x10a715000 -        0x10a715fff +libiconv.dylib (0) /nix/*/libiconv.dylib
       0x10a717000 -        0x10a718ff7 +libharfbuzz-icu.0.dylib (0) /nix/*/libharfbuzz-icu.0.dylib
       0x10a71b000 -        0x10a71dffb +libwebpdemux.2.dylib (0) /nix/*/libwebpdemux.2.dylib
       0x10a720000 -        0x10a78a70f  dyld (655.1.1) <AF217C8D-5AF1-34FF-8643-A3FB0537E9D0> /usr/lib/dyld
       0x10a7eb000 -        0x10ae54fff +libgtk-3.0.dylib (0) /nix/*/libgtk-3.0.dylib
       0x10af83000 -        0x10c2bbffb +libjavascriptcoregtk-4.0.18.dylib (0) /nix/*/libjavascriptcoregtk-4.0.18.dylib
       0x10c7e8000 -        0x10e33efff +libicudata.69.1.dylib (0) /nix/*/libicudata.69.1.dylib
       0x10e340000 -        0x10e540ff7 +libicui18n.69.1.dylib (0) /nix/*/libicui18n.69.1.dylib
       0x10e64d000 -        0x10e791fff +libgio-2.0.0.dylib (0) /nix/*/libgio-2.0.0.dylib
       0x10e809000 -        0x10e844ff3 +libgobject-2.0.0.dylib (0) /nix/*/libgobject-2.0.0.dylib
       0x10e859000 -        0x10e956ff7 +libglib-2.0.0.dylib (0) /nix/*/libglib-2.0.0.dylib
       0x10e97d000 -        0x10e986ffb +libintl.8.dylib (0) /nix/*/libintl.8.dylib
       0x10e98c000 -        0x10ea0dffb +libc++.1.0.dylib (0) /nix/*/libc++.1.0.dylib
       0x10ea68000 -        0x10ea6dff7 +libnotify.4.dylib (0) /nix/*/libnotify.4.dylib
       0x10ea72000 -        0x10eba1ff7 +libxml2.2.dylib (0) /nix/*/libxml2.2.dylib
       0x10ebd1000 -        0x10ed54ff3 +libsqlite3.0.dylib (0) /nix/*/libsqlite3.0.dylib
       0x10ed70000 -        0x10ed9aff3 +libxslt.1.dylib (0) /nix/*/libxslt.1.dylib
       0x10eda5000 -        0x10edafff7 +libwoff2dec.1.0.2.dylib (0) /nix/*/libwoff2dec.1.0.2.dylib
       0x10edb3000 -        0x10ededffb +libfontconfig.1.dylib (0) /nix/*/libfontconfig.1.dylib
       0x10edfa000 -        0x10eeacff7 +libfreetype.6.dylib (0) /nix/*/libfreetype.6.dylib
       0x10eec6000 -        0x10efb8247 +libgcrypt.20.dylib (0) /nix/*/libgcrypt.20.dylib
       0x10efe2000 -        0x10efedff3 +libgstapp-1.0.0.dylib (0) /nix/*/libgstapp-1.0.0.dylib
       0x10eff4000 -        0x10f059ff3 +libgstbase-1.0.0.dylib (0) /nix/*/libgstbase-1.0.0.dylib
       0x10f06e000 -        0x10f15dff7 +libgstreamer-1.0.0.dylib (0) /nix/*/libgstreamer-1.0.0.dylib
       0x10f19f000 -        0x10f1c8ff7 +libgstpbutils-1.0.0.dylib (0) /nix/*/libgstpbutils-1.0.0.dylib
       0x10f1db000 -        0x10f245ffb +libgstaudio-1.0.0.dylib (0) /nix/*/libgstaudio-1.0.0.dylib
       0x10f260000 -        0x10f291ffb +libgsttag-1.0.0.dylib (0) /nix/*/libgsttag-1.0.0.dylib
       0x10f29e000 -        0x10f344ffb +libgstvideo-1.0.0.dylib (0) /nix/*/libgstvideo-1.0.0.dylib
       0x10f376000 -        0x10f407fef +libjpeg.62.dylib (0) /nix/*/libjpeg.62.dylib
       0x10f41c000 -        0x10f44bff7 +libpng16.16.dylib (0) /nix/*/libpng16.16.dylib
       0x10f454000 -        0x10f4a6ff7 +libopenjp2.7.dylib (0) /nix/*/libopenjp2.7.dylib
       0x10f4af000 -        0x10f52efff +libwebp.7.dylib (0) /nix/*/libwebp.7.dylib
       0x10f53c000 -        0x10f5a6ff3 +libsoup-2.4.1.dylib (0) /nix/*/libsoup-2.4.1.dylib
       0x10f5d1000 -        0x10f5d9fff +libenchant-2.2.dylib (0) /nix/*/libenchant-2.2.dylib
       0x10f5de000 -        0x10f5e0ffb +libgmodule-2.0.0.dylib (0) /nix/*/libgmodule-2.0.0.dylib
       0x10f5e3000 -        0x10f621ff7 +libsecret-1.0.dylib (0) /nix/*/libsecret-1.0.dylib
       0x10f63e000 -        0x10f64dffb +libtasn1.6.dylib (0) /nix/*/libtasn1.6.dylib
       0x10f651000 -        0x10f6ddfff +libpcre.1.dylib (0) /nix/*/libpcre.1.dylib
       0x10f6e2000 -        0x10f7c1ff7 +libiconv-nocharset.dylib (0) /nix/*/libiconv-nocharset.dylib
       0x10f7cc000 -        0x10f7ccffb +libcharset.1.dylib (0) /nix/*/libcharset.1.dylib
       0x10f7cf000 -        0x10f7d5fb7 +libffi.7.dylib (0) /nix/*/libffi.7.dylib
       0x10f7d9000 -        0x10f7fbff3 +libresolv.9.dylib (0) /nix/*/libresolv.9.dylib
       0x10f804000 -        0x10f825ff7 +libc++abi.dylib (0) /nix/*/libc++abi.dylib
       0x10f839000 -        0x10f90aff7 +libharfbuzz.0.dylib (0) /nix/*/libharfbuzz.0.dylib
       0x10f933000 -        0x10f942ff3 +libpangoft2-1.0.0.dylib (0) /nix/*/libpangoft2-1.0.0.dylib
       0x10f94d000 -        0x10f966ff3 +libfribidi.0.dylib (0) /nix/*/libfribidi.0.dylib
       0x10f96a000 -        0x10f9d6ff3 +libepoxy.0.dylib (0) /nix/*/libepoxy.0.dylib
       0x10fa78000 -        0x10fb25fff +libpixman-1.0.dylib (0) /nix/*/libpixman-1.0.dylib
       0x10fb3a000 -        0x10fb4aff3 +libbz2.1.dylib (0) /nix/*/libbz2.1.dylib
       0x10fb4d000 -        0x10fb6eff7 +libexpat.1.dylib (0) /nix/*/libexpat.1.dylib
       0x10fb75000 -        0x10fb7bff3 +libthai.0.dylib (0) /nix/*/libthai.0.dylib
       0x10fb7f000 -        0x10fb83ff3 +libdatrie.1.dylib (0) /nix/*/libdatrie.1.dylib
       0x10fb87000 -        0x10fba3fff +libgraphite2.3.dylib (0) /nix/*/libgraphite2.3.dylib
       0x10fbab000 -        0x10fbadff3 +libwoff2common.1.0.2.dylib (0) /nix/*/libwoff2common.1.0.2.dylib
       0x10fbb0000 -        0x10fbbbff3 +libbrotlidec.1.dylib (0) /nix/*/libbrotlidec.1.dylib
       0x10fbbe000 -        0x10fbdefff +libbrotlicommon.1.dylib (0) /nix/*/libbrotlicommon.1.dylib
       0x10fbe1000 -        0x10fbfaff7 +libgpg-error.0.dylib (0) /nix/*/libgpg-error.0.dylib
       0x10fc03000 -        0x10fc85fff +liborc-0.4.0.dylib (0) /nix/*/liborc-0.4.0.dylib
       0x10fc9c000 -        0x10fcaaff7 +libpsl.5.dylib (0) /nix/*/libpsl.5.dylib
       0x10fcad000 -        0x10fe19ff3 +libunistring.2.dylib (0) /nix/*/libunistring.2.dylib
       0x10fe2b000 -        0x10fe49ffb +libidn2.0.dylib (0) /nix/*/libidn2.0.dylib
       0x10fe4d000 -        0x10feb6fff +libaspell.15.dylib (0) /nix/*/libaspell.15.dylib
       0x112a06000 -        0x112a0dffb +libwebkit2gtkinjectedbundle.so (0) /nix/*/libwebkit2gtkinjectedbundle.so
    0x7fff472e3000 -     0x7fff472e3fff  com.apple.Accelerate (1.11 - Accelerate 1.11) <762942CB-CFC9-3A0C-9645-A56523A06426> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    0x7fff472fb000 -     0x7fff47994fef  com.apple.vImage (8.1 - ???) <53FA3611-894E-3158-A654-FBD2F70998FE> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    0x7fff47995000 -     0x7fff47c0eff3  libBLAS.dylib (1243.200.4) <417CA0FC-B6CB-3FB3-ACBC-8914E3F62D20> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    0x7fff47c0f000 -     0x7fff47c81ffb  libBNNS.dylib (38.250.1) <538D12A2-9B9D-3E22-9896-F90F6E69C06E> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
    0x7fff47c82000 -     0x7fff4802bff3  libLAPACK.dylib (1243.200.4) <92175DF4-863A-3780-909A-A3E5C410F2E9> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    0x7fff4802c000 -     0x7fff48041feb  libLinearAlgebra.dylib (1243.200.4) <CB671EE6-DEA1-391C-9B2B-AA09A46B4D7A> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
    0x7fff48042000 -     0x7fff48047ff3  libQuadrature.dylib (3.200.2) <1BAE7E22-2862-379F-B334-A3756067730F> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
    0x7fff48048000 -     0x7fff480c4ff3  libSparse.dylib (79.200.5) <E78B33D3-672A-3C53-B512-D3DDB2E9AC8D> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
    0x7fff480c5000 -     0x7fff480d8fe3  libSparseBLAS.dylib (1243.200.4) <E9243341-DB77-37C1-97C5-3DFA00DD70FA> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
    0x7fff480d9000 -     0x7fff482c0ff7  libvDSP.dylib (671.250.4) <7B110627-A9C1-3FB7-A077-0C7741BA25D8> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    0x7fff482c1000 -     0x7fff48374ff7  libvMisc.dylib (671.250.4) <D5BA4812-BFFC-3CD0-B382-905CD8555DA6> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    0x7fff48375000 -     0x7fff48375fff  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <74288115-EF61-30B6-843F-0593B31D4929> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    0x7fff48517000 -     0x7fff492ccffb  com.apple.AppKit (6.9 - 1671.60.109) <13EBDF4A-1B54-36F6-BC85-E23526B163F6> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
    0x7fff4931e000 -     0x7fff4931efff  com.apple.ApplicationServices (50.1 - 50.1) <89FD39C7-7065-32AC-92A5-1A39269C8420> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
    0x7fff4931f000 -     0x7fff4938afff  com.apple.ApplicationServices.ATS (377 - 453.11.2.2) <A258DA73-114B-3102-A056-4AAAD3CEB9DD> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
    0x7fff49423000 -     0x7fff4953afff  libFontParser.dylib (228.6.2.12) <247BA958-137F-3763-A9F3-9B9FFBDCB3D6> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
    0x7fff4953b000 -     0x7fff4957dfff  libFontRegistry.dylib (228.12.2.4) <6DDE44EC-FF6B-3893-9209-45E0955ABDD5> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
    0x7fff495d7000 -     0x7fff49609fff  libTrueTypeScaler.dylib (228.6.2.12) <30A5AE06-93B9-3BA4-B867-A0BF145E4115> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libTrueTypeScaler.dylib
    0x7fff4966e000 -     0x7fff49672ff3  com.apple.ColorSyncLegacy (4.13.0 - 1) <E8E9342C-47EB-359D-A373-554AC19B174A> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
    0x7fff4970d000 -     0x7fff4975fff7  com.apple.HIServices (1.22 - 628) <2BE461FF-80B9-30D3-A574-AED5724B1C1B> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
    0x7fff49760000 -     0x7fff4976ffff  com.apple.LangAnalysis (1.7.0 - 1.7.0) <F5617A2A-FEA6-3832-B5BA-C2111B98786F> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
    0x7fff49770000 -     0x7fff497b9ff7  com.apple.print.framework.PrintCore (14.7 - 503.8) <E1D0FCBC-155E-372E-A90F-4A20B94FC114> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
    0x7fff497ba000 -     0x7fff497f3ff7  com.apple.QD (3.12 - 407.2) <28C7D39F-59C9-3314-BECC-67045487229C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
    0x7fff497f4000 -     0x7fff49800fff  com.apple.speech.synthesis.framework (8.1.3 - 8.1.3) <5E7B9BD4-122B-3012-A044-3259C97E7509> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
    0x7fff49801000 -     0x7fff49a78ff7  com.apple.audio.toolbox.AudioToolbox (1.14 - 1.14) <4E6EAEDA-CC0F-384A-8563-7CAE1D976503> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
    0x7fff49a7a000 -     0x7fff49a7afff  com.apple.audio.units.AudioUnit (1.14 - 1.14) <1CD6D278-2BC1-3BB9-B692-08120882C3C5> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
    0x7fff49dd3000 -     0x7fff4a175fff  com.apple.CFNetwork (978.6 - 978.6) <F6AC3859-B6F9-3212-A357-54AA096DAA9E> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    0x7fff4a18a000 -     0x7fff4a18afff  com.apple.Carbon (158 - 158) <2B882FDA-8576-3986-8E09-F1A4E5FE48D3> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
    0x7fff4a18b000 -     0x7fff4a18effb  com.apple.CommonPanels (1.2.6 - 98) <1CD6D56D-8EC7-3528-8CBC-FC69533519B5> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
    0x7fff4a18f000 -     0x7fff4a486fff  com.apple.HIToolbox (2.1.1 - 918.7) <88D7F19C-8C9D-384B-BAB5-8205CA282F2C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
    0x7fff4a487000 -     0x7fff4a48aff3  com.apple.help (1.3.8 - 66) <A08517EB-8958-36C9-AEE0-1A8FEEACBE3F> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
    0x7fff4a48b000 -     0x7fff4a490ff7  com.apple.ImageCapture (9.0 - 1534.2) <DB063E87-ED8F-3E4E-A7E2-A6B45FA73EF7> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
    0x7fff4a491000 -     0x7fff4a526ff3  com.apple.ink.framework (10.9 - 225) <7C7E9483-2E91-3DD3-B1E0-C238F42CA0DD> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
    0x7fff4a527000 -     0x7fff4a53fff7  com.apple.openscripting (1.7 - 179.1) <9B8C1ECC-5864-3E21-9149-863E884EA25C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
    0x7fff4a55f000 -     0x7fff4a560ff7  com.apple.print.framework.Print (14.2 - 267.4) <A7A9D2A0-D4E0-35EF-A0F7-50521F707C33> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
    0x7fff4a561000 -     0x7fff4a563ff7  com.apple.securityhi (9.0 - 55006) <05717F77-7A7B-37E6-AB3E-03F063E9095B> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
    0x7fff4a564000 -     0x7fff4a56aff7  com.apple.speech.recognition.framework (6.0.3 - 6.0.3) <3CC050FB-EBCB-3087-8EA5-F378C8F99217> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
    0x7fff4a68c000 -     0x7fff4a68cfff  com.apple.Cocoa (6.11 - 23) <511C680D-A2D3-3C10-A67D-06E812525FE7> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
    0x7fff4a69a000 -     0x7fff4a7e9ff7  com.apple.ColorSync (4.13.0 - 3345.6) <356BA478-76DE-3087-86BE-5E884276AB83> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
    0x7fff4a975000 -     0x7fff4a9fbfff  com.apple.audio.CoreAudio (4.3.0 - 4.3.0) <E6E4A58D-9BAE-30B1-856E-E1332B98E9ED> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
    0x7fff4aa5f000 -     0x7fff4aa89ffb  com.apple.CoreBluetooth (1.0 - 1) <4F2DDEF0-1F92-384B-8CDA-4958725D0A8E> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
    0x7fff4aa8a000 -     0x7fff4ae0ffef  com.apple.CoreData (120 - 866.6) <132CB39B-8D58-30FA-B8AD-49BFFF34B293> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
    0x7fff4ae10000 -     0x7fff4af00ff7  com.apple.CoreDisplay (101.3 - 110.18) <6DD41271-E145-3E99-9D49-7CC8AC1C65B6> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
    0x7fff4af01000 -     0x7fff4b347fff  com.apple.CoreFoundation (6.9 - 1575.405) <D1BE2B09-17CD-35FE-A165-43F8328E77A8> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff4b349000 -     0x7fff4b9d9fe7  com.apple.CoreGraphics (2.0 - 1265.13) <C4238967-56E7-3AE5-A3F4-1A878EB5FFD8> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
    0x7fff4b9db000 -     0x7fff4bcfbfff  com.apple.CoreImage (14.4.0 - 750.0.140) <11026E39-D2FF-3CF6-8ACE-7BA293F9853E> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
    0x7fff4c159000 -     0x7fff4c159fff  com.apple.CoreServices (946 - 946) <C2BA6E71-CDF9-314B-8E10-D53C0180720F> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    0x7fff4c15a000 -     0x7fff4c1d6ff7  com.apple.AE (773 - 773) <55AE7C9E-27C3-30E9-A047-3B92A6FD53B4> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    0x7fff4c1d7000 -     0x7fff4c4aefff  com.apple.CoreServices.CarbonCore (1178.33 - 1178.33) <CB87F0C7-2CD6-3983-8E32-B6A2EC925352> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    0x7fff4c4af000 -     0x7fff4c4f7ff7  com.apple.DictionaryServices (1.2 - 284.16.4) <746EB200-DC51-30AE-9CBC-608A7B4CC8DA> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
    0x7fff4c4f8000 -     0x7fff4c500ffb  com.apple.CoreServices.FSEvents (1239.200.13 - 1239.200.13) <5913F08D-4AA2-3200-B998-012E6A19A66D> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
    0x7fff4c501000 -     0x7fff4c6b2ff7  com.apple.LaunchServices (946 - 946) <A0C91634-9410-38E8-BC11-7A5A369E6BA5> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    0x7fff4c6b3000 -     0x7fff4c751ff7  com.apple.Metadata (10.7.0 - 1191.58) <89DA10B4-5695-3FD9-A920-C34C33957868> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    0x7fff4c752000 -     0x7fff4c79cff7  com.apple.CoreServices.OSServices (946 - 946) <20C4EEF8-D5AC-39A0-9B4A-78F88E3EFBCC> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    0x7fff4c79d000 -     0x7fff4c804ff7  com.apple.SearchKit (1.4.0 - 1.4.0) <DA08AA6F-A6F1-36C0-87F4-E26294E51A3A> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    0x7fff4c805000 -     0x7fff4c826ff3  com.apple.coreservices.SharedFileList (71.28 - 71.28) <487A8464-729E-305A-B5D1-E3FE8EB9CFC5> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
    0x7fff4cb31000 -     0x7fff4cc95ff3  com.apple.CoreText (352.0 - 584.26.3.8) <403650AA-266C-36C0-A2C3-B38D91B5FA57> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
    0x7fff4cc96000 -     0x7fff4ccd6ff3  com.apple.CoreVideo (1.8 - 281.4) <10CF8E52-07E3-382B-8091-2CEEEFFA69B4> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
    0x7fff4ccd7000 -     0x7fff4cd66fff  com.apple.framework.CoreWLAN (13.0 - 1375.2) <A476486C-B863-3941-BAE6-A78BDFED4A3B> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
    0x7fff4cfbd000 -     0x7fff4cfc2ffb  com.apple.DiskArbitration (2.7 - 2.7) <04909487-FEF7-3AB9-B8B6-A5FB3DE938BE> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    0x7fff4d189000 -     0x7fff4d537ffb  com.apple.Foundation (6.9 - 1575.405) <1177B3CF-C81D-3982-BCC2-819731D99F01> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    0x7fff4d5a6000 -     0x7fff4d5d5ffb  com.apple.GSS (4.0 - 2.0) <4B72210D-63E7-34C9-BFD4-48E11F857EE1> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
    0x7fff4d6d5000 -     0x7fff4d7dffff  com.apple.Bluetooth (6.0.14 - 6.0.14d12) <0904E4FC-DE05-3B78-BD49-832A5AC2967D> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
    0x7fff4d842000 -     0x7fff4d8d1fff  com.apple.framework.IOKit (2.0.2 - 1483.260.5) <C00462C2-9CF3-3E3E-BD1E-B57AF6AB562E> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    0x7fff4d8d3000 -     0x7fff4d8e2ffb  com.apple.IOSurface (255.6.1 - 255.6.1) <85F85EBB-EA59-3A8B-B3EB-7C20F3CC77AE> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    0x7fff4d936000 -     0x7fff4dac3ff7  com.apple.ImageIO.framework (3.3.0 - 1850.2.14) <A32566AF-0155-3A50-BA23-0288D3F5D35E> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
    0x7fff4dac4000 -     0x7fff4dac8ffb  libGIF.dylib (1850.2.14) <E0A55FF4-0EA2-38DE-9BC3-CDDA18855E0B> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
    0x7fff4dac9000 -     0x7fff4dba5ff7  libJP2.dylib (1850.2.14) <0B1933D0-EFCE-3A6E-94AC-6E25C8B9A34B> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
    0x7fff4dba6000 -     0x7fff4dbcbfeb  libJPEG.dylib (1850.2.14) <2864EF55-B068-3634-865A-C71858CC396D> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
    0x7fff4dea1000 -     0x7fff4dec7feb  libPng.dylib (1850.2.14) <A7920CA1-CD86-39B3-85EB-9808AF1DC731> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
    0x7fff4dec8000 -     0x7fff4decaffb  libRadiance.dylib (1850.2.14) <EDBC5EA7-76E1-354C-A631-819889C0BDC4> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
    0x7fff4decb000 -     0x7fff4df18ff3  libTIFF.dylib (1850.2.14) <4443BFAC-4DBF-3EE0-91BE-F714BA304DC3> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
    0x7fff4f08b000 -     0x7fff4f0a4fff  com.apple.Kerberos (3.0 - 1) <DB1E0679-37E1-3B93-9789-32F63D660C3B> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
    0x7fff4fac0000 -     0x7fff4fb68ff7  com.apple.Metal (162.2 - 162.2) <B65C71BF-D40E-3BB3-940C-117DDD203551> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
    0x7fff4fb84000 -     0x7fff4fba3ff7  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <44CE8362-E972-3697-AD6F-15BC863BAEB8> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSCore.framework/Versions/A/MPSCore
    0x7fff4fba4000 -     0x7fff4fc20fe7  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <EE8440DA-66DF-3923-ABBC-E0543211C069> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSImage.framework/Versions/A/MPSImage
    0x7fff4fc21000 -     0x7fff4fc48fff  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <E64450DF-2B96-331E-B7F4-666E00571C70> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
    0x7fff4fc49000 -     0x7fff4fd74ff7  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <F2CF26B6-73F1-3644-8FE9-CDB9B2C4501F> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
    0x7fff4fd75000 -     0x7fff4fd8ffff  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <B33A35C3-0393-366B-ACFB-F4BB6A5F7B4A> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
    0x7fff4fd90000 -     0x7fff4fd91ff7  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <69F14BCF-C5C5-3BF8-9C31-8F87D2D6130A> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
    0x7fff50b8e000 -     0x7fff50b9aff7  com.apple.NetFS (6.0 - 4.0) <1C8237D6-731D-3E32-8BD5-B92A33D08A30> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
    0x7fff53638000 -     0x7fff5368fff7  com.apple.opencl (2.15.3 - 2.15.3) <5D9915B4-59F6-355A-948C-E81CEEEF4933> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
    0x7fff53690000 -     0x7fff536abff7  com.apple.CFOpenDirectory (10.14 - 207.200.4) <F03D84EB-49B2-3A00-9127-B9A269824026> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    0x7fff536ac000 -     0x7fff536b7ffb  com.apple.OpenDirectory (10.14 - 207.200.4) <A8020CEE-5B78-3581-A735-EA2833683F31> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    0x7fff54007000 -     0x7fff54009fff  libCVMSPluginSupport.dylib (17.7.3) <D1E81264-9C8F-38D2-8669-31944FA2FD95> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
    0x7fff5400a000 -     0x7fff5400fff3  libCoreFSCache.dylib (166.7) <B4FA6DF5-D5F7-32B9-8FCD-8FD4E80D31E5> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
    0x7fff54010000 -     0x7fff54014fff  libCoreVMClient.dylib (166.7) <F24595D0-011C-39C3-A48F-C1ADE643E18A> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
    0x7fff54015000 -     0x7fff5401dff7  libGFXShared.dylib (17.7.3) <9D0250B9-5914-3AA3-BE1E-5431C7646B07> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
    0x7fff5401e000 -     0x7fff54029fff  libGL.dylib (17.7.3) <5AB5AF8E-9B3E-39C5-AC86-AB30E057803A> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
    0x7fff5402a000 -     0x7fff54064fef  libGLImage.dylib (17.7.3) <68240F7A-470B-3C66-9FEE-95DB2E06EEDB> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
    0x7fff541d8000 -     0x7fff54216fff  libGLU.dylib (17.7.3) <A19060B3-970A-3C7D-A6CB-34E889CA629F> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
    0x7fff54bb3000 -     0x7fff54bc2ffb  com.apple.opengl (17.7.3 - 17.7.3) <7AC113CD-89D7-3123-9E44-898F5B238BEC> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
    0x7fff559cc000 -     0x7fff55c23ff7  com.apple.QuartzCore (1.11 - 701.14) <799289BE-DE8E-390A-9DEC-82DDCF5BA319> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
    0x7fff5645b000 -     0x7fff5675cff7  com.apple.security (7.0 - 58286.270.14) <BDD08930-4D92-3D2A-8FED-F7F74A086BED> /System/Library/Frameworks/Security.framework/Versions/A/Security
    0x7fff5675d000 -     0x7fff567e9fff  com.apple.securityfoundation (6.0 - 55185.260.1) <5CBF715E-7C88-3B8C-8C2F-10B59FA80842> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    0x7fff5681b000 -     0x7fff5681ffff  com.apple.xpc.ServiceManagement (1.0 - 1) <AE9930FD-1AC9-391A-B769-03F6A0F05063> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    0x7fff56bb8000 -     0x7fff56c25fff  com.apple.SystemConfiguration (1.17 - 1.17) <30C8327F-3EFF-3520-9C50-016F8B6B954F> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    0x7fff59e61000 -     0x7fff59f06fef  com.apple.APFS (1.0 - 1) <121C4AD9-617C-3865-8DF5-988E7C686611> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
    0x7fff5a91b000 -     0x7fff5a91cff7  com.apple.AggregateDictionary (1.0 - 1) <A6AF8AC4-1F25-37C4-9157-A02E9C200926> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
    0x7fff5af1f000 -     0x7fff5af4bff7  com.apple.framework.Apple80211 (13.0 - 1380.2) <E4D12303-8B12-303C-91E2-3B40F60832BA> /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
    0x7fff5b073000 -     0x7fff5b082fc7  com.apple.AppleFSCompression (96.200.3 - 1.0) <3CF60CE8-976E-3CB8-959D-DD0948C1C2DE> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    0x7fff5b17e000 -     0x7fff5b189fff  com.apple.AppleIDAuthSupport (1.0 - 1) <2E9D1398-DBE6-328B-ADDA-20FA5FAD7405> /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
    0x7fff5b1ca000 -     0x7fff5b213ff3  com.apple.AppleJPEG (1.0 - 1) <4C1F426B-7D77-3980-9633-7DBD8C666B9A> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
    0x7fff5b467000 -     0x7fff5b489fff  com.apple.applesauce (1.0 - ???) <F49107C7-3C51-3024-8EF1-C57643BE4F3B> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
    0x7fff5b5e8000 -     0x7fff5b5fcffb  com.apple.AssertionServices (1.0 - 1) <456E507A-4561-3628-9FBE-173ACE7429D8> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
    0x7fff5b9cc000 -     0x7fff5bab8ff7  com.apple.AuthKit (1.0 - 1) <2765ABE9-54F2-3E45-8A93-1261E251B90D> /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
    0x7fff5bc7a000 -     0x7fff5bc82fff  com.apple.coreservices.BackgroundTaskManagement (1.0 - 57.1) <2A396FC0-7B79-3088-9A82-FB93C1181A57> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
    0x7fff5bc83000 -     0x7fff5bd18fff  com.apple.backup.framework (1.10.7 - ???) <5243C2BC-0159-3DBB-9FAB-22EA01E58052> /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
    0x7fff5bd19000 -     0x7fff5bd86ff3  com.apple.BaseBoard (360.28 - 360.28) <68FA8044-F3CD-3BC6-9DAB-27DACF52BFC0> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
    0x7fff5d9f3000 -     0x7fff5d9fcffb  com.apple.CommonAuth (4.0 - 2.0) <B07CB4D3-12A9-31E0-B393-67BCBD5F8ADB> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
    0x7fff5e6d5000 -     0x7fff5e6e6ff7  com.apple.CoreEmoji (1.0 - 69.19.9) <228457B3-E191-356E-9A5B-3C0438D05FBA> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
    0x7fff5ec90000 -     0x7fff5ecf6ff7  com.apple.CoreNLP (1.0 - 130.15.22) <27877820-17D0-3B02-8557-4014E876CCC7> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
    0x7fff5efa3000 -     0x7fff5efabff7  com.apple.CorePhoneNumbers (1.0 - 1) <11F97C7E-C183-305F-8E6C-9B374F50E26B> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
    0x7fff5f127000 -     0x7fff5f158ff3  com.apple.CoreServicesInternal (358 - 358) <DD6EF60D-048F-3186-83DA-EB191EDF48AE> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
    0x7fff5f51f000 -     0x7fff5f5a3fff  com.apple.CoreSymbolication (10.2 - 64490.25.1) <28B2FF2D-3FDE-3A20-B343-341E5BD4E22F> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
    0x7fff5f633000 -     0x7fff5f75eff7  com.apple.coreui (2.1 - 499.10) <A80F4B09-F940-346F-A9DF-4EFADD9220A8> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
    0x7fff5f75f000 -     0x7fff5f8fffff  com.apple.CoreUtils (5.9 - 590.16) <BF9A990D-24C0-3633-A753-F19F4DFCA663> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
    0x7fff5f953000 -     0x7fff5f9b6ff7  com.apple.framework.CoreWiFi (13.0 - 1375.2) <7E9CC352-BB06-3C97-A51F-6A35F09EBA16> /System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
    0x7fff5f9b7000 -     0x7fff5f9c8ff3  com.apple.CrashReporterSupport (10.13 - 938.29) <5942C233-DB5E-3119-8DA3-201A5C080191> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
    0x7fff5fa58000 -     0x7fff5fa67fff  com.apple.framework.DFRFoundation (1.0 - 211.1) <E3F02F2A-2059-39CC-85DA-969676EB88EB> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
    0x7fff5fa68000 -     0x7fff5fa6cff7  com.apple.DSExternalDisplay (3.1 - 380) <787B9748-B120-3453-B8FE-61D9E363A9E0> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
    0x7fff5faed000 -     0x7fff5fb62ffb  com.apple.datadetectorscore (7.0 - 590.27) <06FB1A07-7AE6-3ADD-8E7E-41955FAB38E8> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
    0x7fff5fbae000 -     0x7fff5fbebff7  com.apple.DebugSymbols (190 - 190) <6F4FAACA-E06B-38AD-A0C2-14EA5408A231> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
    0x7fff5fbec000 -     0x7fff5fd27ff7  com.apple.desktopservices (1.13.6 - ???) <7536F3F3-90F1-3D1C-9249-91B809FE5328> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
    0x7fff60c6e000 -     0x7fff61089fff  com.apple.vision.FaceCore (3.3.4 - 3.3.4) <A576E2DA-BF6F-3B18-8FEB-324E5C5FA9BD> /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
    0x7fff65fde000 -     0x7fff65fe3fff  com.apple.GPUWrangler (3.50.16 - 3.50.16) <1156CF8C-729B-3173-B3CC-00BB17156BCC> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
    0x7fff66def000 -     0x7fff66dfefff  com.apple.GraphVisualizer (1.0 - 5) <48D020B7-5938-3FAE-B468-E291AEE2C06F> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
    0x7fff66f64000 -     0x7fff66fd8ff3  com.apple.Heimdal (4.0 - 2.0) <EDF4255F-704F-32BA-A6EF-F3477A4B1D5B> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
    0x7fff682e3000 -     0x7fff682eaffb  com.apple.IOAccelerator (404.15 - 404.15) <15B11DC6-DF66-3E0F-BAB2-573727CEA327> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    0x7fff682ee000 -     0x7fff68306fff  com.apple.IOPresentment (1.0 - 42.6) <B5E36058-DB24-3CED-A8FF-980FDCCD6575> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
    0x7fff686ae000 -     0x7fff686dbff7  com.apple.IconServices (379 - 379) <7BAD562D-4FA3-3E11-863C-1EEBE2406D2C> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
    0x7fff6896e000 -     0x7fff68980ff3  com.apple.security.KeychainCircle.KeychainCircle (1.0 - 1) <40D1221D-1DFE-3CF3-8DC1-07313F10DA17> /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
    0x7fff6899b000 -     0x7fff68a76ff7  com.apple.LanguageModeling (1.0 - 159.15.15) <3DE3CE61-542B-37B7-883E-4B9717CAC65F> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
    0x7fff68a77000 -     0x7fff68ab3ff7  com.apple.Lexicon-framework (1.0 - 33.15.10) <4B5E843E-2809-3E70-9560-9254E2656419> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
    0x7fff68aba000 -     0x7fff68abffff  com.apple.LinguisticData (1.0 - 238.25) <F529B961-098C-3E4C-A3E9-9DA9BFA1B3F0> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
    0x7fff697b5000 -     0x7fff697ddff7  com.apple.spotlight.metadata.utilities (1.0 - 1191.58) <23E8580B-19C0-3E4F-A9FE-368DA80EAA6F> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
    0x7fff697de000 -     0x7fff6986bff7  com.apple.gpusw.MetalTools (1.0 - 1) <9B542958-6363-3041-A265-EC7AC7BD7A43> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
    0x7fff69a67000 -     0x7fff69a82ffb  com.apple.MobileKeyBag (2.0 - 1.0) <39337CBB-1D39-3DDC-A998-591194C76523> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
    0x7fff69b0b000 -     0x7fff69b35ffb  com.apple.MultitouchSupport.framework (2450.1 - 2450.1) <42A23EC9-64A7-31C7-BF33-DF4412ED8A3F> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
    0x7fff69d71000 -     0x7fff69d7bfff  com.apple.NetAuth (6.2 - 6.2) <0D01BBE5-0269-310D-B148-D19DAE143DEB> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
    0x7fff6a5dd000 -     0x7fff6a62eff3  com.apple.OTSVG (1.0 - ???) <E43F65D0-080B-3D5C-ADB3-14200AB5CAE4> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
    0x7fff6b7c8000 -     0x7fff6b7d7ff7  com.apple.PerformanceAnalysis (1.218.3.1 - 218.3.1) <B6FF319A-FC61-3EA9-A72D-68E1430429A7> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
    0x7fff6d669000 -     0x7fff6d687ff7  com.apple.ProtocolBuffer (1 - 263.2) <907D6C95-D050-31DE-99CA-16A5135BC6F9> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
    0x7fff6d81f000 -     0x7fff6d86ffff  com.apple.ROCKit (27.6 - 27.6) <756C2253-E8B1-3C48-9945-DE8D6AD24DE2> /System/Library/PrivateFrameworks/ROCKit.framework/Versions/A/ROCKit
    0x7fff6d9c9000 -     0x7fff6d9ebfff  com.apple.RemoteViewServices (2.0 - 128) <8FB0E4EB-DCBB-32E6-94C6-AA9BA9EE4CAC> /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
    0x7fff6f1f5000 -     0x7fff6f313fff  com.apple.Sharing (1288.62.5 - 1288.62.5) <BB647030-839A-3271-B205-D4325346DD3B> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
    0x7fff70128000 -     0x7fff703d7ff3  com.apple.SkyLight (1.600.0 - 340.56) <C62B4595-5FE6-3C62-9B90-A86143CD623B> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
    0x7fff70b7b000 -     0x7fff70b87fff  com.apple.SpeechRecognitionCore (5.0.21 - 5.0.21) <7A6A67DB-C813-328E-AAFB-D267A5B50B3D> /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
    0x7fff712d8000 -     0x7fff71363fc7  com.apple.Symbolication (10.2 - 64490.38.1) <9FDCC98D-5B32-35AD-A9BF-94DF2B78507F> /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
    0x7fff71849000 -     0x7fff71855ffb  com.apple.TCC (1.0 - 1) <E3691073-7284-35E4-94F3-16587A7F380F> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    0x7fff71abb000 -     0x7fff71b83ff3  com.apple.TextureIO (3.8.4 - 3.8.1) <7CEAC05A-D283-3D5A-B1E3-C849285FA0BF> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
    0x7fff71c40000 -     0x7fff71df8ffb  com.apple.UIFoundation (1.0 - 551.5) <A0FDC3A4-45C6-3C87-B77F-7DC394374C08> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
    0x7fff72a74000 -     0x7fff72b4dfff  com.apple.ViewBridge (407 - 407) <41AB432A-08A7-3808-8079-B07D742D3F33> /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
    0x7fff73325000 -     0x7fff73328fff  com.apple.dt.XCTTargetBootstrap (1.0 - 14490.66) <7AE3457F-AF40-3508-93FB-1D9E31EB1C9D> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
    0x7fff73729000 -     0x7fff7372bffb  com.apple.loginsupport (1.0 - 1) <3F8D6334-BCD6-36C1-BA20-CC8503A84375> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
    0x7fff739f5000 -     0x7fff73a29fff  libCRFSuite.dylib (41.15.4) <406DAC06-0C77-3F90-878B-4D38F11F0256> /usr/lib/libCRFSuite.dylib
    0x7fff73a2c000 -     0x7fff73a36ff7  libChineseTokenizer.dylib (28.15.3) <9B7F6109-3A5D-3641-9A7E-31D2239D73EE> /usr/lib/libChineseTokenizer.dylib
    0x7fff73ac4000 -     0x7fff73ac5ffb  libDiagnosticMessagesClient.dylib (107) <A14D0819-0970-34CD-8680-80E4D7FE8C2C> /usr/lib/libDiagnosticMessagesClient.dylib
    0x7fff73afc000 -     0x7fff73d53ff3  libFosl_dynamic.dylib (18.3.4) <1B5DD4E2-8AE0-315E-829E-D5BFCD264EA8> /usr/lib/libFosl_dynamic.dylib
    0x7fff73da4000 -     0x7fff73dc3fff  libMobileGestalt.dylib (645.270.1) <99A06C8A-97D6-383D-862C-F453BABB48A4> /usr/lib/libMobileGestalt.dylib
    0x7fff73dc4000 -     0x7fff73dc4fff  libOpenScriptingUtil.dylib (179.1) <4D603146-EDA5-3A74-9FF8-4F75D8BB9BC6> /usr/lib/libOpenScriptingUtil.dylib
    0x7fff73f04000 -     0x7fff73f05ffb  libSystem.B.dylib (1252.250.1) <99D9FDA4-DC94-32F4-BAD9-3726618F00FC> /usr/lib/libSystem.B.dylib
    0x7fff73f81000 -     0x7fff73f82fff  libThaiTokenizer.dylib (2.15.1) <ADB37DC3-7D9B-3E73-A72A-BCC3433C937A> /usr/lib/libThaiTokenizer.dylib
    0x7fff73f94000 -     0x7fff73faaffb  libapple_nghttp2.dylib (1.24.1) <6F04250A-6686-3FDC-9A8D-290C64B06502> /usr/lib/libapple_nghttp2.dylib
    0x7fff73fab000 -     0x7fff73fd4ffb  libarchive.2.dylib (54.250.1) <47289946-8504-3966-9127-6CE39993DC2C> /usr/lib/libarchive.2.dylib
    0x7fff73fd5000 -     0x7fff74054fff  libate.dylib (1.13.8) <92B44EDB-369D-3EE8-AEC5-61F8B9313DBF> /usr/lib/libate.dylib
    0x7fff74058000 -     0x7fff74058ff3  libauto.dylib (187) <3E3780E1-96F3-3A22-91C5-92F9A5805518> /usr/lib/libauto.dylib
    0x7fff7412a000 -     0x7fff7413affb  libbsm.0.dylib (39.200.18) <CF381E0B-025B-364F-A83D-2527E03F1AA3> /usr/lib/libbsm.0.dylib
    0x7fff7413b000 -     0x7fff74148fff  libbz2.1.0.dylib (38.200.3) <272953A1-8D36-329B-BDDB-E887B347710F> /usr/lib/libbz2.1.0.dylib
    0x7fff74149000 -     0x7fff7419cff7  libc++.1.dylib (400.9.4) <9A60A190-6C34-339F-BB3D-AACE942009A4> /usr/lib/libc++.1.dylib
    0x7fff7419d000 -     0x7fff741b2ff7  libc++abi.dylib (400.17) <38C09CED-9090-3719-90F3-04A2749F5428> /usr/lib/libc++abi.dylib
    0x7fff741b3000 -     0x7fff741b3ff3  libcharset.1.dylib (51.200.6) <2A27E064-314C-359C-93FC-8A9B06206174> /usr/lib/libcharset.1.dylib
    0x7fff741b4000 -     0x7fff741c4ffb  libcmph.dylib (6.15.1) <9C52B2FE-179F-32AC-B87E-2AFC49ABF817> /usr/lib/libcmph.dylib
    0x7fff741c5000 -     0x7fff741ddffb  libcompression.dylib (52.250.2) <7F4BB18C-1FB4-3825-8D8B-6E6B168774C6> /usr/lib/libcompression.dylib
    0x7fff74452000 -     0x7fff74468fff  libcoretls.dylib (155.220.1) <4C64BE3E-41E3-3020-8BB7-07E90C0C861C> /usr/lib/libcoretls.dylib
    0x7fff74469000 -     0x7fff7446aff3  libcoretls_cfhelpers.dylib (155.220.1) <0959B3E9-6643-3589-8BB3-21D52CDF0EF1> /usr/lib/libcoretls_cfhelpers.dylib
    0x7fff74916000 -     0x7fff7496cff3  libcups.2.dylib (462.16) <E82021D0-36AD-3FB7-AE47-A03A6947C7D0> /usr/lib/libcups.2.dylib
    0x7fff74aa1000 -     0x7fff74aa1fff  libenergytrace.dylib (17.200.1) <80BB567A-FD18-3497-BF97-353F57D98CDD> /usr/lib/libenergytrace.dylib
    0x7fff74ad3000 -     0x7fff74ad8ff7  libgermantok.dylib (17.15.2) <E5F0F794-FF27-3D64-AE52-C78C6A84DD67> /usr/lib/libgermantok.dylib
    0x7fff74ad9000 -     0x7fff74adeff7  libheimdal-asn1.dylib (520.270.7) <F5FFC8CB-8530-3FD0-B8C9-0CA2F8BF1035> /usr/lib/libheimdal-asn1.dylib
    0x7fff74b09000 -     0x7fff74bf9fff  libiconv.2.dylib (51.200.6) <2047C9B7-3F74-3A95-810D-2ED8F0475A99> /usr/lib/libiconv.2.dylib
    0x7fff74bfa000 -     0x7fff74e5bffb  libicucore.A.dylib (62141.0.1) <A0D63918-76E9-3C1B-B255-46F4C1DA7FE8> /usr/lib/libicucore.A.dylib
    0x7fff74ea8000 -     0x7fff74ea9fff  liblangid.dylib (128.15.1) <22D05C4F-769B-3075-ABCF-44A0EBACE028> /usr/lib/liblangid.dylib
    0x7fff74eaa000 -     0x7fff74ec2ff3  liblzma.5.dylib (10.200.3) <E1F4FD60-1CE4-37B9-AD95-29D348AF1AC0> /usr/lib/liblzma.5.dylib
    0x7fff74eda000 -     0x7fff74f7eff7  libmecab.1.0.0.dylib (779.24.1) <A8D0379B-85FA-3B3D-89ED-5CF2C3826AB2> /usr/lib/libmecab.1.0.0.dylib
    0x7fff74f7f000 -     0x7fff75183fff  libmecabra.dylib (779.24.1) <D71F71E0-30E2-3DB3-B636-7DE13D51FB4B> /usr/lib/libmecabra.dylib
    0x7fff7535b000 -     0x7fff756acff7  libnetwork.dylib (1229.250.15) <72C7E9E3-B2BE-3300-BE1B-64606222022C> /usr/lib/libnetwork.dylib
    0x7fff7573e000 -     0x7fff75ec3fdf  libobjc.A.dylib (756.2) <7C312627-43CB-3234-9324-4DEA92D59F50> /usr/lib/libobjc.A.dylib
    0x7fff75ed5000 -     0x7fff75ed9ffb  libpam.2.dylib (22.200.1) <586CF87F-349C-393D-AEEB-FB75F94A5EB7> /usr/lib/libpam.2.dylib
    0x7fff75edc000 -     0x7fff75f11fff  libpcap.A.dylib (79.250.4) <17AD7BD4-CF1C-32A0-A4FB-F1B460D652B9> /usr/lib/libpcap.A.dylib
    0x7fff7602a000 -     0x7fff76042ffb  libresolv.9.dylib (65.200.3) <1FB0982D-84D9-36E0-B3D8-C808891EFF50> /usr/lib/libresolv.9.dylib
    0x7fff76095000 -     0x7fff76272fff  libsqlite3.dylib (274.26) <6404BA3B-BCA4-301F-B2FE-8776105A2AA3> /usr/lib/libsqlite3.dylib
    0x7fff7648b000 -     0x7fff7648eff7  libutil.dylib (51.200.4) <CE9B18C9-66ED-32D4-9D29-01F8FCB467B0> /usr/lib/libutil.dylib
    0x7fff7648f000 -     0x7fff7649cfff  libxar.1.dylib (417.1) <39CCF46B-C81A-34B1-92A1-58C4E5DA846E> /usr/lib/libxar.1.dylib
    0x7fff764a1000 -     0x7fff76584fff  libxml2.2.dylib (32.19) <0A511058-87D0-3CBE-9298-5CBBDAE9A125> /usr/lib/libxml2.2.dylib
    0x7fff76585000 -     0x7fff765adff3  libxslt.1.dylib (16.7.2) <1D461E00-A0A1-374C-9EED-3230BFA30042> /usr/lib/libxslt.1.dylib
    0x7fff765ae000 -     0x7fff765c0ff7  libz.1.dylib (70.200.4) <B048FC1F-058F-3A08-A1FE-81D5308CB3E6> /usr/lib/libz.1.dylib
    0x7fff76da4000 -     0x7fff76da8ff3  libcache.dylib (81) <1987D1E1-DB11-3291-B12A-EBD55848E02D> /usr/lib/system/libcache.dylib
    0x7fff76da9000 -     0x7fff76db3ff3  libcommonCrypto.dylib (60118.250.2) <1765BB6E-6784-3653-B16B-CB839721DC9A> /usr/lib/system/libcommonCrypto.dylib
    0x7fff76db4000 -     0x7fff76dbbff7  libcompiler_rt.dylib (63.4) <5212BA7B-B7EA-37B4-AF6E-AC4F507EDFB8> /usr/lib/system/libcompiler_rt.dylib
    0x7fff76dbc000 -     0x7fff76dc5ff7  libcopyfile.dylib (146.250.1) <98CD00CD-9B91-3B5C-A9DB-842638050FA8> /usr/lib/system/libcopyfile.dylib
    0x7fff76dc6000 -     0x7fff76e4bfff  libcorecrypto.dylib (602.260.3) <9D9C206B-AB19-3257-95D7-59A993845640> /usr/lib/system/libcorecrypto.dylib
    0x7fff76ed2000 -     0x7fff76f0bff7  libdispatch.dylib (1008.270.1) <97273678-E94C-3C8C-89F6-2E2020F4B43B> /usr/lib/system/libdispatch.dylib
    0x7fff76f0c000 -     0x7fff76f38ff7  libdyld.dylib (655.1.1) <002418CC-AD11-3D10-865B-015591D24E6C> /usr/lib/system/libdyld.dylib
    0x7fff76f39000 -     0x7fff76f39ffb  libkeymgr.dylib (30) <0D0F9CA2-8D5A-3273-8723-59987B5827F2> /usr/lib/system/libkeymgr.dylib
    0x7fff76f3a000 -     0x7fff76f46ff3  libkxld.dylib (4903.278.68) <67395DF6-BAB8-3A46-8A31-AA8D1FC2806C> /usr/lib/system/libkxld.dylib
    0x7fff76f47000 -     0x7fff76f47ff7  liblaunch.dylib (1336.261.7) <688DAED5-8930-3271-BAEF-68AA48DF5EBB> /usr/lib/system/liblaunch.dylib
    0x7fff76f48000 -     0x7fff76f4dfff  libmacho.dylib (927.0.3) <A377D608-77AB-3F6E-90F0-B4F251A5C12F> /usr/lib/system/libmacho.dylib
    0x7fff76f4e000 -     0x7fff76f50ff7  libquarantine.dylib (86.270.1) <3F36A3D6-9606-3D90-B520-809BAEF981C3> /usr/lib/system/libquarantine.dylib
    0x7fff76f51000 -     0x7fff76f52ff7  libremovefile.dylib (45.200.2) <9FBEB2FF-EEBE-31BC-BCFC-C71F8D0E99B6> /usr/lib/system/libremovefile.dylib
    0x7fff76f53000 -     0x7fff76f6aff3  libsystem_asl.dylib (356.200.4) <A62A7249-38B8-33FA-9875-F1852590796C> /usr/lib/system/libsystem_asl.dylib
    0x7fff76f6b000 -     0x7fff76f6bff7  libsystem_blocks.dylib (73) <A453E8EE-860D-3CED-B5DC-BE54E9DB4348> /usr/lib/system/libsystem_blocks.dylib
    0x7fff76f6c000 -     0x7fff76ff3fff  libsystem_c.dylib (1272.250.1) <7EDACF78-2FA3-35B8-B051-D70475A35117> /usr/lib/system/libsystem_c.dylib
    0x7fff76ff4000 -     0x7fff76ff7ffb  libsystem_configuration.dylib (963.270.3) <2B4A836D-68A4-33E6-8D48-CD4486B03387> /usr/lib/system/libsystem_configuration.dylib
    0x7fff76ff8000 -     0x7fff76ffbff7  libsystem_coreservices.dylib (66.1) <44E0194F-06DA-3902-9A45-556606F85168> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff76ffc000 -     0x7fff77002fff  libsystem_darwin.dylib (1272.250.1) <EC9B39A5-9592-3577-8997-7DC721D20D8C> /usr/lib/system/libsystem_darwin.dylib
    0x7fff77003000 -     0x7fff77009ffb  libsystem_dnssd.dylib (878.270.3) <D5352ABD-0311-3327-8E64-93F29EB19BF1> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff7700a000 -     0x7fff77055ffb  libsystem_info.dylib (517.200.9) <D09D5AE0-2FDC-3A6D-93EC-729F931B1457> /usr/lib/system/libsystem_info.dylib
    0x7fff77056000 -     0x7fff7707eff7  libsystem_kernel.dylib (4903.278.68) <CC310B22-03FD-3068-89D5-46E87FC92EA4> /usr/lib/system/libsystem_kernel.dylib
    0x7fff7707f000 -     0x7fff770caff7  libsystem_m.dylib (3158.200.7) <F19B6DB7-014F-3820-831F-389CCDA06EF6> /usr/lib/system/libsystem_m.dylib
    0x7fff770cb000 -     0x7fff770f5fff  libsystem_malloc.dylib (166.270.1) <011F3AD0-8E6A-3A89-AE64-6E5F6840F30A> /usr/lib/system/libsystem_malloc.dylib
    0x7fff770f6000 -     0x7fff77100ff7  libsystem_networkextension.dylib (767.250.2) <FF06F13A-AEFE-3A27-A073-910EF78AEA36> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff77101000 -     0x7fff77108fff  libsystem_notify.dylib (172.200.21) <145B5CFC-CF73-33CE-BD3D-E8DDE268FFDE> /usr/lib/system/libsystem_notify.dylib
    0x7fff77109000 -     0x7fff77112fef  libsystem_platform.dylib (177.270.1) <9D1FE5E4-EB7D-3B3F-A8D1-A96D9CF1348C> /usr/lib/system/libsystem_platform.dylib
    0x7fff77113000 -     0x7fff7711dff7  libsystem_pthread.dylib (330.250.2) <2D5C08FF-484F-3D59-9132-CE1DCB3F76D7> /usr/lib/system/libsystem_pthread.dylib
    0x7fff7711e000 -     0x7fff77121ff7  libsystem_sandbox.dylib (851.270.5) <20D11F30-783F-3A56-9BD2-6CF38C049332> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff77122000 -     0x7fff77124ff3  libsystem_secinit.dylib (30.260.2) <EF1EA47B-7B22-35E8-BD9B-F7003DCB96AE> /usr/lib/system/libsystem_secinit.dylib
    0x7fff77125000 -     0x7fff7712cff3  libsystem_symptoms.dylib (820.267.2) <0DA60956-0403-3456-9D6A-11F2DB9E3819> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff7712d000 -     0x7fff77142ff7  libsystem_trace.dylib (906.260.3) <5B6FAE61-EF5C-381F-B71B-9B6F6428FEE2> /usr/lib/system/libsystem_trace.dylib
    0x7fff77144000 -     0x7fff77149ffb  libunwind.dylib (35.4) <24A97A67-F017-3CFC-B0D0-6BD0224B1336> /usr/lib/system/libunwind.dylib
    0x7fff7714a000 -     0x7fff77179fff  libxpc.dylib (1336.261.7) <404F0E1A-30BC-3CFB-98D3-4A2167CC2AB8> /usr/lib/system/libxpc.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 83673
    thread_create: 0
    thread_set_state: 1005

VM Region Summary:
ReadOnly portion of Libraries: Total=513.4M resident=0K(0%) swapped_out_or_unallocated=513.4M(100%)
Writable regions: Total=1.1G written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=1.1G(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Activity Tracing                   256K        1 
CoreUI image file                  140K        2 
Dispatch continuations            8192K        1 
Kernel Alloc Once                    8K        1 
MALLOC                            41.5M       18 
MALLOC guard page                   32K        8 
Memory Tag 242                      12K        1 
STACK GUARD                       56.0M       11 
Stack                             13.1M       12 
VM_ALLOCATE                        1.0G        7 
__DATA                            26.1M      323 
__FONT_DATA                          4K        1 
__LINKEDIT                       254.6M       76 
__TEXT                           258.8M      306 
__UNICODE                          564K        1 
mapped file                       39.1M       13 
shared memory                      660K        6 
===========                     =======  ======= 
TOTAL                              1.7G      788 
```
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @mjlbach @jmercouris