### PR TITLE
vaultwarden: update to 1.21.0, rename from bitwarden_rs

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -339,6 +339,116 @@
           release instead of the old 2.31.0 version.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>bitwarden_rs</literal> packages and modules were
+          renamed to <literal>vaultwarden</literal>
+          <link xlink:href="https://github.com/dani-garcia/vaultwarden/discussions/1642">following
+          upstream</link>. More specifically,
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              <literal>pkgs.bitwarden_rs</literal>,
+              <literal>pkgs.bitwarden_rs-sqlite</literal>,
+              <literal>pkgs.bitwarden_rs-mysql</literal> and
+              <literal>pkgs.bitwarden_rs-postgresql</literal> were
+              renamed to <literal>pkgs.vaultwarden</literal>,
+              <literal>pkgs.vaultwarden-sqlite</literal>,
+              <literal>pkgs.vaultwarden-mysql</literal> and
+              <literal>pkgs.vaultwarden-postgresql</literal>,
+              respectively.
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  Old names are preserved as aliases for backwards
+                  compatibility, but may be removed in the future.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  The <literal>bitwarden_rs</literal> executable was
+                  also renamed to <literal>vaultwarden</literal> in all
+                  packages.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>pkgs.bitwarden_rs-vault</literal> was renamed to
+              <literal>pkgs.vaultwarden-vault</literal>.
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  <literal>pkgs.bitwarden_rs-vault</literal> is
+                  preserved as an alias for backwards compatibility, but
+                  may be removed in the future.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  The static files were moved from
+                  <literal>/usr/share/bitwarden_rs</literal> to
+                  <literal>/usr/share/vaultwarden</literal>.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>
+              The <literal>services.bitwarden_rs</literal> config module
+              was renamed to <literal>services.vaultwarden</literal>.
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  <literal>services.bitwarden_rs</literal> is preserved
+                  as an alias for backwards compatibility, but may be
+                  removed in the future.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>systemd.services.bitwarden_rs</literal>,
+              <literal>systemd.services.backup-bitwarden_rs</literal>
+              and <literal>systemd.timers.backup-bitwarden_rs</literal>
+              were renamed to
+              <literal>systemd.services.vaultwarden</literal>,
+              <literal>systemd.services.backup-vaultwarden</literal> and
+              <literal>systemd.timers.backup-vaultwarden</literal>,
+              respectively.
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  Old names are preserved as aliases for backwards
+                  compatibility, but may be removed in the future.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>users.users.bitwarden_rs</literal> and
+              <literal>users.groups.bitwarden_rs</literal> were renamed
+              to <literal>users.users.vaultwarden</literal> and
+              <literal>users.groups.vaultwarden</literal>, respectively.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              The data directory remains located at
+              <literal>/var/lib/bitwarden_rs</literal>, for backwards
+              compatibility.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -85,6 +85,32 @@ In addition to numerous new and upgraded packages, this release has the followin
 * The `libwnck` package now defaults to the 3.x release instead of the
   old 2.31.0 version.
 
