### PR TITLE
Revert "python3Packages.tensorflow: 2.4.1 -> 2.5.0"

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -72,7 +72,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "2.5.0";
+  version = "2.4.1";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -110,7 +110,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "0v5qfzkfj9p7z50kp6zfq584n4pzyvjhsajbf5mpydgw4zm7af13";
+      sha256 = "sha256-J62QfP45g5nxN9Nqa1tAGyc4vD2JKh50ddHLrd6/qsY=";
     };
 
     patches = [

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -110,7 +110,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "1jdw2i1rq06zqd6aabh7bbm0avsg4pygnfmd7gviv0blhih9054l";
+      sha256 = "0v5qfzkfj9p7z50kp6zfq584n4pzyvjhsajbf5mpydgw4zm7af13";
     };
 
     patches = [

--- a/pkgs/development/python-modules/tensorflow/relax-dependencies.patch
+++ b/pkgs/development/python-modules/tensorflow/relax-dependencies.patch
@@ -1,27 +1,26 @@
 diff --git a/tensorflow/tools/pip_package/setup.py b/tensorflow/tools/pip_package/setup.py
-index 354657a7bfc..eac85d4dba0 100644
+index 65133afdafe..8ef6364ff7e 100644
 --- a/tensorflow/tools/pip_package/setup.py
 +++ b/tensorflow/tools/pip_package/setup.py
-@@ -78,24 +78,24 @@ REQUIRED_PACKAGES = [
-     # NOTE: As numpy has releases that break semver guarantees and several other
-     # deps depend on numpy without an upper bound, we must install numpy before
-     # everything else.
--    'numpy ~= 1.19.2',
-+    'numpy >= 1.19.2',
-     # Install other dependencies
+@@ -75,23 +75,23 @@ if '--project_name' in sys.argv:
+ # comment the versioning scheme.
+ # NOTE: Please add test only packages to `TEST_PACKAGES` below.
+ REQUIRED_PACKAGES = [
 -    'absl-py ~= 0.10',
 -    'astunparse ~= 1.6.3',
 -    'flatbuffers ~= 1.12.0',
 -    'google_pasta ~= 0.2',
--    'h5py ~= 3.1.0',
+-    'h5py ~= 2.10.0',
 -    'keras_preprocessing ~= 1.1.2',
+-    'numpy ~= 1.19.2',
 -    'opt_einsum ~= 3.3.0',
 +    'absl-py >= 0.10',
 +    'astunparse >= 1.6.3',
 +    'flatbuffers >= 1.12.0',
 +    'google_pasta >= 0.2',
-+    'h5py >= 3.1.0',
++    'h5py >= 2.10.0',
 +    'keras_preprocessing >= 1.1.2',
++    'numpy >= 1.19.1',
 +    'opt_einsum >= 3.3.0',
      'protobuf >= 3.9.2',
 -    'six ~= 1.15.0',
@@ -32,21 +31,21 @@ index 354657a7bfc..eac85d4dba0 100644
 +    'six >= 1.15.0',
 +    'termcolor >= 1.1.0',
 +    'typing_extensions >= 3.7.4',
-+    'wheel >= 0.35',
++    'wheel >= 0.34.2',
 +    'wrapt >= 1.12.1',
-     # These packages need to be pinned exactly as newer versions are
+     # These packages needs to be pinned exactly as newer versions are
      # incompatible with the rest of the ecosystem
--    'gast == 0.4.0',
-+    'gast >= 0.4.0',
+-    'gast == 0.3.3',
++    'gast >= 0.3.3',
      # TensorFlow ecosystem packages that TF exposes API for
      # These need to be in sync with the existing TF version
      # They are updated during the release process
-@@ -127,7 +127,7 @@ if 'tf_nightly' in project_name:
+@@ -118,7 +118,7 @@ if 'tf_nightly' in project_name:
  # BoringSSL support.
  # See https://github.com/tensorflow/tensorflow/issues/17882.
  if sys.byteorder == 'little':
--  REQUIRED_PACKAGES.append('grpcio ~= 1.34.0')
-+  REQUIRED_PACKAGES.append('grpcio >= 1.34.0')
+-  REQUIRED_PACKAGES.append('grpcio ~= 1.32.0')
++  REQUIRED_PACKAGES.append('grpcio >= 1.31.0')
  
  
  # Packages which are only needed for testing code.


### PR DESCRIPTION
Reverts NixOS/nixpkgs#125328

Script which merges if everything was successfully built still triggered after canceling the `nixpkgs-review`... I apologize for the bad merge