### PR TITLE
emuflight-configurator: init at 0.3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1202,6 +1202,12 @@
     github = "beardhatcode";
     githubId = 662538;
   };
+  beezow = {
+    name = "beezow";
+    email = "zbeezow@gmail.com";
+    github = "beezow";
+    githubId = 42082156;
+  };
   bendlas = {
     email = "herwig@bendlas.net";
     github = "bendlas";

--- a/pkgs/applications/science/robotics/emuflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/emuflight-configurator/default.nix
@@ -1,0 +1,53 @@
+{lib, stdenv, fetchurl, unzip, makeDesktopItem, copyDesktopItems, nwjs
+, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
+
+let
+in
+stdenv.mkDerivation rec {
+  pname = "emuflight-configurator";
+  version = "0.3.5";
+
+  src = fetchurl {
+    url = "https://github.com/emuflight/EmuConfigurator/releases/download/${version}/emuflight-configurator_${version}_linux64.zip";
+    sha256 = "d55bdc52cf93d58c728ccb296ef912a5fc0f42c57ed95f3ded5f85d1c10838c4";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook unzip copyDesktopItems ];
+
+  buildInputs = [ gsettings-desktop-schemas gtk3 ];
+
+  installPhase = ''
+    mkdir -p $out/bin \
+             $out/share/${pname}
+
+    cp -r . $out/share/${pname}/
+    install -m 444 -D icon/emu_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png
+
+    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/share/${pname}
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "Emuflight configuration tool";
+      desktopName = "Emuflight Configurator";
+      genericName = "Flight controller configuration tool";
+    })
+  ];
+
+  meta = with lib; {
+    description = "The Emuflight flight control system configuration tool";
+    longDescription = ''
+      A crossplatform configuration tool for the Emuflight flight control system.
+      Various types of aircraft are supported by the tool and by Emuflight, e.g.
+      quadcopters, hexacopters, octocopters and fixed-wing aircraft.
+      The application allows you to configure the Emuflight software running on any supported Emuflight target.
+    '';
+    homepage    = "https://github.com/emuflight/EmuConfigurator";
+    license     = licenses.gpl3Only;
+    maintainers = with maintainers; [ beezow ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/robotics/emuflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/emuflight-configurator/default.nix
@@ -1,8 +1,6 @@
 {lib, stdenv, fetchurl, unzip, makeDesktopItem, copyDesktopItems, nwjs
 , wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
 
-let
-in
 stdenv.mkDerivation rec {
   pname = "emuflight-configurator";
   version = "0.3.5";
@@ -17,8 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gsettings-desktop-schemas gtk3 ];
 
   installPhase = ''
-    mkdir -p $out/bin \
-             $out/share/${pname}
+    mkdir -p $out/bin $out/share/${pname}
 
     cp -r . $out/share/${pname}/
     install -m 444 -D icon/emu_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30355,6 +30355,8 @@ in
 
   betaflight-configurator = callPackage ../applications/science/robotics/betaflight-configurator { };
 
+  emuflight-configurator = callPackage ../applications/science/robotics/emuflight-configurator { };
+
   mission-planner = callPackage ../applications/science/robotics/mission-planner { };
 
   ### MISC


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added new package, emuflight configurator. https://github.com/emuflight/EmuConfigurator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
