### PR TITLE
haskell.compiler.ghc8104: patch for sphinx >= 4.0

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.4.nix
+++ b/pkgs/development/compilers/ghc/8.10.4.nix
@@ -125,6 +125,9 @@ stdenv.mkDerivation (rec {
     # upstream patch. Don't forget to check backport status of the upstream patch
     # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
+    # Fix documentation configuration which causes a syntax error with sphinx 4.*
+    # See https://gitlab.haskell.org/ghc/ghc/-/issues/19962, remove at 8.10.6.
+    ./sphinx-4-configuration.patch
   ] ++ lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release
     (fetchpatch {

--- a/pkgs/development/compilers/ghc/sphinx-4-configuration.patch
+++ b/pkgs/development/compilers/ghc/sphinx-4-configuration.patch
@@ -1,0 +1,11 @@
+--- ghc-8.10.4/docs/users_guide/conf.py.orig	2021-06-21 13:46:34.196383559 +0200
++++ ghc-8.10.4/docs/users_guide/conf.py	2021-06-21 13:46:54.839349941 +0200
+@@ -100,7 +100,7 @@
+ latex_elements = {
+     'inputenc': '',
+     'utf8extra': '',
+-    'preamble': '''
++    'preamble': r'''
+ \usepackage{fontspec}
+ \usepackage{makeidx}
+ \setsansfont{DejaVu Sans}


### PR DESCRIPTION
With sphinx 4, interpreting the conf.py fails due to a decode
error: https://gitlab.haskell.org/ghc/ghc/-/issues/19962

The fix is an one line change which we have to backport from GHC master.
Thus ghcHEAD is not affected by this problem.

9.2 and 8.10.6 will most likely have a fix for this.

TODO: Patch 8.8.4 ~~and 9.0.1~~ (9.0.1 is already working)

Tested `haskell.compiler.ghc8104` on `x86_64-linux`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
