### PR TITLE
urxvt-font-size: 2015-05-22 -> 1.3

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-font-size/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-font-size/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, xrdb, xlsfonts }:
 
-stdenv.mkDerivation {
-  name = "urxvt-font-size-2015-05-22";
-  dontPatchShebangs = true;
+stdenv.mkDerivation rec {
+  name = "urxvt-font-size";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "majutsushi";
     repo = "urxvt-font-size";
-    rev = "fd5b09c10798c6723bbf771d4d8881cf6563bc69";
-    sha256 = "16m3kkypg3y00x597zx05zy167a0kaqpawz0l591wzb2bv1dz55z";
+    rev = "v${version}";
+    sha256 = "1526ap161cp3378f4ijd09nmsh71ld7bkxxhp8p6razdi2v8r16h";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The new version has better default config

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
