### PR TITLE
ell: 0.40 -> 0.41, iwd: 1.14 -> 1.15

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.40";
+  version = "0.41";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/${pname}/${pname}.git";
     rev = version;
-    sha256 = "sha256-Yr08Kb8YU7xqBnhhS8rn+GFXAV68Hgj4aY26eptb9/8=";
+    sha256 = "sha256-UCE+PgGmbePlOoAc8jXxCX6fHr16qf1AQMKxizfSTJM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "1.14";
+  version = "1.15";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     rev = version;
-    sha256 = "sha256-uGe4TO1/bs8k2z3wOJqaZgT6u6yX/7wx4HMSS2hN4XE=";
+    sha256 = "sha256-qGQDIzJfeBT9VLwr9Ci9vXcM0ZvFvjL2E9PcKoZ8E94=";
   };
 
   outputs = [ "out" "man" ]


### PR DESCRIPTION
###### Motivation for this change
ell, https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=0.41
```
ver 0.41:
	Fix issue with endianness of DHCP packets.
	Fix issue with lease handling of the DHCP server.
```

iwd, https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog?h=1.15
```
ver 1.15:
	Add support for FT-over-DS procedure with multiple BSS.
	Add support for estimation of VHT RX data rate.
	Add support for exporting Daemon information.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
