### PR TITLE
[Backport 21.05] php.extensions: Updates to multiple extensions

### DIFF
--- a/pkgs/development/php-packages/ast/default.nix
+++ b/pkgs/development/php-packages/ast/default.nix
@@ -3,8 +3,8 @@
 buildPecl {
   pname = "ast";
 
-  version = "1.0.10";
-  sha256 = "13s5r1szd80g1mqickghdd38mvjkwss221322mmbrykcfgp4fs30";
+  version = "1.0.12";
+  sha256 = "1mcfx989yrakixlsx2d8v6kyxawfwhig4mra9ccpjasfhad0d31x";
 
   meta.maintainers = lib.teams.php.members;
 }

--- a/pkgs/development/php-packages/event/default.nix
+++ b/pkgs/development/php-packages/event/default.nix
@@ -2,8 +2,8 @@
 buildPecl {
   pname = "event";
 
-  version = "3.0.2";
-  sha256 = "1ws4l014z52vb23xbsfj6viwkf7fmh462af639xgbp0n6syf77dq";
+  version = "3.0.4";
+  sha256 = "13yb3zvlx43cncawymiwbqyz8gzpq1g03vd0xjlw9vz75b4mwn1x";
 
   configureFlags = [
     "--with-event-libevent-dir=${libevent.dev}"

--- a/pkgs/development/php-packages/igbinary/default.nix
+++ b/pkgs/development/php-packages/igbinary/default.nix
@@ -3,8 +3,8 @@
 buildPecl {
   pname = "igbinary";
 
-  version = "3.2.1";
-  sha256 = "sha256-YBYgz/07PlWWIAmcBWm4xCR/Ap7BitwCBr8m+ONXU9s=";
+  version = "3.2.2";
+  sha256 = "0321pb0298fa67qwj5nhhabkjiaxna5mag15ljyrqzpivimvny92";
 
   configureFlags = [ "--enable-igbinary" ];
   makeFlags = [ "phpincludedir=$(dev)/include" ];

--- a/pkgs/development/php-packages/maxminddb/default.nix
+++ b/pkgs/development/php-packages/maxminddb/default.nix
@@ -1,7 +1,7 @@
 { buildPecl, lib, fetchFromGitHub, libmaxminddb }:
 let
   pname = "maxminddb";
-  version = "1.10.0";
+  version = "1.10.1";
 in
 buildPecl {
   inherit pname version;
@@ -10,7 +10,7 @@ buildPecl {
     owner = "maxmind";
     repo = "MaxMind-DB-Reader-php";
     rev = "v${version}";
-    sha256 = "sha256-2SnajDdO5uAYcuVpEbOuFlZzMxwo/EqFtUSr9XxT0KQ=";
+    sha256 = "1m5y733x4ykldi1pym54mdahfwfnwy2r1n6fnndwi8jz9px9pa5k";
   };
 
   buildInputs = [ libmaxminddb ];

--- a/pkgs/development/php-packages/mongodb/default.nix
+++ b/pkgs/development/php-packages/mongodb/default.nix
@@ -4,8 +4,8 @@
 buildPecl {
   pname = "mongodb";
 
-  version = "1.9.0";
-  sha256 = "16mbw3p80qxsj86nmjbfch8wv6jaq8wbz4rlpmixvhj9nwbp37hs";
+  version = "1.9.1";
+  sha256 = "1mzyssy2a89grw7rwmh0x22lql377nmnqlcv9piam1c32qiwxlg9";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/development/php-packages/pcov/default.nix
+++ b/pkgs/development/php-packages/pcov/default.nix
@@ -3,8 +3,8 @@
 buildPecl {
   pname = "pcov";
 
-  version = "1.0.8";
-  sha256 = "sha256-6rbniyxLIHPW/e+eWZN1qS8F1rOB7ld1N8JKUS1geRQ=";
+  version = "1.0.9";
+  sha256 = "0q2ig5lxzpwz3qgr05wcyh5jzhfxlygkv6nj6jagkhiialng2710";
 
   buildInputs = [ pcre' ];
 

--- a/pkgs/development/php-packages/protobuf/default.nix
+++ b/pkgs/development/php-packages/protobuf/default.nix
@@ -1,29 +1,12 @@
-{ buildPecl, lib, pcre', fetchpatch }:
+{ buildPecl, lib, pcre' }:
 
 buildPecl {
   pname = "protobuf";
 
-  version = "3.14.0";
-  sha256 = "1ldc4s28hq61cfg8l4c06pgicj0ng7k37f28a0dnnbs7xkr7cibd";
+  version = "3.17.2";
+  sha256 = "0i4npj4sl8ihkzxc6m3vv3nlqk952z9bfwnrk90a9yakw5gfhlz5";
 
   buildInputs = [ pcre' ];
-
-  patches = [
-    # TODO: remove with next update
-    (fetchpatch {
-      url = "https://github.com/protocolbuffers/protobuf/commit/823f351448f7c432bed40b89ee3309e0a94c1855.patch";
-      sha256 = "sha256-ozHtO8s9zvmh/+wBEge3Yn3n0pbpR3dAojJcuAg/G3s=";
-      stripLen = 4;
-      includes = [
-        "array.c"
-        "def.c"
-        "map.c"
-        "message.c"
-        "protobuf.h"
-        "wkt.inc"
-      ];
-    })
-  ];
 
   meta = with lib; {
     description = ''

--- a/pkgs/development/php-packages/redis/default.nix
+++ b/pkgs/development/php-packages/redis/default.nix
@@ -3,8 +3,8 @@
 buildPecl {
   pname = "redis";
 
-  version = "5.3.3";
-  sha256 = "sha256-N3iRYeFkzVIjmjDJojjaYf7FyDlc2sOFtu2PDFD9kvA=";
+  version = "5.3.4";
+  sha256 = "1k5l7xxb06rlwq9jbmbbr03pc74d75vgv7h5bqjkbwan6dphafab";
 
   internalDeps = with php.extensions; [
     session

--- a/pkgs/development/php-packages/swoole/default.nix
+++ b/pkgs/development/php-packages/swoole/default.nix
@@ -3,8 +3,8 @@
 buildPecl {
   pname = "swoole";
 
-  version = "4.6.4";
-  sha256 = "0hgndnn27q7fbsb0nw6bfdg0kyy5di9vrmf7g53jc6lsnf73ha31";
+  version = "4.6.7";
+  sha256 = "107wp403z8skkqrcm240vyyy6wqx5a4v2bqhlshlknyi14r2v165";
 
   buildInputs = [ valgrind pcre' ];
   internalDeps = lib.optionals (lib.versionOlder php.version "7.4") [ php.extensions.hash ];

--- a/pkgs/development/php-packages/xdebug/default.nix
+++ b/pkgs/development/php-packages/xdebug/default.nix
@@ -3,8 +3,8 @@
 buildPecl {
   pname = "xdebug";
 
-  version = "3.0.3";
-  sha256 = "sha256-5yZagVGOOX+XLcki50bRpIRTcXf/SJVDUWfRCeKTJDI=";
+  version = "3.0.4";
+  sha256 = "1bvjmnx9bcfq4ikp02kiqg0f7ccgx4mkmz5d7g6v0d263x4r0wmj";
 
   doCheck = true;
   checkTarget = "test";


### PR DESCRIPTION
###### Motivation for this change
Backport parts of #126351

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
