### PR TITLE
electron-mail: init at 4.12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11679,6 +11679,16 @@
     github = "pulsation";
     githubId = 1838397;
   };
+  princemachiavelli = {
+    name = "Josh Hoffer";
+    email = "jhoffer@sansorgan.es";
+    github = "princemachiavelli";
+    githubId = 2730968;
+    keys = [{
+      longkeyid = "ed25519/0x83124F97A318EA18";
+      fingerprint = "DD54 130B ABEC B65C 1F6B  2A38 8312 4F97 A318 EA18";
+    }];
+  };
   ydlr = {
     name = "ydlr";
     email = "ydlr@ydlr.io";

--- a/pkgs/applications/networking/mailreaders/electron-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/electron-mail/default.nix
@@ -1,0 +1,33 @@
+{ appimageTools, lib, fetchurl }:
+
+let
+  pname = "electron-mail";
+  version = "4.12.2";
+  name = "ElectronMail-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/vladimiry/ElectronMail/releases/download/v${version}/electron-mail-${version}-linux-x86_64.AppImage";
+    sha256 = "D+0qoIb0EwUVbgKOiKQpqoLDgm8l/UKDWm/BjhW4MYU=";
+  };
+
+  appimageContents = appimageTools.extract { inherit name src; };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "ElectronMail is an Electron-based unofficial desktop client for ProtonMail";
+    homepage = "https://github.com/vladimiry/ElectronMail";
+    license = licenses.mit;
+    maintainers = [ maintainers.princemachiavelli ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2550,6 +2550,8 @@ in
 
   electronplayer = callPackage ../applications/video/electronplayer/electronplayer.nix { };
 
+  electron-mail = callPackage ../applications/networking/mailreaders/electron-mail { };
+
   element-desktop = callPackage ../applications/networking/instant-messengers/element/element-desktop.nix { };
 
   element-web = callPackage ../applications/networking/instant-messengers/element/element-web.nix {


### PR DESCRIPTION
https://github.com/vladimiry/ElectronMail

Tested on x86_64 as that is the only supported architecture by the prebuilt upstream packages. Eventually the package could be updated to build the electron app. 

I tested it on sway desktop environment with 'waybar' as my desktop status bar. This is notable as it seems to be one of the few status bars that has issues displaying some tray icons which is an issue as this package defaults to closing & opening minimized. I think this is a very small edge case that user's can manually fix by editing ~/.config/electron-mail/config.json - I mostly just want to document this issue. 

A future update could expose some settings in config.js & hopefully allow setting the master key. It could change the default behavior to not minimize to avoid the issue mentioned above.

Since this is a new package it should be backported to stable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
