### PR TITLE
clang-tools: fix clangd

### DIFF
--- a/pkgs/development/tools/clang-tools/wrapper
+++ b/pkgs/development/tools/clang-tools/wrapper
@@ -19,9 +19,9 @@ buildcpath() {
 }
 
 export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
-                                               $(<@clang@/nix-support/libc-cflags))
+                                               $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
 export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
                                                                                       $(<@clang@/nix-support/libcxx-cxxflags) \
-                                                                                      $(<@clang@/nix-support/libc-cflags))
+                                                                                      $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
 
 exec -a "$0" @unwrapped@/bin/$(basename $0) "$@"


### PR DESCRIPTION
backport #126753.

Whatever change has necessitated
https://github.com/NixOS/nixpkgs/pull/122044, it also broke clangd --
<clang-wrapper>/resource-root/include is no longer automagically
searched for includes, which kills pretty much any indexing since that
directory contains vital stuff like stddef.h etc.

Fix by appending the directory to CPATH & CPLUS_INCLUDE_PATH in the
clangd wrapper.

(cherry picked from commit 8e06a39574aeb6500ad233e3b529e0e43fb80788)

###### Motivation for this change

21.05 should be fixed too.