### PR TITLE
nixos: make GIO_EXTRA_MODULES a session variable

### DIFF
--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -60,7 +60,7 @@ in
     environment.systemPackages = [ pkgs.dconf ];
 
     # Needed for unwrapped applications
-    environment.variables.GIO_EXTRA_MODULES = mkIf cfg.enable [ "${pkgs.dconf.lib}/lib/gio/modules" ];
+    environment.sessionVariables.GIO_EXTRA_MODULES = mkIf cfg.enable [ "${pkgs.dconf.lib}/lib/gio/modules" ];
   };
 
 }

--- a/nixos/modules/services/desktops/gnome/glib-networking.nix
+++ b/nixos/modules/services/desktops/gnome/glib-networking.nix
@@ -38,7 +38,7 @@ with lib;
 
     systemd.packages = [ pkgs.glib-networking ];
 
-    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.glib-networking.out}/lib/gio/modules" ];
+    environment.sessionVariables.GIO_EXTRA_MODULES = [ "${pkgs.glib-networking.out}/lib/gio/modules" ];
 
   };
 

--- a/nixos/modules/services/desktops/gvfs.nix
+++ b/nixos/modules/services/desktops/gvfs.nix
@@ -56,7 +56,7 @@ in
     services.udev.packages = [ pkgs.libmtp.bin ];
 
     # Needed for unwrapped applications
-    environment.variables.GIO_EXTRA_MODULES = [ "${cfg.package}/lib/gio/modules" ];
+    environment.sessionVariables.GIO_EXTRA_MODULES = [ "${cfg.package}/lib/gio/modules" ];
 
   };
 


### PR DESCRIPTION
At the moment, Thunar doesn't render thumbnails for files in the trash, because the tumbler instance started by dbus can't find the gvfs GIO extra modules (tumbler doesn't depend on gvfs so they're not added to `GIO_EXTRA_MODULES` in the `wrapGAppsHook` wrapper, if I understand things correctly).

This PR makes `GIO_EXTRA_MODULES` a `sessionVariable` instead of a `variable` in the three modules that define it, including the gvfs module. This shouldn't break anything, and I have confirmed that it fixes my issue.

cc @worldofpeace @jtojnar 