### PR TITLE
Link to Libera instead of Freenode

### DIFF
--- a/.github/STALE-BOT.md
+++ b/.github/STALE-BOT.md
@@ -3,7 +3,7 @@
 - Thanks for your contribution!
 - To remove the stale label, just leave a new comment.
 - _How to find the right people to ping?_ &rarr; [`git blame`](https://git-scm.com/docs/git-blame) to the rescue! (or GitHub's history and blame buttons.)
-- You can always ask for help on [our Discourse Forum](https://discourse.nixos.org/) or on the [#nixos IRC channel](https://webchat.freenode.net/#nixos).
+- You can always ask for help on [our Discourse Forum](https://discourse.nixos.org/), [our Matrix room](https://matrix.to/#/#nix:nixos.org), or on the [#nixos IRC channel](https://web.libera.chat/#nixos).
 
 ## Suggestions for PRs
 

--- a/doc/builders/packages/weechat.section.md
+++ b/doc/builders/packages/weechat.section.md
@@ -41,7 +41,7 @@ weechat.override {
   configure = { availablePlugins, ... }: {
     init = ''
       /set foo bar
-      /server add freenode chat.freenode.org
+      /server add libera irc.libera.chat
     '';
   };
 }

--- a/nixos/doc/manual/preface.xml
+++ b/nixos/doc/manual/preface.xml
@@ -18,12 +18,13 @@
  <para>
   If you encounter problems, please report them on the
   <literal
-   xlink:href="https://discourse.nixos.org">Discourse</literal> or
-  on the <link
+   xlink:href="https://discourse.nixos.org">Discourse</literal>,
+  the <link
+   xlink:href="https://matrix.to/#nix:nixos.org">Matrix room</link>,
+  or on the <link
    xlink:href="irc://irc.libera.chat/#nixos">
-  <literal>#nixos</literal> channel on Libera.Chat</link>, or
-  consider
-  <link
+  <literal>#nixos</literal> channel on Libera.Chat</link>.
+  Alternatively, consider <link
    xlink:href="#chap-contributing">
    contributing to this manual</link>. Bugs should be
   reported in

--- a/nixos/modules/services/networking/matterbridge.nix
+++ b/nixos/modules/services/networking/matterbridge.nix
@@ -38,8 +38,8 @@ in
           # Use services.matterbridge.configPath instead.
 
           [irc]
-              [irc.freenode]
-              Server="irc.freenode.net:6667"
+              [irc.libera]
+              Server="irc.libera.chat:6667"
               Nick="matterbot"
 
           [mattermost]
@@ -55,7 +55,7 @@ in
           name="gateway1"
           enable=true
               [[gateway.inout]]
-              account="irc.freenode"
+              account="irc.libera"
               channel="#testing"
 
               [[gateway.inout]]

--- a/nixos/modules/services/networking/znc/default.nix
+++ b/nixos/modules/services/networking/znc/default.nix
@@ -133,8 +133,8 @@ in
               Nick = "paul";
               AltNick = "paul1";
               LoadModule = [ "chansaver" "controlpanel" ];
-              Network.freenode = {
-                Server = "chat.freenode.net +6697";
+              Network.libera = {
+                Server = "irc.libera.chat +6697";
                 LoadModule = [ "simple_away" ];
                 Chan = {
                   "#nixos" = { Detached = false; };

--- a/nixos/modules/services/networking/znc/options.nix
+++ b/nixos/modules/services/networking/znc/options.nix
@@ -11,7 +11,7 @@ let
 
       server = mkOption {
         type = types.str;
-        example = "chat.freenode.net";
+        example = "irc.libera.chat";
         description = ''
           IRC server address.
         '';
@@ -150,8 +150,8 @@ in
           '';
           example = literalExample ''
             {
-              "freenode" = {
-                server = "chat.freenode.net";
+              "libera" = {
+                server = "irc.libera.chat";
                 port = 6697;
                 useSSL = true;
                 modules = [ "simple_away" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The project has moved away from Freenode as an IRC network[1], and there
is now a quite large channel on Libera.  As such, we should point users
towards that instead.

This also changes all examples to refer to libera instead of freenode
as, with the recent deletion of all freenode channels, it is perhaps
where most communities are to be found nowadays.

[1]: https://discourse.nixos.org/t/join-us-on-matrix-at-nix-nixos-org-migrating-from-freenode

I have left out some of the comments explaining (presumably) _why_ things were done in a certain way ([example](https://github.com/NixOS/nixpkgs/blob/3b6c3bee9174dfe56fd0e586449457467abe7116/pkgs/development/libraries/qt-mobility/default.nix#L21)) as that would fall under "rewriting history" to me.  These communities are most likely on libera now, so what we may do is add a little `(now on libera)` message, but I wasn't sure about this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  I don't know whether the examples are in any way tested or if they really are just example strings, so I skipped all of these.  Feel free to shout at me for it :)
- [n/a] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [n/a] (Package updates) Added a release notes entry if the change is major or breaking
  - [n/a] (Module updates) Added a release notes entry if the change is significant
  - [n/a] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  This is a doc change and not really focusing on a single package, so it doesn't quite fit the requested commit message format. 
