### PR TITLE
livedl: init at unstable-2021-05-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11004,6 +11004,16 @@
     githubId = 3889405;
     name = "vyp";
   };
+  wakira = {
+    name = "Sheng Wang";
+    email = "sheng@a64.work";
+    github = "wakira";
+    githubId = 2338339;
+    keys = [{
+      longkeyid = "rsa4096/0x8C9B0A8FC0C0D862";
+      fingerprint = "47F7 009E 3AE3 1DA7 988E  12E1 8C9B 0A8F C0C0 D862";
+    }];
+  };
   wamserma = {
     name = "Markus S. Wamser";
     email = "github-dev@mail2013.wamser.eu";

--- a/pkgs/tools/misc/livedl/default.nix
+++ b/pkgs/tools/misc/livedl/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "livedl";
+  version = "unstable-2021-05-16";
+
+  src = fetchFromGitHub {
+    owner = "himananiito";
+    repo = pname;
+    rev = "a8720f1e358e5b0ade6fdeb8aacc00781e6cc504";
+    sha256 = "1zax215jp6sl47m8ahssyyrbzn96dh74srq9g61jc76sq10xg329";
+  };
+
+  sourceRoot = "source/src";
+
+  vendorSha256 = sha256:g5Y1IH1U1zOOHygTzAJuBnUj+MyPe64KHTYikipt3TY=;
+
+  meta = with lib; {
+    description = "Command-line tool to download nicovideo.jp livestreams";
+    homepage = "https://github.com/himananiito/livedl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wakira ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28163,6 +28163,8 @@ in
   };
   litecoind = litecoin.override { withGui = false; };
 
+  livedl = callPackage ../tools/misc/livedl { };
+
   lnd = callPackage ../applications/blockchains/lnd.nix { };
 
   lndconnect = callPackage ../applications/blockchains/lndconnect { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
livedl is a command-line tool written in Go to download nicovideo.jp livestreams

https://github.com/himananiito/livedl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
