### PR TITLE
graalvm: fix graalvm dependencies compilation on darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1062,7 +1062,11 @@
     email = "babathriviere@gmail.com";
     github = "babariviere";
     githubId = 12128029;
-    name = "babariviere";
+    name = "Bastien Rivière";
+    keys = [{
+      longkeyid = "rsa4096/0xF202AD3B6EDF4BD1";
+      fingerprint = "2F85 B362 B274 0012 37E2  81EE F202 AD3B 6EDF 4BD1";
+    }];
   };
   babbaj = {
     name = "babbaj";

--- a/pkgs/development/compilers/graalvm/community-edition.nix
+++ b/pkgs/development/compilers/graalvm/community-edition.nix
@@ -180,7 +180,10 @@ let
             rm $out/jre/lib/jvmci/parentClassLoader.classpath
           '';
           "11-darwin-amd64" = ''
-            echo ""
+            # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
+            substituteInPlace $out/conf/security/java.security \
+              --replace file:/dev/random    file:/dev/./urandom \
+              --replace NativePRNGBlocking  SHA1PRNG
           '';
         }.${javaVersionPlatform};
 
@@ -259,7 +262,8 @@ let
           ''}
 
           echo '1 + 1' | $out/bin/node -i
-        ${lib.optionalString (javaVersion == "11") ''
+        ${lib.optionalString (javaVersion == "11" && stdenv.isLinux) ''
+          # Doesn't work on MacOS, we have this error: "Launching JShell execution engine threw: Operation not permitted (Bind failed)"
           echo '1 + 1' | $out/bin/jshell
         ''}'';
 
@@ -269,7 +273,7 @@ let
           homepage = "https://www.graalvm.org/";
           description = "High-Performance Polyglot VM";
           license = with licenses; [ upl gpl2Classpath bsd3 ];
-          maintainers = with maintainers; [ bandresen volth hlolli glittershark ];
+          maintainers = with maintainers; [ bandresen volth hlolli glittershark babariviere ];
           platforms = [ "x86_64-linux" "x86_64-darwin" ];
         };
       };

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     description = "Language Server Protocol (LSP) for Clojure";
     homepage = "https://github.com/clojure-lsp/clojure-lsp";
     license = licenses.mit;
-    maintainers = [ maintainers.ericdallo maintainers.babariviere ];
+    maintainers = with maintainers; [ ericdallo babariviere ];
     platforms = graalvm11-ce.meta.platforms;
   };
 }

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
 
   GRAALVM_HOME = graalvm11-ce;
   CLOJURE_LSP_JAR = jar;
+  CLOJURE_LSP_XMX = "-J-Xmx4g";
+
+  patches = lib.optionals stdenv.isDarwin [ ./disable-check-toolchain.patch ];
 
   buildInputs = [ graalvm11-ce ];
 
@@ -52,7 +55,7 @@ stdenv.mkDerivation rec {
     description = "Language Server Protocol (LSP) for Clojure";
     homepage = "https://github.com/clojure-lsp/clojure-lsp";
     license = licenses.mit;
-    maintainers = [ maintainers.ericdallo ];
+    maintainers = [ maintainers.ericdallo maintainers.babariviere ];
     platforms = graalvm11-ce.meta.platforms;
   };
 }

--- a/pkgs/development/tools/misc/clojure-lsp/disable-check-toolchain.patch
+++ b/pkgs/development/tools/misc/clojure-lsp/disable-check-toolchain.patch
@@ -1,0 +1,12 @@
+diff --git a/graalvm/native-unix-compile.sh b/graalvm/native-unix-compile.sh
+index ec0e49f..e19a120 100755
+--- a/graalvm/native-unix-compile.sh
++++ b/graalvm/native-unix-compile.sh
+@@ -17,6 +17,7 @@ CLOJURE_LSP_XMX=${CLOJURE_LSP_XMX:-"-J-Xmx4g"}
+ 
+ args=("-jar" "$CLOJURE_LSP_JAR"
+       "-H:+ReportExceptionStackTraces"
++      "-H:-CheckToolchain"
+       "--verbose"
+       "--no-fallback"
+       "--native-image-info"

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     -H:Name=${pname} \
     -H:EnableURLProtocols=https,http \
     -H:+ReportExceptionStackTraces \
+    ${lib.optionalString stdenv.isDarwin ''-H:-CheckToolchain''} \
     --report-unsupported-elements-at-runtime \
     --initialize-at-build-time \
     --no-fallback


### PR DESCRIPTION
###### Motivation for this change

We want to be able to run programs like `babashka` and `clojure-lsp` on darwin.

Closes #122557

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
