### PR TITLE
kodiPackages: make the package set extensible

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,11 +1,11 @@
-{ callPackage, ... } @ args:
+{ lib, callPackage, kodiPackages, ... } @ args:
 let
-  unwrapped = callPackage ./unwrapped.nix (removeAttrs args [ "callPackage" ]);
-  kodiPackages = callPackage ../../../top-level/kodi-packages.nix { kodi = unwrapped; };
+  unwrapped = callPackage ./unwrapped.nix (removeAttrs args [ "callPackage" "kodiPackages" ]);
 in
   unwrapped.overrideAttrs (oldAttrs: {
     passthru = oldAttrs.passthru // {
-      packages = kodiPackages;
+      # avoid going in an inifite loop between kodi.packages -> kodiPackages.kodi -> ...
+      packages = lib.dontRecurseIntoAttrs kodiPackages;
       withPackages = func: callPackage ./wrapper.nix {
         kodi = unwrapped;
         addons = kodiPackages.requiredKodiAddons (func kodiPackages);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27665,21 +27665,35 @@ in
     gtk = gtk2;
   };
 
-  kodiPackages = recurseIntoAttrs (kodi.packages);
+  kodiPackagesFor = kodi:
+    let fun = callPackage ./kodi-packages.nix { }; in
+    recurseIntoAttrs (lib.makeExtensible (self: with self; {
+      inherit kodi;
+      callPackage = newScope self;
+    } // (fun self)));
+
+  kodiPackages = kodi.packages;
 
   kodi = callPackage ../applications/video/kodi {
     jre_headless = jdk11_headless;
   };
 
+
   kodi-wayland = callPackage ../applications/video/kodi {
     jre_headless = jdk11_headless;
     waylandSupport = true;
+    kodiPackages = kodiWaylandPackages;
   };
+
+  kodiWaylandPackages = kodiPackagesFor kodi-wayland;
 
   kodi-gbm = callPackage ../applications/video/kodi {
     jre_headless = jdk11_headless;
     gbmSupport = true;
+    kodiPackages = kodiGbmPackages;
   };
+
+  kodiGbmPackages = kodiPackagesFor kodi-gbm;
 
   kodi-cli = callPackage ../tools/misc/kodi-cli { };
 

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -1,15 +1,11 @@
-{ lib, newScope, kodi }:
+{ lib }:
 
 with lib;
 
-let self = rec {
+self: with self; {
 
   addonDir = "/share/kodi/addons";
   rel = "Matrix";
-
-  callPackage = newScope self;
-
-  inherit kodi;
 
   # Convert derivation to a kodi module. Stolen from ../../../top-level/python-packages.nix
   toKodiAddon = drv: drv.overrideAttrs (oldAttrs: {
@@ -126,4 +122,4 @@ let self = rec {
 
   urllib3 = callPackage ../applications/video/kodi-packages/urllib3 { };
 
-}; in self
+}


### PR DESCRIPTION
###### Motivation for this change

With this change we gain the ability to create a kodiPackages set for a
given kodi instance that can be extended in user configurations.

Downstream consumers can now declare an overlay to add another package
(or change a dependency like so):

```nix
{
  nixpkgs.overlays = [
    (self: super: {
      kodiPackages = super.kodiPackages.extend (kself: ksuper: {
      	somePackage = ksuper.override {
          someFeatureFlag = true;
	};
      });
    })
  ];
}
```

The `kodePackages` attribute is equivalent to the previous package set
for the kodi package. The other package sets for kodi did previosly
exist but weren't accessible to users. They only ever surfaced through
the `withPackages` function.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (aarch64-linux)
- [x] Tested a kodi-wayland with the `pvr-iptvsimple` plugin