### PR TITLE
wikidpad: init wikidpad-master-2019-07-31

### DIFF
--- a/pkgs/applications/misc/wikidpad/default.nix
+++ b/pkgs/applications/misc/wikidpad/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, writeShellScript
+, fetchFromGitHub
+, python3Packages # TODO@deliciouslytyped: This is overridden in all-packages to be python37 until upstream
+                  # is fixed; python38 deprecates some functions WikidPad relies on, see:
+                  # https://github.com/WikidPad/WikidPad/issues/77
+, wrapGAppsHook
+, sqlite
+}: python3Packages.buildPythonApplication {
+  pname = "wikidpad";
+  version = "master-2019-07-31";
+
+  doCheck = false; #TODO fails on build_ext when trying to build some windows module
+
+  src = fetchFromGitHub {
+    owner = "WikidPad";
+    repo = "WikidPad";
+    rev = "558109638807bc76b4672922686e416ab2d5f79c";
+    hash = "sha256:0hrpzv4hhqi859af0zkik9rhwshk18wphvr6vwrs924h0dm3g3qa";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  propagatedBuildInputs = (with python3Packages;
+    [ setuptools
+      wxPython_4_0 # Shouldn't be updated until https://github.com/WikidPad/WikidPad/issues/78
+      six 
+#      pillow numpy
+    ]) ++ # TODO pillow and numpy shouldn't be needed here, they are not a direct dependency of WikidPad!
+                         # wxPython 4_1 may have added requirements, going by the changelog? https://wxpython.org/pages/changes/index.html
+                         # TODO figure out why this wasn't an issue for whoever made 4_1.
+    [ sqlite ]; # NOTE: wikidpad uses its own ctypes wrapper for sqlite, using cdll.
+                # This is why we add it to LD_LIBRARY_PATH in makeWrapperArgs.
+
+  makeWrapperArgs = [ "--suffix LD_LIBRARY_PATH : ${lib.escapeShellArg (lib.makeLibraryPath [ sqlite ])}" ];
+
+  meta = with lib; {
+    description = "WikidPad is a Wiki-like notebook for storing your thoughts, ideas, todo lists, contacts, or anything else you can think of to write down.";
+    homepage = "http://wikidpad.sourceforge.net/";
+    license = with lib.licenses; [
+      bsd3 # base application
+      mit # bundled jQuery 2
+      asl20 # whoosh
+      lgpl21 # components listed in license-spelladdon.txt
+      psfl # relativedelta.py
+      wxWindows # WikidPad/lib/aui
+    ];
+    maintainers = with maintainers; [ deliciouslytyped ];
+    platforms = platforms.linux; # Windows and MacOS are supported by upstream, but we don't support them (yet?).
+    mainProgram = "wikidpad";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31489,6 +31489,10 @@ in
 
   websocketd = callPackage ../applications/networking/websocketd { };
 
+  wikidpad-master-2019-07-31 = callPackage ../applications/misc/wikidpad {
+    python3Packages = python37Packages;
+  };
+
   wikicurses = callPackage ../applications/misc/wikicurses {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
This commit adds a package for the latest WikidPad master commit and closes #55681.

The previous stable versions, 2.2 and 2.3 (not in nixpkgs), still used Python 2 and wxGTK 2.

IIUC the first release to use Python 3 is tagged `WikidPad-2-4-alpha01`.

The setup.py (as far as I can tell) doesn't do standard things like making a wheel,
or running the test infrastructure, so I just copy the source to $out and a wrapper to $out/bin.

With respect to packaging, the following things are done:
- wrapGAppsHook because it's a GTK app.
- WikidPad has it's own sqlite.so wrapper, so we add sqlite to LD_LIBRARY_PATH