### PR TITLE
skytemple: add webkitgtk to buildInputs

### DIFF
--- a/pkgs/applications/misc/skytemple/default.nix
+++ b/pkgs/applications/misc/skytemple/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, gobject-introspection, gtk3, gtksourceview3, wrapGAppsHook, python3Packages }:
+{ lib, fetchFromGitHub, gobject-introspection, gtk3, gtksourceview3, webkitgtk, wrapGAppsHook, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
   pname = "skytemple";
@@ -11,7 +11,15 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0l2c4qngv58j6zkp0va6m96zksx8gqn3mjc3isqybfnhjr6nd3v9";
   };
 
-  buildInputs = [ gobject-introspection gtk3 gtksourceview3 ];
+  buildInputs = [
+    gobject-introspection
+    gtk3
+    gtksourceview3
+    # webkitgkt is used for rendering interactive statistics graph which
+    # can be seen by opening a ROM, entering Pokemon section, selecting
+    # any Pokemon, and clicking Stats and Moves tab.
+    webkitgtk
+  ];
   nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
   propagatedBuildInputs = with python3Packages; [
     natsort


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

WebKit is used for rendering interactive statistics graph, see https://github.com/SkyTemple/skytemple/blob/6413bd9028b658afe20d31a248cf9ea4cb8562e3/skytemple/module/monster/controller/level_up.py#L455. This feature is rather minor, and optional, but may as well put into dependencies if that dependency is actually used. This increases closure size quite a bit (140MB or so), however the impact is pretty much none when using GNOME as `webkitgtk` is used by GNOME, and the package is admittedly quite niche, so 99.99% of NixOS/Nixpkgs users wouldn't be affected.

I tested that this change actually works and enables interactivity in the graph.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
