### PR TITLE
mautrix-telegram: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "mautrix";
-  version = "0.8.17";
+  version = "0.9.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9a15a8e39f9d0b36c91dfe0f5dd1efc8752cc1d317057840a3dbffd6ee90e068";
+    sha256 = "sha256-FDXddvSikrLDNP8Llyv2tqAGwNAo8B7b1NPmVfyzq3s=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "mautrix";
-  version = "0.9.4";
+  version = "0.9.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-FDXddvSikrLDNP8Llyv2tqAGwNAo8B7b1NPmVfyzq3s=";
+    sha256 = "1810deb7f780700e7e0734e1844c1b4b2525ee990b8665f7b98e3f335a31bbcf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "telethon";
-  version = "1.17.5";
+  version = "1.21.1";
 
   src = fetchPypi {
     inherit version;
     pname = "Telethon";
-    sha256 = "1v1rgr030z8s1ldv5lm1811znyd568c22pmlrzzf3ls972xk514m";
+    sha256 = "sha256-mTyDfvdFrd+XKifXv7oM5Riihj0aUOBzclW3ZNI+DvI=";
   };
 
   patchPhase = ''

--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -1,6 +1,18 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, python3, fetchFromGitHub }:
 
-python3Packages.buildPythonPackage rec {
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      mautrix = super.mautrix.overridePythonAttrs (oldAttrs: rec {
+        version = "0.8.18";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "32daf7a7dcf5d4013b37321df7b319f36523f38884ccc3e2e965917d0a5c73c1";
+        };
+      });
+    };
+  };
+in python.pkgs.buildPythonPackage rec {
   pname = "mautrix-signal";
   version = "0.1.1";
 
@@ -11,7 +23,7 @@ python3Packages.buildPythonPackage rec {
     sha256 = "11snsl7i407855h39g1fgk26hinnq0inr8sjrgd319li0d3jwzxl";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python.pkgs; [
     CommonMark
     aiohttp
     asyncpg
@@ -41,7 +53,7 @@ python3Packages.buildPythonPackage rec {
     " > $out/bin/mautrix-signal
     chmod +x $out/bin/mautrix-signal
     wrapProgram $out/bin/mautrix-signal \
-      --set PATH ${python3Packages.python}/bin \
+      --set PATH ${python}/bin \
       --set PYTHONPATH "$PYTHONPATH"
   '';
 

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -21,14 +21,14 @@ let
 
 in python.pkgs.buildPythonPackage rec {
   pname = "mautrix-telegram";
-  version = "0.9.0";
+  version = "0.10.0";
   disabled = python.pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "tulir";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1543ljjl3jg3ayid7ifi4bamqh4gq85pmlbs3m8i7phjbbm7g9dn";
+    sha256 = "sha256-lLVKD+/pKqs8oWBdyL+R1lk22LqQOC9nbMlxhCK39xA=";
   };
 
   patches = [ ./0001-Re-add-entrypoint.patch ./0002-Don-t-depend-on-pytest-runner.patch ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ChangeLog: https://github.com/tulir/mautrix-telegram/releases/tag/v0.10.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