+* The `bitwarden_rs` packages and modules were renamed to `vaultwarden`
+  [following upstream](https://github.com/dani-garcia/vaultwarden/discussions/1642). More specifically,
+
+  * `pkgs.bitwarden_rs`, `pkgs.bitwarden_rs-sqlite`, `pkgs.bitwarden_rs-mysql` and
+    `pkgs.bitwarden_rs-postgresql` were renamed to `pkgs.vaultwarden`, `pkgs.vaultwarden-sqlite`,
+    `pkgs.vaultwarden-mysql` and `pkgs.vaultwarden-postgresql`, respectively.
+    * Old names are preserved as aliases for backwards compatibility, but may be removed in the future.
+    * The `bitwarden_rs` executable was also renamed to `vaultwarden` in all packages.
+
+  * `pkgs.bitwarden_rs-vault` was renamed to `pkgs.vaultwarden-vault`.
+    * `pkgs.bitwarden_rs-vault` is preserved as an alias for backwards compatibility, but may be removed in the future.
+    * The static files were moved from `/usr/share/bitwarden_rs` to `/usr/share/vaultwarden`.
+
+  * The `services.bitwarden_rs` config module was renamed to `services.vaultwarden`.
+    * `services.bitwarden_rs` is preserved as an alias for backwards compatibility, but may be removed in the future.
+
+  * `systemd.services.bitwarden_rs`, `systemd.services.backup-bitwarden_rs` and `systemd.timers.backup-bitwarden_rs`
+    were renamed to `systemd.services.vaultwarden`, `systemd.services.backup-vaultwarden` and
+    `systemd.timers.backup-vaultwarden`, respectively.
+    * Old names are preserved as aliases for backwards compatibility, but may be removed in the future.
+
+  * `users.users.bitwarden_rs` and `users.groups.bitwarden_rs` were renamed to `users.users.vaultwarden` and
+    `users.groups.vaultwarden`, respectively.
+
+  * The data directory remains located at `/var/lib/bitwarden_rs`, for backwards compatibility.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -874,7 +874,6 @@
   ./services/search/hound.nix
   ./services/search/kibana.nix
   ./services/search/solr.nix
-  ./services/security/bitwarden_rs/default.nix
   ./services/security/certmgr.nix
   ./services/security/cfssl.nix
   ./services/security/clamav.nix
@@ -900,6 +899,7 @@
   ./services/security/torsocks.nix
   ./services/security/usbguard.nix
   ./services/security/vault.nix
+  ./services/security/vaultwarden/default.nix
   ./services/security/yubikey-agent.nix
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix

--- a/nixos/modules/services/security/vaultwarden/backup.sh
+++ b/nixos/modules/services/security/vaultwarden/backup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Based on: https://github.com/dani-garcia/bitwarden_rs/wiki/Backing-up-your-vault
+# Based on: https://github.com/dani-garcia/vaultwarden/wiki/Backing-up-your-vault
 if ! mkdir -p "$BACKUP_FOLDER"; then
   echo "Could not create backup folder '$BACKUP_FOLDER'" >&2
   exit 1

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -42,7 +42,6 @@ in
   bind = handleTest ./bind.nix {};
   bitcoind = handleTest ./bitcoind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};
-  bitwarden = handleTest ./bitwarden.nix {};
   blockbook-frontend = handleTest ./blockbook-frontend.nix {};
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
   boot-stage1 = handleTest ./boot-stage1.nix {};
@@ -446,6 +445,7 @@ in
   v2ray = handleTest ./v2ray.nix {};
   vault = handleTest ./vault.nix {};
   vault-postgresql = handleTest ./vault-postgresql.nix {};
+  vaultwarden = handleTest ./vaultwarden.nix {};
   vector = handleTest ./vector.nix {};
   victoriametrics = handleTest ./victoriametrics.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -4,7 +4,7 @@
 }:
 
 # These tests will:
-#  * Set up a bitwarden-rs server
+#  * Set up a vaultwarden server
 #  * Have Firefox use the web vault to create an account, log in, and save a password to the valut
 #  * Have the bw cli log in and read that password from the vault
 #
@@ -24,8 +24,8 @@ let
 
   storedPassword = "seeeecret";
 
-  makeBitwardenTest = backend: makeTest {
-    name = "bitwarden_rs-${backend}";
+  makeVaultwardenTest = backend: makeTest {
+    name = "vaultwarden-${backend}";
     meta = {
       maintainers = with pkgs.lib.maintainers; [ jjjollyjim ];
     };
@@ -45,9 +45,9 @@ let
               package = pkgs.mariadb;
             };
 
-            services.bitwarden_rs.config.databaseUrl = "mysql://bitwardenuser:${dbPassword}@localhost/bitwarden";
+            services.vaultwarden.config.databaseUrl = "mysql://bitwardenuser:${dbPassword}@localhost/bitwarden";
 
-            systemd.services.bitwarden_rs.after = [ "mysql.service" ];
+            systemd.services.vaultwarden.after = [ "mysql.service" ];
           };
 
           postgresql = {
@@ -60,9 +60,9 @@ let
               '';
             };
 
