### PR TITLE
dina-font: use fonttosfnt instead of fontforge to generate OTB files

### DIFF
--- a/pkgs/data/fonts/dina/default.nix
+++ b/pkgs/data/fonts/dina/default.nix
@@ -1,10 +1,12 @@
 { lib, stdenv, fetchurl, unzip
-, bdftopcf, mkfontscale, fontforge
+, bdftopcf, mkfontscale, fonttosfnt
 }:
 
 stdenv.mkDerivation {
   pname = "dina-font";
   version = "2.92";
+
+  outputs = [ "out" "bdf" ];
 
   src = fetchurl {
     url = "http://www.donationcoder.com/Software/Jibz/Dina/downloads/Dina.zip";
@@ -12,42 +14,46 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs =
-    [ unzip bdftopcf mkfontscale fontforge ];
+    [ unzip bdftopcf mkfontscale fonttosfnt ];
 
-  patchPhase = "sed -i 's/microsoft-cp1252/ISO8859-1/' *.bdf";
+  postPatch = ''
+    sed -i 's/microsoft-cp1252/ISO8859-1/' *.bdf
+  '';
 
   buildPhase = ''
+    runHook preBuild
+
     newName() {
-      test "''${1:5:1}" = i && _it=Italic || _it=
-      case ''${1:6:3} in
-        400) test -z $it && _weight=Medium ;;
-        700) _weight=Bold ;;
-      esac
-      _pt=''${1%.bdf}
-      _pt=''${_pt#*-}
-      echo "Dina$_weight$_it$_pt"
+        test "''${1:5:1}" = i && _it=Italic || _it=
+        case ''${1:6:3} in
+            400) test -z $it && _weight=Medium ;;
+            700) _weight=Bold ;;
+        esac
+        _pt=''${1%.bdf}
+        _pt=''${_pt#*-}
+        echo "Dina$_weight$_it$_pt"
     }
 
-    # convert bdf fonts to pcf
-    for i in *.bdf; do
-      bdftopcf -t -o $(newName "$i").pcf "$i"
+    for f in *.bdf; do
+        name=$(newName "$f")
+        bdftopcf -t -o "$name.pcf" "$f"
+        fonttosfnt -v -o "$name.otb" "$f"
     done
     gzip -n -9 *.pcf
 
-    # convert bdf fonts to otb
-    for i in *.bdf; do
-      fontforge -lang=ff -c "Open(\"$i\"); Generate(\"$(newName $i).otb\")"
-    done
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -D -m 644 -t "$out/share/fonts/misc" *.pcf.gz *.otb
     install -D -m 644 -t "$bdf/share/fonts/misc" *.bdf
     mkfontdir "$out/share/fonts/misc"
     mkfontdir "$bdf/share/fonts/misc"
-  '';
 
-  outputs = [ "out" "bdf" ];
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A monospace bitmap font aimed at programmers";


### PR DESCRIPTION
###### Motivation for this change

Using  fontforge results in weird spacing issues in lemonbar-xft: no matter what I try, glyphs seem to have uneven widths.

fonttosfnt 1.2.2 (#126906) [fixed](https://gitlab.freedesktop.org/xorg/app/fonttosfnt/-/merge_requests/11) the last issue I had with the fonttosfnt-generated version; it now renders perfectly at all sizes in lemonbar-xft, firefox, rofi, alacritty and xterm. It's also much lighter than fontforge, so I suggest we switch.

@rnhmjoj do you remember what exactly the Unicode problem you mentioned in 36ca91e25306df0f72332a24c8dd67f7a59552bd was, and if it's still a thing?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
