### PR TITLE
{box2d,liblangtag}: enable on darwin

### DIFF
--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "2D physics engine";
     homepage = "https://box2d.org/";
     maintainers = [ maintainers.raskin ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.zlib;
   };
 }

--- a/pkgs/development/libraries/liblangtag/default.nix
+++ b/pkgs/development/libraries/liblangtag/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchFromBitbucket, autoreconfHook, gtk-doc, gettext
+{ lib, stdenv, fetchurl, autoreconfHook, gtk-doc, gettext
 , pkg-config, glib, libxml2, gobject-introspection, gnome-common, unzip
 }:
 
@@ -6,11 +6,10 @@ stdenv.mkDerivation rec {
   pname = "liblangtag";
   version = "0.6.3";
 
-  src = fetchFromBitbucket {
-    owner = "tagoh";
-    repo = pname;
-    rev = version;
-    sha256 = "10rycs8xrxzf9frzalv3qx8cs1jcildhrr4imzxdmr9f4l585z96";
+  # Artifact tarball contains lt-localealias.h needed for darwin
+  src = fetchurl {
+    url = "https://bitbucket.org/tagoh/liblangtag/downloads/${pname}-${version}.tar.bz2";
+    sha256 = "sha256-HxKiCgLsOo0i5U3tuLaDpDycFgvaG6M3vxBgYHrnM70=";
   };
 
   core_zip = fetchurl {
@@ -31,19 +30,19 @@ stdenv.mkDerivation rec {
     cp "${language_subtag_registry}" data/language-subtag-registry
   '';
 
-  configureFlags = [
-    "--with-locale-alias=${stdenv.cc.libc}/share/locale/locale.alias"
-  ];
+  configureFlags =
+    lib.optional
+      (stdenv.hostPlatform.libc == "glibc")
+      "--with-locale-alias=${stdenv.cc.libc}/share/locale/locale.alias";
 
   buildInputs = [ gettext glib libxml2 gobject-introspection gnome-common ];
   nativeBuildInputs = [ autoreconfHook gtk-doc gettext pkg-config unzip ];
 
-  meta = {
-    inherit version;
+  meta = with lib; {
     description = "An interface library to access tags for identifying languages";
-    license = lib.licenses.mpl20;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.unix;
     # There are links to a homepage that are broken by a BitBucket change
     homepage = "https://bitbucket.org/tagoh/liblangtag/overview";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These are dependencies of libreoffice (haven't figured how to fix that one yet).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
