### PR TITLE
discourse: Fix plugin support

### DIFF
--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -30,6 +30,9 @@ in
       package = lib.mkOption {
         type = lib.types.package;
         default = pkgs.discourse;
+        apply = p: p.override {
+          plugins = lib.unique (p.enabledPlugins ++ cfg.plugins);
+        };
         defaultText = "pkgs.discourse";
         description = ''
           The discourse package to use.
@@ -731,8 +734,6 @@ in
 
           cp -r ${cfg.package}/share/discourse/config.dist/* /run/discourse/config/
           cp -r ${cfg.package}/share/discourse/public.dist/* /run/discourse/public/
-          cp -r ${cfg.package}/share/discourse/plugins.dist/* /run/discourse/plugins/
-          ${lib.concatMapStringsSep "\n" (p: "ln -sf ${p} /run/discourse/plugins/") cfg.plugins}
           ln -sf /var/lib/discourse/uploads /run/discourse/public/uploads
           ln -sf /var/lib/discourse/backups /run/discourse/public/backups
 

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -199,6 +199,10 @@ let
       # Log Unicorn messages to the journal and make request timeout
       # configurable
       ./unicorn_logging_and_timeout.patch
+
+      # Use mv instead of rename, since rename doesn't work across
+      # device boundaries
+      ./use_mv_instead_of_rename.patch
     ];
 
     postPatch = ''
@@ -207,8 +211,6 @@ let
       # warnings and means we don't have to link back to lib from the
       # state directory.
       find config -type f -execdir sed -Ei "s,(\.\./)+(lib|app)/,$out/share/discourse/\2/," {} \;
-
-      ${replace}/bin/replace-literal -f -r -e 'File.rename(temp_destination, destination)' "FileUtils.mv(temp_destination, destination)" .
     '';
 
     buildPhase = ''

--- a/pkgs/servers/web-apps/discourse/plugin_gem_api_version.patch
+++ b/pkgs/servers/web-apps/discourse/plugin_gem_api_version.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/plugin_gem.rb b/lib/plugin_gem.rb
+index 855d1aca2c..8115623547 100644
+--- a/lib/plugin_gem.rb
++++ b/lib/plugin_gem.rb
+@@ -4,7 +4,7 @@ module PluginGem
+   def self.load(path, name, version, opts = nil)
+     opts ||= {}
+ 
+-    gems_path = File.dirname(path) + "/gems/#{RUBY_VERSION}"
++    gems_path = File.dirname(path) + "/gems/#{Gem.ruby_api_version}"
+ 
+     spec_path = gems_path + "/specifications"
+ 

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -1,0 +1,12 @@
+{ mkDiscoursePlugin, newScope, fetchFromGitHub, ... }@args:
+let
+  callPackage = newScope args;
+in
+{
+  discourse-spoiler-alert = callPackage ./discourse-spoiler-alert {};
+  discourse-solved = callPackage ./discourse-solved {};
+  discourse-canned-replies = callPackage ./discourse-canned-replies {};
+  discourse-math = callPackage ./discourse-math {};
+  discourse-github = callPackage ./discourse-github {};
+  discourse-yearly-review = callPackage ./discourse-yearly-review {};
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-canned-replies/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-canned-replies/default.nix
@@ -1,0 +1,11 @@
+{ mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-canned-replies";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-canned-replies";
+    rev = "7ee748f18a276aca42185e2079c1d4cadeecdaf8";
+    sha256 = "0j10kxfr6v2rdd58smg2i7iac46z74qnnjk8b91jd1svazhis1ph";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'sawyer', '0.8.2'
+gem 'octokit', '4.21.0'

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    multipart-post (2.1.1)
+    octokit (4.21.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    public_suffix (4.0.6)
+    ruby2_keywords (0.0.4)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit (= 4.21.0)
+  sawyer (= 0.8.2)
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
@@ -1,0 +1,12 @@
+{ mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-github";
+  bundlerEnvArgs.gemdir = ./.;
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-github";
+    rev = "151e353a5a1971157c70c2e2b0f56387f212a81f";
+    sha256 = "00kra6zd2k1f2vwcdvxnxnammzh72f5qxcqbb94m0z6maj598wdy";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
@@ -1,0 +1,126 @@
+{
+  addressable = {
+    dependencies = ["public_suffix"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fvchp2rhp2rmigx7qglf69xvjqvzq7x0g49naliw29r2bz656sy";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  faraday = {
+    dependencies = ["faraday-em_http" "faraday-em_synchrony" "faraday-excon" "faraday-net_http" "faraday-net_http_persistent" "multipart-post" "ruby2_keywords"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07mhk70gv453pg38md346470hknyhipdqppnplq706ll3k3lzb7v";
+      type = "gem";
+    };
+    version = "1.4.2";
+  };
+  faraday-em_http = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12cnqpbak4vhikrh2cdn94assh3yxza8rq2p9w2j34bqg5q4qgbs";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  faraday-em_synchrony = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vgrbhkp83sngv6k4mii9f2s9v5lmp693hylfxp2ssfc60fas3a6";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  faraday-excon = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h09wkb0k0bhm6dqsd47ac601qiaah8qdzjh8gvxfd376x1chmdh";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  faraday-net_http = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fi8sda5hc54v1w3mqfl5yz09nhx35kglyx72w7b8xxvdr0cwi9j";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  faraday-net_http_persistent = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l2c835wl7gv34xp49fhd1bl4czkpw2g3ahqsak2251iqv5589ka";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  multipart-post = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zgw9zlwh2a6i1yvhhc4a84ry1hv824d6g2iw2chs3k5aylpmpfj";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  octokit = {
+    dependencies = ["faraday" "sawyer"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ak64rb48d8z98nw6q70r6i0i3ivv61iqla40ss5l79491qfnn27";
+      type = "gem";
+    };
+    version = "4.21.0";
+  };
+  public_suffix = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xqcgkl7bwws1qrlnmxgh8g4g9m10vg60bhlw40fplninb3ng6d9";
+      type = "gem";
+    };
+    version = "4.0.6";
+  };
+  ruby2_keywords = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15wfcqxyfgka05v2a7kpg64x57gl1y4xzvnc9lh60bqx5sf1iqrs";
+      type = "gem";
+    };
+    version = "0.0.4";
+  };
+  sawyer = {
+    dependencies = ["addressable" "faraday"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yrdchs3psh583rjapkv33mljdivggqn99wkydkjdckcjn43j3cz";
+      type = "gem";
+    };
+    version = "0.8.2";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-math/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-math/default.nix
@@ -1,0 +1,11 @@
+{ mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-math";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-math";
+    rev = "143ddea4558ea9a1b3fd71635bc11e055763c8e7";
+    sha256 = "18pq5ybl3g34i39cpixc3nszvq8gx5yji58zlbbl6428mm011cbx";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
@@ -1,0 +1,11 @@
+{ mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-solved";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-solved";
+    rev = "179611766d53974308e6f7def21836997c3c55fc";
+    sha256 = "sha256:1s77h42d3bv2lqw33akxh8ss482vxnz4d7qz6xicwqfwv34qjf03";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-spoiler-alert/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-spoiler-alert/default.nix
@@ -1,0 +1,11 @@
+{ mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-spoiler-alert";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-spoiler-alert";
+    rev = "e200cfa571d252cab63f3d30d619b370986e4cee";
+    sha256 = "0ya69ix5g77wz4c9x9gmng6l25ghb5xxlx3icr6jam16q14dzc33";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-yearly-review/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-yearly-review/default.nix
@@ -1,0 +1,11 @@
+{ mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-yearly-review";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-yearly-review";
+    rev = "d1471bdb68945f55342e72e2c525b4f628419a50";
+    sha256 = "sha256:0xpl0l1vpih8xzb6y7k1lm72nj4ya99378viyhqfvpwzsn5pha2a";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/use_mv_instead_of_rename.patch
+++ b/pkgs/servers/web-apps/discourse/use_mv_instead_of_rename.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/discourse.rb b/lib/discourse.rb
+index ea2a3cbafd..66454d9157 100644
+--- a/lib/discourse.rb
++++ b/lib/discourse.rb
+@@ -62,7 +62,7 @@ module Discourse
+         fd.fsync()
+       end
+ 
+-      File.rename(temp_destination, destination)
++      FileUtils.mv(temp_destination, destination)
+ 
+       nil
+     end
+@@ -76,7 +76,7 @@ module Discourse
+       FileUtils.mkdir_p(File.join(Rails.root, 'tmp'))
+       temp_destination = File.join(Rails.root, 'tmp', SecureRandom.hex)
+       execute_command('ln', '-s', source, temp_destination)
+-      File.rename(temp_destination, destination)
++      FileUtils.mv(temp_destination, destination)
+ 
+       nil
+     end


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix #127795.

For Discourse plugins to work properly, their assets need to be precompiled along with the rest of Discourse's assets. This means we need to build new packages when the list of plugins change.

This moves the plugin file handling from the module over to the package, where the plugin files are put in place before the assets are built.

cc @Dehumanizer77

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
