### PR TITLE
jitsi-meet: stable/jitsi-meet_5390 -> stable/jitsi-meet_5963

### DIFF
--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -187,8 +187,8 @@ in
       ];
       extraModules = [ "pubsub" ];
       extraConfig = mkAfter ''
-        Component "focus.${cfg.hostName}"
-          component_secret = os.getenv("JICOFO_COMPONENT_SECRET")
+        Component "focus.${cfg.hostName}" "client_proxy"
+          target_address = "focus@auth.${cfg.hostName}"
       '';
       virtualHosts.${cfg.hostName} = {
         enabled = true;
@@ -254,6 +254,7 @@ in
       + optionalString cfg.prosody.enable ''
         ${config.services.prosody.package}/bin/prosodyctl register focus auth.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jicofo-user-secret)"
         ${config.services.prosody.package}/bin/prosodyctl register jvb auth.${cfg.hostName} "$(cat ${videobridgeSecret})"
+        ${config.services.prosody.package}/bin/prosodyctl mod_roster_command subscribe focus.${cfg.hostName} focus@auth.${cfg.hostName}
 
         # generate self-signed certificates
         if [ ! -f /var/lib/jitsi-meet.crt ]; then

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -186,6 +186,7 @@ in
         }
       ];
       extraModules = [ "pubsub" ];
+      extraPluginPaths = [ "${pkgs.jitsi-meet-prosody}/share/prosody-plugins" ];
       extraConfig = mkAfter ''
         Component "focus.${cfg.hostName}" "client_proxy"
           target_address = "focus@auth.${cfg.hostName}"

--- a/nixos/tests/jitsi-meet.nix
+++ b/nixos/tests/jitsi-meet.nix
@@ -8,6 +8,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     client = { nodes, pkgs, ... }: {
     };
     server = { config, pkgs, ... }: {
+      virtualisation.memorySize = 512;
       services.jitsi-meet = {
         enable = true;
         hostName = "server";
@@ -37,13 +38,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         "journalctl -b -u jitsi-videobridge2 -o cat | grep -q 'Performed a successful health check'"
     )
     server.wait_until_succeeds(
-        "journalctl -b -u jicofo -o cat | grep -q 'connected .JID: focus@auth.server'"
-    )
-    server.wait_until_succeeds(
         "journalctl -b -u prosody -o cat | grep -q 'Authenticated as focus@auth.server'"
-    )
-    server.wait_until_succeeds(
-        "journalctl -b -u prosody -o cat | grep -q 'focus.server:component: External component successfully authenticated'"
     )
     server.wait_until_succeeds(
         "journalctl -b -u prosody -o cat | grep -q 'Authenticated as jvb@auth.server'"

--- a/pkgs/misc/jitsi-meet-prosody/default.nix
+++ b/pkgs/misc/jitsi-meet-prosody/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl, dpkg, nixosTests }:
+
+stdenv.mkDerivation rec {
+  pname = "jitsi-meet-prosody";
+  version = "1.0.5056";
+  src = fetchurl {
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "06qxa9h2ry92xrk2jklp76nv3sl8nvykdvsqmhn33lz6q6vmw2xr";
+  };
+
+  dontBuild = true;
+
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $src debcontents";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share
+    mv usr/share/jitsi-meet/prosody-plugins $out/share/
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    single-node-smoke-test = nixosTests.jitsi-meet;
+  };
+
+  meta = with lib; {
+    description = "Prosody configuration for Jitsi Meet";
+    longDescription = ''
+        This package contains configuration for Prosody to be used with Jitsi Meet.
+    '';
+    homepage = "https://github.com/jitsi/jitsi-meet/";
+    license = licenses.asl20;
+    maintainers = teams.jitsi.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/jicofo/default.nix
+++ b/pkgs/servers/jicofo/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-690";
+  version = "1.0-756";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "1w5nz2p6scd7w0ac93vhxlk5i8in5160c0icwl27m4x4km9xf6al";
+    sha256 = "07qmxqp1llpn8kh590iz35zk17c2k4yg7i43nb2l0sfm40crpwfz";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/servers/jitsi-videobridge/default.nix
+++ b/pkgs/servers/jitsi-videobridge/default.nix
@@ -2,10 +2,10 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.1-416-g2f43d1b4";
+  version = "2.1-508-gb24f756c";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    sha256 = "0s9wmbba1nlpxaawzmaqg92882y5sfs2ws64w5sqvpi7n77hy54m";
+    sha256 = "0kjsm3k7chgrfvvqxkp8xdw6wfrs122j4h8gcvyvpf9lg51p199g";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jitsi-meet";
-  version = "1.0.4628";
+  version = "1.0.5056";
 
   src = fetchurl {
     url = "https://download.jitsi.org/jitsi-meet/src/jitsi-meet-${version}.tar.bz2";
-    sha256 = "1kw4byy6mvqk3qd5nk5raka1bl9jp0kniszq6j5kc8nz3jql4qdz";
+    sha256 = "0vmxy22zpgmvmg84y6rf9s8y3ann1xzhpaipz7fk9z4ykmkj5knw";
   };
 
   dontBuild = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19328,6 +19328,8 @@ in
 
   jitsi-meet = callPackage ../servers/web-apps/jitsi-meet { };
 
+  jitsi-meet-prosody = callPackage ../misc/jitsi-meet-prosody { };
+
   jitsi-videobridge = callPackage ../servers/jitsi-videobridge { };
 
   kapowbang = callPackage ../servers/kapowbang { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/120583 is out of date and appears to have stalled. Motivation remains the same, "Jitsi has gotten more functionality visible in the UI in the most recent version over the one that is currently in nixpkgs, there is also a [variety of fixes](https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-WEB.md)."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This PR is a WIP. The newer versions of jitsi-meet and jitsi-videobridge work fine, but updating Jicofo breaks Jitsi.