### PR TITLE
octant{,-desktop}: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "octant";
-  version = "0.20.0";
+  version = "0.21.0";
 
   src =
     let
@@ -19,10 +19,10 @@ stdenv.mkDerivation rec {
       };
     in
     fetchsrc version {
-      x86_64-linux = "sha256-VFlZP5d6/YhzVIhveqMc4HfapBt0K/XjtqjCQNc514A=";
-      aarch64-linux = "sha256-RfdMfimmoHG4ixBtUVJ/V+mDhQ9aD+yeohkeUMUP8Zg=";
-      x86_64-darwin = "sha256-2Qgl3RdA4mMRTqR7o3Q86Zip5wtgvFp1vZn689FUtSI=";
-      aarch64-darwin = "sha256-+eZVg+B5YYf+XnDhNd6OU4+yFM9GtyiavcAr/EXh7XE=";
+      x86_64-linux = "sha256-Ben2wAquHADWBv1MEfPWxs96pLz1bK2F6bLoYVTSkng=";
+      aarch64-linux = "sha256-1kK0Gu4cQYk+QDJJJiiDan4SnP3Xjr8nLOBtv26UDV4=";
+      x86_64-darwin = "sha256-gOkHpUTWKrikKYZmkfgck3Lf3g5Pakcn0i2A9Hd07UE=";
+      aarch64-darwin = "sha256-Xpl8odVXw4WzF7CEZ+Bbxa6oQDBv9VMzHCNOjIcFGzE=";
     };
 
   dontConfigure = true;

--- a/pkgs/applications/networking/cluster/octant/desktop.nix
+++ b/pkgs/applications/networking/cluster/octant/desktop.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "octant-desktop";
-  version = "0.20.0";
+  version = "0.21.0";
   name = "${pname}-${version}";
 
   inherit (stdenv.hostPlatform) system;
@@ -15,8 +15,8 @@ let
   src = fetchurl {
     url = "https://github.com/vmware-tanzu/octant/releases/download/v${version}/Octant-${version}.${suffix}";
     sha256 = {
-      x86_64-linux = "sha256-mPD5qa/IYsakjcoPnWVpkmhgkhnRK0qTGQ6hanzDt/Y=";
-      x86_64-darwin = "sha256-nxpwBRUeLSPqNEFjF8hKzRhA2ahqh/KyAitnSxYdyJ8=";
+      x86_64-linux = "sha256-Woridi8uGsxvccdeaDzVLs+2YrRKUnm3WbX5LhorM1Y=";
+      x86_64-darwin = "sha256-NF3bm8WFEs4kgrUp+7qCbj6Z6pUMRUp7h4nhJQDJnoY=";
     }.${system};
   };
 

--- a/pkgs/applications/networking/cluster/octant/update.sh
+++ b/pkgs/applications/networking/cluster/octant/update.sh
@@ -30,9 +30,11 @@ OCTANT_VER=$(curl -Ls -w "%{url_effective}" -o /dev/null https://github.com/vmwa
 OCTANT_LINUX_X64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-64bit")
 OCTANT_LINUX_AARCH64_SHA256=$(fetch_arch "$OCTANT_VER" "Linux-arm64")
 OCTANT_DARWIN_X64_SHA256=$(fetch_arch "$OCTANT_VER" "macOS-64bit")
+OCTANT_DARWIN_AARCH64_SHA256=$(fetch_arch "$OCTANT_VER" "macOS-arm64")
 
 sed -i "s/version = \".*\"/version = \"$OCTANT_VER\"/" "$NIX_DRV"
 
 replace_sha "x86_64-linux" "$OCTANT_LINUX_X64_SHA256"
 replace_sha "aarch64-linux" "$OCTANT_LINUX_AARCH64_SHA256"
 replace_sha "x86_64-darwin" "$OCTANT_DARWIN_X64_SHA256"
+replace_sha "aarch64-darwin" "$OCTANT_DARWIN_AARCH64_SHA256"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- octant: 0.20.0 -> 0.21.0
  - fix update script to actually update aarch64-darwin
- octant-desktop: 0.20.0 -> 0.21.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
