### PR TITLE
[staging] glib: add removeGIOModuleCache postIntall phase

### DIFF
--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -32,3 +32,16 @@ if [[ " ${preFixupPhases:-} " =~ " gappsWrapperArgsHook " ]]; then
 else
     preFixupPhases+=" glibPreFixupPhase"
 fi
+
+
+removeGIOModuleCache() {
+  echo "Executing removeGIOModuleCache"
+
+  rm -f ${!outputLib}/lib/gio/modules/giomodule.cache
+
+  echo "Finished removeGIOModuleCache"
+}
+
+if [ -z ${dontRemoveGIOModuleCache:-} ]; then
+  preFixupPhases+=" removeGIOModuleCache"
+fi


### PR DESCRIPTION
###### Motivation for this change

glib-querymodules may leave behind a giomodule.cache.
However, this cache does not make sense on a per-package
basis, as it's meant to represent the present modules
in a given environment. So when many packages are introduced
these cache will no longer be valid. Not to mention they
cause collisions when present with other packages.

This hook hopes to remove any presence of the cache across
any package which utilizes glib.

(properly) closes: #13488 
related: https://discourse.nixos.org/t/21-05-not-installing/13547/11

cc @NixOS/gnome 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
