### PR TITLE
printrun: make gsettings schemas available

### DIFF
--- a/pkgs/applications/misc/printrun/default.nix
+++ b/pkgs/applications/misc/printrun/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub, glib, wrapGAppsHook }:
 
 python3Packages.buildPythonApplication rec {
   pname = "printrun";
@@ -10,6 +10,8 @@ python3Packages.buildPythonApplication rec {
     rev = "${pname}-${version}";
     sha256 = "179x8lwrw2h7cxnkq7izny6qcb4nhjnd8zx893i77zfhzsa6kx81";
   };
+
+  nativeBuildInputs = [ glib wrapGAppsHook ];
 
   propagatedBuildInputs = with python3Packages; [
     appdirs cython dbus-python numpy six wxPython_4_0 psutil pyglet pyopengl pyserial
@@ -27,6 +29,14 @@ python3Packages.buildPythonApplication rec {
     for f in $out/share/applications/*.desktop; do
       sed -i -e "s|/usr/|$out/|g" "$f"
     done
+  '';
+
+  dontWrapGApps = true;
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   meta = with lib; {


### PR DESCRIPTION
When doing certain operations in `pronterface.py` (like File → Open), it currently crashes with `GLib-GIO-ERROR **: No GSettings schemas are installed on the system`. This PR makes the gsettings schemas available to pronterface by wrapping the executable with the arguments generated by `wrapGAppsHook` and `glib`’s hook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
