### PR TITLE
[21.05] aws-iam-authenticator: 0.5.2 -> 0.5.3

### DIFF
--- a/pkgs/tools/security/aws-iam-authenticator/default.nix
+++ b/pkgs/tools/security/aws-iam-authenticator/default.nix
@@ -2,16 +2,18 @@
 
 buildGoModule rec {
   pname = "aws-iam-authenticator";
-  version = "0.5.2";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1xfc3a0dik4930va30sbl6687v6i5irv96fwis9lrqh5rjqnblqp";
+    sha256 = "0ga3vf5gn7533iqnxn7kchb6xg5wvk92livlqzkhi5qvqhl1sbw0";
   };
 
-  vendorSha256 = null;
+  # Upstream has inconsistent vendoring, see https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/377
+  deleteVendor = true;
+  vendorSha256 = "+Z8sENIMWXP29Piwb/W6i7UdNXVq6ZnO7AZbSaUYCME=";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=v${version}" ];
 


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/126335 to stable

