### PR TITLE
nix-linter: 2020-09-25 -> 2021-06-16

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -22,6 +22,8 @@ self: super: {
   # https://github.com/spacchetti/spago/issues/512
   spago = self.callPackage ../tools/purescript/spago/spago.nix { };
 
+  nix-linter = self.callPackage ../../development/tools/analysis/nix-linter { };
+
   nix-output-monitor = self.callPackage ../../tools/nix/nix-output-monitor { };
 
   # cabal2nix --revision <rev> https://github.com/hasura/ci-info-hs.git

--- a/pkgs/development/tools/analysis/nix-linter/default.nix
+++ b/pkgs/development/tools/analysis/nix-linter/default.nix
@@ -17,18 +17,17 @@
 , containers
 , hnix
 , bytestring
-, fetchpatch
 }:
 
 mkDerivation rec {
   pname = "nix-linter-unstable";
-  version = "2020-09-25";
+  version = "2021-06-16";
 
   src = fetchFromGitHub {
     owner = "Synthetica9";
     repo = "nix-linter";
-    rev = "2516a8cda41f9bb553a1c3eca38e3dd94ebf53de";
-    sha256 = "07mn2c9v67wsm57jlxv9pqac9hahw4618vngmj2sfbgihx8997kb";
+    rev = "74707ed48dcc58dbfa27ae25ee0e044c072cc344";
+    sha256 = "17scghkinpx3pzlw3hw023ybnd8cy7bqfy8b48vwaq8a7bnm2rs3";
   };
 
   isLibrary = false;
@@ -36,14 +35,6 @@ mkDerivation rec {
   libraryHaskellDepends = [ fixplate ];
   executableHaskellDepends = [ streamly mtl path pretty-terminal text base aeson cmdargs containers hnix bytestring path-io ];
   testHaskellDepends = [ tasty tasty-hunit tasty-th ];
-
-  patches = [
-    # Fix compatibility with hnix≥0.13.0 https://github.com/Synthetica9/nix-linter/pull/51
-    (fetchpatch {
-      url = "https://github.com/Synthetica9/nix-linter/commit/f73acacd8623dc25c9a35f8e04e4ff33cc596af8.patch";
-      sha256 = "139fm21hdg3vcw8hv35kxj4awd52bjqbb76mpzx191hzi9plj8qc";
-    })
-  ];
 
   description = "Linter for Nix(pkgs), based on hnix";
   homepage = "https://github.com/Synthetica9/nix-linter";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30873,7 +30873,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  nix-linter = haskell.lib.justStaticExecutables (haskellPackages.callPackage ../development/tools/analysis/nix-linter { });
+  nix-linter = haskell.lib.justStaticExecutables (haskellPackages.nix-linter);
 
   nix-pin = callPackage ../tools/package-management/nix-pin { };
 


### PR DESCRIPTION
Also add to haskellPackages


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).