### PR TITLE
python3Packages.pre-commit: 2.11.0 -> 2.13.0

### DIFF
--- a/pkgs/development/python-modules/pre-commit/default.nix
+++ b/pkgs/development/python-modules/pre-commit/default.nix
@@ -1,11 +1,13 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
 , aspy-yaml
 , cached-property
 , cfgv
 , identify
 , importlib-metadata
 , importlib-resources
-, isPy27
 , nodeenv
 , python
 , six
@@ -15,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "pre-commit";
-  version = "2.11.0";
-  disabled = isPy27;
+  version = "2.13.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit version;
     pname = "pre_commit";
-    sha256 = "15f1chxrbmfcajk1ngk3jvf6jjbigb5dg66wnn7phmlywaawpy06";
+    sha256 = "sha256-dklyxgaT3GaLqOhuspZU7DFEUBMQ9xmHQqdnvsOFo3g=";
   };
 
   patches = [
@@ -52,6 +54,8 @@ buildPythonPackage rec {
     substituteInPlace $out/${python.sitePackages}/pre_commit/languages/node.py \
       --subst-var-by nodeenv ${nodeenv}
   '';
+
+  pythonImportsCheck = [ "pre_commit" ];
 
   meta = with lib; {
     description = "A framework for managing and maintaining multi-language pre-commit hooks";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.13.0

Change log:
- https://github.com/pre-commit/pre-commit/releases/tag/v2.13.0
- https://github.com/pre-commit/pre-commit/releases/tag/v2.12.1
- https://github.com/pre-commit/pre-commit/releases/tag/v2.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
