### PR TITLE
bosh-cli: init at 6.4.3

### DIFF
--- a/pkgs/applications/networking/cluster/bosh-cli/default.nix
+++ b/pkgs/applications/networking/cluster/bosh-cli/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, makeWrapper
+, openssh
+}:
+
+buildGoModule rec {
+  pname = "bosh-cli";
+
+  version = "6.4.3";
+
+  src = fetchFromGitHub {
+    owner = "cloudfoundry";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1glxwk0fv52rjim7ihcxkjx19fsn9k7gzg9zmwxgx8wpsjrdcq3f";
+  };
+  vendorSha256 = null;
+
+  postPatch = ''
+    substituteInPlace cmd/version.go --replace '[DEV BUILD]' '${version}'
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  subPackages = [ "." ];
+
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/bosh-cli $out/bin/bosh
+    wrapProgram $out/bin/bosh --prefix PATH : '${lib.makeBinPath [ openssh ]}'
+  '';
+
+  meta = with lib; {
+    description = "A command line interface to CloudFoundry BOSH";
+    homepage = "https://bosh.io";
+    changelog = "https://github.com/cloudfoundry/bosh-cli/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14446,6 +14446,8 @@ in
 
   boost_process = callPackage ../development/libraries/boost-process { };
 
+  bosh-cli = callPackage ../applications/networking/cluster/bosh-cli { };
+
   botan = callPackage ../development/libraries/botan {
     openssl = openssl_1_0_2;
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;


### PR DESCRIPTION
###### Motivation for this change
Some people find themselves managing cloudfoundry clusters. https://bosh.io/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
