### PR TITLE
git-cola: fix usage of git-cola-sequence-editor

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, python3Packages, gettext, git, qt5 }:
+{ lib, fetchFromGitHub, fetchpatch, python3Packages, gettext, git, qt5 }:
 
 let
   inherit (python3Packages) buildPythonApplication pyqt5 sip_4 pyinotify;
@@ -13,6 +13,14 @@ in buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "11186pdgaw5p4iv10dqcnynf5pws2v9nhqqqca7z5b7m20fpfjl7";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/git-cola/git-cola/commit/bdd6121f795186bbed9335995ef77a47ed007092.patch";
+      sha256 = "sha256-mTOGWatIcKB8+DBh5wu1GfcP1LZDiQjhAshlVgguKdk=";
+      name = "bdd6121f795186bbed9335995ef77a47ed007092.patch";
+    })
+  ];
 
   buildInputs = [ git gettext ];
   propagatedBuildInputs = [ pyqt5 sip_4 pyinotify ];


### PR DESCRIPTION
## Motivation for this change

Fixes https://github.com/git-cola/git-cola/pull/1143

This patch applies https://github.com/git-cola/git-cola/pull/1143 to the current version of git-cola. `git-cola-sequence-editor` is called by `git-cola` using the `python3` executable (`python3 git-cola-sequence-editor`) where it presumes the `git-cola-sequence-editor` in `bin` is a python program. For NixOS this is not the case, as it is a wrapped executable using bash, which cannot be interpreted by python3.

This patch makes sure `git-cola-sequence-editor` is called as-is without explicitly using `python3`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
