### PR TITLE
llvmPackages_git: fix variable shadowing

### DIFF
--- a/pkgs/development/compilers/llvm/update-git.py
+++ b/pkgs/development/compilers/llvm/update-git.py
@@ -64,7 +64,7 @@ default_nix = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'git/defa
 with fileinput.FileInput(default_nix, inplace=True) as f:
     for line in f:
         result = re.sub(r'^  release_version = ".+";', f'  release_version = "{release_version}";', line)
-        result = re.sub(r'^  version = ".+";', f'  version = "{version}";', line)
+        result = re.sub(r'^  version = ".+";', f'  version = "{version}";', result)
         result = re.sub(r'^  rev = ".*";', f'  rev = "{commit["sha"]}";', result)
         result = re.sub(r'^    sha256 = ".+";', f'    sha256 = "{hash}";', result)
         print(result, end='')


### PR DESCRIPTION
###### Motivation for this change

The first substitution was not passed to the 2nd re.sub call as seems to
be the intention of the original change.


###### Things done

I haven't executed the script after this as I just spotted the typo while browsing the repo.