### PR TITLE
vsftpd: fix cross-compilation, remove -Werror

### DIFF
--- a/pkgs/servers/ftp/vsftpd/default.nix
+++ b/pkgs/servers/ftp/vsftpd/default.nix
@@ -18,17 +18,18 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile \
       --replace -dirafter "" \
       --replace /usr $out \
-      --replace /etc $out/etc
+      --replace /etc $out/etc \
+      --replace "-Werror" ""
+
 
     mkdir -p $out/sbin $out/man/man{5,8}
   '';
 
-  NIX_LDFLAGS = "-lcrypt -lssl -lcrypto -lpam -lcap";
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
 
-  # On gcc9, this would produce
-  #   error: '-Werror=enum-conversion': no option -Wenum-conversion
-  NIX_CFLAGS_COMPILE = lib.optionalString (lib.versionAtLeast stdenv.cc.version "10")
-    "-Wno-error=enum-conversion";
+  NIX_LDFLAGS = "-lcrypt -lssl -lcrypto -lpam -lcap";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation. Not using this package myself, but was an easy fix and I made this patch anyway when trying to get random packages to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note that there's an update available upstream as well. https://security.appspot.com/vsftpd.html#download. I'm not super interested in making that work, but it seems relatively easy.