### PR TITLE
joystickwake: init at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1220,6 +1220,16 @@
     github = "benneti";
     githubId = 11725645;
   };
+  bertof = {
+    name = "Filippo Berto";
+    email = "berto.f@protonmail.com";
+    github = "bertof";
+    githubId = 9915675;
+    keys = [{
+      longkeyid = "rsa4096/0xFE98AE5EC52B1056";
+      fingerprint = "17C5 1EF9 C0FE 2EB2 FE56  BB53 FE98 AE5E C52B 1056";
+    }];
+  };
   bennofs = {
     email = "benno.fuenfstueck@gmail.com";
     github = "bennofs";

--- a/pkgs/tools/games/joystickwake/default.nix
+++ b/pkgs/tools/games/joystickwake/default.nix
@@ -1,0 +1,26 @@
+{ lib, python3, fetchFromGitHub }:
+python3.pkgs.buildPythonApplication rec {
+  pname = "joystickwake";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "foresto";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j8xwfmzzmc9s88zvzc3lv67821r6x28vy6vli3srvx859wprppd";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ pyudev xlib ];
+
+  meta = with lib; {
+    description = "A joystick-aware screen waker";
+    longDescription = ''
+      Linux gamers often find themselves unexpectedly staring at a blank screen, because their display server fails to recognize game controllers as input devices, allowing the screen blanker to activate during gameplay.
+      This program works around the problem by temporarily disabling screen blankers when joystick activity is detected.
+    '';
+    homepage = "https://github.com/foresto/joystickwake";
+    maintainers = with maintainers; [ bertof ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2887,6 +2887,8 @@ in
 
   joycond = callPackage ../os-specific/linux/joycond { };
 
+  joystickwake = callPackage ../tools/games/joystickwake {};
+
   jwt-cli = callPackage ../tools/security/jwt-cli {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add package for [joystickwake](https://github.com/foresto/joystickwake), an utility for disabling screensavers and auto-lock while any input is received from a gamepad. This solves the annoying issue of auto-lock locking the session while playing games.

###### Things done
- Add package definition in `pkgs/tools/games/joystickwake/default.nix`
- Add package to the `all-packages.nix` file
- Add myself as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


