### PR TITLE
quickjs: 2020-11-08 -> 2021-03-27, edbrowse: 3.7.7 -> 3.8.0

### DIFF
--- a/pkgs/applications/editors/edbrowse/0001-small-fixes.patch
+++ b/pkgs/applications/editors/edbrowse/0001-small-fixes.patch
@@ -1,0 +1,20 @@
+diff -Naur source.old/src/makefile source/src/makefile
+--- source.old/src/makefile	1969-12-31 21:00:01.000000000 -0300
++++ source/src/makefile	2021-06-07 18:58:48.851231787 -0300
+@@ -101,14 +101,14 @@
+ 
+ #  need packages nodejs and libnode-dev
+ js_hello_v8 : js_hello_v8.cpp
+-	g++ -I/usr/include/v8 js_hello_v8.cpp -lv8 -lstdc++ -o js_hello_v8
++	$(CXX) -I/usr/include/v8 js_hello_v8.cpp -lv8 -lstdc++ -o js_hello_v8
+ 
+ HELLOEXTRA = stringfile.o messages.o msg-strings.o startwindow.o ebrc.o format.o http.o isup.o fetchmail.o sendmail.o plugin.o buffers.o dbstubs.o html.o decorate.o html-tidy.o css.o
+ js_hello_moz : js_hello_moz.o $(HELLOEXTRA) jseng-moz.o
+ 	$(CC) js_hello_moz.o $(HELLOEXTRA) jseng-moz.o $(LDFLAGS) -lmozjs-$(SMV) -lstdc++ -o $@
+ 
+ js_hello_quick : js_hello_quick.c
+-	gcc $(CFLAGS) js_hello_quick.c stringfile.o messages.o msg-strings.o ebrc.o format.o -o js_hello_quick -L/usr/local/lib/quickjs -lquickjs -lm -ldl -lpthread -latomic
++	$(CC) $(CFLAGS) js_hello_quick.c stringfile.o messages.o msg-strings.o ebrc.o format.o -o js_hello_quick $(QUICKJS_LDFLAGS) -lm -lpthread
+ 
+ hello: js_hello_duk js_hello_v8 js_hello_moz js_hello_quick
+ 

--- a/pkgs/applications/editors/edbrowse/default.nix
+++ b/pkgs/applications/editors/edbrowse/default.nix
@@ -1,41 +1,79 @@
-{ lib, stdenv, fetchFromGitHub, duktape, curl, pcre, readline, openssl, perl, html-tidy }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, curl
+, duktape
+, html-tidy
+, openssl
+, pcre
+, perl
+, pkg-config
+, quickjs
+, readline
+, which
+}:
 
 stdenv.mkDerivation rec {
   pname = "edbrowse";
-  version = "3.7.7";
+  version = "3.8.0";
 
-  buildInputs = [ curl pcre readline openssl duktape perl html-tidy ];
+  src = fetchFromGitHub {
+    owner = "CMB";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ZXxzQBAmu7kM3sjqg/rDLBXNucO8sFRFKXV8UxQVQZU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+  ];
+  buildInputs = [
+    curl
+    duktape
+    html-tidy
+    openssl
+    pcre
+    perl
+    quickjs
+    readline
+  ];
+
+  patches = [
+    # Fixes some small annoyances on src/makefile
+    ./0001-small-fixes.patch
+  ];
 
   postPatch = ''
-    for i in ./tools/*.pl
-    do
-      substituteInPlace $i --replace "/usr/bin/perl" "${perl}/bin/perl"
+    substituteInPlace src/makefile --replace\
+      '-L/usr/local/lib/quickjs' '-L${quickjs}/lib/quickjs'
+    for i in $(find ./tools/ -type f ! -name '*.c'); do
+      patchShebangs $i
     done
   '';
 
   makeFlags = [
     "-C" "src"
-    "prefix=${placeholder "out"}"
+    "PREFIX=${placeholder "out"}"
   ];
 
-  src = fetchFromGitHub {
-    owner = "CMB";
-    repo = "edbrowse";
-    rev = "v${version}";
-    sha256 = "0cw9d60mdhwna57r1vxn53s8gl81rr3cxnvm769ifq3xyh49vfcf";
-  };
   meta = with lib; {
+    homepage = "https://edbrowse.org/";
     description = "Command Line Editor Browser";
     longDescription = ''
-      Edbrowse is a combination editor, browser, and mail client that is 100% text based.
-      The interface is similar to /bin/ed, though there are many more features, such as editing multiple files simultaneously, and rendering html.
-      This program was originally written for blind users, but many sighted users have taken advantage of the unique scripting capabilities of this program, which can be found nowhere else.
-      A batch job, or cron job, can access web pages on the internet, submit forms, and send email, with no human intervention whatsoever.
-      edbrowse can also tap into databases through odbc. It was primarily written by Karl Dahlke.
-      '';
+      Edbrowse is a combination editor, browser, and mail client that is 100%
+      text based. The interface is similar to /bin/ed, though there are many
+      more features, such as editing multiple files simultaneously, and
+      rendering html. This program was originally written for blind users, but
+      many sighted users have taken advantage of the unique scripting
+      capabilities of this program, which can be found nowhere else. A batch
+      job, or cron job, can access web pages on the internet, submit forms, and
+      send email, with no human intervention whatsoever. edbrowse can also tap
+      into databases through odbc. It was primarily written by Karl Dahlke.
+    '';
     license = licenses.gpl1Plus;
-    homepage = "https://edbrowse.org/";
     maintainers = with maintainers; [ schmitthenner vrthra equirosa ];
     platforms = platforms.linux;
   };
 }
+# TODO: send the patch to upstream developers

--- a/pkgs/development/interpreters/quickjs/default.nix
+++ b/pkgs/development/interpreters/quickjs/default.nix
@@ -1,16 +1,36 @@
-{ lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, texinfo
+}:
 
 stdenv.mkDerivation rec {
   pname = "quickjs";
-  version = "2020-11-08";
+  version = "2021-03-27";
 
-  src = fetchurl {
-    url = "https://bellard.org/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0yqqcjxi3cqagw184mqrxpvqg486x7c233r3cp9mxachngd6779f";
+  src = fetchFromGitHub {
+    owner = "bellard";
+    repo = pname;
+    rev = "b5e62895c619d4ffc75c9d822c8d85f1ece77e5b";
+    hash = "sha256-VMaxVVQuJ3DAwYrC14uJqlRBg0//ugYvtyhOXsTUbCA=";
   };
 
   makeFlags = [ "prefix=${placeholder "out"}" ];
   enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    texinfo
+  ];
+
+  postBuild = ''
+    (cd doc
+     makeinfo *texi)
+  '';
+
+  postInstall = ''
+    (cd doc
+     install -Dt $out/share/doc *texi *info)
+  '';
 
   doInstallCheck = true;
   installCheckPhase = ''
@@ -32,7 +52,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A small and embeddable Javascript engine";
     homepage = "https://bellard.org/quickjs/";
-    maintainers = with maintainers; [ stesie ];
+    maintainers = with maintainers; [ stesie AndersonTorres ];
     platforms = platforms.linux;
     license = licenses.mit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
