### PR TITLE
[python-unstable] home-assistant-cli: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -4,11 +4,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "homeassistant-cli";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "18h6bc99skzb0a1pffb6lr2z04928srrcz1w2zy66bndasic5yfs";
+    sha256 = "03kiyqpp3zf8rg30d12h4fapihh0rqwpv5p8jfxb3iq0chfmjx2f";
   };
 
   postPatch = ''
@@ -30,11 +30,13 @@ python3.pkgs.buildPythonApplication rec {
     tabulate
   ];
 
-  postInstall = ''
-    mkdir -p "$out/share/bash-completion/completions" "$out/share/zsh/site-functions"
-    $out/bin/hass-cli completion bash > "$out/share/bash-completion/completions/hass-cli"
-    $out/bin/hass-cli completion zsh > "$out/share/zsh/site-functions/_hass-cli"
-  '';
+  # Completion needs to be ported to work with click > 8.0
+  # https://github.com/home-assistant-ecosystem/home-assistant-cli/issues/367
+  #postInstall = ''
+  #  mkdir -p "$out/share/bash-completion/completions" "$out/share/zsh/site-functions"
+  #  $out/bin/hass-cli completion bash > "$out/share/bash-completion/completions/hass-cli"
+  #  $out/bin/hass-cli completion zsh > "$out/share/zsh/site-functions/_hass-cli"
+  #'';
 
   checkInputs = with python3.pkgs; [
     pytestCheckHook
@@ -43,7 +45,7 @@ python3.pkgs.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Command-line tool for Home Assistant";
-    homepage = "https://github.com/home-assistant/home-assistant-cli";
+    homepage = "https://github.com/home-assistant-ecosystem/home-assistant-cli";
     changelog = "https://github.com/home-assistant-ecosystem/home-assistant-cli/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = teams.home-assistant.members;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.4

This fixes the test failure but also disable the completion which needs to be ported to work with `click` > 8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
