### PR TITLE
treewide: use quotes for url

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -742,7 +742,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
   stk = {
     shortName = "stk";
     fullName = "Synthesis Tool Kit 4.3";
-    url = https://github.com/thestk/stk/blob/master/LICENSE;
+    url = "https://github.com/thestk/stk/blob/master/LICENSE";
   };
 
   tcltk = spdx {

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -3,7 +3,7 @@
   # This example pins nixpkgs: https://nix.dev/tutorials/towards-reproducibility-pinning-nixpkgs.html
   /*nixpkgsSource ? (builtins.fetchTarball {
     name = "nixpkgs-20.09";
-    url = https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz;
+    url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
     sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
   }),
   pkgs ? import nixpkgsSource {},
@@ -41,7 +41,7 @@ let
   # If you copy this example out of nixpkgs, something like this will work:
   /*androidEnvNixpkgs = fetchTarball {
     name = "androidenv";
-    url = https://github.com/NixOS/nixpkgs/archive/<fill me in from Git>.tar.gz;
+    url = "https://github.com/NixOS/nixpkgs/archive/<fill me in from Git>.tar.gz";
     sha256 = "<fill me in with nix-prefetch-url --unpack>";
   };
 

--- a/pkgs/os-specific/linux/dstat/default.nix
+++ b/pkgs/os-specific/linux/dstat/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
     ./fix_pluginpath.patch
     # this fixes another bug with python3
     (fetchpatch {
-      url = https://github.com/efexgee/dstat/commit/220a785321b13b6df92a536080aca6ef1cb644ad.patch ;
+      url = "https://github.com/efexgee/dstat/commit/220a785321b13b6df92a536080aca6ef1cb644ad.patch";
       sha256 = "08kcz3yxvl35m55y7g1pr73x3bjcqnv0qlswxqyq8cqxg9zd64cn";
     })
   ];

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -22,11 +22,11 @@ buildPythonPackage rec {
 
   patches = [
     (fetchpatch {
-      url = https://gitlab.com/mailman/mailman/-/commit/4b206e2a5267a0e17f345fd7b2d957122ba57566.patch;
+      url = "https://gitlab.com/mailman/mailman/-/commit/4b206e2a5267a0e17f345fd7b2d957122ba57566.patch";
       sha256 = "06axmrn74p81wvcki36c7gfj5fp5q15zxz2yl3lrvijic7hbs4n2";
     })
     (fetchpatch {
-      url = https://gitlab.com/mailman/mailman/-/commit/9613154f3c04fa2383fbf017031ef263c291418d.patch;
+      url = "https://gitlab.com/mailman/mailman/-/commit/9613154f3c04fa2383fbf017031ef263c291418d.patch";
       sha256 = "0vyw87s857vfxbf7kihwb6w094xyxmxbi1bpdqi3ybjamjycp55r";
     })
     ./log-stderr.patch


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- use quotes for url

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
