### PR TITLE
taskspooler: init at 1.0

### DIFF
--- a/pkgs/tools/system/taskspooler/default.nix
+++ b/pkgs/tools/system/taskspooler/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchurl, makeWrapper, coreutils }:
+
+stdenv.mkDerivation rec {
+  pname = "taskspooler";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://vicerveza.homeunix.net/%7Eviric/wsgi-bin/hgweb.wsgi/ts/archive/7cf9a8bda6d3.tar.gz";
+    sha256 = "11i21s8sdmjl4gy5f3dyfsxsmg1japgs4r5ym0b3jdyp99xhpbl1";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "PREFIX?=/usr/local" "PREFIX=$out"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/ts \
+      --set-default TS_SLOTS "$(${coreutils}/bin/nproc --all)"
+  '';
+
+  meta = with lib; {
+    description = "Simple single node task scheduler";
+    license = licenses.gpl2Plus;
+    homepage = "https://vicerveza.homeunix.net/~viric/wsgi-bin/hgweb.wsgi/ts";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22539,6 +22539,8 @@ in
 
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 
+  taskspooler = callPackage ../tools/system/taskspooler { };
+
   tamsyn = callPackage ../data/fonts/tamsyn { inherit (buildPackages.xorg) mkfontscale; };
 
   tamzen = callPackage ../data/fonts/tamzen { inherit (buildPackages.xorg) mkfontscale; };


### PR DESCRIPTION
###### Motivation for this change
Adds the small taskspooler tool. It provides a queue management system for a single node and helps scheduling multiple long running task on a workstation. Especially useful for long running calculations.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
