### PR TITLE
build-support.ocaml.dune: check for minimalOCamlVersion typo

### DIFF
--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -4,8 +4,8 @@
 
 let Dune = if args.useDune2 or false then dune_2 else dune_1; in
 
-if args ? minimumOCamlVersion &&
-   ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+if (args ? minimumOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion) ||
+   (args ? minimalOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimalOCamlVersion)
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation ({
     runHook postInstall
   '';
 
-} // args // {
+} // (builtins.removeAttrs args [ "minimalOCamlVersion" ]) // {
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 


### PR DESCRIPTION
build-support.ocaml.dune:
* accept both `minimalOcamlVersion` and `minimumOCamlVersion` silently.