### PR TITLE
python2Packages.certifi: init at 2019.11.28

### DIFF
--- a/pkgs/development/python-modules/certifi/python2.nix
+++ b/pkgs/development/python-modules/certifi/python2.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, python3
+}:
+
+let
+  inherit (python3.pkgs) certifi;
+
+in buildPythonPackage rec {
+  pname = "certifi";
+  version = "2019.11.28";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f";
+  };
+
+  postPatch = ''
+    cp ${certifi.src}/certifi/cacert.pem certifi/cacert.pem
+  '';
+
+  pythonImportsCheck = [ "certifi" ];
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://certifi.io/";
+    description = "Python package for providing Mozilla's CA Bundle";
+    license = licenses.isc;
+    maintainers = with maintainers; [ ]; # NixOps team
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -46,6 +46,8 @@ with self; with super; {
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
+  certifi = callPackage ../development/python-modules/certifi/python2.nix { };
+
   chardet = callPackage ../development/python-modules/chardet/2.nix { };
 
   cheetah = callPackage ../development/python-modules/cheetah { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/127423

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @tollb @NixOS/nixops-committers 