### PR TITLE
tests.writers: give all test derivations unique names

### DIFF
--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -13,11 +13,11 @@ with writers;
 let
 
   bin = {
-    bash = writeBashBin "test_writers" ''
+    bash = writeBashBin "test_writers_bash_bin" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
     '';
 
-    c = writeCBin "test_writers" { libraries = [ ]; } ''
+    c = writeCBin "test_writers_c" { libraries = [ ]; } ''
       #include <stdio.h>
       int main() {
         printf("success\n");
@@ -25,17 +25,17 @@ let
       }
     '';
 
-    dash = writeDashBin "test_writers" ''
+    dash = writeDashBin "test_writers_dash_bin" ''
      test '~' = '~' && echo 'success'
     '';
 
-    rust = writeRustBin "test_writers" {} ''
+    rust = writeRustBin "test_writers_rust_bin" {} ''
       fn main(){
         println!("success")
       }
     '';
 
-    haskell = writeHaskellBin "test_writers" { libraries = [ haskellPackages.acme-default ]; } ''
+    haskell = writeHaskellBin "test_writers_haskell_bin" { libraries = [ haskellPackages.acme-default ]; } ''
       import Data.Default
 
       int :: Int
@@ -47,7 +47,7 @@ let
         _ -> print "fail"
     '';
 
-    js = writeJSBin "test_writers" { libraries = [ nodePackages.semver ]; } ''
+    js = writeJSBin "test_writers_js_bin" { libraries = [ nodePackages.semver ]; } ''
       var semver = require('semver');
 
       if (semver.valid('1.2.3')) {
@@ -57,12 +57,12 @@ let
       }
     '';
 
-    perl = writePerlBin "test_writers" { libraries = [ perlPackages.boolean ]; } ''
+    perl = writePerlBin "test_writers_perl_bin" { libraries = [ perlPackages.boolean ]; } ''
       use boolean;
       print "success\n" if true;
     '';
 
-    python2 = writePython2Bin "test_writers" { libraries = [ python2Packages.enum ]; } ''
+    python2 = writePython2Bin "test_writers_python2_bin" { libraries = [ python2Packages.enum ]; } ''
       from enum import Enum
 
 
@@ -73,7 +73,7 @@ let
       print Test.a
     '';
 
-    python3 = writePython3Bin "test_writers" { libraries = [ python3Packages.pyyaml ]; } ''
+    python3 = writePython3Bin "test_writers_python3_bin" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
       y = yaml.load("""
@@ -84,11 +84,11 @@ let
   };
 
   simple = {
-    bash = writeBash "test_bash" ''
+    bash = writeBash "test_writers_bash" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
     '';
 
-    c = writeC "test_c" { libraries = [ glib.dev ]; } ''
+    c = writeC "test_writers_c" { libraries = [ glib.dev ]; } ''
       #include <gio/gio.h>
       #include <stdio.h>
       int main() {
@@ -106,11 +106,11 @@ let
       }
     '';
 
-    dash = writeDash "test_dash" ''
+    dash = writeDash "test_writers_dash" ''
      test '~' = '~' && echo 'success'
     '';
 
-    haskell = writeHaskell "test_haskell" { libraries = [ haskellPackages.acme-default ]; } ''
+    haskell = writeHaskell "test_writers_haskell" { libraries = [ haskellPackages.acme-default ]; } ''
       import Data.Default
 
       int :: Int
@@ -122,7 +122,7 @@ let
         _ -> print "fail"
     '';
 
-    js = writeJS "test_js" { libraries = [ nodePackages.semver ]; } ''
+    js = writeJS "test_writers_js" { libraries = [ nodePackages.semver ]; } ''
       var semver = require('semver');
 
       if (semver.valid('1.2.3')) {
@@ -132,12 +132,12 @@ let
       }
     '';
 
-    perl = writePerl "test_perl" { libraries = [ perlPackages.boolean ]; } ''
+    perl = writePerl "test_writers_perl" { libraries = [ perlPackages.boolean ]; } ''
       use boolean;
       print "success\n" if true;
     '';
 
-    python2 = writePython2 "test_python2" { libraries = [ python2Packages.enum ]; } ''
+    python2 = writePython2 "test_writers_python2" { libraries = [ python2Packages.enum ]; } ''
       from enum import Enum
 
 
@@ -148,7 +148,7 @@ let
       print Test.a
     '';
 
-    python3 = writePython3 "test_python3" { libraries = [ python3Packages.pyyaml ]; } ''
+    python3 = writePython3 "test_writers_python3" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
       y = yaml.load("""
@@ -157,21 +157,21 @@ let
       print(y[0]['test'])
     '';
 
-    python2NoLibs = writePython2 "test_python2_no_libs" {} ''
+    python2NoLibs = writePython2 "test_writers_python2_no_libs" {} ''
       print("success")
     '';
 
-    python3NoLibs = writePython3 "test_python3_no_libs" {} ''
+    python3NoLibs = writePython3 "test_writers_python3_no_libs" {} ''
       print("success")
     '';
   };
 
 
   path = {
-    bash = writeBash "test_bash" (writeText "test" ''
+    bash = writeBash "test_writers_bash_path" (writeText "test" ''
       if [[ "test" == "test" ]]; then echo "success"; fi
     '');
-    haskell = writeHaskell "test_haskell" { libraries = [ haskellPackages.acme-default ]; } (writeText "test" ''
+    haskell = writeHaskell "test_writers_haskell_path" { libraries = [ haskellPackages.acme-default ]; } (writeText "test" ''
       import Data.Default
 
       int :: Int
@@ -184,8 +184,8 @@ let
     '');
   };
 
-  writeTest = expectedValue: test:
-    writeDash "test-writers" ''
+  writeTest = expectedValue: name: test:
+    writeDash "run-${name}" ''
       if test "$(${test})" != "${expectedValue}"; then
         echo 'test ${test} failed'
         exit 1
@@ -196,9 +196,9 @@ in runCommand "test-writers" {
   passthru = { inherit writeTest bin simple; };
   meta.platforms = lib.platforms.all;
 } ''
-  ${lib.concatMapStringsSep "\n" (test: writeTest "success" "${test}/bin/test_writers") (lib.attrValues bin)}
-  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test) (lib.attrValues simple)}
-  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test) (lib.attrValues path)}
+  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test.name "${test}/bin/${test.name}") (lib.attrValues bin)}
+  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test.name test) (lib.attrValues simple)}
+  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test.name test) (lib.attrValues path)}
 
   echo 'nix-writers successfully tested' >&2
   touch $out

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -13,11 +13,11 @@ with writers;
 let
 
   bin = {
-    bash = writeBashBin "test_writers_bash_bin" ''
+    bash = writeBashBin "test-writers-bash-bin" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
     '';
 
-    c = writeCBin "test_writers_c" { libraries = [ ]; } ''
+    c = writeCBin "test-writers-c" { libraries = [ ]; } ''
       #include <stdio.h>
       int main() {
         printf("success\n");
@@ -25,17 +25,17 @@ let
       }
     '';
 
-    dash = writeDashBin "test_writers_dash_bin" ''
+    dash = writeDashBin "test-writers-dash-bin" ''
      test '~' = '~' && echo 'success'
     '';
 
-    rust = writeRustBin "test_writers_rust_bin" {} ''
+    rust = writeRustBin "test-writers-rust-bin" {} ''
       fn main(){
         println!("success")
       }
     '';
 
-    haskell = writeHaskellBin "test_writers_haskell_bin" { libraries = [ haskellPackages.acme-default ]; } ''
+    haskell = writeHaskellBin "test-writers-haskell-bin" { libraries = [ haskellPackages.acme-default ]; } ''
       import Data.Default
 
       int :: Int
@@ -47,7 +47,7 @@ let
         _ -> print "fail"
     '';
 
-    js = writeJSBin "test_writers_js_bin" { libraries = [ nodePackages.semver ]; } ''
+    js = writeJSBin "test-writers-js-bin" { libraries = [ nodePackages.semver ]; } ''
       var semver = require('semver');
 
       if (semver.valid('1.2.3')) {
@@ -57,12 +57,12 @@ let
       }
     '';
 
-    perl = writePerlBin "test_writers_perl_bin" { libraries = [ perlPackages.boolean ]; } ''
+    perl = writePerlBin "test-writers-perl-bin" { libraries = [ perlPackages.boolean ]; } ''
       use boolean;
       print "success\n" if true;
     '';
 
-    python2 = writePython2Bin "test_writers_python2_bin" { libraries = [ python2Packages.enum ]; } ''
+    python2 = writePython2Bin "test-writers-python2-bin" { libraries = [ python2Packages.enum ]; } ''
       from enum import Enum
 
 
@@ -73,7 +73,7 @@ let
       print Test.a
     '';
 
-    python3 = writePython3Bin "test_writers_python3_bin" { libraries = [ python3Packages.pyyaml ]; } ''
+    python3 = writePython3Bin "test-writers-python3-bin" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
       y = yaml.load("""
@@ -84,11 +84,11 @@ let
   };
 
   simple = {
-    bash = writeBash "test_writers_bash" ''
+    bash = writeBash "test-writers-bash" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
     '';
 
-    c = writeC "test_writers_c" { libraries = [ glib.dev ]; } ''
+    c = writeC "test-writers-c" { libraries = [ glib.dev ]; } ''
       #include <gio/gio.h>
       #include <stdio.h>
       int main() {
@@ -106,11 +106,11 @@ let
       }
     '';
 
-    dash = writeDash "test_writers_dash" ''
+    dash = writeDash "test-writers-dash" ''
      test '~' = '~' && echo 'success'
     '';
 
-    haskell = writeHaskell "test_writers_haskell" { libraries = [ haskellPackages.acme-default ]; } ''
+    haskell = writeHaskell "test-writers-haskell" { libraries = [ haskellPackages.acme-default ]; } ''
       import Data.Default
 
       int :: Int
@@ -122,7 +122,7 @@ let
         _ -> print "fail"
     '';
 
-    js = writeJS "test_writers_js" { libraries = [ nodePackages.semver ]; } ''
+    js = writeJS "test-writers-js" { libraries = [ nodePackages.semver ]; } ''
       var semver = require('semver');
 
       if (semver.valid('1.2.3')) {
@@ -132,12 +132,12 @@ let
       }
     '';
 
-    perl = writePerl "test_writers_perl" { libraries = [ perlPackages.boolean ]; } ''
+    perl = writePerl "test-writers-perl" { libraries = [ perlPackages.boolean ]; } ''
       use boolean;
       print "success\n" if true;
     '';
 
-    python2 = writePython2 "test_writers_python2" { libraries = [ python2Packages.enum ]; } ''
+    python2 = writePython2 "test-writers-python2" { libraries = [ python2Packages.enum ]; } ''
       from enum import Enum
 
 
@@ -148,7 +148,7 @@ let
       print Test.a
     '';
 
-    python3 = writePython3 "test_writers_python3" { libraries = [ python3Packages.pyyaml ]; } ''
+    python3 = writePython3 "test-writers-python3" { libraries = [ python3Packages.pyyaml ]; } ''
       import yaml
 
       y = yaml.load("""
@@ -157,21 +157,21 @@ let
       print(y[0]['test'])
     '';
 
-    python2NoLibs = writePython2 "test_writers_python2_no_libs" {} ''
+    python2NoLibs = writePython2 "test-writers-python2-no-libs" {} ''
       print("success")
     '';
 
-    python3NoLibs = writePython3 "test_writers_python3_no_libs" {} ''
+    python3NoLibs = writePython3 "test-writers-python3-no-libs" {} ''
       print("success")
     '';
   };
 
 
   path = {
-    bash = writeBash "test_writers_bash_path" (writeText "test" ''
+    bash = writeBash "test-writers-bash-path" (writeText "test" ''
       if [[ "test" == "test" ]]; then echo "success"; fi
     '');
-    haskell = writeHaskell "test_writers_haskell_path" { libraries = [ haskellPackages.acme-default ]; } (writeText "test" ''
+    haskell = writeHaskell "test-writers-haskell-path" { libraries = [ haskellPackages.acme-default ]; } (writeText "test" ''
       import Data.Default
 
       int :: Int


### PR DESCRIPTION
This makes it easier to debug test failures since the derivation name
will give an indication which writer it belongs to.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
