### PR TITLE
hdf4: fix build on aarch64-darwin

### DIFF
--- a/pkgs/tools/misc/hdf4/darwin-aarch64.patch
+++ b/pkgs/tools/misc/hdf4/darwin-aarch64.patch
@@ -1,0 +1,11 @@
+--- a/hdf/src/hdfi.h	2021-06-16 16:31:31.000000000 +1200
++++ b/hdf/src/hdfi.h	2021-06-16 16:42:26.000000000 +1200
+@@ -1343,7 +1343,7 @@
+ #endif /* IA64 */
+ 
+ /* Linux AArch64 */
+-#if defined __aarch64__
++#if defined __aarch64__ && !defined __APPLE__
+ 
+ #ifdef GOT_MACHINE
+ If you get an error on this line more than one machine type has been defined.

--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-aarch64.patch";
       sha256 = "112svcsilk16ybbsi8ywnxfl2p1v44zh3rfn4ijnl8z08vfqrvvs";
     })
+    ./darwin-aarch64.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This resolves #126156 by preventing the headers from confusing Linux aarch64 with Apple. This fix goes some way to unblocking the builds of gdal, postgis and probably some other popular packages.

The package's own extensive tests pass fine without further changes.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
