### PR TITLE
llvmPackages_git: Abort updates if no new version is available

### DIFF
--- a/pkgs/development/compilers/llvm/update-git.py
+++ b/pkgs/development/compilers/llvm/update-git.py
@@ -7,10 +7,14 @@ import json
 import os
 import re
 import subprocess
+import sys
 
 from codecs import iterdecode
 from datetime import datetime
 from urllib.request import urlopen, Request
+
+
+DEFAULT_NIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'git/default.nix')
 
 
 def get_latest_chromium_build():
@@ -39,6 +43,16 @@ def get_commit(ref):
         return json.loads(http_response.read().decode())
 
 
+def get_current_revision():
+    """Get the current revision of llvmPackages_git."""
+    with open(DEFAULT_NIX) as f:
+        for line in f:
+            rev = re.search(r'^  rev = "(.*)";', line)
+            if rev:
+                return rev.group(1)
+    sys.exit(1)
+
+
 def nix_prefetch_url(url, algo='sha256'):
     """Prefetches the content of the given URL."""
     print(f'nix-prefetch-url {url}')
@@ -55,13 +69,15 @@ clang_revision = re.search(r"^CLANG_REVISION = '(.+)'$", clang_update_script, re
 clang_commit_short = re.search(r"llvmorg-[0-9]+-init-[0-9]+-g([0-9a-f]{8})", clang_revision).group(1)
 release_version = re.search(r"^RELEASE_VERSION = '(.+)'$", clang_update_script, re.MULTILINE).group(1)
 commit = get_commit(clang_commit_short)
+if get_current_revision() == commit["sha"]:
+    print('No new update available.')
+    sys.exit(0)
 date = datetime.fromisoformat(commit['commit']['committer']['date'].rstrip('Z')).date().isoformat()
 version = f'unstable-{date}'
 print('Prefetching source tarball...')
 hash = nix_prefetch_url(f'https://github.com/llvm/llvm-project/archive/{commit["sha"]}.tar.gz')
 print('Updating default.nix...')
-default_nix = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'git/default.nix')
-with fileinput.FileInput(default_nix, inplace=True) as f:
+with fileinput.FileInput(DEFAULT_NIX, inplace=True) as f:
     for line in f:
         result = re.sub(r'^  release_version = ".+";', f'  release_version = "{release_version}";', line)
         result = re.sub(r'^  rev = ".*";', f'  rev = "{commit["sha"]}";', result)


### PR DESCRIPTION
No need to fetch the source tarball in this case.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
