### PR TITLE
Fix obs-browser

### DIFF
--- a/pkgs/applications/video/obs-studio/Change-product_version-to-user_agent_product.patch
+++ b/pkgs/applications/video/obs-studio/Change-product_version-to-user_agent_product.patch
@@ -1,0 +1,26 @@
+From 635772c4c5ecf11a0f84e6c9fc273dce6b9a5688 Mon Sep 17 00:00:00 2001
+From: V <v@anomalous.eu>
+Date: Thu, 10 Jun 2021 18:36:22 +0200
+Subject: [PATCH] Change product_version to user_agent_product
+
+This is its name as of CEF 91.1.0.
+---
+ obs-browser-plugin.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/obs-browser-plugin.cpp b/obs-browser-plugin.cpp
+index 1a6a009..5eb379e 100644
+--- a/plugins/obs-browser/obs-browser-plugin.cpp
++++ b/plugins/obs-browser/obs-browser-plugin.cpp
+@@ -298,7 +298,7 @@ static void BrowserInit(void)
+ 	prod_ver << std::to_string(obs_maj) << "." << std::to_string(obs_min)
+ 		 << "." << std::to_string(obs_pat);
+ 
+-	CefString(&settings.product_version) = prod_ver.str();
++	CefString(&settings.user_agent_product) = prod_ver.str();
+ 
+ #ifdef USE_QT_LOOP
+ 	settings.external_message_pump = true;
+-- 
+2.31.1
+

