### PR TITLE
grapejuice: init at 3.11.4

### DIFF
--- a/pkgs/games/grapejuice/default.nix
+++ b/pkgs/games/grapejuice/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, fetchFromGitLab
+, gobject-introspection
+, python3Packages
+, gtk3
+, wrapGAppsHook
+, glib
+, cairo
+, desktop-file-utils
+, xdg-utils
+, xdg-user-dirs
+, wine
+, winetricks
+}:
+
+python3Packages.buildPythonApplication rec  {
+  pname = "grapejuice";
+  version = "3.12.5";
+
+  src = fetchFromGitLab {
+    owner = "BrinkerVII";
+    repo = "grapejuice";
+    rev = "v${version}";
+    sha256 = "1xgxyfwwghy9l17i6y40axdrpp4fgxgdr5y97flwmfivif01ifs1";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    desktop-file-utils
+    glib
+    gtk3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    cairo
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    pygobject3
+    dbus-python
+    packaging
+    psutil
+    setuptools
+  ];
+
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+    "--prefix PATH : ${lib.makeBinPath [ xdg-user-dirs xdg-utils wine (winetricks.override { wine = wine; }) ]}"
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "PyGObject-stubs" ""
+
+    substituteInPlace src/grapejuice_common/assets/desktop/grapejuice.desktop \
+      --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
+      --replace \$GRAPEJUICE_ICON grapejuice
+
+    substituteInPlace src/grapejuice_common/assets/desktop/roblox-player.desktop \
+      --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
+      --replace \$PLAYER_ICON "grapejuice-roblox-player"
+
+    substituteInPlace src/grapejuice_common/assets/desktop/roblox-app.desktop \
+      --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
+      --replace \$PLAYER_ICON "grapejuice-roblox-player"
+
+    substituteInPlace src/grapejuice_common/assets/desktop/roblox-studio.desktop \
+      --replace \$GRAPEJUICE_EXECUTABLE "$out/bin/grapejuice" \
+      --replace \$STUDIO_ICON "grapejuice-roblox-studio"
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/icons" "$out/share/applications" "$out/share/mime/packages"
+    cp -r src/grapejuice_common/assets/desktop/* $out/share/applications/
+    cp -r src/grapejuice_common/assets/icons $out/share/
+    cp src/grapejuice_common/assets/mime_xml/*.xml $out/share/mime/packages/
+  '';
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "grapejuice" ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/brinkervii/grapejuice";
+    description = "Simple Wine+Roblox management tool";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ artturin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2813,6 +2813,10 @@ in
 
   gti = callPackage ../tools/misc/gti { };
 
+  grapejuice = callPackage ../games/grapejuice {
+    wine = wineWowPackages.unstable;
+  };
+
   hdate = callPackage ../applications/misc/hdate { };
 
   heatseeker = callPackage ../tools/misc/heatseeker { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

a tool for managing roblox in wine

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
