### PR TITLE
bear: 3.0.9 -> 3.0.12

### DIFF
--- a/pkgs/development/tools/build-managers/bear/default.nix
+++ b/pkgs/development/tools/build-managers/bear/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bear";
-  version = "3.0.9";
+  version = "3.0.12";
 
   src = fetchFromGitHub {
     owner = "rizsotto";
     repo = pname;
     rev = version;
-    sha256 = "xac8PYo3qYjtQbDy8piOz5BQQpcVlAvMCv1qHrVZmPQ=";
+    sha256 = "0nalvmkl9iwbs4wbsacryrwr46vk3x6jzqj9v5wfyf6aim3s1szs";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/rizsotto/Bear";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = [ maintainers.babariviere ];
+    maintainers = with maintainers; [ babariviere qyliss ];
     # ld: symbol(s) not found for architecture x86_64
     broken = stdenv.isDarwin;
   };

--- a/pkgs/development/tools/build-managers/bear/no-double-relative.patch
+++ b/pkgs/development/tools/build-managers/bear/no-double-relative.patch
@@ -1,14 +1,22 @@
-diff --git a/source/config.h.in b/source/config.h.in
-index 728c234..a3e76c6 100644
---- a/source/config.h.in
-+++ b/source/config.h.in
-@@ -65,6 +65,6 @@ constexpr char VERSION[] = "@CMAKE_PROJECT_VERSION@";
+diff --git i/source/config.h.in w/source/config.h.in
+index ffcce3a..0caba6d 100644
+--- i/source/config.h.in
++++ w/source/config.h.in
+@@ -107,7 +107,7 @@ namespace cmd {
+     }
  
- constexpr char CITNAMES_DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/citnames";
- constexpr char INTERCEPT_DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/intercept";
--constexpr char LIBRARY_DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBEXECDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
--constexpr char WRAPPER_DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBEXECDIR@/wrapper";
--constexpr char WRAPPER_DIR_DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBEXECDIR@/wrapper.d";
-+constexpr char LIBRARY_DEFAULT_PATH[] = "@CMAKE_INSTALL_LIBEXECDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
-+constexpr char WRAPPER_DEFAULT_PATH[] = "@CMAKE_INSTALL_LIBEXECDIR@/wrapper";
-+constexpr char WRAPPER_DIR_DEFAULT_PATH[] = "@CMAKE_INSTALL_LIBEXECDIR@/wrapper.d";
+     namespace wrapper {
+-        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@PRIVATE_INSTALLDIR@/wrapper";
++        constexpr char DEFAULT_PATH[] = "@PRIVATE_INSTALLDIR@/wrapper";
+         constexpr char DEFAULT_DIR_PATH[] = "@ROOT_INSTALL_PREFIX@/@PRIVATE_INSTALLDIR@/wrapper.d";
+ 
+         constexpr char FLAG_VERBOSE[] = "--verbose";
+@@ -120,7 +120,7 @@ namespace cmd {
+     }
+ 
+     namespace library {
+-        constexpr char DEFAULT_PATH[] = "@ROOT_INSTALL_PREFIX@/@PRIVATE_INSTALLDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
++        constexpr char DEFAULT_PATH[] = "@PRIVATE_INSTALLDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@exec@CMAKE_SHARED_LIBRARY_SUFFIX@";
+ 
+         constexpr char KEY_REPORTER[] = "INTERCEPT_REPORT_COMMAND";
+         constexpr char KEY_DESTINATION[] = "INTERCEPT_REPORT_DESTINATION";


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/117413

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
