### PR TITLE
nix-direnv: make flakes support optional and off by default

### DIFF
--- a/pkgs/tools/misc/nix-direnv/default.nix
+++ b/pkgs/tools/misc/nix-direnv/default.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, gnugrep, nixUnstable }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, gnugrep
+, nixStable
+, nixUnstable
+, enableFlakes ? false
+}:
 
+let
+  nix = if enableFlakes then nixUnstable else nixStable;
+in
 stdenv.mkDerivation rec {
   pname = "nix-direnv";
   version = "1.2.6";
@@ -14,7 +24,7 @@ stdenv.mkDerivation rec {
   # Substitute instead of wrapping because the resulting file is
   # getting sourced, not executed:
   postPatch = ''
-    sed -i "1a NIX_BIN_PREFIX=${nixUnstable}/bin/" direnvrc
+    sed -i "1a NIX_BIN_PREFIX=${nix}/bin/" direnvrc
     substituteInPlace direnvrc --replace "grep" "${gnugrep}/bin/grep"
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Resolves https://github.com/nix-community/nix-direnv/issues/89. nix-direnv depends on nixUnstable for flakes support, but that causes it to print a warning unless your user is trusted or the `experimental-features` setting is enabled. Neither of these are desirable (note that setting `experimental-features` in nix.conf causes warnings on nixStable).

Since flakes are experimental, this PR makes the default `nixStable` and optionally allows `nixUnstable` with a new flag `enableFlakes`, prioritising a good experience for users not using experimental features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
