### PR TITLE
whitesur-icon-theme: init at 2021-05-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4275,6 +4275,12 @@
     githubId = 3661115;
     name = "Ingo Blechschmidt";
   };
+  icy-thought = {
+    name = "Icy-Thought";
+    email = "gilganyx@pm.me";
+    github = "Icy-Thought";
+    githubId = 53710398;
+  };
   idontgetoutmuch = {
     email = "dominic@steinitz.org";
     github = "idontgetoutmuch";

--- a/pkgs/data/icons/whitesur-icon-theme/default.nix
+++ b/pkgs/data/icons/whitesur-icon-theme/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, gtk3
+, gnome
+, gnome-icon-theme
+, hicolor-icon-theme
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "Whitesur-icon-theme";
+  version = "2021-05-20";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "KboUYozTleOBKNun66g2oj7u/36hyQsPtRSk/x/LAWo=";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  BuildInputs = [
+    gnome-icon-theme
+    gnome.adwaita-icon-theme
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons/WhiteSur{,-dark}/status
+    echo "$out/share/icons/WhiteSur/status $out/share/icons/WhiteSur-dark/status" | xargs -n 1 cp -r src/status/{16,22,24,32,symbolic}
+    echo "$out/share/icons/WhiteSur $out/share/icons/WhiteSur-dark" | xargs -n 1 cp -r ./{COPYING,AUTHORS} src/index.theme src/{actions,animations,apps,categories,devices,emblems,mimes,places} links/{actions,apps,categories,devices,emblems,mimes,places,status}
+
+    # Change icon color for dark theme
+    sed -i "s/#363636/#dedede/g" $out/share/icons/WhiteSur-dark/{actions,devices,places,status}/{16,22,24}/*
+    sed -i "s/#363636/#dedede/g" $out/share/icons/WhiteSur-dark/actions/32/*
+    sed -i "s/#363636/#dedede/g" $out/share/icons/WhiteSur-dark/{actions,apps,categories,emblems,devices,mimes,places,status}/symbolic/*
+
+    for f in actions animations apps categories devices emblems mimes places status; do
+      ln -sf $out/share/icons/WhiteSur/$f $out/share/icons/WhiteSur/$f@2x
+      ln -sf $out/share/icons/WhiteSur-dark/$f $out/share/icons/WhiteSur-dark/$f@2x
+    done
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "MacOS Big Sur style icon theme for Linux desktops";
+    homepage = "https://github.com/vinceliuice/WhiteSur-icon-theme";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ icy-thought ];
+  };
+
+}

--- a/pkgs/data/icons/whitesur-icon-theme/default.nix
+++ b/pkgs/data/icons/whitesur-icon-theme/default.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ gtk3 ];
 
-  BuildInputs = [
+  buildInputs = [
     gnome-icon-theme
     gnome.adwaita-icon-theme
     hicolor-icon-theme

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22530,6 +22530,8 @@ in
 
   weather-icons = callPackage ../data/fonts/weather-icons { };
 
+  whitesur-icon-theme = callPackage ../data/icons/whitesur-icon-theme { };
+
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };
 
   work-sans  = callPackage ../data/fonts/work-sans { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add `Whitesur-icon-theme` to nixpkgs for the sake of reducing the effort required by the user to install an icon theme.

I do apologize for re-creating this pull-request (#126491). I had accidentally re-based more than my own commits even though I had cancelled the re-base operation through `:!q`.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
