### PR TITLE
cups-kyocera-ecosys-m552x-p502x: init at 8.1602

### DIFF
--- a/pkgs/misc/cups/drivers/kyocera-ecosys-m552x-p502x/default.nix
+++ b/pkgs/misc/cups/drivers/kyocera-ecosys-m552x-p502x/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, lib
+, fetchzip
+  # can either be "EU" or "Global"; it's unclear what the difference is
+, region ? "Global"
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cups-kyocera-ecosys-m552x-p502x";
+  version = "8.1602";
+
+  src = fetchzip {
+    url = "https://www.kyoceradocumentsolutions.de/content/download-center/de/drivers/all/Linux_8_1602_ECOSYS_M5521_5526_P5021_5026_zip.download.zip";
+    sha256 = "sha256-XDH5deZmWNghfoO7JaYYvnVq++mbQ8RwLY57L2CKYaY=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/cups/model/Kyocera
+    cp ${region}/English/*.PPD $out/share/cups/model/Kyocera/
+  '';
+
+  meta = with lib; {
+    description = "PPD files for Kyocera ECOSYS M5521cdn/M5521cdw/M5526cdn/M5526cdw/P5021cdn/P5021cdw/P5026cdn/P5026cdw";
+    homepage = "https://www.kyoceradocumentsolutions.com";
+    license = licenses.unfree;
+    maintainers = [ maintainers.mbrgm ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30298,6 +30298,8 @@ in
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};
 
+  cups-kyocera-ecosys-m552x-p502x = callPackage ../misc/cups/drivers/kyocera-ecosys-m552x-p502x {};
+
   cups-kyodialog3 = callPackage ../misc/cups/drivers/kyodialog3 {};
 
   cups-dymo = callPackage ../misc/cups/drivers/dymo {};


### PR DESCRIPTION
###### Motivation for this change

Add PPD files for listed printers.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
