### PR TITLE
nwg-menu: init at unstable-2021-06-12

### DIFF
--- a/pkgs/applications/misc/nwg-menu/default.nix
+++ b/pkgs/applications/misc/nwg-menu/default.nix
@@ -1,0 +1,48 @@
+{ lib, fetchFromGitHub
+, buildGoModule, pkg-config, wrapGAppsHook, gobject-introspection
+, gtk-layer-shell, gtk3, pango, gdk-pixbuf, atk
+}:
+
+buildGoModule rec {
+  pname = "nwg-menu";
+  version = "unstable-2021-06-12";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = "nwg-menu";
+    rev = "b0746e26514a047ed9c6b975a71b7263aa39bd56";
+    hash = "sha256-rxyf3CfpfWnRAlIR/pl+s7LGAZbZjdtNWPPK7BecdhQ=";
+  };
+
+  vendorSha256 = "sha256-nN5iBleK12SKY9PBiDA+tM4B8FiVGZLXbtJM2+YrEfA=";
+
+  runVend = true;
+
+  doCheck = false;
+
+  buildInputs = [ atk gtk3 gdk-pixbuf gtk-layer-shell pango ];
+  nativeBuildInputs = [ pkg-config wrapGAppsHook gobject-introspection ];
+
+  prePatch = ''
+    for file in main.go tools.go; do
+      substituteInPlace $file --replace '/usr/share/nwg-menu' $out/share
+    done
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/
+    cp menu-start.css $out/share/
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "$out/share")
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/nwg-piotr/nwg-menu";
+    description = "MenuStart plugin for nwg-panel";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ berbiche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25549,6 +25549,8 @@ in
 
   nwg-launchers = callPackage ../applications/misc/nwg-launchers { };
 
+  nwg-menu = callPackage ../applications/misc/nwg-menu { };
+
   ocenaudio = callPackage ../applications/audio/ocenaudio { };
 
   onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };


### PR DESCRIPTION
###### Motivation for this change

[nwg-menu](https://github.com/nwg-piotr/nwg-menu) is a menu to be used with nwg-panel.

Related nwg-panel pr: #127163 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
