### PR TITLE
busybox: 1.32.1 -> 1.33.1; clarify license

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, fetchurl, fetchFromGitLab, fetchpatch
+{ stdenv, lib, buildPackages, fetchurl, fetchFromGitLab
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableMinimal ? false
 # Allow forcing musl without switching stdenv itself, e.g. for our bootstrapping:
@@ -32,7 +32,7 @@ let
     CONFIG_FEATURE_WTMP n
   '';
 
-  # The debian version lacks behind the upstream version and also contains
+  # The debian version lags behind the upstream version and also contains
   # a debian-specific suffix. We only fetch the debian repository to get the
   # default.script
   debianVersion = "1.30.1-6";
@@ -49,17 +49,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "busybox";
-  # TODO: When bumping to next version, remove the patch
-  # for CVE-2021-28831 (assuming the patch was included in
-  # the next upstream release)
-  version = "1.32.1";
+  version = "1.33.1";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "https://busybox.net/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "1vhd59qmrdyrr1q7rvxmyl96z192mxl089hi87yl0hcp6fyw8mwx";
+    sha256 = "0a0dcvsh7nxnhxc5y73fky0z30i9p7r30qfidm2akn0n5fywdkhj";
   };
 
   hardeningDisable = [ "format" "pie" ]
@@ -67,11 +64,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./busybox-in-store.patch
-    (fetchpatch {
-      name = "CVE-2021-28831.patch";
-      url = "https://git.busybox.net/busybox/patch/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd";
-      sha256 = "0y79flfbk45krwn963nnbqc21a88bsz4k4asqwvcnfk2lkciadxm";
-    }) # TODO: Removing when bumping the version
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 
   postPatch = "patchShebangs .";
@@ -142,7 +134,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tiny versions of common UNIX utilities in a single small executable";
     homepage = "https://busybox.net/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ TethysSvensson ];
     platforms = platforms.linux;
     priority = 10;


### PR DESCRIPTION
The patch for CVE-2021-28831 is included in this release.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
