### PR TITLE
libvpx: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libvpx/1_8.nix
+++ b/pkgs/development/libraries/libvpx/1_8.nix
@@ -69,7 +69,14 @@ stdenv.mkDerivation rec {
 #    ./CVE-2019-9232.CVE-2019-9325.CVE-2019-9371.CVE-2019-9433.patch
   ];
 
-  postPatch = "patchShebangs .";
+  postPatch = ''
+    patchShebangs --build \
+      build/make/*.sh \
+      build/make/*.pl \
+      build/make/*.pm \
+      test/*.sh \
+      configure
+  '';
 
   outputs = [ "bin" "dev" "out" ];
   setOutputFlags = false;
@@ -135,11 +142,6 @@ stdenv.mkDerivation rec {
                     experimentalFpMbStatsSupport ||
                     experimentalEmulateHardwareSupport) "experimental")
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    #"--extra-cflags="
-    #"--extra-cxxflags="
-    #"--prefix="
-    #"--libc="
-    #"--libdir="
     "--enable-external-build"
     # libvpx darwin targets include darwin version (ie. ARCH-darwinXX-gcc, XX being the darwin version)
     # See all_platforms: https://github.com/webmproject/libvpx/blob/master/configure


### PR DESCRIPTION
This is done by removing some warnings that are not supported by the
cross-compiler.

We also need to disable the --enable-external-build flag, which breaks
the build completely.
This PR: https://github.com/NixOS/nixpkgs/pull/100210 added the flag,
but it doesn't explain why it was added. It also doesn't show any
attempt at trying to cross-compile for either darwin or aarch64. So
let's remove it again, since it 'just' seems to break the build anyway.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Support cross-compilation for libvpx, which is a dependency of ffmpeg.

I've tested building this with `nix build .#pkgsCross.aarch64-multiplatform.libvpx`, which works. With https://github.com/NixOS/nixpkgs/pull/123915 applied, ffmpeg now also cross-compiles for aarch64-multipllatform :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This reverts a change made in https://github.com/NixOS/nixpkgs/pull/118783. @TredwellGit do you have any idea why the --enable-external-build flag was added there? It doesn't seem like you attempted a cross-build (looking at the PR at least), but maybe you did?
 