### PR TITLE
networkmanager: 1.30.4 -> 1.32.4

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -49,6 +49,7 @@ let
       rc-manager =
         if config.networking.resolvconf.enable then "resolvconf"
         else "unmanaged";
+      firewall-backend = cfg.firewallBackend;
     })
     (mkSection "keyfile" {
       unmanaged-devices =
@@ -241,6 +242,15 @@ in {
         default = "internal";
         description = ''
           Which program (or internal library) should be used for DHCP.
+        '';
+      };
+
+      firewallBackend = mkOption {
+        type = types.enum [ "iptables" "nftables" "none" ];
+        default = "iptables";
+        description = ''
+          Which firewall backend should be used for configuring masquerading with shared mode.
+          If set to none, NetworkManager doesn't manage the configuration at all.
         '';
       };
 

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -103,6 +103,7 @@ in
     }];
     boot.blacklistedKernelModules = [ "ip_tables" ];
     environment.systemPackages = [ pkgs.nftables ];
+    networking.networkmanager.firewallBackend = mkDefault "nftables";
     systemd.services.nftables = {
       description = "nftables firewall";
       before = [ "network-pre.target" ];

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -14,6 +14,7 @@
 , ppp
 , dhcp
 , iptables
+, nftables
 , python3
 , vala
 , libgcrypt
@@ -53,11 +54,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.30.4";
+  version = "1.32.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "sha256-YFC3JCEuo85zhhEzWb6pr6H2eaVPYNmZpZmYkuZywZA=";
+    sha256 = "sha256-Kay9QceLfvh/+I/sU2DR6vi1tvy5BVXXORq8XjaSMVg=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -85,6 +86,7 @@ stdenv.mkDerivation rec {
     "-Diwd=true"
     "-Dpppd=${ppp}/bin/pppd"
     "-Diptables=${iptables}/bin/iptables"
+    "-Dnft=${nftables}/bin/nft"
     "-Dmodem_manager=true"
     "-Dnmtui=true"
     "-Ddnsmasq=${dnsmasq}/bin/dnsmasq"
@@ -173,7 +175,7 @@ stdenv.mkDerivation rec {
     # though, so we need to replace the absolute path with a local one during build.
     # We are using a symlink that will be overridden during installation.
     mkdir -p ${placeholder "out"}/lib
-    ln -s $PWD/libnm/libnm.so.0 ${placeholder "out"}/lib/libnm.so.0
+    ln -s $PWD/src/libnm-client-impl/libnm.so.0 ${placeholder "out"}/lib/libnm.so.0
   '';
 
   passthru = {
@@ -188,7 +190,8 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Projects/NetworkManager";
     description = "Network configuration and management tool";
     license = licenses.gpl2Plus;
-    maintainers = teams.freedesktop.members ++ (with maintainers; [ phreedom domenkozar obadz ]);
+    changelog = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/raw/${version}/NEWS";
+    maintainers = teams.freedesktop.members ++ (with maintainers; [ phreedom domenkozar obadz maxeaubrey ]);
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -1,26 +1,5 @@
-diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
-index 15c47c3ec..4d1913aa6 100644
---- a/clients/common/nm-vpn-helpers.c
-+++ b/clients/common/nm-vpn-helpers.c
-@@ -208,15 +208,7 @@ nm_vpn_openconnect_authenticate_helper(const char *host,
-         NULL,
-     };
- 
--    path = nm_utils_file_search_in_paths("openconnect",
--                                         "/usr/sbin/openconnect",
--                                         DEFAULT_PATHS,
--                                         G_FILE_TEST_IS_EXECUTABLE,
--                                         NULL,
--                                         NULL,
--                                         error);
--    if (!path)
--        return FALSE;
-+    path = "@openconnect@/bin/openconnect";
- 
-     if (!g_spawn_sync(NULL,
-                       (char **) NM_MAKE_STRV(path, "--authenticate", host),
 diff --git a/data/84-nm-drivers.rules b/data/84-nm-drivers.rules
-index e398cb9f2..a43d61864 100644
+index e398cb9f2f..a43d61864f 100644
 --- a/data/84-nm-drivers.rules
 +++ b/data/84-nm-drivers.rules
 @@ -7,6 +7,6 @@ ACTION!="add|change", GOTO="nm_drivers_end"
@@ -32,7 +11,7 @@ index e398cb9f2..a43d61864 100644
  
  LABEL="nm_drivers_end"
 diff --git a/data/NetworkManager.service.in b/data/NetworkManager.service.in
-index 91ebd9a36..5201a56c3 100644
+index e23b3a5282..c7246a3b61 100644
 --- a/data/NetworkManager.service.in
 +++ b/data/NetworkManager.service.in
 @@ -8,7 +8,7 @@ Before=network.target @DISTRO_NETWORK_SERVICE@
@@ -44,23 +23,11 @@ index 91ebd9a36..5201a56c3 100644
  #ExecReload=/bin/kill -HUP $MAINPID
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
-diff --git a/libnm/meson.build b/libnm/meson.build
-index d0846419c..a7adb2cc6 100644
---- a/libnm/meson.build
-+++ b/libnm/meson.build
-@@ -280,7 +280,6 @@ if enable_introspection
-     output: 'nm-settings-docs-gir.xml',
-     command: [
-       generate_setting_docs_env,
--      python.path(),
-       join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-gir.py'),
-       '--lib-path', meson.current_build_dir(),
-       '--gir', '@INPUT@',
 diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index 040dd0b4d..98aea3aa9 100644
+index 21863b9533..c9b709659d 100644
 --- a/src/core/devices/nm-device.c
 +++ b/src/core/devices/nm-device.c
-@@ -13957,14 +13957,14 @@ nm_device_start_ip_check(NMDevice *self)
+@@ -13994,14 +13994,14 @@ nm_device_start_ip_check(NMDevice *self)
              gw = nm_ip4_config_best_default_route_get(priv->ip_config_4);
              if (gw) {
                  _nm_utils_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
@@ -77,11 +44,31 @@ index 040dd0b4d..98aea3aa9 100644
                  log_domain  = LOGD_IP6;
              }
          }
-diff --git a/src/core/nm-core-utils.c b/src/core/nm-core-utils.c
-index 9075c30dd..4b140e92b 100644
---- a/src/core/nm-core-utils.c
-+++ b/src/core/nm-core-utils.c
-@@ -333,7 +333,7 @@ nm_utils_modprobe(GError **error, gboolean suppress_error_logging, const char *a
+diff --git a/src/libnm-client-impl/meson.build b/src/libnm-client-impl/meson.build
+index 21a01e0b04..091c98428f 100644
+--- a/src/libnm-client-impl/meson.build
++++ b/src/libnm-client-impl/meson.build
+@@ -162,7 +162,6 @@ if enable_introspection
+       input: libnm_core_settings_sources,
+       output: 'nm-propery-infos-' + info + '.xml',
+       command: [
+-        python.path(),
+         join_paths(meson.source_root(), 'tools', 'generate-docs-nm-property-infos.py'),
+         info,
+         '@OUTPUT@',
+@@ -219,7 +218,6 @@ if enable_introspection
+       'env',
+       'GI_TYPELIB_PATH=' + gi_typelib_path,
+       'LD_LIBRARY_PATH=' + ld_library_path,
+-      python.path(),
+       join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-gir.py'),
+       '--lib-path', meson.current_build_dir(),
+       '--gir', '@INPUT@',
+diff --git a/src/libnm-platform/nm-platform-utils.c b/src/libnm-platform/nm-platform-utils.c
+index 6435dcc482..214d01194e 100644
+--- a/src/libnm-platform/nm-platform-utils.c
++++ b/src/libnm-platform/nm-platform-utils.c
+@@ -2097,7 +2097,7 @@ nmp_utils_modprobe(GError **error, gboolean suppress_error_logging, const char *
  
      /* construct the argument list */
      argv = g_ptr_array_sized_new(4);
@@ -90,3 +77,58 @@ index 9075c30dd..4b140e92b 100644
      g_ptr_array_add(argv, "--use-blacklist");
      g_ptr_array_add(argv, (char *) arg1);
  
+diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
+index 72691e34c2..95495b6585 100644
+--- a/src/libnmc-base/nm-vpn-helpers.c
++++ b/src/libnmc-base/nm-vpn-helpers.c
+@@ -198,25 +198,8 @@ nm_vpn_openconnect_authenticate_helper(const char *host,
+     gs_free const char **output_v = NULL;
+     const char *const *  iter;
+     const char *         path;
+-    const char *const    DEFAULT_PATHS[] = {
+-        "/sbin/",
+-        "/usr/sbin/",
+-        "/usr/local/sbin/",
+-        "/bin/",
+-        "/usr/bin/",
+-        "/usr/local/bin/",
+-        NULL,
+-    };
+ 
+-    path = nm_utils_file_search_in_paths("openconnect",
+-                                         "/usr/sbin/openconnect",
+-                                         DEFAULT_PATHS,
+-                                         G_FILE_TEST_IS_EXECUTABLE,
+-                                         NULL,
+-                                         NULL,
+-                                         error);
+-    if (!path)
+-        return FALSE;
++    path = "@openconnect@/bin/openconnect";
+ 
+     if (!g_spawn_sync(NULL,
+                       (char **) NM_MAKE_STRV(path, "--authenticate", host),
+diff --git a/src/libnmc-setting/meson.build b/src/libnmc-setting/meson.build
+index 8f07ae634e..a1326b3403 100644
+--- a/src/libnmc-setting/meson.build
++++ b/src/libnmc-setting/meson.build
+@@ -6,7 +6,6 @@ if enable_docs
+     input: [nm_settings_docs_xml_gir, nm_property_infos_xml['nmcli']],
+     output: 'settings-docs-input.xml',
+     command: [
+-      python.path(),
+       join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-merge.py'),
+       '@OUTPUT@',
+       nm_property_infos_xml['nmcli'],
+diff --git a/src/tests/client/meson.build b/src/tests/client/meson.build
+index b2e455bbbd..a12ebf212a 100644
+--- a/src/tests/client/meson.build
++++ b/src/tests/client/meson.build
+@@ -6,7 +6,6 @@ test(
+   args: [
+     build_root,
+     source_root,
+-    python.path(),
+   ],
+   timeout: 120,
+ )


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/1.32.4/NEWS
```markdown
===============================================
NetworkManager-1.32.4
Overview of changes since NetworkManager-1.32.2
===============================================

* core: remove stale entries from "seen-bssids" and "timestamp"
  files in "/var/lib/NetworkManager".
* bond: support the peer_notif_delay option.
* core: add ipv[46].required-timeout option to wait for IP
  configuration while activating.
* core: send ARP announcements when there is carrier.
* core: start DHCPv6 when a prefix delegation is needed for shared
  mode.
* firewall: fix nftables backend to create "ip" table for
  IPv4 only.
* initrd: set required-timeout of 20 seconds for default IPv4 configuration
  to opportunistically wait for IPv4.
* ifcfg: log warning about invalid keys in ifcfg files.
* ifcfg: reject non-UTF-8 from ifcfg files.
* nmcli: show DNS SEARCH field in device information.
* cloud-setup: add support for Aliyun cloud.


=============================================
NetworkManager-1.32.2
Overview of changes since NetworkManager-1.32
=============================================

* hostname: prefer IPv4 addresses for reverse DNS lookup.
* dhcp: ignore unauthenticated FORCERENEW messages with
  internal, systemd-based DHCPv4 plugin (CVE-2020-13529).
  This plugin is not used, unless the undocumented dhcp=systemd
  option was set.
* cloud-setup: preserve IP addresses, routes and rules from
  currently active connection profile.
* Various bugfixes and performance improvements.

=============================================
NetworkManager-1.32
Overview of changes since NetworkManager-1.30
=============================================

* Add an 'accept-all-mac-addresses' property to the ethernet setting
  to accept frames with any MAC address (also known as promiscuous
  mode).
* nmcli: fix setting property aliases to empty value to reset the
  default value.
* BEHAVIOR CHANGE: Enforce valid lower case UUID format for the "connection.uuid"
  by normalizing the value. This changes the UUID of existing profiles with an
  invalid or non-normalized value. Also normalize "connection.secondaries" to only
  contain valid and distinct UUIDs. Profiles that set "connection.master" or the
  "parent" properties to a non-normalized UUID need adjustment. Using such
  non-normalized UUIDs should be rare and affect few users.
* API CHANGE: D-Bus: remove long deprecated "PropertiesChanged" signal from D-Bus
  API. They are replaced by standard "PropertiesChanged" signal on the
  "org.freedesktop.DBus.Properties" interface. It is not expected that anybody
  is still using this API.
* Now NetworkManager uses systemd-resolved API to lookup the system
  hostname via reverse DNS. If systemd-resolved is not available, a
  'nm-daemon-helper' binary is spawned to perform the lookup using
  the 'dns' NSS module.
* dhcp: honor "ID_NET_DHCP_BROADCAST" udev attribute to set the broadcast flag.
  This allows to configure devices in udev for which DHCPOFFER messages are to be
  broadcast.
* firewall: add nftables firewall backend for configuring IPv4 NAT with shared
  mode. Now two backends are supported, "iptables" and "nftables". The default
  gets detected based on whether /usr/sbin/nft or /usr/sbin/iptables is installed,
  with nftables preferred.
  Please note that SELinux might prevent NetworkManager from communicating with nft.
* ethtool: add support for pause settings.
* Support "prohibit"/"blackhole"/"unreachable" type routing rules.
* Now NetworkManager preserves by default the existing traffic control
  configuration (qdiscs and filters) when activating a connection.
* wifi/iwd: mirror NetworkManager connection profiles to iwd config files.
* API CHANGE: vala: fix wrongly generated vapi for WireGuard API.
* wifi: fix parsing of Microsoft Network Cost information element for
  detecting metered networks.
* dhcp: support option 249 (Microsoft Classless Static Route) with nettools
  internal DHCP plugin.
* initrd: support the "rd.net.dhcp.retry" kernel argument for controlling retry
  and timeout to get a DHCP lease.
* API CHANGE: hide definitions of structs for NMSetting and NMSimpleConnection from
  public headers.
* Major restructuring of the source code.
* Many bugfixes and minor improvements.
```

~~Switched from iptables to nftables as it's upstream's preference. The paths patch needed rebasing again due to major restructuring.~~ When `nftables` is enabled, the NetworkManager module will now set the backend appropriately, additionally exposing the ability to disable this completely.

~~The `nss` dependency is from building `libnm-crypto-nss`, which after the restructuring gets built regardless of us using `gnutls`.~~ This is now resolved, with a patch already merged upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
