### PR TITLE
ocamlPackages.bz2: add bzip2 to propagatedBuildInputs

### DIFF
--- a/pkgs/development/ocaml-modules/bz2/default.nix
+++ b/pkgs/development/ocaml-modules/bz2/default.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ocaml
     findlib
+  ];
+
+  propagatedBuildInputs = [
     bzip2
   ];
 


### PR DESCRIPTION
* ocamlPackages.bz2: add bzip2 to propagatedBuildInputs

Fixes package. :)