### PR TITLE
kmail, kontact: wrap external executable dependencies

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -146,7 +146,7 @@ let
       klines = callPackage ./klines.nix {};
       kmag = callPackage ./kmag.nix {};
       kmahjongg = callPackage ./kmahjongg.nix {};
-      kmail = callPackage ./kmail.nix {};
+      kmail = callPackage ./kmail.nix {pimExternalApplications = callPackage ./pimExternalApplications.nix {};};
       kmail-account-wizard = callPackage ./kmail-account-wizard.nix {};
       kmailtransport = callPackage ./kmailtransport.nix {};
       kmbox = callPackage ./kmbox.nix {};
@@ -163,7 +163,7 @@ let
       kolourpaint = callPackage ./kolourpaint.nix {};
       kompare = callPackage ./kompare.nix {};
       konsole = callPackage ./konsole.nix {};
-      kontact = callPackage ./kontact.nix {};
+      kontact = callPackage ./kontact.nix {pimExternalApplications = callPackage ./pimExternalApplications.nix {};};
       kontactinterface = callPackage ./kontactinterface.nix {};
       konquest = callPackage ./konquest.nix {};
       konqueror = callPackage ./konqueror.nix {};

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -1,10 +1,8 @@
 { mkDerivation
 , lib
 , akonadi
-, akonadi-import-wizard
 , akonadi-search
 , extra-cmake-modules
-, kaddressbook
 , kbookmarks
 , kcalutils
 , kcmutils
@@ -22,8 +20,6 @@
 , kinit
 , kio
 , kldap
-, kleopatra
-, kmail-account-wizard
 , kmailtransport
 , knotifications
 , knotifyconfig
@@ -43,11 +39,13 @@
 , libsecret
 , mailcommon
 , messagelib
-, pim-data-exporter
 , pim-sieve-editor
 , qtkeychain
 , qtscript
 , qtwebengine
+# external applications needing to be called are specified in an external file,
+# such that they can be re-used by `kontact`
+, pimExternalApplications
 }:
 
 mkDerivation {
@@ -73,7 +71,6 @@ mkDerivation {
     kinit
     kio
     kldap
-    kmail-account-wizard
     kmailtransport
     knotifications
     knotifyconfig
@@ -96,15 +93,12 @@ mkDerivation {
     qtkeychain
     qtscript
     qtwebengine
-    akonadi-import-wizard
-    kaddressbook
-    kleopatra
-    pim-data-exporter
-  ];
+  ]
+  ++ pimExternalApplications.kmailApplications;
   outputs = [ "out" "doc" ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
   postFixup = ''
     wrapProgram "$out/bin/kmail" \
-      --prefix PATH : "${lib.makeBinPath [ akonadi akonadi-import-wizard kaddressbook kleopatra kmail-account-wizard pim-data-exporter ]}"
+      --prefix PATH : "${lib.makeBinPath pimExternalApplications.kmailApplications}"
   '';
 }

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -93,8 +93,7 @@ mkDerivation {
     qtkeychain
     qtscript
     qtwebengine
-  ]
-  ++ pimExternalApplications.kmailApplications;
+  ] ++ pimExternalApplications.kmailApplications;
   outputs = [ "out" "doc" ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
   postFixup = ''

--- a/pkgs/applications/kde/kontact.nix
+++ b/pkgs/applications/kde/kontact.nix
@@ -4,7 +4,9 @@
   qtwebengine,
   kcmutils, kcrash, kdbusaddons, kparts, kwindowsystem,
   akonadi, grantleetheme, kontactinterface, kpimtextedit,
-  mailcommon, libkdepim, pimcommon
+  mailcommon, libkdepim, pimcommon,
+  # some PIM applications embedded by Kontact need to call external executables
+  pimExternalApplications
 }:
 
 mkDerivation {
@@ -19,5 +21,12 @@ mkDerivation {
     kcmutils kcrash kdbusaddons kparts kwindowsystem
     akonadi grantleetheme kontactinterface kpimtextedit
     mailcommon libkdepim pimcommon
-  ];
+  ]
+  ++ pimExternalApplications.kmailApplications;
+  # create wrapper for being able to call external executables,
+  # please concatenate the external dependencies of all PIM components specified in `pimExternalApplications`
+  postFixup = ''
+    wrapProgram "$out/bin/kontact" \
+    --prefix PATH : "${lib.makeBinPath ([] ++ pimExternalApplications.kmailApplications)}"
+    '';
 }

--- a/pkgs/applications/kde/kontact.nix
+++ b/pkgs/applications/kde/kontact.nix
@@ -21,8 +21,7 @@ mkDerivation {
     kcmutils kcrash kdbusaddons kparts kwindowsystem
     akonadi grantleetheme kontactinterface kpimtextedit
     mailcommon libkdepim pimcommon
-  ]
-  ++ pimExternalApplications.kmailApplications;
+  ] ++ pimExternalApplications.kmailApplications;
   # create wrapper for being able to call external executables,
   # please concatenate the external dependencies of all PIM components specified in `pimExternalApplications`
   postFixup = ''

--- a/pkgs/applications/kde/pimExternalApplications.nix
+++ b/pkgs/applications/kde/pimExternalApplications.nix
@@ -1,0 +1,18 @@
+# Some PIM applications need to call external executables and thus need to be wrapped.
+# As these components are also used as a part of `kontact`, they need to be added to its
+# wrapper as well. To avoid duplication, these dependencies are defined in this separate file.
+# If any application turns out to require calling external applications, please specify them
+# in the respective attribute and adjust their derivation, as well as `kontact.nix` accordingly.
+{ akonadi
+, akonadi-import-wizard
+, kaddressbook
+, kleopatra
+, kmail-account-wizard
+, pim-data-exporter
+}:
+
+{
+  kmailApplications = [ akonadi akonadi-import-wizard kaddressbook kleopatra kmail-account-wizard pim-data-exporter ];
+  # further applications:
+  #korganizerApplications = [];
+}


### PR DESCRIPTION

###### Motivation for this change


follow-up to #108824

It turns out that the wrapping done for each KDE PIM component needs to
be done for the component itself as well as for kontact, which then
aggregates all of these components as KParts.
This commit introuduces specifying these wrapping dependencies in a
separate file to make them available for import from their respective
derivations.
It is designed to be extendable in case other PIM components turn out to
require external executables as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

DISCLAIMER: Due to the impure runtime discovery of KParts in `kontact`, I only tested the execution and proper calling of external executables in `kontact` via a backport of these changes to release-21.05. As these branches do not diverge largely yet, that shouldn't be a problem.
