### PR TITLE
lib/customisation: Use lists of attrsets for callPackageWith

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -113,9 +113,11 @@ let
     inherit (pkgs.stdenv) buildPlatform targetPlatform hostPlatform;
   };
 
-  splicedPackagesWithXorg = splicedPackages // builtins.removeAttrs splicedPackages.xorg [
+  splicedXorg = builtins.removeAttrs splicedPackages.xorg [
     "callPackage" "newScope" "overrideScope" "packages"
   ];
+
+  splicedPackagesWithXorg = [ splicedPackages splicedXorg ];
 
 in
 
@@ -129,7 +131,7 @@ in
 
   callPackages = lib.callPackagesWith splicedPackagesWithXorg;
 
-  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
+  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg ++ lib.toList extra);
 
   # Haskell package sets need this because they reimplement their own
   # `newScope`.


### PR DESCRIPTION
###### Motivation for this change
This commit allows `callPackage[s]With` to take a list of attrsets as the
autoArgs instead. Doing this allows for a very easy optimization: When
we want to `callPackageWith` two (or more) attribute sets, instead of
having to `//` them together, which has to allocate a _new_ attribute set
that can store both sides, we can just pass them as two separate
attribute sets instead. The `callPackageWith` then first intersects these
two attribute sets with the function arguments before merging them.
Because the number of function arguments is usually rather small, we
never allocate any new big attribute sets.

We essentially just use the fact that

    intersectAttrs funArgs (a // b) == intersectAttrs funArgs a // intersectAttrs funArgs b

to our advantage to not have to allocate huge attribute sets when a or
b are already huge.

**In my measurements, this patch saves about up to 10% of memory usage
when evaluating packages!**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
