### PR TITLE
ripasso-cursive: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/tools/security/ripasso/cursive.nix
+++ b/pkgs/tools/security/ripasso/cursive.nix
@@ -1,32 +1,34 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, ncurses, python3, openssl, libgpgerror, gpgme, xorg, AppKit, Security }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, ncurses, python3, openssl, libgpgerror, gpgme, xorg, AppKit, Security, installShellFiles }:
 
 with rustPlatform;
 buildRustPackage rec {
-  version = "0.4.0";
+  version = "0.5.1";
   pname = "ripasso-cursive";
 
   src = fetchFromGitHub {
     owner = "cortex";
     repo = "ripasso";
     rev  = "release-${version}";
-    sha256 = "164da20j727p8l7hh37j2r8pai9sj402nhswvg0nrlgj53nr6083";
+    sha256 = "1jx6qv7skikl1ap3g1r34rkz4ab756kra7dgwwv45vl2fb6x74k4";
   };
 
   patches = [ ./fix-tests.patch ];
 
-  cargoSha256 = "1sv5czhrafk15yj5xyd1x9jdqn1dz6aqpxxnyz49icx53qlg9f8g";
+  cargoSha256 = "1li1gmcs7lnjr4qhzs0rrgngdcxy1paiibjwk9zx2rrs71021cgk";
 
-  cargoBuildFlags = [ "-p ripasso-cursive -p ripasso-man" ];
+  cargoBuildFlags = [ "-p ripasso-cursive" ];
 
-  nativeBuildInputs = [ pkg-config gpgme python3 ];
+  nativeBuildInputs = [ pkg-config gpgme python3 installShellFiles ];
   buildInputs = [
     ncurses openssl libgpgerror gpgme xorg.libxcb
   ] ++ lib.optionals stdenv.isDarwin [ AppKit Security ];
 
-  preFixup = ''
-    mkdir -p "$out/man/man1"
-    $out/bin/ripasso-man > $out/man/man1/ripasso-cursive.1
-    rm $out/bin/ripasso-man
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  postInstall = ''
+    installManPage target/man-page/cursive/ripasso-cursive.1
   '';
 
   meta = with lib; {

--- a/pkgs/tools/security/ripasso/fix-tests.patch
+++ b/pkgs/tools/security/ripasso/fix-tests.patch
@@ -1,35 +1,82 @@
-diff --git a/src/pass/test.rs b/src/pass/test.rs
-index c980a2f..2e6c8cc 100644
 --- a/src/pass/test.rs
-+++ b/src/pass/test.rs
-@@ -56,6 +56,7 @@ fn populate_password_list_small_repo() {
++++ a/src/pass/test.rs
+@@ -83,6 +83,7 @@
      base_path.pop();
      base_path.pop();
      base_path.pop();
 +    base_path.pop();
      base_path.push("testres");
  
-     let mut password_dir: PathBuf = base_path.clone();
-@@ -84,6 +85,7 @@ fn populate_password_list_repo_with_deleted_files() {
+     let home: PathBuf = base_path.clone();
+@@ -114,6 +115,7 @@
      base_path.pop();
      base_path.pop();
      base_path.pop();
 +    base_path.pop();
      base_path.push("testres");
  
-     let mut password_dir: PathBuf = base_path.clone();
-@@ -112,6 +114,7 @@ fn populate_password_list_directory_without_git() {
+     let home: PathBuf = base_path.clone();
+@@ -144,6 +146,7 @@
      base_path.pop();
      base_path.pop();
      base_path.pop();
 +    base_path.pop();
      base_path.push("testres");
  
-     let mut password_dir: PathBuf = base_path.clone();
-@@ -149,4 +152,4 @@ fn parse_signing_keys_empty() {
-     let result = PasswordStore::parse_signing_keys(&None).unwrap();
+     let home: PathBuf = base_path.clone();
+@@ -185,6 +188,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.push("testres");
  
-     assert_eq!(result.len(), 0);
--}
-\ No newline at end of file
-+}
+     let home: PathBuf = base_path.clone();
+@@ -220,6 +224,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.push("testres");
+ 
+     let home: PathBuf = base_path.clone();
+@@ -267,6 +272,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.push("testres");
+ 
+     let home: PathBuf = base_path.clone();
+@@ -298,6 +304,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.push("testres");
+ 
+     let home: PathBuf = base_path.clone();
+@@ -337,6 +344,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.push("testres");
+ 
+     let home: PathBuf = base_path.clone();
+@@ -828,6 +836,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.push("testres");
+ 
+     let home: PathBuf = base_path.clone();
+@@ -860,6 +869,7 @@
+     base_path.pop();
+     base_path.pop();
+     base_path.pop();
++    base_path.pop();
+     base_path.pop();
+     base_path.push("testres");
+ 


### PR DESCRIPTION
https://github.com/cortex/ripasso/releases/tag/release-0.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
