### PR TITLE
home-assistant: support epson component

### DIFF
--- a/pkgs/development/python-modules/epson-projector/default.nix
+++ b/pkgs/development/python-modules/epson-projector/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, async-timeout
+, pyserial-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "epson-projector";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    pname = "epson_projector";
+    inherit version;
+    sha256 = "4ade1c7a0f7008d23b08bd886c8790c44cf7d60453d1eb5a8077c92aaf790d30";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    pyserial-asyncio
+  ];
+
+  # tests need real device
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "epson_projector"
+    "epson_projector.const"
+    "epson_projector.projector_http"
+    "epson_projector.projector_serial"
+    "epson_projector.projector_tcp"
+  ];
+
+  meta = with lib; {
+    description = "Epson projector support for Python";
+    homepage = "https://github.com/pszafer/epson_projector";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -232,7 +232,7 @@
     "envirophat" = ps: with ps; [ smbus-cffi ]; # missing inputs: envirophat
     "envisalink" = ps: with ps; [ pyenvisalink ];
     "ephember" = ps: with ps; [ ]; # missing inputs: pyephember
-    "epson" = ps: with ps; [ ]; # missing inputs: epson-projector
+    "epson" = ps: with ps; [ epson-projector ];
     "epsonworkforce" = ps: with ps; [ ]; # missing inputs: epsonprinter
     "eq3btsmart" = ps: with ps; [ construct ]; # missing inputs: python-eq3bt
     "esphome" = ps: with ps; [ aioesphomeapi aiohttp-cors ifaddr zeroconf ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -372,6 +372,7 @@ in with py.pkgs; buildPythonApplication rec {
     "emonitor"
     "emulated_hue"
     "enphase_envoy"
+    "epson"
     "esphome"
     "everlights"
     "ezviz"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2299,6 +2299,8 @@ in {
 
   ephem = callPackage ../development/python-modules/ephem { };
 
+  epson-projector = callPackage ../development/python-modules/epson-projector { };
+
   eradicate = callPackage ../development/python-modules/eradicate { };
 
   escapism = callPackage ../development/python-modules/escapism { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
