### PR TITLE
trivial-builders: refactor writeTextFile to be overridable, fixes #126344

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -116,7 +116,7 @@ rec {
     , checkPhase ? ""    # syntax checks, e.g. for scripts
     }:
     runCommand name
-      { inherit text executable;
+      { inherit text executable checkPhase;
         passAsFile = [ "text" ];
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;
@@ -132,7 +132,7 @@ rec {
           echo -n "$text" > "$n"
         fi
 
-        ${checkPhase}
+        eval "$checkPhase"
 
         (test -n "$executable" && chmod +x "$n") || true
       '';

--- a/pkgs/build-support/trivial-builders/test-overriding.nix
+++ b/pkgs/build-support/trivial-builders/test-overriding.nix
@@ -1,0 +1,119 @@
+# Check that overriding works for trivial-builders like
+# `writeShellScript` via `overrideAttrs`. This is useful
+# to override the `checkPhase`, e. g. when you want
+# to enable extglob in `writeShellScript`.
+#
+# Run using `nix-build -A tests.trivial-overriding`.
+{ lib
+, runtimeShell
+, runCommand
+, callPackage
+, writeShellScript
+, writeTextFile
+, writeShellScriptBin
+}:
+
+let
+  extglobScript = ''
+    shopt -s extglob
+    touch success
+    echo @(success|failure)
+    rm success
+  '';
+
+  # Reuse the old `checkPhase` of `writeShellScript`, but enable extglob.
+  allowExtglob = old: {
+    checkPhase = ''
+      # make sure we don't change the settings for
+      # the rest of the derivation's build
+      (
+        export BASHOPTS
+        shopt -s extglob
+        ${old.checkPhase}
+      )
+    '';
+  };
+
+  # Run old checkPhase, but only succeed if it fails.
+  # This HACK is required because we can't introspect build failures
+  # in nix: With `assertFail` we want to make sure that the default
+  # `checkPhase` would fail if extglob was used in the script.
+  assertFail = old: {
+    # write old checkPhase into a shell script, so we can check for
+    # the phase to fail even though we have `set -e`.
+    checkPhase = ''
+      if source ${writeShellScript "old-check-phase" old.checkPhase} 2>/dev/null; then
+        exit 1
+      fi
+    '';
+  };
+
+  simpleCase = case:
+    writeShellScript "test-trivial-overriding-${case}" extglobScript;
+
+  callPackageCase = case: callPackage (
+    { writeShellScript }:
+    writeShellScript "test-trivial-callpackage-overriding-${case}" extglobScript
+  ) { };
+
+  binCase = case:
+    writeShellScriptBin "test-trivial-overriding-bin-${case}" extglobScript;
+
+  # building this derivation would fail without overriding
+  textFileCase = writeTextFile {
+    name = "test-trivial-overriding-text-file";
+    checkPhase = "false";
+    text = ''
+      #!${runtimeShell}
+      echo success
+    '';
+    executable = true;
+  };
+
+  mkCase = f: type: isBin:
+    let
+      drv = (f type).overrideAttrs
+        (if type == "succ" then allowExtglob else assertFail);
+    in if isBin then "${drv}/bin/${drv.name}" else drv;
+
+  writeTextOverrides = {
+    # Enabling globbing in checkPhase
+    simpleSucc = mkCase simpleCase "succ" false;
+    # Ensure it's possible to fail; in this case globbing is not enabled.
+    simpleFail = mkCase simpleCase "fail" false;
+    # Do the same checks after wrapping with callPackage
+    # to make sure callPackage doesn't mess with the override
+    callpSucc = mkCase callPackageCase "succ" false;
+    callpFail = mkCase callPackageCase "fail" false;
+    # Do the same check using `writeShellScriptBin`
+    binSucc = mkCase binCase "succ" true;
+    binFail = mkCase binCase "fail" true;
+    # Check that we can also override plain writeTextFile
+    textFileSuccess = textFileCase.overrideAttrs (_: {
+      checkPhase = "true";
+    });
+  };
+
+  # `runTest` forces nix to build the script of our test case and
+  # run its `checkPhase` which is our main interest. Additionally
+  # it executes the script and thus makes sure that extglob also
+  # works at run time.
+  runTest = script:
+    let
+      name = script.name or (builtins.baseNameOf script);
+    in writeShellScript "run-${name}" ''
+      if [ "$(${script})" != "success" ]; then
+        echo "Failed in ${script}"
+        exit 1
+      fi
+    '';
+in
+
+runCommand "test-writeShellScript-overriding" {
+  passthru = { inherit writeTextOverrides; };
+} ''
+  ${lib.concatMapStrings (test: ''
+      ${runTest test}
+    '') (lib.attrValues writeTextOverrides)}
+  touch "$out"
+''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -52,6 +52,7 @@ with pkgs;
   cuda = callPackage ./cuda { };
 
   trivial = callPackage ../build-support/trivial-builders/test.nix {};
+  trivial-overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
 
   writers = callPackage ../build-support/writers/test.nix {};
 }


### PR DESCRIPTION
NOTE: For anyone that looks at this after it's merged, the most up to date and detailed information will be in the commit message.

###### Motivation for this change
This fixes #126344, specifically with the goal of enabling overriding the
checkPhase argument.

This allows among other things, enabling bash extension for the checkPhase.
Previously using such bash extensions was prohibited by the writeShellScript
code because there was no way to enable the extension in the checker.

Here is an example of what is now possible:

```nix
(writeShellScript "foo" ''
  shopt -s extglob
  echo @(foo|bar)
  '').override (old: {
    checkPhase = ''
      export BASHOPTS
      shopt -s extglob
      ${old.checkPhase}
      #shopt -u extglob\n
      '';
    })
```

###### Things done
I tested if the example expression above evals.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
