### PR TITLE
sway: add postSessionCommands

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -28,6 +28,7 @@ let
 
   swayPackage = pkgs.sway.override {
     extraSessionCommands = cfg.extraSessionCommands;
+    postSessionCommands = cfg.postSessionCommands;
     extraOptions = cfg.extraOptions;
     withBaseWrapper = cfg.wrapperFeatures.base;
     withGtkWrapper = cfg.wrapperFeatures.gtk;
@@ -69,6 +70,17 @@ in {
         <link xlink:href="https://github.com/swaywm/sway/wiki/Running-programs-natively-under-wayland" />
         and <link xlink:href="https://github.com/swaywm/wlroots/blob/master/docs/env_vars.md" />
         for some useful environment variables.
+      '';
+    };
+
+    postSessionCommands = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        systemctl --user stop graphical-session.target
+      '';
+      description = ''
+        Shell commands executed after Sway is exited.
       '';
     };
 

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -1,7 +1,7 @@
 { lib
 , sway-unwrapped
 , makeWrapper, symlinkJoin, writeShellScriptBin
-, withBaseWrapper ? true, extraSessionCommands ? "", dbus
+, withBaseWrapper ? true, extraSessionCommands ? "", postSessionCommands ? "", dbus
 , withGtkWrapper ? false, wrapGAppsHook, gdk-pixbuf, glib, gtk3
 , extraOptions ? [] # E.g.: [ "--verbose" ]
 # Used by the NixOS module:
@@ -23,10 +23,11 @@ let
      fi
      if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
        export DBUS_SESSION_BUS_ADDRESS
-       exec ${sway}/bin/sway "$@"
+       ${sway}/bin/sway "$@"
      else
-       exec ${dbus}/bin/dbus-run-session ${sway}/bin/sway "$@"
+       ${dbus}/bin/dbus-run-session ${sway}/bin/sway "$@"
      fi
+     ${postSessionCommands}
    '';
 in symlinkJoin {
   name = "sway-${sway.version}";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

tested with 
```
disabledModules = [ "programs/sway.nix" ];

imports = let
  pkgsArtturin = builtins.fetchTarball {
    url = "https://github.com/Artturin/nixpkgs/archive/e2cb7cc64376e79b5e3aa0205fef4802f12f7dc3.tar.gz";
    sha256 = "08npq9awcd5w296jminbrz63vv6r1h4y1hkz3a1ysa6qm0n2qvl9";
  };
in [
  (import "${pkgsArtturin}/nixos/modules/programs/sway.nix")
];

nixpkgs.overlays = let
    pkgsArtturin = pkgs.fetchFromGitHub {
    owner = "Artturin";
    repo = "nixpkgs";
    rev = "e2cb7cc64376e79b5e3aa0205fef4802f12f7dc3";
    sha256 = "08npq9awcd5w296jminbrz63vv6r1h4y1hkz3a1ysa6qm0n2qvl9";
  };
    sway-overlay = self: super: {
      sway = super.callPackage "${pkgsArtturin}/pkgs/applications/window-managers/sway/wrapper.nix" { };
    };
  in
  [
    sway-overlay 
  ];

  programs.sway = {
    enable = true;
    postSessionCommands = ''
      echo "a test" > /home/USER/ifexists-then-it-works
    '';
    wrapperFeatures.gtk = true;
  };
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
