### PR TITLE
nixos/cowsay: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -126,6 +126,7 @@
   ./programs/chromium.nix
   ./programs/clickshare.nix
   ./programs/command-not-found/command-not-found.nix
+  ./programs/cowsay.nix
   ./programs/criu.nix
   ./programs/dconf.nix
   ./programs/digitalbitbox/default.nix

--- a/nixos/modules/programs/cowsay.nix
+++ b/nixos/modules/programs/cowsay.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.cowsay;
+
+  mkCow = cow: ''
+    $the_cow = <<EOC;
+      ${builtins.replaceStrings [ "\n" ] [ "\n  " ] cow}
+    EOC
+  '';
+
+  mkCows = cows:
+    let
+      mkCowFile = name: cow: {
+        "cowsayCow${name}" = {
+          target = "cows/${name}.cow";
+          text = mkCow cow;
+        };
+      };
+    in mkMerge (attrsets.mapAttrsToList mkCowFile cows);
+
+in {
+  options.programs.cowsay = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable cowsay.
+        Might conflict with cowsay installed via other means.
+      '';
+    };
+
+    package = mkOption {
+      type = types.path;
+      description = ''
+        The cowsay package to use.
+      '';
+      default = pkgs.cowsay;
+      example = literalExample "pkgs.cowsay";
+    };
+
+    cows = mkOption {
+      type = types.attrsOf types.lines;
+      default = { };
+      description = ''
+        Set of cows; Backslashes have to be escaped
+      '';
+      example = lib.literalExample ''{
+        giraffe = \'\'
+          $thoughts
+           $thoughts
+            $thoughts
+               ^__^
+               (oo)
+               (__)
+                 \\ \\
+                  \\ \\
+                   \\ \\
+                    \\ \\
+                     \\ \\
+                      \\ \\
+                       \\ \\
+                        \\ \\______
+                         \\       )\\/\\/\\
+                          ||----w |
+                          ||     ||
+        \'\';
+      };'';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = with pkgs; [
+        (writeShellScriptBin "cowsay" ''
+          export COWPATH="/etc/cows:${cfg.package}/share/cows"
+          exec "${cfg.package}/bin/cowsay" $@
+        '')
+        (writeShellScriptBin "cowthink" ''
+          export COWPATH="/etc/cows:${cfg.package}/share/cows"
+          exec "${cfg.package}/bin/cowthink" $@
+        '')
+        # only installs the man pages
+        #TODO: is there a way to fix conflicts that could arise when also using native-package-manager/nix-env/home-manager/nix-shell
+        (cowsay.overrideAttrs (oldAttrs: {
+          meta = oldAttrs.meta // {
+            outputsToInstall = [ "man" ];
+          };
+        }))
+      ];
+
+      etc = mkCows cfg.cows;
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
adds a cowsay module, to declaratively manage cows

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
