### PR TITLE
[staging] SDL: fix hashes

### DIFF
--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -73,18 +73,18 @@ stdenv.mkDerivation rec {
     })
     # Fix drops of keyboard events for SDL_EnableUNICODE
     (fetchpatch {
-      url = "http://hg.libsdl.org/SDL/raw-rev/0aade9c0203f";
-      sha256 = "1y9izncjlqvk1mkz1pkl9lrk9s452cmg2izjjlqqrhbn8279xy50";
+      url = "https://github.com/libsdl-org/SDL-1.2/commit/0332e2bb18dc68d6892c3b653b2547afe323854b.patch";
+      sha256 = "0g458iv6pp9sikdch6ms8svz60lf5ks2q5wgid8s9rydhk98lpp5";
     })
     # Ignore insane joystick axis events
     (fetchpatch {
-      url = "http://hg.libsdl.org/SDL/raw-rev/95abff7adcc2";
-      sha256 = "0i8x0kx0pw12ld5bfxhyzs466y3c0n9dscw1ijhq1b96r72xyhqq";
+      url = "https://github.com/libsdl-org/SDL-1.2/commit/ab99cc82b0a898ad528d46fa128b649a220a94f4.patch";
+      sha256 = "1b3473sawfdbkkxaqf1hg0vn37yk8hf655jhnjwdk296z4gclazh";
     })
     # https://bugzilla.libsdl.org/show_bug.cgi?id=1769
     (fetchpatch {
-      url = "http://hg.libsdl.org/SDL/raw-rev/91ad7b43317a";
-      sha256 = "15g537vbl2my4mfrjxfkcx9ri6bk2gjvaqj650rjdxwk2nkdkn4b";
+      url = "https://github.com/libsdl-org/SDL-1.2/commit/5d79977ec7a6b58afa6e4817035aaaba186f7e9f.patch";
+      sha256 = "1k7y57b1zy5afib1g7w3in36n8cswbcrzdbrjpn5cb105rnb9vmp";
     })
     # Workaround X11 bug to allow changing gamma
     # Ticket: https://bugs.freedesktop.org/show_bug.cgi?id=27222
@@ -96,12 +96,12 @@ stdenv.mkDerivation rec {
     # Fix a build failure on OS X Mavericks
     # Ticket: https://bugzilla.libsdl.org/show_bug.cgi?id=2085
     (fetchpatch {
-      url = "http://hg.libsdl.org/SDL/raw-rev/e9466ead70e5";
-      sha256 = "0mpwdi09h89df2wxqw87m1rdz7pr46k0w6alk691k8kwv970z6pl";
+      url = "https://github.com/libsdl-org/SDL-1.2/commit/19039324be71738d8990e91b9ba341b2ea068445.patch";
+      sha256 = "0ckwling2ad27c9vxgp97ndjd098d6zbrydza8b9l77k8airj98c";
     })
     (fetchpatch {
-      url = "http://hg.libsdl.org/SDL/raw-rev/bbfb41c13a87";
-      sha256 = "1336g7waaf1c8yhkz11xbs500h8bmvabh4h437ax8l1xdwcppfxv";
+      url = "https://github.com/libsdl-org/SDL-1.2/commit/7933032ad4d57c24f2230db29f67eb7d21bb5654.patch";
+      sha256 = "1by16firaxyr0hjvn35whsgcmq6bl0nwhnpjf75grjzsw9qvwyia";
     })
   ];
 

--- a/pkgs/development/libraries/SDL_image/default.nix
+++ b/pkgs/development/libraries/SDL_image/default.nix
@@ -12,8 +12,9 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "CVE-2017-2887";
-      url = "https://hg.libsdl.org/SDL_image/raw-diff/318484db0705/IMG_xcf.c";
-      sha256 = "140dyszz9hkpgwjdiwp1b7jdd8f8l5d862xdaf3ml4cimga1h5kv";
+      url = "https://github.com/libsdl-org/SDL_image/commit/e7723676825cd2b2ffef3316ec1879d7726618f2.patch";
+      includes = [ "IMG_xcf.c" ];
+      sha256 = "174ka2r95i29nlshzgp6x5vc68v7pi8lhzf33and2b1ms49g4jb7";
     })
   ];
 


### PR DESCRIPTION
SDL migrated from hg.libsdl.org to github.com and transparently
redirects the patch urls, but the patch contents are not identical due
to the mercurial -> git migration.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
