### PR TITLE
wlroots: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "0ixl45g0m8b75gvbjm3gf5qg0yplspgs0xpm2619wn5sygc47sb1";
   };
 
+  patches = [
+    # To fix the build with wlroots 0.14.0:
+    ./wlroots-0_14.patch
+  ];
+
   nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];
 
   buildInputs = [

--- a/pkgs/applications/window-managers/cage/wlroots-0_14.patch
+++ b/pkgs/applications/window-managers/cage/wlroots-0_14.patch
@@ -1,0 +1,36 @@
+From 9a4523d47efeafd674d419169fe161e5a3b31cb3 Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Thu, 3 Jun 2021 17:53:11 +0000
+Subject: [PATCH 1/3] view: chase swaywm/wlroots@9e58301df7f0
+
+view.c:238:52: error: no member named 'subsurfaces' in 'struct wlr_surface'
+        wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces, parent_link) {
+                                       ~~~~~~~~~~~~~~~~~  ^
+/usr/include/wayland-util.h:443:30: note: expanded from macro 'wl_list_for_each'
+        for (pos = wl_container_of((head)->next, pos, member);  \
+                                    ^~~~
+/usr/include/wayland-util.h:409:32: note: expanded from macro 'wl_container_of'
+        (__typeof__(sample))((char *)(ptr) -                            \
+                                      ^~~
+
+Based on https://github.com/swaywm/sway/commit/3162766eef14
+---
+ view.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/view.c b/view.c
+index b9ba9c2..3f3b0ed 100644
+--- a/view.c
++++ b/view.c
+@@ -235,7 +235,10 @@ view_map(struct cg_view *view, struct wlr_surface *surface)
+ 	view->wlr_surface = surface;
+ 
+ 	struct wlr_subsurface *subsurface;
+-	wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces, parent_link) {
++	wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces_below, parent_link) {
++		subsurface_create(view, subsurface);
++	}
++	wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces_above, parent_link) {
+ 		subsurface_create(view, subsurface);
+ 	}
+ 

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cairo
 , fontconfig
 , libxkbcommon
@@ -30,6 +31,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-1IztedN5/I/4TDKHLJ26fSrDsvJ5QAr+cbzS2PQITDE=";
   };
+
+  patches = [
+    # To fix the build with wlroots 0.14.0:
+    (fetchpatch {
+      # Add fixes for wlroots 0.14.0
+      url = "https://github.com/project-repo/cagebreak/commit/d57869d43add58331386fc8e89c14bb2b74afe17.patch";
+      sha256 = "0g6sl8y4kk0bm5x6pxqbxw2j0gyg3ybr2v9m70q2pxp70kms4lqg";
+    })
+  ];
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/applications/window-managers/labwc/default.nix
+++ b/pkgs/applications/window-managers/labwc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -29,6 +30,15 @@ stdenv.mkDerivation rec {
     rev = "fddeb74527e5b860d9c1a91a237d390041c758b6";
     sha256 = "0rhniv5j4bypqxxj0nbpa3hclmn8znal9rldv0mrgbizn3wsbs54";
   };
