### PR TITLE
ligjpeg-turbo: v7 and 8 abi compatibility

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,9 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, cmake, nasm
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, nasm
 , openjdk
 , enableJava ? false # whether to build the java wrapper
+, enableJpeg7 ? false # whether to build libjpeg with v7 compatibility
+, enableJpeg8 ? false # whether to build libjpeg with v8 compatibility
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
+
+assert !(enableJpeg7 && enableJpeg8);  # pick only one or none, not both
 
 stdenv.mkDerivation rec {
 
@@ -20,7 +28,7 @@ stdenv.mkDerivation rec {
   # This is needed by freeimage
   patches = [ ./0001-Compile-transupp.c-as-part-of-the-library.patch ]
     ++ lib.optional (stdenv.hostPlatform.libc or null == "msvcrt")
-      ./mingw-boolean.patch;
+    ./mingw-boolean.patch;
 
   outputs = [ "bin" "dev" "dev_private" "out" "man" "doc" ];
 
@@ -40,6 +48,10 @@ stdenv.mkDerivation rec {
     "-DENABLE_SHARED=${if enableShared then "1" else "0"}"
   ] ++ lib.optionals enableJava [
     "-DWITH_JAVA=1"
+  ] ++ lib.optionals enableJpeg7 [
+    "-DWITH_JPEG7=1"
+  ] ++ lib.optionals enableJpeg8 [
+    "-DWITH_JPEG8=1"
   ] ++ lib.optionals stdenv.hostPlatform.isRiscV [
     # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/428
     # https://github.com/libjpeg-turbo/libjpeg-turbo/commit/88bf1d16786c74f76f2e4f6ec2873d092f577c75
@@ -53,7 +65,7 @@ stdenv.mkDerivation rec {
     homepage = "https://libjpeg-turbo.org/";
     description = "A faster (using SIMD) libjpeg implementation";
     license = licenses.ijg; # and some parts under other BSD-style licenses
-    maintainers = with maintainers; [ vcunat colemickens ];
+    maintainers = with maintainers; [ vcunat colemickens kamadorueda ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
- Add build-time flags as explained in the
  [BUILDING.md](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/BUILDING.md#libjpeg-v7-or-v8-apiabi-emulation) to build the library with v7 and v8 abi compatibility
- In general the change is 100% backwards compatible, if someone wants to use these flags they can .override the enableJpeg7 or enableJpeg8 booleans
- Format the expression with nixpkgs-fmt
- Add myself as maintainer, this is a core library for a
  software that I'll be uploading next
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
