### PR TITLE
pythonPackages.pybind11: improve expression

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -3,12 +3,12 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
-, python
-, pytest
 , cmake
+, eigen
+, python
 , catch
 , numpy
-, eigen
+, pytest
 , scipy
 }:
 
@@ -33,37 +33,40 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ catch ];
+  dontUseCmakeBuildDir = true;
 
   cmakeFlags = [
     "-DEIGEN3_INCLUDE_DIR=${eigen}/include/eigen3"
+    "-DBUILD_TESTING=on"
   ] ++ lib.optionals (python.isPy3k && !stdenv.cc.isClang) [
-  # Enable some tests only on Python 3. The "test_string_view" test
-  # 'testTypeError: string_view16_chars(): incompatible function arguments'
-  # fails on Python 2.
-    "-DPYBIND11_CPP_STANDARD=-std=c++17"
+    "-DPYBIND11_CXX_STANDARD=-std=c++17"
   ];
 
-  dontUseSetuptoolsBuild = true;
-  dontUsePipInstall = true;
-  dontUseSetuptoolsCheck = true;
+  postBuild = ''
+    # build tests
+    make
+  '';
 
-  preFixup = ''
-    pushd ..
-    export PYBIND11_USE_CMAKE=1
-    setuptoolsBuildPhase
-    pipInstallPhase
+  postInstall = ''
     # Symlink the CMake-installed headers to the location expected by setuptools
     mkdir -p $out/include/${python.libPrefix}
     ln -sf $out/include/pybind11 $out/include/${python.libPrefix}/pybind11
-    popd
   '';
 
   checkInputs = [
-    pytest
+    catch
     numpy
+    pytest
     scipy
   ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    make check
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/pybind/pybind11";
@@ -74,6 +77,6 @@ buildPythonPackage rec {
       bindings of existing C++ code.
     '';
     license = licenses.bsd3;
-    maintainers = with maintainers;[ yuriaisaka ];
+    maintainers = with maintainers; [ yuriaisaka dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -1,9 +1,9 @@
 {lib, fetchPypi, python, buildPythonPackage, gfortran, nose, pytest, numpy, pybind11}:
 
 let
-  pybind = pybind11.overridePythonAttrs(oldAttrs: {
+  pybind = pybind11.overridePythonAttrs (oldAttrs: {
     cmakeFlags = oldAttrs.cmakeFlags ++ [
-      "-DPYBIND11_TEST=off"
+      "-DBUILD_TESTING=off"
     ];
     doCheck = false; # Circular test dependency
   });


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We shouldn't build and install the package in preFixup.
And the tests weren't actually running before this I think.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
