### PR TITLE
nixos/manual: update documentation on Qt themes

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -191,9 +191,12 @@
   <para>
    GTK themes can be installed either to user profile or system-wide (via
    <literal>environment.systemPackages</literal>). To make Qt 5 applications
-   look similar to GTK2 ones, you can install <literal>qt5.qtbase.gtk</literal>
-   package into your system environment. It should work for all Qt 5 library
-   versions.
+   look similar to GTK ones, you can use the following configuration:
+<programlisting>
+<xref linkend="opt-qt5.enable"/> = true;
+<xref linkend="opt-qt5.platformTheme"/> = "gtk2";
+<xref linkend="opt-qt5.style"/> = "gtk2";
+</programlisting>
   </para>
  </simplesect>
  <simplesect xml:id="custom-xkb-layouts">


### PR DESCRIPTION
###### Motivation for this change

The `qt5.qtbase.gtk` output was removed [a long time ago](https://github.com/qt/qtbase/commit/899a815414e95da8d9429a4a4f4d7094e49cfc55). Hint at the `qt5` options instead.

cc @worldofpeace 