### PR TITLE
pythonPackages.construct: Remove pytest-benchmark check dependency

### DIFF
--- a/pkgs/development/python-modules/construct/2.10.54.nix
+++ b/pkgs/development/python-modules/construct/2.10.54.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "1mqspsn6bf3ibvih1zna2glkg8iw7vy5zg9gzg0d1m8zcndk2c48";
   };
 
-  checkInputs = [ pytestCheckHook pytest-benchmark enum34 numpy ];
+  checkInputs = [ pytestCheckHook enum34 numpy ];
 
   # these have dependencies that are broken on Python 2
   disabledTestPaths = [
@@ -24,12 +24,11 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    "test_benchmarks"
     "test_timestamp"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_multiprocessing"
   ];
-
-  pytestFlagsArray = [ "--benchmark-disable" ];
 
   meta = with lib; {
     description = "Powerful declarative parser (and builder) for binary data";

--- a/pkgs/development/python-modules/construct/default.nix
+++ b/pkgs/development/python-modules/construct/default.nix
@@ -22,11 +22,9 @@ buildPythonPackage rec {
     lz4
   ];
 
-  checkInputs = [ pytestCheckHook pytest-benchmark numpy arrow ruamel-yaml cloudpickle ];
+  checkInputs = [ pytestCheckHook numpy arrow ruamel-yaml cloudpickle ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [ "test_multiprocessing" ];
-
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  disabledTests = [ "test_benchmarks" ] ++ lib.optionals stdenv.isDarwin [ "test_multiprocessing" ];
 
   meta = with lib; {
     description = "Powerful declarative parser (and builder) for binary data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

No need to pull it in at all when the benchmarks are skipped anyways.

<del>Also disable one of its dependencies, py-cpuinfo, on RISC-V since it's unsupported.</del> Dropping this for now since upstream has finally added RISC-V support recently, pending release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
