### PR TITLE
xfce.thunar-media-tags-plugin: init at 0.3.0

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -35,6 +35,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   thunar-dropbox-plugin = callPackage ./thunar-plugins/dropbox { };
 
+  thunar-media-tags-plugin = callPackage ./thunar-plugins/media-tags { };
+
   tumbler = callPackage ./core/tumbler { };
 
   xfce4-panel = callPackage ./core/xfce4-panel { };

--- a/pkgs/desktops/xfce/thunar-plugins/media-tags/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/media-tags/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, mkXfceDerivation
+, gtk3
+, thunar
+, exo
+, libxfce4util
+, intltool
+, gettext
+, taglib
+}:
+
+mkXfceDerivation {
+  category = "thunar-plugins";
+  pname = "thunar-media-tags-plugin";
+  version = "0.3.0";
+
+  sha256 = "sha256-jtgcHH5U5GOvzDVUwPEreMtTdk5DT6sXvFPDbzbF684=";
+
+  nativeBuildInputs = [
+    intltool
+    gettext
+  ];
+
+  buildInputs = [
+    thunar
+    exo
+    gtk3
+    libxfce4util
+    taglib
+  ];
+
+  meta = with lib; {
+    description = "Thunar plugin providing tagging and renaming features for media files";
+    maintainers = with maintainers; [ ncfavier ];
+  };
+}


### PR DESCRIPTION
cc @romildo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested that this actually works
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
