### PR TITLE
unvanquished: workaround NVidia proprietary driver bug

### DIFF
--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchzip, fetchurl, fetchFromGitHub, buildFHSUserEnv
-, runCommandNoCC, makeDesktopItem, copyDesktopItems, gcc, cmake, gmp
-, libGL, zlib, ncurses, geoip, lua5, nettle, curl, SDL2, freetype, glew
-, openal, libopus, opusfile, libogg, libvorbis, libjpeg, libwebp, libpng
+{ lib, stdenv, fetchzip, fetchFromGitHub, buildFHSUserEnv, makeDesktopItem
+, copyDesktopItems, gcc, cmake, gmp , libGL, zlib, ncurses, geoip, lua5
+, nettle, curl, SDL2, freetype, glew , openal, libopus, opusfile, libogg
+, libvorbis, libjpeg, libwebp, libpng
 , cacert, aria2 # to download assets
 }:
 
@@ -127,6 +127,7 @@ in stdenv.mkDerivation rec {
     "-DBUILD_SGAME=NO"
     "-DUSE_HARDENING=TRUE"
     "-DUSE_LTO=TRUE"
+    "-DOpenGL_GL_PREFERENCE=LEGACY" # https://github.com/DaemonEngine/Daemon/issues/474
   ];
 
   desktopItems = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Game doesn't start with NVidia proprietary drivers otherwise


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes): none fit
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
