### PR TITLE
element-{desktop,web}: 1.7.30 -> 1.7.31

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "src/electron-main.js",
-  "version": "1.7.30",
+  "version": "1.7.31",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -43,8 +43,8 @@
   },
   "devDependencies": {
     "asar": "^2.0.1",
-    "electron-builder": "22.10.5",
-    "electron-builder-squirrel-windows": "22.10.5",
+    "electron-builder": "22.11.4",
+    "electron-builder-squirrel-windows": "22.11.4",
     "electron-devtools-installer": "^3.1.1",
     "electron-notarize": "^1.0.0",
     "eslint": "7.18.0",
@@ -68,7 +68,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "12.0.9",
+    "electronVersion": "12.0.11",
     "files": [
       "package.json",
       {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-yarndeps.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-yarndeps.nix
@@ -2,14 +2,6 @@
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
-      name = "7zip_bin___7zip_bin_5.0.3.tgz";
-      path = fetchurl {
-        name = "7zip_bin___7zip_bin_5.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.0.3.tgz";
-        sha1 = "bc5b5532ecafd923a61f2fb097e3b108c0106a3f";
-      };
-    }
-    {
       name = "7zip_bin___7zip_bin_5.1.1.tgz";
       path = fetchurl {
         name = "7zip_bin___7zip_bin_5.1.1.tgz";
@@ -138,11 +130,11 @@
       };
     }
     {
-      name = "_electron_universal___universal_1.0.4.tgz";
+      name = "_electron_universal___universal_1.0.5.tgz";
       path = fetchurl {
-        name = "_electron_universal___universal_1.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/@electron/universal/-/universal-1.0.4.tgz";
-        sha1 = "231ac246c39d45b80e159bd21c3f9027dcaa10f5";
+        name = "_electron_universal___universal_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/@electron/universal/-/universal-1.0.5.tgz";
+        sha1 = "b812340e4ef21da2b3ee77b2b4d35c9b86defe37";
       };
     }
     {
@@ -418,6 +410,14 @@
       };
     }
     {
+      name = "_malept_flatpak_bundler___flatpak_bundler_0.4.0.tgz";
+      path = fetchurl {
+        name = "_malept_flatpak_bundler___flatpak_bundler_0.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz";
+        sha1 = "e8a32c30a95d20c2b1bb635cc580981a06389858";
+      };
+    }
+    {
       name = "_sindresorhus_is___is_0.14.0.tgz";
       path = fetchurl {
         name = "_sindresorhus_is___is_0.14.0.tgz";
@@ -450,11 +450,11 @@
       };
     }
     {
-      name = "_types_fs_extra___fs_extra_9.0.9.tgz";
+      name = "_types_fs_extra___fs_extra_9.0.11.tgz";
       path = fetchurl {
-        name = "_types_fs_extra___fs_extra_9.0.9.tgz";
-        url  = "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.9.tgz";
-        sha1 = "11ed43b3f3c6b3490f1ef9bd17f58da896e2d861";
+        name = "_types_fs_extra___fs_extra_9.0.11.tgz";
+        url  = "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz";
+        sha1 = "8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87";
       };
     }
     {
@@ -514,11 +514,11 @@
       };
     }
     {
-      name = "_types_yargs___yargs_15.0.13.tgz";
+      name = "_types_yargs___yargs_16.0.3.tgz";
       path = fetchurl {
-        name = "_types_yargs___yargs_15.0.13.tgz";
-        url  = "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.13.tgz";
-        sha1 = "34f7fec8b389d7f3c1fd08026a5763e072d3c6dc";
+        name = "_types_yargs___yargs_16.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.3.tgz";
+        sha1 = "4b6d35bb8e680510a7dc2308518a80ee1ef27e01";
       };
     }
     {
@@ -730,19 +730,19 @@
       };
     }
     {
-      name = "app_builder_bin___app_builder_bin_3.5.12.tgz";
+      name = "app_builder_bin___app_builder_bin_3.5.13.tgz";
       path = fetchurl {
-        name = "app_builder_bin___app_builder_bin_3.5.12.tgz";
-        url  = "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.12.tgz";
-        sha1 = "bbe174972cc1f481f73d6d92ad47a8b4c7eb4530";
+        name = "app_builder_bin___app_builder_bin_3.5.13.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.13.tgz";
+        sha1 = "6dd7f4de34a4e408806f99b8c7d6ef1601305b7e";
       };
     }
     {
-      name = "app_builder_lib___app_builder_lib_22.10.5.tgz";
+      name = "app_builder_lib___app_builder_lib_22.11.4.tgz";
       path = fetchurl {
-        name = "app_builder_lib___app_builder_lib_22.10.5.tgz";
-        url  = "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.10.5.tgz";
-        sha1 = "24a88581c891e5b187a0d569aa44e7c4a0dc8de2";
+        name = "app_builder_lib___app_builder_lib_22.11.4.tgz";
+        url  = "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.11.4.tgz";
+        sha1 = "f476e8f1c843d2bcce0348d60e2deae3a71b3474";
       };
     }
     {
@@ -938,11 +938,11 @@
       };
     }
     {
-      name = "balanced_match___balanced_match_1.0.0.tgz";
+      name = "balanced_match___balanced_match_1.0.2.tgz";
       path = fetchurl {
-        name = "balanced_match___balanced_match_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz";
-        sha1 = "89b4d199ab2bee49de164ea02b89ce462d71b767";
+        name = "balanced_match___balanced_match_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz";
+        sha1 = "e83e3a7e3f300b34cb9d87f615fa0cbf357690ee";
       };
     }
     {
@@ -983,14 +983,6 @@
         name = "bin_links___bin_links_1.1.8.tgz";
         url  = "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.8.tgz";
         sha1 = "bd39aadab5dc4bdac222a07df5baf1af745b2228";
-      };
-    }
-    {
-      name = "binaryextensions___binaryextensions_4.15.0.tgz";
-      path = fetchurl {
-        name = "binaryextensions___binaryextensions_4.15.0.tgz";
-        url  = "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-4.15.0.tgz";
-        sha1 = "c63a502e0078ff1b0e9b00a9f74d3c2b0f8bd32e";
       };
     }
     {
@@ -1098,19 +1090,19 @@
       };
     }
     {
-      name = "builder_util_runtime___builder_util_runtime_8.7.3.tgz";
+      name = "builder_util_runtime___builder_util_runtime_8.7.5.tgz";
       path = fetchurl {
-        name = "builder_util_runtime___builder_util_runtime_8.7.3.tgz";
-        url  = "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz";
-        sha1 = "0aaafa52d25295c939496f62231ca9ff06c30e40";
+        name = "builder_util_runtime___builder_util_runtime_8.7.5.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.5.tgz";
+        sha1 = "fbe59e274818885e0d2e358d5b7017c34ae6b0f5";
       };
     }
     {
-      name = "builder_util___builder_util_22.10.5.tgz";
+      name = "builder_util___builder_util_22.11.4.tgz";
       path = fetchurl {
-        name = "builder_util___builder_util_22.10.5.tgz";
-        url  = "https://registry.yarnpkg.com/builder-util/-/builder-util-22.10.5.tgz";
-        sha1 = "8d0b04a3be6acc74938679aa90dcb3181b1ae86b";
+        name = "builder_util___builder_util_22.11.4.tgz";
+        url  = "https://registry.yarnpkg.com/builder-util/-/builder-util-22.11.4.tgz";
+        sha1 = "5deee8e067d6e3248791977ce2928b98fe514342";
       };
     }
     {
@@ -1135,6 +1127,14 @@
         name = "byte_size___byte_size_5.0.1.tgz";
         url  = "https://registry.yarnpkg.com/byte-size/-/byte-size-5.0.1.tgz";
         sha1 = "4b651039a5ecd96767e71a3d7ed380e48bed4191";
+      };
+    }
+    {
+      name = "cacache___cacache_12.0.4.tgz";
+      path = fetchurl {
+        name = "cacache___cacache_12.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz";
+        sha1 = "668bcbd105aeb5f1d92fe25570ec9525c8faa40c";
       };
     }
     {
@@ -1226,6 +1226,14 @@
       };
     }
     {
+      name = "chalk___chalk_4.1.1.tgz";
+      path = fetchurl {
+        name = "chalk___chalk_4.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz";
+        sha1 = "c80b3fab28bf6371e6863325eee67e618b77e6ad";
+      };
+    }
+    {
       name = "chownr___chownr_1.1.4.tgz";
       path = fetchurl {
         name = "chownr___chownr_1.1.4.tgz";
@@ -1263,6 +1271,14 @@
         name = "ci_info___ci_info_2.0.0.tgz";
         url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz";
         sha1 = "67a9e964be31a51e15e5010d58e6f12834002f46";
+      };
+    }
+    {
+      name = "ci_info___ci_info_3.2.0.tgz";
+      path = fetchurl {
+        name = "ci_info___ci_info_3.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz";
+        sha1 = "2876cb948a498797b5236f0095bc057d0dca38b6";
       };
     }
     {
@@ -1658,6 +1674,14 @@
       };
     }
     {
+      name = "debug___debug_3.2.7.tgz";
+      path = fetchurl {
+        name = "debug___debug_3.2.7.tgz";
+        url  = "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz";
+        sha1 = "72580b7e9145fb39b6676f9c5e5fb100b934179a";
+      };
+    }
+    {
       name = "debug___debug_3.2.6.tgz";
       path = fetchurl {
         name = "debug___debug_3.2.6.tgz";
@@ -1818,19 +1842,19 @@
       };
     }
     {
-      name = "dmg_builder___dmg_builder_22.10.5.tgz";
+      name = "dmg_builder___dmg_builder_22.11.4.tgz";
       path = fetchurl {
-        name = "dmg_builder___dmg_builder_22.10.5.tgz";
-        url  = "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.10.5.tgz";
-        sha1 = "65a33c106ead5a350c7de8997c546559bd6e0e7c";
+        name = "dmg_builder___dmg_builder_22.11.4.tgz";
+        url  = "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.11.4.tgz";
+        sha1 = "8e3a31bd835d51d3b686d1a6be6c0d08d3e7b1f4";
       };
     }
     {
-      name = "dmg_license___dmg_license_1.0.8.tgz";
+      name = "dmg_license___dmg_license_1.0.9.tgz";
       path = fetchurl {
-        name = "dmg_license___dmg_license_1.0.8.tgz";
-        url  = "https://registry.yarnpkg.com/dmg-license/-/dmg-license-1.0.8.tgz";
-        sha1 = "d52e234815f1a07a59706e5f2a2fea71991cf784";
+        name = "dmg_license___dmg_license_1.0.9.tgz";
+        url  = "https://registry.yarnpkg.com/dmg-license/-/dmg-license-1.0.9.tgz";
+        sha1 = "a2fb8d692af0e30b0730b5afc91ed9edc2d9cb4f";
       };
     }
     {
@@ -1850,11 +1874,11 @@
       };
     }
     {
-      name = "dot_prop___dot_prop_4.2.0.tgz";
+      name = "dot_prop___dot_prop_4.2.1.tgz";
       path = fetchurl {
-        name = "dot_prop___dot_prop_4.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz";
-        sha1 = "1f19e0c2e1aa0e32797c49799f2837ac6af69c57";
+        name = "dot_prop___dot_prop_4.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz";
+        sha1 = "45884194a71fc2cda71cbb4bceb3a4dd2f433ba4";
       };
     }
     {
@@ -1882,11 +1906,11 @@
       };
     }
     {
-      name = "dotenv___dotenv_8.2.0.tgz";
+      name = "dotenv___dotenv_9.0.2.tgz";
       path = fetchurl {
-        name = "dotenv___dotenv_8.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz";
-        sha1 = "97e619259ada750eea3e4ea3e26bceea5424b16a";
+        name = "dotenv___dotenv_9.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz";
+        sha1 = "dacc20160935a37dea6364aa1bef819fb9b6ab05";
       };
     }
     {
@@ -1914,14 +1938,6 @@
       };
     }
     {
-      name = "editions___editions_6.1.0.tgz";
-      path = fetchurl {
-        name = "editions___editions_6.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/editions/-/editions-6.1.0.tgz";
-        sha1 = "ba6c6cf9f4bb571d9e53ea34e771a602e5a66549";
-      };
-    }
-    {
       name = "editor___editor_1.0.0.tgz";
       path = fetchurl {
         name = "editor___editor_1.0.0.tgz";
@@ -1938,19 +1954,19 @@
       };
     }
     {
-      name = "electron_builder_squirrel_windows___electron_builder_squirrel_windows_22.10.5.tgz";
+      name = "electron_builder_squirrel_windows___electron_builder_squirrel_windows_22.11.4.tgz";
       path = fetchurl {
-        name = "electron_builder_squirrel_windows___electron_builder_squirrel_windows_22.10.5.tgz";
-        url  = "https://registry.yarnpkg.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-22.10.5.tgz";
-        sha1 = "83d3bf498110341a522cc5263fb4474ae6e05caf";
+        name = "electron_builder_squirrel_windows___electron_builder_squirrel_windows_22.11.4.tgz";
+        url  = "https://registry.yarnpkg.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-22.11.4.tgz";
+        sha1 = "6dc50a26396d813f58a4d8e5b90ee3cedb56f4d8";
       };
     }
     {
-      name = "electron_builder___electron_builder_22.10.5.tgz";
+      name = "electron_builder___electron_builder_22.11.4.tgz";
       path = fetchurl {
-        name = "electron_builder___electron_builder_22.10.5.tgz";
-        url  = "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.10.5.tgz";
-        sha1 = "03b156b93e6012609027c3aaa69201a3ad21e454";
+        name = "electron_builder___electron_builder_22.11.4.tgz";
+        url  = "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.11.4.tgz";
+        sha1 = "aadb57a4fc90863e82ebdbc66131400fc3bb4c82";
       };
     }
     {
@@ -1970,11 +1986,11 @@
       };
     }
     {
-      name = "electron_publish___electron_publish_22.10.5.tgz";
+      name = "electron_publish___electron_publish_22.11.4.tgz";
       path = fetchurl {
-        name = "electron_publish___electron_publish_22.10.5.tgz";
-        url  = "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.10.5.tgz";
-        sha1 = "9cbe46266b6c79d8c6e99840755682e2262d3543";
+        name = "electron_publish___electron_publish_22.11.4.tgz";
+        url  = "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.11.4.tgz";
+        sha1 = "0f526edb7e0c3f0155103ff3b8a2e363a3a392f1";
       };
     }
     {
@@ -2010,11 +2026,11 @@
       };
     }
     {
-      name = "encoding___encoding_0.1.12.tgz";
+      name = "encoding___encoding_0.1.13.tgz";
       path = fetchurl {
-        name = "encoding___encoding_0.1.12.tgz";
-        url  = "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz";
-        sha1 = "538b66f3ee62cd1ab51ec323829d1f9480c74beb";
+        name = "encoding___encoding_0.1.13.tgz";
+        url  = "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz";
+        sha1 = "56574afdd791f54a8e9b2785c0582a2d26210fa9";
       };
     }
     {
@@ -2047,14 +2063,6 @@
         name = "err_code___err_code_1.1.2.tgz";
         url  = "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz";
         sha1 = "06e0116d3028f6aef4806849eb0ea6a748ae6960";
-      };
-    }
-    {
-      name = "errlop___errlop_4.1.0.tgz";
-      path = fetchurl {
-        name = "errlop___errlop_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/errlop/-/errlop-4.1.0.tgz";
-        sha1 = "8e7b8f4f1bf0a6feafce4d14f0c0cf4bf5ef036b";
       };
     }
     {
@@ -2474,6 +2482,14 @@
       };
     }
     {
+      name = "fs_extra___fs_extra_10.0.0.tgz";
+      path = fetchurl {
+        name = "fs_extra___fs_extra_10.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz";
+        sha1 = "9ff61b655dde53fb34a82df84bb214ce802e17c1";
+      };
+    }
+    {
       name = "fs_extra___fs_extra_8.1.0.tgz";
       path = fetchurl {
         name = "fs_extra___fs_extra_8.1.0.tgz";
@@ -2482,19 +2498,19 @@
       };
     }
     {
-      name = "fs_extra___fs_extra_9.0.1.tgz";
-      path = fetchurl {
-        name = "fs_extra___fs_extra_9.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz";
-        sha1 = "910da0062437ba4c39fedd863f1675ccfefcb9fc";
-      };
-    }
-    {
       name = "fs_extra___fs_extra_9.1.0.tgz";
       path = fetchurl {
         name = "fs_extra___fs_extra_9.1.0.tgz";
         url  = "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz";
         sha1 = "5954460c764a8da2094ba3554bf839e6b9a7c86d";
+      };
+    }
+    {
+      name = "fs_extra___fs_extra_9.0.1.tgz";
+      path = fetchurl {
+        name = "fs_extra___fs_extra_9.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz";
+        sha1 = "910da0062437ba4c39fedd863f1675ccfefcb9fc";
       };
     }
     {
@@ -2642,11 +2658,11 @@
       };
     }
     {
-      name = "glob_parent___glob_parent_5.1.1.tgz";
+      name = "glob_parent___glob_parent_5.1.2.tgz";
       path = fetchurl {
-        name = "glob_parent___glob_parent_5.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz";
-        sha1 = "b6c1ef417c4e5663ea498f1c45afac6916bbc229";
+        name = "glob_parent___glob_parent_5.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz";
+        sha1 = "869832c58034fe68a4093c17dc15e8340d8401c4";
       };
     }
     {
@@ -2655,6 +2671,14 @@
         name = "glob___glob_7.1.6.tgz";
         url  = "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz";
         sha1 = "141f33b81a7c2492e125594307480c46679278a6";
+      };
+    }
+    {
+      name = "glob___glob_7.1.7.tgz";
+      path = fetchurl {
+        name = "glob___glob_7.1.7.tgz";
+        url  = "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz";
+        sha1 = "3b193e9233f01d42d0b3f78294bbeeb418f94a90";
       };
     }
     {
@@ -2719,6 +2743,14 @@
         name = "graceful_fs___graceful_fs_4.2.3.tgz";
         url  = "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz";
         sha1 = "4a12ff1b60376ef09862c2093edd908328be8423";
+      };
+    }
+    {
+      name = "graceful_fs___graceful_fs_4.2.6.tgz";
+      path = fetchurl {
+        name = "graceful_fs___graceful_fs_4.2.6.tgz";
+        url  = "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz";
+        sha1 = "ff040b2b0853b23c3d31027523706f1885d76bee";
       };
     }
     {
@@ -2810,27 +2842,11 @@
       };
     }
     {
-      name = "hosted_git_info___hosted_git_info_2.8.5.tgz";
+      name = "hosted_git_info___hosted_git_info_2.8.9.tgz";
       path = fetchurl {
-        name = "hosted_git_info___hosted_git_info_2.8.5.tgz";
-        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz";
-        sha1 = "759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c";
-      };
-    }
-    {
-      name = "hosted_git_info___hosted_git_info_2.8.8.tgz";
-      path = fetchurl {
-        name = "hosted_git_info___hosted_git_info_2.8.8.tgz";
-        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz";
-        sha1 = "7539bd4bc1e0e0a895815a2e0262420b12858488";
-      };
-    }
-    {
-      name = "hosted_git_info___hosted_git_info_3.0.8.tgz";
-      path = fetchurl {
-        name = "hosted_git_info___hosted_git_info_3.0.8.tgz";
-        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz";
-        sha1 = "6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d";
+        name = "hosted_git_info___hosted_git_info_2.8.9.tgz";
+        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz";
+        sha1 = "dffc0bf9a21c02209090f2aa69429e1414daf3f9";
       };
     }
     {
@@ -2890,11 +2906,11 @@
       };
     }
     {
-      name = "iconv_corefoundation___iconv_corefoundation_1.1.5.tgz";
+      name = "iconv_corefoundation___iconv_corefoundation_1.1.6.tgz";
       path = fetchurl {
-        name = "iconv_corefoundation___iconv_corefoundation_1.1.5.tgz";
-        url  = "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.5.tgz";
-        sha1 = "90596d444a579aeb109f5ca113f6bb665a41be2b";
+        name = "iconv_corefoundation___iconv_corefoundation_1.1.6.tgz";
+        url  = "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.6.tgz";
+        sha1 = "27c135470237f6f8d13462fa1f5eaf250523c29a";
       };
     }
     {
@@ -2906,11 +2922,11 @@
       };
     }
     {
-      name = "iconv_lite___iconv_lite_0.6.2.tgz";
+      name = "iconv_lite___iconv_lite_0.6.3.tgz";
       path = fetchurl {
-        name = "iconv_lite___iconv_lite_0.6.2.tgz";
-        url  = "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz";
-        sha1 = "ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01";
+        name = "iconv_lite___iconv_lite_0.6.3.tgz";
+        url  = "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz";
+        sha1 = "a52f80bf38da1952eb5c681790719871a1a72501";
       };
     }
     {
@@ -3122,19 +3138,19 @@
       };
     }
     {
+      name = "is_ci___is_ci_3.0.0.tgz";
+      path = fetchurl {
+        name = "is_ci___is_ci_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz";
+        sha1 = "c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994";
+      };
+    }
+    {
       name = "is_cidr___is_cidr_3.1.0.tgz";
       path = fetchurl {
         name = "is_cidr___is_cidr_3.1.0.tgz";
         url  = "https://registry.yarnpkg.com/is-cidr/-/is-cidr-3.1.0.tgz";
         sha1 = "72e233d8e1c4cd1d3f11713fcce3eba7b0e3476f";
-      };
-    }
-    {
-      name = "is_core_module___is_core_module_2.2.0.tgz";
-      path = fetchurl {
-        name = "is_core_module___is_core_module_2.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz";
-        sha1 = "97037ef3d52224d85163f5597b2b63d9afed981a";
       };
     }
     {
@@ -3330,6 +3346,14 @@
       };
     }
     {
+      name = "isbinaryfile___isbinaryfile_4.0.8.tgz";
+      path = fetchurl {
+        name = "isbinaryfile___isbinaryfile_4.0.8.tgz";
+        url  = "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz";
+        sha1 = "5d34b94865bd4946633ecc78a026fc76c5b11fcf";
+      };
+    }
+    {
       name = "isexe___isexe_2.0.0.tgz";
       path = fetchurl {
         name = "isexe___isexe_2.0.0.tgz";
@@ -3343,14 +3367,6 @@
         name = "isstream___isstream_0.1.2.tgz";
         url  = "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz";
         sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
-      };
-    }
-    {
-      name = "istextorbinary___istextorbinary_5.12.0.tgz";
-      path = fetchurl {
-        name = "istextorbinary___istextorbinary_5.12.0.tgz";
-        url  = "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-5.12.0.tgz";
-        sha1 = "2f84777838668fdf524c305a2363d6057aaeec84";
       };
     }
     {
@@ -3394,11 +3410,11 @@
       };
     }
     {
-      name = "js_yaml___js_yaml_4.0.0.tgz";
+      name = "js_yaml___js_yaml_4.1.0.tgz";
       path = fetchurl {
-        name = "js_yaml___js_yaml_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz";
-        sha1 = "f426bc0ff4b4051926cd588c71113183409a121f";
+        name = "js_yaml___js_yaml_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz";
+        sha1 = "c1fb65f8f5017901cdd2c951864ba18458a10602";
       };
     }
     {
@@ -3482,11 +3498,11 @@
       };
     }
     {
-      name = "json5___json5_2.1.3.tgz";
+      name = "json5___json5_2.2.0.tgz";
       path = fetchurl {
-        name = "json5___json5_2.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz";
-        sha1 = "c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43";
+        name = "json5___json5_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz";
+        sha1 = "2dfefe720c6ba525d9ebd909950f0515316c89a3";
       };
     }
     {
@@ -3567,6 +3583,14 @@
         name = "lazy_val___lazy_val_1.0.4.tgz";
         url  = "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.4.tgz";
         sha1 = "882636a7245c2cfe6e0a4e3ba6c5d68a137e5c65";
+      };
+    }
+    {
+      name = "lazy_val___lazy_val_1.0.5.tgz";
+      path = fetchurl {
+        name = "lazy_val___lazy_val_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.5.tgz";
+        sha1 = "6cf3b9f5bc31cee7ee3e369c0832b7583dcd923d";
       };
     }
     {
@@ -4162,11 +4186,11 @@
       };
     }
     {
-      name = "node_fetch_npm___node_fetch_npm_2.0.2.tgz";
+      name = "node_fetch_npm___node_fetch_npm_2.0.4.tgz";
       path = fetchurl {
-        name = "node_fetch_npm___node_fetch_npm_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz";
-        sha1 = "7258c9046182dca345b4208eda918daf33697ff7";
+        name = "node_fetch_npm___node_fetch_npm_2.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz";
+        sha1 = "6507d0e17a9ec0be3bec516958a497cec54bf5a4";
       };
     }
     {
@@ -4218,14 +4242,6 @@
       };
     }
     {
-      name = "normalize_package_data___normalize_package_data_3.0.2.tgz";
-      path = fetchurl {
-        name = "normalize_package_data___normalize_package_data_3.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.2.tgz";
-        sha1 = "cae5c410ae2434f9a6c1baa65d5bc3b9366c8699";
-      };
-    }
-    {
       name = "normalize_path___normalize_path_3.0.0.tgz";
       path = fetchurl {
         name = "normalize_path___normalize_path_3.0.0.tgz";
@@ -4234,11 +4250,11 @@
       };
     }
     {
-      name = "normalize_url___normalize_url_4.5.0.tgz";
+      name = "normalize_url___normalize_url_4.5.1.tgz";
       path = fetchurl {
-        name = "normalize_url___normalize_url_4.5.0.tgz";
-        url  = "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz";
-        sha1 = "453354087e6ca96957bd8f5baf753f5982142129";
+        name = "normalize_url___normalize_url_4.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz";
+        sha1 = "0dd90cf1288ee1d1313b87081c9a5932ee48518a";
       };
     }
     {
@@ -4343,14 +4359,6 @@
         name = "npm_profile___npm_profile_4.0.4.tgz";
         url  = "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.4.tgz";
         sha1 = "28ee94390e936df6d084263ee2061336a6a1581b";
-      };
-    }
-    {
-      name = "npm_registry_fetch___npm_registry_fetch_4.0.2.tgz";
-      path = fetchurl {
-        name = "npm_registry_fetch___npm_registry_fetch_4.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-4.0.2.tgz";
-        sha1 = "2b1434f93ccbe6b6385f8e45f45db93e16921d7a";
       };
     }
     {
@@ -5026,11 +5034,11 @@
       };
     }
     {
-      name = "read_config_file___read_config_file_6.0.0.tgz";
+      name = "read_config_file___read_config_file_6.2.0.tgz";
       path = fetchurl {
-        name = "read_config_file___read_config_file_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/read-config-file/-/read-config-file-6.0.0.tgz";
-        sha1 = "224b5dca6a5bdc1fb19e63f89f342680efdb9299";
+        name = "read_config_file___read_config_file_6.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/read-config-file/-/read-config-file-6.2.0.tgz";
+        sha1 = "71536072330bcd62ba814f91458b12add9fc7ade";
       };
     }
     {
@@ -5234,14 +5242,6 @@
       };
     }
     {
-      name = "resolve___resolve_1.20.0.tgz";
-      path = fetchurl {
-        name = "resolve___resolve_1.20.0.tgz";
-        url  = "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz";
-        sha1 = "629a013fb3f70755d6f0b7935cc1c2c5378b1975";
-      };
-    }
-    {
       name = "responselike___responselike_1.0.2.tgz";
       path = fetchurl {
         name = "responselike___responselike_1.0.2.tgz";
@@ -5290,11 +5290,11 @@
       };
     }
     {
-      name = "safe_buffer___safe_buffer_5.2.0.tgz";
+      name = "safe_buffer___safe_buffer_5.2.1.tgz";
       path = fetchurl {
-        name = "safe_buffer___safe_buffer_5.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz";
-        sha1 = "b74daec49b1148f88c64b68d49b1e815c1f2f519";
+        name = "safe_buffer___safe_buffer_5.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz";
+        sha1 = "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6";
       };
     }
     {
@@ -5303,14 +5303,6 @@
         name = "safe_buffer___safe_buffer_5.1.2.tgz";
         url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz";
         sha1 = "991ec69d296e0313747d59bdfd2b745c35f8828d";
-      };
-    }
-    {
-      name = "safe_buffer___safe_buffer_5.2.1.tgz";
-      path = fetchurl {
-        name = "safe_buffer___safe_buffer_5.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz";
-        sha1 = "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6";
       };
     }
     {
@@ -5383,6 +5375,14 @@
         name = "semver___semver_7.3.4.tgz";
         url  = "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz";
         sha1 = "27aaa7d2e4ca76452f98d3add093a72c943edc97";
+      };
+    }
+    {
+      name = "semver___semver_7.3.5.tgz";
+      path = fetchurl {
+        name = "semver___semver_7.3.5.tgz";
+        url  = "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz";
+        sha1 = "0b621c879348d8998e4b0e4be94b3f12e6018ef7";
       };
     }
     {
@@ -5842,11 +5842,11 @@
       };
     }
     {
-      name = "temp_file___temp_file_3.3.7.tgz";
+      name = "temp_file___temp_file_3.4.0.tgz";
       path = fetchurl {
-        name = "temp_file___temp_file_3.3.7.tgz";
-        url  = "https://registry.yarnpkg.com/temp-file/-/temp-file-3.3.7.tgz";
-        sha1 = "686885d635f872748e384e871855958470aeb18a";
+        name = "temp_file___temp_file_3.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/temp-file/-/temp-file-3.4.0.tgz";
+        sha1 = "766ea28911c683996c248ef1a20eea04d51652c7";
       };
     }
     {
@@ -5863,14 +5863,6 @@
         name = "text_table___text_table_0.2.0.tgz";
         url  = "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz";
         sha1 = "7f5ee823ae805207c00af2df4a84ec3fcfa570b4";
-      };
-    }
-    {
-      name = "textextensions___textextensions_5.12.0.tgz";
-      path = fetchurl {
-        name = "textextensions___textextensions_5.12.0.tgz";
-        url  = "https://registry.yarnpkg.com/textextensions/-/textextensions-5.12.0.tgz";
-        sha1 = "b908120b5c1bd4bb9eba41423d75b176011ab68a";
       };
     }
     {
@@ -5930,11 +5922,27 @@
       };
     }
     {
+      name = "tmp_promise___tmp_promise_3.0.2.tgz";
+      path = fetchurl {
+        name = "tmp_promise___tmp_promise_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz";
+        sha1 = "6e933782abff8b00c3119d63589ca1fb9caaa62a";
+      };
+    }
+    {
       name = "tmp___tmp_0.1.0.tgz";
       path = fetchurl {
         name = "tmp___tmp_0.1.0.tgz";
         url  = "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz";
         sha1 = "ee434a4e22543082e294ba6201dcc6eafefa2877";
+      };
+    }
+    {
+      name = "tmp___tmp_0.2.1.tgz";
+      path = fetchurl {
+        name = "tmp___tmp_0.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz";
+        sha1 = "8457fc3037dcf4719c251367a1af6500ee1ccf14";
       };
     }
     {
@@ -6282,22 +6290,6 @@
       };
     }
     {
-      name = "version_compare___version_compare_1.1.0.tgz";
-      path = fetchurl {
-        name = "version_compare___version_compare_1.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/version-compare/-/version-compare-1.1.0.tgz";
-        sha1 = "7b3e67e7e6cec5c72d9c9e586f8854e419ade17c";
-      };
-    }
-    {
-      name = "version_range___version_range_1.1.0.tgz";
-      path = fetchurl {
-        name = "version_range___version_range_1.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/version-range/-/version-range-1.1.0.tgz";
-        sha1 = "1c233064202ee742afc9d56e21da3b2e15260acf";
-      };
-    }
-    {
       name = "walk___walk_2.3.14.tgz";
       path = fetchurl {
         name = "walk___walk_2.3.14.tgz";
@@ -6514,19 +6506,19 @@
       };
     }
     {
-      name = "y18n___y18n_3.2.1.tgz";
+      name = "y18n___y18n_3.2.2.tgz";
       path = fetchurl {
-        name = "y18n___y18n_3.2.1.tgz";
-        url  = "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz";
-        sha1 = "6d15fba884c08679c0d77e88e7759e811e07fa41";
+        name = "y18n___y18n_3.2.2.tgz";
+        url  = "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz";
+        sha1 = "85c901bd6470ce71fc4bb723ad209b70f7f28696";
       };
     }
     {
-      name = "y18n___y18n_4.0.0.tgz";
+      name = "y18n___y18n_4.0.3.tgz";
       path = fetchurl {
-        name = "y18n___y18n_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz";
-        sha1 = "95ef94f85ecc81d007c264e190a120f0a3c8566b";
+        name = "y18n___y18n_4.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz";
+        sha1 = "b5f259c82cd6e336921efd7bfd8bf560de9eeedf";
       };
     }
     {
@@ -6602,11 +6594,11 @@
       };
     }
     {
-      name = "yargs___yargs_16.2.0.tgz";
+      name = "yargs___yargs_17.0.1.tgz";
       path = fetchurl {
-        name = "yargs___yargs_16.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz";
-        sha1 = "1c82bf0f6b6a66eafce7ef30e376f49a12477f66";
+        name = "yargs___yargs_17.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz";
+        sha1 = "6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb";
       };
     }
     {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -8,12 +8,12 @@
 
 let
   executableName = "element-desktop";
-  version = "1.7.30";
+  version = "1.7.31";
   src = fetchFromGitHub {
     owner = "vector-im";
     repo = "element-desktop";
     rev = "v${version}";
-    sha256 = "09k1xxmzqvw8c1x9ndsdvwj4598rdx9zqraz3rmr3i58s51vycxp";
+    sha256 = "14vyqzf69g4n3i7qjm1pgq2kwym6cira0jwvirzdrwxkfsl0dsq6";
   };
 in mkYarnPackage rec {
   name = "element-desktop-${version}";

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "element-web";
-  version = "1.7.30";
+  version = "1.7.31";
 
   src = fetchurl {
     url = "https://github.com/vector-im/element-web/releases/download/v${version}/element-v${version}.tar.gz";
-    sha256 = "1pnmgdyacxfk8hdf930rqqvqrcvckc3m4pb5mkznlirsmw06nfay";
+    sha256 = "1p0vg5bkri7qiqv5yic56hjjbb5zvhvyzsm5zi7fx3yb7zdxmr3f";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/vector-im/element-web/blob/v1.7.31/CHANGELOG.md
https://github.com/vector-im/element-desktop/blob/v1.7.31/CHANGELOG.md

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).