### PR TITLE
factorio: 1.1.34 → 1.1.35

### DIFF
--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -80,6 +80,12 @@ def fetch_versions() -> FactorioVersionsJSON:
 def generate_our_versions(factorio_versions: FactorioVersionsJSON) -> OurVersionJSON:
     rec_dd = lambda: defaultdict(rec_dd)
     output = rec_dd()
+
+    # Deal with times where there's no experimental version
+    for rc in RELEASE_CHANNELS:
+        if not factorio_versions[rc.name]:
+            factorio_versions[rc.name] = factorio_versions['stable']
+
     for system in SYSTEMS:
         for release_type in RELEASE_TYPES:
             for release_channel in RELEASE_CHANNELS:

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,56 +2,56 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.34.tar.xz",
+        "name": "factorio_alpha_x64-1.1.35.tar.xz",
         "needsAuth": true,
-        "sha256": "1gba6ivxdhj8khk6kfja2nzvqbbjlq1gzk8vlb23mkzqcmf4gnqc",
+        "sha256": "1svjjpyffdrmll1b3icsrikfi4v2r1z6j7iqq0v36iq0zw7vw3bk",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.34/alpha/linux64",
-        "version": "1.1.34"
+        "url": "https://factorio.com/get-download/1.1.35/alpha/linux64",
+        "version": "1.1.35"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.34.tar.xz",
+        "name": "factorio_alpha_x64-1.1.35.tar.xz",
         "needsAuth": true,
-        "sha256": "1gba6ivxdhj8khk6kfja2nzvqbbjlq1gzk8vlb23mkzqcmf4gnqc",
+        "sha256": "1svjjpyffdrmll1b3icsrikfi4v2r1z6j7iqq0v36iq0zw7vw3bk",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.34/alpha/linux64",
-        "version": "1.1.34"
+        "url": "https://factorio.com/get-download/1.1.35/alpha/linux64",
+        "version": "1.1.35"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.30.tar.xz",
+        "name": "factorio_demo_x64-1.1.35.tar.xz",
         "needsAuth": false,
-        "sha256": "1b3na8xn9lhlvrsd6hxr130nf9p81s26n25a4qdgkczz6waysgjv",
+        "sha256": "0yqb4gf2avpxr4vwafws9pv74xyd9g84zggfikfc801ldc7sp29f",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.30/demo/linux64",
-        "version": "1.1.30"
+        "url": "https://factorio.com/get-download/1.1.35/demo/linux64",
+        "version": "1.1.35"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.34.tar.xz",
+        "name": "factorio_demo_x64-1.1.35.tar.xz",
         "needsAuth": false,
-        "sha256": "1ld373lxfx1xbaqq394az8sxfxpjwkyqwwr77wbmg4sm2g9dinxm",
+        "sha256": "0yqb4gf2avpxr4vwafws9pv74xyd9g84zggfikfc801ldc7sp29f",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.34/demo/linux64",
-        "version": "1.1.34"
+        "url": "https://factorio.com/get-download/1.1.35/demo/linux64",
+        "version": "1.1.35"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.34.tar.xz",
+        "name": "factorio_headless_x64-1.1.35.tar.xz",
         "needsAuth": false,
-        "sha256": "0sfafdvfhhvxnhf7q23xnvckx8nihg5xzzc6dw39a3iprwhr75i1",
+        "sha256": "0xpiw89ad6cfpc576g5jpsyzwjncs3jrx01056p52wj01747fm94",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.34/headless/linux64",
-        "version": "1.1.34"
+        "url": "https://factorio.com/get-download/1.1.35/headless/linux64",
+        "version": "1.1.35"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.34.tar.xz",
+        "name": "factorio_headless_x64-1.1.35.tar.xz",
         "needsAuth": false,
-        "sha256": "0sfafdvfhhvxnhf7q23xnvckx8nihg5xzzc6dw39a3iprwhr75i1",
+        "sha256": "0xpiw89ad6cfpc576g5jpsyzwjncs3jrx01056p52wj01747fm94",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.34/headless/linux64",
-        "version": "1.1.34"
+        "url": "https://factorio.com/get-download/1.1.35/headless/linux64",
+        "version": "1.1.35"
       }
     }
   }


### PR DESCRIPTION
###### Motivation for this change

- Fix bug in `update.py`  
  The script wouldn't run (and generate data for the derivation) without this change.
  Making the `experimental` versions in nixpkgs be `max(stable, experimental)` seemed like the most coherent way
  to solve the issue (keeping the previously-packaged version would mean having `factorio-experimental` be sometimes
  older than `factorio`)
- factorio: 1.1.34 → 1.1.35


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ N/A
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
