### PR TITLE
xcfun: init at 2.1.1

### DIFF
--- a/pkgs/development/libraries/science/chemistry/xcfun/default.nix
+++ b/pkgs/development/libraries/science/chemistry/xcfun/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub, cmake, gfortran, python3 } :
+
+stdenv.mkDerivation rec {
+  pname = "xcfun";
+  version = "2.1.1";
+
+  src = fetchFromGitHub  {
+    owner = "dftlibs";
+    repo = pname;
+    rev = "v${version}";
+    sha256= "1bj70cnhbh6ziy02x988wwl7cbwaq17ld7qwhswqkgnnx8rpgxid";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  propagatedBuildInputs = [ (python3.withPackages (p: with p; [ pybind11 ])) ];
+
+  cmakeFlags = [ "-DXCFUN_MAX_ORDER=3" ];
+
+  meta = with lib; {
+    description = "A library of exchange-correlation functionals with arbitrary-order derivatives";
+    homepage = "https://github.com/dftlibs/xcfun";
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31992,6 +31992,8 @@ in
 
   xcolor = callPackage ../tools/graphics/xcolor { };
 
+  xcfun = callPackage ../development/libraries/science/chemistry/xcfun { };
+
   zthrottle = callPackage ../tools/misc/zthrottle { };
 
   zktree = callPackage ../applications/misc/zktree {};


### PR DESCRIPTION
###### Motivation for this change
Adds xcfun, which is a missing dependency for PySCF (quantum chemistry in python). Part of the packages @markuskowa and me want to merge from markuskowa/NixOS-QChem#56 .

(I am not very confident where to put libraries like this. For now I've put it into `development/libraries/science/chemistry`)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
