### PR TITLE
xlockmore: add preConfigure to compile with DPMS support

### DIFF
--- a/pkgs/misc/screensavers/xlockmore/default.nix
+++ b/pkgs/misc/screensavers/xlockmore/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, pam ? null, libX11, libXext, libXinerama
-, libXdmcp, libXt }:
+, libXdmcp, libXt, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "xlockmore-5.66";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
   };
 
   # Optionally, it can use GTK.
-  buildInputs = [ pam libX11 libXext libXinerama libXdmcp libXt ];
+  buildInputs = [ pam libX11 libXext.dev libXinerama libXdmcp libXt ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   # Don't try to install `xlock' setuid. Password authentication works
   # fine via PAM without super user privileges.


### PR DESCRIPTION
###### Motivation for this change

The `xlock` command can switch the display off if it supports DPMS but the 
command shipped with NixOS does not support it.

The build of xlockmore produced only the minimum set of features. DPMS
support, Xinerama etc was disabled because the changes in the postPatch
step were never applied by re-running autoconf.

Furthermore, DPMS was not supported because it couldn't find the
`dpms.h` header file in order to compile the support for DPMS features.

This patch uses the `autoreconfHook` in which we run
`autoconf` to apply the changes of `configure.ac` to the `configure`
script. The patch also uses the `libXext.dev` `buildInput` in order to
allow access to the right header files.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
