### PR TITLE
antlr: make 4.8 default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -309,6 +309,12 @@
           </listitem>
         </itemizedlist>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>antlr</literal> package now defaults to the 4.x
+          release instead of the old 2.7.7 version.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -85,4 +85,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   - GitVersionTree
   - NDeskOptions
 
+* The `antlr` package now defaults to the 4.x release instead of the
+  old 2.7.7 version.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}

--- a/pkgs/applications/version-management/srcml/default.nix
+++ b/pkgs/applications/version-management/srcml/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, libxml2, libxslt, boost, libarchive, python, antlr,
+{ lib, stdenv, fetchurl, cmake, libxml2, libxslt, boost, libarchive, python, antlr2,
   curl
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     ./gcc6.patch
   ];
 
-  nativeBuildInputs = [ cmake antlr ];
+  nativeBuildInputs = [ cmake antlr2 ];
   buildInputs = [ libxml2 libxslt boost libarchive python curl ];
 
   meta = {

--- a/pkgs/development/libraries/nco/default.nix
+++ b/pkgs/development/libraries/nco/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchzip, netcdf, netcdfcxx4, gsl, udunits, antlr, which, curl, flex, coreutils }:
+{ lib, stdenv, fetchzip, netcdf, netcdfcxx4, gsl, udunits, antlr2, which, curl, flex, coreutils }:
 
 stdenv.mkDerivation rec {
   version = "4.9.8";
   pname = "nco";
 
-  nativeBuildInputs = [ flex which antlr ];
+  nativeBuildInputs = [ flex which antlr2 ];
   buildInputs = [ netcdf netcdfcxx4 gsl udunits curl coreutils ];
 
   src = fetchzip {

--- a/pkgs/development/python-modules/stringtemplate/default.nix
+++ b/pkgs/development/python-modules/stringtemplate/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonPackage, antlr, isPy3k }:
+{ lib, fetchurl, buildPythonPackage, antlr2, isPy3k }:
 
 buildPythonPackage rec {
   pname = "PyStringTemplate";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "0lbib0l8c1q7i1j610rwcdagymr1idahrql4dkgnm5rzyg2vk3ml";
   };
 
-  propagatedBuildInputs = [ antlr ];
+  propagatedBuildInputs = [ antlr2 ];
 
   disabled = isPy3k;
 

--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, antlr
+{ mkDerivation, lib, fetchFromGitHub, cmake
 , qtbase, qttools, sqlite }:
 
 mkDerivation rec {
@@ -16,7 +16,7 @@ mkDerivation rec {
   # but qscintilla is currently in a bit of a mess as some consumers expect a
   # -qt4 or -qt5 prefix while others do not.
   # We *really* should get that cleaned up.
-  buildInputs = [ antlr qtbase sqlite ];
+  buildInputs = [ qtbase sqlite ];
 
   nativeBuildInputs = [ cmake qttools ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12787,7 +12787,7 @@ in
 
   ansible-lint = with python3.pkgs; toPythonApplication ansible-lint;
 
-  antlr = callPackage ../development/tools/parsing/antlr/2.7.7.nix {
+  antlr2 = callPackage ../development/tools/parsing/antlr/2.7.7.nix {
     jdk = jdk8; # todo: remove override https://github.com/nixos/nixpkgs/pull/89731
   };
 
@@ -12804,6 +12804,8 @@ in
   };
 
   antlr4 = antlr4_8;
+
+  antlr = antlr4;
 
   apacheAnt = callPackage ../development/tools/build-managers/apache-ant { };
   apacheAnt_1_9 = callPackage ../development/tools/build-managers/apache-ant/1.9.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addressing #40015. Added a new `antlr2` attribute for the old version and updated the derivations that used plain `antlr` to use that instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
