### PR TITLE
gwe: init at 0.15.3

### DIFF
--- a/pkgs/development/python-modules/injector/default.nix
+++ b/pkgs/development/python-modules/injector/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, typing-extensions }:
+
+buildPythonPackage rec {
+  pname = "injector";
+  version = "0.18.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10miwi58g4b8rvdf1pl7s7x9j91qyxxv3kdn5idzkfc387hqxn6f";
+  };
+
+  propagatedBuildInputs = [ typing-extensions ];
+
+  doCheck = false; # No tests are available
+  pythonImportsCheck = [ "injector" ];
+
+  meta = with lib; {
+    description = "Python dependency injection framework, inspired by Guice";
+    homepage = "https://github.com/alecthomas/injector";
+    maintainers = [ maintainers.ivar ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/tools/misc/gwe/default.nix
+++ b/pkgs/tools/misc/gwe/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, wrapGAppsHook
+, makeWrapper
+, pkg-config
+, meson
+, ninja
+, cmake
+, gobject-introspection
+, desktop-file-utils
+, python3
+, gtk3
+, libdazzle
+, libappindicator-gtk3
+, libnotify
+, nvidia_x11
+ }:
+
+let
+ pythonEnv = python3.withPackages (pypkgs: with pypkgs; [
+   injector
+   matplotlib
+   peewee
+   pynvml
+   pygobject3
+   xlib
+   pyxdg
+   requests
+   rx
+   gtk3
+ ]);
+in stdenv.mkDerivation rec {
+  pname = "gwe";
+  version = "0.15.3";
+
+  src = fetchFromGitLab {
+    owner = "leinardi";
+    repo = pname;
+    rev = version;
+    sha256 = "1znd2g02j0klg8w6cgwvaxc8anan6sidadknl0vh9jxmzz75xp9z";
+  };
+
+  prePatch = ''
+    patchShebangs scripts/{make_local_manifest,meson_post_install}.py
+
+    substituteInPlace gwe/repository/nvidia_repository.py \
+      --replace "from py3nvml import py3nvml" "import pynvml" \
+      --replace "py3nvml.py3nvml" "pynvml" \
+      --replace "py3nvml" "pynvml"
+  '';
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    pkg-config
+    meson
+    ninja
+    cmake
+    gobject-introspection
+    desktop-file-utils
+    pythonEnv
+  ];
+
+  buildInputs = [
+    gtk3
+    libdazzle
+    libappindicator-gtk3
+    libnotify
+  ];
+
+  postInstall = ''
+    mv $out/bin/gwe $out/lib/gwe-bin
+
+    makeWrapper ${pythonEnv}/bin/python $out/bin/gwe \
+      --add-flags "$out/lib/gwe-bin" \
+      --prefix LD_LIBRARY_PATH : "/run/opengl-driver/lib" \
+      --prefix PATH : "${builtins.concatStringsSep ":" [ (lib.makeBinPath [ nvidia_x11 nvidia_x11.settings ]) "/run/wrappers/bin" ]}" \
+      --unset "SHELL" \
+      ''${gappsWrapperArgs[@]}
+  '';
+
+  meta = with lib; {
+    description = "System utility designed to provide information, control the fans and overclock your NVIDIA card";
+    homepage = "https://gitlab.com/leinardi/gwe";
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11153,6 +11153,10 @@ in
 
   gprolog = callPackage ../development/compilers/gprolog { };
 
+  gwe = callPackage ../tools/misc/gwe {
+    nvidia_x11 = linuxPackages.nvidia_x11;
+  };
+
   gwt240 = callPackage ../development/compilers/gwt/2.4.0.nix { };
 
   idrisPackages = dontRecurseIntoAttrs (callPackage ../development/idris-modules {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3400,6 +3400,8 @@ in {
 
   iniparse = callPackage ../development/python-modules/iniparse { };
 
+  injector = callPackage ../development/python-modules/injector { };
+
   inotify-simple = callPackage ../development/python-modules/inotify-simple { };
 
   inquirer = callPackage ../development/python-modules/inquirer { };


### PR DESCRIPTION

###### Motivation for this change
Note that running with root is required, unless `gnome-polkit` is installed on the system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
