### PR TITLE
Revert "terraform: drop old versions"

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -156,6 +156,43 @@ rec {
   # Constructor for other terraform versions
   mkTerraform = attrs: pluggable (generic attrs);
 
+  terraform_0_12 = mkTerraform {
+    version = "0.12.31";
+    sha256 = "03p698xdbk5gj0f9v8v1fpd74zng3948dyy4f2hv7zgks9hid7fg";
+    patches = [
+      ./provider-path.patch
+      (fetchpatch {
+        name = "fix-mac-mojave-crashes.patch";
+        url = "https://github.com/hashicorp/terraform/commit/cd65b28da051174a13ac76e54b7bb95d3051255c.patch";
+        sha256 = "1k70kk4hli72x8gza6fy3vpckdm3sf881w61fmssrah3hgmfmbrs";
+      })
+    ];
+    passthru = { inherit plugins; };
+  };
+
+  terraform_0_13 = mkTerraform {
+    version = "0.13.7";
+    sha256 = "1cahnmp66dk21g7ga6454yfhaqrxff7hpwpdgc87cswyq823fgjn";
+    patches = [ ./provider-path.patch ];
+    passthru = { inherit plugins; };
+  };
+
+  terraform_0_14 = mkTerraform {
+    version = "0.14.11";
+    sha256 = "1yi1jj3n61g1kn8klw6l78shd23q79llb7qqwigqrx3ki2mp279j";
+    vendorSha256 = "1d93aqkjdrvabkvix6h1qaxpjzv7w1wa7xa44czdnjs2lapx4smm";
+    patches = [ ./provider-path.patch ];
+    passthru = { inherit plugins; };
+  };
+
+  terraform_0_15 = mkTerraform {
+    version = "0.15.5";
+    sha256 = "18f4a6l24s3cym7gk40agxikd90i56q84wziskw1spy9rgv2yx6d";
+    vendorSha256 = "12hrpxay6k3kz89ihyhl91c4lw4wp821ppa245w9977fq09fhnx0";
+    patches = [ ./provider-path-0_15.patch ];
+    passthru = { inherit plugins; };
+  };
+
   terraform_1_0 = mkTerraform {
     version = "1.0.0";
     sha256 = "sha256-ddcT/I2Qn1pKFyhXgh+CcD3fSv2steSNmjyyiS2SE/o=";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -818,10 +818,6 @@ mapAliases ({
   telepathy_salut = telepathy-salut; # added 2018-02-25
   telnet = inetutils; # added 2018-05-15
   terraform_1_0_0 = terraform_1_0; # added 2021-06-15
-  terraform_0_12 = throw "terraform 0.12 has been removed"; # added 2021-06-15
-  terraform_0_13 = throw "terraform 0.13 has been removed"; # added 2021-06-15
-  terraform_0_14 = throw "terraform 0.14 has been removed"; # added 2021-06-15
-  terraform_0_15 = throw "terraform 0.15 has been removed"; # added 2021-06-15
   terraform-provider-ibm = terraform-providers.ibm; # added 2018-09-28
   terraform-provider-libvirt = terraform-providers.libvirt; # added 2018-09-28
   terraform-provider-lxd = terraform-providers.lxd; # added 2020-03-16

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31269,6 +31269,10 @@ in
 
   inherit (callPackage ../applications/networking/cluster/terraform { })
     mkTerraform
+    terraform_0_12
+    terraform_0_13
+    terraform_0_14
+    terraform_0_15
     terraform_1_0
     terraform_plugins_test
     ;


### PR DESCRIPTION
Leave a bit of breathing rooms for users to upgrade.

This reverts commit 3919d7303074924cdc6ca941eb0424829d4fec54.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
