### PR TITLE
qcachegrind: fix fatal Could not find the Qt platform plugin "xcb" in ""

### DIFF
--- a/pkgs/development/tools/analysis/qcachegrind/default.nix
+++ b/pkgs/development/tools/analysis/qcachegrind/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, qmake, qtbase, perl, python, php, kcachegrind }:
+{ lib, stdenv, qmake, qtbase, perl, python, php, kcachegrind, wrapQtAppsHook }:
 
 let
   name = lib.replaceStrings ["kcachegrind"] ["qcachegrind"] kcachegrind.name;
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [ qtbase perl python php ];
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
 
   dontWrapQtApps = true;
 
@@ -32,6 +32,10 @@ in stdenv.mkDerivation {
     install -Dm644 kcachegrind/32-apps-kcachegrind.png "$out/share/icons/hicolor/32x32/apps/kcachegrind.png"
     install -Dm644 kcachegrind/48-apps-kcachegrind.png "$out/share/icons/hicolor/48x48/apps/kcachegrind.png"
   '');
+
+  preFixup = ''
+    wrapQtApp "$out/bin/qcachegrind"
+  '';
 
   meta = with lib; {
     description = "A Qt GUI to visualize profiling data";

--- a/pkgs/development/tools/analysis/qcachegrind/default.nix
+++ b/pkgs/development/tools/analysis/qcachegrind/default.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
 
   meta = with lib; {
     description = "A Qt GUI to visualize profiling data";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ periklis ];
   };


### PR DESCRIPTION
###### Motivation for this change
Be able to start qcachegrind.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
