### PR TITLE
libfx2: fix git ref

### DIFF
--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "whitequark";
     repo = "libfx2";
-    rev = version;
+    rev = "v${version}";
     sha256 = "sha256-Uk+K7ym92JX4fC3PyTNxd0UvBzoNZmtbscBYjSWChuk=";
   };
 


### PR DESCRIPTION
cache.nixos.org has the actual source cached, so this didn't impact
builds for anyone using that cache.

    edef@jaguar ~/s/nixpkgs> nix eval -I nixpkgs=. nixpkgs.pythonPackages.fx2.src.urls
    [ "https://github.com/whitequark/libfx2/archive/0.9.tar.gz" ]
    edef@jaguar ~/s/nixpkgs> curl -L https://github.com/whitequark/libfx2/archive/0.9.tar.gz
    404: Not Found

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
