### PR TITLE
esphome: fix permissions on src file before modifying them

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -21,6 +21,11 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "0bz6gkrvn7mwmjsqrazgpy9r64m5jj462v0izgvdymkx8bjd8mpi";
   };
 
+  patches = [
+    # fix missing write permissions on src files before modifing them
+   ./fix-src-permissions.patch
+  ];
+
   postPatch = ''
     # remove all version pinning (E.g tornado==5.1.1 -> tornado)
     sed -i -e "s/==[0-9.]*//" requirements.txt

--- a/pkgs/tools/misc/esphome/fix-src-permissions.patch
+++ b/pkgs/tools/misc/esphome/fix-src-permissions.patch
@@ -1,0 +1,46 @@
+From f72c5035944065941daaa236b60664657c777726 Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Wed, 23 Jun 2021 04:50:35 +0200
+Subject: [PATCH] Set u+w for copied src files before trying to overwrite them
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We store esphome in the nix store, which results in its file permissions
+being 0444. Esphome, when compiling a firmware image, will copy these
+files from the nix store to a working directory. When updating between
+versions it will notice these files changed and try to copy the new
+version over, which would break, because the user had no write
+permissions on the files.
+
+❯ esphome compile 01e4ac.yml
+INFO Reading configuration 01e4ac.yml...
+INFO Detected timezone 'CET' with UTC offset 1 and daylight saving time from 27 March 02:00:00 to 30 October 03:00:00
+INFO Generating C++ source...
+ERROR Error copying file /nix/store/lmzrgl1arqfd98jcss4rsmmy6dbffddn-esphome-1.19.2/lib/python3.8/site-packages/esphome/components/api/api_connection.cpp to 01e4ac/src/esphome/components/api/api_connection.cpp: [Errno 13] Permission denied: '01e4ac/src/esphome/components/api/api_connection.cpp'
+
+To fix this we modify chmod to 0644 just before esphome tries a copy
+operation, which will fix permissions on existing working directories
+just in time.
+---
+ esphome/helpers.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/esphome/helpers.py b/esphome/helpers.py
+index ad7b8272..c456f4ff 100644
+--- a/esphome/helpers.py
++++ b/esphome/helpers.py
+@@ -228,6 +228,10 @@ def copy_file_if_changed(src: os.PathLike, dst: os.PathLike) -> None:
+     if file_compare(src, dst):
+         return
+     mkdir_p(os.path.dirname(dst))
++    try:
++        os.chmod(dst, 0o644)
++    except OSError:
++        pass
+     try:
+         shutil.copy(src, dst)
+     except OSError as err:
+-- 
+2.31.1
+


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

We store esphome in the nix store, which results in its file permissions
being 0444. Esphome, when compiling a firmware image, will copy these
files from the nix store to a working directory. When updating between
versions it will notice these files changed and try to copy the new
version over, which would break, because the user had no write
permissions on the files.
 
```
❯ esphome compile 01e4ac.yml
INFO Reading configuration 01e4ac.yml...
INFO Detected timezone 'CET' with UTC offset 1 and daylight saving time from 27 March 02:00:00 to 30 October 03:00:00
INFO Generating C++ source...
ERROR Error copying file /nix/store/lmzrgl1arqfd98jcss4rsmmy6dbffddn-esphome-1.19.2/lib/python3.8/site-packages/esphome/components/api/api_connection.cpp to 01e4ac/src/esphome/components/api/api_connection.cpp: [Errno 13] Permission denied: '01e4ac/src/esphome/components/api/api_connection.cpp'
```

To fix this we modify chmod to 0644 just before esphome tries a copy
operation, which will fix permissions on existing working directories
just in time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
