### PR TITLE
polkit: 0.118 -> 0.119

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -20,28 +20,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "polkit";
-  version = "0.118";
+  version = "0.119";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/${pname}/releases/${pname}-${version}.tar.gz";
-    sha256 = "0swmg37jsxsxfsd2b3qm0l3zxr9ldvhpjw8lsgq3j8q7wy2fjm3d";
+    sha256 = "0p0zzmr0kh3mpmqya4q27y4h9b920zp5ya0i8909ahp9hvdrymy8";
   };
 
-  patches = [
-    # Don't use etc/dbus-1/system.d
-    # Upstream MR: https://gitlab.freedesktop.org/polkit/polkit/merge_requests/11
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/polkit/polkit/commit/5dd4e22efd05d55833c4634b56e473812b5acbf2.patch";
-      sha256 = "17lv7xj5ksa27iv4zpm4zwd4iy8zbwjj4ximslfq3sasiz9kxhlp";
-    })
-    (fetchpatch {
-      # https://www.openwall.com/lists/oss-security/2021/06/03/1
-      # https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/79
-      name = "CVE-2021-3560.patch";
-      url = "https://gitlab.freedesktop.org/polkit/polkit/-/commit/a04d13affe0fa53ff618e07aa8f57f4c0e3b9b81.patch";
-      sha256 = "157ddsizgr290jsb8fpafrc37gc1qw5pdvl351vnn3pzhqs7n6f4";
-    })
-  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+  patches = lib.optionals stdenv.hostPlatform.isMusl [
     # Make netgroup support optional (musl does not have it)
     # Upstream MR: https://gitlab.freedesktop.org/polkit/polkit/merge_requests/10
     # We use the version of the patch that Alpine uses successfully.
@@ -110,18 +96,22 @@ stdenv.mkDerivation rec {
   inherit doCheck;
   checkInputs = [ dbus ];
   checkPhase = ''
+    runHook preCheck
+
     # unfortunately this test needs python-dbusmock, but python-dbusmock needs polkit,
     # leading to a circular dependency
     substituteInPlace test/Makefile --replace polkitbackend ""
 
     # tests need access to the system bus
     dbus-run-session --config-file=${./system_bus.conf} -- sh -c 'DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS make check'
+
+    runHook postCheck
   '';
 
   meta = with lib; {
     homepage = "http://www.freedesktop.org/wiki/Software/polkit";
     description = "A toolkit for defining and handling the policy that allows unprivileged processes to speak to privileged processes";
-    license = licenses.gpl2;
+    license = licenses.lgpl2Plus;
     platforms = platforms.unix;
     maintainers = teams.freedesktop.members ++ (with maintainers; [ ]);
   };


### PR DESCRIPTION
The 0.119 release of polkit integrates the following changes, so the
patches implemented to incorporate these changes are no longer needed.

    * https://gitlab.freedesktop.org/polkit/polkit/-/commit/273357a39520423b2074e7d664f83922ad047176
    * https://gitlab.freedesktop.org/polkit/polkit/-/blob/0.119/src/polkit/polkitsystembusname.c#L438-440

Fixes: CVE-2021-3560 without a patch

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
