### PR TITLE
libfprint-2-tod1-vfs0090: init at 0.8.5

### DIFF
--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/0001-vfs0090-add-missing-explicit-dependencies-in-meson.b.patch
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/0001-vfs0090-add-missing-explicit-dependencies-in-meson.b.patch
@@ -1,0 +1,28 @@
+From c02f2e040dd1e7664777c5a705272e4eb7bfb569 Mon Sep 17 00:00:00 2001
+From: Vincent Breitmoser <look@my.amazin.horse>
+Date: Thu, 10 Jun 2021 14:09:19 +0200
+Subject: [PATCH] vfs0090: add missing explicit dependencies in meson.build
+
+Make all dependencies explicit, so they can be found when building with Nix.
+
+---
+ meson.build | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 54a7ca4..88f8793 100644
+--- a/meson.build
++++ b/meson.build
+@@ -17,6 +17,9 @@ udev_dep = dependency('udev')
+ vfs009x_deps += libfprint_tod_dep
+ vfs009x_deps += dependency('nss')
+ vfs009x_deps += dependency('openssl')
++vfs009x_deps += dependency('gusb')
++vfs009x_deps += dependency('libfprint-2')
++vfs009x_deps += dependency('glib-2.0')
+ 
+ vfs0090_deps += dependency('pixman-1')
+ 
+-- 
+2.31.1
+

--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/0002-vfs0090-add-missing-linux-limits.h-include.patch
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/0002-vfs0090-add-missing-linux-limits.h-include.patch
@@ -1,0 +1,26 @@
+From 5405e02c629e689449e852424aed8cca217ed309 Mon Sep 17 00:00:00 2001
+From: Vincent Breitmoser <look@my.amazin.horse>
+Date: Thu, 10 Jun 2021 14:10:52 +0200
+Subject: [PATCH] vfs0090: add missing <linux/limits.h> include
+
+This header is needed for the NAME_MAX constant used in this file.
+
+---
+ vfs0090.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vfs0090.c b/vfs0090.c
+index 8034faf..6070df7 100644
+--- a/vfs0090.c
++++ b/vfs0090.c
+@@ -24,6 +24,7 @@
+ 
+ #include <errno.h>
+ #include <ctype.h>
++#include <linux/limits.h>
+ #include <nss.h>
+ #include <pk11pub.h>
+ #include <sechash.h>
+-- 
+2.31.1
+

--- a/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitLab, pkg-config, libfprint, libfprint-tod, gusb, udev, nss, openssl, meson, pixman, ninja, glib }:
+stdenv.mkDerivation {
+  pname = "libfprint-2-tod1-vfs0090";
+  version = "0.8.5";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "3v1n0";
+    repo = "libfprint-tod-vfs0090";
+    rev = "6084a1545589beec0c741200b18b0902cca225ba";
+    sha256 = "sha256-tSML/8USd/LuHF/YGLvNgykixF6VYtfE4SXzeV47840=";
+  };
+
+  patches = [
+    # TODO remove once https://gitlab.freedesktop.org/3v1n0/libfprint-tod-vfs0090/-/merge_requests/1 is merged
+    ./0001-vfs0090-add-missing-explicit-dependencies-in-meson.b.patch
+    # TODO remove once https://gitlab.freedesktop.org/3v1n0/libfprint-tod-vfs0090/-/merge_requests/2 is merged
+    ./0002-vfs0090-add-missing-linux-limits.h-include.patch
+  ];
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [ libfprint libfprint-tod glib gusb udev nss openssl pixman ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t "$out/lib/libfprint-2/tod-1/" libfprint-tod-vfs009x.so
+    install -D -t "$out/lib/udev/rules.d/" $src/60-libfprint-2-tod-vfs0090.rules
+
+    runHook postInstall
+  '';
+
+  passthru.driverPath = "/lib/libfprint-2/tod-1";
+
+  meta = with lib; {
+    description = "A libfprint-2-tod Touch OEM Driver for 2016 ThinkPad's fingerprint readers";
+    homepage = "https://gitlab.freedesktop.org/3v1n0/libfprint-tod-vfs0090";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ valodim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16111,6 +16111,8 @@ in
 
   libfprint-2-tod1-goodix = callPackage ../development/libraries/libfprint-2-tod1-goodix { };
 
+  libfprint-2-tod1-vfs0090 = callPackage ../development/libraries/libfprint-2-tod1-vfs0090 { };
+
   libfpx = callPackage ../development/libraries/libfpx { };
 
   libgadu = callPackage ../development/libraries/libgadu { };


### PR DESCRIPTION
###### Motivation for this change

add vfs0090 tod module, which allow usage of the fingerprint sensor built into 2016 thinkpad, such as the T460p

upstream: https://gitlab.freedesktop.org/3v1n0/libfprint-tod-vfs0090

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
