### PR TITLE
nixos/tests/overlayfs: Fix erroneous backslashes

### DIFF
--- a/nixos/tests/overlayfs.nix
+++ b/nixos/tests/overlayfs.nix
@@ -15,36 +15,33 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     # Test ext4 + overlayfs
     machine.succeed(
-        """
-          mkfs.ext4 -F -L overlay-ext4 /dev/vdb
-          mount -t ext4 /dev/vdb /tmp/mnt
-          mkdir -p /tmp/mnt/upper /tmp/mnt/lower /tmp/mnt/work /tmp/mnt/merged
-          # Setup some existing files
-          echo 'Replace' > /tmp/mnt/lower/replace.txt
-          echo 'Append' > /tmp/mnt/lower/append.txt
-          echo 'Overwrite' > /tmp/mnt/lower/overwrite.txt
-          mount -t overlay overlay -o lowerdir=/tmp/mnt/lower,upperdir=/tmp/mnt/upper,workdir=/tmp/mnt/work /tmp/mnt/merged
-          # Test new
-          echo 'New' > /tmp/mnt/merged/new.txt
-          [[ "$(cat /tmp/mnt/merged/new.txt)" == "New" ]]
-          # Test replace
-          [[ "$(cat /tmp/mnt/merged/replace.txt)" == "Replace" ]]
-          echo 'Replaced' > /tmp/mnt/merged/replace-tmp.txt
-          mv /tmp/mnt/merged/replace-tmp.txt /tmp/mnt/merged/replace.txt
-          [[ "$(cat /tmp/mnt/merged/replace.txt)" == "Replaced" ]]
-          # Overwrite
-          [[ "$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwrite" ]]
-          echo 'Overwritten' > /tmp/mnt/merged/overwrite.txt
-          [[ "$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwritten" ]]
-          # Test append
-          [[ "$(cat /tmp/mnt/merged/append.txt)" == "Append" ]]
-          echo 'ed' >> /tmp/mnt/merged/append.txt
-          #"cat /tmp/mnt/merged/append.txt && exit 1
-          [[ "$(cat /tmp/mnt/merged/append.txt)" == "Append\ned" ]]
-          umount /tmp/mnt/merged
-          umount /tmp/mnt
-          udevadm settle
-      """
+      'mkfs.ext4 -F -L overlay-ext4 /dev/vdb',
+      'mount -t ext4 /dev/vdb /tmp/mnt',
+      'mkdir -p /tmp/mnt/upper /tmp/mnt/lower /tmp/mnt/work /tmp/mnt/merged',
+      # Setup some existing files
+      'echo Replace > /tmp/mnt/lower/replace.txt',
+      'echo Append > /tmp/mnt/lower/append.txt',
+      'echo Overwrite > /tmp/mnt/lower/overwrite.txt',
+      'mount -t overlay overlay -o lowerdir=/tmp/mnt/lower,upperdir=/tmp/mnt/upper,workdir=/tmp/mnt/work /tmp/mnt/merged',
+      # Test new
+      'echo New > /tmp/mnt/merged/new.txt',
+      '[[ "$(cat /tmp/mnt/merged/new.txt)" == New ]]',
+      # Test replace
+      '[[ "$(cat /tmp/mnt/merged/replace.txt)" == Replace ]]',
+      'echo Replaced > /tmp/mnt/merged/replace-tmp.txt',
+      'mv /tmp/mnt/merged/replace-tmp.txt /tmp/mnt/merged/replace.txt',
+      '[[ "$(cat /tmp/mnt/merged/replace.txt)" == Replaced ]]',
+      # Overwrite
+      '[[ "$(cat /tmp/mnt/merged/overwrite.txt)" == Overwrite ]]',
+      'echo Overwritten > /tmp/mnt/merged/overwrite.txt',
+      '[[ "$(cat /tmp/mnt/merged/overwrite.txt)" == Overwritten ]]',
+      # Test append
+      '[[ "$(cat /tmp/mnt/merged/append.txt)" == Append ]]',
+      'echo ed >> /tmp/mnt/merged/append.txt',
+      '[[ "$(cat /tmp/mnt/merged/append.txt)" == "Append\ned" ]]',
+      'umount /tmp/mnt/merged',
+      'umount /tmp/mnt',
+      'udevadm settle',
     )
   '';
 })

--- a/nixos/tests/overlayfs.nix
+++ b/nixos/tests/overlayfs.nix
@@ -26,21 +26,21 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           mount -t overlay overlay -o lowerdir=/tmp/mnt/lower,upperdir=/tmp/mnt/upper,workdir=/tmp/mnt/work /tmp/mnt/merged
           # Test new
           echo 'New' > /tmp/mnt/merged/new.txt
-          [[ "\$(cat /tmp/mnt/merged/new.txt)" == "New" ]]
+          [[ "$(cat /tmp/mnt/merged/new.txt)" == "New" ]]
           # Test replace
-          [[ "\$(cat /tmp/mnt/merged/replace.txt)" == "Replace" ]]
+          [[ "$(cat /tmp/mnt/merged/replace.txt)" == "Replace" ]]
           echo 'Replaced' > /tmp/mnt/merged/replace-tmp.txt
           mv /tmp/mnt/merged/replace-tmp.txt /tmp/mnt/merged/replace.txt
-          [[ "\$(cat /tmp/mnt/merged/replace.txt)" == "Replaced" ]]
+          [[ "$(cat /tmp/mnt/merged/replace.txt)" == "Replaced" ]]
           # Overwrite
-          [[ "\$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwrite" ]]
+          [[ "$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwrite" ]]
           echo 'Overwritten' > /tmp/mnt/merged/overwrite.txt
-          [[ "\$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwritten" ]]
+          [[ "$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwritten" ]]
           # Test append
-          [[ "\$(cat /tmp/mnt/merged/append.txt)" == "Append" ]]
+          [[ "$(cat /tmp/mnt/merged/append.txt)" == "Append" ]]
           echo 'ed' >> /tmp/mnt/merged/append.txt
           #"cat /tmp/mnt/merged/append.txt && exit 1
-          [[ "\$(cat /tmp/mnt/merged/append.txt)" == "Append\ned" ]]
+          [[ "$(cat /tmp/mnt/merged/append.txt)" == "Append\ned" ]]
           umount /tmp/mnt/merged
           umount /tmp/mnt
           udevadm settle


### PR DESCRIPTION
Since commit b7749c76715ba96727f7a12bc2514ddfa6847813, commands run as part of VM tests are exiting immediately if an error happens.

When converting the overlayfs test to Python in commit 5ae92144ba04caefaf56b4204abe85b71dbb527b, the individual test commands were crammed into one big string instead of using a series of test commands like done in the Perl version.

Additionally, the backslash-escaped dollar signs were necessary in Perl's double-quoted strings to avoid variable interpolation, for Python however, this results in an actual backslash being inserted into the command.

While this obviously results in an exit code of 1 (without an error message, since it's using bash's expression evaluation command), the test didn't fail because putting all these commands in one string will result in only the last error code being relevant.

With the change to `set -e` for commands sent to test machines, this has changed and with the exit code of all commands now relevant, the test now fails because the errors from individual command substitutions that were prevented by escaping the dollar sign are now actually visible.

This in turn also means that until now, we wouldn't have noticed if the overlayfs test would have failed for real.