### PR TITLE
haskellPackages: remove haskell-gi overrides obsolete due to lts

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1290,30 +1290,9 @@ self: super: {
   # https://github.com/kowainik/policeman/issues/57
   policeman = doJailbreak super.policeman;
 
-  # nixpkgs has bumped gdkpixbuf C lib, so we need gi-gdkpixbuf_2_0_26 to link against that.
-  # This leads to all this bumps which can be removed once stackage has haskell-gi 0.25.
-  haskell-gi = self.haskell-gi_0_25_0;
-  haskell-gi-base = addBuildDepends super.haskell-gi-base_0_25_0 [ pkgs.gobject-introspection ];
-  gi-glib = self.gi-glib_2_0_25;
-  gi-cairo = self.gi-cairo_1_0_25;
-  gi-gobject = self.gi-gobject_2_0_26;
-  gi-atk = self.gi-atk_2_0_23;
-  gi-gio = self.gi-gio_2_0_28;
-  gi-harfbuzz = self.gi-harfbuzz_0_0_4;
-  gi-javascriptcore = self.gi-javascriptcore_4_0_23;
-  gi-pango = self.gi-pango_1_0_24;
-  gi-soup = self.gi-soup_2_4_24;
-  gi-gdkpixbuf = self.gi-gdkpixbuf_2_0_26;
-  gi-gdk = self.gi-gdk_3_0_24;
-  gi-gtk = self.gi-gtk_3_0_37;
-  gi-webkit2 = self.gi-webkit2_4_0_27;
+  # Too strict version bounds on haskell-gi
   gi-cairo-render = doJailbreak super.gi-cairo-render;
   gi-cairo-connector = doJailbreak super.gi-cairo-connector;
-  gi-gtk-hs = self.gi-gtk-hs_0_3_10;
-  gi-dbusmenu = self.gi-dbusmenu_0_4_9;
-  gi-xlib = self.gi-xlib_2_0_10;
-  gi-gdkx11 = self.gi-gdkx11_3_0_11;
-  gi-dbusmenugtk3 = self.gi-dbusmenugtk3_0_4_10;
 
   # Missing -Iinclude parameter to doc-tests (pull has been accepted, so should be resolved when 0.5.3 released)
   # https://github.com/lehins/massiv/pull/104

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -73,10 +73,6 @@ default-package-overrides:
   # gi-gdkx11-4.x requires gtk-4.x, which is still under development and
   # not yet available in Nixpkgs
   - gi-gdkx11 < 4
-  # Needs Cabal 3.4 for Setup.hs
-  - gi-javascriptcore < 4.0.23 #
-  - gi-soup < 2.4.24 #
-  - gi-webkit2 < 4.0.27 #
   # 2021-05-11: not all diagrams libraries have adjusted to
   # monoid-extras 0.6 yet, keep them pinned to lower versions
   # until we can do a full migration, see


### PR DESCRIPTION
stackage LTS 18 luckily updated haskell-gi and related libraries to
0.25, so we can remove a lot of overrides. I also unrestricted some of
them in configuration-hackage2nix/main.yml and removed the overrides
updating them in configuration-common.nix (I guess the person doing
the upgrades thought those libraries were also in stackage).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
