### PR TITLE
terraform-providers.ct: 0.6.1 -> 0.8.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -235,10 +235,11 @@
   },
   "ct": {
     "owner": "poseidon",
+    "provider-source-address": "registry.terraform.io/poseidon/ct",
     "repo": "terraform-provider-ct",
-    "rev": "v0.6.1",
-    "sha256": "0hh3hvi8lwb0h8x9viz5p991w94gn7354nw95b51rdmir9qi2x89",
-    "version": "0.6.1"
+    "rev": "v0.8.0",
+    "sha256": "1mm86q3rl81dm2yfg2hdf88x8g5mhwwixrxgrffpkjvjqy42a8h7",
+    "version": "0.8.0"
   },
   "datadog": {
     "owner": "terraform-providers",


### PR DESCRIPTION
Bumps the Terraform SDK from 1.8.0 to 2.3.0, ensuring compatibility with
future versions of terraform.

Adds Fedora CoreOS Config v1.3.0 support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
