### PR TITLE
[21.05] sylpheed: Use SNI; fixes TLSv1.3 to imap.gmail.com

### DIFF
--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, gtk2, openssl ? null, gpgme ? null
-, gpgSupport ? true, sslSupport ? true }:
+, gpgSupport ? true, sslSupport ? true, fetchpatch }:
 
 assert gpgSupport -> gpgme != null;
 assert sslSupport -> openssl != null;
@@ -14,6 +14,17 @@ stdenv.mkDerivation rec {
     url = "https://sylpheed.sraoss.jp/sylpheed/v3.7/${pname}-${version}.tar.xz";
     sha256 = "0j9y5vdzch251s264diw9clrn88dn20bqqkwfmis9l7m8vmwasqd";
   };
+
+  patches = [
+    (fetchpatch {
+      # patch upstream bug https://sylpheed.sraoss.jp/redmine/issues/306
+      name = "patch-libsylph_ssl_c.patch";
+      url = "https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/mail/sylpheed/patches/patch-libsylph_ssl_c?rev=1.4&content-type=text/plain";
+      sha256 = "sha256-k9OwPtHrEjaxXdH0trNqXgJMhR8kjgtei9pi6OFvILk=";
+    })
+  ];
+
+  patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
see https://github.com/NixOS/nixpkgs/pull/126915

###### Things done
(cherry picked from commit f28175adcf42adbdddd97aae93d7875fd56e4241)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
