### PR TITLE
timeshift: init at 22.06.1

### DIFF
--- a/pkgs/applications/backup/timeshift/default.nix
+++ b/pkgs/applications/backup/timeshift/default.nix
@@ -1,0 +1,33 @@
+{ callPackage
+, timeshift-unwrapped
+, lib
+, rsync
+, coreutils
+, mount
+, umount
+, psmisc
+, cron
+, btrfs-progs
+, grubPackage
+}:
+let
+  timeshift-wrapper = callPackage ./wrapper.nix { };
+in
+(timeshift-wrapper timeshift-unwrapped ([
+  rsync
+  coreutils
+  mount
+  umount
+  psmisc
+  cron
+  btrfs-progs
+  grubPackage
+])).overrideAttrs (oldAttrs: {
+  meta = oldAttrs.meta // {
+    description = oldAttrs.meta.description;
+    longDescription = oldAttrs.meta.longDescription + ''
+      This package comes with runtime dependencies of command utilities provided by rsync, coreutils, mount, umount, psmisc, cron and (optionally) btrfs.
+      If you want to use the commands provided by the system, override the propagatedBuildInputs or use timeshift-minimal instead
+    '';
+  };
+})

--- a/pkgs/applications/backup/timeshift/minimal.nix
+++ b/pkgs/applications/backup/timeshift/minimal.nix
@@ -1,0 +1,15 @@
+{ callPackage
+, timeshift-unwrapped
+}:
+let
+  timeshift-wrapper = callPackage ./wrapper.nix { };
+in
+(timeshift-wrapper timeshift-unwrapped [ ]).overrideAttrs (oldAttrs: {
+  meta = oldAttrs.meta // {
+    description = oldAttrs.meta.description + " (without runtime dependencies)";
+    longDescription = oldAttrs.meta.longDescription + ''
+      This package is a wrapped version of timeshift-unwrapped
+      without runtime dependencies of command utilities.
+    '';
+  };
+})

