### PR TITLE
dhcp: Update config.guess in bundled BIND source tree

### DIFF
--- a/pkgs/tools/networking/dhcp/bind-config-files.patch
+++ b/pkgs/tools/networking/dhcp/bind-config-files.patch
@@ -1,0 +1,13 @@
+diff --git a/bind/Makefile.in b/bind/Makefile.in
+index 8fe8883f..29d81a94 100644
+--- a/bind/Makefile.in
++++ b/bind/Makefile.in
+@@ -42,6 +42,8 @@ bind1:
+ 		echo ${bindsrcdir} already unpacked... ;  \
+ 	else                                              \
+ 		gunzip -c bind.tar.gz | tar xf - ;        \
++		cp ../config.guess bind*/config.guess; \
++		cp ../config.sub bind*/config.sub; \
+ 	fi
+ 
+ # Configure the libraries

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation rec {
         url = "https://gitlab.isc.org/isc-projects/dhcp/-/commit/46d101b97c5a3b19a3f63f7b60e5f88994a64e22.patch";
         sha256 = "1y3nsmqjzcg4bhp1xmqp47v7rkl3bpcildkx6mlrg255yvxapmdp";
       })
+
+      # Update config.guess in bundled BIND
+      ./bind-config-files.patch
     ];
 
   nativeBuildInputs = [ perl makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The ISC DHCP source contains a tarball of BIND 9.11.14 which the Makefile will untar and build. The autoconf config files in the tarball (config.guess, config.sub) are outdated, preventing compilation on newer platforms (riscv64).

There is an option to use our own libbind (`--with-libbind`), but the API has changed and the version we are shipping is no longer compatible (I've tried). Resistance is futile - Just accept the ancient tarball of BIND that is also sitting [right in their git repo](https://gitlab.isc.org/isc-projects/dhcp/-/tree/master/bind) :vomiting_face: I never knew this was a thing, and now I can't unsee it.

Tested to build on riscv64 and x86-64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
