### PR TITLE
widelands: 21 -> 1.0

### DIFF
--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -1,52 +1,90 @@
-{ lib, stdenv, fetchurl, cmake, python, gettext
-, boost, libpng, zlib, glew, lua, doxygen, icu
-, SDL2, SDL2_image, SDL2_mixer, SDL2_net, SDL2_ttf
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, SDL2_image
+, SDL2_mixer
+, SDL2_net
+, SDL2_ttf
+, boost
+, cmake
+, curl
+, doxygen
+, gettext
+, glew
+, graphviz
+, icu
+, installShellFiles
+, libpng
+, lua
+, python3
+, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "widelands";
-  version = "21";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "widelands";
+    repo = "widelands";
+    rev = "v${version}";
+    sha256 = "sha256-gNumYoeKePaxiAzrqEPKibMxFwv9vyBrCSoua+MKhcM=";
+  };
+
+  patches = [ ./bincmake.patch ];
+
+  postPatch = ''
+    substituteInPlace xdg/org.widelands.Widelands.desktop \
+      --replace 'Exec=widelands' "Exec=$out/bin/widelands"
+  '';
+
+  cmakeFlags = [
+    "-Wno-dev" # dev warnings are only needed for upstream development
+    "-DWL_INSTALL_BASEDIR=${placeholder "out"}"
+    "-DWL_INSTALL_DATADIR=${placeholder "out"}/share/widelands"
+    "-DWL_INSTALL_BINARY=${placeholder "out"}/bin"
+  ];
+
+  nativeBuildInputs = [ cmake doxygen gettext graphviz installShellFiles ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+    SDL2_net
+    SDL2_ttf
+    boost
+    curl
+    glew
+    icu
+    libpng
+    lua
+    python3
+    zlib
+  ];
+
+  postInstall = ''
+    install -Dm444 -t $out/share/applications ../xdg/org.widelands.Widelands.desktop
+
+    for s in 16 32 48 64 128; do
+      install -Dm444 ../data/images/logos/wl-ico-''${s}.png $out/share/icons/hicolor/''${s}x''${s}/org.widelands.Widelands.png
+    done
+
+    installManPage ../xdg/widelands.6
+  '';
 
   meta = with lib; {
     description = "RTS with multiple-goods economy";
-    homepage    = "http://widelands.org/";
+    homepage = "https://widelands.org/";
     longDescription = ''
       Widelands is a real time strategy game based on "The Settlers" and "The
       Settlers II". It has a single player campaign mode, as well as a networked
       multiplayer mode.
     '';
-    license        = licenses.gpl2Plus;
-    platforms      = platforms.linux;
-    maintainers    = with maintainers; [ raskin jcumming ];
-    hydraPlatforms = [];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin jcumming ];
+    platforms = platforms.linux;
+    hydraPlatforms = [ ];
   };
-
-  patches = [
-    ./bincmake.patch
-  ];
-
-  src = fetchurl {
-    url = "https://launchpad.net/widelands/build${version}/build${version}/+download/widelands-build${version}-source.tar.gz";
-    sha256 = "sha256-YB4OTG+Rs/sOzizRuD7PsCNEobkZT7tw7z9w4GmU41c=";
-  };
-
-  preConfigure = ''
-    cmakeFlags="
-      -DWL_INSTALL_BASEDIR=$out
-      -DWL_INSTALL_DATADIR=$out/share/widelands
-      -DWL_INSTALL_BINARY=$out/bin
-    "
-  '';
-
-  nativeBuildInputs = [ cmake python gettext ];
-
-  buildInputs = [
-    boost libpng zlib glew lua doxygen icu
-    SDL2 SDL2_image SDL2_mixer SDL2_net SDL2_ttf
-  ];
-
-  postInstall = ''
-    mkdir -p "$out/share/applications/"
-    cp -v "../xdg/org.widelands.Widelands.desktop" "$out/share/applications/"
-  '';
 }


### PR DESCRIPTION
###### Motivation for this change

Proper release.

Also add a few missing bits (icons, man page)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
