### PR TITLE
sentry-cli: init at 1.66.0

### DIFF
--- a/pkgs/development/tools/sentry-cli/default.nix
+++ b/pkgs/development/tools/sentry-cli/default.nix
@@ -1,0 +1,34 @@
+{ rustPlatform
+, fetchFromGitHub
+, lib
+, openssl
+, pkg-config
+, stdenv
+, curl
+, Security
+, runCommand
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "sentry-cli";
+  version = "1.66.0";
+
+  src = fetchFromGitHub {
+    owner = "getsentry";
+    repo = "sentry-cli";
+    rev = version;
+    sha256 = "sha256-ivQBn5GGb64Jq0gpywAg20309QQMpasg/Bu5sHKj02Y=";
+  };
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security curl ];
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoSha256 = "sha256-xS88KZWYkg3v8TJZUVVgQhR++CrZGD0DQnLPktSUJQk=";
+
+  meta = with lib; {
+    homepage = "https://docs.sentry.io/cli/";
+    license = licenses.bsd3;
+    description = "A command line utility to work with Sentry.";
+    maintainers = with maintainers; [ rizary ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/sentry-cli/default.nix
+++ b/pkgs/development/tools/sentry-cli/default.nix
@@ -2,6 +2,8 @@
 , fetchFromGitHub
 , lib
 , openssl
+, file
+, rpm
 , pkg-config
 , stdenv
 , curl
@@ -19,7 +21,10 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-ivQBn5GGb64Jq0gpywAg20309QQMpasg/Bu5sHKj02Y=";
   };
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security curl ];
+  # Needed to get openssl-sys to use pkgconfig.
+  OPENSSL_NO_VENDOR = 1;
+
+  buildInputs = [ openssl file rpm ] ++ lib.optionals stdenv.isDarwin [ Security curl ];
   nativeBuildInputs = [ pkg-config ];
 
   cargoSha256 = "sha256-xS88KZWYkg3v8TJZUVVgQhR++CrZGD0DQnLPktSUJQk=";

--- a/pkgs/development/tools/sentry-cli/default.nix
+++ b/pkgs/development/tools/sentry-cli/default.nix
@@ -20,6 +20,7 @@ rustPlatform.buildRustPackage rec {
     rev = version;
     sha256 = "sha256-ivQBn5GGb64Jq0gpywAg20309QQMpasg/Bu5sHKj02Y=";
   };
+  doCheck = false;
 
   # Needed to get openssl-sys to use pkgconfig.
   OPENSSL_NO_VENDOR = 1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9574,6 +9574,10 @@ in
     inherit (python27Packages) ldap;
   };
 
+  sentry-cli = callPackage ../development/tools/sentry-cli {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   vtun = callPackage ../tools/networking/vtun {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding sentry-cli to nixpkgs.

###### Things done



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
