### PR TITLE
haskellPackages.xmonad-wallpaper: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -698,6 +698,9 @@ self: super: {
   uuid-types = doJailbreak super.uuid-types;
   uuid = doJailbreak super.uuid;
 
+  # Bypass version check for random < 1.2 (1.2 works fine).
+  xmonad-wallpaper = doJailbreak super.xmonad-wallpaper;
+
   # The tests spuriously fail
   libmpd = dontCheck super.libmpd;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5204,7 +5204,6 @@ broken-packages:
   - xmonad-dbus
   - xmonad-eval
   - xmonad-vanessa
-  - xmonad-wallpaper
   - xmonad-windownames
   - xor
   - Xorshift128Plus


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

On 2021-06-10, stackage bumped the `random` library from `1.1` to `1.2.0`. Unfortunately this breaks `xmonad-wallpaper`, as that library has a bound limit of `random >=1.1 && <1.2`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Fortunately, `xmonad-wallpaper` builds just fine with `random-1.2.0`. I have tested building the package both by editing the cabal file directly and with my changes here via:

```sh
nix-build --no-out-link A haskellPackages.xmonad-wallpaper --arg config '{ allowBroken = true; }'
```

I'm currently attempting to rebuild my system with my version of `nixpkgs`, but this takes a very long time :wink:. Previously my builds failed in under a minute due to the error:

```sh
Setup: Encountered missing or private dependencies:
random ==1.1.*
```

 So this looks promising to me.

I contacted `xmonad-wallpaper`'s maintainer about increasing the bound on hackage, as that's probably the right thing to do and would make this whole exercise unnecessary. Still, I made this PR in case we want to provide a quicker workaround (it would at least be useful for me, as I can't update `nixpkgs` until this is fixed). But I will, of course, defer to whatever the reviewers think is the best course of action. If this fix is merged, I can make a second PR once the package on hackage is updated.

Thanks!

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
