### PR TITLE
yabridge, yabridgectl: 3.2.0 → 3.3.1

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -57,14 +57,14 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.3.0";
+  version = "3.3.1";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    hash = "sha256-e0tHvuHJ3eib0keCu6/U6UGEm8pn7rcKN5sN0eNINUY=";
+    hash = "sha256-3B+6YuCWVJljqdyGpePjPf5JDwLSWFNgOCeLt8e4mO8=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , substituteAll
 , meson
 , ninja
@@ -58,14 +57,14 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.2.0";
+  version = "3.3.0";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    hash = "sha256-UT6st0Rc6HOaObE3N+qlPZZ8U1gl/MFLU0mjFuScdes=";
+    hash = "sha256-e0tHvuHJ3eib0keCu6/U6UGEm8pn7rcKN5sN0eNINUY=";
   };
 
   # Unpack subproject sources
@@ -80,13 +79,6 @@ in stdenv.mkDerivation rec {
   )'';
 
   patches = [
-    # Fix for wine 6.8+ (remove patch in next release):
-    (fetchpatch {
-      url = "https://github.com/robbert-vdh/yabridge/commit/5577c4bfd842c60a8ae8ce2889bbfeb53a51c62b.patch";
-      sha256 = "sha256-bTT08iWwDBVqi2PZPa7oal7/MqVu8t2Bh1gpjFMqLvQ=";
-      excludes = [ "CHANGELOG.md" ];
-    })
-
     # Hard code wine path so wine version is correct in logs
     (substituteAll {
       src = ./hardcode-wine.patch;

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoHash = "sha256-GY868xz+3uBeLy7tlludmbd8dJAot2/ewe5gToRtJnw=";
+  cargoHash = "sha256-f5k5OF+bEzH0b6M14Mdp8t4Qd5dP5Qj2fDsdiG1MkYk=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoHash = "sha256-cB4Xp8pNLQRcPQ6HtVkDkLbfNSmM9yl+oRcEzcqrmkY=";
+  cargoHash = "sha256-GY868xz+3uBeLy7tlludmbd8dJAot2/ewe5gToRtJnw=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using
@@ -34,5 +34,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/robbert-vdh/yabridge/tree/master/tools/yabridgectl";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ kira-bruneau ];
+    platforms = yabridge.meta.platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/robbert-vdh/yabridge/releases/tag/3.3.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).