### PR TITLE
libvori: init at 210412

### DIFF
--- a/pkgs/development/libraries/libvori/default.nix
+++ b/pkgs/development/libraries/libvori/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, fetchurl, cmake } :
+
+stdenv.mkDerivation rec {
+  pname = "libvori";
+  version = "210412";
+
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchurl {
+    url = "https://brehm-research.de/files/${pname}-${version}.tar.gz";
+    sha256 = "1b4hpwibf3k7gl6n984l3wdi0zyl2fmpz84m9g2di4yhm6p8c61k";
+  };
+
+  meta = with lib; {
+    description = "Library for Voronoi intergration of electron densities";
+    homepage = "https://brehm-research.de/libvori.php";
+    license = with licenses; [ lgpl3Only ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/libraries/libvori/default.nix
+++ b/pkgs/development/libraries/libvori/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, cmake } :
+{ stdenv, lib, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "libvori";

--- a/pkgs/development/libraries/libvori/default.nix
+++ b/pkgs/development/libraries/libvori/default.nix
@@ -4,12 +4,12 @@ stdenv.mkDerivation rec {
   pname = "libvori";
   version = "210412";
 
-  nativeBuildInputs = [ cmake ];
-
   src = fetchurl {
     url = "https://brehm-research.de/files/${pname}-${version}.tar.gz";
     sha256 = "1b4hpwibf3k7gl6n984l3wdi0zyl2fmpz84m9g2di4yhm6p8c61k";
   };
+
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     description = "Library for Voronoi intergration of electron densities";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16993,6 +16993,8 @@ in
 
   libvorbis = callPackage ../development/libraries/libvorbis { };
 
+  libvori = callPackage ../development/libraries/libvori { };
+
   libwebcam = callPackage ../os-specific/linux/libwebcam { };
 
   libwebp = callPackage ../development/libraries/libwebp { };


### PR DESCRIPTION
###### Motivation for this change
Adds libvori, which is a missing dependency for CP2K (quantum chemistry, molecular dynamics, ...). Part of the packages @markuskowa and me want to merge from https://github.com/markuskowa/NixOS-QChem/issues/56 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
