### PR TITLE
python3Packages.angrcli: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/angrcli/default.nix
+++ b/pkgs/development/python-modules/angrcli/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, angr
+, buildPythonPackage
+, cmd2
+, coreutils
+, fetchFromGitHub
+, pygments
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "angrcli";
+  version = "1.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "fmagin";
+    repo = "angr-cli";
+    rev = "v${version}";
+    sha256 = "0mz3yzsw08xwpj6188rxmr7darilh4ismcnh8nhp9945wjyzl4kr";
+  };
+
+  propagatedBuildInputs = [
+    angr
+    cmd2
+    pygments
+  ];
+
+  checkInputs = [
+    coreutils
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Version mismatch, https://github.com/fmagin/angr-cli/pull/11
+    substituteInPlace setup.py \
+      --replace "version='1.1.0'," "version='${version}',"
+    substituteInPlace tests/test_derefs.py \
+      --replace "/bin/ls" "${coreutils}/bin/ls"
+  '';
+
+  disabledTests = [
+    "test_sims"
+  ];
+
+  pythonImportsCheck = [
+    "angrcli"
+  ];
+
+  meta = with lib; {
+    description = "Python modules to allow easier interactive use of angr";
+    homepage = "https://github.com/fmagin/angr-cli";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -461,6 +461,10 @@ in {
 
   angr = callPackage ../development/python-modules/angr { };
 
+  angrcli = callPackage ../development/python-modules/angrcli {
+    inherit (pkgs) coreutils;
+  };
+
   angrop = callPackage ../development/python-modules/angrop { };
 
   aniso8601 = callPackage ../development/python-modules/aniso8601 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python modules to allow easier interactive use of angr

https://github.com/fmagin/angr-cli

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
