### PR TITLE
pn: init at unstable-2021-01-28

### DIFF
--- a/pkgs/tools/text/pn/default.nix
+++ b/pkgs/tools/text/pn/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake, libphonenumber, icu, protobuf }:
+
+stdenv.mkDerivation rec {
+  pname = "pn";
+  version = "unstable-2021-01-28";
+
+  src = fetchFromGitHub {
+    owner = "Orange-OpenSource";
+    repo = pname;
+    rev = "41e1215397129ed0d42b5f137fb35b5e0648edda";
+    sha256 = "1g8r7y230k01ghraa55g1bhz3fiz6bjdgcsddy2dfa5ih8c4s3jm";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libphonenumber icu protobuf ];
+
+  meta = with lib; {
+    description = "A libphonenumber command-line wrapper";
+    homepage = "https://github.com/Orange-OpenSource/pn";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3117,6 +3117,8 @@ in
 
   playerctl = callPackage ../tools/audio/playerctl { };
 
+  pn = callPackage ../tools/text/pn { };
+
   poweralertd = callPackage ../tools/misc/poweralertd { };
 
   ps_mem = callPackage ../tools/system/ps_mem { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
pn is a dependency for [Sxmo](https://sxmo.org).  I don't know how to build the gawk extension the nix way so it's disabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).