### PR TITLE
pony-corral: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/development/compilers/ponyc/pony-corral.nix
+++ b/pkgs/development/compilers/ponyc/pony-corral.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation ( rec {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "sha256:1g4dkf5hsnykn3x6yx6ycjzmzzr1nwl59lj13j7zyka1ibv53hwf";
+    sha256 = "1g4dkf5hsnykn3x6yx6ycjzmzzr1nwl59lj13j7zyka1ibv53hwf";
   };
 
   buildInputs = [ ponyc ];

--- a/pkgs/development/compilers/ponyc/pony-corral.nix
+++ b/pkgs/development/compilers/ponyc/pony-corral.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation ( rec {
   pname = "corral";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "sha256-mQ/SxnppChZ+6PKVo5VM+QiNn94F4qJT1kQSrwXTa7k=";
+    sha256 = "sha256:1g4dkf5hsnykn3x6yx6ycjzmzzr1nwl59lj13j7zyka1ibv53hwf";
   };
 
   buildInputs = [ ponyc ];


### PR DESCRIPTION
  * Fixes compilation error caused by changes in RFC69


###### Motivation for this change

A breaking change in pony's stdlib causes version 0.5.0 of this package to fail to compile.  This update fixes this compilation error.

This is a simple version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
