### PR TITLE
pythonPackages.certifi: does not support python2

### DIFF
--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -1,11 +1,14 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "certifi";
   version = "2020.12.5";
+
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Support was officially dropped in https://github.com/certifi/python-certifi/commit/5efdd48f719d9c3c7c8f9a812da2256d088eab78.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Effect of this PR:
```
15 packages removed:
buttersink (†0.6.9) cloudmonkey (†5.3.3) datadog-agent (†6.11.2) euca2ools (†2.1.4) fast-export (†200213) fMBT (†0.42) graal (†19.2.1) jvmci (†19.3-b05) mercurial (†4.9.1) mx (†5.247.1) nixops (†1.7) opae (†1.0.0) python2.7-bitbucket-cli (†0.5.1) tsung (†1.7.0) zabbix-cli (†2.2.1)
```

@NixOS/nixops-committers Merge https://github.com/NixOS/nixpkgs/pull/127453 if you care about NixOps 1.7.