### PR TITLE
python3Packages.hupper: 1.10.2 -> 1.10.3

### DIFF
--- a/pkgs/development/python-modules/hupper/default.nix
+++ b/pkgs/development/python-modules/hupper/default.nix
@@ -3,25 +3,35 @@
 , buildPythonPackage
 , fetchPypi
 , pytestCheckHook
-, pytest-cov
 , watchdog
 }:
 
 buildPythonPackage rec {
   pname = "hupper";
-  version = "1.10.2";
+  version = "1.10.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3818f53dabc24da66f65cf4878c1c7a9b5df0c46b813e014abdd7c569eb9a02a";
+    sha256 = "sha256-zW9Rtyx1h7ybzopl7NAloelfGwMoRRm/6RKE0BAxbNk=";
   };
 
   # FIXME: watchdog dependency is disabled on Darwin because of #31865, which causes very silent
   # segfaults in the testsuite that end up failing the tests in a background thread (in myapp)
-  checkInputs = [ pytestCheckHook pytest-cov ] ++ lib.optional (!stdenv.isDarwin) watchdog;
+  checkInputs = [
+    pytestCheckHook
+  ] ++ lib.optional (!stdenv.isDarwin) [
+    watchdog
+  ];
+
+  disabledTestPaths = [
+    # Doesn't work with an exported home, RuntimeError: timeout waiting for change to file=/build/tmpgfn145cx
+    "tests/test_it.py"
+  ];
+
+  pythonImportsCheck = [ "hupper" ];
 
   meta = with lib; {
-    description = "in-process file monitor / reloader for reloading your code automatically during development";
+    description = "In-process file monitor/reloader for reloading your code automatically during development";
     homepage = "https://github.com/Pylons/hupper";
     license = licenses.mit;
     maintainers = with maintainers; [ ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.10.3

Change log: https://github.com/Pylons/hupper/blob/master/CHANGES.rst#1103-2021-05-13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
