### PR TITLE
qt5: add at-spi2-core to qtbase

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -11,7 +11,7 @@
 , libXcursor, libXext, libXi, libXrender, libinput, libjpeg, libpng
 , libxcb, libxkbcommon, libxml2, libxslt, openssl, pcre16, pcre2, sqlite, udev
 , xcbutil, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, xcbutilwm
-, zlib
+, zlib, at-spi2-core
 
   # optional dependencies
 , cups ? null, libmysqlclient ? null, postgresql ? null
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
     ] ++ lib.optional libGLSupported libGL
   );
 
-  buildInputs = [ python3 ]
+  buildInputs = [ python3 at-spi2-core ]
     ++ lib.optionals (!stdenv.isDarwin)
     (
       [ libinput ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #39499

###### Things done

i added `at-spi2-core` to qtbase.nix `buildInputs`

After
```Checking for atspi...
Trying source 0 (type pkgConfig) of library atspi ...
+ pkg-config --exists --silence-errors atspi-2
+ pkg-config --modversion atspi-2
> 2.40.1
+ pkg-config --libs-only-L atspi-2
> -L/nix/store/dcb3cyba5wl6qimv6vwdpbi0kg0g1nlb-glib-2.68.2/lib -L/nix/store/s6aszyzvfph06i9dcic7x6yci5qjjn10-at-spi2-core-2.40.1/lib -L/nix/store/3ywkzq38n9kfjpb84ac2qz5kfhmzjrhv-dbus-1.12.20-lib/lib
+ pkg-config --libs-only-l atspi-2
> -latspi -ldbus-1 -lglib-2.0
+ pkg-config --cflags atspi-2
> -I/nix/store/d9zs9xg86lhqjqni0v8h2ibdrjb57fn4-glib-2.68.2-dev/include/glib-2.0 -I/nix/store/dcb3cyba5wl6qimv6vwdpbi0kg0g1nlb-glib-2.68.2/lib/glib-2.0/include -I/nix/store/qab61iyr99kcny3p9jgivh581cjgm2la-at-spi2-core-2.40.1-dev/include/at-spi-2.0 -I/nix/store/gmvb8249szs44gryl92716wycrw895dy-dbus-1.12.20-dev/include/dbus-1.0 -I/nix/store/3ywkzq38n9kfjpb84ac2qz5kfhmzjrhv-dbus-1.12.20-lib/lib/dbus-1.0/include
 => source accepted.
```

vs Before

```
Checking for atspi... 
Trying source 0 (type pkgConfig) of library atspi ...
+ pkg-config --exists --silence-errors atspi-2
pkg-config did not find package.
  => source produced no result.
test config.qtbase_gui.libraries.atspi FAILED
```


from https://hydra.nixos.org/build/144353470/nixlog/1

at-spi2-atk gets inherited from somewhere else since its visible in the hydra log

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
