### PR TITLE
connman: 1.39 -> 1.40

### DIFF
--- a/pkgs/tools/networking/connman/connman.nix
+++ b/pkgs/tools/networking/connman/connman.nix
@@ -55,10 +55,10 @@ let inherit (lib) optionals; in
 
 stdenv.mkDerivation rec {
   pname = "connman";
-  version = "1.39";
+  version = "1.40";
   src = fetchurl {
     url = "mirror://kernel/linux/network/connman/${pname}-${version}.tar.xz";
-    sha256 = "sha256-n2KnFpt0kcZwof8uM1sNlmMI+y9i4oXHgRBeuQ8YGvM=";
+    sha256 = "sha256-GleufOI0qjoXRKrDvlwhIdmNzpmUQO+KucxO39XtyxI=";
   };
 
   buildInputs = [
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     libmnl
     gnutls
     readline
-  ];
+  ] ++ optionals (enableOpenconnect) [ openconnect ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Motivation for this change

https://git.kernel.org/pub/scm/network/connman/connman.git/commit/?h=1.40&id=25479cf866e60b0101cda0d80e825cd8128bb4eb

There is a security issue in 1.39: https://www.openwall.com/lists/oss-security/2021/06/09/1

###### Things done

I've updated it and it does build, but I have no idea if it actually works since I don't use it (and don't know how to). If someone were willing to test that this works, that would be great.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).