### PR TITLE
haskellPackages.shellFor: Work around hoogle generation failure

### DIFF
--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -63,10 +63,13 @@ buildPackages.stdenv.mkDerivation {
   passAsFile = ["buildCommand"];
 
   buildCommand = ''
-    ${lib.optionalString (packages != [] -> docPackages == [])
+    ${let # Filter out nulls here to work around https://github.com/NixOS/nixpkgs/issues/82245
+          # If we don't then grabbing `p.name` here will fail.
+          packages' = lib.filter (p: p != null) packages;
+      in lib.optionalString (packages' != [] -> docPackages == [])
        ("echo WARNING: localHoogle package list empty, even though"
        + " the following were specified: "
-       + lib.concatMapStringsSep ", " (p: p.name) packages)}
+       + lib.concatMapStringsSep ", " (p: p.name) packages')}
     mkdir -p $out/share/doc/hoogle
 
     echo importing builtin packages


### PR DESCRIPTION
Workaround for https://github.com/NixOS/nixpkgs/issues/82245

Although this doesn't tackle the root cause of a null package sneaking
in (via executableHaskellDepends), it does effectively treat the symptom
by just ignoring any null packages.

Seeing as that issue has been open for more than a year I think this
band-aid is necessary.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).