### PR TITLE
amidst: use jre instead of jre8

### DIFF
--- a/pkgs/tools/games/amidst/default.nix
+++ b/pkgs/tools/games/amidst/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, jre8 }: # TODO: Update this to the latest version of java upon the next release. This is currently not done because of https://github.com/toolbox4minecraft/amidst/issues/960
+, jre }:
 
 stdenv.mkDerivation rec {
   pname = "amidst";
@@ -15,12 +15,12 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ jre8 makeWrapper ];
+  nativeBuildInputs = [ jre makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/{bin,lib/amidst}
     cp $src $out/lib/amidst/amidst.jar
-    makeWrapper ${jre8}/bin/java $out/bin/amidst \
+    makeWrapper ${jre}/bin/java $out/bin/amidst \
       --add-flags "-jar $out/lib/amidst/amidst.jar"
   '';
 


### PR DESCRIPTION

###### Motivation for this change
As https://github.com/toolbox4minecraft/amidst/issues/960 is now fixed, we can use the latest version of java.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
