### PR TITLE
imagination: init at 3.6

### DIFF
--- a/pkgs/applications/video/imagination/default.nix
+++ b/pkgs/applications/video/imagination/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchurl, autoreconfHook, docbook_xsl, ffmpeg-full, glib, gtk3
+, intltool, libxslt, pkg-config, sox, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "imagination";
+  version = "3.6";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "139dgb9vfr2q7bxvjskykdz526xxwrn0bh463ir8m2p7rx5a3pw5";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook_xsl
+    intltool
+    libxslt
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [ ffmpeg-full glib gtk3 sox ];
+
+  preBuild = ''
+    substituteInPlace src/main-window.c \
+      --replace 'gtk_icon_theme_load_icon(icon_theme,"image", 20, 0, NULL)' \
+      'gtk_icon_theme_load_icon(icon_theme,"insert-image", 20, 0, NULL)' \
+      --replace 'gtk_icon_theme_load_icon(icon_theme,"sound", 20, 0, NULL)' \
+      'gtk_icon_theme_load_icon(icon_theme,"audio-x-generic", 20, 0, NULL)'
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+       --prefix PATH : "${lib.makeBinPath [ ffmpeg-full sox ]}"
+    )
+  '';
+
+  meta = with lib; {
+    description = "Lightweight and simple DVD slide show maker";
+    homepage = "http://imagination.sourceforge.net";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ austinbutler ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24578,6 +24578,8 @@ in
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Foundation;
   });
 
+  imagination = callPackage ../applications/video/imagination { };
+
   inherit (nodePackages) imapnotify;
 
   img2pdf = with python3Packages; toPythonApplication img2pdf;


### PR DESCRIPTION
###### Motivation for this change

Add the package. It's a really easy, nice way to make a slideshow video with some music.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).