### PR TITLE
redfang: init at 2.5

### DIFF
--- a/pkgs/tools/networking/redfang/default.nix
+++ b/pkgs/tools/networking/redfang/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitLab, fetchpatch, bluez }:
+
+stdenv.mkDerivation rec {
+  pname = "redfang";
+  version = "2.5";
+
+  src = fetchFromGitLab {
+    group = "kalilinux";
+    owner = "packages";
+    repo = pname;
+    rev = "upstream/${version}";
+    sha256 = "sha256-dF9QmBckyHAZ+JbLr0jTmp0eMu947unJqjrTMsJAfIE=";
+  };
+
+  patches = [
+    # make install rule
+    (fetchpatch {
+      url = "https://gitlab.com/kalilinux/packages/redfang/-/merge_requests/1.diff";
+      sha256 = "sha256-oxIrUAucxsBL4+u9zNNe2XXoAd088AEAHcRB/AN7B1M=";
+    })
+  ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-format-security";
+
+  buildInputs = [ bluez ];
+
+  meta = with lib; {
+    description = "A small proof-of-concept application to find non discoverable bluetooth devices";
+    homepage = "https://gitlab.com/kalilinux/packages/redfang";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -872,6 +872,8 @@ in
 
   quich = callPackage ../tools/misc/quich { } ;
 
+  redfang = callPackage ../tools/networking/redfang { };
+
   tfk8s = callPackage ../tools/misc/tfk8s { };
 
   tnat64 = callPackage ../tools/networking/tnat64 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
