### PR TITLE
git: Drop POSIXPERM for the tests

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -290,11 +290,13 @@ stdenv.mkDerivation {
       fi
     }
 
-    # Shared permissions are forbidden in sandbox builds.
-    disable_test t0001-init shared
+    # Shared permissions are forbidden in sandbox builds:
+    substituteInPlace t/test-lib.sh \
+      --replace "test_set_prereq POSIXPERM" ""
+    # TODO: Investigate while these still fail (without POSIXPERM):
+    disable_test t0001-init 'shared overrides system'
+    disable_test t0001-init 'init honors global core.sharedRepository'
     disable_test t1301-shared-repo
-    disable_test t5324-split-commit-graph 'split commit-graph respects core.sharedrepository'
-    disable_test t4129-apply-samemode 'do not use core.sharedRepository for working tree files'
 
     # Our patched gettext never fallbacks
     disable_test t0201-gettext-fallbacks


### PR DESCRIPTION
Shared permissions are forbidden in the Nix build sandbox which is why
some of the tests fail. Dropping the POSIXPERM test prerequisite, that
is added unconditionally on Linux, should help us avoiding uninteresting
test failures after Git updates. The drawback is that this disables a
few additional tests (as of Git 2.32.0 approx. 71 out of more than 20k
subtests require POSIXPERM).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This might make things easier to manage in the long run but it isn't required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
