### PR TITLE
neo4j-desktop: init at 1.4.5

### DIFF
--- a/pkgs/applications/misc/neo4j-desktop/default.nix
+++ b/pkgs/applications/misc/neo4j-desktop/default.nix
@@ -1,0 +1,32 @@
+{ appimageTools, lib, fetchurl }:
+let
+  pname = "neo4j-desktop";
+  version = "1.4.5";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://s3-eu-west-1.amazonaws.com/dist.neo4j.org/${pname}/linux-offline/${name}-x86_64.AppImage";
+    sha256 = "sha256-TCkjYhvGhgqgrDEMvC4Ww/sDxRhHC70YgfDlCIFitMo";
+  };
+
+  appimageContents = appimageTools.extract { inherit src; name = pname; };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraPkgs = pkgs: with pkgs; [ libsecret ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "A GUI front-end for Neo4j";
+    homepage = "http://www.neo4j.org/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.bobvanderlinden ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/misc/neo4j-desktop/default.nix
+++ b/pkgs/applications/misc/neo4j-desktop/default.nix
@@ -24,7 +24,7 @@ in appimageTools.wrapType2 {
 
   meta = with lib; {
     description = "A GUI front-end for Neo4j";
-    homepage = "http://www.neo4j.org/";
+    homepage = "https://neo4j.com/";
     license = licenses.unfree;
     maintainers = [ maintainers.bobvanderlinden ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19478,6 +19478,8 @@ in
 
   neo4j = callPackage ../servers/nosql/neo4j { };
 
+  neo4j-desktop = callPackage ../applications/misc/neo4j-desktop { };
+
   check-esxi-hardware = callPackage ../servers/monitoring/plugins/esxi.nix {};
 
   net-snmp = callPackage ../servers/monitoring/net-snmp { };


### PR DESCRIPTION
###### Motivation for this change

neo4j-desktop was not yet in nixpkgs. The AppImage that is supplied by neo4j doesn't work with Nix because of glibc not matching.

What also works is neo4j-desktop downloading neo4j on-the-fly. Surprised me a bit, but very convenient :+1:

This package was based on a number of other AppImage applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
