### PR TITLE
Bump my packages

### DIFF
--- a/pkgs/applications/audio/ptcollab/default.nix
+++ b/pkgs/applications/audio/ptcollab/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , nix-update-script
 , qmake
+, pkg-config
 , qtbase
 , qtmultimedia
 , libvorbis
@@ -12,21 +13,16 @@
 
 mkDerivation rec {
   pname = "ptcollab";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "yuxshao";
     repo = "ptcollab";
     rev = "v${version}";
-    sha256 = "1yfnf47saxxj17x0vyxihr343kp7gz3fashzky79j80sqlm6ng85";
+    sha256 = "sha256-98v9it9M5FXCsOpWvO10uKYmEH15v1FEH1hH73XHa7w=";
   };
 
-  postPatch = ''
-    substituteInPlace src/editor.pro \
-      --replace '/usr/include/rtmidi' '${rtmidi}/include/rtmidi'
-  '';
-
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake pkg-config ];
 
   buildInputs = [ qtbase qtmultimedia libvorbis rtmidi ];
 

--- a/pkgs/applications/audio/sidplayfp/default.nix
+++ b/pkgs/applications/audio/sidplayfp/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, nix-update-script
 , autoreconfHook
 , perl
 , pkg-config
@@ -15,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sidplayfp";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "libsidplayfp";
     repo = "sidplayfp";
     rev = "v${version}";
-    sha256 = "0s3xmg3yzfqbsnlh2y46w7b5jim5zq7mshs6hx03q8wdr75cvwh4";
+    sha256 = "sha256-hN7225lhuYyo4wPDiiEc9FaPg90pZ13mLw93V8tb/P0=";
   };
 
   nativeBuildInputs = [ autoreconfHook perl pkg-config ];
@@ -36,6 +37,12 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     description = "A SID player using libsidplayfp";

--- a/pkgs/development/libraries/libsidplayfp/default.nix
+++ b/pkgs/development/libraries/libsidplayfp/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
+, nix-update-script
 , autoreconfHook
 , pkg-config
 , perl
@@ -16,28 +16,15 @@
 
 stdenv.mkDerivation rec {
   pname = "libsidplayfp";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "libsidplayfp";
     repo = "libsidplayfp";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0487gap2b0ypikyra74lk1qwqwr0vncldamk5xb1db2x97v504fd";
+    sha256 = "sha256-lDM4nJozZF8Rt+XWnM41hBAYatZVsmvvQajgHLI9uy0=";
   };
-
-  # https://github.com/libsidplayfp/libsidplayfp/issues/13
-  # Remove on next version bump
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/libsidplayfp/libsidplayfp/commit/84f5498f5653261ed84328e1b5676c31e3ba9e6e.patch";
-      sha256 = "1vysbl4fkdzm11k40msng2ag6i6mb6z9jsw32vyj9calcfha5957";
-    })
-    (fetchpatch {
-      url = "https://github.com/libsidplayfp/libsidplayfp/commit/c1a1b732cc2e791d910522d58f47c6d094493c6d.patch";
-      sha256 = "1d3sgdly0q9dysgkx5afxbwfas6p0m8n3lw1hmj4n6wm3j9sdz4g";
-    })
-  ];
 
   postPatch = ''
     patchShebangs .
@@ -71,6 +58,12 @@ stdenv.mkDerivation rec {
     mkdir -p $doc/share/doc/libsidplayfp
     mv docs/html $doc/share/doc/libsidplayfp/
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     description = "A library to play Commodore 64 music derived from libsidplay2";

--- a/pkgs/misc/emulators/punes/default.nix
+++ b/pkgs/misc/emulators/punes/default.nix
@@ -17,13 +17,13 @@
 
 mkDerivation rec {
   pname = "punes";
-  version = "unstable-2021-04-25";
+  version = "unstable-2021-06-05";
 
   src = fetchFromGitHub {
     owner = "punesemu";
     repo = "puNES";
-    rev = "4b4c3495a56d3989544cb56079ce641da8aa9b35";
-    sha256 = "1wszvdgm38513v26p14k58shbkxn1qhkn8l0hsqi04vviicad59s";
+    rev = "07fd123f62b2d075894a0cc966124db7b427b791";
+    sha256 = "1wxff7b397ayd2s2v14w6a0zfgklc7y0kv3mkz1gg5x47mnll24l";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Bumping some of my packages with update.nix.

- ptcollab: 0.4.0 -> 0.4.1
- libsidplayfp: 2.1.1 -> 2.2.0
- sidplayfp: 2.1.1 -> 2.2.0
- punes: unstable-2021-04-25 -> unstable-2021-06-05 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
