### PR TITLE
xdg-desktop-portal-wlr: 0.3.0 -> 0.4.0 and module

### DIFF
--- a/nixos/doc/manual/configuration/wayland.xml
+++ b/nixos/doc/manual/configuration/wayland.xml
@@ -20,4 +20,14 @@
   essential utilities. Now you can start <package>sway</package> from the TTY
   console.
  </para>
+
+ <para>
+  If you are using a wlroots-based compositor, like sway, and want to be able to
+  share your screen, you might want to activate this option:
+<programlisting>
+<xref linkend="opt-xdg.portal.wlr.enable"/> = true;
+</programlisting>
+  and configure Pipewire using <xref linkend="opt-services.pipewire.enable"/>
+  and related options.
+ </para>
 </chapter>

--- a/nixos/modules/config/xdg/portals/wlr.nix
+++ b/nixos/modules/config/xdg/portals/wlr.nix
@@ -1,0 +1,67 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.xdg.portal.wlr;
+  package = pkgs.xdg-desktop-portal-wlr;
+  settingsFormat = pkgs.formats.ini { };
+  configFile = settingsFormat.generate "xdg-desktop-portal-wlr.ini" cfg.settings;
+in
+{
+  meta = {
+    maintainers = with maintainers; [ minijackson ];
+  };
+
+  options.xdg.portal.wlr = {
+    enable = mkEnableOption ''
+      desktop portal for wlroots-based desktops
+
+      This will add the <package>xdg-desktop-portal-wlr</package> package into
+      the <option>xdg.portal.extraPortals</option> option, and provide the
+      configuration file
+    '';
+
+    settings = mkOption {
+      description = ''
+        Configuration for <package>xdg-desktop-portal-wlr</package>.
+
+        See <literal>xdg-desktop-portal-wlr(5)</literal> for supported
+        values.
+      '';
+
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+      };
+
+      default = { };
+
+      # Example taken from the manpage
+      example = literalExample ''
+        {
+          screencast = {
+            output_name = "HDMI-A-1";
+            max_fps = 30;
+            exec_before = "disable_notifications.sh";
+            exec_after = "enable_notifications.sh";
+            chooser_type = "simple";
+            chooser_cmd = "''${pkgs.slurp}/bin/slurp -f %o -or";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ package ];
+    };
+
+    systemd.user.services.xdg-desktop-portal-wlr.serviceConfig.ExecStart = [
+      # Empty ExecStart value to override the field
+      ""
+      "${package}/libexec/xdg-desktop-portal-wlr --config=${configFile}"
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -9,6 +9,7 @@
   ./config/xdg/menus.nix
   ./config/xdg/mime.nix
   ./config/xdg/portal.nix
+  ./config/xdg/portals/wlr.nix
   ./config/appstream.nix
   ./config/console.nix
   ./config/xdg/sounds.nix

--- a/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
@@ -1,20 +1,20 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper
 , meson, ninja, pkg-config, wayland-protocols
-, pipewire, wayland, systemd, libdrm, iniparser, scdoc, grim, slurp }:
+, pipewire, wayland, systemd, libdrm, inih, scdoc, grim, slurp }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-wlr";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-6ArUQfWx5rNdpsd8Q22MqlpxLT8GTSsymAf21zGe1KI=";
+    sha256 = "sha256:13fbzh8bjnhk4xs8j9bpc01q3hy27zpbf0gkk1fnh3hm5pnyfyiv";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wayland-protocols makeWrapper ];
-  buildInputs = [ pipewire wayland systemd libdrm iniparser scdoc ];
+  buildInputs = [ pipewire wayland systemd libdrm inih scdoc ];
 
   mesonFlags = [
     "-Dsd-bus-provider=libsystemd"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog: https://github.com/emersion/xdg-desktop-portal-wlr/releases/tag/v0.4.0

This also introduces a NixOS module that generates a config file, and add the wlr portal to `xdg.portal.extraPortals`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @NixOS/freedesktop since to my knowledge it's the first desktop portal to have its own module, so I want to check if you're fine with the design.