### PR TITLE
nixos/test-driver: Fix passing passthru attribute

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -217,13 +217,13 @@ rec {
           );
 
       driver = setupDriverForTest {
-        inherit testScript enableOCR skipLint;
+        inherit testScript enableOCR skipLint passthru;
         testName = name;
         qemu_pkg = pkgs.qemu_test;
         nodes = nodes pkgs.qemu_test;
       };
       driverInteractive = setupDriverForTest {
-        inherit testScript enableOCR skipLint;
+        inherit testScript enableOCR skipLint passthru;
         testName = name;
         qemu_pkg = pkgs.qemu;
         nodes = nodes pkgs.qemu;


### PR DESCRIPTION
Apparently this looks like it was forgotten when doing commit 3884ff70badca0c93c717e6190946a9a2846e948, which refactored the test runner and driver a bit.

The `passthru` argument actually was correctly reintroduced in `setupDriverForTest`, but the actual `makeTest` function didn't use it.

This fixes the nixpkgs tarball job, which previously failed with:

```
attribute 'elkPackages' missing, at /build/source/pkgs/tools/misc/logstash/6.x.nix:58:30
```

Fixes: https://github.com/NixOS/nixpkgs/issues/127274