### PR TITLE
mathpix-snipping-tool: init at 03.00.0025

### DIFF
--- a/pkgs/tools/misc/mathpix-snipping-tool/default.nix
+++ b/pkgs/tools/misc/mathpix-snipping-tool/default.nix
@@ -1,0 +1,31 @@
+{ appimageTools, lib, fetchurl }:
+let
+  pname = "mathpix-snipping-tool";
+  version = "03.00.0025";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://download.mathpix.com/linux/Mathpix_Snipping_Tool-x86_64.v${version}.AppImage";
+    sha256 = "0p39rsmjfz3m5s3k9pmmkqbp8f21s1cwjgspz8m47dq5jjls8ay8";
+  };
+
+  appimageContents = appimageTools.extract { inherit name src; };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "OCR tool to convert pictures to LaTeX.";
+    homepage = "https://mathpix.com/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.hiro98 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6311,6 +6311,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  mathpix-snipping-tool = callPackage ../tools/misc/mathpix-snipping-tool { };
+
   /* Python 3.8 is currently broken with matrix-synapse since `python38Packages.bleach` fails
     (https://github.com/NixOS/nixpkgs/issues/76093) */
   matrix-synapse = callPackage ../servers/matrix-synapse { /*python3 = python38;*/ };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I use the mathpix-snipping-tool quite heavily and thought others might appreciate its availability on nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
