### PR TITLE
kernel: enable PHY_ROCKCHIP_PCIE and PCIE_ROCKCHIP_HOST

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -877,6 +877,9 @@ let
       # Keeping it a built-in ensures it will be used if possible.
       FB_SIMPLE = yes;
 
+      # Rockchip PCIe endpoint controller support
+      PHY_ROCKCHIP_PCIE = yes;
+      PCIE_ROCKCHIP_HOST = yes;
     } // optionalAttrs (stdenv.hostPlatform.system == "armv7l-linux") {
       ARM_LPAE = yes;
     };


### PR DESCRIPTION
###### Motivation for this change
Fixes failure to detect NVMe SSD in Rockchip devices like [NanoPC-T4](https://wiki.friendlyarm.com/wiki/index.php/NanoPC-T4).

More details can be seen in:
https://github.com/NixOS/nixos-hardware/pull/259
https://github.com/NixOS/nixpkgs/pull/111034

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
