### PR TITLE
pass-import: 3.1 -> 3.2

### DIFF
--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -9,37 +9,21 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pass-import";
-  version = "3.1";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "roddhjav";
     repo = "pass-import";
     rev = "v${version}";
-    sha256 = "sha256-nH2xAqWfMT+Brv3z9Aw6nbvYqArEZjpM28rKsRPihqA=";
+    sha256 = "0hrpg7yiv50xmbajfy0zdilsyhbj5iv0qnlrgkfv99q1dvd5qy56";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "support-for-keepass-4.0.0.patch";
-      url = "https://github.com/roddhjav/pass-import/commit/86cfb1bb13a271fefe1e70f24be18e15a83a04d8.patch";
-      sha256 = "0mrlblqlmwl9gqs2id4rl4sivrcclsv6zyc6vjqi78kkqmnwzhxh";
-    })
-    # by default, tries to install scripts/pimport, which is a bash wrapper around "python -m pass_import ..."
-    # This is a better way to do the same, and takes advantage of the existing Nix python environments
-    # from https://github.com/roddhjav/pass-import/pull/138
-    (fetchpatch {
-      name = "pass-import-pr-138-pimport-entrypoint.patch";
-      url = "https://github.com/roddhjav/pass-import/commit/ccdb6995bee6436992dd80d7b3101f0eb94c59bb.patch";
-      sha256 = "sha256-CO8PyWxa4eLuTQBB+jKTImFPlPn+1yt6NBsIp+SPk94=";
-    })
-  ];
 
   propagatedBuildInputs = with python3Packages; [
     cryptography
     defusedxml
     pyaml
     pykeepass
-    python_magic  # similar API to "file-magic", but already in nixpkgs.
+    python_magic # similar API to "file-magic", but already in nixpkgs.
     secretstorage
   ];
 
@@ -52,18 +36,19 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [
     "test_import_gnome_keyring" # requires dbus, which pytest doesn't support
   ];
-  postCheck = ''
-    $out/bin/pimport --list-exporters --list-importers
-  '';
 
   postInstall = ''
     mkdir -p $out/lib/password-store/extensions
-    cp ${src}/scripts/import.bash $out/lib/password-store/extensions/import.bash
+    cp ${src}/import.bash $out/lib/password-store/extensions/import.bash
     wrapProgram $out/lib/password-store/extensions/import.bash \
-      --prefix PATH : "${python3Packages.python.withPackages(_: propagatedBuildInputs)}/bin" \
+      --prefix PATH : "${python3Packages.python.withPackages (_: propagatedBuildInputs)}/bin" \
       --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}" \
       --run "export PREFIX"
     cp -r ${src}/share $out/
+  '';
+
+  postCheck = ''
+    $out/bin/pimport --list-exporters --list-importers
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

copied from release notes:
###### Added

* Keepass: initial support for TOTP
* Add support for modern firefox import.
* Keepass: enable reference substitution
* Add gopass support
###### Changed

* Fully deprecate Makefile in favor of setup.py
* Make pimport a setuptools script
* Support for pykeepass 4.0.0
* Support for python 3.9

###### Fixed

* Update Dashlane Json format
* Fix importer var name.
* Fix install for MacOS.
* Update Bitwarden Json format.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
