### PR TITLE
notify: init at 0.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4017,6 +4017,12 @@
     githubId = 1742172;
     name = "Hamish Hutchings";
   };
+  hanemile = {
+    email = "mail@emile.space";
+    github = "hanemile";
+    githubId = 22756350;
+    name = "Emile Hansmaennel";
+  };
   hansjoergschurr = {
     email = "commits@schurr.at";
     github = "hansjoergschurr";

--- a/pkgs/tools/misc/notify/default.nix
+++ b/pkgs/tools/misc/notify/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "notify";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "projectdiscovery";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1nlsl4himxs5jv0fcd48jkwjnmn1w3alp0dcm1awmp6702zrsgqj";
+  };
+
+  vendorSha256 = "13dz0sk3561hrixsl1ghr9y0pzap2a8zrlbzzb7zs7550snbdcyg";
+
+  modRoot = ".";
+  subPackages = [
+    "cmd/notify/"
+  ];
+
+  # Test files are not part of the release tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Notify allows sending the output from any tool to Slack, Discord and Telegram";
+    longDescription = ''
+      Notify is a helper utility written in Go that allows you to post the output from any tool
+      to Slack, Discord, and Telegram.
+    '';
+    homepage = "https://github.com/projectdiscovery/notify";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hanemile ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3069,6 +3069,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  notify = callPackage ../tools/misc/notify { };
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   nwipe = callPackage ../tools/security/nwipe { };


### PR DESCRIPTION
###### Motivation for this change

Adds the [projectdiscovery](https://github.com/projectdiscovery/) [notify](https://github.com/projectdiscovery/notify) package and myself as a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
