### PR TITLE
swaybg: fix cross-compilation by adding wayland-scanner

### DIFF
--- a/pkgs/applications/window-managers/sway/bg.nix
+++ b/pkgs/applications/window-managers/sway/bg.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , meson, ninja, pkg-config, scdoc
 , wayland, wayland-protocols, cairo, gdk-pixbuf
+, wayland-scanner
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lmqz5bmig90gq2m7lwf02d2g7z4hzf8fhqz78c8vk92c6p4xwbc";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config scdoc ];
+  nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
   buildInputs = [ wayland wayland-protocols cairo gdk-pixbuf ];
 
   mesonFlags = [


### PR DESCRIPTION
###### Motivation for this change

Ensure swaybg cross-compiles by adding a missing dependency.

Targeting staging because some changes this depends on are on staging (https://github.com/NixOS/nixpkgs/pull/123927). I could target master, but it wouldn't build, so that makes it harder to review. However, since this change is not too intrusive, we could target master anyway. It wouldn't build though, since gdk-pixbuf doesn't cross-compile yet on master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
