### PR TITLE
kitty: 0.21.0 -> 0.21.1

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -21,14 +21,14 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.21.0";
+  version = "0.21.1";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "sha256-n8ipIQAfKPVApJhuTrlSSsd6dlPeCUvk7rdiVmL9i+4=";
+    sha256 = "sha256-/+OSVjC4++A4kaxEfI2kIgjXxL67lfoXCdH2PykLWxA=";
   };
 
   buildInputs = [

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -68,17 +68,21 @@ buildPythonApplication rec {
 
   dontConfigure = true;
 
-  buildPhase = if stdenv.isDarwin then ''
-    ${python.interpreter} setup.py kitty.app \
-    --update-check-interval=0 \
-    --disable-link-time-optimization
-    make man
-  '' else ''
-    ${python.interpreter} setup.py linux-package \
-    --update-check-interval=0 \
-    --egl-library='${lib.getLib libGL}/lib/libEGL.so.1' \
-    --startup-notification-library='${libstartup_notification}/lib/libstartup-notification-1.so' \
-    --canberra-library='${libcanberra}/lib/libcanberra.so'
+  buildPhase = ''
+    runHook preBuild
+    ${if stdenv.isDarwin then ''
+      ${python.interpreter} setup.py kitty.app \
+      --update-check-interval=0 \
+      --disable-link-time-optimization
+      make man
+    '' else ''
+      ${python.interpreter} setup.py linux-package \
+      --update-check-interval=0 \
+      --egl-library='${lib.getLib libGL}/lib/libEGL.so.1' \
+      --startup-notification-library='${libstartup_notification}/lib/libstartup-notification-1.so' \
+      --canberra-library='${libcanberra}/lib/libcanberra.so'
+    ''}
+    runHook postBuild
   '';
 
   checkInputs = [ pillow ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/kovidgoyal/kitty/releases/tag/v0.21.1
Update kitty and also run preBuild and postBuild in the buildPhase.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).