### PR TITLE
roon-server: 1.8-790 -> 1.8-795

### DIFF
--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -10,16 +10,16 @@
 , stdenv
 , zlib
 }: stdenv.mkDerivation rec {
-  name = "roon-server";
-  version = "100800790";
+  pname = "roon-server";
+  version = "1.8-795";
 
   # N.B. The URL is unstable. I've asked for them to provide a stable URL but
   # they have ignored me. If this package fails to build for you, you may need
   # to update the version and sha256.
   # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
   src = fetchurl {
-    url = "https://web.archive.org/web/20210428204513/https://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
-    sha256 = "1jhj52fmkdgr9qfang1i9qrl1z56h56x07k31n3kllknkv02lc8p";
+    url = "https://web.archive.org/web/20210610060249/http://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
+    sha256 = "sha256-gC+UquDMyDpgCEYKPp2RRIkHD/4itJssl0hcSEQO5Rc=";
   };
 
   buildInputs = [
@@ -64,6 +64,7 @@
 
   meta = with lib; {
     description = "The music player for music lovers";
+    changelog = "https://community.roonlabs.com/c/roon/software-release-notes/18";
     homepage = "https://roonlabs.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ lovesegfault steell ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
