### PR TITLE
Qemu restoration

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1022,6 +1022,40 @@ Superuser created successfully.
       </listitem>
       <listitem>
         <para>
+          In NixOS virtual machines (QEMU), the
+          <literal>virtualisation</literal> module has been updated with
+          new options to configure:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              IPv4 port forwarding
+              (<link xlink:href="options.html#opt-virtualisation.forwardPorts"><literal>virtualisation.forwardPorts</literal></link>),
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              shared host directories
+              (<link xlink:href="options.html#opt-virtualisation.sharedDirectories"><literal>virtualisation.sharedDirectories</literal></link>),
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              screen resolution
+              (<link xlink:href="options.html#opt-virtualisation.resolution"><literal>virtualisation.resolution</literal></link>).
+            </para>
+          </listitem>
+        </itemizedlist>
+        <para>
+          In addition, the default
+          <link xlink:href="options.html#opt-virtualisation.msize"><literal>msize</literal></link>
+          parameter in 9P filesystems (including /nix/store and all
+          shared directories) has been increased to 16K for improved
+          performance.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The setting
           <link xlink:href="options.html#opt-services.openssh.logLevel"><literal>services.openssh.logLevel</literal></link>
           <literal>&quot;VERBOSE&quot;</literal>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -310,8 +310,16 @@ To be able to access the web UI this port needs to be opened in the firewall.
 
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
+
 - The linux kernel package infrastructure was moved out of `all-packages.nix`, and restructured. Linux related functions and attributes now live under the `pkgs.linuxKernel` attribute set.
   In particular the versioned `linuxPackages_*` package sets (such as `linuxPackages_5_4`) and kernels from `pkgs` were moved there and now live under `pkgs.linuxKernel.packages.*`. The unversioned ones (such as `linuxPackages_latest`) remain untouched.
+
+- In NixOS virtual machines (QEMU), the `virtualisation` module has been updated with new options to configure:
+    - IPv4 port forwarding ([`virtualisation.forwardPorts`](options.html#opt-virtualisation.forwardPorts)),
+    - shared host directories ([`virtualisation.sharedDirectories`](options.html#opt-virtualisation.sharedDirectories)),
+    - screen resolution ([`virtualisation.resolution`](options.html#opt-virtualisation.resolution)).
+
+  In addition, the default [`msize`](options.html#opt-virtualisation.msize) parameter in 9P filesystems (including /nix/store and all shared directories) has been increased to 16K for improved performance.
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.
 

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -4,15 +4,14 @@
 , # Ignored
   config ? null
 , # Nixpkgs, for qemu, lib and more
-  pkgs
+  pkgs, lib
 , # !!! See comment about args in lib/modules.nix
   specialArgs ? {}
 , # NixOS configuration to add to the VMs
   extraConfigurations ? []
 }:
 
-with pkgs.lib;
-with import ../lib/qemu-flags.nix { inherit pkgs; };
+with lib;
 
 rec {
 
@@ -93,8 +92,9 @@ rec {
                          "${config.networking.hostName}\n"));
 
                   virtualisation.qemu.options =
-                    flip concatMap interfacesNumbered
-                      ({ fst, snd }: qemuNICFlags snd fst m.snd);
+                    let qemu-common = import ../lib/qemu-common.nix { inherit lib pkgs; };
+                    in flip concatMap interfacesNumbered
+                      ({ fst, snd }: qemu-common.qemuNICFlags snd fst m.snd);
                 };
             }
           )

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -93,7 +93,7 @@ rec {
                          "${config.networking.hostName}\n"));
 
                   virtualisation.qemu.options =
-                    forEach interfacesNumbered
+                    flip concatMap interfacesNumbered
                       ({ fst, snd }: qemuNICFlags snd fst m.snd);
                 };
             }

--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -1,12 +1,12 @@
-# QEMU flags shared between various Nix expressions.
-{ pkgs }:
+# QEMU-related utilities shared between various Nix expressions.
+{ lib, pkgs }:
 
 let
   zeroPad = n:
