### PR TITLE
nixos: move default module location logic to `eval-config.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,35 +21,13 @@
 
         nixos = import ./nixos/lib { lib = final; };
 
-        nixosSystem = { modules, ... } @ args:
+        nixosSystem = args:
           import ./nixos/lib/eval-config.nix (args // {
-            modules =
-              let
-                moduleDeclarationFile =
-                  let
-                    # Even though `modules` is a mandatory argument for `nixosSystem`, it doesn't
-                    # mean that the evaluator always keeps track of its position. If there
-                    # are too many levels of indirection, the position gets lost at some point.
-                    intermediatePos = builtins.unsafeGetAttrPos "modules" args;
-                  in
-                    if intermediatePos == null then null else intermediatePos.file;
-
-                # Add the invoking file as error message location for modules
-                # that don't have their own locations; presumably inline modules.
-                addModuleDeclarationFile =
-                  m: if moduleDeclarationFile == null then m else {
-                    _file = moduleDeclarationFile;
-                    imports = [ m ];
-                  };
-
-              in
-              map addModuleDeclarationFile modules ++ [
-                {
-                  system.nixos.versionSuffix =
-                    ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
-                  system.nixos.revision = final.mkIf (self ? rev) self.rev;
-                }
-              ];
+            modules = args.modules ++ [ {
+              system.nixos.versionSuffix =
+                ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
+              system.nixos.revision = final.mkIf (self ? rev) self.rev;
+            } ];
           });
       });
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -111,8 +111,8 @@ let
       cleanSource sourceByRegex sourceFilesBySuffices
       commitIdFromGitRepo cleanSourceWith pathHasContext
       canCleanSource pathIsRegularFile pathIsGitRepo;
-    inherit (self.modules) evalModules unifyModuleSyntax
-      applyIfFunction mergeModules
+    inherit (self.modules) evalModules setDefaultModuleLocation
+      unifyModuleSyntax applyIfFunction mergeModules
       mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions
       pushDownProperties dischargeProperties filterOverrides
       sortProperties fixupOptionType mkIf mkAssert mkMerge mkOverride


### PR DESCRIPTION
~This patch refactors `nixosSystem` in a few ways.~

~Semantically, it changes two things:~
1. ~the `lib` argument that is passed to `nixos/lib/eval-config.nix` now defaults to `final`: this makes extensions of the lib (including `nixosSystem` itself) available in the modules by default.~
2. ~`system.nixos.versionSuffix` and `system.nixos.revision` are now also set in the VM configs, not only in the top-level config.~

~I have tested both of these things.~

~Syntactically, it removes a bit of duplication.~

The only thing that is now being done by this PR is to move the `addModuleDeclarationFile` bit into `eval-config.nix` as it doesn't only make sense for flake configs.

cc @edolstra @cole-h 