### PR TITLE
mvapich: fix default compilers

### DIFF
--- a/pkgs/development/libraries/mvapich/default.nix
+++ b/pkgs/development/libraries/mvapich/default.nix
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
     done
 
     # Ensure the default compilers are the ones mvapich was built with
-    substituteInPlace $out/bin/mpicc --replace 'CC="gcc"' 'CC=${stdenv.cc}/bin/gcc'
-    substituteInPlace $out/bin/mpicxx --replace 'CXX="g++"' 'CC=${stdenv.cc}/bin/g++'
-    substituteInPlace $out/bin/mpifort --replace 'FC="gfortran"' 'CC=${gfortran}/bin/gfortran'
+    substituteInPlace $out/bin/mpicc --replace 'CC="gcc"' 'CC=${stdenv.cc}/bin/cc'
+    substituteInPlace $out/bin/mpicxx --replace 'CXX="g++"' 'CXX=${stdenv.cc}/bin/c++'
+    substituteInPlace $out/bin/mpifort --replace 'FC="gfortran"' 'FC=${gfortran}/bin/gfortran'
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Fix some typos which resulted in an infinite recursion when mpic++ was called.
Also optimize the substitution to work with a non-gcc compiler.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
