### PR TITLE
ocamlPackages.cairo2: refactor

### DIFF
--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -6,21 +6,25 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tbz";
-    sha256 = "sha256-a7P1kiVmIwT6Fhtwxs29ffgO4iexsulxUoc9cnJmEK4=";
+    sha256 = "1bhhcrr74gc7a9qykcmi4zi0xy3xpp6wcw0v2vx088v64n9gbcvb";
   };
 
-  minimalOCamlVersion = "4.02";
   useDune2 = true;
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ cairo dune-configurator ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    dune-configurator
+  ];
 
   doCheck = !(stdenv.isDarwin
   # https://github.com/Chris00/ocaml-cairo/issues/19
   || lib.versionAtLeast ocaml.version "4.10");
 
   meta = with lib; {
-    homepage = "https://github.com/Chris00/ocaml-cairo";
     description = "Binding to Cairo, a 2D Vector Graphics Library";
     longDescription = ''
       This is a binding to Cairo, a 2D graphics library with support for
@@ -28,6 +32,7 @@ buildDunePackage rec {
       the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
       and SVG file output.
     '';
+    homepage = "https://github.com/Chris00/ocaml-cairo";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ jirkamarsik vbgl ];
   };


### PR DESCRIPTION
* Checksum has been changed! Used `nix-prefetch-url`.
  * I don't understand why it is different with `nix-prefetch-url`.
* Removes: minimalOCamlVersion ["4.02"; (typo)]
* clean-up