### PR TITLE
nixos/borgbackup: add extraPackages option

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -75,7 +75,7 @@ let
       description = "BorgBackup job ${name}";
       path = with pkgs; [
         borgbackup openssh
-      ];
+      ] ++ cfg.path;
       script = mkBackupScript cfg;
       serviceConfig = {
         User = cfg.user;
@@ -555,6 +555,18 @@ in {
             example = "--save-space";
           };
 
+          path = mkOption {
+            type = with types; listOf package;
+            default = [];
+            defaultText = literalExample "[]";
+            example = literalExample ''
+              with pkgs; [ btrfs-progs ]
+            '';
+            description = ''
+              Packages to be added to the service script path.This might be useful for example to
+              create a BTRFS snapshot of your data in the <literal>$preHook</literal>.
+            '';
+          };
         };
       }
     ));


### PR DESCRIPTION
Needed to (properly) add additional packages for the hooks (e.g. btrfs-progs to create snapshots).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I am transitioning my backup solution from BTRFS snapshots to borg repositories and therefore, I can use snapshots to provide borg a consistent, read-only version of my data. I've added pre- and post-hooks to create and delete snapshots, but it requires the package `btrfs-progs` to be in `PATH`. My temporary solution is to manually set the path of the service, but it uses the hard-coded, final name of the service and will therefore break if the naming scheme changes. I guess I'm not the only one with this requirement and that an extra option for that would be nice. So, here it is!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
