### PR TITLE
python3Packages.pynobo: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pynobo/default.nix
+++ b/pkgs/development/python-modules/pynobo/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "pynobo";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "echoromeo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0f98qm9vp7f0hqaxhihv7y5swciyp60222la44f4936g0rvs005x";
+  };
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pynobo" ];
+
+  meta = with lib; {
+    description = "Python 3 TCP/IP interface for Nobo Hub/Nobo Energy Control devices";
+    homepage = "https://github.com/echoromeo/pynobo";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5160,6 +5160,8 @@ in {
 
   pynndescent = callPackage ../development/python-modules/pynndescent { };
 
+  pynobo = callPackage ../development/python-modules/pynobo { };
+
   pynuki = callPackage ../development/python-modules/pynuki { };
 
   pynws = callPackage ../development/python-modules/pynws { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python TCP/IP interface for Nobo Hub/Nobo Energy Control devices

https://github.com/echoromeo/pynobo

- Related Home Assistant change: https://github.com/home-assistant/core/pull/50913
- Target Home Assistant release: 2021.x.x

ToDo:

- [ ] Update `component-packages` 
- [ ] Enable tests in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
