### PR TITLE
rust-bindgen: some features of bindgen require a recent version of llvm

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, clang, llvmPackages, rustfmt, writeScriptBin
+{ lib, fetchFromGitHub, rustPlatform, clang, llvmPackages_latest, rustfmt, writeScriptBin
 , runtimeShell
 , bash
 }:
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "0r60smhlx1992a1s1k5sxjpdqllb2xsqcimgx3ldp5fdkfphk3cw";
 
   #for substituteAll
-  libclang = llvmPackages.libclang.lib;
+  libclang = llvmPackages_latest.libclang.lib;
   inherit bash;
 
   buildInputs = [ libclang ];


### PR DESCRIPTION
###### Motivation for this change

Features likes 'asm goto' are only available if compiled with llvm >= 11.

This is required for rust-in-linux development for example. I believe
binding to llvmPackages_latest is an acceptable tradeoff.

<details>

```
  RUSTC L rust/build_error.o
error: unknown argument: '-fmacro-prefix-map=./='
error: unknown argument: '-fno-stack-clash-protection'
error: unknown warning option '-Wno-frame-address'; did you mean '-Wno-address'? [-Wunknown-warning-option]
error: unknown warning option '-Wno-pointer-to-enum-cast' [-Wunknown-warning-option]
./arch/x86/include/asm/bitops.h:138:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/bitops.h:162:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/bitops.h:201:9: error: 'asm goto' constructs are not supported yet
./include/linux/list.h:282:9: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
./include/linux/list.h:318:27: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
./include/linux/list.h:821:10: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
./include/linux/list.h:830:10: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
./arch/x86/include/asm/atomic.h:83:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic.h:123:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic.h:137:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic.h:152:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic64_64.h:76:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic64_64.h:118:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic64_64.h:132:9: error: 'asm goto' constructs are not supported yet
./arch/x86/include/asm/atomic64_64.h:147:9: error: 'asm goto' constructs are not supported yet
./include/linux/jump_label.h:278:2: error: expected '(' after 'asm'
./include/linux/jump_label.h:284:2: error: expected '(' after 'asm'
./include/linux/jump_label.h:306:2: error: expected '(' after 'asm'
./include/linux/jump_label.h:309:3: error: expected '(' after 'asm'
./include/linux/jump_label.h:317:2: error: expected '(' after 'asm'
./include/linux/jump_label.h:320:3: error: expected '(' after 'asm'
./include/linux/llist.h:189:9: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
fatal error: too many errors emitted, stopping now [-ferror-limit=]
error: unknown argument: '-fmacro-prefix-map=./=', err: true
error: unknown argument: '-fno-stack-clash-protection', err: true
error: unknown warning option '-Wno-frame-address'; did you mean '-Wno-address'? [-Wunknown-warning-option], err: true
error: unknown warning option '-Wno-pointer-to-enum-cast' [-Wunknown-warning-option], err: true
./arch/x86/include/asm/bitops.h:138:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/bitops.h:162:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/bitops.h:201:9: error: 'asm goto' constructs are not supported yet, err: true
./include/linux/list.h:282:9: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier], err: false
./include/linux/list.h:318:27: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier], err: false
./include/linux/list.h:821:10: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier], err: false
./include/linux/list.h:830:10: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier], err: false
./arch/x86/include/asm/atomic.h:83:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic.h:123:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic.h:137:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic.h:152:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic64_64.h:76:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic64_64.h:118:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic64_64.h:132:9: error: 'asm goto' constructs are not supported yet, err: true
./arch/x86/include/asm/atomic64_64.h:147:9: error: 'asm goto' constructs are not supported yet, err: true
./include/linux/jump_label.h:278:2: error: expected '(' after 'asm', err: true
./include/linux/jump_label.h:284:2: error: expected '(' after 'asm', err: true
./include/linux/jump_label.h:306:2: error: expected '(' after 'asm', err: true
./include/linux/jump_label.h:309:3: error: expected '(' after 'asm', err: true
./include/linux/jump_label.h:317:2: error: expected '(' after 'asm', err: true
./include/linux/jump_label.h:320:3: error: expected '(' after 'asm', err: true
./include/linux/llist.h:189:9: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier], err: false
fatal error: too many errors emitted, stopping now [-ferror-limit=], err: true
thread 'main' panicked at 'Unable to generate bindings: ()', src/main.rs:54:36
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make[1]: *** [rust/Makefile:141: rust/bindings_generated.rs] Error 1
make[1]: *** Deleting file 'rust/bindings_generated.rs'
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
