### PR TITLE
attract-mode: ffmpeg_3 -> ffmpeg

### DIFF
--- a/pkgs/misc/emulators/attract-mode/default.nix
+++ b/pkgs/misc/emulators/attract-mode/default.nix
@@ -1,4 +1,4 @@
-{ expat, fetchFromGitHub, ffmpeg_3, fontconfig, freetype, libarchive, libjpeg
+{ expat, fetchFromGitHub, ffmpeg, fontconfig, freetype, libarchive, libjpeg
 , libGLU, libGL, openal, pkg-config, sfml, lib, stdenv, zlib
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    expat ffmpeg_3 fontconfig freetype libarchive libjpeg libGLU libGL openal sfml zlib
+    expat ffmpeg fontconfig freetype libarchive libjpeg libGLU libGL openal sfml zlib
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Replace insecure FFMPEG v3 with current version.

See https://github.com/NixOS/nixpkgs/issues/120705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