-    pkgs.lib.optionalString (n < 16) "0" +
+    lib.optionalString (n < 16) "0" +
       (if n > 255
        then throw "Can't have more than 255 nets or nodes!"
-       else pkgs.lib.toHexString n);
+       else lib.toHexString n);
 in
 
 rec {

--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -14,7 +14,7 @@ rec {
 
   qemuNICFlags = nic: net: machine:
     [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=${qemuNicMac net machine}"
-      "-netdev vde,id=vlan${toString nic},sock=$QEMU_VDE_SOCKET_${toString net}"
+      ''-netdev vde,id=vlan${toString nic},sock="$QEMU_VDE_SOCKET_${toString net}"''
     ];
 
   qemuSerialDevice = if pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64 then "ttyS0"

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -217,7 +217,7 @@ rec {
       nodes = qemu_pkg:
         let
           build-vms = import ./build-vms.nix {
-            inherit system pkgs minimal specialArgs;
+            inherit system lib pkgs minimal specialArgs;
             extraConfigurations = extraConfigurations ++ [(
               {
                 virtualisation.qemu.package = qemu_pkg;
@@ -256,7 +256,6 @@ rec {
       test // {
         inherit test driver driverInteractive nodes;
       };
-
 
   abortForFunction = functionName: abort ''The ${functionName} function was
     removed because it is not an essential part of the NixOS testing

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -6,7 +6,11 @@ let
 
   cfg = config.documentation;
 
-  manualModules = baseModules ++ optionals cfg.nixos.includeAllModules (extraModules ++ modules);
+  manualModules =
+    baseModules
+    # Modules for which to show options even when not imported
+    ++ [ ../virtualisation/qemu-vm.nix ]
+    ++ optionals cfg.nixos.includeAllModules (extraModules ++ modules);
 
   /* For the purpose of generating docs, evaluate options with each derivation
     in `pkgs` (recursively) replaced by a fake with path "\${pkgs.attribute.path}".

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -10,10 +10,10 @@
 { config, lib, pkgs, options, ... }:
 
 with lib;
-with import ../../lib/qemu-flags.nix { inherit pkgs; };
 
 let
 
+  qemu-common = import ../../lib/qemu-common.nix { inherit lib pkgs; };
 
   cfg = config.virtualisation;
 
@@ -152,7 +152,7 @@ let
       '')}
 
       # Start QEMU.
-      exec ${qemuBinary qemu} \
+      exec ${qemu-common.qemuBinary qemu} \
           -name ${config.system.name} \
           -m ${toString config.virtualisation.memorySize} \
           -smp ${toString config.virtualisation.cores} \
@@ -549,7 +549,7 @@ in
       consoles = mkOption {
         type = types.listOf types.str;
         default = let
-          consoles = [ "${qemu-flags.qemuSerialDevice},115200n8" "tty0" ];
+          consoles = [ "${qemu-common.qemuSerialDevice},115200n8" "tty0" ];
         in if cfg.graphics then consoles else reverseList consoles;
         example = [ "console=tty1" ];
         description = ''

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -350,6 +350,16 @@ in
             '';
       };
 
+    virtualisation.resolution =
+      mkOption {
+        type = options.services.xserver.resolutions.type.nestedTypes.elemType;
+        default = { x = 1024; y = 768; };
+        description =
+          ''
+            The resolution of the virtual machine display.
+          '';
+      };
+
     virtualisation.cores =
       mkOption {
         type = types.ints.positive;
@@ -601,6 +611,7 @@ in
         then driveDeviceName 2 # second disk
         else cfg.bootDevice
     );
+    boot.loader.grub.gfxmodeBios = with cfg.resolution; "${toString x}x${toString y}";
 
     boot.initrd.extraUtilsCommands =
       ''
@@ -780,7 +791,7 @@ in
     # video driver the host uses.
     services.xserver.videoDrivers = mkVMOverride [ "modesetting" ];
     services.xserver.defaultDepth = mkVMOverride 0;
-    services.xserver.resolutions = mkVMOverride [ { x = 1024; y = 768; } ];
+    services.xserver.resolutions = mkVMOverride [ cfg.resolution ];
     services.xserver.monitorSection =
       ''
         # Set a higher refresh rate so that resolutions > 800x600 work.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -273,10 +273,11 @@ in
 
     virtualisation.memorySize =
       mkOption {
+        type = types.ints.positive;
         default = 384;
         description =
           ''
-            Memory size (M) of virtual machine.
+            The memory size in megabytes of the virtual machine.
           '';
       };
 
@@ -294,15 +295,17 @@ in
 
     virtualisation.diskSize =
       mkOption {
+        type = types.nullOr types.ints.positive;
         default = 512;
         description =
           ''
-            Disk size (M) of virtual machine.
+            The disk size in megabytes of the virtual machine.
           '';
       };
 
     virtualisation.diskImage =
       mkOption {
+        type = types.str;
         default = "./${config.system.name}.qcow2";
         description =
           ''
@@ -314,7 +317,7 @@ in
 
     virtualisation.bootDevice =
       mkOption {
-        type = types.str;
+        type = types.path;
         example = "/dev/vda";
         description =
           ''
@@ -324,8 +327,8 @@ in
 
     virtualisation.emptyDiskImages =
       mkOption {
+        type = types.listOf types.ints.positive;
         default = [];
-        type = types.listOf types.int;
         description =
           ''
             Additional disk images to provide to the VM. The value is
@@ -336,6 +339,7 @@ in
 
     virtualisation.graphics =
       mkOption {
+        type = types.bool;
         default = true;
         description =
           ''
@@ -347,8 +351,8 @@ in
 
     virtualisation.cores =
       mkOption {
+        type = types.ints.positive;
         default = 1;
-        type = types.int;
         description =
           ''
             Specify the number of cores the guest is permitted to use.
@@ -359,6 +363,7 @@ in
 
     virtualisation.pathsInNixDB =
       mkOption {
+        type = types.listOf types.path;
         default = [];
         description =
           ''
@@ -372,6 +377,7 @@ in
 
     virtualisation.vlans =
       mkOption {
+        type = types.listOf types.ints.unsigned;
         default = [ 1 ];
         example = [ 1 2 ];
         description =
@@ -389,6 +395,7 @@ in
 
     virtualisation.writableStore =
       mkOption {
+        type = types.bool;
         default = true; # FIXME
         description =
           ''
@@ -400,6 +407,7 @@ in
 
     virtualisation.writableStoreUseTmpfs =
       mkOption {
+        type = types.bool;
         default = true;
         description =
           ''
@@ -410,6 +418,7 @@ in
 
     networking.primaryIPAddress =
       mkOption {
+        type = types.str;
         default = "";
         internal = true;
         description = "Primary IP address used in /etc/hosts.";
@@ -426,7 +435,7 @@ in
 
       options =
         mkOption {
-          type = types.listOf types.unspecified;
+          type = types.listOf types.str;
           default = [];
           example = [ "-vga std" ];
           description = "Options passed to QEMU.";
@@ -475,16 +484,16 @@ in
 
       diskInterface =
         mkOption {
+          type = types.enum [ "virtio" "scsi" "ide" ];
           default = "virtio";
           example = "scsi";
-          type = types.enum [ "virtio" "scsi" "ide" ];
           description = "The interface used for the virtual hard disks.";
         };
 
       guestAgent.enable =
         mkOption {
-          default = true;
           type = types.bool;
+          default = true;
           description = ''
             Enable the Qemu guest agent.
           '';
@@ -493,6 +502,7 @@ in
 
     virtualisation.useBootLoader =
       mkOption {
+        type = types.bool;
         default = false;
         description =
           ''
@@ -507,6 +517,7 @@ in
 
     virtualisation.useEFIBoot =
       mkOption {
+        type = types.bool;
         default = false;
         description =
           ''
@@ -518,6 +529,7 @@ in
 
     virtualisation.efiVars =
       mkOption {
+        type = types.str;
         default = "./${config.system.name}-efi-vars.fd";
         description =
           ''
@@ -528,8 +540,8 @@ in
 
     virtualisation.bios =
       mkOption {
-        default = null;
         type = types.nullOr types.package;
+        default = null;
         description =
           ''
             An alternate BIOS (such as <package>qboot</package>) with which to start the VM.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -126,7 +126,7 @@ let
       ${if cfg.useBootLoader then ''
         # Create a writable copy/snapshot of the boot disk.
         # A writable boot disk can be booted from automatically.
-        ${qemu}/bin/qemu-img create -f qcow2 -b ${bootDisk}/disk.img "$TMPDIR/disk.img" || exit 1
+        ${qemu}/bin/qemu-img create -f qcow2 -F qcow2 -b ${bootDisk}/disk.img "$TMPDIR/disk.img" || exit 1
 
         NIX_EFI_VARS=$(readlink -f "''${NIX_EFI_VARS:-${cfg.efiVars}}")
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -280,11 +280,11 @@ in
 
     virtualisation.msize =
       mkOption {
-        default = null;
-        type = types.nullOr types.ints.unsigned;
+        type = types.ints.positive;
+        default = 16384;
         description =
           ''
-            msize (maximum packet size) option passed to 9p file systems, in
+            The msize (maximum packet size) option passed to 9p file systems, in
             bytes. Increasing this should increase performance significantly,
             at the cost of higher RAM usage.
           '';

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -108,7 +108,7 @@ let
     ''
       #! ${pkgs.runtimeShell}
 
-      NIX_DISK_IMAGE=$(readlink -f ''${NIX_DISK_IMAGE:-${config.virtualisation.diskImage}})
+      NIX_DISK_IMAGE=$(readlink -f "''${NIX_DISK_IMAGE:-${config.virtualisation.diskImage}}")
 
       if ! test -e "$NIX_DISK_IMAGE"; then
           ${qemu}/bin/qemu-img create -f qcow2 "$NIX_DISK_IMAGE" \
@@ -121,14 +121,14 @@ let
       fi
 
       # Create a directory for exchanging data with the VM.
-      mkdir -p $TMPDIR/xchg
+      mkdir -p "$TMPDIR/xchg"
 
       ${if cfg.useBootLoader then ''
         # Create a writable copy/snapshot of the boot disk.
         # A writable boot disk can be booted from automatically.
-        ${qemu}/bin/qemu-img create -f qcow2 -b ${bootDisk}/disk.img $TMPDIR/disk.img || exit 1
+        ${qemu}/bin/qemu-img create -f qcow2 -b ${bootDisk}/disk.img "$TMPDIR/disk.img" || exit 1
 
-        NIX_EFI_VARS=$(readlink -f ''${NIX_EFI_VARS:-${cfg.efiVars}})
+        NIX_EFI_VARS=$(readlink -f "''${NIX_EFI_VARS:-${cfg.efiVars}}")
 
         ${if cfg.useEFIBoot then ''
           # VM needs writable EFI vars
@@ -139,7 +139,8 @@ let
         '' else ""}
       '' else ""}
 
-      cd $TMPDIR
+      cd "$TMPDIR" || exit 1
+
       idx=0
       ${flip concatMapStrings cfg.emptyDiskImages (size: ''
         if ! test -e "empty$idx.qcow2"; then
@@ -646,7 +647,7 @@ in
     virtualisation.qemu.drives = mkMerge [
       [{
         name = "root";
-        file = "$NIX_DISK_IMAGE";
+        file = ''"$NIX_DISK_IMAGE"'';
         driveExtraOpts.cache = "writeback";
         driveExtraOpts.werror = "report";
       }]
@@ -655,7 +656,7 @@ in
         # note [Disk layout with `useBootLoader`].
         {
           name = "boot";
-          file = "$TMPDIR/disk.img";
+          file = ''"$TMPDIR"/disk.img'';
           driveExtraOpts.media = "disk";
           deviceExtraOpts.bootindex = "1";
         }

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -8,7 +8,7 @@ with import ../lib/testing-python.nix { inherit system pkgs; };
 with pkgs.lib;
 
 let
-  qemu-flags = import ../lib/qemu-flags.nix { inherit pkgs; };
+  qemu-common = import ../lib/qemu-common.nix { inherit (pkgs) lib pkgs; };
 
   router = { config, pkgs, lib, ... }:
     with pkgs.lib;
@@ -42,7 +42,7 @@ let
         machines = flip map vlanIfs (vlan:
           {
             hostName = "client${toString vlan}";
-            ethernetAddress = qemu-flags.qemuNicMac vlan 1;
+            ethernetAddress = qemu-common.qemuNicMac vlan 1;
             ipAddress = "192.168.${toString vlan}.2";
           }
         );

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -9,9 +9,9 @@
 }:
 
 with pkgs;
-with import ../../../nixos/lib/qemu-flags.nix { inherit pkgs; };
 
 rec {
+  qemu-common = import ../../../nixos/lib/qemu-common.nix { inherit lib pkgs; };
 
   qemu = pkgs.qemu_kvm;
 
@@ -192,13 +192,13 @@ rec {
       export PATH=/bin:/usr/bin:${coreutils}/bin
       echo "Starting interactive shell..."
       echo "(To run the original builder: \$origBuilder \$origArgs)"
-      exec ${busybox}/bin/setsid ${bashInteractive}/bin/bash < /dev/${qemuSerialDevice} &> /dev/${qemuSerialDevice}
+      exec ${busybox}/bin/setsid ${bashInteractive}/bin/bash < /dev/${qemu-common.qemuSerialDevice} &> /dev/${qemu-common.qemuSerialDevice}
     fi
   '';
 
 
   qemuCommandLinux = ''
-    ${qemuBinary qemu} \
+    ${qemu-common.qemuBinary qemu} \
       -nographic -no-reboot \
       -device virtio-rng-pci \
       -virtfs local,path=${storeDir},security_model=none,mount_tag=store \
@@ -206,7 +206,7 @@ rec {
       ''${diskImage:+-drive file=$diskImage,if=virtio,cache=unsafe,werror=report} \
       -kernel ${kernel}/${img} \
       -initrd ${initrd}/initrd \
-      -append "console=${qemuSerialDevice} panic=1 command=${stage2Init} out=$out mountDisk=$mountDisk loglevel=4" \
+      -append "console=${qemu-common.qemuSerialDevice} panic=1 command=${stage2Init} out=$out mountDisk=$mountDisk loglevel=4" \
       $QEMU_OPTS
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The NixOS QEMU module has always been in pretty degraded
state: most of the options are not type-checked or
documented (I think the reason is that the module is not
in the manual, can we fix this too?). Manipulating the
`qemu.options` is painful and `qemu.networkingOptions`
makes a very good footgun. Lots of options are hard-coded
and it's not clear how to override them[1][2].

So, here I try to clean up things a bit and adding some
higher-level options for
- Forwarding ports
- Sharing directories via 9pfs
- Changing screen resolution

The change is quite big but I tried to break into smaller commits.

[1]: https://github.com/NixOS/nixpkgs/issues/18523
[2]: https://github.com/NixOS/nixpkgs/issues/112742

###### Things done

- [x] Tested `virtualisation.resolution`
- [x] Tested host port forwarding
- [x] Tested guest port forwarding
- [x] Tested directory sharing (/nix/store itself is done using the new option)
- [x] Tested `nixos-rebuild build-vm`
- [x] Tested `nixos-build-vms`
- [x] Tested several `nixosTests`
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
