### PR TITLE
ocamlPackages.ocamlgraph: 1.8.8 -> 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -1,39 +1,26 @@
-{ stdenv, lib, fetchurl, ocaml, findlib
-, gtkSupport ? true
-, lablgtk
-}:
+{ lib, fetchurl, buildDunePackage, stdlib-shims }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "ocamlgraph";
-  version = "1.8.8";
+  version = "2.0.0";
 
   src = fetchurl {
-    url = "http://ocamlgraph.lri.fr/download/ocamlgraph-${version}.tar.gz";
-    sha256 = "0m9g16wrrr86gw4fz2fazrh8nkqms0n863w7ndcvrmyafgxvxsnr";
+    url = "https://github.com/backtracking/ocamlgraph/releases/download/${version}/ocamlgraph-${version}.tbz";
+    sha256 = "029692bvdz3hxpva9a2jg5w5381fkcw55ysdi8424lyyjxvjdzi0";
   };
 
-  buildInputs = [ ocaml findlib ]
-  ++ lib.optional gtkSupport lablgtk
-  ;
+  minimalOCamlVersion = "4.03";
+  useDune2 = true;
 
-  createFindlibDestdir = true;
+  propagatedBuildInputs = [
+    stdlib-shims
+  ];
 
-  buildFlags =  [ "all" ];
-  installTargets = [ "install-findlib" ];
-
-  postInstall = lib.optionalString gtkSupport ''
-    mkdir -p $out/bin
-    cp dgraph/dgraph.opt $out/bin/graph-viewer
-    cp editor/editor.opt $out/bin/graph-editor
-  '';
-
-  meta = {
-    homepage = "http://ocamlgraph.lri.fr/";
-    description = "Graph library for Objective Caml";
-    license = lib.licenses.gpl2Oss;
-    platforms = ocaml.meta.platforms or [];
-    maintainers = [
-      lib.maintainers.kkallio
-    ];
+  meta = with lib; {
+      homepage = "http://ocamlgraph.lri.fr/";
+      downloadPage = "https://github.com/backtracking/ocamlgraph";
+      description = "Graph library for OCaml";
+      license = licenses.gpl2Oss;
+      maintainers = with maintainers; [ kkallio superherointj ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlgraph/gtk.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/gtk.nix
@@ -1,0 +1,12 @@
+{ buildDunePackage, lablgtk, ocamlgraph, stdlib-shims, ... }:
+
+buildDunePackage rec {
+  pname = "ocamlgraph_gtk";
+  inherit (ocamlgraph) version src useDune2 meta;
+
+  propagatedBuildInputs = [
+    lablgtk
+    ocamlgraph
+    stdlib-shims
+  ];
+}

--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -15,6 +15,7 @@ let
     mlgmpidl
     num
     ocamlgraph
+    stdlib-shims
     why3
     yojson
     zarith
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf wrapGAppsHook ];
 
   buildInputs = with ocamlPackages; [
-    ncurses ocaml findlib ltl2ba ocamlgraph yojson menhirLib camlzip
+    ncurses ocaml findlib ltl2ba ocamlgraph ocamlgraph_gtk yojson menhirLib camlzip
     lablgtk coq graphviz zarith apron why3 mlgmpidl doxygen
     gdk-pixbuf
   ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -829,6 +829,7 @@ let
     gettext-stub = callPackage ../development/ocaml-modules/ocaml-gettext/stub.nix { };
 
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
+    ocamlgraph_gtk = callPackage ../development/ocaml-modules/ocamlgraph/gtk.nix { };
 
     ocaml_http = callPackage ../development/ocaml-modules/http { };
 


### PR DESCRIPTION
* ocamlPackages.ocamlgraph: 1.8.8 -> 2.0.0
* ocamlPackages.ocamlgraph_gtk: init 2.0.0

`ocamlgraph` upgrade is required for `dose3` package.

## Pending

### Split off executables [editor](https://github.com/backtracking/ocamlgraph/blob/master/editor/dune) and [viewer](https://github.com/backtracking/ocamlgraph/blob/master/dgraph/dune)

Motivation: why would an application depending on this library have to inherit unused executables?

* Building executables ([editor](https://github.com/backtracking/ocamlgraph/blob/master/editor/dune), [viewer](https://github.com/backtracking/ocamlgraph/blob/master/dgraph/dune)) using buildDunePackage errors because it cannot find package, likely because it doesn't have `public_name` entry on dune file and also no opam package for application.

    Dune error is:
    > Error: I don't know about package dGraphViewer (passed through -p)

I don't use these executables and only needed to upgrade library for upgrading `dose3`.
* Possible solutions:
    1. ask upstream to add opam package and dune public_name entry to executables [[which I did](https://github.com/backtracking/ocamlgraph/issues/115)].
    2. patch it.
    3. do nothing.
      - It can be merged now.