### PR TITLE
nixos/desktop-manager/none: add option to run XDG autostart files

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1812,9 +1812,9 @@
           When setting
           <link linkend="opt-i18n.inputMethod.enabled">i18n.inputMethod.enabled</link>
           to <literal>fcitx5</literal>, it no longer creates
-          coresponding systemd user services. It now relies on XDG
+          corresponding systemd user services. It now relies on XDG
           autostart files to start and work properly in your desktop
-          seesions. If your are using only a window manager without a
+          sessions. If you are using only a window manager without a
           desktop manager, you need to enable
           <literal>services.xserver.desktopManager.runXdgAutostartIfNone</literal>
           or using the <literal>dex</literal> package to make

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1809,6 +1809,20 @@
       </listitem>
       <listitem>
         <para>
+          When setting
+          <link linkend="opt-i18n.inputMethod.enabled">i18n.inputMethod.enabled</link>
+          to <literal>fcitx5</literal>, it no longer creates
+          coresponding systemd user services. It now relies on XDG
+          autostart files to start and work properly in your desktop
+          seesions. If your are using only a window manager without a
+          desktop manager, you need to enable
+          <literal>services.xserver.desktopManager.runXdgAutostartIfNone</literal>
+          or using the <literal>dex</literal> package to make
+          <literal>fcitx5</literal> work.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           A new module was added for the Envoy reverse proxy, providing
           the options <literal>services.envoy.enable</literal> and
           <literal>services.envoy.settings</literal>.

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1800,6 +1800,15 @@
       </listitem>
       <listitem>
         <para>
