### PR TITLE
polylith: init at 0.1.0-alpha9

### DIFF
--- a/pkgs/development/tools/misc/polylith/default.nix
+++ b/pkgs/development/tools/misc/polylith/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetchurl, jre, runtimeShell }:
+
+stdenv.mkDerivation rec {
+  pname = "polylith";
+  version = "0.1.0-alpha9";
+
+  src = fetchurl {
+    url = "https://github.com/polyfy/polylith/releases/download/v${version}/poly-${version}.jar";
+    sha256 = "0mjn0fibj7z8wihk5frhyd5ai2bmzm909701sphjs7j9lgg0gc4k";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    cat > "$out/bin/poly" <<EOF
+    #!${runtimeShell}
+    ARGS=""
+    while [ "\$1" != "" ] ; do
+      ARGS="\$ARGS \$1"
+      shift
+    done
+    exec "${jre}/bin/java" "-jar" "${src}" \$ARGS
+    EOF
+    chmod a+x $out/bin/poly
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/poly help | fgrep -q '${version}'
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "A tool used to develop Polylith based architectures in Clojure";
+    homepage = "https://github.com/polyfy/polylith";
+    license = licenses.epl10;
+    maintainers = [ maintainers.ericdallo ];
+    platforms = jre.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26088,6 +26088,8 @@ in
 
   pommed_light = callPackage ../os-specific/linux/pommed-light {};
 
+  polylith = callPackage ../development/tools/misc/polylith { };
+
   polymake = callPackage ../applications/science/math/polymake {
     openjdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };


### PR DESCRIPTION
###### Motivation for this change
init [polylith](https://polylith.gitbook.io/polylith/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
