### PR TITLE
nixos/console: allow console.font to be a path

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -43,13 +43,14 @@ in
 
   options.console  = {
     font = mkOption {
-      type = types.str;
+      type = with types; either str path;
       default = "Lat2-Terminus16";
       example = "LatArCyrHeb-16";
       description = ''
         The font used for the virtual consoles.  Leave empty to use
         whatever the <command>setfont</command> program considers the
         default font.
+        Can be either a font name or a path to a PSF font file.
       '';
     };
 


### PR DESCRIPTION
As for `console.keyMap`, all uses of this option are compatible with paths. This allows doing things like `console.font = pkgs.runCommand ...`.

cc @rnhmjoj 
