### PR TITLE
libharu: use fetchFromGitHub and switch to pname

### DIFF
--- a/pkgs/development/libraries/libharu/default.nix
+++ b/pkgs/development/libraries/libharu/default.nix
@@ -1,10 +1,13 @@
-{ lib, stdenv, fetchzip, cmake, zlib, libpng }:
+{ lib, stdenv, fetchFromGitHub, cmake, zlib, libpng }:
 
-stdenv.mkDerivation {
-  name = "libharu-2.3.0";
+stdenv.mkDerivation rec {
+  pname = "libharu";
+  version = "2.3.0";
 
-  src = fetchzip {
-    url = "https://github.com/libharu/libharu/archive/RELEASE_2_3_0.tar.gz";
+  src = fetchFromGitHub {
+    owner = "libharu";
+    repo = pname;
+    rev = "RELEASE_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "15s9hswnl3qqi7yh29jyrg0hma2n99haxznvcywmsp8kjqlyg75q";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
