### PR TITLE
python3Packages.tf-models-official: init at 2.4.0 

### DIFF
--- a/pkgs/development/python-modules/tensorflow-addons/default.nix
+++ b/pkgs/development/python-modules/tensorflow-addons/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, buildBazelPackage
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, rsync
+, setuptools
+, wheel
+, protobuf
+, packaging
+, tensorflow
+, typeguard
+, pytestCheckHook
+}:
+
+let
+  pname = "tensorflow-addons";
+  version = "0.16.1";
+  format = "setuptools";
+
+  bazel-wheel = buildBazelPackage {
+    name = "${pname}-${version}-py2.py3-none-any.whl";
+
+    src = fetchFromGitHub {
+      owner = "tensorflow";
+      repo = "addons";
+      rev = "v${version}";
+      hash = "sha256-/Jds+/+zUX1jgSrCmFrZpAY3bNx0WRwZa0chNAJo9+I=";
+    };
+
+    nativeBuildInputs = [
+      python
+      rsync
+      setuptools
+      wheel
+    ];
+
+    buildInputs = [
+      protobuf
+    ];
+
+    # https://github.com/tensorflow/addons/blob/master/BUILD
+    bazelTarget = ":build_pip_pkg";
+
+    fetchAttrs = {
+      sha256 = "sha256-1X00azKc3Me6RM7xkM9CB1aNZF4bBDqKb76NXjht/Wk=";
+    };
+
+    TF_CXX11_ABI_FLAG = "0";
+    TF_HEADER_DIR = "${tensorflow}/${python.sitePackages}/tensorflow/include/";
+    TF_SHARED_LIBRARY_DIR = "${tensorflow}/${python.sitePackages}/tensorflow/";
+    TF_SHARED_LIBRARY_NAME = "libtensorflow_framework.so.2";
+
+    buildAttrs = {
+      preBuild = ''
+        patchShebangs .
+      '';
+
+      installPhase = ''
+        export SOURCE_DATE_EPOCH=315532800
+        ./bazel-bin/build_pip_pkg .
+        mv *.whl "$out"
+      '';
+    };
+  };
+
+in buildPythonPackage {
+  inherit pname version;
+  format = "wheel";
+
+  src = bazel-wheel;
+
+  propagatedBuildInputs = [
+    packaging
+    tensorflow
+    typeguard
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tensorflow_addons/tests"
+  ];
+
+  pythonImportsCheck = [
+    "tensorflow_addons"
+  ];
+
+  meta = with lib; {
+    description = "TensorFlow Addons";
+    homepage = "https://github.com/tensorflow/addons";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/tf-models-official/default.nix
+++ b/pkgs/development/python-modules/tf-models-official/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, gin-config
+, google-api-python-client
+, kaggle
+, numpy
+, pandas
+, py-cpuinfo
+, pycocotools
+, pyyaml
+, sentencepiece
+, seqeval
+, tensorflow
+, tensorflow-addons
+, tensorflow-datasets
+}:
+
+buildPythonPackage rec {
+  pname = "tf-models-official";
+  version = "2.8.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    pname = "tf_models_official";
+    inherit version;
+    sha256 = "sha256-HlhQaSAlUPRBaMYhgISYeSDuHpvny8AoLjjoUm77U7M=";
+    format = "wheel";
+  };
+
+  # https://github.com/tensorflow/models/blob/master/official/requirements.txt
+  propagatedBuildInputs = [
+    gin-config
+    google-api-python-client
+    kaggle
+    numpy
+    pandas
+    py-cpuinfo
+    pycocotools
+    pyyaml
+    sentencepiece
+    seqeval
+    tensorflow
+    tensorflow-addons
+    tensorflow-datasets
+  ];
+
+  meta = with lib; {
+    description = "TensorFlow Official Models";
+    homepage = "https://github.com/tensorflow/models";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9818,6 +9818,8 @@ in {
 
   tensorboardx = callPackage ../development/python-modules/tensorboardx { };
 
+  tensorflow-addons = callPackage ../development/python-modules/tensorflow-addons { };
+
   tensorflow-bin = callPackage ../development/python-modules/tensorflow/bin.nix {
     cudaSupport = pkgs.config.cudaSupport or false;
     cudatoolkit = tensorflow_compat_cudatoolkit;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9918,6 +9918,8 @@ in {
 
   textwrap3 = callPackage ../development/python-modules/textwrap3 { };
 
+  tf-models-official = callPackage ../development/python-modules/tf-models-official { };
+
   tflearn = callPackage ../development/python-modules/tflearn { };
 
   tgcrypto = callPackage ../development/python-modules/tgcrypto { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- [x] <del>tensorflow-metadata :heavy_check_mark:</del>
- [x] <del>tensorflow-datasets :heavy_check_mark:</del>
- [ ] tensorflow-addons :zap: 
- [ ] tf-models-official :question: 

This is WIP and I have run into an issue with tensorflow-addons and I'm looking for ideas.

```
❯ nom-build -A python3Packages.tensorflow-addons
these derivations will be built:
  /nix/store/9rksf8n8ah0fdrpi7qalgdx29hqnb3g2-python3.8-tensorflow-addons-0.12.1.drv
building '/nix/store/9rksf8n8ah0fdrpi7qalgdx29hqnb3g2-python3.8-tensorflow-addons-0.12.1.drv' on 'ssh://hexa@phoibe.cysec.de'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing wheel setup hook
Using wheelUnpackPhase
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
unpacking sources
Executing wheelUnpackPhase
Finished executing wheelUnpackPhase
patching sources
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
Executing pipInstallPhase
/build/dist /build
Processing ./tensorflow-addons-0.12.1-py2.py3-none-any.whl
Requirement already satisfied: typeguard>=2.7 in /nix/store/i72xh69zlnhhfbyzgbnr55df1qg3r12l-python3.8-typeguard-2.12.0/lib/python3.8/site-packages (from tensorflow==addons) (2.12.0)
Installing collected packages: tensorflow
  Attempting uninstall: tensorflow
    Found existing installation: tensorflow 2.4.0
    Uninstalling tensorflow-2.4.0:
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/nix/store/vk0pfraxv7ad5xbnyldvr6kfjsxi3p43-python3.8-tensorflow-2.4.0/bin/estimator_ckpt_converter'
Consider using the `--user` option or check the permissions.

builder for '/nix/store/9rksf8n8ah0fdrpi7qalgdx29hqnb3g2-python3.8-tensorflow-addons-0.12.1.drv' failed with exit code 1
```

The tensorflow dependency isn't specified upstream, but it requires tensorflow during the test phase, so they kinda leave you with the choice of tensorflow flavor.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
