### PR TITLE
home-assistant: prepare dependencies for python3.9

### DIFF
--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -16,7 +16,6 @@
 buildPythonPackage rec {
   pname = "aioguardian";
   version = "1.0.7";
-  disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "bachya";

--- a/pkgs/development/python-modules/aiohomekit/default.nix
+++ b/pkgs/development/python-modules/aiohomekit/default.nix
@@ -13,7 +13,6 @@ buildPythonPackage rec {
   pname = "aiohomekit";
   version = "0.2.67";
   format = "pyproject";
-  disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "Jc2k";

--- a/pkgs/development/python-modules/pytile/default.nix
+++ b/pkgs/development/python-modules/pytile/default.nix
@@ -14,7 +14,6 @@
 buildPythonPackage rec {
   pname = "pytile";
   version = "5.2.1";
-  disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     owner = "bachya";

--- a/pkgs/development/python-modules/typing-inspect/default.nix
+++ b/pkgs/development/python-modules/typing-inspect/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "typing-inspect";
-  version = "0.6.0";
+  version = "0.7.1";
 
   src = fetchPypi {
     inherit version;
     pname = "typing_inspect";
-    sha256 = "1dzs9a1pr23dhbvmnvms2jv7l7jk26023g5ysf0zvnq8b791s6wg";
+    sha256 = "1al2lyi3r189r5xgw90shbxvd88ic4si9w7n3d9lczxiv6bl0z84";
   };
 
   propagatedBuildInputs = [
@@ -26,6 +26,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/ilevkivskyi/typing_inspect";
     license = licenses.mit;
     maintainers = with maintainers; [ albakham ];
-    broken = isPy39;  # see https://github.com/ilevkivskyi/typing_inspect/issues/65
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -134,19 +134,6 @@ let
       });
     })
 
-    # Remove after https://github.com/NixOS/nixpkgs/pull/121854 has passed staging-next
-    (self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.4.13";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0npsg38d11skv04zvsi90j93f6jdgm8666ds2ri7shr1pz1732hx";
-        };
-        patches = [];
-        propagatedBuildInputs = [ python3.pkgs.greenlet ];
-      });
-    })
-
     # home-assistant-frontend does not exist in python3.pkgs
     (self: super: {
       home-assistant-frontend = self.callPackage ./frontend.nix { };

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -782,6 +782,8 @@ in with py.pkgs; buildPythonApplication rec {
     # onboarding tests rpi_power component, for which we are lacking rpi_bad_power library
     "test_onboarding_core_sets_up_rpi_power"
     "test_onboarding_core_no_rpi_power"
+    # hue/test_sensor_base.py: Race condition when counting events
+    "test_hue_events"
   ];
 
   preCheck = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Did a quick check what it would take to move home-assistant over to python3.9.

Turns out: Not much.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