+
+  patches = [
+    # To fix the build with wlroots 0.14:
+    (fetchpatch {
+      # output: access texture width/height directly
+      url = "https://github.com/johanmalm/labwc/commit/892e93dd84c514b4e6f34a0fab01c727edd2d8de.patch";
+      sha256 = "1p1pg1kd98727wlcspa2sffl7ijhvsfad6bj2rxsw322q0bz3yrh";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,22 +1,25 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config
-, cairo, libdrm, libexecinfo, libinput, libjpeg, libxkbcommon, wayland
+{ lib, stdenv, fetchurl, cmake, meson, ninja, pkg-config
+, cairo, doctest, libdrm, libexecinfo, libinput, libjpeg, libxkbcommon, wayland
 , wayland-protocols, wf-config, wlroots, mesa
 }:
 
 stdenv.mkDerivation rec {
   pname = "wayfire";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchurl {
     url = "https://github.com/WayfireWM/wayfire/releases/download/v${version}/wayfire-${version}.tar.xz";
-    sha256 = "0wgvwbmdhn7gkdr2jl9jndgvl6w4x7ys8gmpj55gqh9b57wqhyaq";
+    sha256 = "1gasijjyfl00zpy6j9hh6qpwv0sw42h9irycbnm693j3vw9mcy66";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config wayland ];
+  nativeBuildInputs = [ cmake meson ninja pkg-config wayland ];
   buildInputs = [
-    cairo libdrm libexecinfo libinput libjpeg libxkbcommon wayland
+    cairo doctest libdrm libexecinfo libinput libjpeg libxkbcommon wayland
     wayland-protocols wf-config wlroots mesa
   ];
+
+  # CMake is just used for finding doctest.
+  dontUseCmakeConfigure = true;
 
   mesonFlags = [ "--sysconfdir" "/etc" ];
 

--- a/pkgs/development/libraries/wlroots/0.13.nix
+++ b/pkgs/development/libraries/wlroots/0.13.nix
@@ -1,18 +1,18 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland-scanner
 , libGL, wayland, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg, xcbutilrenderutil, xwayland, libseat
+, libpng, ffmpeg, libuuid, xcbutilrenderutil, xwayland
 }:
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.14.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "103sf9bsyqw18kmaih11mlxwqi9ddymm95w1lfxz06pf69xwhd39";
+    sha256 = "01plhbnsp5yg18arz0v8fr0pr9l4w4pdzwkg9px486qdvb3s1vgy";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -23,8 +23,10 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libGL wayland wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg xcbutilrenderutil xwayland libseat
+    libpng ffmpeg libuuid xcbutilrenderutil xwayland
   ];
+
+  mesonFlags = [ "-Dlogind-provider=systemd" "-Dlibseat=disabled" ];
 
   postFixup = ''
     # Install ALL example programs to $examples:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24541,8 +24541,11 @@ in
   };
 
   wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
+  wlroots_0_13 = callPackage ../development/libraries/wlroots/0.13.nix {};
 
-  sway-unwrapped = callPackage ../applications/window-managers/sway { };
+  sway-unwrapped = callPackage ../applications/window-managers/sway {
+    wlroots = wlroots_0_13;
+  };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
@@ -24562,7 +24565,9 @@ in
 
   wbg = callPackage ../applications/misc/wbg { };
 
-  hikari = callPackage ../applications/window-managers/hikari { };
+  hikari = callPackage ../applications/window-managers/hikari {
+    wlroots = wlroots_0_13;
+  };
 
   i3 = callPackage ../applications/window-managers/i3 {
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
@@ -27564,7 +27569,8 @@ in
   wayfireApplications = wayfireApplications-unwrapped.withPlugins (plugins: [ plugins.wf-shell ]);
   inherit (wayfireApplications) wayfire wcm;
   wayfireApplications-unwrapped = recurseIntoAttrs (
-    callPackage ../applications/window-managers/wayfire/applications.nix { }
+    (callPackage ../applications/window-managers/wayfire/applications.nix { }).
+    extend (_: _: { wlroots = wlroots_0_13; })
   );
   wayfirePlugins = recurseIntoAttrs (
     callPackage ../applications/window-managers/wayfire/plugins.nix {
@@ -27614,7 +27620,9 @@ in
 
   weston = callPackage ../applications/window-managers/weston { pipewire = pipewire_0_2; };
 
-  wio = callPackage ../applications/window-managers/wio { };
+  wio = callPackage ../applications/window-managers/wio {
+    wlroots = wlroots_0_13;
+  };
 
   whitebox-tools = callPackage ../applications/gis/whitebox-tools {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27569,8 +27569,7 @@ in
   wayfireApplications = wayfireApplications-unwrapped.withPlugins (plugins: [ plugins.wf-shell ]);
   inherit (wayfireApplications) wayfire wcm;
   wayfireApplications-unwrapped = recurseIntoAttrs (
-    (callPackage ../applications/window-managers/wayfire/applications.nix { }).
-    extend (_: _: { wlroots = wlroots_0_13; })
+    callPackage ../applications/window-managers/wayfire/applications.nix { }
   );
   wayfirePlugins = recurseIntoAttrs (
     callPackage ../applications/window-managers/wayfire/plugins.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/swaywm/wlroots/releases/tag/0.14.0

###### Current status:

<details>
<summary>nixpkgs-review output</summary>

```
1 package added:
wlroots_0_13 (init at 0.13.0)

17 packages updated:
cage cagebreak dwl fuzzel labwc-unstable qt-video-wlr river-unstable waybar waybox-unstable wayfireApplications-unwrapped.wayfire (0.7.1 → 0.7.2) wayfire (0.7.1-wrapped → 0.7.2-wrapped) wbg-unstable wcm wcm wf-sh
ell wio wlroots (0.13.0 → 0.14.0)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/michael/.cache/nixpkgs-review/rev-258dafee0ce2912f5c0351fae5f24feb2fdbfc58/build.nix
18 packages built:
cage cagebreak dwl fuzzel labwc qt-video-wlr river waybar waybox wayfire wayfireApplications-unwrapped.wayfire wayfireApplications-unwrapped.wayfirePlugins.wf-shell wayfireApplications-unwrapped.wcm wbg wcm wio wlroots wlroots_0_13
```
</details>

Builds:
- [x] dwl
- [x] fuzzel
- [x] qt-video-wlr river
- [x] waybox
- [x] wbg
- [x] wlroots
- [x] cage (`https://github.com/Hjdskes/cage/pull/191`)
  - [-] wio (unmaintained, we'll have to switch to a fork)
- [x] cagebreak (https://github.com/project-repo/cagebreak/commit/d57869d43add58331386fc8e89c14bb2b74afe17)
- [-] hikari (nothing yet)
- [x] labwc (`https://github.com/johanmalm/labwc/pull/35`)
- [-] sway-unwrapped sway sway-contrib.grimshot (progress: `https://github.com/swaywm/sway/pull/6339` and `https://github.com/swaywm/sway/pull/6340`)
  - [x] waybar
- [x] wayfire wayfireApplications-unwrapped.wayfire wayfireApplications-unwrapped.wayfirePlugins.wf-shell wayfireApplications-unwrapped.wcm wcm (at least https://github.com/WayfireWM/wayfire/commit/1a65ae3115f3f8fb715a6b25ea96a5be155c4ab6, https://github.com/WayfireWM/wayfire/commit/48275e46b4705a1f9b827d94d7a61921ada2ea51, and https://github.com/WayfireWM/wayfire/commit/1f56528484350dc15196e7bde10266a1a97d4c4a should be required)

Tested:
- nixosTests.cage
- nixosTests.cagebreak
- nixosTests.sway
- Manual tests

###### TODOs

- [x] Wait for updates of reverse-dependencies (to make them build with wlroots 0.14)
  - [x] But we'll likely have to introduce `wlroots_0_13`
  - [ ] ~~Ask upstream if wlroots 0.13.1 is still planned: https://github.com/swaywm/wlroots/milestone/7~~
- [x] nixpkgs-review
- [x] Squash the commits

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
