### PR TITLE
system76-power: init at 1.1.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5140,6 +5140,12 @@
     email = "jwilberding@afiniate.com";
     name = "Jordan Wilberding";
   };
+  jwoudenberg = {
+    email = "nixpkgs@jasperwoudenberg.com";
+    github = "jwoudenberg";
+    githubId = 1525551;
+    name = "Jasper Woudenberg";
+  };
   jwygoda = {
     email = "jaroslaw@wygoda.me";
     github = "jwygoda";

--- a/nixos/modules/hardware/system-76.nix
+++ b/nixos/modules/hardware/system-76.nix
@@ -34,6 +34,25 @@ let
       wantedBy = [ "multi-user.target" ];
     };
   };
+
+  power-pkg = pkgs.system76-power;
+  powerConfig = mkIf cfg.power-daemon.enable {
+    # Make system76-power usable by root from the command line.
+    environment.systemPackages = [ power-pkg ];
+
+    services.dbus.packages = [ power-pkg ];
+
+    systemd.services.system76-power = {
+      description = "System76 Power Daemon";
+      serviceConfig = {
+        ExecStart = "${power-pkg}/bin/system76-power daemon";
+        Restart = "on-failure";
+        Type = "dbus";
+        BusName = "com.system76.PowerDaemon";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
 in {
   options = {
     hardware.system76 = {
@@ -52,8 +71,15 @@ in {
         description = "Whether to make the system76 out-of-tree kernel modules available";
         type = types.bool;
       };
+
+      power-daemon.enable = mkOption {
+        default = cfg.enableAll;
+        example = true;
+        description = "Whether to enable the system76 power daemon";
+        type = types.bool;
+      };
     };
   };
 
-  config = mkMerge [ moduleConfig firmwareConfig ];
+  config = mkMerge [ moduleConfig firmwareConfig powerConfig ];
 }

--- a/pkgs/os-specific/linux/system76-power/default.nix
+++ b/pkgs/os-specific/linux/system76-power/default.nix
@@ -1,0 +1,30 @@
+{ pkg-config, libusb1, dbus, lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "system76-power";
+  version = "1.1.16";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "system76-power";
+    rev = version;
+    sha256 = "sha256-OtrhvUkNNgg6KlrqjwiBKL4zuQZBWevb0xgtSlEW2rQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dbus libusb1 ];
+
+  cargoSha256 = "sha256-ImACDbnUbwc0ZXgF3xxzes8+vUjt76B1xxgqzhgAYX4=";
+
+  postInstall = ''
+    install -D -m 0644 data/system76-power.conf $out/etc/dbus-1/system.d/system76-power.conf
+  '';
+
+  meta = with lib; {
+    description = "System76 Power Management";
+    homepage = "https://github.com/pop-os/system76-power";
+    license = licenses.gpl3Plus;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ maintainers.jwoudenberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20829,6 +20829,8 @@ in
 
     system76-acpi = callPackage ../os-specific/linux/system76-acpi { };
 
+    system76-power = callPackage ../os-specific/linux/system76-power { };
+
     system76-io = callPackage ../os-specific/linux/system76-io { };
 
     tmon = callPackage ../os-specific/linux/tmon { };


### PR DESCRIPTION
###### Motivation for this change

NixOS already comes bundled with support for system76 firmware. It was great to see this when I bought a new system76 machine, and it worked out of the box.

I did notice when booting into NixOS for the first time that the fans were significantly louder than they were in the preinstalled PopOS installation. After some investigation I found this was because I wasn't running the system76-power daemon. This PR adds support for that daemon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
