### PR TITLE
sgx-sdk: init at 2.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9532,6 +9532,12 @@
     githubId = 720864;
     name = "Sébastien Bourdeauducq";
   };
+  sbellem = {
+    email = "sbellem@gmail.com";
+    github = "sbellem";
+    githubId = 125458;
+    name = "Sylvain Bellemare";
+  };
   sbond75 = {
     name = "sbond75";
     email = "43617712+sbond75@users.noreply.github.com";

--- a/pkgs/os-specific/linux/sgx-sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx-sdk/default.nix
@@ -1,0 +1,159 @@
+{ lib
+, stdenv
+, fetchpatch
+, fetchurl
+, fetchFromGitHub
+, callPackage
+, autoconf
+, automake
+, binutils
+, cmake
+, file
+, git
+, libtool
+, nasm
+, ncurses
+, ocaml
+, ocamlPackages
+, openssl
+, perl
+, python3
+, texinfo
+, which
+, writeShellScript
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sgx-sdk";
+  version = "2.14";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "linux-sgx";
+    rev = "0cea078f17a24fb807e706409972d77f7a958db9";
+    sha256 = "1cr2mkk459s270ng0yddgcryi0zc3dfmg9rmdrdh9mhy2mc1kx0g";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "replace-bin-cp-with-cp.patch";
+      url = "https://github.com/intel/linux-sgx/commit/e0db5291d46d1c124980719d63829d65f89cf2c7.patch";
+      sha256 = "0xwlpm1r4rl4anfhjkr6fgz0gcyhr0ng46fv8iw9hfsh891yqb7z";
+    })
+    (fetchpatch {
+      name = "sgx_ippcp.h.patch";
+      url = "https://github.com/intel/linux-sgx/commit/e5929083f8161a8e7404afc0577936003fbb9d0b.patch";
+      sha256 = "12bgs9rxlq82hn5prl9qz2r4mwypink8hzdz4cki4k4cmkw961f5";
+    })
+  ];
+  postPatch = ''
+    patchShebangs ./linux/installer/bin/build-installpkg.sh \
+      ./linux/installer/common/sdk/createTarball.sh \
+      ./linux/installer/common/sdk/install.sh
+  '';
+
+  dontConfigure = true;
+
+  # SDK built with stackprotector produces broken enclaves which crash at runtime.
+  # Disable all to be safe, SDK build configures compiler mitigations manually.
+  hardeningDisable = [ "all" ];
+
+  nativeBuildInputs = [
+    cmake
+    git
+    ocaml
+    ocamlPackages.ocamlbuild
+    perl
+    python3
+    texinfo
+    nasm
+    file
+    ncurses
+    autoconf
+    automake
+  ];
+
+  buildInputs = [
+    libtool
+    openssl
+  ];
+
+  BINUTILS_DIR = "${binutils}/bin";
+
+  # Build external/ippcp_internal first. The Makefile is rewritten to make the
+  # build faster by splitting different versions of ipp-crypto builds and to
+  # avoid patching the Makefile for reproducibility issues.
+  buildPhase = let
+    ipp-crypto-no_mitigation = callPackage (import ./ipp-crypto.nix) {};
+
+    sgx-asm-pp = "python ${src}/build-scripts/sgx-asm-pp.py --assembler=nasm";
+
+    nasm-load = writeShellScript "nasm-load" "${sgx-asm-pp} --MITIGATION-CVE-2020-0551=LOAD $@";
+    ipp-crypto-cve_2020_0551_load = callPackage (import ./ipp-crypto.nix) {
+      extraCmakeFlags = [ "-DCMAKE_ASM_NASM_COMPILER=${nasm-load}" ];
+    };
+
+    nasm-cf = writeShellScript "nasm-cf" "${sgx-asm-pp} --MITIGATION-CVE-2020-0551=CF $@";
+    ipp-crypto-cve_2020_0551_cf = callPackage (import ./ipp-crypto.nix) {
+      extraCmakeFlags = [ "-DCMAKE_ASM_NASM_COMPILER=${nasm-cf}" ];
+    };
+  in ''
+    cd external/ippcp_internal
+
+    mkdir -p lib/linux/intel64/no_mitigation
+    cp ${ipp-crypto-no_mitigation}/lib/intel64/libippcp.a lib/linux/intel64/no_mitigation
+    chmod a+w lib/linux/intel64/no_mitigation/libippcp.a
+    cp ${ipp-crypto-no_mitigation}/include/* ./inc
+
+    mkdir -p lib/linux/intel64/cve_2020_0551_load
+    cp ${ipp-crypto-cve_2020_0551_load}/lib/intel64/libippcp.a lib/linux/intel64/cve_2020_0551_load
+    chmod a+w lib/linux/intel64/cve_2020_0551_load/libippcp.a
+
+    mkdir -p lib/linux/intel64/cve_2020_0551_cf
+    cp ${ipp-crypto-cve_2020_0551_cf}/lib/intel64/libippcp.a lib/linux/intel64/cve_2020_0551_cf
+    chmod a+w lib/linux/intel64/cve_2020_0551_cf/libippcp.a
+
+    rm -f ./inc/ippcp.h
+    patch ${ipp-crypto-no_mitigation}/include/ippcp.h -i ./inc/ippcp20u3.patch -o ./inc/ippcp.h
+
+    mkdir -p license
+    cp ${ipp-crypto-no_mitigation.src}/LICENSE ./license
+
+    # Build the SDK installation package.
+    cd ../..
+
+    # Nix patches make so that $(SHELL) defaults to "sh" instead of "/bin/sh".
+    # The build uses $(SHELL) as an argument to file -L which requires a path.
+    make SHELL=$SHELL sdk_install_pkg
+
+    runHook postBuild
+  '';
+
+  postBuild = ''
+    patchShebangs ./linux/installer/bin/sgx_linux_x64_sdk_*.bin
+  '';
+
+  installPhase = ''
+    echo -e 'no\n'$out | ./linux/installer/bin/sgx_linux_x64_sdk_*.bin
+  '';
+
+  dontFixup = true;
+
+  doInstallCheck = true;
+  installCheckInputs = [ which ];
+  installCheckPhase = ''
+    source $out/sgxsdk/environment
+    cd SampleCode/SampleEnclave
+    make SGX_MODE=SGX_SIM
+    ./app
+  '';
+
+  meta = with lib; {
+    description = "Intel SGX SDK for Linux built with IPP Crypto Library";
+    homepage = "https://github.com/intel/linux-sgx";
+    maintainers = with maintainers; [ sbellem arturcygan ];
+    platforms = [ "x86_64-linux" ];
+    license = with licenses; [ bsd3 ];
+  };
+}

--- a/pkgs/os-specific/linux/sgx-sdk/ipp-crypto.nix
+++ b/pkgs/os-specific/linux/sgx-sdk/ipp-crypto.nix
@@ -1,0 +1,24 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+, nasm
+, extraCmakeFlags ? []
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ipp-crypto";
+  version = "2020_update3";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ipp-crypto";
+    rev = "ipp-crypto_${version}";
+    sha256 = "02vlda6mlhbd12ljzdf65klpx4kmx1ylch9w3yllsiya4hwqzy4b";
+  };
+
+  cmakeFlags = [ "-DARCH=intel64" ] ++ extraCmakeFlags;
+
+  nativeBuildInputs = [ cmake python3 nasm ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21961,6 +21961,8 @@ in
 
   seturgent = callPackage ../os-specific/linux/seturgent { };
 
+  sgx-sdk = callPackage ../os-specific/linux/sgx-sdk { };
+
   shadow = callPackage ../os-specific/linux/shadow { };
 
   sinit = callPackage ../os-specific/linux/sinit {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add a derivation for Intel's SGX SDK, which is a fundamental building block for enclave applications, aimed at Intel SGX -enabled computers. Trusted hardware such as Intel SGX allows user to have confidence, (under certain assumptions), that a remote computer is running the software they expect. In order to gain trust that the remote computer is indeed running the expected software, reproducible builds are required. A verifying party uses the trusted software code to reproduce an enclave build to check it against the build that is running on the remote computer, through a process known as remote attestation. This is where `nix` come into the picture as `nix` allows us to build software in a reproducible way, hence the motivation for this pull request.

###### Background
The SGX SDK depends on a cryptographic library, named `ipp-crypto` which takes around 1h30 to build. The current build toolchain provided by Intel uses prebuilt binaries, although it's possible to build it from source. The SGX SDK could be built in roughly 3 ways:

1. Use the pre-built binary to build the SGX SDK from source (less desirable from an Open Source standpoint).
2. Build everything from source, all in one nix derivation, since the IPP Crypto lib is a git submodule, and the Linux SGX SDK repo contains a specific `Makefile` and patch to build the IPP Crypto for SGX.
3. Build everything from source, but in separate nix derivations, such that the IPP Crypto library has its own dedicated nix derivation and is a dependency to the SGX SDK.

The current draft PR contains a nix derivation to build the IPP Crypto library for SGX as a standalone package, as a demonstration and for test purposes. There's a nix derivation for the SGX SDK that follows point 2 above, meaning that both the IPP Crypto dependency and the SGX SDK are built with the same nix derivation. It should be noted that when it is built for the purpose of SGX, the IPP Crypto library appears to have a slightly different build configuration. This needs to be clarified with Intel's Linux SGX team, but is nevertheless quite clear from the `Makefile`, patch and python script used that appear to be specific to SGX. (See https://github.com/intel/linux-sgx/tree/master/external/ippcp_internal for the details of how IPP Crypto is build from the linux-sgx repository, and https://github.com/initc3/sgx-ipp-crypto for an isolation of what appears to be strictly necessary to build IPP Crypto). Currently, it seems that most users do not build the IPP Crypto library from source but instead use the pre-built binaries, although some users have expressed disappointment with this as they would like to have a way to build the SGX SDK from components that are all open source. Whether the SGX SDK is built following the approaches in point 2 or 3, the current toolchain of the linux-sgx repository will need some minor changes to remove the current hard requirement of downloading pre-built binaries. This PR, for demonstration and test purposes is using a fork of the current linux-sgx repository, in which these minor changes have been implemented. This will need to go through Intel's team for approval before Intel's repository can be used.

To sum up, things to clarify:
- [ ] How to the build the IPP Crypto dependency: in a standalone derivation or within the SGX SDK derivation?
- [ ] Work with Intel to adapt the current build toolchain such that building the SGX SDK "fully" from source is possible.

If the IPP Crypto is built separately:
- [ ] the dependencies (`buildInputs`) listed in the current derivation (`ippcrypto/default.nix`) need to be reviewed as many are perhaps superfluous.

###### Preliminary Build Tests
Some preliminary tests to build both derivations included in this draft PR have been done on GitHub CI using a very recent [nixpkgs/nix](https://hub.docker.com/r/nixpkgs/nix) docker image (`nixpkgs/nix@sha256:c7ab99ed60cc587ac784742e2814303331283cca121507a1d4c0dd21ed1bdf83`) as a base. The results of these builds can be viewed at https://github.com/sbellem/nixpkgs/actions/workflows/sgxsdk.yml. The derivations were built for the `master` and `release-21.05` branches, and for tag `21.11-pre`. 

A binary cache on cachix has been added to store the successfully built packages (only for master currently). The cache is at https://app.cachix.org/api/v1/cache/gluonixpkgs/contents.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
