### PR TITLE
vdirsyncer: 0.16.8 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/click-threading/default.nix
+++ b/pkgs/development/python-modules/click-threading/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "click-threading";
-  version = "0.4.4";
+  version = "0.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b2b0fada5bf184b56afaccc99d0d2548d8ab07feb2e95e29e490f6b99c605de7";
+    sha256 = "sha256-rc/mI8AqWVwQfDFAcvZ6Inj+TrQLcsDRoskDzHivNDk=";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
-, isPy27
+, pythonOlder
 , click
 , click-log
 , click-threading
@@ -18,21 +18,23 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.16.8";
+  version = "0.18.0";
   pname = "vdirsyncer";
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bfdb422f52e1d4d60bd0635d203fb59fa7f613397d079661eb48e79464ba13c5";
+    sha256 = "sha256-J7w+1R93STX7ujkpFcjI1M9jmuUaRLZ0aGtJoQJfwgE=";
   };
 
   propagatedBuildInputs = [
-    click click-log click-threading
-    requests_toolbelt
+    atomicwrites
+    click
+    click-log
+    click-threading
     requests
     requests_oauthlib # required for google oauth sync
-    atomicwrites
+    requests_toolbelt
   ];
 
   nativeBuildInputs = [
@@ -46,16 +48,8 @@ buildPythonPackage rec {
     pytest-subtesthack
   ];
 
-  patches = [
-    (fetchpatch {
-      name = "update-usage-deprecated-method.patch";
-      url = "https://github.com/pimutils/vdirsyncer/commit/7577fa21177442aacc2d86640ef28cebf1c4aaef.patch";
-      sha256 = "0inkr1wfal20kssij8l5myhpjivxg8wlvhppqc3lvml9d1i75qbh";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace setup.py --replace "click>=5.0,<6.0" "click"
+    sed -i -e '/--cov/d' -e '/--no-cov/d' setup.cfg
   '';
 
   preCheck = ''
@@ -63,8 +57,9 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    "test_verbosity"
     "test_create_collections" # Flaky test exceeds deadline on hydra: https://github.com/pimutils/vdirsyncer/issues/837
+    "test_request_ssl"
+    "test_verbosity"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Includes dependency update: python3Packages.click-threading: 0.4.4 -> 0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
