### PR TITLE
python3Packages.aiotractive: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/aiotractive/default.nix
+++ b/pkgs/development/python-modules/aiotractive/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "aiotractive";
+  version = "0.5.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "zhulik";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09zbca84dn1sprwqpfanmxxnmaknbzjz98xa87agpgy8xb3wpw7j";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    yarl
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "aiotractive" ];
+
+  meta = with lib; {
+    description = "Python client for the Tractive REST API";
+    homepage = "https://github.com/zhulik/aiotractive";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -353,6 +353,8 @@ in {
 
   aiosyncthing = callPackage ../development/python-modules/aiosyncthing { };
 
+  aiotractive = callPackage ../development/python-modules/aiotractive { };
+
   aiounifi = callPackage ../development/python-modules/aiounifi { };
 
   aiounittest = callPackage ../development/python-modules/aiounittest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for the Tractive REST API

https://github.com/zhulik/aiotractive

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51002
- Target Home Assistant release: 2021.7.0

ToDo:

- [ ] Update `component-packages` 
- [ ] Enable tests in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
