### PR TITLE
blender: add libharu as dependency

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -12,7 +12,7 @@
 , pugixml, llvmPackages, SDL, Cocoa, CoreGraphics, ForceFeedback, OpenAL, OpenGL
 , potrace
 , openxr-loader
-, embree, gmp
+, embree, gmp, libharu
 }:
 
 with lib;
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
       gmp
       pugixml
       potrace
+      libharu
     ]
     ++ (if (!stdenv.isDarwin) then [
       libXi libX11 libXext libXrender


### PR DESCRIPTION
###### Motivation for this change
This allows to export Grease Pencil drawings as pdfs. For more
information, see:

https://wiki.blender.org/wiki/Reference/Release_Notes/2.93/Grease_Pencil

https://developer.blender.org/rBa8a92cd15a52

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
