### PR TITLE
unison: build 2.51.3 with ocaml 4.12

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchFromGitHub, ocamlPackages, fontschumachermisc, xset, makeWrapper, ncurses, gnugrep
+{lib, stdenv, fetchFromGitHub, ocamlPackages, fontschumachermisc, xset, makeWrapper, ncurses, gnugrep, fetchpatch
 , enableX11 ? true}:
 
 let inherit (ocamlPackages) ocaml lablgtk; in
@@ -16,6 +16,16 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ ocaml ncurses ];
+
+  patches = [
+    # Patch to fix build with ocaml 4.12. Remove in 2.51.4
+    # https://github.com/bcpierce00/unison/pull/481
+    (fetchpatch {
+      name = "fix-compile-with-ocaml-4.12.patch";
+      url = "https://github.com/bcpierce00/unison/commit/14b885316e0a4b41cb80fe3daef7950f88be5c8f.patch?full_index=1";
+      sha256 = "0j1rma1cwdsfql19zvzhfj2ys5c4lbhjcp6jrnck04xnckxxiy3d";
+    })
+  ];
 
   preBuild = (if enableX11 then ''
     sed -i "s|\(OCAMLOPT=.*\)$|\1 -I $(echo "${lablgtk}"/lib/ocaml/*/site-lib/lablgtk2)|" src/Makefile.OCaml

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27157,7 +27157,6 @@ in
   unipicker = callPackage ../applications/misc/unipicker { };
 
   unison = callPackage ../applications/networking/sync/unison {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_09;
     enableX11 = config.unison.enableX11 or true;
   };
 


### PR DESCRIPTION
Add patch which fixes builds with (at least) ocaml 4.12.0, and
remove build constraint for 4.09. Fixes interop with unison 
built with ocaml 4.12.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

unison in nixpkgs is currently built with ocaml 4.09, but when built against ocaml 4.09, unison is 
not compatible with unisons built with ocaml 4.12. Unpatched unison 2.51.3 does not build 
with ocaml 4.12, but there is a patch which allows unison 2.51.3 to be built with ocaml 4.12.
This PR applies that patch and also removes the ocaml 4.09 restriction. The resulting 
unison has been tested successfully against unison 2.51.3 installed with Homebrew on MacOS 11
(the patch was found in [the Homebrew recipe](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/unison.rb)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
