### PR TITLE
home-assistant: support huawei_lte component

### DIFF
--- a/pkgs/development/python-modules/huawei-lte-api/default.nix
+++ b/pkgs/development/python-modules/huawei-lte-api/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, dicttoxml
+, requests
+, xmltodict
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "huawei-lte-api";
+  version = "1.4.18";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "Salamek";
+    repo = "huawei-lte-api";
+    rev = version;
+    sha256 = "1qaqxmh03j10wa9wqbwgc5r3ays8wfr7bldvsm45fycr3qfyn5fg";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner" ""
+  '';
+
+  propagatedBuildInputs = [
+    dicttoxml
+    requests
+    xmltodict
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "huawei_lte_api.AuthorizedConnection"
+    "huawei_lte_api.Client"
+    "huawei_lte_api.Connection"
+  ];
+
+  meta = with lib; {
+    description = "API For huawei LAN/WAN LTE Modems";
+    homepage = "https://github.com/Salamek/huawei-lte-api";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -368,7 +368,7 @@
     "html5" = ps: with ps; [ aiohttp-cors pywebpush ];
     "http" = ps: with ps; [ aiohttp-cors ];
     "htu21d" = ps: with ps; [ smbus-cffi ]; # missing inputs: i2csense
-    "huawei_lte" = ps: with ps; [ getmac stringcase url-normalize ]; # missing inputs: huawei-lte-api
+    "huawei_lte" = ps: with ps; [ getmac huawei-lte-api stringcase url-normalize ];
     "huawei_router" = ps: with ps; [ ];
     "hue" = ps: with ps; [ aiohue ];
     "huisbaasje" = ps: with ps; [ ]; # missing inputs: huisbaasje-client

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -454,6 +454,7 @@ in with py.pkgs; buildPythonApplication rec {
     "homematicip_cloud"
     "html5"
     "http"
+    "huawei_lte"
     "hue"
     "humidifier"
     "hyperion"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3324,6 +3324,8 @@ in {
 
   httpx = callPackage ../development/python-modules/httpx { };
 
+  huawei-lte-api = callPackage ../development/python-modules/huawei-lte-api { };
+
   huey = callPackage ../development/python-modules/huey { };
 
   hug = callPackage ../development/python-modules/hug { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
