### PR TITLE
xfce.mkXfceDerivation: fix homepage

### DIFF
--- a/pkgs/desktops/xfce/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce/mkXfceDerivation.nix
@@ -47,7 +47,7 @@ let
     };
 
     meta = with lib; {
-      homepage = "https://gitlab.xfce.org/${category}/${pname}/about";
+      homepage = "https://gitlab.xfce.org/${category}/${pname}";
       license = licenses.gpl2Plus; # some libraries are under LGPLv2+
       platforms = platforms.linux;
     };


### PR DESCRIPTION
`/about` redirects to a sign in page, so link to the repo's root instead.

Example: https://gitlab.xfce.org/xfce/thunar/about
