### PR TITLE
litecli: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -1,16 +1,15 @@
-{ lib, python3Packages }:
+{ lib
+, python3Packages
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "litecli";
-  version = "1.5.0";
-
-  # Python 2 won't have prompt_toolkit 2.x.x
-  # See: https://github.com/NixOS/nixpkgs/blob/f49e2ad3657dede09dc998a4a98fd5033fb52243/pkgs/top-level/python-packages.nix#L3408
-  disabled = python3Packages.isPy27;
+  version = "1.6.0";
+  disabled = python3Packages.pythonOlder "3.4";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "b09f0804d26b018360b240778612390810e8e00ea0f79d5412fd0d4775c0e3cd";
+    sha256 = "sha256-TSdOFHW007syOEg4gwvEqDiJkrfLgRmqjP/H/6oBZ/k=";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -26,6 +25,8 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
     mock
   ];
+
+  pythonImportsCheck = [ "litecli" ];
 
   meta = with lib; {
     description = "Command-line interface for SQLite";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.6.0

Change log: https://github.com/dbcli/litecli/blob/master/CHANGELOG.md#160---2021-03-15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
