### PR TITLE
texlive.texdoc: build Data.tlpdb.lua

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -105,4 +105,18 @@
     mkdir "$out"
     mv document*.svg "$out"/
   '';
+
+  texdoc = runCommandNoCC "texlive-test-texdoc" {
+    nativeBuildInputs = [
+      (with texlive; combine {
+        inherit scheme-infraonly luatex texdoc;
+        pkgFilter = pkg: lib.elem pkg.tlType [ "run" "bin" "doc" ];
+      })
+    ];
+  } ''
+    texdoc --version
+
+    texdoc --debug --list texdoc | tee "$out"
+    grep texdoc.pdf "$out"
+  '';
 }

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -7,6 +7,7 @@
 , makeWrapper, python3, ruby, perl
 , useFixedHashes ? true
 , recurseIntoAttrs
+, fetchpatch
 }:
 let
   # various binaries (compiled)
@@ -56,6 +57,37 @@ let
       collection-plaingeneric = orig.collection-plaingeneric // {
         deps = orig.collection-plaingeneric.deps // { inherit (tl) xdvi; };
       };
+
+      texdoc = orig.texdoc // {
+        # build Data.tlpdb.lua (part of the 'tlType == "run"' package)
+        postUnpack = let
+          # commit that ensures reproducibility of Data.tlpdb.lua
+          # remove on the next texdoc update
+          reproPatch = fetchpatch {
+            name = "make-data-tlpdb-lua-reproducible.patch";
+            url = "https://github.com/TeX-Live/texdoc/commit/82aff83d5453a887c1117b9e771a98bddd8a605a.patch";
+            sha256 = "0y04y468i7db4p5bsyyhgzip8q4fi1756x9a15ndha9xfnasbf44";
+            stripLen = 2;
+            extraPrefix = "scripts/texdoc/";
+          };
+        in ''
+          if [[ -f "$out"/scripts/texdoc/texdoc.tlu ]]; then
+            patch -p1 -d "$out" < "${reproPatch}"
+
+            unxz --stdout "${tlpdb}" > texlive.tlpdb
+
+            # create dummy doc file to ensure that texdoc does not return an error
+            mkdir -p support/texdoc
+            touch support/texdoc/NEWS
+
+            TEXMFCNF="${bin.core}"/share/texmf-dist/web2c TEXMF="$out" TEXDOCS=. TEXMFVAR=. \
+              "${bin.luatex}"/bin/texlua "$out"/scripts/texdoc/texdoc.tlu \
+              -c texlive_tlpdb=texlive.tlpdb -lM texdoc
+
+            cp texdoc/cache-tlpdb.lua "$out"/scripts/texdoc/Data.tlpdb.lua
+          fi
+        '';
+      };
     }); # overrides
 
     # tl =
@@ -91,6 +123,16 @@ let
     year = "2021";
     month = "04";
     day = "08";
+  };
+
+  tlpdb = fetchurl {
+    # use the same mirror(s) as urlPrefixes below
+    urls = [
+      #"http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2019/tlnet-final/tlpkg/texlive.tlpdb.xz"
+      #"ftp://tug.org/texlive/historic/2019/tlnet-final/tlpkg/texlive.tlpdb.xz"
+      "https://texlive.info/tlnet-archive/${snapshot.year}/${snapshot.month}/${snapshot.day}/tlnet/tlpkg/texlive.tlpdb.xz"
+    ];
+    sha512 = "1dsj4bza84g2f2z0w31yil3iwcnggcyg9f1xxwmp6ljk5xlzyr39cb556prx9691zbwpbrwbb5hnbqxqlnwsivgk0pmbl9mbjbk9cz0";
   };
 
   # create a derivation that contains an unpacked upstream TL package

--- a/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixedHashes.nix
@@ -729,7 +729,7 @@
 "texdiff.doc-0.4"="r9wsmivjyiwdnav7qc35kydk9b8pbcz8";
 "texdirflatten-1.3"="135358h2mb608wg3ni93rrsvvqgxm4ya";
 "texdirflatten.doc-1.3"="n9jxdwjiylvwy6n55vgci9a32qi10xhl";
-"texdoc-3.3"="3sjc6kp2l1p97qnhqqby5qcahcfj8irf";
+"texdoc-3.3"="zybis3ds27vzr62qsvkmph787jb12msz";
 "texdoc.doc-3.3"="ri2jcsh0ja8wmjs9y9692m0zc0z8gxvi";
 "texdoctk-0.6.0"="p6c2lakbnbg1wdc7i4iavscn9k0xamw5";
 "texdoctk.doc-0.6.0"="xfl4g9m6d9nbn4f9hgxj58jg9g4laa7l";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes part of #118757 (making `texdoc` run).

Rough edges:
- to make `texdoc` fixed output, we need `Data.tlpdb.lua` to be reproducible, hence we need to backport a commit until the next texdoc release
- the urls for `tlpdb` duplicate the ones in `mkPkg`, ideally they should be generated from the same list (e.g. `mirrors`?)

To test: you must include some `tlType == "doc"` packages in `texlive.combine` (not all of them because we still have the conflicts of #118757). For instance
```bash
$ nix-shell -I nixpkgs=. --pure -p 'texlive.combine { inherit (texlive) scheme-infraonly texdoc luatex; pkgFilter = (pkg: with lib; with pkg; elem tlType [ "run" "bin" ] || elem pname [ "core" "texdoc" ]); }' --run 'texdoc -l texdoc'
 1 /nix/store/ryw8j0j05rh3sdr5fcglpsp91y3mdf33-texlive-combined-2021/share/texmf/doc/support/texdoc/texdoc.pdf
   = Package documentation
 2 /nix/store/ryw8j0j05rh3sdr5fcglpsp91y3mdf33-texlive-combined-2021/share/texmf/doc/support/texdoc/README.md
   = Readme
 3 /nix/store/ryw8j0j05rh3sdr5fcglpsp91y3mdf33-texlive-combined-2021/share/texmf/doc/support/texdoc/NEWS
 4 /nix/store/ryw8j0j05rh3sdr5fcglpsp91y3mdf33-texlive-combined-2021/share/texmf/doc/man/man1/texdoc.man1.pdf
Enter number of file to view, RET to view 1, anything else to skip:
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
