### PR TITLE
skytemple-files: add support for patches

### DIFF
--- a/pkgs/development/compilers/armips/default.nix
+++ b/pkgs/development/compilers/armips/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "armips";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "Kingcom";
+    repo = "armips";
+    rev = "v${version}";
+    sha256 = "sha256-L+Uxww/WtvDJn1xZqoqA6Pkzq/98sy1qTxZbv6eEjbA=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp armips $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Kingcom/armips";
+    description = "Assembler for various ARM and MIPS platforms.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-files/default.nix
+++ b/pkgs/development/python-modules/skytemple-files/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, appdirs, explorerscript, ndspy, pillow, setuptools, skytemple-rust, tilequant }:
+{ lib, buildPythonPackage, fetchFromGitHub, appdirs, explorerscript, ndspy, pillow, setuptools, skytemple-rust, tilequant, armips, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "skytemple-files";
@@ -8,8 +8,25 @@ buildPythonPackage rec {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "1vklg4kcj3kb9ryrzrcmywn131b2bp3vy94cd4x4y4s7hkhgwg74";
+    sha256 = "sha256-/S0otBujwO/IMiLKgA2o8wlD6xk1/DpwOAfemojV9NU=";
+    fetchSubmodules = true;
   };
+
+  patches = [
+    # fix patching https://github.com/SkyTemple/skytemple-files/pull/128
+    # merged, remove for next update
+    (fetchpatch {
+      url = "http://github.com/SkyTemple/skytemple-files/commit/71dd71e6abb7435405e30225e8a37592b990d692.patch";
+      sha256 = "sha256-CSBaT+LVP9J0C1FlUCduTJroq9z2EAJG6lruvlHlQLI=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace skytemple_files/patch/arm_patcher.py \
+      --replace "exec_name = os.getenv('SKYTEMPLE_ARMIPS_EXEC', f'{prefix}armips')" "exec_name = \"${armips}/bin/armips\""
+  '';
+
+  buildInputs = [ armips ];
 
   propagatedBuildInputs = [ appdirs explorerscript ndspy pillow setuptools skytemple-rust tilequant ];
 
@@ -20,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/SkyTemple/skytemple-files";
     description = "Python library to edit the ROM of Pokémon Mystery Dungeon Explorers of Sky";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ xfix ];
+    maintainers = with maintainers; [ xfix marius851000 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10429,6 +10429,8 @@ in
 
   aliceml = callPackage ../development/compilers/aliceml { };
 
+  armips = callPackage ../development/compilers/armips { };
+
   arachne-pnr = callPackage ../development/compilers/arachne-pnr { };
 
   asciigraph = callPackage ../tools/text/asciigraph { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to use the patch functionallity, but it appeared to not work.

###### Things done
Packaged armips (used to apply patch)
made a patch for skytemple-files (merged upstream) to ensure that file copied from the nix store to the temporary directory is writable by the program.
Added myself as a maintainers of the thing I added.

tested the application of some patches

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@xfix 