### PR TITLE
wiggle: cleanup

### DIFF
--- a/pkgs/development/tools/wiggle/default.nix
+++ b/pkgs/development/tools/wiggle/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "neilbrown";
     repo = "wiggle";
     rev = "v${version}";
-    sha256 = "sha256-/5LPATPB9NzjNWPiY8sw59229KvfhtQnsewUkL7CWvo=";
+    sha256 = "sha256-rlHhYzP81lfblZvtZ1lhiq4iQ6WRpBYukoGqpVP+NKI=";
   };
 
   buildInputs = [ ncurses groff ];

--- a/pkgs/development/tools/wiggle/default.nix
+++ b/pkgs/development/tools/wiggle/default.nix
@@ -1,11 +1,13 @@
-{ lib, stdenv, fetchurl, ncurses, groff }:
+{ lib, stdenv, fetchFromGitHub, ncurses, groff }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  name = "wiggle";
+  version = "1.3";
 
-  name = "wiggle-1.3";
-
-  src = fetchurl {
-    url = "https://github.com/neilbrown/wiggle/archive/v1.3.tar.gz";
+  src = fetchFromGitHub {
+    owner = "neilbrown";
+    repo = "wiggle";
+    rev = "v${version}";
     sha256 = "sha256-/5LPATPB9NzjNWPiY8sw59229KvfhtQnsewUkL7CWvo=";
   };
 
@@ -21,24 +23,22 @@ stdenv.mkDerivation {
     patchShebangs .
   '';
 
-  meta = {
-    homepage = "http://blog.neil.brown.name/category/wiggle/";
+  meta = with lib; {
+    homepage = "https://blog.neil.brown.name/category/wiggle/";
     description = "Tool for applying patches with conflicts";
-
     longDescription = ''
-       Wiggle applies patches to a file in a similar manner to the patch(1)
-       program. The distinctive difference is, however, that wiggle will
-       attempt to apply a patch even if the "before" part of the patch doesn't
-       match the target file perfectly. This is achieved by breaking the file
-       and patch into words and finding the best alignment of words in the file
-       with words in the patch. Once this alignment has been found, any
-       differences (word-wise) in the patch are applied to the file as best as
-       possible. Also, wiggle will (in some cases) detect changes that have
-       already been applied, and will ignore them.
+      Wiggle applies patches to a file in a similar manner to the patch(1)
+      program. The distinctive difference is, however, that wiggle will
+      attempt to apply a patch even if the "before" part of the patch doesn't
+      match the target file perfectly. This is achieved by breaking the file
+      and patch into words and finding the best alignment of words in the file
+      with words in the patch. Once this alignment has been found, any
+      differences (word-wise) in the patch are applied to the file as best as
+      possible. Also, wiggle will (in some cases) detect changes that have
+      already been applied, and will ignore them.
     '';
-
-    license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.all;
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = [ ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
