### PR TITLE
opencv: update cuda_opt_flow.patch

### DIFF
--- a/pkgs/development/libraries/nvidia-optical-flow-sdk/default.nix
+++ b/pkgs/development/libraries/nvidia-optical-flow-sdk/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "nvidia-optical-flow-sdk";
-  version = "1.0";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "NVIDIAOpticalFlowSDK";
-    rev = "79c6cee80a2df9a196f20afd6b598a9810964c32";
-    sha256 = "1y6igwv75v1ynqm7j6la3ky0f15mgnj1jyyak82yvhcsx1aax0a1";
+    rev = "edb50da3cf849840d680249aa6dbef248ebce2ca";
+    sha256 = "0hv0m0k9wl2wjhhl886j7ymngnf2xz7851nfh57s1gy5bv9lgdgz";
   };
 
   # # We only need the header files. The library files are
@@ -25,4 +25,3 @@ stdenv.mkDerivation {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -301,7 +301,7 @@ stdenv.mkDerivation {
     "-DCUDA_FAST_MATH=ON"
     "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
     "-DCUDA_NVCC_FLAGS=--expt-relaxed-constexpr"
-    "-DNVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH=${nvidia-optical-flow-sdk}"
+    "-DNVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH=${nvidia-optical-flow-sdk}"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DWITH_OPENCL=OFF"
     "-DWITH_LAPACK=OFF"

--- a/pkgs/development/libraries/opencv/cuda_opt_flow.patch
+++ b/pkgs/development/libraries/opencv/cuda_opt_flow.patch
@@ -1,26 +1,27 @@
-diff --git a/opencv_contrib/cudaoptflow/CMakeLists.txt b/opencv_contrib/cudaoptflow/CMakeLists.txt
-index e5b823ab4a..a728060d0b 100644
---- a/opencv_contrib/cudaoptflow/CMakeLists.txt
-+++ b/opencv_contrib/cudaoptflow/CMakeLists.txt
-@@ -11,18 +11,6 @@ ocv_define_module(cudaoptflow opencv_video opencv_optflow opencv_cudaarithm open
- set(NVIDIA_OPTICAL_FLOW_1_0_HEADERS_COMMIT "79c6cee80a2df9a196f20afd6b598a9810964c32")
- set(NVIDIA_OPTICAL_FLOW_1_0_HEADERS_MD5 "ca5acedee6cb45d0ec610a6732de5c15")
- set(NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH "${OpenCV_BINARY_DIR}/3rdparty/NVIDIAOpticalFlowSDK_1_0_Headers")
--ocv_download(FILENAME "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_COMMIT}.zip"
--               HASH ${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_MD5}
--               URL
--                 "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/"
--               DESTINATION_DIR "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH}"
--               STATUS NVIDIA_OPTICAL_FLOW_1_0_HEADERS_DOWNLOAD_SUCCESS
--               ID "NVIDIA_OPTICAL_FLOW"
--               UNPACK RELATIVE_URL)
- 
--if(NOT NVIDIA_OPTICAL_FLOW_1_0_HEADERS_DOWNLOAD_SUCCESS)
--  message(STATUS "Failed to download NVIDIA_Optical_Flow_1_0 Headers")
--else()
--  add_definitions(-DHAVE_NVIDIA_OPTFLOW=1)
--  ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH}/NVIDIAOpticalFlowSDK-${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_COMMIT}")
+diff --unified --recursive --text a/opencv_contrib/cudaoptflow/CMakeLists.txt b/opencv_contrib/cudaoptflow/CMakeLists.txt
+--- a/opencv_contrib/cudaoptflow/CMakeLists.txt	2021-06-12 01:35:47.536395972 +0300
++++ b/opencv_contrib/cudaoptflow/CMakeLists.txt	2021-06-12 01:36:02.029498597 +0300
+@@ -12,19 +12,6 @@
+   set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT "edb50da3cf849840d680249aa6dbef248ebce2ca")
+   set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5 "a73cd48b18dcc0cc8933b30796074191")
+   set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH "${OpenCV_BINARY_DIR}/3rdparty/NVIDIAOpticalFlowSDK_2_0_Headers")
+-  ocv_download(FILENAME "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}.zip"
+-                 HASH ${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5}
+-                 URL "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/"
+-                 DESTINATION_DIR "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}"
+-                 STATUS NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS
+-                 ID "NVIDIA_OPTICAL_FLOW"
+-                 UNPACK RELATIVE_URL)
+-
+-  if(NOT NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS)
+-    message(STATUS "Failed to download NVIDIA_Optical_Flow_2_0 Headers")
+-  else()
+-    message(STATUS "Building with NVIDIA Optical Flow API 2.0")
+-    add_definitions(-DHAVE_NVIDIA_OPTFLOW=2)
+-    ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}/NVIDIAOpticalFlowSDK-${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}")
+-  endif()
 -endif()
 \ No newline at end of file
-+add_definitions(-DHAVE_NVIDIA_OPTFLOW=1)
-+ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_1_0_HEADERS_PATH}")
++  add_definitions(-DHAVE_NVIDIA_OPTFLOW=2)
++  ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}")
++endif()


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #126623

###### Things done
updated the patch

i was able to compile it but i do not have nvidia so i cannot test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
