### PR TITLE
mangohud: 0.6.1 → 0.6.3

### DIFF
--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
+, fetchurl
 , substituteAll
 , coreutils
 , curl
@@ -9,7 +9,7 @@
 , glxinfo
 , gnugrep
 , gnused
-, pciutils
+, lsof
 , xdg-utils
 , dbus
 , hwdata
@@ -22,33 +22,49 @@
 , ninja
 , pkg-config
 , python3Packages
+, unzip
 , vulkan-loader
 , libXNVCtrl
 , wayland
 }:
 
-stdenv.mkDerivation rec {
+let
+  # Derived from subprojects/imgui.wrap
+  imgui = rec {
+    version = "1.81";
+    src = fetchFromGitHub {
+      owner = "ocornut";
+      repo = "imgui";
+      rev = "v${version}";
+      hash = "sha256-rRkayXk3xz758v6vlMSaUu5fui6NR8Md3njhDB0gJ18=";
+    };
+    patch = fetchurl {
+      url = "https://wrapdb.mesonbuild.com/v2/imgui_${version}-1/get_patch";
+      hash = "sha256-bQC0QmkLalxdj4mDEdqvvOFtNwz2T1MpTDuMXGYeQ18=";
+    };
+  };
+in stdenv.mkDerivation rec {
   pname = "mangohud";
-  version = "0.6.1";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "flightlessmango";
     repo = "MangoHud";
     rev = "v${version}";
-    sha256 = "1bzfp37qrx9kk5zaq7sfisgkyccwnxd7i3b1l0blfcy2lrxgx0n6";
+    sha256 = "wL+/wAqvVFph1QzuXPBbSEFjs33VA0S6euNWr/1J1Mk=";
     fetchSubmodules = true;
   };
 
   outputs = [ "out" "doc" "man" ];
 
-  patches = [
-    # Adds option to specify Vulkan's datadir when it's not the same as MangoHud's
-    # See https://github.com/flightlessmango/MangoHud/pull/522
-    (fetchpatch {
-      url = "https://github.com/flightlessmango/MangoHud/commit/56682985d8cec711af7ad0841888a44099249b1b.patch";
-      sha256 = "0l5vb374lfgfh54jiy4097bzsccpv4zsl1fdhn55sxggklymcad8";
-    })
+  # Unpack subproject sources
+  postUnpack = ''(
+    cd "$sourceRoot/subprojects"
+    cp -R --no-preserve=mode,ownership ${imgui.src} imgui-${imgui.version}
+    unzip ${imgui.patch}
+  )'';
 
+  patches = [
     # Hard code dependencies. Can't use makeWrapper since the Vulkan
     # layer can be used without the mangohud executable by setting MANGOHUD=1.
     (substituteAll {
@@ -61,7 +77,7 @@ stdenv.mkDerivation rec {
         glxinfo
         gnugrep
         gnused
-        pciutils
+        lsof
         xdg-utils
       ];
 
@@ -96,6 +112,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3Packages.Mako
     python3Packages.python
+    unzip
     vulkan-loader
   ];
 

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  outputs = [ "out" "doc" "man" ];
+
   patches = [
     # Adds option to specify Vulkan's datadir when it's not the same as MangoHud's
     # See https://github.com/flightlessmango/MangoHud/pull/522

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -116,8 +116,7 @@ stdenv.mkDerivation rec {
   # Support overlaying Vulkan applications without requiring mangohud to be installed
   postFixup = ''
     wrapProgram "$out/bin/mangohud" \
-      --prefix VK_LAYER_PATH : "$out/share/vulkan/implicit_layer.d" \
-      --prefix VK_INSTANCE_LAYERS : VK_LAYER_MANGOHUD_overlay
+      --prefix XDG_DATA_DIRS : "$out/share"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -26,6 +26,7 @@
 , vulkan-loader
 , libXNVCtrl
 , wayland
+, addOpenGLRunpath
 }:
 
 let
@@ -130,9 +131,11 @@ in stdenv.mkDerivation rec {
       "$out/share/vulkan/implicit_layer.d/MangoHud.x86.json"
   '';
 
-  # Support overlaying Vulkan applications without requiring mangohud to be installed
+  # Support Nvidia cards by adding OpenGL path and support overlaying
+  # Vulkan applications without requiring MangoHud to be installed
   postFixup = ''
     wrapProgram "$out/bin/mangohud" \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ addOpenGLRunpath.driverLink ]} \
       --prefix XDG_DATA_DIRS : "$out/share"
   '';
 

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -24,6 +24,7 @@
 , python3Packages
 , vulkan-loader
 , libXNVCtrl
+, wayland
 }:
 
 stdenv.mkDerivation rec {
@@ -82,6 +83,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Duse_system_vulkan=enabled"
     "-Dvulkan_datadir=${vulkan-headers}/share"
+    "-Dwith_wayland=enabled"
   ];
 
   nativeBuildInputs = [
@@ -99,6 +101,7 @@ stdenv.mkDerivation rec {
     dbus
     libX11
     libXNVCtrl
+    wayland
   ];
 
   # Support 32bit Vulkan applications by linking in 32bit Vulkan layer

--- a/pkgs/tools/graphics/mangohud/hardcode-dependencies.patch
+++ b/pkgs/tools/graphics/mangohud/hardcode-dependencies.patch
@@ -1,9 +1,9 @@
 diff --git a/src/dbus.cpp b/src/dbus.cpp
-index 0acccc3..7dd7c49 100644
+index 44ffafc..9baf57b 100644
 --- a/src/dbus.cpp
 +++ b/src/dbus.cpp
-@@ -157,7 +157,7 @@ bool dbus_manager::init(const std::string& requested_player) {
-         m_requested_player = "org.mpris.MediaPlayer2." + requested_player;
+@@ -162,7 +162,7 @@ bool dbus_manager::init(const std::string& requested_player) {
+         return true;
      }
  
 -    if (!m_dbus_ldr.IsLoaded() && !m_dbus_ldr.Load("libdbus-1.so.3")) {
@@ -22,11 +22,11 @@ index 25c65bf..87488d5 100644
 -std::shared_ptr<libx11_loader> g_x11(new libx11_loader("libX11.so.6"));
 +std::shared_ptr<libx11_loader> g_x11(new libx11_loader("@libX11@/lib/libX11.so.6"));
 diff --git a/src/logging.cpp b/src/logging.cpp
-index f2c4271..d33e793 100644
+index ee8600b..c7c91a0 100644
 --- a/src/logging.cpp
 +++ b/src/logging.cpp
-@@ -17,7 +17,10 @@ string exec(string command) {
-    string result = "";
+@@ -19,7 +19,10 @@ string exec(string command) {
+ #ifdef __gnu_linux__
  
     // Open pipe to file
 +   char* originalPath = getenv("PATH");

--- a/pkgs/tools/graphics/mangohud/opengl32-nix-workaround.patch
+++ b/pkgs/tools/graphics/mangohud/opengl32-nix-workaround.patch
@@ -1,5 +1,5 @@
 diff --git a/bin/mangohud.in b/bin/mangohud.in
-index eadce2d..e7b1aa4 100755
+index 8ec21de..f65304a 100755
 --- a/bin/mangohud.in
 +++ b/bin/mangohud.in
 @@ -23,6 +23,6 @@ fi


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/flightlessmango/MangoHud/releases/tag/v0.6.3

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@ZerataX