### PR TITLE
nixos/libvirtd: rename libvirtd group to libvirt

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -104,7 +104,7 @@ in
       smtpq = 64;
       supybot = 65;
       iodined = 66;
-      #libvirtd = 67; # unused
+      #libvirt = 67; # unused
       graphite = 68;
       #statsd = 69; # removed 2018-11-14
       transmission = 70;
@@ -420,7 +420,7 @@ in
       smtpq = 64;
       supybot = 65;
       iodined = 66;
-      libvirtd = 67;
+      libvirt = 67;
       graphite = 68;
       #statsd = 69; # removed 2018-11-14
       transmission = 70;

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -40,7 +40,7 @@ in {
       default = false;
       description = ''
         This option enables libvirtd, a daemon that manages
-        virtual machines. Users in the "libvirtd" group can interact with
+        virtual machines. Users in the "libvirt" group can interact with
         the daemon (e.g. to start or stop VMs) using the
         <command>virsh</command> command line tool, among others.
       '';
@@ -164,7 +164,7 @@ in {
 
     boot.kernelModules = [ "tun" ];
 
-    users.groups.libvirtd.gid = config.ids.gids.libvirtd;
+    users.groups.libvirt.gid = config.ids.gids.libvirt;
 
     # libvirtd runs qemu as this user and group by default
     users.extraGroups.qemu-libvirtd.gid = config.ids.gids.qemu-libvirtd;
@@ -280,7 +280,7 @@ in {
     security.polkit.extraConfig = ''
       polkit.addRule(function(action, subject) {
         if (action.id == "org.libvirt.unix.manage" &&
-          subject.isInGroup("libvirtd")) {
+          subject.isInGroup("libvirt")) {
           return polkit.Result.YES;
         }
       });

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -164,7 +164,13 @@ in {
 
     boot.kernelModules = [ "tun" ];
 
-    users.groups.libvirt.gid = config.ids.gids.libvirt;
+    users.groups.libvirt.gid = let id = config.ids.gids.libvirt; in
+      if
+        lib.any
+          (groups: builtins.elem "libvirtd" groups)
+          (lib.mapAttrsToList (name: value: value.extraGroups) users.users)
+      then
+        builtins.trace "warning: the group libvirtd is deprecated, use libvirt instead" id else id;
 
     # libvirtd runs qemu as this user and group by default
     users.extraGroups.qemu-libvirtd.gid = config.ids.gids.qemu-libvirtd;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolves #127356

This change is in order to be consistent with the majority of other distros

I haven't changed the `qemu-libvirtd` user & group yet as I wanted to check if we're going to rename it to `qemu-libvirt` or something else depending on what's more common in other distros.

Also this the correct method for modifying groups? Can it keep the old ID or should it have a new one?

I've put this against `staging-next-21.05` but LMK if that's the wrong branch.

Also TODO: add release notes in `nixos/doc/manual/release-notes/rl-2111.section.md`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
