### PR TITLE
rshijack: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/networking/rshijack/default.nix
+++ b/pkgs/tools/networking/rshijack/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rshijack";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "kpcyrd";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0y01hi3jpfawqlqs8ka0vwfhjw5j5gkhk2nz5m13ns2h27bw20v7";
+    sha256 = "sha256-jpiwbjsYsb5scFbjtv2eTv6oo0HWWTYLpnpTZ8DEqb0=";
   };
 
-  cargoSha256 = "1rbp94wxr8kqjfg35hf44vn3qa0f0jcq8i50a8d0g5y2qf12h04d";
+  cargoSha256 = "sha256-biHDnLu7OiYpnwtmayk2m6QYvX51YUVJH2FGP4qo14Q=";
 
   meta = with lib; {
     description = "TCP connection hijacker";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.0

Change log: https://github.com/kpcyrd/rshijack/releases/tag/v0.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
