### PR TITLE
bunnyfetch: fix build of bunnyfetch

### DIFF
--- a/pkgs/tools/misc/bunnyfetch/default.nix
+++ b/pkgs/tools/misc/bunnyfetch/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "bunnyfetch";
-  version = "unstable-2021-05-24";
+  version = "unstable-2021-06-19";
 
   src = fetchFromGitHub {
-    owner = "Mewyuna";
-    repo = pname;
-    rev = "7bcc45fb590b37f410e60af893e679eb0729ecb1";
-    sha256 = "1lgqrwmxdxd1d99rr0akydfwcsbcmz75fkbq9zrl842rksnp5q3r";
+    owner = "Rosettea";
+    repo = "bunnyfetch";
+    rev = "24370338b936bae1ebdefea73e8372ac0b4d2858";
+    sha256 = "09wcffx6ak4djm2lrxq43n27p9qmczng4rf11qpwx3w4w67jvpz9";
   };
 
   vendorSha256 = "1vv69y0x06kn99lw995sbkb7vgd0yb18flkr2ml8ss7q2yvz37vi";
@@ -16,11 +16,9 @@ buildGoModule rec {
   # No upstream tests
   doCheck = false;
 
-  subPackages = [ "." ];
-
   meta = with lib; {
     description = "Tiny system info fetch utility";
-    homepage = "https://github.com/Mewyuna/bunnyfetch";
+    homepage = "https://github.com/Rosettea/bunnyfetch";
     license = licenses.mit;
     maintainers = with maintainers; [ devins2518 ];
     platforms = platforms.linux;


### PR DESCRIPTION
bunnyfetch moved organizations and now requires Go 1.16

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The build for `bunnyfetch` is broken. It requires Go 1.16 and has moved from the Mewyuna organization to Rosettea.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
