### PR TITLE
dart: 2.12.2 -> 2.13.1

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -5,39 +5,17 @@ let
     let files = builtins.attrNames (builtins.readDir dir);
     in map (f: dir + ("/" + f)) files;
   version = "2.2.1";
-  dartVersion = "2.13.1";
   channel = "stable";
   filename = "flutter_linux_${version}-${channel}.tar.xz";
-  dartStable = dart.override {
-    version = dartVersion;
-    sources = {
-      "${dartVersion}-x86_64-darwin" = fetchurl {
-        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-macos-x64-release.zip";
-        sha256 = "0kb6r2rmp5d0shvgyy37fmykbgww8qaj4f8k79rmqfv5lwa3izya";
-      };
-      "${dartVersion}-x86_64-linux" = fetchurl {
-        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-x64-release.zip";
-        sha256 = "0zq8wngyrw01wjc5s6w1vz2jndms09ifiymjjixxby9k41mr6jrq";
-      };
-      "${dartVersion}-i686-linux" = fetchurl {
-        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-ia32-release.zip";
-        sha256 = "0zv4q8xv2i08a6izpyhhnil75qhs40m5mgyvjqjsswqkwqdf7lkj";
-      };
-      "${dartVersion}-aarch64-linux" = fetchurl {
-        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-arm64-release.zip";
-        sha256 = "0bb9jdmg5p608jmmiqibp13ydiw9avgysxlmljvgsl7wl93j6rgc";
-      };
-    };
-  };
 in
 {
   mkFlutter = mkFlutter;
   stable = mkFlutter rec {
-    dart = dartStable;
-    inherit version;
+    inherit dart version;
     pname = "flutter";
     src = fetchurl {
-      url = "https://storage.googleapis.com/flutter_infra/releases/${channel}/linux/${filename}";
+      url =
+        "https://storage.googleapis.com/flutter_infra/releases/${channel}/linux/${filename}";
       sha256 = "009pwk2casz10gibgjpz08102wxmkq9iq3994b3c2q342g6526g0";
     };
     patches = getPatches ./patches;

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -14,8 +14,7 @@ in
     inherit dart version;
     pname = "flutter";
     src = fetchurl {
-      url =
-        "https://storage.googleapis.com/flutter_infra/releases/${channel}/linux/${filename}";
+      url = "https://storage.googleapis.com/flutter_infra/releases/${channel}/linux/${filename}";
       sha256 = "009pwk2casz10gibgjpz08102wxmkq9iq3994b3c2q342g6526g0";
     };
     patches = getPatches ./patches;

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -14,23 +14,19 @@
   in
   {
     "${version}-x86_64-darwin" = fetchurl {
-      url =
-        "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
       sha256 = "0kb6r2rmp5d0shvgyy37fmykbgww8qaj4f8k79rmqfv5lwa3izya";
     };
     "${version}-x86_64-linux" = fetchurl {
-      url =
-        "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
       sha256 = "0zq8wngyrw01wjc5s6w1vz2jndms09ifiymjjixxby9k41mr6jrq";
     };
     "${version}-i686-linux" = fetchurl {
-      url =
-        "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
+      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
       sha256 = "0zv4q8xv2i08a6izpyhhnil75qhs40m5mgyvjqjsswqkwqdf7lkj";
     };
     "${version}-aarch64-linux" = fetchurl {
-      url =
-        "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
+      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
       sha256 = "0bb9jdmg5p608jmmiqibp13ydiw9avgysxlmljvgsl7wl93j6rgc";
     };
   }
@@ -45,8 +41,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ unzip ];
 
-  src = sources."${version}-${stdenv.hostPlatform.system}" or (throw
-    "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
+  src = sources."${version}-${stdenv.hostPlatform.system}" or (throw "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
 
   installPhase = ''
     mkdir -p $out
@@ -62,8 +57,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://www.dartlang.org/";
     maintainers = with maintainers; [ grburst thiagokokada ];
-    description =
-      "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
+    description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
     longDescription = ''
       Dart is a class-based, single inheritance, object-oriented language
       with C-style syntax. It offers compilation to JavaScript, interfaces,

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -2,33 +2,36 @@
 , lib
 , fetchurl
 , unzip
-, version ? "2.12.2"
-, sources ?
-  let
+, version ? "2.13.1"
+, sources ? let
     base = "https://storage.googleapis.com/dart-archive/channels";
     x86_64 = "x64";
     i686 = "ia32";
     aarch64 = "arm64";
     # Make sure that if the user overrides version parameter they're
     # also need to override sources, to avoid mistakes
-    version = "2.12.2";
+    version = "2.13.1";
   in
   {
     "${version}-x86_64-darwin" = fetchurl {
-      url = "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "0h6mpy0kfc842vhg053fyxbjnd8lw1d1shdcsj800048260lxhyd";
+      url =
+        "${base}/stable/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "0kb6r2rmp5d0shvgyy37fmykbgww8qaj4f8k79rmqfv5lwa3izya";
     };
     "${version}-x86_64-linux" = fetchurl {
-      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "1gg210gf4yif3bl9k19znkndc4c1cd529xwxpi20ykaw3zfxxz2z";
+      url =
+        "${base}/stable/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
+      sha256 = "0zq8wngyrw01wjc5s6w1vz2jndms09ifiymjjixxby9k41mr6jrq";
     };
     "${version}-i686-linux" = fetchurl {
-      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "1wngxba71j20gq9vy7n8q0m9rnqs047xm5b03bxk3hhaq6dyzkwn";
+      url =
+        "${base}/stable/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
+      sha256 = "0zv4q8xv2i08a6izpyhhnil75qhs40m5mgyvjqjsswqkwqdf7lkj";
     };
     "${version}-aarch64-linux" = fetchurl {
-      url = "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "0rqsmzl5g5kgk54qb03kamjm5n5g5pqfl79np37xdzwqbv0zx22b";
+      url =
+        "${base}/stable/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
+      sha256 = "0bb9jdmg5p608jmmiqibp13ydiw9avgysxlmljvgsl7wl93j6rgc";
     };
   }
 }:
@@ -40,11 +43,10 @@ stdenv.mkDerivation {
   pname = "dart";
   inherit version;
 
-  nativeBuildInputs = [
-    unzip
-  ];
+  nativeBuildInputs = [ unzip ];
 
-  src = sources."${version}-${stdenv.hostPlatform.system}" or (throw "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
+  src = sources."${version}-${stdenv.hostPlatform.system}" or (throw
+    "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
 
   installPhase = ''
     mkdir -p $out
@@ -60,7 +62,8 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://www.dartlang.org/";
     maintainers = with maintainers; [ grburst thiagokokada ];
-    description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
+    description =
+      "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
     longDescription = ''
       Dart is a class-based, single inheritance, object-oriented language
       with C-style syntax. It offers compilation to JavaScript, interfaces,


### PR DESCRIPTION
also use regular dart derivation in flutter again instead of an overridden one

###### Motivation for this change
updating stuff :p
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

tested dart create and dart run, flutter derivation stayed the same (nixpkgs-review didn't recognize it as an updated package)