### PR TITLE
[21.05] python3Packages.datasette: add patch for CVE-2021-32670

### DIFF
--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , aiofiles
 , asgi-csrf
 , click
@@ -35,6 +36,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-Ixh56X9dI/FIJPXHXXGnFiYj3qeBmvW5L1FF7/0ofUQ=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-32670.patch";
+      url = "https://github.com/simonw/datasette/commit/26fc539312bca2551b6f048b6bcf4ffbb491289f.patch";
+      sha256 = "1d4yy6dqb4l7y0c5xpdvl66522ckdb34wnqvzqw73pdl2hr5jsml";
+    })
+  ];
 
   nativeBuildInputs = [ pytestrunner ];
 
@@ -80,6 +89,8 @@ buildPythonPackage rec {
   # just run the csv tests, as this should give some indictation of correctness
   pytestFlagsArray = [
     "tests/test_csv.py"
+    # covers patched CVE-2021-32670
+    "tests/test_html.py"
   ];
   disabledTests = [
     "facet"


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-32670
https://github.com/simonw/datasette/security/advisories/GHSA-xw7c-jx9m-xh5g

Enable included test to prove patch's validity.

See #126242 for master
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
