### PR TITLE
pyscf: init at 1.7.6

### DIFF
--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -1,6 +1,6 @@
 { buildPythonPackage, lib, fetchFromGitHub, libcint, libxc, xcfun, blas
 , numpy, scipy, h5py
-} :
+}:
 
 buildPythonPackage rec {
   pname = "pyscf";

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage rec {
   PYSCF_INC_DIR="${libcint}:${libxc}:${xcfun}";
 
   doCheck = true;
+  pythonImportsCheck = [ "pyscf" ];
+  checkInputs = [ ];
 
   meta = with lib; {
     description = "Python-based simulations of chemistry framework";

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python-based simulations of chemistry framework";
-    homepage = "https://pyscf.github.io/";
+    homepage = "https://github.com/pyscf/pyscf";
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = [ maintainers.sheepforce ];

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage, lib, fetchFromGitHub, libcint, libxc, xcfun, blas,
+  numpy, scipy, h5py, python3
+} :
+
+buildPythonPackage rec {
+  pname = "pyscf";
+  version = "1.7.6.post1";
+
+  src = fetchFromGitHub {
+    owner = "pyscf";
+    repo = pname;
+    rev = "f6c9c6654dd9609c5e467a1edd5c2c076f793acc";
+    sha256  = "0xbwkjxxysfpqz72qn6n4a0zr2h6sprbcal8j7kzymh7swjy117w";
+  };
+
+  buildInputs = [
+    libcint
+    libxc
+    xcfun
+    blas
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    h5py
+    python3
+  ];
+
+  PYSCF_INC_DIR="${libcint}:${libxc}:${xcfun}";
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Python-based simulations of chemistry framework";
+    homepage = "https://pyscf.github.io/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -28,9 +28,8 @@ buildPythonPackage rec {
 
   PYSCF_INC_DIR="${libcint}:${libxc}:${xcfun}";
 
-  doCheck = true;
+  doCheck = false;
   pythonImportsCheck = [ "pyscf" ];
-  checkInputs = [ ];
 
   meta = with lib; {
     description = "Python-based simulations of chemistry framework";

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -1,5 +1,5 @@
-{ buildPythonPackage, lib, fetchFromGitHub, libcint, libxc, xcfun, blas,
-  numpy, scipy, h5py, python3
+{ buildPythonPackage, lib, fetchFromGitHub, libcint, libxc, xcfun, blas
+, numpy, scipy, h5py
 } :
 
 buildPythonPackage rec {
@@ -24,7 +24,6 @@ buildPythonPackage rec {
     numpy
     scipy
     h5py
-    python3
   ];
 
   PYSCF_INC_DIR="${libcint}:${libxc}:${xcfun}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6439,6 +6439,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
   };
 
+  pyscf = callPackage ../development/python-modules/pyscf { };
+
   pyschedule = callPackage ../development/python-modules/pyschedule { };
 
   pyscreenshot = callPackage ../development/python-modules/pyscreenshot { };


### PR DESCRIPTION
###### Motivation for this change
Adds pyscf, a quantum chemistry software written in python. Part of the packages @markuskowa and me want to merge from markuskowa/NixOS-QChem#56 .

The test suite is disabled, as it is for some reasons very sensitive to the filesystem, the build is running on. @markuskowa and my journey with this here: https://github.com/markuskowa/NixOS-QChem/issues/29

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
