### PR TITLE
qbe: unstable-2020-10-05 -> unstable-2021-06-17, enable tests, add passthru.tests

### DIFF
--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchgit
 , unstableGitUpdater
+, callPackage
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +16,10 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru = {
+    tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};
+    updateScript = unstableGitUpdater { };
+  };
 
   meta = with lib; {
     homepage = "https://c9x.me/compile/";

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   pname = "qbe";
-  version = "unstable-2020-10-05";
+  version = "unstable-2021-06-17";
 
   src = fetchgit {
     url = "git://c9x.me/qbe.git";
-    rev = "496c069405cd79aed968f59dd5a5f92d1f96809f";
-    sha256 = "1vpszl77j9mnw8r0p9l23k8nxbnz31lgii7v3mai130nbpjsjsdf";
+    rev = "6d9ee1389572ae985f6a39bb99dbd10cdf42c123";
+    sha256 = "NaURS5Eu8NBd92wGQcyFEXCALU9Z93nNQeZ8afq4KMw=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  doCheck = true;
+
   passthru = {
     tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};
     updateScript = unstableGitUpdater { };

--- a/pkgs/development/compilers/qbe/test-can-run-hello-world.nix
+++ b/pkgs/development/compilers/qbe/test-can-run-hello-world.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, writeText
+, qbe
+}:
+
+# The hello world program available at https://c9x.me/compile/
+let helloWorld = writeText "hello-world.ssa" ''
+  function w $add(w %a, w %b) {        # Define a function add
+  @start
+    %c =w add %a, %b                   # Adds the 2 arguments
+    ret %c                             # Return the result
+  }
+  export function w $main() {          # Main function
+  @start
+    %r =w call $add(w 1, w 1)          # Call add(1, 1)
+    call $printf(l $fmt, w %r, ...)    # Show the result
+    ret 0
+  }
+  data $fmt = { b "One and one make %d!\n", b 0 }
+'';
+
+in stdenv.mkDerivation {
+  name = "qbe-test-can-run-hello-world";
+  meta.timeout = 10;
+  buildCommand = ''
+    ${qbe}/bin/qbe -o asm.s ${helloWorld}
+    cc -o out asm.s
+    ./out | grep 'One and one make 2!'
+    touch $out
+  '';
+}
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
