### PR TITLE
nixos/sysctl: dynamic inotify watches or higher defaults

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -59,5 +59,21 @@ in
     # Disable YAMA by default to allow easy debugging.
     boot.kernel.sysctl."kernel.yama.ptrace_scope" = mkDefault 0;
 
+    # Dynamic since kernel v5.12
+    # https://github.com/torvalds/linux/commit/ac7b79fd190b02e7151bc7d2b9da692f537657f3
+    # From version 5.12 inotify instances are charegd memcg, so to let memcg work
+    # properly in all possible circumstance, kernel mainatainers (see commit) suggest
+    # to make this value ineffective by setting it to the maximum
+    boot.kernel.sysctl."fs.inotify.max_user_instances" =
+      if (config.boot.kernelPackages.kernel.kernelAtLeast "5.12")
+      then mkDefault 2147483647 # INT_MAX, dynamically limited based on available memory
+      else mkDefault 8192; # instead of 128
+
+    # Dynamic since kernel v5.11
+    # https://github.com/torvalds/linux/commit/92890123749bafc317bbfacbe0a62ce08d78efb7
+    boot.kernel.sysctl."fs.inotify.max_user_watches" = mkIf
+      (config.boot.kernelPackages.kernel.kernelOlder "5.11")
+      (mkDefault 1048576); # instead of 8192
+
   };
 }

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -663,12 +663,6 @@ in
       icons.enable = true;
     };
 
-    # The default max inotify watches is 8192.
-    # Nowadays most apps require a good number of inotify watches,
-    # the value below is used by default on several other distros.
-    boot.kernel.sysctl."fs.inotify.max_user_instances" = mkDefault 524288;
-    boot.kernel.sysctl."fs.inotify.max_user_watches" = mkDefault 524288;
-
     systemd.defaultUnit = mkIf cfg.autorun "graphical.target";
 
     systemd.services.display-manager =

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -167,8 +167,6 @@ in {
 
     boot.kernel.sysctl = mkIf cfg.recommendedSysctlSettings {
       "fs.inotify.max_queued_events" = 1048576;
-      "fs.inotify.max_user_instances" = 1048576;
-      "fs.inotify.max_user_watches" = 1048576;
       "vm.max_map_count" = 262144;
       "kernel.dmesg_restrict" = 1;
       "net.ipv4.neigh.default.gc_thresh3" = 8192;


### PR DESCRIPTION
Nowadays most applications require a good amount of inotify watches,
so raise our default to what other distros do. If kernel supports it
enable dynamic setting.
