### PR TITLE
koreader: Add gnutar and sdvc dependencies

### DIFF
--- a/pkgs/applications/misc/koreader/default.nix
+++ b/pkgs/applications/misc/koreader/default.nix
@@ -2,10 +2,12 @@
 , fetchurl
 , makeWrapper
 , dpkg
-, luajit
-, gtk3-x11
-, SDL2
 , glib
+, gnutar
+, gtk3-x11
+, luajit
+, sdcv
+, SDL2
 , noto-fonts
 , nerdfonts }:
 let font-droid = nerdfonts.override { fonts = [ "DroidSansMono" ]; };
@@ -21,7 +23,14 @@ in stdenv.mkDerivation rec {
 
   sourceRoot = ".";
   nativeBuildInputs = [ makeWrapper dpkg ];
-  buildInputs = [ luajit gtk3-x11 SDL2 glib ];
+  buildInputs = [
+    glib
+    gnutar
+    gtk3-x11
+    luajit
+    sdcv
+    SDL2
+  ];
   unpackCmd = "dpkg-deb -x ${src} .";
 
   dontConfigure = true;
@@ -30,7 +39,9 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -R usr/* $out/
-    cp ${luajit}/bin/luajit $out/lib/koreader/luajit
+    ln -sf ${luajit}/bin/luajit $out/lib/koreader/luajit
+    ln -sf ${sdcv}/bin/sdcv $out/lib/koreader/sdcv
+    ln -sf ${gnutar}/bin/tar $out/lib/koreader/tar
     find $out -xtype l -delete
     for i in ${noto-fonts}/share/fonts/truetype/noto/*; do
         ln -s "$i" $out/lib/koreader/fonts/noto/


### PR DESCRIPTION
###### Motivation for this change
The included tar and sdvc binaries don't work on NixOS, which causes issues when attempting to download and unpack a dictionary. Initially I planned on updating koreader as well, but the new release has a crash I'm still investigating.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
