### PR TITLE
Revert "php/generic: Allow to extend PHP_INI_SCAN_DIR"

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -124,15 +124,15 @@ let
                 ln -s ${extraInit} $out/lib/php.ini
 
                 if test -e $out/bin/php; then
-                  wrapProgram $out/bin/php --prefix PHP_INI_SCAN_DIR : $out/lib
+                  wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
                 fi
 
                 if test -e $out/bin/php-fpm; then
-                  wrapProgram $out/bin/php-fpm --prefix PHP_INI_SCAN_DIR : $out/lib
+                  wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
                 fi
 
                 if test -e $out/bin/phpdbg; then
-                  wrapProgram $out/bin/phpdbg --prefix PHP_INI_SCAN_DIR : $out/lib
+                  wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
                 fi
               '';
             };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#125405, which causes issues when PHP is wrapped multiple times, since the same configuration file can end up being loaded multiple times, causing major issues.