### PR TITLE
ocamlPackages.camlbz2: init 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/camlbz2/default.nix
+++ b/pkgs/development/ocaml-modules/camlbz2/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitLab, ocaml, findlib, bzip2, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  pname = "camlbz2";
+  version = "0.7.0";
+
+  src = fetchFromGitLab {
+    owner = "irill";
+    repo = "camlbz2";
+    rev = version;
+    sha256 = "sha256-jBFEkLN2fbC3LxTu7C0iuhvNg64duuckBHWZoBxrV/U=";
+  };
+
+  preConfigure = ''
+    aclocal -I .
+    autoconf
+  '';
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+  ];
+
+  buildInputs = [
+    ocaml
+    findlib
+    bzip2
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    make install DESTDIR=$out
+    runHook postInstall
+  '';
+
+  # passthru.tests = { inherit dose3; }; # To-Do: To be enabled when Dose3 PR is accepted.
+
+  meta = with lib; {
+    description = "CamlBZ2, OCaml bindings for the libbz2 (AKA, bzip2) (de)compression library.";
+    downloadPage = "https://gitlab.com/irill/camlbz2";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -139,6 +139,8 @@ let
 
     cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
+    camlbz2 = callPackage ../development/ocaml-modules/camlbz2 { };
+
     caqti = callPackage ../development/ocaml-modules/caqti { };
 
     caqti-async = callPackage ../development/ocaml-modules/caqti/async.nix { };


### PR DESCRIPTION
ocamlPackages.camlbz2: init 0.7.0

This library is a dependency of `dose3` (which is an Esy dependency).

As dose3 does not exist yet, I have commented this test:
passthru.tests = { inherit dose3; };