### PR TITLE
WIP: python wasmer-compiler

### DIFF
--- a/pkgs/development/python-modules/fastdiff/default.nix
+++ b/pkgs/development/python-modules/fastdiff/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "fastdiff";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ai95vjchl4396zjl1b69xfqvn9kn1y7c40d9l0qxdss0pcx6fk2";
+    sha256 = "4dfa09c47832a8c040acda3f1f55fc0ab4d666f0e14e6951e6da78d59acd945a";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/wasmer-compiler-cranelift/default.nix
+++ b/pkgs/development/python-modules/wasmer-compiler-cranelift/default.nix
@@ -1,0 +1,61 @@
+{ lib, buildPythonPackage, fetchFromGitHub, rustPlatform
+, python
+, llvm_11
+, libffi
+, zlib
+, ncurses
+, libxml2
+, pkg-config
+}:
+
+let
+  pname = "wasmer-compiler-cranelift";
+  # setup.py for wasmer-compiler-cranelift wasn't added until after tag
+  version = "unstable-2021-05-12";
+
+  src = fetchFromGitHub {
+    owner = "wasmerio";
+    repo = "wasmer-python";
+    rev = "c2ef240e0355b7ab3b5f3cf5ae0954cda79304a5";
+    sha256 = "1yq45ggpqjq23pvf3fz3g7wr2maw8ls2mr2x7aq6rrrdp4029ps2";
+  };
+
+  meta = with lib; {
+    description = "Cranelift compiler for the `wasmer` package";
+    homepage = "https://github.com/wasmerio/wasmer-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+
+  nativeExtensions = rustPlatform.buildRustPackage rec {
+    inherit pname version src meta;
+
+    cargoSha256 = "0538zqjg8c1ahahjn92sqnsxixa6hi5sj1rrvw864yxiidddzxpd";
+
+    nativeBuildInputs = [ python pkg-config llvm_11 ];
+
+    buildInputs = [ zlib ncurses libffi libxml2 python ];
+
+    NIX_LDFLAGS = "-lpython3 ";
+
+    # tests are unable to link to python
+    doCheck = false;
+  };
+
+in buildPythonPackage rec {
+  inherit pname version src meta;
+
+  preConfigure = ''
+    cd packages/any-compiler-cranelift/
+  '';
+
+  # the setup.py just installs a __init__.py which throws an error, replace with native extensions
+  postInstall = ''
+    ln -fs -t $out/${python.sitePackages} ${nativeExtensions}/lib/*
+  '';
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "libwasmer_compiler_cranelift" ];
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9020,6 +9020,10 @@ in {
 
   wasmer = callPackage ../development/python-modules/wasmer { };
 
+  wasmer-compiler-cranelift = callPackage ../development/python-modules/wasmer-compiler-cranelift {
+    inherit (pkgs) zlib ncurses libffi libxml2 pkg-config;
+  };
+
   watchdog = callPackage ../development/python-modules/watchdog {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change
Attempt to add `python3Packages.wasmer-compiler-cranelift` hit a wall and gave up:

```
ImportError: dynamic module does not define module export function (PyInit_libwasmer_compiler_cranelift)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
