### PR TITLE
blackshades: svn-110 -> 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6481,10 +6481,14 @@
     name = "Matthias C. M. Troffaes";
   };
   McSinyx = {
-    email = "vn.mcsinyx@gmail.com";
+    email = "mcsinyx@disroot.org";
     github = "McSinyx";
     githubId = 13689192;
     name = "Nguyễn Gia Phong";
+    keys = [{
+      longkeyid = "rsa3072/0x27148B2C06A2224B";
+      fingerprint = "E90E 11B8 0493 343B 6132  E394 2714 8B2C 06A2 224B";
+    }];
   };
   mcwitt = {
     email = "mcwitt@gmail.com";

--- a/pkgs/games/blackshades/default.nix
+++ b/pkgs/games/blackshades/default.nix
@@ -1,34 +1,37 @@
-{lib, stdenv, fetchsvn, SDL, libGLU, libGL, openal, libvorbis, freealut, SDL_image}:
+{ lib, stdenv, fetchFromSourcehut
+, SDL, SDL_image, libGLU, libGL, openal, libvorbis, freealut }:
 
-stdenv.mkDerivation {
-  name = "blackshades-svn-110";
-  src = fetchsvn {
-    url = "svn://svn.icculus.org/blackshades/trunk";
-    rev = "110";
-    sha256 = "0kbrh1dympk8scjxr6av24qs2bffz44l8qmw2m5gyqf4g3rxf6ra";
+stdenv.mkDerivation rec {
+  pname = "blackshades";
+  version = "1.1.1";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "1gx43hcqahbd21ib8blhzmsrwqfzx4qy7f10ck0mh2zc4bfihz64";
   };
-
-  NIX_LDFLAGS = "-lSDL_image";
 
   buildInputs = [ SDL SDL_image libGLU libGL openal libvorbis freealut ];
 
   patchPhase = ''
-    sed -i -e s,Data/,$out/opt/$name/Data/,g \
-      -e s,Data:,$out/opt/$name/Data/,g \
-      Source/*.cpp
+    sed -i -e s,Data/,$out/share/$pname/,g \
+      -e s,Data:,$out/share/$pname/,g \
+      src/*.cpp
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/opt/$name
-    cp objs/blackshades $out/bin
-    cp -R Data IF* Readme $out/opt/$name/
+    mkdir -p $out/bin $out/share/doc/$pname
+    cp build/blackshades $out/bin
+    cp -R Data $out/share/$pname
+    cp README.md $out/share/doc/$pname
   '';
 
   meta = {
-    homepage = "http://icculus.org/blackshades/";
-    description = "Protect the VIP";
-    license = lib.licenses.free;
-    maintainers = with lib.maintainers; [viric];
+    homepage = "https://sr.ht/~cnx/blackshades";
+    description = "A psychic bodyguard FPS";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ McSinyx viric ];
     platforms = with lib.platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I am now the upstream maintainer of this package, which has recently been [relicensed to GPLv3+](https://lists.sr.ht/~cnx/blackshades/%3CCC5KX31G7Y9G.FUEV6FB9UG99%40nix%3E).  This new release corporates a few minor fixes that were previously patched or unnoticed.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
