### PR TITLE
testEqualDerivation: init

### DIFF
--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -1,7 +1,9 @@
 { lib
 , stdenv
 , fetchurl
+, nixos
 , testVersion
+, testEqualDerivation
 , hello
 }:
 
@@ -16,8 +18,15 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  passthru.tests.version =
-    testVersion { package = hello; };
+  passthru.tests = {
+    version = testVersion { package = hello; };
+
+    invariant-under-noXlibs =
+      testEqualDerivation
+        "hello must not be rebuilt when environment.noXlibs is set."
+        hello
+        (nixos { environment.noXlibs = true; }).pkgs.hello;
+  };
 
   meta = with lib; {
     description = "A program that produces a familiar, friendly greeting";

--- a/pkgs/build-support/test-equal-derivation.nix
+++ b/pkgs/build-support/test-equal-derivation.nix
@@ -1,0 +1,43 @@
+{ lib, runCommand, emptyFile, nix-diff }:
+
+/*
+  Checks that two packages produce the exact same build instructions.
+
+  This can be used to make sure that a certain difference of configuration,
+  such as the presence of an overlay does not cause a cache miss.
+
+  When the derivations are equal, the return value is an empty file.
+  Otherwise, the build log explains the difference via `nix-diff`.
+
+  Example:
+
+      testEqualDerivation
+        "The hello package must stay the same when enabling checks."
+        hello
+        (hello.overrideAttrs(o: { doCheck = true; }))
+
+*/
+assertion: a: b:
+let
+  drvA = builtins.unsafeDiscardOutputDependency a.drvPath or (throw "testEqualDerivation second argument must be a package");
+  drvB = builtins.unsafeDiscardOutputDependency b.drvPath or (throw "testEqualDerivation third argument must be a package");
+  name =
+    if a?name
+    then lib.strings.sanitizeDerivationName "testEqualDerivation-${a.name}"
+    else "testEqualDerivation";
+in
+if drvA == drvB then
+  emptyFile
+else
+  runCommand name
+    {
+      inherit assertion drvA drvB;
+      nativeBuildInputs = [ nix-diff ];
+    } ''
+      echo "$assertion"
+      echo "However, the derivations differ:"
+      echo
+      echo nix-diff $drvA $drvB
+      nix-diff $drvA $drvB
+      exit 1
+    ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10135,6 +10135,8 @@ with pkgs;
 
   termplay = callPackage ../tools/misc/termplay { };
 
+  testEqualDerivation = callPackage ../build-support/test-equal-derivation.nix { };
+
   tetrd = callPackage ../applications/networking/tetrd { };
 
   tewisay = callPackage ../tools/misc/tewisay { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `environment.noXlibs` overlay got me thinking that if we want to take that seriously (ie #29135), we'll want to control rebuilds. For example, we'll want to prevent regressions of, say, #126611.

`testEqualDerivation` makes this easy to check and reports the differences nicely with `nix-diff`.

See for yourself:

```
gh pr checkout 126718
nix-build --expr 'with import <nixpkgs> {}; testEqualDerivation "ghc does not have to be rebuilt when environment.noXlibs is set." ghc (nixos { environment.noXlibs = true;})._module.args.pkgs.ghc'
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
