### PR TITLE
terraform-ls: 0.16.2 -> 0.18.0

### DIFF
--- a/pkgs/development/tools/misc/terraform-ls/default.nix
+++ b/pkgs/development/tools/misc/terraform-ls/default.nix
@@ -2,25 +2,30 @@
 
 buildGoModule rec {
   pname = "terraform-ls";
-  version = "0.16.2";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-5+h1fyTCp1jUZeKRCeDhfqAA11SMyR5nw2Y2x6JyIwY=";
+    sha256 = "sha256-JctiWJ2HeFtrrOwCe1MCzxTkE2855FsgFocaAgK4fMk=";
   };
-  vendorSha256 = "sha256-m5ddUwuTX0mSihkoGIMQKidptwUL8Bao5HgHJBWX0os=";
+  vendorSha256 = "sha256-r4/WTzI1unvmjKOSJsaHVkws2/qWLuRrHLlzwckrm2Q=";
 
-  # tests fail in sandbox mode because of trying to download stuff from releases.hashicorp.com
-  doCheck = false;
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-s -w -X main.version=v${version} -X main.prerelease=")
+  '';
 
-  buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
+  preCheck = ''
+    # Remove test that requires networking
+    rm internal/terraform/exec/exec_test.go
+  '';
 
   meta = with lib; {
     description = "Terraform Language Server (official)";
     homepage = "https://github.com/hashicorp/terraform-ls";
+    changelog = "https://github.com/hashicorp/terraform-ls/blob/v${version}/CHANGELOG.md";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ mbaillie ];
+    maintainers = with maintainers; [ mbaillie jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump terraform-ls to `0.18.0`

Also:
Set buildFlagsArray in bash
Ensure pre-release is empty
Remove the check that requires networking so we can run tests
Add changelog

Also added myself as a maintainer if you dont mind @martinbaillie


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
