### PR TITLE
nwg-panel: init at 0.3.2

### DIFF
--- a/pkgs/applications/misc/nwg-panel/default.nix
+++ b/pkgs/applications/misc/nwg-panel/default.nix
@@ -1,0 +1,57 @@
+{ lib, fetchFromGitHub
+, python3Packages, wrapGAppsHook, gobject-introspection
+, gtk-layer-shell, pango, gdk-pixbuf, atk
+# Extra packages called by various internal nwg-panel modules
+, sway             # swaylock, swaymsg
+, systemd          # systemctl
+, wlr-randr        # wlr-randr
+, nwg-menu         # nwg-menu
+, light            # light
+, pamixer          # pamixer
+, pulseaudio       # pactl
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "nwg-panel";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = "nwg-panel";
+    rev = "v${version}";
+    hash = "sha256-x5lGVF6eRhOVXrsBatdsiUiWs/+FxRlCtp79zA206RY=";
+  };
+
+  # No tests
+  doCheck = false;
+
+  # Because of wrapGAppsHook
+  strictDeps = false;
+  dontWrapGApps = true;
+
+  buildInputs = [ atk gdk-pixbuf gtk-layer-shell pango ];
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
+  propagatedBuildInputs = with python3Packages; [ i3ipc netifaces psutil pybluez pygobject3 ];
+
+  postInstall = ''
+    mkdir -p $out/share/{applications,pixmaps}
+    cp $src/nwg-panel-config.desktop $out/share/applications/
+    cp $src/nwg-shell.svg $src/nwg-panel.svg $out/share/pixmaps/
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix XDG_DATA_DIRS : "$out/share"
+      --prefix PATH : "${lib.makeBinPath [ light nwg-menu pamixer pulseaudio sway systemd wlr-randr ]}"
+    )
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/nwg-piotr/nwg-panel";
+    description = "GTK3-based panel for Sway window manager";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ berbiche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25684,6 +25684,8 @@ in
 
   nwg-menu = callPackage ../applications/misc/nwg-menu { };
 
+  nwg-panel = callPackage ../applications/misc/nwg-panel { };
+
   ocenaudio = callPackage ../applications/audio/ocenaudio { };
 
   onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };


### PR DESCRIPTION
###### Motivation for this change

[nwg-panel](https://github.com/nwg-piotr/nwg-panel) is a customizable panel for Sway.

cc: https://github.com/nix-community/nixpkgs-wayland/issues/274

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
