### PR TITLE
drogon: add options for optional dependencies

### DIFF
--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, fetchFromGitHub, cmake, jsoncpp, libossp_uuid, zlib, openssl, lib }:
+{ stdenv, fetchFromGitHub, cmake, jsoncpp, libossp_uuid, zlib, openssl, lib
+# miscellaneous
+, brotli, c-ares
+# databases
+, sqliteSupport ? true, sqlite
+, postgresSupport ? false, postgresql
+, redisSupport ? false, hiredis
+, mysqlSupport ? false, libmysqlclient, mariadb }:
 
 stdenv.mkDerivation rec {
   pname = "drogon";
@@ -24,7 +31,13 @@ stdenv.mkDerivation rec {
     libossp_uuid
     zlib
     openssl
-  ];
+    brotli
+    c-ares
+  ] ++ lib.optional sqliteSupport sqlite
+    ++ lib.optional postgresSupport postgresql
+    ++ lib.optional redisSupport hiredis
+    # drogon uses mariadb for mysql (see https://github.com/an-tao/drogon/wiki/ENG-02-Installation#Library-Dependencies)
+    ++ lib.optional mysqlSupport [ libmysqlclient mariadb ];
 
   patches = [
     # this part of the test would normally fail because it attempts to configure a CMake project that uses find_package on itself


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done
- add options for including brotli, c-ares, sqlite, postgres, redis, and mysql

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
