### PR TITLE
usql: init at 0.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3739,6 +3739,16 @@
     githubId = 1176131;
     name = "George Whewell";
   };
+  georgyo = {
+    email = "george@shamm.as";
+    github = "georgyo";
+    githubId = 19374;
+    name = "George Shammas";
+    keys = [{
+      longkeyid = "rsa4096/0x82BB70D541AE2DB4";
+      fingerprint = "D0CF 440A A703 E0F9 73CB  A078 82BB 70D5 41AE 2DB4";
+    }];
+  };
   gerschtli = {
     email = "tobias.happ@gmx.de";
     github = "Gerschtli";

--- a/pkgs/applications/misc/usql/default.nix
+++ b/pkgs/applications/misc/usql/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, unixODBC
+, icu
+}:
+
+buildGoModule rec {
+  pname = "usql";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "xo";
+    repo = "usql";
+    rev = "v${version}";
+    sha256 = "sha256-fcKn4kHIRvMdgGFKDNQg49YxLc0Y5j/8VwKoDLiXbEU=";
+  };
+
+  vendorSha256 = "sha256-uAV8NLnqXjIDILfnbbkVr2BOIucQ8vX89KI5yIkVtus=";
+
+  buildInputs = [ unixODBC icu ];
+
+  # These tags and flags are copied from build-release.sh
+  buildFlags = [ "-tags" ];
+  buildFlagsArray = [
+    "most"
+    "sqlite_app_armor"
+    "sqlite_fts5"
+    "sqlite_introspect"
+    "sqlite_json1"
+    "sqlite_stat4"
+    "sqlite_userauth"
+    "sqlite_vtable"
+    "sqlite_icu"
+    "no_adodb"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/xo/usql/text.CommandVersion=${version}"
+  ];
+
+  # All the checks currently require docker instances to run the databases.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Universal command-line interface for SQL databases";
+    homepage = "https://github.com/xo/usql";
+    license = licenses.mit;
+    maintainers = with maintainers; [ georgyo ];
+    # usql does not build on ARM.
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31337,6 +31337,8 @@ in
 
   urbit = callPackage ../misc/urbit { };
 
+  usql = callPackage ../applications/misc/usql { };
+
   utf8cpp = callPackage ../development/libraries/utf8cpp { };
 
   utf8proc = callPackage ../development/libraries/utf8proc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Usql (https://github.com/xo/usql) is universal command-line interface for SQL databases. It makes for a consistent interface no matter which database you are talking to.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
