### PR TITLE
gnuradio.pkgs.ais: 2015-12-20 -> 2020-08-13

### DIFF
--- a/pkgs/development/gnuradio-modules/ais/default.nix
+++ b/pkgs/development/gnuradio-modules/ais/default.nix
@@ -8,18 +8,22 @@
 , cppunit
 , log4cpp
 , osmosdr
+, gmp
+, mpir
+, fftwFloat
+, icu
 }:
 
 mkDerivation rec {
   pname = "gr-ais";
-  version = "2015-12-20";
+  version = "2020-08-13";
   src = fetchFromGitHub {
     owner = "bistromath";
     repo = "gr-ais";
-    rev = "cdc1f52745853f9c739c718251830eb69704b26e";
-    sha256 = "1vl3kk8xr2mh5lf31zdld7yzmwywqffffah8iblxdzblgsdwxfl6";
+    rev = "2162103226f3dae43c8c2ab23b79483b84346665";
+    sha256 = "1vackka34722d8pcspfwj0j6gc9ic7dqq64sgkrpjm94sh3bmb0b";
   };
-  disabledForGRafter = "3.8";
+  disabledForGRafter = "3.9";
 
   nativeBuildInputs = [
     cmake
@@ -32,6 +36,10 @@ mkDerivation rec {
     osmosdr
     boost
     log4cpp
+    gmp
+    mpir
+    fftwFloat
+    icu
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
This adds support for GR3.8.

(cherry picked from commit 3e8fb944c24f1e6761e94a66aa7d347053375ea3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
