### PR TITLE
python3Packages.wled: 0.4.4 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/wled/default.nix
+++ b/pkgs/development/python-modules/wled/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , aiohttp
 , backoff
+, poetry-core
 , packaging
 , yarl
 , aresponses
@@ -13,15 +14,20 @@
 
 buildPythonPackage rec {
   pname = "wled";
-  version = "0.4.4";
-  disabled = pythonOlder "3.7";
+  version = "0.5.0";
+  disabled = pythonOlder "3.8";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "frenck";
     repo = "python-wled";
     rev = "v${version}";
-    sha256 = "1adh23v4c9kia3ddqdq0brksd5rhgh4ff7l5hil8klx4dmkrjfz3";
+    sha256 = "123806fmdihdf9y8dqp5rli5c4i9a74j9rmhay8m68igm1326d5f";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     aiohttp
@@ -36,10 +42,17 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    # Upstream doesn't set a version for the pyproject.toml
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}" \
+      --replace "--cov" ""
+  '';
+
   pythonImportsCheck = [ "wled" ];
 
   meta = with lib; {
-    description = "Asynchronous Python client for WLED";
+    description = "Python client for WLED";
     homepage = "https://github.com/frenck/python-wled";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/development/python-modules/wled/default.nix
+++ b/pkgs/development/python-modules/wled/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "wled" ];
 
   meta = with lib; {
-    description = "Python client for WLED";
+    description = "Asynchronous Python client for WLED";
     homepage = "https://github.com/frenck/python-wled";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.0

Change log: https://github.com/frenck/python-wled/releases/tag/v0.5.0

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51632
- Target Home Assistant release: 2021.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
