### PR TITLE
ocamlPackages.ocaml-migrate-parsetree: 2.1.0 → 2.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
@@ -2,15 +2,15 @@
 
 buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
-   version = "2.1.0";
+   version = "2.2.0";
 
    useDune2 = true;
 
-   minimumOCamlVersion = "4.02";
+   minimalOCamlVersion = "4.02";
 
    src = fetchurl {
      url = "https://github.com/ocaml-ppx/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-     sha256 = "07x7lm45kny0mi0fjvzw51445brm0dgy099cw0gpyly0wj77hyrq";
+     sha256 = "188v3z09bg4gyv80c138fa3a3j2w54w5gc4r1ajw7klr70yqz9mj";
    };
 
    meta = {

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -7,7 +7,7 @@
 , result
 , ounit
 , ocaml-migrate-parsetree
-, ocaml-migrate-parsetree-2-1
+, ocaml-migrate-parsetree-2
 }:
 
 let params =
@@ -40,7 +40,7 @@ buildDunePackage rec {
   buildInputs = [ ppxlib cppo ];
   propagatedBuildInputs = [
     (if params.useOMP2
-    then ocaml-migrate-parsetree-2-1
+    then ocaml-migrate-parsetree-2
     else ocaml-migrate-parsetree)
     ppx_derivers
     result

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -4,7 +4,7 @@
   then if lib.versionAtLeast ocaml.version "4.08"
   then "0.22.0" else "0.15.0" else "0.13.0"
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
-, stdlib-shims, ocaml-migrate-parsetree-2-1
+, stdlib-shims, ocaml-migrate-parsetree-2
 }:
 
 let param = {
@@ -57,7 +57,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     ocaml-compiler-libs
     (if param.useOMP2 or true
-     then ocaml-migrate-parsetree-2-1
+     then ocaml-migrate-parsetree-2
      else ocaml-migrate-parsetree)
     ppx_derivers
     stdio

--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -56,5 +56,6 @@ buildDunePackage rec {
     description = "Ocaml bindings to Pytorch";
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.asl20;
+    broken = true;
   };
 }

--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     install -Dm644 resources/shell/bash-completion $out/share/bash-completion/completions/flow
   '';
 
-  buildInputs = (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml-migrate-parsetree-2-1 dtoa core_kernel sedlex_2 ocaml_lwt lwt_log lwt_ppx ppx_deriving ppx_gen_rec ppx_tools_versioned visitors wtf8 ])
+  buildInputs = (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml-migrate-parsetree-2 dtoa core_kernel sedlex_2 ocaml_lwt lwt_log lwt_ppx ppx_deriving ppx_gen_rec ppx_tools_versioned visitors wtf8 ])
     ++ lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with lib; {

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -83,7 +83,7 @@ buildDunePackage {
       ocaml-version
       # Changed since 0.16.0:
       (ppxlib.override { version = "0.22.0"; })
-      ocaml-migrate-parsetree-2-1
+      ocaml-migrate-parsetree-2
     ]
     else if lib.versionAtLeast version "0.15.1"
     then [

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -609,7 +609,7 @@ let
     };
 
     lwt = callPackage ../development/ocaml-modules/lwt {
-      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2-1;
+      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2;
     };
 
     ocaml_lwt = lwt;
@@ -844,12 +844,12 @@ let
 
     ocaml-migrate-parsetree-1-8 = callPackage ../development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix { };
 
-    ocaml-migrate-parsetree-2-1 = callPackage ../development/ocaml-modules/ocaml-migrate-parsetree/2.1.x.nix { };
+    ocaml-migrate-parsetree-2 = callPackage ../development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix { };
 
     ocamlmod = callPackage ../development/tools/ocaml/ocamlmod { };
 
     ocaml-monadic = callPackage ../development/ocaml-modules/ocaml-monadic {
-      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2-1;
+      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2;
     };
 
     ocaml_mysql = callPackage ../development/ocaml-modules/mysql { };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.13

(The change to `torch` is unrelated but its build failure was annoying when testing this change).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
