### PR TITLE
xkeyboard_config: 2.31 -> 2.33

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2523,11 +2523,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xkeyboardconfig = callPackage ({ stdenv, pkg-config, fetchurl, libX11, xorgproto, python3 }: stdenv.mkDerivation {
-    name = "xkeyboard-config-2.31";
+    name = "xkeyboard-config-2.33";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.31.tar.bz2";
-      sha256 = "18xddaxh83zm698syh50w983jg6b7b8zgv0dfaf7ha485hgihi6s";
+      url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.33.tar.bz2";
+      sha256 = "1g6kn7l0mixw50kgn7d97gwv1990c5rczr2x776q3xywss8dfzv5";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config python3 ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -75,7 +75,7 @@ mirror://xorg/individual/app/xwininfo-1.1.4.tar.bz2
 mirror://xorg/individual/app/xwud-1.0.5.tar.bz2
 mirror://xorg/individual/data/xbitmaps-1.1.2.tar.bz2
 mirror://xorg/individual/data/xcursor-themes-1.0.6.tar.bz2
-mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.31.tar.bz2
+mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.33.tar.bz2
 mirror://xorg/individual/doc/xorg-docs-1.7.1.tar.bz2
 mirror://xorg/individual/doc/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.6.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/tags/xkeyboard-config-2.33

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).