### PR TITLE
Use `uuid` attribute on gnome extensions

### DIFF
--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -20,6 +20,7 @@ let
 
   stdenv.mkDerivation {
     pname = "gnome-shell-extension-${pname}";
+    uuid = uuid;
     version = builtins.toString version;
     src = fetchzip {
       url = "https://extensions.gnome.org/extension-data/${


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - The norm for extension uuids has been via the `uuid` attribute ([example](https://github.com/NixOS/nixpkgs/blob/master/pkgs/desktops/gnome/extensions/appindicator/default.nix#L19)).
 - Semantically, `extension.uuid` makes more sense than `extension.extensionUuid`
 - Should probably deprecate `extensionUuid`

My current config looks like this

```
      enabled-extensions = with pkgs; [
          gnomeExtensions.caffeine.uuid
          pop-os-shell.uuid
          simply-workspaces.uuid
          gnomeExtensions.appindicator.uuid
          gnomeExtensions.just-perfection.extensionUuid # <- `uuid` doesn't exist on auto-generated derivation
        ];
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
