### PR TITLE
google-fonts: unstable-2021-01-19 -> unstable-2021-06-12

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -1,21 +1,17 @@
-{ lib
-, stdenv
-, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "google-fonts";
-  version = "unstable-2021-01-19";
+  version = "unstable-2021-06-12";
 
   outputs = [ "out" "adobeBlank" ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
-    rev = "a3a831f0fe44cd58465c6937ea06873728f2ba0d";
-    sha256 = "19abx2bj7mkysv2ihr43m3kpyf6kv6v2qjlm1skxc82rb72xqhix";
+    rev = "370c795d7e5f9b02db9a793c2779e2c8f94c6adc";
+    sha256 = "sha256-XKjxmupY2KuefCtKZMXWaba1TnNwdYM/P0xGXOtBGmM=";
   };
-
-  phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
   patchPhase = ''
     # These directories need to be removed because they contain
@@ -32,6 +28,8 @@ stdenv.mkDerivation {
       exit 1
     fi
   '';
+
+  dontBuild = true;
 
   installPhase = ''
     adobeBlankDest=$adobeBlank/share/fonts/truetype

--- a/pkgs/data/fonts/ricty/default.nix
+++ b/pkgs/data/fonts/ricty/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "4.1.1";
 
   src = fetchurl {
-      url = "http://www.yusa.lab.uec.ac.jp/~yusa/ricty/ricty_generator-${version}.sh";
+      url = "https://rictyfonts.github.io/files/ricty_generator-${version}.sh";
       sha256 = "03fngb8f5hl7ifigdm5yljhs4z2x80cq8y8kna86d07ghknhzgw6";
   };
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A high-quality Japanese font based on Inconsolata and Migu 1M";
-    homepage = "http://www.yusa.lab.uec.ac.jp/~yusa/ricty.html";
+    homepage = "https://rictyfonts.github.io";
     license = licenses.unfree;
     maintainers = [ maintainers.mikoim ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump google fonts to `unstable-2021-06-12`

Also move to `stdenvNoCC` to reduce rebuilds

I garbage collect fairly often but I have quite a few instances of google-fonts in my nix-store even though it hasn't updated.
This could be resolved by moving it to just be `fetchFromGithub` and drop `mkDerivation` but because of the `outputs` the next best solution seems to be `stdenvNoCC`

```
λ fd ".*google-fonts-unstable.*" -t d /
/nix/store/xq9xkhzhvp5x861ij28d7ghsmmlyqbvi-google-fonts-unstable-2021-06-12-adobeBlank
/nix/store/9g80rj2wi2pcd2l8i8crjxhjp8fj9vra-google-fonts-unstable-2021-01-19-adobeBlank
/nix/store/8dfqhff381s4aqfgnc6sqcz4ynkfky1h-google-fonts-unstable-2021-01-19
/nix/store/jyank786cx426n66yz7iw956yd60b94x-google-fonts-unstable-2021-01-19
/nix/store/dx64fvyhvw3y6jx40dn4kr9j390ih3j2-google-fonts-unstable-2021-01-19-adobeBlank
/nix/store/y94277acj1grbyg9rz7ada6c4wnn62pr-google-fonts-unstable-2021-01-19
/nix/store/5kwp5jaym1kcd9szv4lv91rjrsbaqdsm-google-fonts-unstable-2021-01-19
/nix/store/nqv275a7414g2vjzm19ri8f4kl79i65i-google-fonts-unstable-2021-01-19-adobeBlank
/nix/store/xmcwks59b9q13fqcy3d6lq1algzy66ph-google-fonts-unstable-2021-06-12
```

```
# trimmed anything below 1k
λ fd ".*google-fonts.*" -t d / --exec du -d1
1480288	/nix/store/xmcwks59b9q13fqcy3d6lq1algzy66ph-google-fonts-unstable-2021-06-12/share
1480292	/nix/store/xmcwks59b9q13fqcy3d6lq1algzy66ph-google-fonts-unstable-2021-06-12
1345964	/nix/store/jyank786cx426n66yz7iw956yd60b94x-google-fonts-unstable-2021-01-19/share
1345968	/nix/store/jyank786cx426n66yz7iw956yd60b94x-google-fonts-unstable-2021-01-19
1345964	/nix/store/y94277acj1grbyg9rz7ada6c4wnn62pr-google-fonts-unstable-2021-01-19/share
1345968	/nix/store/y94277acj1grbyg9rz7ada6c4wnn62pr-google-fonts-unstable-2021-01-19
1345960	/nix/store/5kwp5jaym1kcd9szv4lv91rjrsbaqdsm-google-fonts-unstable-2021-01-19/share
1345964	/nix/store/5kwp5jaym1kcd9szv4lv91rjrsbaqdsm-google-fonts-unstable-2021-01-19
1346008	/nix/store/8dfqhff381s4aqfgnc6sqcz4ynkfky1h-google-fonts-unstable-2021-01-19/share
1346012	/nix/store/8dfqhff381s4aqfgnc6sqcz4ynkfky1h-google-fonts-unstable-2021-01-19

# total 13728388 or 13GiB 
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
