### PR TITLE
veracrypt: 1.24-Hotfix1 -> 1.24-Update7 and hardcode mkfs paths

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -7,6 +7,11 @@
 , fuse
 , wxGTK
 , lvm2
+, substituteAll
+, e2fsprogs
+, exfat
+, ntfs3g
+, btrfs-progs
 }:
 
 with lib;
@@ -19,6 +24,18 @@ stdenv.mkDerivation rec {
     url = "https://launchpad.net/${pname}/trunk/${toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
     sha256 = "0i7h44zn2mjzgh416l7kfs0dk6qc7b1bxsaxqqqcvgrpl453n7bc";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      ext2 = "${e2fsprogs}/bin/mkfs.ext2";
+      ext3 = "${e2fsprogs}/bin/mkfs.ext3";
+      ext4 = "${e2fsprogs}/bin/mkfs.ext4";
+      exfat = "${exfat}/bin/mkfs.exfat";
+      ntfs = "${ntfs3g}/bin/mkfs.ntfs";
+      btrfs = "${btrfs-progs}/bin/mkfs.btrfs";
+    })
+  ];
 
   sourceRoot = "src";
 

--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -1,31 +1,24 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, makeself, yasm, fuse, wxGTK, lvm2 }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, makeself
+, yasm
+, fuse
+, wxGTK
+, lvm2
+}:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "veracrypt";
-  version = "1.24-Hotfix1";
+  version = "1.24-Update7";
 
   src = fetchurl {
     url = "https://launchpad.net/${pname}/trunk/${toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
-    sha256 = "8b40ece805b216843d7a71b1a30069c4057931341b030bf65caace59263c5c8c";
+    sha256 = "0i7h44zn2mjzgh416l7kfs0dk6qc7b1bxsaxqqqcvgrpl453n7bc";
   };
-
-
-  patches = [
-    # https://github.com/veracrypt/VeraCrypt/issues/529 - fix build on non-x86
-    (fetchpatch {
-      url = "https://github.com/veracrypt/VeraCrypt/commit/afe6b2f45b15393026a1159e5f3d165ac7d0b94a.patch";
-      sha256 = "1xm9cl6zinlr0vah5xr9bvh0y9gw4331zl7d2n5xvqrcdxw3ww1y";
-      stripLen = 1;
-    })
-    # https://github.com/veracrypt/VeraCrypt/issues/529 - fix build on non-x86
-    (fetchpatch {
-      url = "https://github.com/veracrypt/VeraCrypt/commit/3fa636d477119fff6e372074568edb42d038f508.patch";
-      sha256 = "0qsccilip0ksnlzxina38a052gb533r4s422lxhrj3wv9zgpp7l3";
-      stripLen = 1;
-    })
-  ];
 
   sourceRoot = "src";
 

--- a/pkgs/applications/misc/veracrypt/fix-paths.patch
+++ b/pkgs/applications/misc/veracrypt/fix-paths.patch
@@ -1,0 +1,22 @@
+diff --color --unified --recursive --text a/Core/VolumeCreator.h b/Core/VolumeCreator.h
+--- a/Core/VolumeCreator.h	2021-06-20 20:54:50.725210056 +0300
++++ b/Core/VolumeCreator.h	2021-06-20 20:58:46.117742419 +0300
+@@ -77,12 +77,12 @@
+ 				switch (fsType)
+ 				{
+ 	#if defined (TC_LINUX)
+-				case VolumeCreationOptions::FilesystemType::Ext2:		return "mkfs.ext2";
+-				case VolumeCreationOptions::FilesystemType::Ext3:		return "mkfs.ext3";
+-				case VolumeCreationOptions::FilesystemType::Ext4:		return "mkfs.ext4";
+-				case VolumeCreationOptions::FilesystemType::NTFS:		return "mkfs.ntfs";
+-				case VolumeCreationOptions::FilesystemType::exFAT:		return "mkfs.exfat";
+-				case VolumeCreationOptions::FilesystemType::Btrfs:		return "mkfs.btrfs";
++				case VolumeCreationOptions::FilesystemType::Ext2:		return "@ext2@";
++				case VolumeCreationOptions::FilesystemType::Ext3:		return "@ext3@";
++				case VolumeCreationOptions::FilesystemType::Ext4:		return "@ext4@";
++				case VolumeCreationOptions::FilesystemType::NTFS:		return "@ntfs@";
++				case VolumeCreationOptions::FilesystemType::exFAT:		return "@exfat@";
++				case VolumeCreationOptions::FilesystemType::Btrfs:		return "@btrfs@";
+ 	#elif defined (TC_MACOSX)
+ 				case VolumeCreationOptions::FilesystemType::MacOsExt:	return "newfs_hfs";
+ 				case VolumeCreationOptions::FilesystemType::exFAT:		return "newfs_exfat";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #107360
https://github.com/veracrypt/VeraCrypt/compare/VeraCrypt_1.24-Hotfix1...VeraCrypt_1.24-Update7

###### Things done

I tested benchmarking and making a btrfs container

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
