### PR TITLE
openal-soft: 1.19.1 -> 1.21.1

### DIFF
--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -10,21 +10,21 @@ assert alsaSupport -> alsaLib != null;
 assert pulseSupport -> libpulseaudio != null;
 
 stdenv.mkDerivation rec {
-  version = "1.19.1";
+  version = "1.21.1";
   pname = "openal-soft";
 
   src = fetchFromGitHub {
     owner = "kcat";
     repo = "openal-soft";
-    rev = "${pname}-${version}";
-    sha256 = "0b0g0q1c36nfb289xcaaj3cmyfpiswvvgky3qyalsf9n4dj7vnzi";
+    rev = "${version}";
+    sha256 = "025qlh2sm4l75hljhcw740i0fh84pdmz97hz16nbwrfs6n93l1xf";
   };
 
   # this will make it find its own data files (e.g. HRTF profiles)
   # without any other configuration
   patches = [ ./search-out.patch ];
   postPatch = ''
-    substituteInPlace Alc/helpers.c \
+    substituteInPlace alc/helpers.cpp \
       --replace "@OUT@" $out
   '';
 
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     ++ optional pulseSupport "-lpulse");
 
   meta = {
-    description = "OpenAL alternative";
-    homepage = "https://kcat.strangesoft.net/openal.html";
+    description = "Software implementation of OpenAL";
+    homepage = "https://kcat.tomasu.net/openal.html";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ftrvxmtrx];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/openal-soft/search-out.patch
+++ b/pkgs/development/libraries/openal-soft/search-out.patch
@@ -1,12 +1,13 @@
-diff -Nuar a/Alc/helpers.c b/Alc/helpers.c
---- a/Alc/helpers.c	1970-01-01 00:00:01.000000000 +0000
-+++ b/Alc/helpers.c	1970-01-01 00:00:02.000000000 +0000
-@@ -951,6 +951,8 @@
-             }
-         }
- 
-+        DirectorySearch("@OUT@/share", ext, &results);
-+
-         alstr_reset(&path);
+diff --git a/alc/helpers.cpp b/alc/helpers.cpp
+index 8c1c8562..59947ba2 100644
+--- a/alc/helpers.cpp
++++ b/alc/helpers.cpp
+@@ -384,7 +384,7 @@ al::vector<std::string> SearchDataFiles(const char *ext, const char *subdir)
      }
  
+     // Search global data dirs
+-    std::string datadirs{al::getenv("XDG_DATA_DIRS").value_or("/usr/local/share/:/usr/share/")};
++    std::string datadirs{al::getenv("XDG_DATA_DIRS").value_or("@OUT@/share/:/usr/local/share/:/usr/share/")};
+ 
+     size_t curpos{0u};
+     while(curpos < datadirs.size())


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updating the the OpenAL Soft version and information.  The site change is due to a domain pricing issue: kcat/alure#47

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
