### PR TITLE
Add parsec gaming (desktop streaming)

### DIFF
--- a/pkgs/applications/misc/parsec-gaming/default.nix
+++ b/pkgs/applications/misc/parsec-gaming/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchurl, dpkg }:
+
+with lib;
+
+stdenv.mkDerivation {
+  name = "parsec-gaming";
+  src = fetchurl {
+    url = "https://builds.parsecgaming.com/package/parsec-linux.deb";
+    sha256 = "1hfdzjd8qiksv336m4s4ban004vhv00cv2j461gc6zrp37s0fwhc";
+  };
+  phases = [ "buildPhase" ];
+  buildInputs = [ dpkg ];
+  buildPhase = ''
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # Fix desktop file
+    sed -i "s|/usr|$out|g" $out/usr/share/applications/parsecd.desktop
+
+    # dpkg-deb makes $out group-writable, which nix doesn't like
+    chmod 755 $out
+    mv $out/usr/* $out
+    rmdir $out/usr
+  '';
+  meta = {
+    description = "Remote desktop for work and gaming";
+    homepage = "https://parsec.app/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.linux;
+  };
+};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

# About

**Not currently working**. Could use some help here!

I found some dependent libraries from unpacking the deb file (control file)

```
Source: no
Package: parsec
Maintainer: Parsec <founders@parsec.tv>
Section: misc
Priority: optional
Standards-Version: 3.9.8
Architecture: amd64
Description: Simple, low-latency game streaming.
Homepage: http://parsecgaming.com/
Depends: libc6 (>= 2.17),
  libgcc1 (>= 1:3.0),
  libgl1-mesa-glx | libgl1,
  libsm6,
  libstdc++6 (>= 5.2),
  libx11-6,
  libxxf86vm1
Version: 150-28
```

Parsec also [document the libraries required](https://support.parsec.app/hc/en-us/articles/115003477771-Using-Parsec-With-other-Linux-Distros) for use on other distributions.

I've tried using `patchelf` to get this to work. Doing so fixed any "file not found" errors but I'm immediately getting an exit code `2` when running


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
