### PR TITLE
nixos/testing: mark test attr sets for recursion by tools

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -13,7 +13,7 @@ let
   discoverTests = val:
     if !isAttrs val then val
     else if hasAttr "test" val then callTest val
-    else mapAttrs (n: s: discoverTests s) val;
+    else recurseIntoAttrs (mapAttrs (n: s: discoverTests s) val);
   handleTest = path: args:
     discoverTests (import path ({ inherit system pkgs; } // args));
   handleTestOn = systems: path: args:


### PR DESCRIPTION
This is intended to teach ofborg to happily evaluate
`@ofborg test installer` as _all_ tests under the installer node
