### PR TITLE
efont-unicode: init at 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7207,6 +7207,16 @@
     githubId = 1386642;
     name = "Noah Brenowitz";
   };
+  ncfavier = {
+    email = "n@monade.li";
+    github = "ncfavier";
+    githubId = 4323933;
+    name = "Naïm Favier";
+    keys = [{
+      longkeyid = "rsa2048/0x49B07322580B7EE2";
+      fingerprint = "51A0 705E 7DD2 3CBC 5EAA  B43E 49B0 7322 580B 7EE2";
+    }];
+  };
   nckx = {
     email = "github@tobias.gr";
     github = "nckx";

--- a/pkgs/data/fonts/efont-unicode/default.nix
+++ b/pkgs/data/fonts/efont-unicode/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchzip, libfaketime, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "efont-unicode";
+  version = "0.4.2";
+
+  src = fetchzip {
+    url = "http://openlab.ring.gr.jp/efont/dist/unicode-bdf/${pname}-bdf-${version}.tar.bz2";
+    sha256 = "0bib3jgikq8s1m96imw4mlgbl5cbq1bs5sqig74s2l2cdfx3jaqc";
+  };
+
+  nativeBuildInputs = with xorg;
+    [ libfaketime bdftopcf fonttosfnt mkfontscale ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # convert bdf fonts to pcf
+    for f in *.bdf; do
+        bdftopcf -t -o "''${f%.bdf}.pcf" "$f"
+    done
+    gzip -n -9 *.pcf
+
+    # convert bdf fonts to otb
+    for f in *.bdf; do
+        faketime -f "1970-01-01 00:00:01" \
+        fonttosfnt -v -m 2 -o "''${f%.bdf}.otb" "$f"
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dir=share/fonts/misc
+    install -D -m 644 -t "$out/$dir" *.otb *.pcf.gz
+    install -D -m 644 -t "$bdf/$dir" *.bdf
+    mkfontdir "$out/$dir"
+    mkfontdir "$bdf/$dir"
+
+    runHook postInstall
+  '';
+
+  outputs = [ "out" "bdf" ];
+
+  meta = with lib; {
+    description = "The /efont/ Unicode bitmap font";
+    homepage = "http://openlab.ring.gr.jp/efont/unicode/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.ncfavier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21845,6 +21845,8 @@ in
 
   edusong = callPackage ../data/fonts/edusong { };
 
+  efont-unicode = callPackage ../data/fonts/efont-unicode { };
+
   elliptic_curves = callPackage ../data/misc/elliptic_curves { };
 
   equilux-theme = callPackage ../data/themes/equilux-theme { };


### PR DESCRIPTION
###### Motivation for this change

Adds the [/efont/ Unicode](http://openlab.ring.gr.jp/efont/unicode/) bitmap font, with `.pcf.gz` and `.otb` files in the `out` output and `.bdf` files in the `bdf` output.

Other bitmap font packages I looked at (`siji`, `tewi-font`, `dina-font`) seem to be called with
```nix
{ inherit (buildPackages.xorg) mkfontscale fonttosfnt; }
```
in `all-packages.nix`, what is that for? Should I do that as well? Why isn't `bdftopcf` included there?

cc @rnhmjoj 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

