### PR TITLE
autoconf: use pname & version instead of name

### DIFF
--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -6,10 +6,11 @@
 # files.
 
 stdenv.mkDerivation rec {
-  name = "autoconf-2.71";
+  pname = "autoconf";
+  version = "2.71";
 
   src = fetchurl {
-    url = "mirror://gnu/autoconf/${name}.tar.xz";
+    url = "mirror://gnu/autoconf/${pname}-${version}.tar.xz";
     sha256 = "197sl23irn6s9pd54rxj5vcp5y8dv65jb9yfqgr2g56cxg7q6k7i";
   };
 

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "2.71";
 
   src = fetchurl {
-    url = "mirror://gnu/autoconf/${pname}-${version}.tar.xz";
+    url = "mirror://gnu/autoconf/autoconf-${version}.tar.xz";
     sha256 = "197sl23irn6s9pd54rxj5vcp5y8dv65jb9yfqgr2g56cxg7q6k7i";
   };
 


### PR DESCRIPTION
###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
