### PR TITLE
tensorflow-lite: set CXXSTANDARD to c++17

### DIFF
--- a/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
@@ -83,6 +83,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/tensorflow/tensorflow/commit/f3c4f4733692150fd6174f2cd16438cfaba2e5ab.patch";
       sha256 = "0zx4hbz679kn79f30159rl1mq74dg45cvaawii0cyv48z472yy4k";
     })
+    # TODO: remove on the next version bump
+    (fetchpatch {
+      name = "cxxstandard-var.patch";
+      url = "https://github.com/tensorflow/tensorflow/commit/9b128ae4200e10b4752f903492d1e7d11957ed5c.patch";
+      sha256 = "1q0izdwdji5fbyqll6k4dmkzfykyvvz5cvc6hysdj285nkn2wy6h";
+    })
   ];
 
   buildInputs = [ zlib flatbuffers ];
@@ -140,7 +146,14 @@ stdenv.mkDerivation rec {
       # tensorflow lite expects to compile abseil into `libtensorflow-lite.a`
       ln -s ${abseil-cpp.src} "$prefix/absl"
 
-      buildFlagsArray+=(INCLUDES="-I $PWD ${includes}" TARGET_TOOLCHAIN_PREFIX="" -j$NIX_BUILD_CORES all)
+      # set CXXSTANDARD=c++17 here because abseil-cpp in nixpkgs is set as
+      # such and would be used in dependents like libedgetpu
+      buildFlagsArray+=(
+        INCLUDES="-I $PWD ${includes}"
+        CXXSTANDARD=-std=c++17
+        TARGET_TOOLCHAIN_PREFIX=""
+        -j$NIX_BUILD_CORES
+        all)
     '';
 
   installPhase = ''

--- a/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
@@ -150,7 +150,7 @@ stdenv.mkDerivation rec {
       # such and would be used in dependents like libedgetpu
       buildFlagsArray+=(
         INCLUDES="-I $PWD ${includes}"
-        CXXSTANDARD=-std=c++17
+        CXXSTANDARD="-std=c++17"
         TARGET_TOOLCHAIN_PREFIX=""
         -j$NIX_BUILD_CORES
         all)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds setting the CXXSTANDARD Makefile variable to the `tensorflow-lite` package.
This is necessary to avoid linker errors when a downstream library uses abseil-cpp
from nixpkgs along with `tensorflow-lite`, which is fairly common.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
