### PR TITLE
flashrom: Build and install manpage

### DIFF
--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -7,6 +7,7 @@
 , libftdi1
 , libusb1
 , pciutils
+, installShellFiles
 }:
 
 stdenv.mkDerivation rec {
@@ -18,8 +19,15 @@ stdenv.mkDerivation rec {
     sha256 = "0ax4kqnh7kd3z120ypgp73qy1knz47l6qxsqzrfkd97mh5cdky71";
   };
 
+  # Meson build doesn't build and install manpage. Only Makefile can.
+  # Build manpage from source directory. Here we're inside the ./build subdirectory
+  postInstall = ''
+    make flashrom.8 -C ..
+    installManPage ../flashrom.8
+  '';
+
   mesonFlags = lib.optionals stdenv.isAarch64 [ "-Dpciutils=false" ];
-  nativeBuildInputs = [ meson pkg-config ninja ];
+  nativeBuildInputs = [ meson pkg-config ninja installShellFiles ];
   buildInputs = [ libftdi1 libusb1 pciutils ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
It seems flashrom has two build systems at the moment.
One based on meson/ninja and one based on Make.

The latter can build and install the manpage but the former cannot.
ArchLinux does the same, call make after finishing the meson build: https://github.com/archlinux/svntogit-community/blob/packages/flashrom/trunk/PKGBUILD#L32

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
