### PR TITLE
apfsprogs: init at 2021.05.07

### DIFF
--- a/pkgs/tools/filesystems/apfsprogs/default.nix
+++ b/pkgs/tools/filesystems/apfsprogs/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "apfsprogs";
+  version = "unstable-2021-05-07";
+
+  src = fetchFromGitHub {
+    owner = "linux-apfs";
+    repo = "apfsprogs";
+    rev = "d360211a30608a907e3ee8ad4468d606c40ec2d7";
+    sha256 = "sha256-SeFs/GQfIEvnxERyww+mnynjR7E02DdtBA6JsknEM+Q=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    make -C apfsck $makeFlags
+    make -C mkapfs $makeFlags
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    make -C apfsck install BINDIR="$out/bin" MANDIR="$out/share/man8" $installFlags
+    make -C mkapfs install BINDIR="$out/bin" MANDIR="$out/share/man8" $installFlags
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Experimental APFS tools for linux";
+    homepage = "https://github.com/linux-apfs/apfsprogs";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1067,6 +1067,8 @@ in
 
   apfs-fuse = callPackage ../tools/filesystems/apfs-fuse { };
 
+  apfsprogs = callPackage ../tools/filesystems/apfsprogs { };
+
   apk-tools = callPackage ../tools/package-management/apk-tools {
     lua = lua5_3;
   };


### PR DESCRIPTION
###### Motivation for this change
This adds apfsprogs, which contains the program apfsck to fsck an APFS filesystem and mkapfs to create a new APFS filesystem.
I'll add the kernel modules to mount an APFS filesystem in a different PR. Until then, the apfs-fuse program is also available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).