+          The option
+          <link linkend="opt-services.xserver.desktopManager.runXdgAutostartIfNone">services.xserver.desktopManager.runXdgAutostartIfNone</link>
+          was added in order to automatically run XDG autostart files
+          for sessions without a desktop manager. This replaces helpers
+          like the <literal>dex</literal> package.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           A new module was added for the Envoy reverse proxy, providing
           the options <literal>services.envoy.enable</literal> and
           <literal>services.envoy.settings</literal>.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -662,9 +662,9 @@ In addition to numerous new and upgraded packages, this release has the followin
   This replaces helpers like the `dex` package.
 
 - When setting [i18n.inputMethod.enabled](#opt-i18n.inputMethod.enabled) to `fcitx5`,
-  it no longer creates coresponding systemd user services.
-  It now relies on XDG autostart files to start and work properly in your desktop seesions.
-  If your are using only a window manager without a desktop manager, you need to enable
+  it no longer creates corresponding systemd user services.
+  It now relies on XDG autostart files to start and work properly in your desktop sessions.
+  If you are using only a window manager without a desktop manager, you need to enable
   `services.xserver.desktopManager.runXdgAutostartIfNone` or using the `dex` package to make `fcitx5` work.
 
 - A new module was added for the Envoy reverse proxy, providing the options `services.envoy.enable` and `services.envoy.settings`.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -656,6 +656,11 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `services.stubby` module was converted to a [settings-style](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) configuration.
 
+- The option
+  [services.xserver.desktopManager.runXdgAutostartIfNone](#opt-services.xserver.desktopManager.runXdgAutostartIfNone)
+  was added in order to automatically run XDG autostart files for sessions without a desktop manager.
+  This replaces helpers like the `dex` package.
+
 - A new module was added for the Envoy reverse proxy, providing the options `services.envoy.enable` and `services.envoy.settings`.
 
 - The option `services.duplicati.dataDir` has been added to allow changing the location of duplicati's files.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -661,6 +661,12 @@ In addition to numerous new and upgraded packages, this release has the followin
   was added in order to automatically run XDG autostart files for sessions without a desktop manager.
   This replaces helpers like the `dex` package.
 
+- When setting [i18n.inputMethod.enabled](#opt-i18n.inputMethod.enabled) to `fcitx5`,
+  it no longer creates coresponding systemd user services.
+  It now relies on XDG autostart files to start and work properly in your desktop seesions.
+  If your are using only a window manager without a desktop manager, you need to enable
+  `services.xserver.desktopManager.runXdgAutostartIfNone` or using the `dex` package to make `fcitx5` work.
+
 - A new module was added for the Envoy reverse proxy, providing the options `services.envoy.enable` and `services.envoy.settings`.
 
 - The option `services.duplicati.dataDir` has been added to allow changing the location of duplicati's files.

--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -28,11 +28,5 @@ in {
       QT_IM_MODULE = "fcitx";
       XMODIFIERS = "@im=fcitx";
     };
-
-    systemd.user.services.fcitx5-daemon = {
-      enable = true;
-      script = "${fcitx5Package}/bin/fcitx5";
-      wantedBy = [ "graphical-session.target" ];
-    };
   };
 }

--- a/nixos/modules/services/x11/desktop-managers/none.nix
+++ b/nixos/modules/services/x11/desktop-managers/none.nix
@@ -1,7 +1,46 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  runXdgAutostart = config.services.xserver.desktopManager.runXdgAutostartIfNone;
+in
 {
-  services.xserver.desktopManager.session =
-    [ { name = "none";
-        start = "";
-      }
-    ];
+  options = {
+    services.xserver.desktopManager.runXdgAutostartIfNone = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to run XDG autostart files for sessions without a desktop manager
+        (with only a window manager), these sessions usually don't handle XDG
+        autostart files by default.
+
+        Some services like <option>i18n.inputMethod</option> and
+        <option>service.earlyoom</option> use XDG autostart files to start.
+        If this option is not set to <literal>true</literal> and you are using
+        a window manager without a desktop manager, you need to manually start
+        them or running <package>dex</package> somewhere.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    {
+      services.xserver.desktopManager.session = [
+        {
+          name = "none";
+          start = optionalString runXdgAutostart ''
+            /run/current-system/systemd/bin/systemctl --user start xdg-autostart-if-no-desktop-manager.target
+          '';
+        }
+      ];
+    }
+    (mkIf runXdgAutostart {
+      systemd.user.targets.xdg-autostart-if-no-desktop-manager = {
+        description = "Run XDG autostart files";
+        # From `plasma-workspace`, `share/systemd/user/plasma-workspace@.target`.
+        requires = [ "xdg-desktop-autostart.target" "graphical-session.target" ];
+        before = [ "xdg-desktop-autostart.target" "graphical-session.target" ];
+        bindsTo = [ "graphical-session.target" ];
+      };
+    })
+  ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -591,6 +591,7 @@ in
   xautolock = handleTest ./xautolock.nix {};
   xfce = handleTest ./xfce.nix {};
   xmonad = handleTest ./xmonad.nix {};
+  xmonad-xdg-autostart = handleTest ./xmonad-xdg-autostart.nix {};
   xrdp = handleTest ./xrdp.nix {};
   xss-lock = handleTest ./xss-lock.nix {};
   xterm = handleTest ./xterm.nix {};

--- a/nixos/tests/xmonad-xdg-autostart.nix
+++ b/nixos/tests/xmonad-xdg-autostart.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "xmonad-xdg-autostart";
+  meta.maintainers = with lib.maintainers; [ oxalica ];
+
+  nodes.machine = { pkgs, config, ... }: {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+    test-support.displayManager.auto.user = "alice";
+    services.xserver.displayManager.defaultSession = "none+xmonad";
+    services.xserver.windowManager.xmonad.enable = true;
+    services.xserver.desktopManager.runXdgAutostartIfNone = true;
+
+    environment.systemPackages = [
+      (pkgs.writeTextFile {
+        name = "test-xdg-autostart";
+        destination = "/etc/xdg/autostart/test-xdg-autostart.desktop";
+        text = ''
+          [Desktop Entry]
+          Name=test-xdg-autoatart
+          Type=Application
+          Terminal=false
+          Exec=${pkgs.coreutils}/bin/touch ${config.users.users.alice.home}/xdg-autostart-executed
+        '';
+      })
+    ];
+  };
+
+  testScript = { nodes, ... }:
+    let
+      user = nodes.machine.config.users.users.alice;
+    in
+    ''
+      machine.wait_for_x()
+      machine.wait_for_file("${user.home}/xdg-autostart-executed")
+    '';
+})


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`fcitx5` and `service.earlyoom` rely on use XDG autostart files to start. But for X session with only window manager and no desktop manager (`none` is used), no one can start them.

This options is added to run these autostart files for sessions without desktop manager to make other services just work.

Currently, `fcitx5` has both systemd service and autostart file, which is launched twice if there is a desktop manager (and the second attempt fails), but once if not (eg. using bare `xmonad`). See https://github.com/NixOS/nixpkgs/pull/125303#issuecomment-863121614

@Vonfry for testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
