### PR TITLE
xserver module: Make user-provided config render after default config

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -14,7 +14,10 @@
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
-<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+- The setting [`services.xserver.config`](#opt-services.xserver.config) now has a changed order, so that if the user sets this option, their config is rendered _after_ NixOS's default Xorg config.
+  This is because in `xorg.conf`, later sections have precedence, and we usually want the user section to take precedence (otherwise the user settings may be silently ignored, see example from [#127166](https://github.com/NixOS/nixpkgs/pull/127166)).
+
+  There may be unlikely user configurations that rely on the user config being overridden. If you have such a config, use `services.xserver.config = lib.mkBefore ...` on your config to invoke the old behaviour.
 
 - Create the first release note entry in this section!
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -513,9 +513,13 @@ in
           This option is set by multiple modules, and the configs are
           concatenated together.
 
-          In Xorg configs the last config entries take precedence,
-          so you may want to use `lib.mkAfter` on this option
-          to override NixOS's defaults.
+          In Xorg configs the last config entries take precedence.
+          The NixOS default config has a `lib.mkOrder`
+          set so that if you just set this option without explicit order,
+          your config will be rendered after the default config
+          (thus overriding the default config).
+          If you want your config to be rendered before the default config,
+          you can use `lib.mkBefore` on this option.
         '';
       };
 
@@ -922,7 +926,14 @@ in
         ''
     );
 
-    services.xserver.config = ''
+    # In xorg.conf, later configs override previous ones.
+    # We give the default NixOS entries a less-than-default order of 900,
+    # so that the order is:
+    #     mkBefore
+    #     this-default-config
+    #     user-setting-config-without-order-priority
+    #     mkAfter
+    services.xserver.config = mkOrder 900 ''
       Section "ServerFlags"
         Option "AllowMouseOpenFail" "on"
         Option "DontZap" "${if cfg.enableCtrlAltBackspace then "off" else "on"}"


### PR DESCRIPTION
###### Motivation for this change

Implements https://github.com/NixOS/nixpkgs/pull/127166#issuecomment-864828352, fixing the user's `services.xorg.config` being silently overridden by the NixOS default config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
