### PR TITLE
litestream: init at 0.3.5

### DIFF
--- a/pkgs/development/tools/database/litestream/default.nix
+++ b/pkgs/development/tools/database/litestream/default.nix
@@ -26,6 +26,5 @@ buildGoModule rec {
     license = licenses.asl20;
     homepage = "https://litestream.io/";
     maintainers = with maintainers; [ fbrs ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/database/litestream/default.nix
+++ b/pkgs/development/tools/database/litestream/default.nix
@@ -1,0 +1,31 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+buildGoModule rec {
+  pname = "litestream";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "benbjohnson";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-OQ8j0FOUWU5TfCl4AZpmX5tuhtHAbrhvzT6ve6AJNn0=";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  vendorSha256 = "sha256-ScG8cukUuChOvN9r0HvVJsYnu1X9DSO7aD32iu55jIM=";
+
+  meta = with lib; {
+    description = "Streaming replication for SQLite";
+    license = licenses.asl20;
+    homepage = "https://litestream.io/";
+    maintainers = with maintainers; [ fbrs ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13654,6 +13654,8 @@ in
 
   litecli = callPackage ../development/tools/database/litecli {};
 
+  litestream = callPackage ../development/tools/database/litestream {};
+
   lsof = callPackage ../development/tools/misc/lsof { };
 
   ltrace = callPackage ../development/tools/misc/ltrace { };


### PR DESCRIPTION
###### Motivation for this change

Add `litestream` https://litestream.io/ a neat and simple tool for replicating SQLite databases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
