### PR TITLE
python3Packages.websocket-client: 0.58.0 -> 1.1.0

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -33,6 +33,22 @@ let
         (mkOverride "unidecode" "0.04.21" "280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051")
         (mkOverride "sarge" "0.1.5.post0" "1c1ll7pys9vra5cfi8jxlgrgaql6c27l6inpy15aprgqhc4ck36s")
 
+        # Requires websocket-client <1.0, >=0.57. Cannot do mkOverride b/c differing underscore/hyphen in pypi source name
+        (
+          self: super: {
+            websocket-client = super.websocket-client.overridePythonAttrs (
+              oldAttrs: rec {
+                version = "0.58.0";
+                src = oldAttrs.src.override {
+                  pname = "websocket_client";
+                  inherit version;
+                  sha256 = "63509b41d158ae5b7f67eb4ad20fecbb4eee99434e73e140354dc3ff8e09716f";
+                };
+              }
+            );
+          }
+        )
+
         # Octoprint needs zeroconf >=0.24 <0.25. While this should be done in
         # the mkOverride aboves, this package also has broken tests, so we need
         # a proper override.

--- a/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
+++ b/pkgs/development/python-modules/jellyfin-apiclient-python/default.nix
@@ -1,5 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi, requests
-, websocket-client, pythonOlder }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, requests
+, six
+, websocket-client
+}:
 
 buildPythonPackage rec {
   pname = "jellyfin-apiclient-python";
@@ -11,7 +17,11 @@ buildPythonPackage rec {
     sha256 = "sha256-nSLUa9/jAT6XrHo77kV5HYBxPO/lhcWKqPfpES7ul9A=";
   };
 
-  propagatedBuildInputs = [ requests websocket-client ];
+  propagatedBuildInputs = [
+    requests
+    six
+    websocket-client
+  ];
 
   doCheck = false; # no tests
   pythonImportsCheck = [ "jellyfin_apiclient_python" ];

--- a/pkgs/development/python-modules/websocket-client/default.nix
+++ b/pkgs/development/python-modules/websocket-client/default.nix
@@ -1,27 +1,22 @@
 { lib
-, backports_ssl_match_hostname
 , buildPythonPackage
 , fetchPypi
-, isPy27
+, pythonOlder
 , pytestCheckHook
-, six
+, pysocks
 }:
 
 buildPythonPackage rec {
   pname = "websocket-client";
-  version = "0.58.0";
+  version = "1.1.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    pname = "websocket_client";
-    inherit version;
-    sha256 = "sha256-Y1CbQdFYrlt/Z+tK0g/su07umUNOc+FANU3D/44JcW8=";
+    inherit pname version;
+    sha256 = "sha256-to5JWdcEdo+iDjXJ1QjI3Cu8BB/Y0mfA1zRc/+KCRWg=";
   };
 
-  propagatedBuildInputs = [
-    six
-  ] ++ lib.optional isPy27 backports_ssl_match_hostname;
-
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [ pytestCheckHook pysocks ];
 
   pythonImportsCheck = [ "websocket" ];
 
@@ -30,5 +25,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/websocket-client/websocket-client";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ fab ];
+    changelog = "https://github.com/websocket-client/websocket-client/blob/v${version}/ChangeLog";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update websocket-client to latest version. Found update when trying to update downstream package that requires newest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
