### PR TITLE
visidata: add missing deps, enable tests

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -2,16 +2,23 @@
 , lib
 , fetchFromGitHub
 , dateutil
-, pyyaml
+, pandas
+, requests
+, lxml
 , openpyxl
 , xlrd
 , h5py
-, fonttools
-, lxml
-, pandas
+, psycopg2
 , pyshp
+, fonttools
+, pyyaml
+, pdfminer
+, vobject
+, tabulate
+, wcwidth
+, zstandard
 , setuptools
-, withPcap ? true, dpkt ? null, dnslib ? null
+, withPcap ? true, dpkt, dnslib
 }:
 buildPythonApplication rec {
   pname = "visidata";
@@ -25,15 +32,32 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [
+    # from visidata/requirements.txt
+    # packages not (yet) present in nixpkgs are commented
     dateutil
-    pyyaml
+    pandas
+    requests
+    lxml
     openpyxl
     xlrd
     h5py
-    fonttools
-    lxml
-    pandas
+    psycopg2
     pyshp
+    #mapbox-vector-tile
+    #pypng
+    fonttools
+    #sas7bdat
+    #xport
+    #savReaderWriter
+    pyyaml
+    #namestand
+    #datapackage
+    pdfminer
+    #tabula
+    vobject
+    tabulate
+    wcwidth
+    zstandard
     setuptools
   ] ++ lib.optionals withPcap [ dpkt dnslib ];
 


### PR DESCRIPTION
###### Motivation for this change

This adds some missing dependencies for the visidata package and enables running the test suite.


###### Remarks

* Some other optional dependencies which are not already packaged on nixpkgs are omitted (commented).

* Almost all of the added and existing dependencies are optional, although nice to have by default in this "data multi-tool app".
  I'm not sure whether it's necessary to add `withDep ? true, dep ? null` parameters for all of them since they can be easily be disabled by setting them to `null` when calling the package.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
