### PR TITLE
python3Packages.bme680: 1.0.5 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/bme680/default.nix
+++ b/pkgs/development/python-modules/bme680/default.nix
@@ -1,30 +1,39 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, mock
 , smbus-cffi
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "bme680";
-  version = "1.0.5";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "pimoroni";
     repo = "bme680-python";
     rev = "v${version}";
-    sha256 = "sha256-oIXh1JnGTI/Cj4MQFpWq+sWR2X+ioCsK0Q+T7wPITCQ=";
+    sha256 = "sha256-gmdRxMJ0DoCyNcb/bYp746PBi4HktHAAYOcSQJ0Uheg=";
   };
 
-  propagatedBuildInputs = [ smbus-cffi ];
+  propagatedBuildInputs = [
+    smbus-cffi
+  ];
 
   preBuild = ''
     cd library
   '';
-  checkInputs = [ pytestCheckHook ];
 
-  # next release will have tests, but not the current one
-  doCheck = false;
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace library/setup.cfg \
+      --replace "smbus" "smbus-cffi"
+  '';
 
   pythonImportsCheck = [ "bme680" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest upstream release 1.1.1

Change log: https://github.com/pimoroni/bme680-python/releases/tag/v1.1.1

- Related Home Assistant change: -
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
