### PR TITLE
lastpass-cli: Add gitcredentials helper and format

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -1,5 +1,16 @@
-{ stdenv, lib, fetchFromGitHub, asciidoc, cmake, docbook_xsl, pkg-config
-, bash-completion, openssl, curl, libxml2, libxslt }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, asciidoc
+, cmake
+, docbook_xsl
+, pkg-config
+, bash-completion
+, openssl
+, curl
+, libxml2
+, libxslt
+}:
 
 stdenv.mkDerivation rec {
   pname = "lastpass-cli";
@@ -15,7 +26,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ asciidoc cmake docbook_xsl pkg-config ];
 
   buildInputs = [
-    bash-completion curl openssl libxml2 libxslt
+    bash-completion
+    curl
+    openssl
+    libxml2
+    libxslt
   ];
 
   installTargets = [ "install" "install-doc" ];
@@ -23,13 +38,14 @@ stdenv.mkDerivation rec {
   postInstall = ''
     install -Dm644 -T ../contrib/lpass_zsh_completion $out/share/zsh/site-functions/_lpass
     install -Dm644 -T ../contrib/completions-lpass.fish $out/share/fish/vendor_completions.d/lpass.fish
+    install -Dm755 -T ../contrib/examples/git-credential-lastpass $out/bin/git-credential-lastpass
   '';
 
   meta = with lib; {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";
-    homepage    = "https://github.com/lastpass/lastpass-cli";
-    license     = licenses.gpl2Plus;
-    platforms   = platforms.unix;
+    homepage = "https://github.com/lastpass/lastpass-cli";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ cstrahan ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #126471

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
