### PR TITLE
agebox: init at 0.5.2

### DIFF
--- a/pkgs/tools/security/agebox/default.nix
+++ b/pkgs/tools/security/agebox/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "agebox";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "slok";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zn7jibhw5jd9wp1alx9ahj4szaig4a54ci3676kk5zqxr2hjz0c";
+  };
+  vendorSha256 = "0bc2pwz3yhzwqi0bcwqkkkrglg473qxhmz5s5955fvgajvjk7drn";
+
+  ldflags = [
+    "-s" "-w"
+    "-X main.Version=${version}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/slok/agebox";
+    changelog = "https://github.com/slok/agebox/releases/tag/v${version}";
+    description = "Age based repository file encryption gitops tool";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lesuisse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3788,6 +3788,8 @@ in
 
   age = callPackage ../tools/security/age { };
 
+  agebox = callPackage ../tools/security/agebox { };
+
   brotli = callPackage ../tools/compression/brotli { };
 
   biosdevname = callPackage ../tools/networking/biosdevname { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
