### PR TITLE
gbsplay: 2016-12-17 -> 0.0.94

### DIFF
--- a/pkgs/applications/audio/gbsplay/default.nix
+++ b/pkgs/applications/audio/gbsplay/default.nix
@@ -1,28 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, libpulseaudio }:
+{ lib, stdenv, fetchFromGitHub, installShellFiles, libpulseaudio, nas }:
 
-stdenv.mkDerivation {
-  name = "gbsplay-2016-12-17";
+stdenv.mkDerivation rec {
+  pname = "gbsplay";
+  version = "0.0.94";
 
   src = fetchFromGitHub {
     owner = "mmitch";
     repo = "gbsplay";
-    rev = "2c4486e17fd4f4cdea8c3fd79ae898c892616b70";
-    sha256 = "1214j67sr87zfhvym41cw2g823fmqh4hr451r7y1s9ql3jpjqhpz";
+    rev = version;
+    sha256 = "VpaXbjotmc/Ref1geiKkBX9UhbPxfAGkFAdKVxP8Uxo=";
   };
 
-  buildInputs = [ libpulseaudio ];
+  configureFlags = [
+    "--without-test" # See mmitch/gbsplay#62
+    "--without-contrib"
+  ];
 
-  configureFlags =
-   [ "--without-test" "--without-contrib" "--disable-devdsp"
-     "--enable-pulse" "--disable-alsa" "--disable-midi"
-     "--disable-nas" "--disable-dsound" "--disable-i18n" ];
+  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = [ libpulseaudio nas ];
 
-  makeFlags = [ "tests=" ];
+  postInstall = ''
+    installShellCompletion --bash --name gbsplay contrib/gbsplay.bashcompletion
+  '';
 
   meta = with lib; {
-    description = "gameboy sound player";
+    description = "Gameboy sound player";
     license = licenses.gpl1;
-    platforms = ["i686-linux" "x86_64-linux"];
+    platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = with maintainers; [ dasuxullebt ];
   };
 }


### PR DESCRIPTION
Add the "nas" output plugin. Remove configure flags since those should get detected automatically. Install bash completions. Format through nixpkgs-fmt.

###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
