### PR TITLE
[Backport release-21.05] x2goclient: unstable-2019-07-24 -> 4.1.2.2, fix #78907

### DIFF
--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -1,20 +1,20 @@
-{ lib, fetchgit, cups, libssh, libXpm, nx-libs, openldap, openssh
+{ lib, fetchurl, cups, libssh, libXpm, nx-libs, openldap, openssh
 , mkDerivation, qtbase, qtsvg, qtx11extras, qttools, phonon, pkg-config }:
 
-mkDerivation {
+mkDerivation rec {
   pname = "x2goclient";
-  version = "unstable-2019-07-24";
+  version = "4.1.2.2";
 
-  src = fetchgit {
-   url = "git://code.x2go.org/x2goclient.git";
-   rev = "704c4ab92d20070dd160824c9b66a6d1c56dcc49";
-   sha256 = "1pndp3lfzwifyxqq0gps3p1bwakw06clbk6n8viv020l4bsfmq5f";
+  src = fetchurl {
+    url = "https://code.x2go.org/releases/source/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "yZUyZ8QPpnEZrZanO6yx8mYZbaIFnwzc0bjVGZQh0So=";
   };
 
   buildInputs = [ cups libssh libXpm nx-libs openldap openssh
                   qtbase qtsvg qtx11extras qttools phonon pkg-config ];
 
   postPatch = ''
+     substituteInPlace src/onmainwindow.cpp --replace "/usr/sbin/sshd" "${openssh}/bin/sshd"
      substituteInPlace Makefile \
        --replace "SHELL=/bin/bash" "SHELL=$SHELL" \
        --replace "lrelease-qt4" "${qttools.dev}/bin/lrelease" \
@@ -33,6 +33,7 @@ mkDerivation {
   meta = with lib; {
     description = "Graphical NoMachine NX3 remote desktop client";
     homepage = "http://x2go.org/";
+    maintainers = with maintainers; [ mkg20001 ];
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
Co-authored-by: Sandro <sandro.jaeckel@gmail.com>
(cherry picked from commit c4100d81bdbfb28f63f326204a4ee19133233a7b)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix x2goclient in release, ref #78907

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
