### PR TITLE
lucenepp: use fetchFromGitHub

### DIFF
--- a/pkgs/development/libraries/lucene++/default.nix
+++ b/pkgs/development/libraries/lucene++/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchurl, cmake, boost, gtest }:
+{ lib, stdenv, fetchFromGitHub, cmake, boost, gtest }:
 
 stdenv.mkDerivation rec {
   pname = "lucene++";
   version = "3.0.7";
 
-  src = fetchurl {
-    url = "https://github.com/luceneplusplus/LucenePlusPlus/"
-        + "archive/rel_${version}.tar.gz";
-    sha256 = "032yb35b381ifm7wb8cy2m3yndklnxyi5cgprjh48jqy641z46bc";
+  src = fetchFromGitHub {
+    owner = "luceneplusplus";
+    repo = "LucenePlusPlus";
+    rev = "rel_${version}";
+    sha256 = "06b37fly6l27zc6kbm93f6khfsv61w792j8xihfagpcm9cfz2zi1";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
