### PR TITLE
vmware-horizon-client: 2012 -> 2103

### DIFF
--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -39,19 +39,19 @@
 , zlib
 }:
 let
-  version = "2012";
+  version = "2103";
 
   sysArch =
     if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
     else throw "Unsupported system: ${stdenv.hostPlatform.system}";
-  # The downloaded archive also contains i386 and ARM binaries, but these have not been tested.
+  # The downloaded archive also contains ARM binaries, but these have not been tested.
 
   vmwareHorizonClientFiles = stdenv.mkDerivation {
     name = "vmwareHorizonClientFiles";
     inherit version;
     src = fetchurl {
-      url = "https://download3.vmware.com/software/view/viewclients/CART21FQ4/VMware-Horizon-Client-Linux-2012-8.1.0-17349998.tar.gz";
-      sha256 = "0afda1f3116e75a4e7f89990d8ee60ccea5f3bb8a2360652162fa11c795724ce";
+      url = "https://download3.vmware.com/software/view/viewclients/CART22FQ1/VMware-Horizon-Client-Linux-2103-8.2.0-17742757.tar.gz";
+      sha256 = "62f95bb802b058a98f5ee6c2296b89bd7e15884a24dc8a8ba7ce89de7e0798e4";
     };
     nativeBuildInputs = [ makeWrapper ];
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Video performance, and keyboard behavior improvements.
https://docs.vmware.com/en/VMware-Horizon-Client-for-Linux/2103/rn/horizon-client-linux-2103-release-notes.html
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
