### PR TITLE
goofys: init at unstable-2021-03-26

### DIFF
--- a/pkgs/tools/filesystems/goofys/default.nix
+++ b/pkgs/tools/filesystems/goofys/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule {
+  pname = "goofys";
+  version = "unstable-2021-03-26";
+
+  src = fetchFromGitHub {
+    owner = "kahing";
+    repo = "goofys";
+    # Same as v0.24.0 but migrated to Go modules
+    rev = "0c993271269b539196330a18716a33fbeeebd624";
+    sha256 = "18is5sv2a9wmsm0qpakly988z1qyl2b2hf2105lpxrgl659sf14p";
+  };
+
+  vendorSha256 = "15yq0msh9icxd5n2zkkqrlwxifizhpa99d4aznv8clg32ybs61fj";
+
+  subPackages = [ "." ];
+
+  # Tests are using networking
+  postPatch = ''
+    rm internal/*_test.go
+  '';
+
+  meta = {
+    homepage = "https://github.com/kahing/goofys";
+    description = "A high-performance, POSIX-ish Amazon S3 file system written in Go.";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.adisbladis ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5315,6 +5315,8 @@ in
 
   go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };
 
+  goofys = callPackage ../tools/filesystems/goofys { };
+
   go-sct = callPackage ../tools/X11/go-sct { };
 
   # rename to upower-notify?


### PR DESCRIPTION
###### Motivation for this change
`goofys` is a much faster/simpler implementation than `s3fs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
