### PR TITLE
broot: 1.4.0 -> 1.6.0

### DIFF
--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -14,14 +14,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "broot";
-  version = "1.4.0";
+  version = "1.6.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-6UveXa0rMWt5FbmhB0CsYRMGMXxL8FB/XivB4Ec93PY=";
+    sha256 = "sha256-H/QT/fmQI9sHjl6wMJjrfjvbOhY9VyBkAGetvcUqGrE=";
   };
 
-  cargoHash = "sha256-c6U1ZOaXZ7RnKD7q0WTkam9gL8SL/naSeHGbB5I82lk=";
+  cargoHash = "sha256-5mqLVbB/dLAk3Ck7ilHhVn0CB/6Ln82SaTxZ/vkx+9k=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

> v1.6.0 - 2021-06-16
> - `{root}` argument (current tree root) can be used in verb patterns
> - `working_dir` verb attribute
> - client-server mode fixed, no longer feature-gated (but still only available on unix like systems)
> - broot tries to keep same selection on option changes
> - `:tree_up` and `:tree_down` internals, mapped to ctrl-up and ctrl-down
> - better handling of auto color mode: two separate behaviors: for app running and for export when leaving
> - remove the deprecated `--no-style` launch argument (use `--color no` instead)
> - deprecate the `--out` argument (redirecting the output is the recommanded solution)
> - fix a few minor bugs
> 
> v1.5.1 - 2021-06-03
> - fixed a few problems with the `:del_word_right` internal
> 
> v1.5.0 - 2021-06-02
> - new `auto_exec` verb property: a non-auto_exec verb isn't executed directly on a keyboard shortcut but fills the input so that it may be edited before execution on enter key
> - add support for backtab key (by default it's bound to :previous_match)
> - `:rename` built-in verb, best used with its keyboard shortcut F2
> - new standard verb arguments: `{file-stem}`, `{file-extension}`, and `{file-dot-extension}`,
> - new `:toggle_second_tree` internal
> - total size of staging area computed and displayed if sizes displayed elsewhere
> - new `file_sum_threads_count` conf property to define the number of threads used for file summing (size, count, last modified). The goal is to more easily search what's the best value depending on the cpu, OS and disk type/speed
> - `:input_clear` internal

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
