### PR TITLE
openjdk11: remove default library path

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -39,6 +39,7 @@ let
       ./read-truststore-from-env-jdk10.patch
       ./currency-date-range-jdk10.patch
       ./increase-javadoc-heap.patch
+      ./fix-library-path-jdk11.patch
     ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk10.patch
     ];

--- a/pkgs/development/compilers/openjdk/fix-library-path-jdk11.patch
+++ b/pkgs/development/compilers/openjdk/fix-library-path-jdk11.patch
@@ -1,0 +1,37 @@
+diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+index 0dbe03349e..847d56778d 100644
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -326,13 +326,13 @@ void os::init_system_properties_values() {
+   //        ...
+   //        7: The default directories, normally /lib and /usr/lib.
+ #if defined(AMD64) || (defined(_LP64) && defined(SPARC)) || defined(PPC64) || defined(S390)
+-  #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
++  #define DEFAULT_LIBPATH ""
+ #else
+-  #define DEFAULT_LIBPATH "/lib:/usr/lib"
++  #define DEFAULT_LIBPATH ""
+ #endif
+ 
+ // Base path of extensions installed on the system.
+-#define SYS_EXT_DIR     "/usr/java/packages"
++#define SYS_EXT_DIR     ""
+ #define EXTENSIONS_DIR  "/lib/ext"
+ 
+   // Buffer that fits several sprintfs.
+@@ -392,13 +392,13 @@ void os::init_system_properties_values() {
+                                                      strlen(v) + 1 +
+                                                      sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1,
+                                                      mtInternal);
+-    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
++    sprintf(ld_library_path, "%s", v);
+     Arguments::set_library_path(ld_library_path);
+     FREE_C_HEAP_ARRAY(char, ld_library_path);
+   }
+ 
+   // Extensions directories.
+-  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
++  sprintf(buf, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
+   Arguments::set_ext_dirs(buf);
+ 
+   FREE_C_HEAP_ARRAY(char, buf);


### PR DESCRIPTION
###### Motivation for this change

This is a follow up to #123708 which does the similar patch but for OpenJDK11.
Please see the linked issue for more detailed rationale.


###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
