### PR TITLE
gnomeExtensions.system-monitor: 2021-05-04 -> 2021-06-19

### DIFF
--- a/pkgs/desktops/gnome/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome/extensions/system-monitor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-system-monitor";
-  version = "unstable-2021-05-04";
+  version = "unstable-2021-06-19";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";
     repo = "gnome-shell-system-monitor-applet";
-    rev = "bc38ccf49ac0ffae0fc0436f3c2579fc86949f10";
-    sha256 = "0yb5sb2xv4m18a24h4daahnxgnlmbfa0rfzic0zs082qv1kfi5h8";
+    rev = "bece7be22352b81d3d81e64e18a385812851b8de";
+    sha256 = "08nnsg7z3cqk25hfgy4wm02hd2wpz13kig498kn4mf5f1q4hslmx";
   };
 
   buildInputs = [
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./paths_and_nonexisting_dirs.patch;
-      clutter_path = gnome.mutter.libdir; # this should not be used in settings but 🤷‍♀️
+      clutter_path = gnome.mutter.libdir; # only needed for GNOME < 40.
       gtop_path = "${libgtop}/lib/girepository-1.0";
       glib_net_path = "${glib-networking}/lib/girepository-1.0";
     })


### PR DESCRIPTION
###### Motivation for this change
Fixes crash when opening "Preferences" in NixOS with GNOME 40.

Closes #123260.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
