### PR TITLE
[21.05] ptcollab: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/applications/audio/ptcollab/default.nix
+++ b/pkgs/applications/audio/ptcollab/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , nix-update-script
 , qmake
+, pkg-config
 , qtbase
 , qtmultimedia
 , libvorbis
@@ -12,21 +13,16 @@
 
 mkDerivation rec {
   pname = "ptcollab";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "yuxshao";
     repo = "ptcollab";
     rev = "v${version}";
-    sha256 = "1yfnf47saxxj17x0vyxihr343kp7gz3fashzky79j80sqlm6ng85";
+    sha256 = "sha256-98v9it9M5FXCsOpWvO10uKYmEH15v1FEH1hH73XHa7w=";
   };
 
-  postPatch = ''
-    substituteInPlace src/editor.pro \
-      --replace '/usr/include/rtmidi' '${rtmidi}/include/rtmidi'
-  '';
-
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake pkg-config ];
 
   buildInputs = [ qtbase qtmultimedia libvorbis rtmidi ];
 


### PR DESCRIPTION
(cherry picked from commit dffffdc912c6dfc3690f31edb55a51c2becffa6a)

###### Motivation for this change
Backport of simple patch bump from #127061. Should be better now @dotlambda.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
