### PR TITLE
libzip: 1.7.3 -> 1.8.0

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , cmake
-, fetchpatch
 , fetchurl
 , perl
 , zlib
@@ -11,24 +10,18 @@
 , xz
 , withOpenssl ? false
 , openssl
+, withZstd ? false
+, zstd
 }:
 
 stdenv.mkDerivation rec {
   pname = "libzip";
-  version = "1.7.3";
+  version = "1.8.0";
 
   src = fetchurl {
     url = "https://libzip.org/download/${pname}-${version}.tar.gz";
-    sha256 = "1k5rihiz7m1ahhjzcbq759hb9crzqkgw78pkxga118y5a32pc8hf";
+    sha256 = "17l3ygrnbszm3b99dxmw94wcaqpbljzg54h4c0y8ss8aij35bvih";
   };
-
-  # Remove in next release
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/nih-at/libzip/commit/351201419d79b958783c0cfc7c370243165523ac.patch";
-      sha256 = "0d93z98ki0yiaza93268cxkl35y1r7ll9f7l8sivx3nfxj2c1n8a";
-    })
-  ];
 
   outputs = [ "out" "dev" "man" ];
 
@@ -36,7 +29,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ zlib ];
   buildInputs = lib.optionals withLZMA [ xz ]
     ++ lib.optionals withBzip2 [ bzip2 ]
-    ++ lib.optionals withOpenssl [ openssl ];
+    ++ lib.optionals withOpenssl [ openssl ]
+    ++ lib.optionals withZstd [ zstd ];
 
   preCheck = ''
     # regress/runtest is a generated file


### PR DESCRIPTION
###### Motivation for this change
https://libzip.org/news/release-1.8.0.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
