### PR TITLE
python3Packages.typed-ast: 1.4.1 -> 1.4.3

### DIFF
--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,20 +1,40 @@
-{ buildPythonPackage, fetchFromGitHub, lib, pythonOlder }:
+{ buildPythonPackage, fetchFromGitHub, lib, pythonOlder, pytest }:
 buildPythonPackage rec {
   pname = "typed-ast";
-  version = "1.4.1";
-  src = fetchFromGitHub{
+  version = "1.4.3";
+  src = fetchFromGitHub {
     owner = "python";
     repo = "typed_ast";
     rev = version;
-    sha256 = "086r9qhls6mz1w72a6d1ld3m4fbkxklf6mgwbs8wpw0zlxjm7y40";
+    sha256 = "16mn9snwik5n2ib65sw2xcaqdm02j8ps21zgjxf8kyy7qnx2mx4w";
   };
   # Only works with Python 3.3 and newer;
   disabled = pythonOlder "3.3";
-  # No tests in archive
-  doCheck = false;
+
+  pythonImportsCheck = [
+    "typed_ast"
+    "typed_ast.ast27"
+    "typed_ast.ast3"
+    "typed_ast.conversions"
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+  checkPhase = ''
+    runHook preCheck
+
+    # We can't use pytestCheckHook because that invokes pytest with python -m pytest
+    # which adds the current directory to sys.path at the beginning.
+    # _That_ version of the typed_ast module doesn't have the C extensions we need.
+    pytest
+
+    runHook postCheck
+  '';
+
   meta = {
-    homepage = "https://pypi.python.org/pypi/typed-ast";
-    description = "a fork of Python 2 and 3 ast modules with type comment support";
+    homepage = "https://github.com/python/typed_ast";
+    description = "Python 2 and 3 ast modules with type comment support";
     license = lib.licenses.asl20;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/python/typed_ast


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
