### PR TITLE
nixos-rebuild: Pass flakes flags when doing local flakes build

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -215,7 +215,7 @@ nixBuild() {
 
 nixFlakeBuild() {
     if [ -z "$buildHost" ]; then
-        nix build "$@" --out-link "${tmpDir}/result"
+        nix "${flakeFlags[@]}" build "$@" --out-link "${tmpDir}/result"
         readlink -f "${tmpDir}/result"
     else
         local attr="$1"


### PR DESCRIPTION
###### Motivation for this change
Make local --flake builds work without relying on nix.conf again.

This fixes a regression introduced in 456aa2db499409ab500d98c464b3321d4b7cecc3 in https://github.com/NixOS/nixpkgs/pull/119540 of the don't-depend-on-nix.conf functionality introduced in c6a3a0f4f59bc6b2cc24aa1f4d6572906c95e9b9 in https://github.com/NixOS/nixpkgs/pull/95194 .

@chvp @domenkozar @ju1m

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
