### PR TITLE
reproxy: 0.7.0 → 0.8.0

### DIFF
--- a/pkgs/servers/reproxy/default.nix
+++ b/pkgs/servers/reproxy/default.nix
@@ -2,19 +2,21 @@
 
 buildGoModule rec {
   pname = "reproxy";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "umputun";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-TwqfnOKWpFC3fnHNu3/F6KLHuzE7uF6WEgZOArntpWI=";
+    hash = "sha256-zwQZr6BbvJ2Ol5pCLkZ49j0j5KWTK0N8BybvTr8PPeg=";
   };
 
   postPatch = ''
     # Requires network access
     substituteInPlace app/main_test.go \
       --replace "Test_Main" "Skip_Main"
+    substituteInPlace app/proxy/proxy_test.go \
+      --replace "TestHttp_matchHandler" "SkipHttp_matchHandler"
   '' + lib.optionalString stdenv.isDarwin ''
     # Fails on Darwin.
     # https://github.com/umputun/reproxy/issues/77


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/umputun/reproxy/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
