### PR TITLE
materia-kde-theme: init at 20210612

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2529,6 +2529,12 @@
     githubId = 8404455;
     name = "Diego Lelis";
   };
+  diffumist = {
+    email = "diffumist@gmail.com";
+    github = "diffumist";
+    githubId = 32810399;
+    name = "Diffumist";
+  };
   diogox = {
     name = "Diogo Xavier";
     email = "13244408+diogox@users.noreply.github.com";

--- a/pkgs/data/themes/materia-kde/default.nix
+++ b/pkgs/data/themes/materia-kde/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "materia-kde-theme";
+  version = "20210612";
+
+  src = fetchFromGitHub {
+    owner = "PapirusDevelopmentTeam";
+    repo = "materia-kde";
+    rev = version;
+    sha256 = "P76rLj7x4KpYb3hdHBSUM8X/RcxKoJl1THIXHdfPoAY=";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  # Make this a fixed-output derivation
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  ouputHash = "Xvr2yoIcErt5tCvwonSDN696juc9S9/F/RkAQgrIXOM=";
+
+  meta = {
+    description = "A port of the materia theme for Plasma";
+    homepage = "https://git.io/materia-kde";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.diffumist ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/data/themes/materia-kde/default.nix
+++ b/pkgs/data/themes/materia-kde/default.nix
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
   outputHashAlgo = "sha256";
   ouputHash = "Xvr2yoIcErt5tCvwonSDN696juc9S9/F/RkAQgrIXOM=";
 
-  meta = {
+  meta = with lib; {
     description = "A port of the materia theme for Plasma";
-    homepage = "https://git.io/materia-kde";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.diffumist ];
-    platforms = lib.platforms.all;
+    homepage = "https://github.com/PapirusDevelopmentTeam/materia-kde";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.diffumist ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/data/themes/materia-kde/default.nix
+++ b/pkgs/data/themes/materia-kde/default.nix
@@ -13,11 +13,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  # Make this a fixed-output derivation
-  outputHashMode = "recursive";
-  outputHashAlgo = "sha256";
-  ouputHash = "Xvr2yoIcErt5tCvwonSDN696juc9S9/F/RkAQgrIXOM=";
-
   meta = with lib; {
     description = "A port of the materia theme for Plasma";
     homepage = "https://github.com/PapirusDevelopmentTeam/materia-kde";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22224,6 +22224,8 @@ in
 
   materia-theme = callPackage ../data/themes/materia-theme { };
 
+  materia-kde-theme = callPackage ../data/themes/materia-kde { };
+
   material-design-icons = callPackage ../data/fonts/material-design-icons { };
 
   material-icons = callPackage ../data/fonts/material-icons { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I plan to switch from archlinux with nix to nixos, so I'm trying to add this pkg to nixpkgs, with some reference to the arc-kde implementation for some work. Please let me know if there are any shortcomings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
