### PR TITLE
firefox: use nss without p11-kit

### DIFF
--- a/nixos/tests/custom-ca.nix
+++ b/nixos/tests/custom-ca.nix
@@ -107,8 +107,15 @@ in
           '';
         };
 
-      environment.systemPackages = with pkgs;
-        [ xdotool firefox chromium falkon midori ];
+      environment.systemPackages = with pkgs; [
+        xdotool
+        # Firefox was disabled here, because we needed to disable p11-kit support in nss,
+        # which is why it will not use the system certificate store for the time being.
+        # firefox
+        chromium
+        falkon
+        midori
+      ];
     };
 
   testScript = ''
@@ -145,7 +152,14 @@ in
     with subtest("Unknown CA is untrusted in curl"):
         machine.fail("curl -fv https://bad.example.com")
 
-    browsers = ["firefox", "chromium", "falkon", "midori"]
+    browsers = [
+      # Firefox was disabled here, because we needed to disable p11-kit support in nss,
+      # which is why it will not use the system certificate store for the time being.
+      # "firefox",
+      "chromium",
+      "falkon",
+      "midori"
+    ]
     errors = ["Security Risk", "not private", "Certificate Error", "Security"]
 
     machine.wait_for_x()

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -116,7 +116,9 @@ let
                 then overrideCC stdenv llvmPackages.clangUseLLVM
                 else stdenv;
 
-  nss_pkg = if lib.versionOlder ffversion "83" then nss_3_53 else nss;
+  # Disable p11-kit support in nss until our cacert packages has caught up exposing CKA_NSS_MOZILLA_CA_POLICY
+  # https://github.com/NixOS/nixpkgs/issues/126065
+  nss_pkg = if lib.versionOlder ffversion "83" then nss_3_53 else nss.override { useP11kit = false; };
 
   # --enable-release adds -ffunction-sections & LTO that require a big amount of
   # RAM and the 32-bit memory space cannot handle that linking


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Quickfix to allow firefox to recognize certificates as trusted by
Mozilla.

Downside: NixOS managed certificates will not be passed into firefox anymore until we fixup cacert.

Related: #126065

CC: @rnhmjoj @NixOS/nixos-release-managers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

