### PR TITLE
clipbuzz: init at 2.0.0

### DIFF
--- a/pkgs/tools/misc/clipbuzz/default.nix
+++ b/pkgs/tools/misc/clipbuzz/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromSourcehut, zig, libX11, libXfixes }:
+
+stdenv.mkDerivation rec {
+  pname = "clipbuzz";
+  version = "2.0.0";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "1qn98bwp7v7blw4v0g4pckgxrky5ggvq9m0kck2kqw8jg9jc15jp";
+  };
+
+  nativeBuildInputs = [ zig ];
+  buildInputs = [ libX11 libXfixes ];
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase = ''
+    zig build -Drelease-safe -Dcpu=baseline --prefix $out install
+  '';
+
+  meta = with lib; {
+    description = "Buzz on new X11 clipboard events";
+    homepage = "https://git.sr.ht/~cnx/clipbuzz";
+    license = licenses.unlicense;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10008,6 +10008,8 @@ in
 
   clipnotify = callPackage ../tools/misc/clipnotify { };
 
+  clipbuzz = callPackage ../tools/misc/clipbuzz { };
+
   xclip = callPackage ../tools/misc/xclip { };
 
   xcur2png = callPackage ../tools/graphics/xcur2png { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
clipbuzz is a fork of clipnotify to be used with my clipboard manager.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
