### PR TITLE
buf: 0.41.0 -> 0.43.2

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -2,30 +2,54 @@
 , buildGoModule
 , fetchFromGitHub
 , protobuf
+, git
 }:
 
 buildGoModule rec {
   pname = "buf";
-  version = "0.41.0";
+  version = "0.43.2";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-f1UcvsXWW+fMAgTRtHkEXmUN/DTrJ/Xd+9HbR2FjFog=";
+    sha256 = "sha256-Go0wLcJrxMgB67WlAI7TwX2UU2sQ/yfmC0h2igOkjc4=";
+    leaveDotGit = true; # Required by TestWorkspaceGit
   };
+  vendorSha256 = "sha256-HT0dsGniBoQW2Y7MhahDeFvE0nCASoPdzHETju0JuRY=";
 
   patches = [
     ./skip_test_requiring_network.patch
   ];
 
+  nativeBuildInputs = [ protobuf ];
+  checkInputs = [ git ];
+
+  ldflags = [ "-s" "-w" ];
+
   preCheck = ''
     export PATH=$PATH:$GOPATH/bin
+    # To skip TestCloneBranchAndRefToBucket
+    export CI=true
   '';
 
-  nativeBuildInputs = [ protobuf ];
+  installPhase = ''
+    runHook preInstall
 
-  vendorSha256 = "sha256-XMGXVsSLEzuzujX5Fg3LLkgzyJY+nIBJEO9iI2t9eGc=";
+    mkdir -p "$out/bin"
+    dir="$GOPATH/bin"
+    # Only install required binaries, don't install testing binaries
+    for file in \
+      "buf" \
+      "protoc-gen-buf-breaking" \
+      "protoc-gen-buf-lint" \
+      "protoc-gen-buf-check-breaking" \
+      "protoc-gen-buf-check-lint"; do
+      cp "$dir/$file" "$out/bin/"
+    done
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Create consistent Protobuf APIs that preserve compatibility and comply with design best-practices";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump buf to `0.43.2`

Also:

Fix new git tests
Add ldflags to slightly reduce binary size
Only install required binaries (See release assets, [release.bash](https://github.com/bufbuild/buf/blob/master/make/buf/scripts/release.bash#L78-L82), [brew.sh](https://github.com/bufbuild/buf/blob/master/make/buf/scripts/brew.sh#L23-L27))

```sh
# before
λ du result/bin
133504	result/bin
λ du result/bin/*
18956	result/bin/buf
3592	result/bin/ddiff
1768	result/bin/git-ls-files-unstaged
3668	result/bin/license-header
15252	result/bin/protoc-gen-buf-breaking
15252	result/bin/protoc-gen-buf-check-breaking
8432	result/bin/protoc-gen-buf-check-lint
8432	result/bin/protoc-gen-buf-lint
6956	result/bin/protoc-gen-go-api
6952	result/bin/protoc-gen-go-apiclient
6980	result/bin/protoc-gen-go-apiclientgrpc
6980	result/bin/protoc-gen-go-apiclienttwirp
6048	result/bin/protoc-gen-insertion-point-receiver
6048	result/bin/protoc-gen-insertion-point-writer
7204	result/bin/protoc-gen-proxy
7028	result/bin/spdx-go-data
3952	result/bin/storage-go-data

# after
λ du result/bin
59992	result/bin
λ du result/bin/*
17096	result/bin/buf
13792	result/bin/protoc-gen-buf-breaking
13796	result/bin/protoc-gen-buf-check-breaking
7652	result/bin/protoc-gen-buf-check-lint
7652	result/bin/protoc-gen-buf-lint
```

Maintainer: @raboof

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