-            services.bitwarden_rs.config.databaseUrl = "postgresql://bitwardenuser:${dbPassword}@localhost/bitwarden";
+            services.vaultwarden.config.databaseUrl = "postgresql://bitwardenuser:${dbPassword}@localhost/bitwarden";
 
-            systemd.services.bitwarden_rs.after = [ "postgresql.service" ];
+            systemd.services.vaultwarden.after = [ "postgresql.service" ];
           };
 
           sqlite = { };
@@ -71,7 +71,7 @@ let
         mkMerge [
           backendConfig.${backend}
           {
-            services.bitwarden_rs = {
+            services.vaultwarden = {
               enable = true;
               dbBackend = backend;
               config.rocketPort = 80;
@@ -152,7 +152,7 @@ let
 
     testScript = ''
       start_all()
-      server.wait_for_unit("bitwarden_rs.service")
+      server.wait_for_unit("vaultwarden.service")
       server.wait_for_open_port(80)
 
       with subtest("configure the cli"):
@@ -184,6 +184,6 @@ let
 in
 builtins.listToAttrs (
   map
-    (backend: { name = backend; value = makeBitwardenTest backend; })
+    (backend: { name = backend; value = makeVaultwardenTest backend; })
     backends
 )

--- a/pkgs/development/python-modules/selenium/default.nix
+++ b/pkgs/development/python-modules/selenium/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   '';
 
   passthru.tests = {
-    testing-bitwarden = nixosTests.bitwarden;
+    testing-vaultwarden = nixosTests.vaultwarden;
   };
 
   meta = with lib; {

--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, nixosTests
+{ lib, stdenv, rustPlatform, fetchFromGitHub, fetchurl, nixosTests
 , pkg-config, openssl
 , libiconv, Security, CoreServices
 , dbBackend ? "sqlite", libmysqlclient, postgresql }:
@@ -7,15 +7,17 @@ let
   featuresFlag = "--features ${dbBackend}";
 
 in rustPlatform.buildRustPackage rec {
-  pname = "bitwarden_rs";
-  version = "1.20.0";
+  pname = "vaultwarden";
+  version = "1.22.1";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = pname;
     rev = version;
-    sha256 = "1ncy4iwmdzdp8rv1gc5i4s1rp97d94n4l4bh08v6w4zdpx0zn8b9";
+    sha256 = "sha256-aXbnNO3mTAgE1yNx7YVDo1vPpO8ACZpBGHQ633fNZ3k=";
   };
+
+  cargoSha256 = "sha256-SFzq3OU0a0s3zlEzUkqGdZb/knYafqDamLy4ghH4i8I=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = with lib; [ openssl ]
@@ -25,7 +27,6 @@ in rustPlatform.buildRustPackage rec {
 
   RUSTC_BOOTSTRAP = 1;
 
-  cargoSha256 = "0vdi792bzqxj8g215r9r5anzs4qhqsm6sjzwpj1l9861bn7j4xsz";
   cargoBuildFlags = [ featuresFlag ];
 
   checkPhase = ''
@@ -35,11 +36,11 @@ in rustPlatform.buildRustPackage rec {
     runHook postCheck
   '';
 
-  passthru.tests = nixosTests.bitwarden;
+  passthru.tests = nixosTests.vaultwarden;
 
   meta = with lib; {
     description = "Unofficial Bitwarden compatible server written in Rust";
-    homepage = "https://github.com/dani-garcia/bitwarden_rs";
+    homepage = "https://github.com/dani-garcia/vaultwarden";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ msteen ];
   };

--- a/pkgs/tools/security/vaultwarden/vault.nix
+++ b/pkgs/tools/security/vaultwarden/vault.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
-  pname = "bitwarden_rs-vault";
+  pname = "vaultwarden-vault";
   version = "2.19.0";
 
   src = fetchurl {
@@ -10,16 +10,16 @@ stdenv.mkDerivation rec {
   };
 
   buildCommand = ''
-    mkdir -p $out/share/bitwarden_rs/
-    cd $out/share/bitwarden_rs/
+    mkdir -p $out/share/vaultwarden/
+    cd $out/share/vaultwarden/
     tar xf $src
     mv web-vault vault
   '';
 
-  passthru.tests = nixosTests.bitwarden;
+  passthru.tests = nixosTests.vaultwarden;
 
   meta = with lib; {
-    description = "Integrates the web vault into bitwarden_rs";
+    description = "Integrates the web vault into vaultwarden";
     homepage = "https://github.com/dani-garcia/bw_web_builds";
     platforms = platforms.all;
     license = licenses.gpl3Plus;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -88,6 +88,14 @@ mapAliases ({
   bittorrentSync = throw "bittorrentSync has been deprecated by resilio-sync."; # added 2019-06-03
   bittorrentSync14 = throw "bittorrentSync14 has been deprecated by resilio-sync."; # added 2019-06-03
   bittorrentSync20 = throw "bittorrentSync20 has been deprecated by resilio-sync."; # added 2019-06-03
+
+  # bitwarden_rs renamed to vaultwarden with release 1.21.0 (2021-04-30)
+  bitwarden_rs = vaultwarden;
+  bitwarden_rs-sqlite = vaultwarden-sqlite;
+  bitwarden_rs-mysql = vaultwarden-mysql;
+  bitwarden_rs-postgresql = vaultwarden-postgresql;
+  bitwarden_rs-vault = vaultwarden-vault;
+
   bs1770gain = throw "bs1770gain has been removed from nixpkgs, as it had no maintainer or reverse dependencies."; # added 2021-01-02
   btc1 = throw "btc1 has been removed, it was abandoned by upstream"; # added 2020-11-03
   buildPerlPackage = perlPackages.buildPerlPackage; # added 2018-10-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1308,15 +1308,6 @@ in
 
   inherit (nodePackages) bitwarden-cli;
 
-  bitwarden_rs = callPackage ../tools/security/bitwarden_rs {
-    inherit (darwin.apple_sdk.frameworks) Security CoreServices;
-  };
-  bitwarden_rs-sqlite = bitwarden_rs;
-  bitwarden_rs-mysql = bitwarden_rs.override { dbBackend = "mysql"; };
-  bitwarden_rs-postgresql = bitwarden_rs.override { dbBackend = "postgresql"; };
-
-  bitwarden_rs-vault = callPackage ../tools/security/bitwarden_rs/vault.nix { };
-
   bkyml = callPackage ../tools/misc/bkyml { };
 
   blockbench-electron = callPackage ../applications/graphics/blockbench-electron { };
@@ -31571,6 +31562,15 @@ in
   vaultenv = haskellPackages.vaultenv;
 
   vazir-code-font = callPackage ../data/fonts/vazir-code-font { };
+
+  vaultwarden = callPackage ../tools/security/vaultwarden {
+    inherit (darwin.apple_sdk.frameworks) Security CoreServices;
+  };
+  vaultwarden-sqlite = vaultwarden;
+  vaultwarden-mysql = vaultwarden.override { dbBackend = "mysql"; };
+  vaultwarden-postgresql = vaultwarden.override { dbBackend = "postgresql"; };
+
+  vaultwarden-vault = callPackage ../tools/security/vaultwarden/vault.nix { };
 
   vazir-fonts = callPackage ../data/fonts/vazir-fonts { };
 


### PR DESCRIPTION
I tried to make this as non-breaking as possible, but it will still
break things slightly for people expecting certain file names in the
packages themselves.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
