### PR TITLE
maim,slop: Remove myself as maintainer

### DIFF
--- a/pkgs/tools/graphics/maim/default.nix
+++ b/pkgs/tools/graphics/maim/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/naelstrof/maim/releases/tag/v${version}";
     platforms = lib.platforms.all;
     license = lib.licenses.gpl3Plus;
-    maintainers = with maintainers; [ primeos mbakke ];
+    maintainers = with maintainers; [ mbakke ];
   };
 }

--- a/pkgs/tools/misc/slop/default.nix
+++ b/pkgs/tools/misc/slop/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     description = "Queries a selection from the user and prints to stdout";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;
-    maintainers = with maintainers; [ primeos mbakke ];
+    maintainers = with maintainers; [ mbakke ];
   };
 }


### PR DESCRIPTION
I've switched to Wayland (using grim and slurp, which are pretty
similar) so I cannot even properly test these X11 tools anymore.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
