### PR TITLE
xorg: regenerate default.nix

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -571,11 +571,11 @@ lib.makeScope newScope (self: with self; {
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   fonttosfnt = callPackage ({ stdenv, pkg-config, fetchurl, libfontenc, freetype, xorgproto }: stdenv.mkDerivation {
-    name = "fonttosfnt-1.2.1";
+    name = "fonttosfnt-1.2.2";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/fonttosfnt-1.2.1.tar.bz2";
-      sha256 = "16r51h5wfy85wnbq3q8v8a184hb25c3ksjgix0mlcywdz7qkbj07";
+      url = "mirror://xorg/individual/app/fonttosfnt-1.2.2.tar.bz2";
+      sha256 = "0r1s43ypy0a9z6hzdq5y02s2acj965rax4flwdyylvc54ppv86qs";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
The [commit history for `pkgs/servers/x11/xorg/default.nix`](https://github.com/NixOS/nixpkgs/commits/master/pkgs/servers/x11/xorg/default.nix) makes no sense to me: f49c857a1d235d9465737bdf53b58fdeb457b105 updates `fonttosfnt` to 1.2.2 in both files, but then the diff for the next commit 91171e295574bd7721cafeaf4200c807952275a7 shows 1.2.1 in `default.nix` in an *unmodified* line.

Anyway, I have no idea what happened or how it happened, but now `tarballs.list` and `default.nix` are out of sync.

This PR is the result of `./generate-expr-from-tarballs.pl tarballs.list`.

cc @jtojnar @jonringer 