### PR TITLE
edgetpu-compiler: init at 15.0

### DIFF
--- a/pkgs/development/libraries/science/robotics/edgetpu-compiler/default.nix
+++ b/pkgs/development/libraries/science/robotics/edgetpu-compiler/default.nix
@@ -1,0 +1,58 @@
+{ autoPatchelfHook
+, dpkg
+, fetchurl
+, lib
+, libcxx
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "edgetpu-compiler";
+  version = "15.0";
+
+  src = fetchurl rec {
+    url = "https://packages.cloud.google.com/apt/pool/${pname}_${version}_amd64_${sha256}.deb";
+    sha256 = "ce03822053c2bddbb8640eaa988396ae66f9bc6b9d6d671914acd1727c2b445a";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    libcxx
+  ];
+
+  unpackPhase = ''
+    mkdir bin pkg
+
+    dpkg -x $src pkg
+
+    rm -r pkg/usr/share/lintian
+
+    cp pkg/usr/bin/edgetpu_compiler_bin/edgetpu_compiler ./bin
+    cp -r pkg/usr/share .
+
+    rm -r pkg
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r ./{bin,share} $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A command line tool that compiles a TensorFlow Lite model into an Edge TPU compatible file.";
+    homepage = "https://coral.ai/docs/edgetpu/compiler";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cpcloud ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4297,6 +4297,8 @@ in
 
   ecryptfs-helper = callPackage ../tools/security/ecryptfs/helper.nix { };
 
+  edgetpu-compiler = callPackage ../development/libraries/science/robotics/edgetpu-compiler { };
+
   edid-decode = callPackage ../tools/misc/edid-decode { };
 
   edid-generator = callPackage ../tools/misc/edid-generator { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the Coral Edge TPU model compiler to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
