### PR TITLE
rakudo: remove references to stdenv.cc.cc

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, icu, zlib, gmp, lib, nqp }:
+{ stdenv, fetchurl, perl, icu, zlib, gmp, lib, nqp, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   pname = "rakudo";
@@ -9,12 +9,19 @@ stdenv.mkDerivation rec {
     sha256 = "11ixlqmvbb37abksdysg5r4lkbwzr486lkc0ssl3wca4iiy3mhgf";
   };
 
+  nativeBuildInputs = [ removeReferencesTo ];
+
   buildInputs = [ icu zlib gmp perl ];
   configureScript = "perl ./Configure.pl";
   configureFlags = [
     "--backends=moar"
     "--with-nqp=${nqp}/bin/nqp"
   ];
+
+  disallowedReferences = [ stdenv.cc.cc ];
+  postFixup = ''
+    remove-references-to -t ${stdenv.cc.cc} "$(readlink -f $out/share/perl6/runtime/dynext/libperl6_ops_moar.so)"
+  '';
 
   meta = with lib; {
     description = "Raku implementation on top of Moar virtual machine";


### PR DESCRIPTION
Rakudo depends on gcc noticeably increasing closure size, this commit removes the references.

Fixes #101097

Thx to @xfix for reporting

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
