### PR TITLE
pantheon.elementary-mail: init at unstable-2021-06-21

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -1,0 +1,82 @@
+{ lib, stdenv
+, fetchFromGitHub
+, nix-update-script
+, pantheon
+, pkg-config
+, meson
+, ninja
+, python3
+, vala
+, desktop-file-utils
+, gtk3
+, libxml2
+, libhandy
+, webkitgtk
+, folks
+, libgdata
+, sqlite
+, granite
+, elementary-icon-theme
+, evolution-data-server
+, appstream
+, wrapGAppsHook
+, libgee
+}:
+
+stdenv.mkDerivation rec {
+  pname = "elementary-mail";
+  version = "unstable-2021-06-21";
+
+  repoName = "mail";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = repoName;
+    rev = "c64c87fabb31dea8dc388152d5a835401993acf4";
+    sha256 = "yEUg1IbYbzOJiklnqR23X+aGVE9j4F9iH8FkmlB15x4=";
+  };
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    libxml2
+    meson
+    ninja
+    pkg-config
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    elementary-icon-theme
+    evolution-data-server
+    folks
+    granite
+    gtk3
+    libgdata
+    libgee
+    libhandy
+    sqlite
+    webkitgtk
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with lib; {
+    description = "Mail app designed for elementary OS";
+    homepage = "https://github.com/elementary/mail";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = pantheon.maintainers ++ [ maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -49,6 +49,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   elementary-feedback = callPackage ./apps/elementary-feedback { };
 
+  elementary-mail = callPackage ./apps/elementary-mail { };
+
   elementary-music = callPackage ./apps/elementary-music { };
 
   elementary-photos = callPackage ./apps/elementary-photos { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/83252
Aids in https://github.com/NixOS/nixpkgs/issues/58161

The reasoning for choosing an unstable version is that there hasn't been a release in ***3 years***. My hope is they'll "release" soon (the project is still seeing very active development) and we can move to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
