### PR TITLE
ghc: 8.10.4 -> 8.10.6

### DIFF
--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -1,4 +1,4 @@
-{ lib, supportedGhcVersions ? [ "884" "8104" ], stdenv, haskellPackages
+{ lib, supportedGhcVersions ? [ "884" "8106" ], stdenv, haskellPackages
 , haskell }:
 #
 # The recommended way to override this package is

--- a/pkgs/os-specific/darwin/xattr/default.nix
+++ b/pkgs/os-specific/darwin/xattr/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchzip
+, buildPythonPackage
+, python
+, ed
+, unifdef
+}:
+
+buildPythonPackage rec {
+  pname = "xattr";
+  version = "61.60.1";
+
+  src = fetchzip rec {
+    url = "https://opensource.apple.com/tarballs/python_modules/python_modules-${version}.tar.gz";
+    sha256 = "19kydl7w4vpdi7zmfd5z9vjkq24jfk2cv4j0pppw69j06czhdwwi";
+  };
+
+  sourceRoot = "${src.name}/Modules/xattr-0.6.4";
+  format = "other";
+
+  nativeBuildInputs = [
+    ed
+    unifdef
+  ];
+
+  makeFlags = [
+    "OBJROOT=$(PWD)"
+    "DSTROOT=${placeholder "out"}"
+    "OSL=${placeholder "doc"}/share/xattr/OpenSourceLicenses"
+    "OSV=${placeholder "doc"}/share/xattr/OpenSourceVersions"
+  ];
+
+  # need to use `out` instead of `bin` since buildPythonPackage ignores the latter
+  outputs = [ "out" "doc" "python" ];
+
+  # We need to patch a reference to gnutar in an included Makefile
+  postUnpack = ''
+    chmod u+w $sourceRoot/..
+  '';
+
+  postPatch = ''
+    substituteInPlace ../Makefile.inc --replace gnutar tar
+    substituteInPlace Makefile --replace "/usr" ""
+  '';
+
+  preInstall = ''
+    # prevent setup.py from trying to download setuptools
+    sed -i xattr-*/setup.py -e '/ez_setup/d'
+
+    # create our custom target dirs we patch in
+    mkdir -p "$doc/share/xattr/"OpenSource{Licenses,Versions}
+    mkdir -p "$python/lib/${python.libPrefix}"
+  '';
+
+  # move python package to its own output to reduce clutter
+  postInstall = ''
+    mv "$out/lib/python" "$python/${python.sitePackages}"
+    rmdir "$out/lib"
+  '';
+
+  makeWrapperArgs = [
+    "--prefix" "PYTHONPATH" ":" "${placeholder "python"}/${python.sitePackages}"
+  ];
+
+  meta = with lib; {
+    description = "Display and manipulate extended attributes";
+    license = [ licenses.psfl licenses.mit ]; # see $doc/share/xattr/OpenSourceLicenses
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://opensource.apple.com/source/python_modules/";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11411,7 +11411,7 @@ with pkgs;
 
   # Please update doc/languages-frameworks/haskell.section.md, “Our
   # current default compiler is”, if you bump this:
-  haskellPackages = dontRecurseIntoAttrs haskell.packages.ghc8104;
+  haskellPackages = dontRecurseIntoAttrs haskell.packages.ghc8106;
 
   inherit (haskellPackages) ghc;
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -156,6 +156,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   usr-include = callPackage ../os-specific/darwin/usr-include { };
 
+  xattr = pkgs.python3Packages.callPackage ../os-specific/darwin/xattr { };
+
   inherit (pkgs.callPackages ../os-specific/darwin/xcode { })
     xcode_8_1 xcode_8_2
     xcode_9_1 xcode_9_2 xcode_9_4 xcode_9_4_1

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -68,7 +68,7 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_7;
       llvmPackages = pkgs.llvmPackages_7;
     };
-    ghc8104 = callPackage ../development/compilers/ghc/8.10.4.nix {
+    ghc8106 = callPackage ../development/compilers/ghc/8.10.6.nix {
       # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
       # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
       bootPkgs = if stdenv.isAarch64 || stdenv.isAarch32 || stdenv.targetPlatform.isMusl then
@@ -76,6 +76,10 @@ in {
         else
           packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
+      # Need to use apple's patched xattr until
+      # https://github.com/xattr/xattr/issues/44 and
+      # https://github.com/xattr/xattr/issues/55 are solved.
+      inherit (buildPackages.darwin) xattr;
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;
     };
@@ -147,9 +151,9 @@ in {
       ghc = bh.compiler.ghc884;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.8.x.nix { };
     };
-    ghc8104 = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc8104;
-      ghc = bh.compiler.ghc8104;
+    ghc8106 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc8106;
+      ghc = bh.compiler.ghc8106;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
     };
     ghc901 = callPackage ../development/haskell-modules {

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -50,7 +50,7 @@ let
   # list of all compilers to test specific packages on
   all = with compilerNames; [
     ghc884
-    ghc8104
+    ghc8106
     ghc901
   ];
 
@@ -300,12 +300,12 @@ let
       # package sets (like Cabal, jailbreak-cabal) are
       # working as expected.
       cabal-install = all;
-      Cabal_3_6_0_0 = with compilerNames; [ ghc884 ghc8104 ];
+      Cabal_3_6_0_0 = with compilerNames; [ ghc884 ghc8106 ];
       cabal2nix-unstable = all;
       funcmp = all;
       # Doesn't currently work on ghc-9.0:
       # https://github.com/haskell/haskell-language-server/issues/297
-      haskell-language-server = with compilerNames; [ ghc884 ghc8104 ];
+      haskell-language-server = with compilerNames; [ ghc884 ghc8106 ];
       hoogle = all;
       hsdns = all;
       jailbreak-cabal = all;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[Release Notes](https://downloads.haskell.org/~ghc/8.10.5/docs/html/users_guide/8.10.5-notes.html)

Main interest for us apart from general bug fixes is the ability to target `aarch64-darwin` which nixpkgs/NixOS supports in a limited capacity as of 21.05.

However, GHC 8.10.5 has an [issue in RTS](https://gitlab.haskell.org/ghc/ghc/-/issues/19763) which breaks (presumably) haskell-language-server and doctest-based testsuites. Since we generally execute test suites, this causes severe regressions in `haskellPackages`. However, it looks like we can apply an [upstream patch](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/5915) to remedy the situation.

The following things would need to be done to make it viable to upgrade our GHC:

* [x] Apply the RTS patch export `allocateWrite` OR upgrade to 8.10.6 when it gets released
* [ ] Package binary GHC 8.10.5 (or 8.10.6) to be able to natively bootstrap `aarch64-darwin` GHC and enable that platform for `haskellPackages`.

In its current state the PR may allow cross compiling for `aarch64-darwin` (but I haven't tested this) which may be useful for interested parties. For nixpkgs itself this is not interesting since we don't rely on cross compilation to provide packages for that platform (except for the bootstrap).

I'm not sure how much I'll be work on GHC 8.10.5 in the near future — I have no stake in `aarch64-darwin` and no way of testing it, so it doesn't really make sense for me. If someone else wants to take point on this, I'll be happy to review PRs target towards `haskell-updates-ghc-8.10.5`.

When GHC 8.10.6 gets released, I'm interested in testing it on `haskell-updates` with the help of Hydra.

cc @TerrorJack @domenkozar @NixOS/haskell 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
