### PR TITLE
darwin: temporarily disable bootstrap stdenv test

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -4,6 +4,7 @@
 , config
 , overlays
 , crossOverlays ? [ ]
+, bootstrapLlvmVersion ? if localSystem.isAarch64 then "11.1.0" else "7.1.0"
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? if localSystem.isAarch64 then
     let
@@ -40,14 +41,11 @@ assert crossSystem == localSystem;
 let
   inherit (localSystem) system;
 
-  # Bootstrap version needs to be known to reference headers included in the bootstrap tools
-  bootstrapLlvmVersion = if localSystem.isAarch64 then "11.1.0" else "7.1.0";
-
   useAppleSDKLibs = localSystem.isAarch64;
   haveKRB5 = localSystem.isx86_64;
 
   # final toolchain is injected into llvmPackages_${finalLlvmVersion}
-  finalLlvmVersion = if localSystem.isAarch64 then "11" else "7";
+  finalLlvmVersion = lib.versions.major bootstrapLlvmVersion;
   finalLlvmPackages = "llvmPackages_${finalLlvmVersion}";
 
   commonImpureHostDeps = [

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -254,6 +254,8 @@ in rec {
     '';
   };
 
+  bootstrapLlvmVersion = llvmPackages.llvm.version;
+
   bootstrapFiles = {
     sh      = "${build}/on-server/sh";
     bzip2   = "${build}/on-server/bzip2";
@@ -408,7 +410,7 @@ in rec {
     system = if crossSystem != null then crossSystem else system;
 
     stdenvStages = args: let
-        args' = args // { inherit bootstrapFiles; };
+        args' = args // { inherit bootstrapLlvmVersion bootstrapFiles; };
       in (import (test-pkgspath + "/pkgs/stdenv/darwin") args').stagesDarwin;
   };
 }

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -174,7 +174,8 @@ let
               # Lightweight distribution and test
               inherit (bootstrap) dist test;
               # Test a full stdenv bootstrap from the bootstrap tools definition
-              inherit (bootstrap.test-pkgs) stdenv;
+              # TODO re-enable with https://github.com/NixOS/nixpkgs/pull/126411
+              # inherit (bootstrap.test-pkgs) stdenv;
             };
 
           # Cross compiled bootstrap tools


### PR DESCRIPTION
###### Motivation for this change

The update bootstrap tools requires changes from the upcoming llvm
update in order to work. Just fixing the llvm version issue isn't enough
to unblock the test.

Fixes #126617

/cc @toonn @thefloweringash

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (still fails, now on cmake but these sort of issues will be fixed in the llvm update)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
