### PR TITLE
vul: init at unstable-2020-02-15

### DIFF
--- a/pkgs/applications/misc/vul/default.nix
+++ b/pkgs/applications/misc/vul/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "vul";
+  version = "unstable-2020-02-15";
+
+  src = fetchFromGitHub {
+    owner = "LukeSmithxyz";
+    repo = pname;
+    rev = "f6ebd8f6b6fb8a111e7b59470d6748fcbe71c559";
+    sha256 = "aUl4f82sGOWkEvTDNILDszj5hztDRvYpHVovFl4oOCc=";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Latin Vulgate Bible on the Command Line";
+    homepage = "https://github.com/LukeSmithxyz/vul";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.j0hax ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9820,6 +9820,8 @@ in
 
   unrar = callPackage ../tools/archivers/unrar { };
 
+  vul = callPackage ../applications/misc/vul { };
+
   xar = callPackage ../tools/compression/xar { };
 
   xarchive = callPackage ../tools/archivers/xarchive { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a minimal script to display the Clementine Vulgate. Similar to the existing [kjv](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/kjv/default.nix) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
