### PR TITLE
gemrb: 0.8.7 -> 0.9.0

### DIFF
--- a/pkgs/games/gemrb/default.nix
+++ b/pkgs/games/gemrb/default.nix
@@ -67,8 +67,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description =
-      "A reimplementation of the Infinity Engine, used by games such as Baldur's Gate";
+    description = "A reimplementation of the Infinity Engine, used by games such as Baldur's Gate";
     longDescription = ''
       GemRB (Game engine made with pre-Rendered Background) is a portable
       open-source implementation of Bioware's Infinity Engine. It was written to

--- a/pkgs/games/gemrb/default.nix
+++ b/pkgs/games/gemrb/default.nix
@@ -1,34 +1,74 @@
-{ lib, stdenv, fetchFromGitHub, cmake
-, freetype, SDL2, SDL2_mixer, openal, zlib, libpng, python2, libvorbis
-, libiconv }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, SDL2
+, SDL2_mixer
+, freetype
+, libGL
+, libiconv
+, libpng
+, libvlc
+, libvorbis
+, openal
+, python2 # 0.9.0 crashes after character generation with py3, so stick to py2 for now
+, zlib
+}:
 
+let
+  # the GLES backend on rpi is untested as I don't have the hardware
+  backend =
+    if (stdenv.isx86_32 || stdenv.isx86_64) then "OpenGL" else "GLES";
+
+in
 stdenv.mkDerivation rec {
   pname = "gemrb";
-  version = "0.8.7";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "gemrb";
     repo = "gemrb";
     rev = "v${version}";
-    sha256 = "14j9mhrbi4gnrbv25nlsvcxzkylijzrnwbqqnrg7pr452lb3srpb";
+    sha256 = "sha256-h/dNPY0QZ2m7aYgRla3r1E8APJqO99ePa2ABhhh3Aoc=";
   };
 
-  # TODO: make libpng, libvorbis, sdl_mixer, freetype, vlc, glew (and other gl
-  # reqs) optional
-  buildInputs = [ freetype python2 openal SDL2 SDL2_mixer zlib libpng libvorbis libiconv ];
+  buildInputs = [
+    SDL2
+    SDL2_mixer
+    freetype
+    libGL
+    libiconv
+    libpng
+    libvlc
+    libvorbis
+    openal
+    python2
+    zlib
+  ];
 
   nativeBuildInputs = [ cmake ];
 
-  # TODO: add proper OpenGL support. We are currently (0.8.7) getting a shader
-  # error on execution when enabled.
+  LIBVLC_INCLUDE_PATH = "${lib.getDev libvlc}/include";
+  LIBVLC_LIBRARY_PATH = "${lib.getLib libvlc}/lib";
+
   cmakeFlags = [
+    # use the Mesa drivers for video on ARM (harmless on x86)
+    "-DDISABLE_VIDEOCORE=ON"
     "-DLAYOUT=opt"
-    # "-DOPENGL_BACKEND=GLES"
-    # "-DOpenGL_GL_PREFERENCE=GLVND"
+    "-DOPENGL_BACKEND=${backend}"
+    "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 
+  postInstall = ''
+    for s in 36 48 72 96 144; do
+      install -Dm444 ../artwork/gemrb-logo-glow-''${s}px.png $out/share/icons/hicolor/''${s}x''${s}/gemrb.png
+    done
+    install -Dm444 ../artwork/gemrb-logo.png $out/share/icons/gemrb.png
+  '';
+
   meta = with lib; {
-    description = "A reimplementation of the Infinity Engine, used by games such as Baldur's Gate";
+    description =
+      "A reimplementation of the Infinity Engine, used by games such as Baldur's Gate";
     longDescription = ''
       GemRB (Game engine made with pre-Rendered Background) is a portable
       open-source implementation of Bioware's Infinity Engine. It was written to
@@ -36,8 +76,7 @@ stdenv.mkDerivation rec {
       ruleset (Baldur's Gate and Icewind Dale series, Planescape: Torment).
     '';
     homepage = "https://gemrb.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

we're unfortunately not ready to do py2 -> py3 yet. Upstream has confirmed a
number of issues with the transition as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
