### PR TITLE
jbofihe: Init at 0.43

### DIFF
--- a/pkgs/tools/text/jbofihe/default.nix
+++ b/pkgs/tools/text/jbofihe/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, bison, flex, perl, }:
+
+stdenv.mkDerivation rec {
+  pname = "jbofihe";
+  version = "0.43";
+
+  src = fetchFromGitHub {
+    owner = "lojban";
+    repo = "jbofihe";
+    rev = "v${version}";
+    sha256 = "1xx7x1256sjncyzx656jl6jl546vn8zz0siymqalz6v9yf341p98";
+  };
+
+  nativeBuildInputs = [ bison flex perl ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    (cd tests && ./run *.in)
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Parser & analyser for Lojban";
+    homepage = "https://github.com/lojban/jbofihe";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ chkno ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6478,6 +6478,9 @@ in
   ispell = callPackage ../tools/text/ispell {};
 
   iodash = callPackage ../development/libraries/iodash { };
+
+  jbofihe = callPackage ../tools/text/jbofihe {};
+
   jumanpp = callPackage ../tools/text/jumanpp {};
 
   jump = callPackage ../tools/system/jump {};


### PR DESCRIPTION
###### Motivation for this change
Make `jbofihe` available.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
