### PR TITLE
nixos/netdata: Disable PrivateTmp setting for Netdata service

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -42,9 +42,10 @@ in stdenv.mkDerivation rec {
     # required to prevent plugins from relying on /etc
     # and /var
     ./no-files-in-etc-and-var.patch
-    # required to put IPC socket in globally accessible
-    # directory, until a proper solurion is provided
-    # upstream
+    # The current IPC location is unsafe as it writes
+    # a fixed path in /tmp, which is world-writable.
+    # Therefore we put it into `/run/netdata`, which is owned
+    # by netdata only.
     ./ipc-socket-in-run.patch
   ];
 

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -42,6 +42,10 @@ in stdenv.mkDerivation rec {
     # required to prevent plugins from relying on /etc
     # and /var
     ./no-files-in-etc-and-var.patch
+    # required to put IPC socket in globally accessible
+    # directory, until a proper solurion is provided
+    # upstream
+    ./ipc-socket-in-run.patch
   ];
 
   NIX_CFLAGS_COMPILE = optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";

--- a/pkgs/tools/system/netdata/ipc-socket-in-run.patch
+++ b/pkgs/tools/system/netdata/ipc-socket-in-run.patch
@@ -1,0 +1,13 @@
+diff --git a/daemon/commands.h b/daemon/commands.h
+index bd4aabfe1cbe4..ce7eb3c730228 100644
+--- a/daemon/commands.h
++++ b/daemon/commands.h
+@@ -6,7 +6,7 @@
+ #ifdef _WIN32
+ # define PIPENAME "\\\\?\\pipe\\netdata-cli"
+ #else
+-# define PIPENAME "/tmp/netdata-ipc"
++# define PIPENAME "/run/netdata/ipc"
+ #endif
+ 
+ #define MAX_COMMAND_LENGTH 4096


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should fix the second issue listed in  #127375, namely that the `netdata-claim.sh` script is unable to find and open the Netdata socket.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
