### PR TITLE
reuse: 0.12.1 -> 0.13.0

### DIFF
--- a/pkgs/tools/package-management/reuse/default.nix
+++ b/pkgs/tools/package-management/reuse/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "reuse";
-  version = "0.12.1";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "fsfe";
     repo = "reuse-tool";
     rev = "v${version}";
-    sha256 = "0ql0krnz0fmq405r2qrm9ysm3cvmqfw14j06pny6na7qshibj78z";
+    sha256 = "0didqsbvrn06aylp71jl3hqb4rd95d8s613xz6jw6mngyjqv0hq2";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change

First new release in half a year. Fixes a bug I've run into.

> ### Added
> 
> - `addheader` recognises file types that specifically require .license files
>   instead of headers using `UncommentableCommentStyle`. (#189)
> 
> - `.hgtags` is ignored. (#227)
> 
> - `spdx-symbol` added to possible copyright styles. (#350)
> 
> - `addheader` ignores case when matching file extensions and names. (#359)
> 
> - Provide `latest-debian` as Docker Hub tag, created by `Dockerfile-debian`. (#321)
> 
> - More file types are recognised:
> 
>   - Javascript modules (`.mjs`)
>   - Jupyter Notebook (`.ipynb`)
>   - Scalable Vector Graphics (`.svg`)
>   - JSON (`.json`)
>   - Comma-separated values (`.csv`)
>   - Racket (`.rkt`)
>   - Org-mode (`.org`)
>   - LaTeX package files (`.sty`)
>   - devicetree (`.dts`, `.dtsi`)
>   - Bitbake (.bb, .bbappend, .bbclass)
>   - XML schemas (`.xsd`)
>   - OpenSCAD (`.scad`)
> 
> - More file names are recognised:
>   - Bash configuration (`.bashrc`)
>   - Coverage.py (`.coveragerc`)
>   - Jenkins (`Jenkinsfile`)
>   - SonarScanner (`sonar-project.properties`)
>   - Gradle (`gradle-wrapper.properties`, `gradlew`)
> 
> ### Changed
> 
> - Bump `alpine` Docker base image to 3.13. (#369)
> 
> ### Fixed
> 
> - Fixed a regression where unused licenses were not at all detected. (#285)
> 
> - Declared dependency on `python-debian != 0.1.39` on Windows. This version does
>   not import on Windows. (#310)
> 
> - `MANIFEST.in` is now recognised instead of the incorrect `Manifest.in` by
>   `addheader`. (#306)
> 
> - `addheader` now checks whether a file is both readable and writeable instead
>   of only writeable. (#241)
> 
> - `addheader` now preserves line endings. (#308)
> 
> - `download` does no longer fail when both `--output` and `--all` are used. (#326)
> 
> - Catch erroneous SPDX expressions. (#331)
> 
> - Updated SPDX license list to 3.13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
