### PR TITLE
webrtc-audio-processing: Enable RISC-V

### DIFF
--- a/pkgs/development/libraries/webrtc-audio-processing/default.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1gsx7k77blfy171b6g3m0k0s0072v6jcawhmx1kjs9w5zlwdkzd0";
   };
 
+  patches = [ ./enable-riscv.patch ];
+
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ ApplicationServices ]);
 
   patchPhase = lib.optionalString stdenv.hostPlatform.isMusl ''

--- a/pkgs/development/libraries/webrtc-audio-processing/enable-riscv.patch
+++ b/pkgs/development/libraries/webrtc-audio-processing/enable-riscv.patch
@@ -1,0 +1,18 @@
+diff --git a/webrtc/typedefs.h b/webrtc/typedefs.h
+index d875490..ce1f3e8 100644
+--- a/webrtc/typedefs.h
++++ b/webrtc/typedefs.h
+@@ -26,6 +26,13 @@
+ #elif defined(__aarch64__)
+ #define WEBRTC_ARCH_64_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(__riscv) || defined(__riscv__)
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#if __riscv_xlen == 64
++#define WEBRTC_ARCH_64_BITS
++#else
++#define WEBRTC_ARCH_32_BITS
++#endif
+ #elif defined(_M_IX86) || defined(__i386__)
+ #define WEBRTC_ARCH_X86_FAMILY
+ #define WEBRTC_ARCH_X86


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds definitions necessary to build the package on RISC-V. A patch is also submitted upstream [here](https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/merge_requests/19).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
