### PR TITLE
[20.09] dino: 0.1.0 -> 0.1.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -4,7 +4,6 @@
 , xorg, libXdmcp, libxkbcommon
 , libnotify, libsoup, libgee
 , librsvg, libsignal-protocol-c
-, fetchpatch
 , libgcrypt
 , epoxy
 , at-spi2-core
@@ -18,23 +17,14 @@
 
 stdenv.mkDerivation rec {
   pname = "dino";
-  version = "0.1.0";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "dino";
     repo = "dino";
     rev = "v${version}";
-    sha256 = "1k5cgj5n8s40i71wqdh6m1q0njl45ichfdbbywx9rga5hljz1c54";
+    sha256 = "15s59hg396j5s3cnpbc6s18fkwbx6damfkzfq05zxf0z1789hk01";
   };
-
-  patches = [
-    (fetchpatch {
-      # Allow newer versions of libsignal-protocol-c
-      url = "https://github.com/dino/dino/commit/fbd70ceaac5ebbddfa21a580c61165bf5b861303.patch";
-      sha256 = "0ydpwsmwrzfsry89fsffkfalhki4n1dw99ixjvpiingdrhjmwyl2";
-      excludes = [ "plugins/signal-protocol/libsignal-protocol-c" ];
-    })
-  ];
 
   nativeBuildInputs = [
     vala


### PR DESCRIPTION
Fixes nvd.nist.gov/vuln/detail/CVE-2021-33896. Port of https://github.com/NixOS/nixpkgs/pull/126115 .

Note: 20.09 is still using the 0.1.x dino lineage, we can't backport
the unstable and 21.05 0.2.x fix, we have to port a fix.

The libsignal patch landed in the upstream tree, we can drop the patch.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
