### PR TITLE
python3Packages.georss-generic-client: 0.4 -> 0.6

### DIFF
--- a/pkgs/development/python-modules/georss-client/default.nix
+++ b/pkgs/development/python-modules/georss-client/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "georss-client";
-  version = "0.13";
+  version = "0.14";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-client";
     rev = "v${version}";
-    sha256 = "1pvx2qb8gs2f7bb8xxq689ydxirsl3bcgsbi5qv5klc4c051dj8i";
+    sha256 = "sha256-rviXXNmDLEVNYOCkqvLT9EXSuVpI5wMlCXnlpUUl1P0=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/georss-generic-client/default.nix
+++ b/pkgs/development/python-modules/georss-generic-client/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "georss-generic-client";
-  version = "0.4";
+  version = "0.6";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-generic-client";
     rev = "v${version}";
-    sha256 = "0i4shx6fvwibx0hlfmd0dyq2n5lkrqwmlm0l476fdb9bw5lkaiy0";
+    sha256 = "sha256-XVejBbVilq8zrmuyBUd0mNPZ4qysSg9lAe/lhbKT+qs=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4 -> 0.6

Change log: https://github.com/exxamalte/python-georss-generic-client/releases/tag/v0.6

- Related Home Assistant change: https://github.com/home-assistant/core/pull/51745
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
