### PR TITLE
desktop-file-utils: hardcode path to update-desktop-database

### DIFF
--- a/pkgs/tools/misc/desktop-file-utils/default.nix
+++ b/pkgs/tools/misc/desktop-file-utils/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ glib libintl ];
 
+  postPatch = ''
+    substituteInPlace src/install.c \
+      --replace \"update-desktop-database\" \"$out/bin/update-desktop-database\"
+  '';
+
   setupHook = ./setup-hook.sh;
 
   meta = {


### PR DESCRIPTION
This is required for `desktop-file-install` to work correctly when used
directly from the Nix store (i.e. when not in `$PATH`).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

One of the changes I made in #115277 uses `desktop-file-install`
inline. Without this patch, VS Code is unable to install the
desktop file that provides handling for its `vsls://` scheme unless
`desktop-file-utils` is already in the user's `$PATH`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
