### PR TITLE
zsh-fast-syntax-highlighting: 1.54 -> 1.55

### DIFF
--- a/pkgs/shells/zsh/zsh-fast-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-fast-syntax-highlighting/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "zsh-fast-syntax-highlighting";
-  version = "1.54";
+  version = "1.55";
 
   src = fetchFromGitHub {
     owner = "zdharma";
     repo = "fast-syntax-highlighting";
     rev = "v${version}";
-    sha256 = "019hda2pj8lf7px4h1z07b9l6icxx4b2a072jw36lz9bh6jahp32";
+    sha256 = "0h7f27gz586xxw7cc0wyiv3bx0x3qih2wwh05ad85bh2h834ar8d";
   };
 
   dontConfigure = true;
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
     plugindir="$out/share/zsh/site-functions"
 
     mkdir -p "$plugindir"
-    cp -r -- {,_,-}fast-* chroma themes "$plugindir"/
+    cp -r -- {,_,-,.}fast-* *chroma themes "$plugindir"/
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Contains some bug fixes. Seems to work fine for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
