### PR TITLE
bitwig-studio: support PipeWire

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
   ldLibraryPath = lib.strings.makeLibraryPath buildInputs;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp -r opt/bitwig-studio $out/libexec
     ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
@@ -41,6 +43,8 @@ stdenv.mkDerivation rec {
     substitute usr/share/applications/bitwig-studio.desktop \
       $out/share/applications/bitwig-studio.desktop \
       --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
+
+      runHook postInstall
   '';
 
   postFixup = ''
@@ -57,7 +61,7 @@ stdenv.mkDerivation rec {
       wrapProgram $f \
         "''${gappsWrapperArgs[@]}" \
         --prefix PATH : "${binPath}" \
-        --prefix LD_LIBRARY_PATH : "${ldLibraryPath}"
+        --suffix LD_LIBRARY_PATH : "${ldLibraryPath}"
     done
 
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
NixOS's `services.pipewire.jack` and `pw-jack` set `LD_LIBRARY_PATH` for PipeWire JACK support. We need to ensure those binaries are prioritized.

###### Things done
Add the `buildInputs` as a suffix rather than prefix to `LD_LIBRARY_PATH` in the wrapper.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
