### PR TITLE
reattach-to-user-namespace: support apple silicon

### DIFF
--- a/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
+++ b/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1qgimh58hcx5f646gj2kpd36ayvrdkw616ad8cb3lcm11kg0ag79";
   };
 
-  buildFlags = [ "ARCHES=x86_64" ];
+  buildFlags =
+    if stdenv.hostPlatform.system == "x86_64-darwin" then [ "ARCHES=x86_64" ]
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then [ "ARCHES=arm64" ]
+    else throw "reattach-to-user-namespace isn't being built for ${stdenv.hostPlatform.system} yet.";
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding `reattach-to-user-namespace` build target for Apple Silicon (`aarch64-darwin`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

c.c @SuperSandro2000 who reviewed my last PR to reattach-to-user-namespace