### PR TITLE
make-wrapper: add __NIX_ARGV0 promise for interpreted shebang scripts

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -101,6 +101,7 @@ makeWrapper() {
         elif [[ "$p" == "--argv0" ]]; then
             argv0="${params[$((n + 1))]}"
             n=$((n + 1))
+            echo "export __NIX_ARGV0=\"$argv0\"  # a promise to interpreted shebang scripts: exec -a NAME has no effect"
         else
             die "makeWrapper doesn't understand the arg $p"
         fi


### PR DESCRIPTION
`exec -a NAME`-calls to interpreted shebang scripts are substituted
as `execve(shbangbin, [<evtl only shebang arg>, <scriptfile>])`. As you
can see, `NAME` is lost. `man execve` makes it clear (w.r.t. interpreted
scripts):

> Note that there is
> no way to get the argv[0] that was passed to the execve() call.

This commit adds a promise / contract to the make wrapper, so that
scripts can have **at least a chance** of knowing what their author
has originally had intended for `argv[0]` to be in the first place.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Make scripts report the truth (`my-script`) instead of an "UX lie" (`.my-script-wrapped`).
- The alternative for those scripts to use `@name@` substitution is unclean: it rebuilds (the script) for arbitrary wrappers however thin they are

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
