### PR TITLE
imv: install .desktop file

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A command line image viewer for tiling window managers";
     homepage = "https://github.com/eXeC64/imv";
-    license = licenses.gpl2;
+    license = licenses.mit;
     maintainers = with maintainers; [ rnhmjoj markus1189 ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -90,6 +90,12 @@ stdenv.mkDerivation rec {
   ] ++ windowSystems."${withWindowSystem}"
     ++ builtins.map (b: backends."${b}") withBackends;
 
+  postInstall = ''
+    # fix the executable path and install the desktop item
+    substituteInPlace ../files/imv.desktop --replace "imv %F" "$out/bin/imv %F"
+    install -Dm644 ../files/imv.desktop $out/share/applications/
+  '';
+
   postFixup = lib.optionalString (withWindowSystem == "all") ''
     # The `bin/imv` script assumes imv-wayland or imv-x11 in PATH,
     # so we have to fix those to the binaries we installed into the /nix/store

--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -5,7 +5,6 @@
 , cmocka
 , docbook_xsl
 , libxslt
-, fontconfig
 , meson
 , ninja
 , pkg-config


### PR DESCRIPTION
###### Motivation for this change

Install upstream's `imv.desktop` file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
