### PR TITLE
python3Packages.wxPython_4_0, python3Packages.wxPython_4_1: add numpy…

### DIFF
--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -18,6 +18,8 @@
 , AudioToolbox
 , OpenGL
 , CoreFoundation
+, pillow
+, numpy
 }:
 
 buildPythonPackage rec {
@@ -41,6 +43,8 @@ buildPythonPackage rec {
   else
     [ wxGTK.gtk ]
   );
+
+  propagatedBuildInputs = [ pillow numpy ];
 
   DOXYGEN = "${doxygen}/bin/doxygen";
 

--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -11,6 +11,8 @@
 , ncurses
 , pango
 , wxGTK
+, pillow
+, numpy
 }:
 let
   dynamic-linker = stdenv.cc.bintools.dynamicLinker;
@@ -35,6 +37,8 @@ buildPythonPackage rec {
     wxGTK.gtk
     ncurses
   ];
+
+  propagatedBuildInputs = [ pillow numpy ];
 
   DOXYGEN = "${doxygen}/bin/doxygen";
 


### PR DESCRIPTION
… and pillow to `propagatedBuildInputs` as required by upstream's dependency settings

See In light of https://github.com/NixOS/nixpkgs/pull/94108#issuecomment-865456203 and https://github.com/NixOS/nixpkgs/pull/94108#issuecomment-865465329 (two consecutive comments) for additional thoughts, quoted here:

> Hm. https://discuss.wxpython.org/t/does-wxpython-4-0-6-must-also-install-numpy/32969/2
> Of course it's never simple.. (that's also a pretty old post, IDK if things have changed)
> 
> I also don't quite understand why no one has run into the issue of `buildPythonApplication` trying to require `numpy` and `pillow` due to `wxPython` yet.
> 
> pip doesn't seem to provide any sane way of excluding deps [pypa/pip#3090](https://github.com/pypa/pip/issues/3090) , so I probably need to use some sort of indirect method if I deem them unnecessary.
> 
> Well, Robin (discuss.wxpython.org link above) does list `--no-deps`, but that seems rather shotgun.
> 
> The concrete example of these deps attempting to be pulled is this: [f33d2a5#diff-9e9c51bfcf7e9562777c9c8d1b946f5a61995d0947955d188c7f1fc5b9a4c5c0R27](https://github.com/NixOS/nixpkgs/commit/f33d2a56923c22742423f7d5ceff4e0beef56e81#diff-9e9c51bfcf7e9562777c9c8d1b946f5a61995d0947955d188c7f1fc5b9a4c5c0R27)
> 
> When run you get:
> 
> ```
> Executing pipInstallPhase
> /build/source/dist /build/source
> Processing ./WikidPad-2.4a1-py3-none-any.whl
> Requirement already satisfied: wxpython>=4.0 in /nix/store/qy1ya8pcgjcjfhqvkm43pzb71w80122r-python3.7-wxPython-4.0.7.post2/lib/python3.7/site-packages (from WikidPad==2.4a1) (4.0.7.post2)
> INFO: pip is looking at multiple versions of wikidpad to determine which version is compatible with other requirements. This could take a while.
> ERROR: Could not find a version that satisfies the requirement pillow (from wxpython)
> ERROR: No matching distribution found for pillow
> ```
> 
> I'm entirely unsure what the best thing to do here is.
> Apparently `wxPython` has `numpy` and `pillow` them as runtime dependencies because they're needed relatively often, but they're actually kind of optional?
> Additionally there are "other packages" that are used less commonly, which are also runtime dependencies, but they aren't listed in the requirements because they're needed less often?
> 
> (Where does one find a list of these optional dependencies?)
> 
> related: [wxWidgets/Phoenix#1932](https://github.com/wxWidgets/Phoenix/issues/1932)

> Hi RobinD42 , can you maybe clarify the dependency situation with `numpy` and `pillow` in wxPython?
> Is there anything significant to pay attention to across versions?
> Is there a list of other more optional packages somewhere? (see above post)
> 
> Specifically I would appreciate clarification on
> 
> > Apparently wxPython has numpy and pillow them as runtime dependencies because they're needed relatively often, but they're actually kind of optional?
> > Additionally there are "other packages" that are used less commonly, which are also runtime dependencies, but they aren't listed in the requirements because they're needed less often?
> 
> in relation to https://discuss.wxpython.org/t/does-wxpython-4-0-6-must-also-install-numpy/32969/2 .
> 
> [wxWidgets/Phoenix#1932](https://github.com/wxWidgets/Phoenix/issues/1932) is already asking to make these dependencies optional, and they seem to have done a little work looking at what's needed where.
> 
> ~- and if I have your attention anyway, would you consider packaging `wxPython` with https://python-poetry.org/ ? I hear good things about it. (I could open an issue on the Phoenix issue tracker I guess). (It's not obvious whether the specific optional dependency handling is any better though at the time of https://stackoverflow.com/questions/60971502/python-poetry-how-to-install-optional-dependencies )~
> 
> From a practical point of view, adding dependencies seems to be easier than removing them. - which contravariantly, means that the requirement should be removed from upstream.

