### PR TITLE
nixos/babeld: update hardening

### DIFF
--- a/nixos/modules/services/networking/babeld.nix
+++ b/nixos/modules/services/networking/babeld.nix
@@ -104,6 +104,7 @@ in
         ExecStart = "${pkgs.babeld}/bin/babeld -c ${configFile} -I /run/babeld/babeld.pid -S /var/lib/babeld/state";
         AmbientCapabilities = [ "CAP_NET_ADMIN" ];
         CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+        DevicePolicy = "closed";
         DynamicUser = true;
         IPAddressAllow = [ "fe80::/64" "ff00::/8" "::1/128" "127.0.0.0/8" ];
         IPAddressDeny = "any";
@@ -123,12 +124,17 @@ in
         RemoveIPC = true;
         ProtectHome = true;
         ProtectHostname = true;
+        ProtectProc = "invisible";
         PrivateMounts = true;
         PrivateTmp = true;
         PrivateDevices = true;
         PrivateUsers = false; # kernel_route(ADD): Operation not permitted
+        ProcSubset = "pid";
         SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service" ];
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @resources"
+        ];
         UMask = "0177";
         RuntimeDirectory = "babeld";
         StateDirectory = "babeld";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update the hardening of babeld.

### Before
```
  NAME                                                        DESCRIPTION                                                                                         EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                                                 0.5
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                                                    0.3
✗ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has network configuration privileges                                                             0.2
✗ DeviceAllow=                                                Service has a device ACL with some special devices                                                       0.1
✗ IPAddressDeny=                                              Service defines IP address allow list with non-localhost entries                                         0.1
✗ PrivateUsers=                                               Service has access to other users                                                                        0.2
✗ ProtectProc=                                                Service has full access to process tree (/proc hidepid=)                                                 0.2
✗ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is included (e.g. chown is allowed)          0.2
✗ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is included (e.g. ioprio_set is allowed)      0.2
✗ AmbientCapabilities=                                        Service process receives ambient capabilities                                                            0.1
✗ RestrictAddressFamilies=~AF_NETLINK                         Service may allocate netlink sockets                                                                     0.1
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                                            0.1
✗ ProcSubset=                                                 Service has full access to non-process /proc files (/proc subset=)                                       0.1

→ Overall exposure level for babeld.service: 1.9 OK :-)
```

### After
```
  NAME                                                        DESCRIPTION                                                                    EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                            0.5
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                               0.3
✗ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has network configuration privileges                                        0.2
✗ DeviceAllow=                                                Service has a device ACL with some special devices                                  0.1
✗ IPAddressDeny=                                              Service defines IP address allow list with non-localhost entries                    0.1
✗ PrivateUsers=                                               Service has access to other users                                                   0.2
✗ AmbientCapabilities=                                        Service process receives ambient capabilities                                       0.1
✗ RestrictAddressFamilies=~AF_NETLINK                         Service may allocate netlink sockets                                                0.1
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                       0.1

→ Overall exposure level for babeld.service: 1.4 OK :-)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
