### PR TITLE
newsflash: 1.4.1 → 1.4.2

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -15,32 +15,26 @@
 , webkitgtk
 , glib-networking
 , librsvg
-, gst_all_1
 , xdg-utils
+, gst_all_1
 }:
 
 stdenv.mkDerivation rec {
   pname = "newsflash";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromGitLab {
     owner = "news-flash";
     repo = "news_flash_gtk";
     rev = version;
-    hash = "sha256-pskmvztKOwutXRHVnW5u68/0DAuV9Gb+Ovp2JbXiMYo=";
+    hash = "sha256-8W158GrvVGu5b3TG5bomK+hAF6jttZuImkmtcZOl91o=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-qq8cZplt5YWUwsXUShMDhQm3RGH2kCEBk64x6bOa50E=";
+    hash = "sha256-zHtD3NVWYQ5njg17Z2YmEttiK2oiq01OiAXIZofIqKI=";
   };
-
-  # https://github.com/CasualX/obfstr/blob/v0.2.4/build.rs#L5
-  # obfstr 0.2.4 fails to set RUSTC_BOOTSTRAP in its build script because cargo
-  # build scripts are forbidden from setting RUSTC_BOOTSTRAP since rustc 1.52.0
-  # https://github.com/rust-lang/rust/blob/1.52.0/RELEASES.md#compatibility-notes
-  RUSTC_BOOTSTRAP = 1;
 
   patches = [
     # Post install tries to generate an icon cache & update the
@@ -79,14 +73,14 @@ stdenv.mkDerivation rec {
     sqlite
     webkitgtk
 
-    # open link in browser
-    xdg-utils
-
     # TLS support for loading external content in webkitgtk WebView
     glib-networking
 
     # SVG support for gdk-pixbuf
     librsvg
+
+    # Open links in browser
+    xdg-utils
   ] ++ (with gst_all_1; [
     # Audio & video support for webkitgtk WebView
     gstreamer
@@ -100,5 +94,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/news-flash/news_flash_gtk";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ kira-bruneau ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/feedreaders/newsflash/no-post-install.patch
+++ b/pkgs/applications/networking/feedreaders/newsflash/no-post-install.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index 53f911c..361a233 100644
+index 1d7089c..1952e7f 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -61,5 +61,3 @@ meson.add_dist_script(


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://gitlab.com/news-flash/news_flash_gtk/-/tags/1.4.2

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).