### PR TITLE
llvmPackages_git: 2021-05-17 -> 2021-06-04

### DIFF
--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -21,8 +21,8 @@ let
   release_version = "13.0.0";
   candidate = ""; # empty or "rcN"
   dash-candidate = lib.optionalString (candidate != "") "-${candidate}";
-  rev = "d3676d4b666ead794fc58bbc7e07aa406dcf487a"; # When using a Git commit
-  rev-version = "unstable-2021-05-17"; # When using a Git commit
+  rev = "50c0aaed47b518beea550a6858c2967eaeaef7eb"; # When using a Git commit
+  rev-version = "unstable-2021-06-04"; # When using a Git commit
   version = if rev != "" then rev-version else "${release_version}${dash-candidate}";
   targetConfig = stdenv.targetPlatform.config;
 
@@ -30,7 +30,7 @@ let
     owner = "llvm";
     repo = "llvm-project";
     rev = if rev != "" then rev else "llvmorg-${version}";
-    sha256 = "0aw5hnlp3m21dqyqz9z8669achsfhyi7lsl17hh0j45q0qlxnmyw";
+    sha256 = "1w1ahcg707yh3xiy6y28b90ag03dwjplj0bg39l4w72krqr28661";
   };
 
   llvm_meta = {
@@ -257,9 +257,7 @@ let
 
     libunwind = callPackage ./libunwind {
       inherit llvm_meta;
-      stdenv = if stdenv.hostPlatform.useLLVM or false
-               then overrideCC stdenv buildLlvmTools.clangNoLibcxx
-               else stdenv;
+      stdenv = overrideCC stdenv buildLlvmTools.clangNoLibcxx;
     };
 
     openmp = callPackage ./openmp {

--- a/pkgs/development/compilers/llvm/git/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/git/openmp/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
+  cmakeFlags = [
+    "-DLIBOMPTARGET_BUILD_AMDGCN_BCLIB=OFF" # Building the AMDGCN device RTL currently fails
+  ];
+
   meta = llvm_meta // {
     homepage = "https://openmp.llvm.org/";
     description = "Support for the OpenMP language";


### PR DESCRIPTION
This also fixes the libunwind build (even with GCC 11 it fails with):
/build/source/libunwind/src/libunwind.cpp:19:5: warning: "__has_feature" is not defined, evaluates to 0 [-Wundef]
   19 | #if __has_feature(address_sanitizer)
      |     ^~~~~~~~~~~~~
/build/source/libunwind/src/libunwind.cpp:19:18: error: missing binary operator before token "("
   19 | #if __has_feature(address_sanitizer)
      |                  ^

And the openmp build which failed with this error:
/nix/store/a4yw1svqqk4d8lhwinn9xp847zz9gfma-bash-4.4-p23/bin/bash: CLANG_TOOL-NOTFOUND: command not found
/nix/store/a4yw1svqqk4d8lhwinn9xp847zz9gfma-bash-4.4-p23/bin/bash: CLANG_TOOL-NOTFOUND: command not found
make[2]: *** [libomptarget/deviceRTLs/amdgcn/CMakeFiles/libomptarget-amdgcn-gfx906.dir/build.make:307: libomptarget/deviceRTLs/amdgcn/task.gfx906.bc] Error 127
make[2]: *** [libomptarget/deviceRTLs/amdgcn/CMakeFiles/libomptarget-amdgcn-gfx900.dir/build.make:307: libomptarget/deviceRTLs/amdgcn/task.gfx900.bc] Error 127

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
