### PR TITLE
python3Packages.jsonstreams: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/jsonstreams/default.nix
+++ b/pkgs/development/python-modules/jsonstreams/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "jsonstreams";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "dcbaker";
     repo = pname;
     rev = version;
-    sha256 = "0c85fdqkj5k4b0v0ngx2d9qbmzdsvglh4j9k9h7508bvn7l8fa4b";
+    sha256 = "0qw74wz9ngz9wiv89vmilbifsbvgs457yn1bxnzhrh7g4vs2wcav";
   };
 
   propagatedBuildInputs = [ six ];


### PR DESCRIPTION
###### Motivation for this change
A new version is available.  [Changelog](https://github.com/dcbaker/jsonstreams/blob/main/docs/source/changes.rst).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
