### PR TITLE
plex-media-player: 2.58.0.1076 -> 2.58.1

### DIFF
--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.58.0.1076";
-  vsnHash = "38e019da";
+  version = "2.58.1";
+  vsnHash = "ae73e074";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "XFwcSHn9wG30bDMGFITBmhp6/VI1RLmxMxFFxjntTmw=";
+    sha256 = "1q20fdp5d0blb0q6p2357bwdc2g65cadkgdp4w533ij2nyaxydjd";
   };
 
   nativeBuildInputs = [ pkg-config cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -7,22 +7,22 @@ rec {
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "AzHlO7Z8SxQoT6++OphwDDQ47Ombnpaby0mh1YNnSvc=";
+    sha256 = "1xsacy1xb8a9rfdrd7lvx7n3hd0cf2c3mgmg9wl18jvwnqxyac83";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "7vUcTuN5ypFFIrBygyutEZu4MYl5WPmFureQl6HvVx8=";
+    sha256 = "07spxyhrg45ppa2zjn3ri4qvi6qimlmq6wmh492r3jkrwd71rxgf";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "xWwXhN2N4Pvalxtm5PwZprkcFU6RIiE6fA71d2E6lP4=";
+    sha256 = "1zll79hpgx8fghx228li9qairfd637yf8rhvjzdgpq4dvn21fv65";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "U8u5SOxPpz8HOJKrYXlIHx0X08Flspl67hlzc57g7v8=";
+    sha256 = "1zzfw2g76wqrxrx9kck5q79if78z91wn3awj703kz9sgxi4bkjsk";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "4Et9d4BO+4UParvsSJglJvb+cnp0oUP3O4MDNnLeP7g=";
+    sha256 = "1f1zvrr3c0w37gvl78blg9rgxxi64nc4iv5vd87qbysfh1vpsjz0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updating plex-media-player mostly for this fix — https://github.com/plexinc/plex-media-player/commit/5d099a167ba44942a5da841a113f23b076b622a2. The package does compile without it, but doesn't run (can't get OpenGL context IIRC, it's been a while since I started running overlay with this fix so might be misremembering the exact issue).

This is my first time doing a PR to nixpkgs, so let me know if I missed something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
