### PR TITLE
ncurses: Enable '--with-termlib' & '--with-versioned-symbols'

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -3,6 +3,7 @@
 , abiVersion ? "6"
 , mouseSupport ? false
 , unicode ? true
+, symversion ? true
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !enableStatic
 , withCxx ? !stdenv.hostPlatform.useAndroidPrebuilt
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
     "--enable-symlinks"
     "--with-manpage-format=normal"
     "--disable-stripping"
+    "--with-termlib"
   ] ++ lib.optional unicode "--enable-widec"
     ++ lib.optional (!withCxx) "--without-cxx"
     ++ lib.optional (abiVersion == "5") "--with-abi-version=5"
@@ -68,6 +70,7 @@ stdenv.mkDerivation rec {
       "--bindir=$dev/bin"
       "--mandir=$man/share/man"
       "--with-pkg-config-libdir=$PKG_CONFIG_LIBDIR"
+      ${lib.optionalString symversion "--with-versioned-symbols=$PWD/package/ncursestw.map"}
     )
   ''
   + lib.optionalString stdenv.isSunOS ''
@@ -92,57 +95,58 @@ stdenv.mkDerivation rec {
     libs="$(ls $dev/lib/pkgconfig | tr ' ' '\n' | sed "s,\(.*\)$suffix\.pc,\1,g")"
     suffixes="$(echo "$suffix" | awk '{for (i=1; i < length($0); i++) {x=substr($0, i+1, length($0)-i); print x}}')"
 
-    # Get the path to the config util
+    # Get the path to the config util.
     cfg=$(basename $dev/bin/ncurses*-config)
 
-    # symlink the full suffixed include directory
+    # Symlink the full suffixed include directory.
     ln -svf . $dev/include/ncurses$suffix
+
+    for dylibtype in so; do
+      if [ -e "$out/lib/libncurses$suffix.$dylibtype" ]; then
+        # Create linker script for -lncurses to pull in -ltinfo
+        rm $out/lib/libncurses$suffix.$dylibtype
+        echo "INPUT(libncurses$suffix.${abiVersion-extension} -ltinfo$suffix)" > $out/lib/libncurses$suffix.$dylibtype
+      fi
+    done
 
     for newsuffix in $suffixes ""; do
       # Create a non-abi versioned config util links
       ln -svf $cfg $dev/bin/ncurses$newsuffix-config
-
       # Allow for end users who #include <ncurses?w/*.h>
       ln -svf . $dev/include/ncurses$newsuffix
-
       for library in $libs; do
-        for dylibtype in so dll dylib; do
+        for dylibtype in so; do
+          if [ -e "$out/lib/lib$library$suffix.$dylibtype" ]; then
+            echo "INPUT(-l$library$suffix)" > $out/lib/lib$library$newsuffix.$dylibtype
+          fi
+        done
+        for dylibtype in dll dylib; do
           if [ -e "$out/lib/lib''${library}$suffix.$dylibtype" ]; then
             ln -svf lib''${library}$suffix.$dylibtype $out/lib/lib$library$newsuffix.$dylibtype
             ln -svf lib''${library}$suffix.${abiVersion-extension} $out/lib/lib$library$newsuffix.${abiVersion-extension}
-            if [ "ncurses" = "$library" ]
-            then
-              # make libtinfo symlinks
-              ln -svf lib''${library}$suffix.$dylibtype $out/lib/libtinfo$newsuffix.$dylibtype
-              ln -svf lib''${library}$suffix.${abiVersion-extension} $out/lib/libtinfo$newsuffix.${abiVersion-extension}
-            fi
           fi
         done
         for statictype in a dll.a la; do
           if [ -e "$out/lib/lib''${library}$suffix.$statictype" ]; then
             ln -svf lib''${library}$suffix.$statictype $out/lib/lib$library$newsuffix.$statictype
-            if [ "ncurses" = "$library" ]
-            then
-              # make libtinfo symlinks
-              ln -svf lib''${library}$suffix.$statictype $out/lib/libtinfo$newsuffix.$statictype
-            fi
           fi
         done
         ln -svf ''${library}$suffix.pc $dev/lib/pkgconfig/$library$newsuffix.pc
       done
     done
 
-    # move some utilities to $bin
-    # these programs are used at runtime and don't really belong in $dev
-    moveToOutput "bin/clear" "$out"
-    moveToOutput "bin/reset" "$out"
-    moveToOutput "bin/tabs" "$out"
-    moveToOutput "bin/tic" "$out"
-    moveToOutput "bin/tput" "$out"
-    moveToOutput "bin/tset" "$out"
-    moveToOutput "bin/captoinfo" "$out"
-    moveToOutput "bin/infotocap" "$out"
-    moveToOutput "bin/infocmp" "$out"
+    # Move some utilities to '$bin'.
+    #
+    # These programs are used at runtime and don't really belong in '$dev'.
+    moveToOutput 'bin/clear'     "$out"
+    moveToOutput 'bin/reset'     "$out"
+    moveToOutput 'bin/tabs'      "$out"
+    moveToOutput 'bin/tic'       "$out"
+    moveToOutput 'bin/tput'      "$out"
+    moveToOutput 'bin/tset'      "$out"
+    moveToOutput 'bin/captoinfo' "$out"
+    moveToOutput 'bin/infotocap' "$out"
+    moveToOutput 'bin/infocmp'   "$out"
   '';
 
   preFixup = lib.optionalString (!stdenv.hostPlatform.isCygwin && !enableStatic) ''
@@ -158,7 +162,6 @@ stdenv.mkDerivation rec {
       format, supports pads and color and multiple highlights and
       forms characters and function-key mapping, and has all the other
       SYSV-curses enhancements over BSD Curses.
-
       The ncurses code was developed under GNU/Linux.  It has been in
       use for some time with OpenBSD as the system curses library, and
       on FreeBSD and NetBSD as an external package.  It should port


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a riff off of #95141 (which I tried and was unable to use locally to resolve some problems); it should address #89769.

As this is mostly an appropriation of the work @andersk did in #95141 with a few extra items, I'm more than happy to close it in favor of that PR if that's preferable.

###### Things done

In addition to the work covered in #95141, this PR incorporates `--with-versioned-syms` in a manner similar to how OpenSUSE packages up `ncurses` (cf. `--with-versioned-syms` from https://build.opensuse.org/package/view_file/home:rhuitl/ncurses/ncurses.spec).

I've tested this locally with a package that refused to compile due to issues with `ltinfo` and these changes seem to have addressed the compilation failures.

Unfortunately I'm still seeing "no version information available" errors for `libtinfo` so I'm not really sure what to do about that... I've gated the `--with-versioned-syms` stuff behind a flag for now and I'm opening this as a draft PR to hopefully start some sort of discussion around this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
