### PR TITLE
roswell: 21.01.14.108 -> 21.05.14.109

### DIFF
--- a/pkgs/development/tools/roswell/default.nix
+++ b/pkgs/development/tools/roswell/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "roswell";
-  version = "21.01.14.108";
+  version = "21.05.14.109";
 
   src = fetchFromGitHub {
     owner = "roswell";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1hj9q3ig7naky3pb3jkl9yjc9xkg0k7js3glxicv0aqffx9hkp3p";
+    sha256 = "0r4r2d0jfwqaxjfnzwl804g194hjrn6lma485crb4gxs7xkziwbx";
   };
 
   preConfigure = ''


### PR DESCRIPTION
**Users may have to delete a file `~/.roswell/env/roswell/impls/x86-64/linux/sbcl-bin/system/dump/roswell.core` to make roswell rebuild its core for a newer sbcl version.**

This happens every time sbcl is updated. How is to be dealt with that? (I could wrap `ros` to print a message to that effect.)

###### Motivation for this change

Update roswell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
