### PR TITLE
kyotocabinet: 1.2.76 -> 1.2.79

### DIFF
--- a/pkgs/development/libraries/kyotocabinet/default.nix
+++ b/pkgs/development/libraries/kyotocabinet/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "kyotocabinet-1.2.76";
+  name = "kyotocabinet-1.2.79";
 
   src = fetchurl {
-    url = "http://fallabs.com/kyotocabinet/pkg/${name}.tar.gz";
-    sha256 = "0g6js20x7vnpq4p8ghbw3mh9wpqksya9vwhzdx6dnlf354zjsal1";
+    url = "https://dbmx.net/kyotocabinet/pkg/${name}.tar.gz";
+    sha256 = "079ymsahlrijswgwfr2la9yw5h57l752cprhp5dz31iamsj1vyv7";
   };
 
   prePatch = lib.optionalString stdenv.isDarwin ''
@@ -24,18 +24,12 @@ stdenv.mkDerivation rec {
         --replace stdc++ c++
   '';
 
-  patches = [(fetchurl {
-    name = "gcc6.patch";
-    url = "https://src.fedoraproject.org/rpms/kyotocabinet/raw/master/f/kyotocabinet-1.2.76-gcc6.patch";
-    sha256 = "1h5k38mkiq7lz8nd2gbn7yvimcz49g3z7phn1cr560bzjih8rz23";
-  })];
-
   buildInputs = [ zlib ];
 
   meta = with lib; {
-    homepage = "http://fallabs.com/kyotocabinet";
+    homepage = "https://dbmx.net/kyotocabinet";
     description = "A library of routines for managing a database";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/kyotocabinet/default.nix
+++ b/pkgs/development/libraries/kyotocabinet/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.2.79";
 
   src = fetchurl {
-    url = "https://dbmx.net/kyotocabinet/pkg/${name}.tar.gz";
+    url = "https://dbmx.net/kyotocabinet/pkg/kyotocabinet-${version}.tar.gz";
     sha256 = "079ymsahlrijswgwfr2la9yw5h57l752cprhp5dz31iamsj1vyv7";
   };
 

--- a/pkgs/development/libraries/kyotocabinet/default.nix
+++ b/pkgs/development/libraries/kyotocabinet/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchurl, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "kyotocabinet-1.2.79";
+  pname = "kyotocabinet";
+  version = "1.2.79";
 
   src = fetchurl {
     url = "https://dbmx.net/kyotocabinet/pkg/${name}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

Also clarify license and fix download URL and homepage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
