### PR TITLE
[21.05] gnomeExtensions: Fix the package names

### DIFF
--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -47,8 +47,11 @@ let
       license = lib.licenses.gpl2Plus; # https://wiki.gnome.org/Projects/GnomeShell/Extensions/Review#Licensing
       maintainers = with lib.maintainers; [ piegames ];
     };
-    # Store the extension's UUID, because we might need it at some places
-    passthru.extensionUuid = uuid;
+    passthru = {
+      extensionPortalSlug = pname;
+      # Store the extension's UUID, because we might need it at some places
+      extensionUuid = uuid;
+    };
   };
 in
   lib.makeOverridable buildGnomeExtension

--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -48,7 +48,7 @@ let
     ))
     # Map all extensions to their pname, with potential overwrites
     (map (extension:
-      lib.nameValuePair (extensionRenames.${extension.extensionUuid} or extension.pname) extension
+      lib.nameValuePair (extensionRenames.${extension.extensionUuid} or extension.extensionPortalSlug) extension
     ))
     builtins.listToAttrs
   ];


### PR DESCRIPTION
###### Motivation for this change
I did not realize the attribute names are derived from the Nix package names
so I accidentally, renamed them in https://github.com/NixOS/nixpkgs/pull/124295.

(cherry picked from commit 571d540abf447f97b9b4db4a1e0665ec0a4dc06f)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
