### PR TITLE
[21.05] Revert "nixos/wireless: make wireless.interfaces mandatory"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -183,15 +183,6 @@
 
    <listitem>
     <para>
-     Enabling wireless networking now requires specifying at least one network
-     interface using <xref linkend="opt-networking.wireless.interfaces"/>.
-     This is to avoid a race condition with the card initialisation (see
-     <link xlink:href="https://github.com/NixOS/nixpkgs/issues/101963">issue
-     #101963</link> for more information).
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      If you are using <option>services.udev.extraRules</option> to assign
      custom names to network interfaces, this may stop working due to a change
      in the initialisation of dhcpcd and systemd networkd. To avoid this, either

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -42,6 +42,11 @@ in {
         description = ''
           The interfaces <command>wpa_supplicant</command> will use. If empty, it will
           automatically use all wireless interfaces.
+          <warning><para>
+            The automatic discovery of interfaces does not work reliably on boot:
+            it may fail and leave the system without network. When possible, specify
+            a known interface name.
+          </para></warning>
         '';
       };
 
@@ -224,6 +229,14 @@ in {
       assertion = with cfg; count (x: x != null) [ psk pskRaw auth ] <= 1;
       message = ''options networking.wireless."${name}".{psk,pskRaw,auth} are mutually exclusive'';
     });
+
+    warnings =
+      optional (cfg.interfaces == [] && config.systemd.services.wpa_supplicant.wantedBy != [])
+      ''
+        No network interfaces for wpa_supplicant have been configured: the service
+        may randomly fail to start at boot. You should specify at least one using the option
+        networking.wireless.interfaces.
+      '';
 
     environment.systemPackages = [ package ];
 

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -40,7 +40,8 @@ in {
         default = [];
         example = [ "wlan0" "wlan1" ];
         description = ''
-          The interfaces <command>wpa_supplicant</command> will use.
+          The interfaces <command>wpa_supplicant</command> will use. If empty, it will
+          automatically use all wireless interfaces.
         '';
       };
 
@@ -219,14 +220,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = cfg.interfaces != [];
-        message = ''
-          No network interfaces for wpa_supplicant have been configured.
-          Please, specify at least one using networking.wireless.interfaces.
-        '';
-      }
-    ] ++ flip mapAttrsToList cfg.networks (name: cfg: {
+    assertions = flip mapAttrsToList cfg.networks (name: cfg: {
       assertion = with cfg; count (x: x != null) [ psk pskRaw auth ] <= 1;
       message = ''options networking.wireless."${name}".{psk,pskRaw,auth} are mutually exclusive'';
     });
@@ -261,7 +255,20 @@ in {
         then echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
         fi
         iface_args="-s -u -D${cfg.driver} ${configStr}"
-        args="${concatMapStringsSep " -N " (i: "-i${i} $iface_args") ifaces}"
+        ${if ifaces == [] then ''
+          for i in $(cd /sys/class/net && echo *); do
+            DEVTYPE=
+            UEVENT_PATH=/sys/class/net/$i/uevent
+            if [ -e "$UEVENT_PATH" ]; then
+              source "$UEVENT_PATH"
+              if [ "$DEVTYPE" = "wlan" -o -e /sys/class/net/$i/wireless ]; then
+                args+="''${args:+ -N} -i$i $iface_args"
+              fi
+            fi
+          done
+        '' else ''
+          args="${concatMapStringsSep " -N " (i: "-i${i} $iface_args") ifaces}"
+        ''}
         exec wpa_supplicant $args
       '';
     };


### PR DESCRIPTION
###### Motivation for this change
backport #126075

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
