### PR TITLE
orocos-kdl: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/orocos-kdl/default.nix
+++ b/pkgs/development/libraries/orocos-kdl/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "orocos-kdl";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "orocos";
     repo = "orocos_kinematics_dynamics";
     rev = "v${version}";
-    sha256 = "0qj56j231h0rnjbglakammxn2lwmhy5f2qa37v1f6pcn81dn13vv";
+    sha256 = "181w2q6lsrfcvrgqwi6m0xrydjlblj1b654apf2d7zjc7qqgd6ca";
+    # Needed to build Python bindings
+    fetchSubmodules = true;
   };
 
   sourceRoot = "source/orocos_kdl";

--- a/pkgs/development/python-modules/pykdl/default.nix
+++ b/pkgs/development/python-modules/pykdl/default.nix
@@ -1,24 +1,20 @@
-{ lib, stdenv, toPythonModule, fetchpatch, cmake, orocos-kdl, python, sip_4 }:
+{ lib, stdenv, toPythonModule, cmake, orocos-kdl, eigen, python }:
 
 toPythonModule (stdenv.mkDerivation {
   pname = "pykdl";
   inherit (orocos-kdl) version src;
 
-  patches = [
-    # Fix build with SIP 4.19.23+. Can be removed with version 1.5.
-    # https://github.com/orocos/orocos_kinematics_dynamics/pull/270
-    (fetchpatch {
-      url = "https://github.com/orocos/orocos_kinematics_dynamics/commit/d8d087ad0e1c41f3489d1a255ebfa27b5695196b.patch";
-      sha256 = "0qyskqxv4a982kidzzyh34xj2iiw791ipbbl29jg4qb4l21xwqlg";
-      stripLen = 1;
-    })
-  ];
-
   sourceRoot = "source/python_orocos_kdl";
 
+  # Fix hardcoded installation path
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace dist-packages site-packages
+  '';
+
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ orocos-kdl ];
-  propagatedBuildInputs = [ python sip_4 ];
+  buildInputs = [ orocos-kdl eigen ];
+  propagatedBuildInputs = [ python ];
 
   meta = with lib; {
     description = "Kinematics and Dynamics Library (Python bindings)";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates orocos-kdl to the latest version. The Python bindings have migrated from SIP to pybind11 (included in the repo as a vendored submodule).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
