### PR TITLE
iosevka-nerdfont: init at 2.1.0

### DIFF
--- a/pkgs/data/fonts/iosevka-nerdfont/default.nix
+++ b/pkgs/data/fonts/iosevka-nerdfont/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "iosevka-nerdfont";
+  version = "2021-04-25";
+
+  src = fetchFromGitHub {
+    owner = "ryanoasis";
+    repo = "nerd-fonts";
+    rev = "2d218ec31e98c959a368fb9bba45c0ee52103c87";
+    sha256 = "18m0w5kwlidp5p5pfa06d0jr2kfqcbcs9223k0bs25sgigqikac5";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp $src/*.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with lib; {
+    description = "Iosevka Nerd Font";
+    homepage = "https://github.com/ryanoasis/nerd-fonts";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

I want to have this font in the repo because I really like the Iosevka font but it doesn't look right with the [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt. Icons are missing the Nerd font version should fix this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Failed to successfully test with `nix-build -A <package>` but the `default.nix` has the same structure as `pkgs.meslo-lg-nf`, which I managed to install via my system configuration. `pkgs.meslo-lg-nf` failed too when trying `nix-build -A <package>` locally on my fork **so I think it is fine and this is a local problem.**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
