### PR TITLE
timedoctor: init at 3.12.12

### DIFF
--- a/pkgs/applications/office/timedoctor/default.nix
+++ b/pkgs/applications/office/timedoctor/default.nix
@@ -1,0 +1,123 @@
+{ appimageTools
+, fetchurl
+, lib
+}:
+
+# You can debug this package with: $ ELECTRON_ENABLE_LOGGING=true timedoctor
+let
+  version = "3.12.12";
+  sha256 = "01j149c6lacgysll3sajxlb43m1al08kdcwc6zyzw80nrp4iagf6";
+in
+appimageTools.wrapType2 {
+  name = "timedoctor-${version}";
+  src = fetchurl {
+    inherit sha256;
+    url = "https://repo2.timedoctor.com/td-desktop-hybrid/prod/v${version}/timedoctor-desktop_${version}_linux-x86_64.AppImage";
+  };
+  multiPkgs = _: with _; [
+    alsaLib
+    atk
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    coreutils
+    cups
+    dbus
+    dbus.lib
+    desktop-file-utils
+    expat
+    expat.dev
+    file
+    freetype
+    gcc
+    gcc-unwrapped.lib
+    gdb
+    gdk-pixbuf
+    git
+    glib
+    glibc
+    gnome.gdk_pixbuf
+    gnome.gtk
+    gnome.gtk.dev
+    gnome.zenity
+    gnome2.GConf
+    gnumake
+    gnutar
+    gpsd
+    gtk3
+    gtk3.dev
+    gtk3-x11
+    gtk3-x11.dev
+    kdialog
+    libappindicator-gtk2.out
+    libexif
+    (libjpeg.override { enableJpeg8 = true; }).out
+    libnotify
+    libpng
+    libxml2
+    libxslt
+    netcat
+    nettools
+    nodePackages.asar
+    nspr
+    nss
+    openjdk
+    pango
+    patchelf
+    python38
+    strace
+    sqlite
+    sqlite.dev
+    udev
+    unzip
+    utillinux
+    watch
+    wget
+    which
+    wrapGAppsHook
+    xdg_utils
+    xorg.libX11
+    xorg.libXau
+    xorg.libXaw
+    xorg.libXaw3d
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXdmcp
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXfont
+    xorg.libXfont2
+    xorg.libXft
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXmu
+    xorg.libXp
+    xorg.libXpm
+    xorg.libXpresent
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXres
+    xorg.libXScrnSaver
+    xorg.libXt
+    xorg.libXTrap
+    xorg.libXtst
+    xorg.libXv
+    xorg.libXvMC
+    xorg.libXxf86dga
+    xorg.libXxf86misc
+    xorg.libXxf86vm
+    xorg.xcbutilkeysyms
+    zip
+    zlib
+    zsh
+  ];
+  meta = with lib; {
+    description = "Employee time tracking software";
+    homepage = "https://www.timedoctor.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ kamadorueda ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1010,6 +1010,8 @@ in
 
   tilix = callPackage ../applications/terminal-emulators/tilix { };
 
+  timedoctor = callPackage ../applications/office/timedoctor { };
+
   twine = with python3Packages; toPythonApplication twine;
 
   wayst = callPackage ../applications/terminal-emulators/wayst { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Me and my team use this software on a daily basis,

For a long time (1 year+), not having this package available in Nix was the stopper for me not using NixOS, 
so I took the time to wrap it on nixpkgs in order to leave ubuntu behind.

I have been testing its functionality since some weeks ago:
- ![image](https://user-images.githubusercontent.com/47480384/122684437-fd684480-d1ca-11eb-8037-654aa85e39d5.png)
- ![image](https://user-images.githubusercontent.com/47480384/122684442-035e2580-d1cb-11eb-8d86-ba96e3e81cb3.png)

It works perfectly, I think it is time to merge into nixpkgs

Notes:
- Yes, it requires all dependencies specified there, I debugged with patchelf until there were no missing .so

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
