### PR TITLE
modemmanager: 1.14.2 -> 1.16.6

### DIFF
--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     description = "WWAN modem manager, part of NetworkManager";
     homepage = "https://www.freedesktop.org/wiki/Software/ModemManager/";
     license = licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = teams.freedesktop.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -1,19 +1,33 @@
-{ lib, stdenv, fetchurl, glib, udev, libgudev, polkit, ppp, gettext, pkg-config
-, libmbim, libqmi, systemd, vala, gobject-introspection, dbus }:
+{ lib, stdenv, fetchurl, fetchpatch
+, glib, udev, libgudev, polkit, ppp, gettext, pkg-config, python3
+, libmbim, libqmi, systemd, vala, gobject-introspection, dbus
+}:
 
 stdenv.mkDerivation rec {
   pname = "modem-manager";
-  version = "1.14.12";
+  version = "1.16.6";
 
-  package = "ModemManager";
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/${package}/${package}-${version}.tar.xz";
-    sha256 = "sha256-0QqXEZndwl3N8VbFasCOkWEsCVOdVlIueu1G1G5IO7E=";
+    url = "https://www.freedesktop.org/software/ModemManager/ModemManager-${version}.tar.xz";
+    sha256 = "05wn94x71qr36avxjzvyf56nj5illynnf9nn15b17lv61wkbd41a";
   };
+
+  patches = [
+    # Fix a broken test.
+    # https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/556
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/a324667386f35df0c3b3bbf615fa0560d215485d.patch";
+      sha256 = "1xj9gfl6spbp4xdp6gn76k8zvzam5m6lgmbiwdn6ixffzhlfwi5l";
+    })
+  ];
 
   nativeBuildInputs = [ vala gobject-introspection gettext pkg-config ];
 
   buildInputs = [ glib udev libgudev polkit ppp libmbim libqmi systemd ];
+
+  installCheckInputs = [
+    python3 python3.pkgs.dbus-python python3.pkgs.pygobject3
+  ];
 
   configureFlags = [
     "--with-polkit"
@@ -26,13 +40,23 @@ stdenv.mkDerivation rec {
     "--with-systemd-journal"
   ];
 
-  preCheck = ''
-    export G_TEST_DBUS_DAEMON="${dbus.daemon}/bin/dbus-daemon"
+  postPatch = ''
+    patchShebangs tools/test-modemmanager-service.py
   '';
 
-  enableParallelBuilding = true;
+  # In Nixpkgs g-ir-scanner is patched to produce absolute paths, and
+  # that interferes with ModemManager's tests, causing them to try to
+  # load libraries from the install path, which doesn't usually exist
+  # when `make check' is run.  So to work around that, we run it as an
+  # install check instead, when those paths will have been created.
+  doInstallCheck = true;
+  preInstallCheck = ''
+    export G_TEST_DBUS_DAEMON="${dbus.daemon}/bin/dbus-daemon"
+    patchShebangs tools/tests/test-wrapper.sh
+  '';
+  installCheckTarget = "check";
 
-  doCheck = true;
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "WWAN modem manager, part of NetworkManager";


### PR DESCRIPTION
Getting the new test to work was an absolute nightmare, but I did it!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
