### PR TITLE
unused: 2.1 -> 2.2

### DIFF
--- a/pkgs/development/tools/misc/unused/default.nix
+++ b/pkgs/development/tools/misc/unused/default.nix
@@ -1,18 +1,18 @@
 { lib, fetchFromGitHub, rustPlatform, cmake }:
 rustPlatform.buildRustPackage rec {
   pname = "unused";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "unused-code";
     repo = pname;
     rev = version;
-    sha256 = "06r6m7k570rdm9szghnp3g4r6ij0vp8apfanqzzxv2hd7gf8v62b";
+    sha256 = "0igpf0y45rrdrwq8bznq0d5nnph0vijvn6fw96mqxhbffz0csbi9";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  cargoSha256 = "0y7vsba4r4v2lwf02i2dxwicnhknajbbzsdlnn5srvg6nvl3kspi";
+  cargoSha256 = "1fngn9mmvx7jw8305w465z0nf9acc2cdl7314p77c2rz25z6rlin";
 
   meta = with lib; {
     description = "A tool to identify potentially unused code";


### PR DESCRIPTION
###### Motivation for this change
Unused 2.2 just released: https://github.com/unused-code/unused/releases/tag/0.2.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
