### PR TITLE
gdu: 5.1.0 -> 5.1.1

### DIFF
--- a/pkgs/tools/system/gdu/default.nix
+++ b/pkgs/tools/system/gdu/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "gdu";
-  version = "5.1.0";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "dundee";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-OellGxW/2I/dKBxWgEv1Ta9OJ/2HUfDIzICQwvmjTCM=";
+    sha256 = "sha256-9o/njurf1AWt04A8u38FMFcteLZlRHDejbH9+ekDjKI=";
   };
 
   vendorSha256 = "sha256-9W1K01PJ+tRLSJ0L7NGHXT5w5oHmlBkT8kwnOLOzSCc=";
@@ -35,15 +35,7 @@ buildGoModule rec {
     installManPage gdu.1
   '';
 
-  # doCheck = !(stdenv.isAarch64 || stdenv.isDarwin);
-  # also fails x86_64-linux on hydra with:
-  # dir_test.go:82:
-  #             Error Trace:    dir_test.go:82
-  #             Error:          Not equal:
-  #                             expected: 0
-  #                             actual  : 512
-  #             Test:           TestFlags
-  doCheck = false;
+  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     description = "Disk usage analyzer with console interface";


### PR DESCRIPTION
###### Motivation for this change
Upstream fixes the tests that were failing, so tests can be re-enabled (dundee/gdu#58)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
