### PR TITLE
protege-distribution: init at 5.5.0

### DIFF
--- a/pkgs/development/web/protege-distribution/default.nix
+++ b/pkgs/development/web/protege-distribution/default.nix
@@ -1,0 +1,73 @@
+{ lib, stdenv, fetchurl, unzip, jre8, copyDesktopItems, makeDesktopItem }:
+
+stdenv.mkDerivation rec {
+  pname = "protege-distribution";
+  version = "5.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/protegeproject/protege-distribution/releases/download/v${version}/Protege-${version}-platform-independent.zip";
+    sha256 = "092x22wyisdnhccx817mqq15sxqdfc7iz4whr4mbvzrd9di6ipjq";
+  };
+
+  nativeBuildInputs = [ unzip copyDesktopItems ];
+
+  postPatch = ''
+    # Delete all those commands meant to change directory to the source directory
+    sed -i -e '3,9d' run.sh
+
+    # Change directory to where the application is stored to avoid heavy patching
+    # of searchpaths
+    sed -i -e "2a\
+    cd $out/protege" run.sh
+
+    # Set the correct Java executable (Protege is a JRE 8 application)
+    substituteInPlace run.sh \
+      --replace "java -X" "exec ${jre8.outPath}/bin/java -X" \
+
+    # Silence console logs, since these are not shown in graphical environments
+    sed -i -e '4,8d;21d' conf/logback.xml
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+
+    # Delete non-Linux launch scripts
+    rm run.{bat,command}
+
+    # Move launch script into /bin, giving it a recognizable name
+    install -D run.sh $out/bin/run-protege
+
+    # Copy icon to where it can be found
+    install -D app/Protege.ico $out/share/icons/hicolor/128x128/apps/protege.ico
+
+    # Move everything else under protege/
+    mkdir $out/protege
+    mv {bin,bundles,conf,plugins} $out/protege
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Protege";
+      desktopName = "Protege Desktop";
+      icon = "protege.ico";
+      comment = "OWL2 ontology editor";
+      exec = "run-protege";
+    })
+  ];
+
+  meta = with lib; {
+    description = "The OWL2 ontology editor from Stanford, with third-party plugins included";
+    homepage = "https://protege.stanford.edu/";
+    downloadPage = "https://protege.stanford.edu/products.php#desktop-protege";
+    maintainers = with maintainers; [ nessdoor ];
+    license = with licenses; [ asl20 bsd2 epl10 lgpl3 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12733,6 +12733,8 @@ in
   pharo-spur64 = assert stdenv.is64bit; pharo-vms.spur64;
   pharo-launcher = callPackage ../development/pharo/launcher { };
 
+  protege-distribution = callPackage ../development/web/protege-distribution { };
+
   umr = callPackage ../development/misc/umr {
     llvmPackages = llvmPackages_latest;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Stanford's Protege is the major open source OWL2 ontology editor for the Semantic Web. Although a web version is available and ready to run on any platform, the desktop version offers some more advanced functionalities (e.g. pluggable reasoner support) and, of course, offline operation.

The packaged application is the "distribution" version, that comes into a zip archive bundled with a collection of third-party plugins. All licenses for such plugins have been included in the meta-attributes.

For now, this is the only packaged version I can provide. In the future, as soon as I manage to get Maven builds work under Nix, I hope to be able to include the "bare" version compiled from the upstream repository, with no included plugins and better patches.

This application is supposedly platform-independent but, since I don't have a Darwin system available, I cannot guarantee functionality of this package on such OS. Help is welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
