### PR TITLE
python3Packages.ambee: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/ambee/default.nix
+++ b/pkgs/development/python-modules/ambee/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, aiohttp
+, poetry-core
+, yarl
+, aresponses
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ambee";
+  version = "0.2.1";
+  disabled = pythonOlder "3.8";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "frenck";
+    repo = "python-ambee";
+    rev = "v${version}";
+    sha256 = "11liw2206lyrnx09giqapjpi25lr2qnbmigi6rgynr2a1i9vxy1s";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Upstream doesn't set a version for the pyproject.toml
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}" \
+      --replace "--cov" ""
+  '';
+
+  pythonImportsCheck = [ "ambee" ];
+
+  meta = with lib; {
+    description = "Python client for Ambee API";
+    homepage = "https://github.com/frenck/python-ambee";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -385,6 +385,8 @@ in {
 
   amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };
 
+  ambee = callPackage ../development/python-modules/ambee { };
+
   ambiclimate = callPackage ../development/python-modules/ambiclimate { };
 
   amcrest = callPackage ../development/python-modules/amcrest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for Ambee API

https://github.com/frenck/python-ambee

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51645
- Target Home Assistant release: 2021.7.0

ToDo:

- [ ] Update `component-packages` 
- [ ] Enable tests in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
