### PR TITLE
tini: don't explicitly depend on glibc

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -11,7 +11,7 @@ rec {
       , tiniRev, tiniSha256, buildxSupport ? false
       # package dependencies
       , stdenv, fetchFromGitHub, buildGoPackage
-      , makeWrapper, installShellFiles, pkg-config
+      , makeWrapper, installShellFiles, pkg-config, glibc
       , go-md2man, go, containerd, runc, docker-proxy, tini, libtool
       , sqlite, iproute2, lvm2, systemd, docker-buildx
       , btrfs-progs, iptables, e2fsprogs, xz, util-linux, xfsprogs, git
@@ -56,7 +56,9 @@ rec {
       };
 
       # Do not remove static from make files as we want a static binary
-      patchPhase = "";
+      postPatch = "";
+
+      buildInputs = [ glibc glibc.static ];
 
       NIX_CFLAGS_COMPILE = "-DMINIMAL=ON";
     });

--- a/pkgs/applications/virtualization/tini/default.nix
+++ b/pkgs/applications/virtualization/tini/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, glibc }:
+{ lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   version = "0.19.0";
@@ -11,12 +11,11 @@ stdenv.mkDerivation rec {
     sha256 ="1hnnvjydg7gi5gx6nibjjdnfipblh84qcpajc08nvr44rkzswck4";
   };
 
-  patchPhase = "sed -i /tini-static/d CMakeLists.txt";
+  postPatch = "sed -i /tini-static/d CMakeLists.txt";
 
   NIX_CFLAGS_COMPILE = "-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ glibc glibc.static ];
 
   meta = with lib; {
     description = "A tiny but valid init for containers";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Fixes pkgsStatic.tini build.
* Use postPatch instead of patchPhase
* Moves glibc dependency into docker.docker-tini

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