--- a/pkgs/applications/video/obs-studio/Enable-file-access-and-universal-access-for-file-URL.patch
+++ b/pkgs/applications/video/obs-studio/Enable-file-access-and-universal-access-for-file-URL.patch
@@ -1,0 +1,36 @@
+From 0de0a90f8fe5e1e48fa4ec7aa7c825ef88770f9d Mon Sep 17 00:00:00 2001
+From: Ryan Foster <RytoEX@gmail.com>
+Date: Mon, 9 Sep 2019 23:55:02 -0400
+Subject: [PATCH] Enable file access and universal access for file URLs
+
+When loading a local file, instead of disabling CEF's web security,
+enable file access and universal access for file URLs. This should allow
+local files to make CORS requests without completely disabling CEF's
+security model.
+---
+ obs-browser-source.cpp | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/obs-browser-source.cpp b/obs-browser-source.cpp
+index ab1181e..c775283 100644
+--- a/plugins/obs-browser/obs-browser-source.cpp
++++ b/plugins/obs-browser/obs-browser-source.cpp
+@@ -179,9 +179,12 @@ bool BrowserSource::CreateBrowser()
+ 
+ #if ENABLE_LOCAL_FILE_URL_SCHEME
+ 		if (is_local) {
+-			/* Disable web security for file:// URLs to allow
+-			 * local content access to remote APIs */
+-			cefBrowserSettings.web_security = STATE_DISABLED;
++			/* Enable file access and universal access from file://
++			 * URLs to allow local content access to remote APIs */
++			cefBrowserSettings.file_access_from_file_urls =
++				STATE_ENABLED;
++			cefBrowserSettings.universal_access_from_file_urls =
++				STATE_ENABLED;
+ 		}
+ #endif
+ 
+-- 
+2.31.1
+

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -53,6 +53,14 @@ in mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Lets obs-browser build against CEF 90.1.0+
+    ./Enable-file-access-and-universal-access-for-file-URL.patch
+
+    # Lets obs-browser build against CEF 91.1.0+
+    ./Change-product_version-to-user_agent_product.patch
+  ];
+
   nativeBuildInputs = [ addOpenGLRunpath cmake pkg-config ];
 
   buildInputs = [

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -1,26 +1,66 @@
-{ lib, stdenv, fetchurl, cmake, alsa-lib, atk, cairo, cups, dbus, expat, fontconfig
-, GConf, gdk-pixbuf, glib, gtk2, libX11, libxcb, libXcomposite, libXcursor
-, libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXScrnSaver
-, libXtst, nspr, nss, pango, libpulseaudio, systemd, at-spi2-atk, at-spi2-core
+{ lib, stdenv, fetchurl, cmake
+, glib
+, nss
+, nspr
+, atk
+, at-spi2-atk
+, libdrm
+, expat
+, libxcb
+, libxkbcommon
+, libX11
+, libXcomposite
+, libXdamage
+, libXext
+, libXfixes
+, libXrandr
+, mesa
+, gtk3
+, pango
+, cairo
+, alsa-lib
+, dbus
+, at-spi2-core
+, cups
+, libxshmfence
 }:
 
 let
-  libPath =
-    lib.makeLibraryPath [
-      alsa-lib atk cairo cups dbus expat fontconfig GConf gdk-pixbuf glib gtk2
-      libX11 libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi
-      libXrandr libXrender libXScrnSaver libXtst nspr nss pango libpulseaudio
-      systemd at-spi2-core at-spi2-atk
-    ];
-in
-stdenv.mkDerivation rec {
+  rpath = lib.makeLibraryPath [
+    glib
+    nss
+    nspr
+    atk
+    at-spi2-atk
+    libdrm
+    expat
+    libxcb
+    libxkbcommon
+    libX11
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    mesa
+    gtk3
+    pango
+    cairo
+    alsa-lib
+    dbus
+    at-spi2-core
+    cups
+    libxshmfence
+  ];
+in stdenv.mkDerivation rec {
   pname = "cef-binary";
-  version = "75.1.14-gc81164e";
+  version = "90.6.7";
+  gitRevision = "19ba721";
+  chromiumVersion = "90.0.4430.212";
 
   src = fetchurl {
-    name = "cef_binary_75.1.14+gc81164e+chromium-75.0.3770.100_linux64_minimal.tar.bz2";
-    url = "http://opensource.spotify.com/cefbuilds/cef_binary_75.1.14%2Bgc81164e%2Bchromium-75.0.3770.100_linux64_minimal.tar.bz2";
-    sha256 = "0985b2bx505j0q693hifjgidzb597wqf5idql5aqxs8lfxhc2pgg";
+    url = "https://cef-builds.spotifycdn.com/cef_binary_${version}+g${gitRevision}+chromium-${chromiumVersion}_linux64_minimal.tar.bz2";
+    sha256 = "1ja711x9fdlf21qw1k9xn3lvjc5zsfgnjga1w1r8sysam73jk7xj";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -32,7 +72,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/ $out/share/cef/
     cp libcef_dll_wrapper/libcef_dll_wrapper.a $out/lib/
     cp ../Release/libcef.so $out/lib/
-    patchelf --set-rpath "${libPath}" $out/lib/libcef.so
+    patchelf --set-rpath "${rpath}" $out/lib/libcef.so
     cp ../Release/*.bin $out/share/cef/
     cp -r ../Resources/* $out/share/cef/
     cp -r ../include $out/
@@ -40,7 +80,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Simple framework for embedding Chromium-based browsers in other applications";
-    homepage = "http://opensource.spotify.com/cefbuilds/index.html";
+    homepage = "https://cef-builds.spotifycdn.com/index.html";
     maintainers = with maintainers; [ puffnfresh ];
     license = licenses.bsd3;
     platforms = with platforms; linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15915,7 +15915,7 @@ in
 
   libcec_platform = callPackage ../development/libraries/libcec/platform.nix { };
 
-  libcef = callPackage ../development/libraries/libcef { inherit (gnome2) GConf; };
+  libcef = callPackage ../development/libraries/libcef {};
 
   libcello = callPackage ../development/libraries/libcello {};
 


### PR DESCRIPTION
Updates CEF to the latest version, and applies a couple of patches to make OBS build against that.

###### Motivation for this change

Fixes #126410

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
