### PR TITLE
opentabletdriver: 0.5.3.1 -> 0.5.3.2

### DIFF
--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -23,18 +23,18 @@
 
 stdenv.mkDerivation rec {
   pname = "OpenTabletDriver";
-  version = "0.5.3.1";
+  version = "0.5.3.2";
 
   src = fetchFromGitHub {
     owner = "InfinityGhost";
     repo = "OpenTabletDriver";
     rev = "v${version}";
-    sha256 = "OT8/c+6wNpZyq/q7uMxIqmyJKNAq0B4ynEAqFF0GWyo=";
+    sha256 = "qRc/9Edp3x7/XVEWgBbPush76MSQz4biYSk+E9Gt68w=";
   };
 
   debPkg = fetchurl {
     url = "https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${version}/OpenTabletDriver.deb";
-    sha256 = "0nm0v1xhphl6g6rz3li4rbdp7408g6sf9l4nh3mbbif5042xa0qh";
+    sha256 = "14k06iyc642x42yadyfmmf8ky84y8rc6kgd63b4ipskkcxyl1gvl";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/X11/opentabletdriver/deps.nix
+++ b/pkgs/tools/X11/opentabletdriver/deps.nix
@@ -1,13 +1,13 @@
 { fetchNuGet }: [
   (fetchNuGet {
     name = "AtkSharp";
-    version = "3.22.25.74";
-    sha256 = "04zjpjrddw5clac0mjpk0q00rbmv45bh1bsqa4s3pc5pb7fm9cd9";
+    version = "3.24.24.34";
+    sha256 = "1jn1vgi9xm0jp7769k6sbdi8d273kigjrsh93i6s4c03hqxv7cqs";
   })
   (fetchNuGet {
     name = "CairoSharp";
-    version = "3.22.25.74";
-    sha256 = "0sx7vmwcrfbkg3g887v051iklcdmdhh43ndp96nk4bccjimmmwl6";
+    version = "3.24.24.34";
+    sha256 = "0pydn1k0cam1gclg9sc1sbnmbyzh28qlc5qanyxcylwghink3kgz";
   })
   (fetchNuGet {
     name = "Eto.Forms";
@@ -15,29 +15,34 @@
     sha256 = "1d71wglk4ixfqfbm6sxmj753x5iwbar8i9zzjy3bh64fy1dn8lz7";
   })
   (fetchNuGet {
+    name = "Eto.Forms";
+    version = "2.5.11";
+    sha256 = "0h86jc19wy3ssj7pb34w1h02v92mg29gdipszwjs3y15piy66z3s";
+  })
+  (fetchNuGet {
     name = "Eto.Platform.Gtk";
-    version = "2.5.10";
-    sha256 = "1pkqvlfx7bzracnw19bl50i9jg4ym376vihmy9qq7m5z5nfdqn4g";
+    version = "2.5.11";
+    sha256 = "1s9njz7l9zghrbzli7lbiav5ss3glqf17npj07f3jldd933nb95j";
   })
   (fetchNuGet {
     name = "GdkSharp";
-    version = "3.22.25.74";
-    sha256 = "07sdfvqk2jmyjj7fyd0mikhnzsk52zd3g2dhip8kz3006cczqm81";
+    version = "3.24.24.34";
+    sha256 = "0r0x0yib7chwsyrbpvicrfwldwqx5lyqq4p86zaxpmzd6zdaj0x5";
   })
   (fetchNuGet {
     name = "GioSharp";
-    version = "3.22.25.74";
-    sha256 = "01l4216bm5jxbxypkkq4d2527c6zd68kbywr3h1lr1darc9nf1d1";
+    version = "3.24.24.34";
+    sha256 = "02hxvgjd4w9jpzbkk7qf9q9bkvyp5hfzwxfqp10vg5lpl9yl3xpx";
   })
   (fetchNuGet {
     name = "GLibSharp";
-    version = "3.22.25.74";
-    sha256 = "0k2p79z4wcswi528v0ykc37rsqfqi6xd6pl0j4csdj9zf19svgx2";
+    version = "3.24.24.34";
+    sha256 = "0kvp033fgdwc8p2abfp5z9pzq66cvwbnjfvr4v4bkpy5s5h181kq";
   })
   (fetchNuGet {
     name = "GtkSharp";
-    version = "3.22.25.74";
-    sha256 = "0vazfvkjyzppcynqa1h70s1jmp4vq2j30v5x2scg8n2c5dxaj0k3";
+    version = "3.24.24.34";
+    sha256 = "0028hzmmqyfx87qqmaf9cgb5psn7gkbmqvixcid67x1d6mzxjicb";
   })
   (fetchNuGet {
     name = "HidSharpCore";
@@ -126,8 +131,8 @@
   })
   (fetchNuGet {
     name = "PangoSharp";
-    version = "3.22.25.74";
-    sha256 = "172i1hjpz4rgqlilir8a57kgmciw9x0shz4zwbhhlr59mndvqbih";
+    version = "3.24.24.34";
+    sha256 = "1r0h14cklglfpv1lhv93cxmzi2w7d5s03gzpq3j5dmrz43flg9zw";
   })
   (fetchNuGet {
     name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v0.5.3.2

Fix a crash on `otd-gui` (as described on the changelog above).

Needs backport to 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
