### PR TITLE
[staging-next] zstd: fix darwin patch

### DIFF
--- a/pkgs/tools/compression/zstd/playtests-darwin.patch
+++ b/pkgs/tools/compression/zstd/playtests-darwin.patch
@@ -1,6 +1,6 @@
 --- a/tests/playTests.sh
 +++ b/tests/playTests.sh
-@@ -112,17 +112,10 @@ case "$OS" in
+@@ -112,22 +112,12 @@ case "$OS" in
  esac
  
  case "$UNAME" in
@@ -16,9 +16,14 @@
 -    Darwin | FreeBSD | OpenBSD | NetBSD) MTIME="stat -f %m" ;;
 -esac
  
- DIFF="diff"
- case "$UNAME" in
-@@ -842,7 +835,6 @@ $MD5SUM dirTestDict/* > tmph1
+ GET_PERMS="stat -c %a"
+-case "$UNAME" in
+-    Darwin | FreeBSD | OpenBSD | NetBSD) GET_PERMS="stat -f %Lp" ;;
+-esac
+ 
+ assertFilePermissions() {
+     STAT1=$($GET_PERMS "$1")
+@@ -967,7 +957,6 @@ $MD5SUM dirTestDict/* > tmph1
  zstd -f --rm dirTestDict/* -D tmpDictC
  zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
  case "$UNAME" in


### PR DESCRIPTION
Since v1.4.9, another stat command has been added to playTests.sh.
Similar to other uses in this file, it attempts to use BSD syntax on
Darwin/BSD, and must be patched to unconditionally use GNU syntax.

Intended for https://github.com/NixOS/nixpkgs/pull/127151

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
