### PR TITLE
nixosTest: Force system.nixos.revision constant

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -41,7 +41,7 @@ rec {
             # The human version (e.g. 21.05-pre) is left as is, because it is useful
             # for external modules that test with e.g. nixosTest and rely on that
             # version number.
-            config.system.nixos.revision = "constant-nixos-revision";
+            config.system.nixos.revision = mkForce "constant-nixos-revision";
           }
           { key = "nodes"; _module.args.nodes = nodes; }
         ] ++ optional minimal ../modules/testing/minimal-kernel.nix;


### PR DESCRIPTION

nixos tests are blended with other system configurations, hence
their settings must be either enforced or defaulted.

This particular setting is set via lib.nixosSystem as
`system.nixos.revision = final.mkIf (self ? rev) self.rev;` which would
mean that without this change no flake generated nixos could be blended
with nixos testing.

This setting was made previously constant in 
169c6b4b1478a3a0c823c99ea39d4082f76a2708 in order to avoid pointless
rebuilds of the testing VMs, but was set without enforcing it.

---

//cc @roberth this is a fixup for 169c6b4b1478a3a0c823c99ea39d4082f76a2708


See for example: https://github.com/divnix/digga/runs/2871922228#step:5:55