### PR TITLE
palemoon: 29.2.0 -> 29.2.1

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,6 +1,3 @@
-# Compiler in stdenv MUST be a supported one for official branding
-# See https://developer.palemoon.org/build/linux/
-# TODO assert if stdenv.cc is supported?
 { stdenv
 , lib
 , fetchFromGitHub
@@ -37,6 +34,15 @@
 , gtk3
 }:
 
+# Only specific GCC versions are supported with branding
+# https://developer.palemoon.org/build/linux/
+assert stdenv.cc.isGNU;
+assert with lib.strings; (
+  versionAtLeast stdenv.cc.version "4.9"
+  && !hasPrefix "6" stdenv.cc.version
+  && versionOlder stdenv.cc.version "11"
+);
+
 let
   libPath = lib.makeLibraryPath [
     ffmpeg
@@ -46,14 +52,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.2.0";
+  version = "29.2.1";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "0pa9j41bbfarwi60a6hxi5vpn52mwgr4p05l98acv4fcs1ccb427";
+    sha256 = "0djjl79jrnny16p32db5w7pwwv0a24dc8mg1s1bnavhlvmmk52vq";
     fetchSubmodules = true;
   };
 
@@ -142,7 +148,6 @@ stdenv.mkDerivation rec {
     ac_add_options --enable-jemalloc
     ac_add_options --enable-strip
     ac_add_options --enable-devtools
-    # Missing from build instructions, https://forum.palemoon.org/viewtopic.php?f=5&t=25843#p214767
     ac_add_options --enable-av1
 
     ac_add_options --disable-eme
@@ -188,7 +193,7 @@ stdenv.mkDerivation rec {
     ./mach install
 
     # Fix missing icon due to wrong WMClass
-    # TODO report upstream
+    # https://forum.palemoon.org/viewtopic.php?f=3&t=26746&p=214221#p214221
     substituteInPlace ./palemoon/branding/official/palemoon.desktop \
       --replace 'StartupWMClass="pale moon"' 'StartupWMClass=Pale moon'
     desktop-file-install --dir=$out/share/applications \
@@ -202,7 +207,7 @@ stdenv.mkDerivation rec {
     done
 
     # Remove unneeded SDK data from installation
-    # TODO: move to a separate output?
+    # https://forum.palemoon.org/viewtopic.php?f=37&t=26796&p=214676#p214729
     rm -rf $out/{include,share/idl,lib/palemoon-devel-${version}}
 
     runHook postInstall
@@ -231,6 +236,7 @@ stdenv.mkDerivation rec {
       extensions and themes to make the browser truly your own.
     '';
     homepage = "https://www.palemoon.org/";
+    changelog = "https://repo.palemoon.org/MoonchildProductions/Pale-Moon/releases/tag/${version}_Release";
     license = licenses.mpl20;
     maintainers = with maintainers; [ AndersonTorres OPNA2608 ];
     platforms = [ "i686-linux" "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change
Just bugfixes, no CVE fixes this time.

https://repo.palemoon.org/MoonchildProductions/Pale-Moon/releases/tag/29.2.1_Release

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
