### PR TITLE
markdown-anki-decks: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/markdown-anki-decks/default.nix
+++ b/pkgs/tools/misc/markdown-anki-decks/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "markdown-anki-decks";
+  version = "1.0.0";
+
+  format = "pyproject";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "R6T8KOHMb1Neg/RG5JQl9+7LxOkAoZL0L5wvVaqm9O0=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    genanki
+    typer
+    colorama
+    shellingham
+    beautifulsoup4
+    markdown
+    python-frontmatter
+  ];
+
+  postPatch = ''
+    # No API changes.
+    substituteInPlace pyproject.toml --replace 'python-frontmatter = "^0.5.0"' 'python-frontmatter = "^1.0.0"'
+  '';
+
+  # No tests available on Pypi and there is only a failing version assertion test in the repo.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Simple program to convert markdown files into anki decks";
+    maintainers = with maintainers; [ jtojnar ];
+    homepage = "https://github.com/lukesmurray/markdown-anki-decks";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/markdown-anki-decks/default.nix
+++ b/pkgs/tools/misc/markdown-anki-decks/default.nix
@@ -1,6 +1,5 @@
-{
-  lib,
-  python3,
+{ lib
+, python3
 }:
 
 python3.pkgs.buildPythonApplication rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17114,6 +17114,8 @@ in
 
   micronucleus = callPackage ../development/tools/misc/micronucleus { };
 
+  markdown-anki-decks = callPackage ../tools/misc/markdown-anki-decks { };
+
   micropython = callPackage ../development/interpreters/micropython { };
 
   MIDIVisualizer = callPackage ../applications/audio/midi-visualizer { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
