### PR TITLE
diodon: init at 1.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6461,7 +6461,7 @@
     name = "Matthias C. M. Troffaes";
   };
   McSinyx = {
-    email = "vn.mcsinyx@gmail.com";
+    email = "mcsinyx@disroot.org";
     github = "McSinyx";
     githubId = 13689192;
     name = "Nguyễn Gia Phong";

--- a/pkgs/applications/misc/diodon/default.nix
+++ b/pkgs/applications/misc/diodon/default.nix
@@ -1,0 +1,34 @@
+{ fetchFromGitHub, lib, stdenv
+, desktop-file-utils, meson, ninja, pkg-config, vala, wrapGAppsHook, xvfb-run
+, gtk3, libXtst, libpeas, zeitgeist
+, appindicatorSupport ? false, libayatana-appindicator }:
+
+stdenv.mkDerivation rec {
+  pname = "diodon";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "diodon-dev";
+    repo = pname;
+    rev = version;
+    sha256 = "1sa38v3lfb95m4f6ngc7zw1mm8ay3h4m3n11dqfn6vx9dwdbx215";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils meson ninja pkg-config vala wrapGAppsHook xvfb-run
+  ];
+  buildInputs = [
+    gtk3 libXtst libpeas zeitgeist
+  ] ++ lib.optionals appindicatorSupport [ libayatana-appindicator ];
+  mesonFlags = lib.optionals (!appindicatorSupport) [
+    "-Ddisable-indicator-plugin=true"
+  ];
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "Integrated clipboard manager for the Gnome/Unity desktop";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23158,6 +23158,8 @@ in
     inherit (pkgs.gnome2) libart_lgpl libgnomeui;
   };
 
+  diodon = callPackage ../applications/misc/diodon { };
+
   direwolf = callPackage ../applications/radio/direwolf { };
 
   dirt = callPackage ../applications/audio/dirt {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Diodon is a nice GTK+ clipboard manager with history drop down at cursor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) 
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).