### PR TITLE
harfbuzz: Remove redundant cairo dependency

### DIFF
--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -54,17 +54,17 @@ stdenv.mkDerivation {
   outputBin = "dev";
 
   mesonFlags = [
-    (mesonFeatureFlag "graphite" withGraphite2)
-    (mesonFeatureFlag "icu" withIcu)
-    (mesonFeatureFlag "coretext" withCoreText)
     # upstream recommends cairo, but it is only used for development purposes
     # and is not part of the library.
     # Cairo causes transitive (build) dependencies on various X11 or other
     # GUI-related libraries, so it shouldn't be re-added lightly.
     (mesonFeatureFlag "cairo" false)
-    (mesonFeatureFlag "introspection" isNativeCompilation)
     # chafa is only used in a development utility, not in the library
     (mesonFeatureFlag "chafa" false)
+    (mesonFeatureFlag "coretext" withCoreText)
+    (mesonFeatureFlag "graphite" withGraphite2)
+    (mesonFeatureFlag "icu" withIcu)
+    (mesonFeatureFlag "introspection" isNativeCompilation)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -24,7 +24,7 @@
 }:
 
 let
-  version = "2.8.0";
+  version = "2.8.1";
   inherit (lib) optional optionals optionalString;
   mesonFeatureFlag = opt: b:
     "-D${opt}=${if b then "enabled" else "disabled"}";
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
     owner = "harfbuzz";
     repo = "harfbuzz";
     rev = version;
-    sha256 = "sha256-JnvOFGK2HWIpzuwgZtyt0IfKfnoXD1LMeVb3RzMmyY4=";
+    sha256 = "107l9jhvwy6pnq5032kr7r21md65qg09j7iikr4jihf9pvh7gn5w";
   };
 
   postPatch = ''
@@ -63,6 +63,8 @@ stdenv.mkDerivation {
     # GUI-related libraries, so it shouldn't be re-added lightly.
     (mesonFeatureFlag "cairo" false)
     (mesonFeatureFlag "introspection" isNativeCompilation)
+    # chafa is only used in a development utility, not in the library
+    (mesonFeatureFlag "chafa" false)
   ];
 
   nativeBuildInputs = [
@@ -77,7 +79,7 @@ stdenv.mkDerivation {
     docbook_xml_dtd_43
   ];
 
-  buildInputs = [ glib freetype fontconfig ]
+  buildInputs = [ glib freetype ]
     ++ lib.optionals withCoreText [ ApplicationServices CoreText ]
     ++ lib.optionals isNativeCompilation [ gobject-introspection ];
 

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , glib
 , freetype
-, cairo
+, fontconfig
 , libintl
 , meson
 , ninja
@@ -57,6 +57,11 @@ stdenv.mkDerivation {
     (mesonFeatureFlag "graphite" withGraphite2)
     (mesonFeatureFlag "icu" withIcu)
     (mesonFeatureFlag "coretext" withCoreText)
+    # upstream recommends cairo, but it is only used for development purposes
+    # and is not part of the library.
+    # Cairo causes transitive (build) dependencies on various X11 or other
+    # GUI-related libraries, so it shouldn't be re-added lightly.
+    (mesonFeatureFlag "cairo" false)
     (mesonFeatureFlag "introspection" isNativeCompilation)
   ];
 
@@ -72,7 +77,7 @@ stdenv.mkDerivation {
     docbook_xml_dtd_43
   ];
 
-  buildInputs = [ glib freetype cairo ] # recommended by upstream
+  buildInputs = [ glib freetype fontconfig ]
     ++ lib.optionals withCoreText [ ApplicationServices CoreText ]
     ++ lib.optionals isNativeCompilation [ gobject-introspection ];
 


### PR DESCRIPTION
###### Motivation for this change

This removes transitive (build) dependencies on various X11 or
other GUI-related libraries, which is desirable for minimizing
rebuilds and maximizing parallellism.

This also adds fontconfig to buildInputs, because this direct lib
dependency was previously found via cairo's propagatedBuildInputs.

To be sure, I've tested harfbuzz by building a gtk app and pasting Indic and Thai text samples from the harfbuzz test data into an input field.

Found in an attempt to reduce the build closure of `pythonPackages.sphinx` #126611 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
