### PR TITLE
home-assistant: 2021.6.4 -> 2021.6.5

### DIFF
--- a/pkgs/development/python-modules/garminconnect-ha/default.nix
+++ b/pkgs/development/python-modules/garminconnect-ha/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "garminconnect-ha";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "cyberjunky";
+    repo = "python-garminconnect-ha";
+    rev = version;
+    sha256 = "0ngas6zikhpja1cdkq64m9pjm4b0z3qaj9g3x88mggy60jsxm1d7";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "garminconnect_ha" ];
+
+  meta = with lib; {
+    description = "Minimal Garmin Connect Python 3 API wrapper for Home Assistant";
+    homepage = "https://github.com/cyberjunky/python-garminconnect-ha";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pydaikin/default.nix
+++ b/pkgs/development/python-modules/pydaikin/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pydaikin";
-  version = "2.4.1";
+  version = "2.4.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromBitbucket {
     owner = "mustang51";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1624adp4lqd1n9flnf0wqrcibml2nd19ga3fmxzjg4x5z6767bs3";
+    sha256 = "13cslszjhd1x7j0ja0n0wpy62hb2sdmkrmjl3qhwqfggps2w2wy1";
   };
 
   propagatedBuildInputs = [
@@ -27,6 +27,10 @@ buildPythonPackage rec {
     netifaces
     urllib3
   ];
+
+  # while they have tests, they do not run them in their CI and they fail as of 2.4.2
+  # AttributeError: 'DaikinBRP069' object has no attribute 'last_hour_cool_energy_consumption'
+  doCheck = false;
 
   checkInputs = [
     freezegun

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.6.4";
+  version = "2021.6.5";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -293,7 +293,7 @@
     "futurenow" = ps: with ps; [ pyfnip ];
     "garadget" = ps: with ps; [ ];
     "garages_amsterdam" = ps: with ps; [ garages-amsterdam ];
-    "garmin_connect" = ps: with ps; [ garminconnect-aio ];
+    "garmin_connect" = ps: with ps; [ garminconnect-ha ];
     "gc100" = ps: with ps; [ ]; # missing inputs: python-gc100
     "gdacs" = ps: with ps; [ aio-georss-gdacs ];
     "generic" = ps: with ps; [ ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -181,7 +181,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.6.4";
+  hassVersion = "2021.6.5";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -200,7 +200,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "058dx5hg0a3zvd85sxglbadigfzajmzx8i5jxvw0ww9yp8002qj1";
+    sha256 = "1cp294hy35k9hjbp8iqmaf1m5qbbkh3jwf92ym49waw8di5a5wvh";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , python3
 , inetutils
-, tzdata
 , nixosTests
 
 # Look up dependencies of specified components in component-packages.nix
@@ -784,9 +783,6 @@ in with py.pkgs; buildPythonApplication rec {
 
     # put ping binary into PATH, e.g. for wake_on_lan tests
     export PATH=${inetutils}/bin:$PATH
-
-    # set up zoneinfo data for backports-zoneinfo in pvpc_hourly_pricing tests
-    export PYTHONTZPATH="${tzdata}/share/zoneinfo"
 
     # error out when component test directory is missing, otherwise hidden by xdist execution :(
     for component in ${lib.concatStringsSep " " (map lib.escapeShellArg componentTests)}; do

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -52,12 +52,12 @@ let
     # https://github.com/home-assistant/core/pull/48137 was merged
     (self: super: {
       iaqualink = super.iaqualink.overridePythonAttrs (oldAttrs: rec {
-        version = "0.3.4";
+        version = "0.3.90";
         src = fetchFromGitHub {
           owner = "flz";
           repo = "iaqualink-py";
           rev = "v${version}";
-          sha256 = "16mn6nd9x3hm6j6da99qhwbqs95hh8wx21r1h1m9csl76z77n9lh";
+          sha256 = "0c8ckbbr1n8gx5k63ymgyfkbz3d0rbdvghg8fqdvbg4nrigrs5v0";
         };
         checkInputs = oldAttrs.checkInputs ++ [ python3.pkgs.asynctest ];
       });

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -219,7 +219,7 @@ in with py.pkgs; buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    # Only packages required in setup.py + hass-frontend
+    # Only packages required in setup.py
     aiohttp
     astral
     async-timeout
@@ -798,11 +798,10 @@ in with py.pkgs; buildPythonApplication rec {
   '';
 
   passthru = {
-    inherit (py.pkgs) hass-frontend;
+    python = py;
     tests = {
       inherit (nixosTests) home-assistant;
     };
-    python = py;
   };
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/update.sh
+++ b/pkgs/servers/home-assistant/update.sh
@@ -26,7 +26,7 @@ sed -i -e "s/hassVersion =.*/hassVersion = \"${TARGET_VERSION}\";/" \
 ./parse-requirements.py
 (
     cd ../../..
-    nix-update --version "$FRONTEND_VERSION" home-assistant.hass-frontend
+    nix-update --version "$FRONTEND_VERSION" home-assistant.python.pkgs.home-assistant-frontend
     nix-update --version "$TARGET_VERSION" --build home-assistant
 )
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2706,6 +2706,8 @@ in {
 
   garminconnect-aio = callPackage ../development/python-modules/garminconnect-aio { };
 
+  garminconnect-ha = callPackage ../development/python-modules/garminconnect-ha { };
+
   gast = callPackage ../development/python-modules/gast { };
 
   garages-amsterdam = callPackage ../development/python-modules/garages-amsterdam { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.6.5

I didn't bump httpcore, because I feel we have quite alot of overrides going already and there is already #126661 open. As 0.13.4 causes problems I asked whether we can go for 0.13.3 for now, which is the same version home-assistant is pinning as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