--- a/pkgs/applications/backup/timeshift/timeshift-launcher.patch
+++ b/pkgs/applications/backup/timeshift/timeshift-launcher.patch
@@ -1,0 +1,26 @@
+diff --git a/src/timeshift-launcher b/src/timeshift-launcher
+index 29b8fc4..5f6cb17 100755
+--- a/src/timeshift-launcher
++++ b/src/timeshift-launcher
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+ 
+-app_command='timeshift-gtk'
++app_command=''"$(realpath "$(dirname "$0")")"'/timeshift-gtk'
+ 
+ if [ "$(id -u)" -eq 0 ]; then
+ 	# user is admin
+@@ -14,11 +14,11 @@ else
+ 		# script is running in non-interactive mode
+ 		if [ "$XDG_SESSION_TYPE" = "wayland" ] ; then
+ 			xhost +SI:localuser:root
+-			pkexec ${app_command}
++			pkexec env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" "${app_command}"
+ 			xhost -SI:localuser:root
+ 			xhost
+ 		elif command -v pkexec >/dev/null 2>&1; then
+-			pkexec ${app_command}
++			pkexec env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" "${app_command}"
+ 		elif command -v sudo >/dev/null 2>&1; then
+ 			x-terminal-emulator -e "sudo ${app_command}"
+ 		elif command -v su >/dev/null 2>&1; then

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gettext
+, pkg-config
+, vala
+, which
+, gtk3
+, json-glib
+, libgee
+, utillinux
+, vte
+, xapps
+}:
+
+stdenv.mkDerivation rec {
+  pname = "timeshift";
+  version = "22.06.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "timeshift";
+    rev = "v${version}";
+    sha256 = "XcxwVBKMv2YwbrI3FFWDQFs8hHruhkZq3YqzkptE6KE=";
+  };
+
+  patches = [
+    ./timeshift-launcher.patch
+  ];
+
+  postPatch = ''
+    while IFS="" read -r -d $'\0' FILE; do
+      substituteInPlace "$FILE" \
+        --replace "/sbin/blkid" "${utillinux}/bin/blkid"
+    done < <(find ./src -mindepth 1 -name "*.vala" -type f -print0)
+    substituteInPlace ./src/Utility/IconManager.vala \
+      --replace "/usr/share" "$out/share"
+    substituteInPlace ./src/Core/Main.vala \
+      --replace "/etc/timeshift/default.json" "$out/etc/timeshift/default.json" \
+      --replace "file_copy(app_conf_path_default, app_conf_path);" "if (!dir_exists(file_parent(app_conf_path))){dir_create(file_parent(app_conf_path));};file_copy(app_conf_path_default, app_conf_path);"
+  '';
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    vala
+    which
+  ];
+
+  buildInputs = [
+    gtk3
+    json-glib
+    libgee
+    vte
+    xapps
+  ];
+
+  preBuild = ''
+    makeFlagsArray+=( \
+      "-C" "src" \
+      "prefix=$out" \
+      "sysconfdir=$out/etc" \
+    )
+  '';
+
+  meta = with lib; {
+    description = "A system restore tool for Linux";
+    longDescription = ''
+      TimeShift creates filesystem snapshots using rsync+hardlinks or BTRFS snapshots.
+      Snapshots can be restored using TimeShift installed on the system or from Live CD or USB.
+    '';
+    homepage = "https://github.com/linuxmint/timeshift";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/applications/backup/timeshift/wrapper.nix
+++ b/pkgs/applications/backup/timeshift/wrapper.nix
@@ -1,0 +1,45 @@
+{ stdenvNoCC
+, lib
+, wrapGAppsHook
+, gdk-pixbuf
+, librsvg
+, xorg
+, shared-mime-info
+}:
+
+timeshift-unwrapped:
+runtimeDeps:
+stdenvNoCC.mkDerivation {
+  inherit (timeshift-unwrapped) pname version;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    xorg.lndir
+    wrapGAppsHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    lndir "${timeshift-unwrapped}" "$out"
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs=(
+      --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+    )
+    gappsWrapperArgs+=(
+      # Thumbnailers
+      --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ gdk-pixbuf librsvg shared-mime-info ]}"
+      "''${makeWrapperArgs[@]}"
+    )
+    wrapProgram "$out/bin/timeshift" "''${makeWrapperArgs[@]}"
+    wrapProgram "$out/bin/timeshift-gtk" "''${gappsWrapperArgs[@]}"
+  '';
+
+  inherit (timeshift-unwrapped) meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30024,6 +30024,12 @@ with pkgs;
 
   timelimit = callPackage ../tools/misc/timelimit { };
 
+  timeshift-unwrapped = callPackage ../applications/backup/timeshift/unwrapped.nix { inherit (cinnamon) xapps; };
+
+  timeshift = callPackage ../applications/backup/timeshift { grubPackage = grub2_full; };
+
+  timeshift-minimal = callPackage ../applications/backup/timeshift/minimal.nix { };
+
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
   timew-sync-server = callPackage ../applications/misc/timew-sync-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Timeshift is commonly seen in Debian-based distros, and is enabled by default on Ubuntu and Linux Mint.

If applied, users will be able to restore their broken distros from timeshift snapshots.

closes #89348

I'm not sure if it's useful for NixOS users, since we already have a powerful package manager that does in-place snapshots and rollback for us. (There is a comment in the package request about the possible use case when updating to a new version.)
Nevertheless, nix users on other distros may find it helpful to be able to install this from Nix and to restore inside that distro or from NixOS.

###### To-do

*   The "periodic snapshot" functionality requires crontab access from superuser. (this can be disabled)
*    ~timeshift-gtk expects /etc/timeshift/timeshift.json or /etc/timeshift/default.json to exist before it starts. I'm not sure how other packages manage that.~ (Solved by `patching src/Core/Main.vala` with `substituteInPlace`)
*   The snapshot creation/restore functionality has not tested yet. It would be great to add corresponding NixOS tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
