### PR TITLE
services.xorg.config: Extend docs

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -358,6 +358,13 @@ in
         description = ''
           The contents of the configuration file of the X server
           (<filename>xorg.conf</filename>).
+
+          This option is set by multiple modules, and the configs are
+          concatenated together.
+
+          In Xorg configs the last config entries take precedence,
+          so you may want to use <literal>lib.mkAfter</literal> on this option
+          to override NixOS's defaults.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

I was surprised that my config had no effect.

Because in Xorg, the last config takes precedence, I had to use `mkAfter` to make mine the most specific, e.g.:

```nix
{
  # xinput to set my preferred scroll behaviour for the Tex Shinobi,
  # via `xorg.conf` so that it also applies when re-plugged.

  services.xserver.config = lib.mkAfter ''
    # Instead of:
    #     xinput set-int-prop "USB-HID Keyboard Mouse" "libinput Scroll Method Enabled" 8 0 0 1
    # See: https://bbs.archlinux.org/viewtopqic.php?pid=1941373#p1941373
    # `0 0 1` translates to `button`, see https://www.mankier.com/4/libinput
    # in section `libinput Scroll Method Enabled`.

    Section "InputClass"
      Identifier   "Tex Shinobi scroll settings"
      MatchDriver  "libinput"
      MatchProduct "USB-HID Keyboard Mouse"
      Option       "ScrollMethod" "button"
    EndSection
  '';
}
```

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
