### PR TITLE
jquake: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7063,6 +7063,11 @@
     githubId = 628342;
     name = "Tim Steinbach";
   };
+  nessdoor = {
+    name = "Tomas Antonio Lopez";
+    email = "entropy.overseer@protonmail.com";
+    githubId = 25993494;
+  };
   netcrns = {
     email = "jason.wing@gmx.de";
     github = "netcrns";

--- a/pkgs/applications/misc/jquake/default.nix
+++ b/pkgs/applications/misc/jquake/default.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, fetchurl, copyDesktopItems, makeDesktopItem, unzip, jre8 }:
+
+stdenv.mkDerivation rec {
+  pname = "jquake";
+  version = "1.6.1";
+
+  src = fetchurl {
+    url = "https://fleneindre.github.io/downloads/JQuake_${version}_linux.zip";
+    sha256 = "0nw6xjc3i1b8rk15arc5d0ji2bycc40rz044qd03vzxvh0h8yvgl";
+  };
+
+  nativeBuildInputs = [ unzip copyDesktopItems ];
+
+  sourceRoot = ".";
+
+  postPatch = ''
+    # JQuake emits a lot of debug-like messages in console, but I
+    # don't think it's in our interest to void them by default. Log them at
+    # the appropriate level.
+    sed -i "/^java/ s/$/\ | logger -p user.debug/" JQuake.sh
+
+    # By default, an 'errors.log' file is created in the current directory.
+    # cd into a temporary directory and let it be created there.
+    substituteInPlace JQuake.sh \
+      --replace "java -jar " "exec ${jre8.outPath}/bin/java -jar $out/lib/" \
+      --replace "[JAR FOLDER]" "\$(mktemp -p /tmp -d jquake-errlog-XXX)"
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    chmod +x JQuake.sh
+
+    mkdir -p $out/{bin,lib}
+    mv JQuake.sh $out/bin/JQuake
+    mv {JQuake.jar,JQuake_lib} $out/lib
+    mv sounds $out/lib
+
+    mkdir -p $out/share/licenses/jquake
+    mv LICENSE* $out/share/licenses/jquake
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "JQuake";
+      desktopName = "JQuake";
+      exec = "JQuake";
+      comment = "Real-time earthquake map of Japan";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Real-time earthquake map of Japan";
+    homepage = "http://jquake.net";
+    downloadPage = "https://jquake.net/?down";
+    changelog = "https://jquake.net/?docu";
+    maintainers = with maintainers; [ nessdoor ];
+    license = licenses.unfree;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29989,6 +29989,8 @@ in
 
   j2cli = with python3Packages; toPythonApplication j2cli;
 
+  jquake = callPackage ../applications/misc/jquake { };
+
   jstest-gtk = callPackage ../tools/misc/jstest-gtk { };
 
   keynav = callPackage ../tools/X11/keynav { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
JQuake can be a very useful application for residents of Japan, and having it as a stand-alone application can be annoying due to the requirement for JRE 8. Its Nix expression turned out to be straightforward, and I don't see a reason for not having it here.

Creating a package that also works for Darwin should be easy, but I don't have a Darwin system, so help on this front is welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
