### PR TITLE
programmer-calculator: init at 2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1883,6 +1883,12 @@
     githubId = 2131991;
     name = "Elmo Todurov";
   };
+  cjab = {
+    email = "chad+nixpkgs@jablonski.xyz";
+    github = "cjab";
+    githubId = 136485;
+    name = "Chad Jablonski";
+  };
   ck3d = {
     email = "ck3d@gmx.de";
     github = "ck3d";

--- a/pkgs/applications/science/math/programmer-calculator/default.nix
+++ b/pkgs/applications/science/math/programmer-calculator/default.nix
@@ -1,0 +1,34 @@
+{ lib, gccStdenv, fetchFromGitHub, ncurses }:
+
+gccStdenv.mkDerivation rec {
+  pname = "programmer-calculator";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "alt-romes";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1vvpbj24ijl9ma0h669n9x0z1im3vqdf8zf2li0xf5h97b14gmv0";
+  };
+
+  buildInputs = [ ncurses ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 555 pcalc -t "$out/bin"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A terminal calculator for programmers";
+    longDescription = ''
+      Terminal calculator made for programmers working with multiple number
+      representations, sizes, and overall close to the bits
+    '';
+    homepage = "https://alt-romes.github.io/programmer-calculator";
+    changelog = "https://github.com/alt-romes/programmer-calculator/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ cjab ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30173,6 +30173,8 @@ in
 
   pcalc = callPackage ../applications/science/math/pcalc { };
 
+  programmer-calculator = callPackage ../applications/science/math/programmer-calculator { };
+
   bcal = callPackage ../applications/science/math/bcal { };
 
   pspp = callPackage ../applications/science/math/pspp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

programmer-calculator is a terminal calculator for programmers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Comments

One concern I have is that this package contains a binary named `pcalc`. A _different_ package named `pcalc` already exists in nixpkgs that also contains a binary with this name. I noticed `priority` in metadata which I think would prioritize one of these over the other? But it wasn't clear to me which is higher priority. Another option is to just rename this binary from `pcalc` -> `programmer-calculator` or something similar. I'm not sure what the usual approach to these sorts of problems is. Any guidance is welcome! Thank you! 😄 
