### PR TITLE
shortwave: 1.1.1 -> 2.0.1

### DIFF
--- a/pkgs/applications/audio/shortwave/default.nix
+++ b/pkgs/applications/audio/shortwave/default.nix
@@ -8,8 +8,8 @@
 , gitMinimal
 , glib
 , gst_all_1
-, gtk3
-, libhandy_0
+, gtk4
+, libadwaita
 , meson
 , ninja
 , openssl
@@ -22,20 +22,20 @@
 
 stdenv.mkDerivation rec {
   pname = "shortwave";
-  version = "1.1.1";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Shortwave";
     rev = version;
-    sha256 = "1vlhp2ss06j41simjrrjg38alp85jddhqyvccy6bhfzm0gzynwld";
+    sha256 = "sha256-25qPb7qlqCwYJzl4qZxAZYx5asxSlXBlc/0dGyBdk1o=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-0+KEbjTLecL0u/3S9FWf2r2h9ZrgcRTY163kS3NKJqA=";
+    hash = "sha256-00dQXcSNmdZb2nSLG3q7jm4sugF9XR4LbH0OmcuHVxA=";
   };
 
   nativeBuildInputs = [
@@ -57,8 +57,8 @@ stdenv.mkDerivation rec {
     dbus
     gdk-pixbuf
     glib
-    gtk3
-    libhandy_0
+    gtk4
+    libadwaita
     openssl
     sqlite
   ] ++ (with gst_all_1; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Lots of small changes. Including UI polish, switch from gtk3+libhandy to gtk4+libadwaita, translations, ...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
