### PR TITLE
auto-cpufreq: 1.6.1 -> 1.6.4

### DIFF
--- a/nixos/modules/services/hardware/auto-cpufreq.nix
+++ b/nixos/modules/services/hardware/auto-cpufreq.nix
@@ -12,7 +12,13 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.auto-cpufreq ];
 
-    systemd.packages = [ pkgs.auto-cpufreq ];
-    systemd.services.auto-cpufreq.path = with pkgs; [ bash coreutils ];
+    systemd = {
+      packages = [ pkgs.auto-cpufreq ];
+      services.auto-cpufreq = {
+        # Workaround for https://github.com/NixOS/nixpkgs/issues/81138
+        wantedBy = [ "multi-user.target" ];
+        path = with pkgs; [ bash coreutils ];
+      };
+    };
   };
 }

--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
-  version = "1.6.1";
+  version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-oz3C1150CPfT0kkx1x7VIX/Rm06dkjyxeDPFCRJaWNc=";
+    sha256 = "sha256-9WYuAWcJGosYEsnnkqvZLXXvqF+1nBEozh6F84Kit6w=";
   };
 
   propagatedBuildInputs = with python3Packages; [ click distro psutil ];

--- a/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
+++ b/pkgs/tools/system/auto-cpufreq/prevent-install-and-copy.patch
@@ -1,18 +1,9 @@
 diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
-index a685db8..1ca1ca1 100644
+index 83d0d64..04b5035 100644
 --- a/auto_cpufreq/core.py
 +++ b/auto_cpufreq/core.py
-@@ -72,7 +72,7 @@ def app_version():
-             print("Git commit:", check_output(["git", "describe", "--always"]).strip().decode())
-         else:
-             print(getoutput("pacman -Qi auto-cpufreq | grep Version"))
--    else:        
-+    else:
-         # source code (auto-cpufreq-installer)
-         try:
-             print("Git commit:", check_output(["git", "describe", "--always"]).strip().decode())
-@@ -179,31 +179,13 @@ def get_current_gov():
-     return print("Currently using:", getoutput("cpufreqctl.auto-cpufreq --governor").strip().split(" ")[0], "governor")
+@@ -204,35 +204,13 @@ def get_current_gov():
+ 
  
  def cpufreqctl():
 -    """
@@ -20,14 +11,18 @@ index a685db8..1ca1ca1 100644
 -    """
 -
 -    # detect if running on a SNAP
--    if os.getenv('PKG_MARKER') == "SNAP":
+-    if os.getenv("PKG_MARKER") == "SNAP":
 -        pass
 -    else:
 -        # deploy cpufreqctl.auto-cpufreq script
 -        if os.path.isfile("/usr/bin/cpufreqctl"):
--            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
+-            shutil.copy(
+-                SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq"
+-            )
 -        else:
--            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
+-            shutil.copy(
+-                SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq"
+-            )
 +    # scripts are already in the correct place
 +    pass
  
@@ -37,7 +32,7 @@ index a685db8..1ca1ca1 100644
 -    remove cpufreqctl.auto-cpufreq script
 -    """
 -    # detect if running on a SNAP
--    if os.getenv('PKG_MARKER') == "SNAP":
+-    if os.getenv("PKG_MARKER") == "SNAP":
 -        pass
 -    else:
 -        if os.path.isfile("/usr/bin/cpufreqctl.auto-cpufreq"):
@@ -45,10 +40,10 @@ index a685db8..1ca1ca1 100644
 +    # no need to restore
 +    pass
  
+ 
  def footer(l=79):
-     print("\n" + "-" * l + "\n")
-@@ -233,74 +215,12 @@ def remove_complete_msg():
-     footer()
+@@ -276,76 +254,13 @@ def remove_complete_msg():
+ 
  
  def deploy_daemon():
 -    print("\n" + "-" * 21 + " Deploying auto-cpufreq as a daemon " + "-" * 22 + "\n")
@@ -66,21 +61,23 @@ index a685db8..1ca1ca1 100644
 -            f.seek(0)
 -            f.truncate()
 -            f.write(content.replace(orig_set, change_set))
--    except:
--        print("\nERROR:\nWas unable to turn off bluetooth on boot")
+-    except Exception as e:
+-        print(f"\nERROR:\nWas unable to turn off bluetooth on boot\n{repr(e)}")
 -
 -    auto_cpufreq_stats_path.touch(exist_ok=True)
 -
 -    print("\n* Deploy auto-cpufreq install script")
--    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install")
+-    shutil.copy(
+-        SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install"
+-    )
 -
 -    print("\n* Deploy auto-cpufreq remove script")
 -    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/bin/auto-cpufreq-remove")
 -
 -    call("/usr/bin/auto-cpufreq-install", shell=True)
--
 +    # prevent needless copying and system changes
 +    pass
+ 
  
  # remove auto-cpufreq daemon
  def remove():
@@ -102,8 +99,8 @@ index a685db8..1ca1ca1 100644
 -            f.seek(0)
 -            f.truncate()
 -            f.write(content.replace(change_set, orig_set))
--    except:
--        print("\nERROR:\nWas unable to turn on bluetooth on boot")
+-    except Exception as e:
+-        print(f"\nERROR:\nWas unable to turn on bluetooth on boot\n{repr(e)}")
 -
 -    # run auto-cpufreq daemon install script
 -    call("/usr/bin/auto-cpufreq-remove", shell=True)
@@ -125,15 +122,6 @@ index a685db8..1ca1ca1 100644
  
  def gov_check():
      for gov in get_avail_gov():
-@@ -331,7 +251,7 @@ def countdown(s):
-     if auto_cpufreq_stats_file is not None:
-         auto_cpufreq_stats_file.seek(0)
-         auto_cpufreq_stats_file.truncate(0)
--                
-+
-         # execution timestamp
-         from datetime import datetime
-         now = datetime.now()
 diff --git a/scripts/cpufreqctl.sh b/scripts/cpufreqctl.sh
 index 63a2b5b..e157efe 100755
 --- a/scripts/cpufreqctl.sh


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Needed to workaround #81138, minor version bump

Closes #126320

###### Things done
Update to 1.6.4
Workaround #81138
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
