### PR TITLE
xhyve: 20191001 -> 20210203

### DIFF
--- a/pkgs/applications/virtualization/xhyve/default.nix
+++ b/pkgs/applications/virtualization/xhyve/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xhyve";
-  version = "20191001";
+  version = "20210203";
 
   src = fetchFromGitHub {
     owner = "machyve";
     repo = "xhyve";
-    rev = "1f46a3d0bbeb6c90883f302425844fcc3800a776";
-    sha256 = "0mm9xa0v6n7xl2qypnppq5abdncd31vffiklrhcrlni5ymyh9ia5";
+    rev = "83516a009c692ea5d2993d1071e68d05d359b11e";
+    sha256 = "1pjdg4ppy6qh3vr1ls5zyw3jzcvwny9wydnmfpadwij1hvns7lj3";
   };
 
   buildInputs = [ Hypervisor vmnet xpc libobjc zlib ];


### PR DESCRIPTION
Updating fixes xhyve problems on Big Sur, see
https://github.com/machyve/xhyve/pull/200 for example.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Recently got my hands on a mbp and of course I had to set up Nix :)

Found that xhyve wasn't working (tried 21.05 and unstable darwin channels), for example:

```
[nix-shell:~/Projects/xhyve]$ ./xhyverun-tinycorelinux.sh
vmx_set_ctlreg: cap_field: 2 bit: 20 unspecified don't care
vmx_init: processor does not support desired secondary processor-based controls
Unable to create VM (22)
```

Updated the git commit hash to latest xhyve master and it starting working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
