### PR TITLE
tt-rss-plugin-tumblr-gdpr: 2.1 -> 2.2

### DIFF
--- a/pkgs/servers/tt-rss/plugin-tumblr-gdpr/default.nix
+++ b/pkgs/servers/tt-rss/plugin-tumblr-gdpr/default.nix
@@ -2,19 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss-plugin-tumblr-gdpr";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "GregThib";
     repo = "ttrss-tumblr-gdpr";
     rev = "v${version}";
-    sha256 = "09cbghi5b6ww4i5677i39qc9rhpq70xmygp0d7x30239r3i23rpq";
+    sha256 = "sha256-oCdpgfOvXNui2KaS48WeyVy8Of6IlPOxQR6gmPiyH0s=";
   };
 
   installPhase = ''
-    mkdir -p $out/tumblr_gdpr
+    runHook preInstall
 
+    mkdir -p $out/tumblr_gdpr
     cp init.php $out/tumblr_gdpr
+
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -24,7 +27,7 @@ stdenv.mkDerivation rec {
 
       The name of the plugin in TT-RSS is 'tumblr_gdpr'.
     '';
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     homepage = "https://github.com/GregThib/ttrss-tumblr-gdpr";
     maintainers = with maintainers; [ das_j ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Current version is incompatible with the current version of tt-rss. It prevents adding new feeds. 21.05 is also affected so I intend to backport. Note that the new release only contains one commit, which is the fix, so the backport seems low risk enough to me.
I have run this for a day, it will get a bit more testing during review :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
