### PR TITLE
chromiumDev: Fix building from the release tarball

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -174,6 +174,12 @@ let
         sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
         revert = true;
       })
+      # To fix building from a release tarball (which we do):
+      (githubPatch {
+        # Revert back to generating chromium_git_revision.h via version.py
+        commit = "bd524d08f8465364d12d32a84fd1aa983aecc502";
+        sha256 = "1jsxidg5jzwkrcpx3lylx4gyg56zjyd7sc957kaaqqc853bn83b4";
+      })
     ];
 
     postPatch = ''


### PR DESCRIPTION
See https://bugs.chromium.org/p/chromium/issues/detail?id=1215229.
Before this the build failed with this error:
[101/47617] ACTION //build/util:chromium_git_revision(//build/toolchain/linux/unbundle:default)oaded_data.pbchain/linux/unbundle:default)
FAILED: gen/build/util/chromium_git_revision.h
python3 ../../build/util/lastchange.py --header gen/build/util/chromium_git_revision.h --revision-id-only --revision-id-prefix @ -m\ CHROMIUM_GIT_REVISION
ERROR:root:Failed to get git top directory from '/build/chromium-93.0.4542.2/build/util': Git command 'git git rev-parse --show-toplevel' in /build/chromium-93.0.4542.2/build/util failed: [Errno 2] No such file or directory: 'git'

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
