### PR TITLE
faust: fix compiler flags when used outside nix shell

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -178,6 +178,12 @@ let
 
         # export parts of the build environment
         for script in "$out"/bin/*; do
+          # e.g. NIX_CC_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu
+          nix_cc_wrapper_target_host="$(printenv | grep ^NIX_CC_WRAPPER_TARGET_HOST | sed 's/=.*//')"
+
+          # e.g. NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu
+          nix_bintools_wrapper_target_host="$(printenv | grep ^NIX_BINTOOLS_WRAPPER_TARGET_HOST | sed 's/=.*//')"
+
           wrapProgram "$script" \
             --set FAUSTLDDIR "${faust}/lib" \
             --set FAUSTLIB "${faust}/share/faust" \
@@ -187,7 +193,9 @@ let
             --prefix PKG_CONFIG_PATH : "$PKG_CONFIG_PATH" \
             --set NIX_CFLAGS_COMPILE "$NIX_CFLAGS_COMPILE" \
             --set NIX_LDFLAGS "$NIX_LDFLAGS -lpthread" \
-            --prefix LIBRARY_PATH $libPath
+            --set "$nix_cc_wrapper_target_host" "''${!nix_cc_wrapper_target_host}" \
+            --set "$nix_bintools_wrapper_target_host" "''${!nix_bintools_wrapper_target_host}" \
+            --prefix LIBRARY_PATH "$libPath"
         done
       '';
     });


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/78610

The issue is some additional environment variables added to the nix
compiler wrappers that also need to be exported by the faust
wrapper.

This "wrapWithBuildEnv" solution is very hacky, but I
don't know of a better solution.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Many faust scripts not working outside of nix-shell


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
