### PR TITLE
[20.09] lldpd: add patch for CVE-2020-27827

### DIFF
--- a/pkgs/tools/networking/lldpd/default.nix
+++ b/pkgs/tools/networking/lldpd/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, pkgconfig, removeReferencesTo
 , libevent, readline, net-snmp, openssl
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -10,6 +11,20 @@ stdenv.mkDerivation rec {
     url = "https://media.luffy.cx/files/lldpd/${pname}-${version}.tar.gz";
     sha256 = "16fbqrs3l976gdslx647nds8x7sz4h5h3h4l4yxzrayvyh9b5lrd";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-27827-1.patch";
+      url = "https://github.com/lldpd/lldpd/commit/a8d3c90feca548fc0656d95b5d278713db86ff61.patch";
+      sha256 = "135hnq3wzga3zpmpy65jyyqyn67id9di1y3kv2qczp5jdgxfx9cy";
+    })
+    (fetchpatch {
+      name = "CVE-2020-27827-2.patch";
+      url = "https://github.com/lldpd/lldpd/commit/7d60bf30effc4c88f17f3d58ecaa72479f16d4be.patch";
+      sha256 = "0b2j8sn2z7p9250iki7rx88f9cdrxv5by7cbmmmwa0h4c5cb6b61";
+      excludes = [ "NEWS" ];
+    })
+  ];
 
   configureFlags = [
     "--localstatedir=/var"


### PR DESCRIPTION
###### Motivation for this change

These are the two patches listed here:
 https://lldpd.github.io/security.html

Fix #120396


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
