### PR TITLE
cmake: add wrapQtAppsHook

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -7,11 +7,11 @@
 , useSharedLibraries ? (!isBootstrap && !stdenv.isCygwin)
 , useOpenSSL ? !isBootstrap, openssl
 , useNcurses ? false, ncurses
-, withQt5 ? false, qtbase
+, withQt5 ? false, qtbase, wrapQtAppsHook
 , buildDocs ? (!isBootstrap && (useNcurses || withQt5)), sphinx, texinfo
 }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   pname = "cmake"
           + lib.optionalString isBootstrap "-boot"
           + lib.optionalString useNcurses "-cursesUI"
@@ -45,7 +45,8 @@ stdenv.mkDerivation (rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   nativeBuildInputs = [ setupHook pkg-config ]
-    ++ lib.optionals buildDocs [ texinfo ];
+    ++ lib.optionals buildDocs [ texinfo ]
+    ++ lib.optionals withQt5 [ wrapQtAppsHook ];
 
   buildInputs = []
     ++ lib.optionals useSharedLibraries [ bzip2 curlMinimal expat libarchive xz zlib libuv rhash ]
@@ -130,5 +131,4 @@ stdenv.mkDerivation (rec {
     maintainers = with maintainers; [ ttuegel lnl7 ];
     license = licenses.bsd3;
   };
-} // (if withQt5 then { dontWrapQtApps = true; } else {})
-)
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #112480

###### Things done

`(if withQt5 then { dontWrapQtApps = true; } else {})` was there because of no `wrapQtAppsHook`
https://github.com/NixOS/nixpkgs/pull/108888

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
