### PR TITLE
[20.09] dovecot: add patches for CVE-2021-29157 & CVE-2021-33515

### DIFF
--- a/pkgs/servers/mail/dovecot/2.3.13-CVE-2021-29157.patch
+++ b/pkgs/servers/mail/dovecot/2.3.13-CVE-2021-29157.patch
@@ -1,0 +1,332 @@
+Based on upstream commits:
+
+https://github.com/dovecot/core/commit/7f06f6274437ea97142df1f64f322b3ced44d0b3.patch
+https://github.com/dovecot/core/commit/7a77e070ddb6a67fe7a40118ba3e3f9b6062a7d1.patch
+https://github.com/dovecot/core/commit/bae4e44596d6548322665d242b055f44fe1dc58d.patch
+https://github.com/dovecot/core/commit/1c61ba32660d47211dfc97c8a8a9b12f026f152d.patch
+
+with a touch of:
+https://github.com/dovecot/core/commit/d61b5dc49fa5da9d2966c2e39fa036e29665d5a1.patch
+
+adapted by ris to apply to 2.3.13
+
+diff --git a/src/lib-oauth2/oauth2-jwt.c b/src/lib-oauth2/oauth2-jwt.c
+index 83b241c558..94810766f1 100644
+--- a/src/lib-oauth2/oauth2-jwt.c
++++ b/src/lib-oauth2/oauth2-jwt.c
+@@ -45,6 +45,38 @@ get_time_field(const struct json_tree *tree, const char *key, long *value_r)
+ 	return 1;
+ }
+ 
++/* Escapes '.', '/' and '%' in identifier to %hex */
++static const char *escape_identifier(const char *identifier)
++{
++	size_t pos = strcspn(identifier, "./%");
++	if (pos < strlen(identifier)) {
++		/* sanitize identifier, cannot allow dots or / in it, so we
++		  encode them */
++		string_t *new_id = t_str_new(strlen(identifier));
++		/* put initial data */
++		str_append_data(new_id, identifier, pos);
++
++		for (const char *c = identifier+pos; *c != '\0'; c++) {
++			switch (*c) {
++			case '.':
++				str_append(new_id, "%2e");
++				break;
++			case '/':
++				str_append(new_id, "%2f");
++				break;
++			case '%':
++				str_append(new_id, "%25");
++				break;
++			default:
++				str_append_c(new_id, *c);
++				break;
++			}
++		}
++		return str_c(new_id);
++	}
++	return identifier;
++}
++
+ static int
+ oauth2_lookup_hmac_key(const struct oauth2_settings *set, const char *azp,
+ 		       const char *alg, const char *key_id,
+@@ -429,31 +461,8 @@ int oauth2_try_parse_jwt(const struct oauth2_settings *set,
+ 	else if (*kid == '\0') {
+ 		*error_r = "'kid' field is empty";
+ 		return -1;
+-	}
+-
+-	size_t pos = strcspn(kid, "./%");
+-	if (pos < strlen(kid)) {
+-		/* sanitize kid, cannot allow dots or / in it, so we encode them */
+-		string_t *new_kid = t_str_new(strlen(kid));
+-		/* put initial data */
+-		str_append_data(new_kid, kid, pos);
+-		for (const char *c = kid+pos; *c != '\0'; c++) {
+-			switch (*c) {
+-			case '.':
+-				str_append(new_kid, "%2e");
+-				break;
+-			case '/':
+-				str_append(new_kid, "%2f");
+-				break;
+-			case '%':
+-				str_append(new_kid, "%25");
+-				break;
+-			default:
+-				str_append_c(new_kid, *c);
+-				break;
+-			}
+-		}
+-		kid = str_c(new_kid);
++	} else {
++		kid = escape_identifier(kid);
+ 	}
+ 
+ 	/* parse body */
+--- a/src/lib-oauth2/oauth2-jwt.c
++++ b/src/lib-oauth2/oauth2-jwt.c
+@@ -49,32 +49,31 @@ get_time_field(const struct json_tree *tree, const char *key, long *value_r)
+ static const char *escape_identifier(const char *identifier)
+ {
+ 	size_t pos = strcspn(identifier, "./%");
+-	if (pos < strlen(identifier)) {
+-		/* sanitize identifier, cannot allow dots or / in it, so we
+-		  encode them */
+-		string_t *new_id = t_str_new(strlen(identifier));
+-		/* put initial data */
+-		str_append_data(new_id, identifier, pos);
+-
+-		for (const char *c = identifier+pos; *c != '\0'; c++) {
+-			switch (*c) {
+-			case '.':
+-				str_append(new_id, "%2e");
+-				break;
+-			case '/':
+-				str_append(new_id, "%2f");
+-				break;
+-			case '%':
+-				str_append(new_id, "%25");
+-				break;
+-			default:
+-				str_append_c(new_id, *c);
+-				break;
+-			}
+-		}
+-		return str_c(new_id);
++	/* nothing to escape */
++	if (identifier[pos] == '\0')
++		return identifier;
++
++	size_t len = strlen(identifier);
++	string_t *new_id = t_str_new(len);
++	str_append_data(new_id, identifier, pos);
++
++	for (size_t i = pos; i < len; i++) {
++	        switch (identifier[i]) {
++	        case '.':
++	                str_append(new_id, "%2e");
++	                break;
++	        case '/':
++	                str_append(new_id, "%2f");
++	                break;
++	        case '%':
++	                str_append(new_id, "%25");
++	                break;
++	        default:
++	                str_append_c(new_id, identifier[i]);
++	                break;
++	        }
+ 	}
+-	return identifier;
++	return str_c(new_id);
+ }
+ 
+ static int
+ 
+--- a/src/lib-oauth2/test-oauth2-jwt.c
++++ b/src/lib-oauth2/test-oauth2-jwt.c
+@@ -181,12 +181,23 @@ append_key_value(string_t *dest, const char *key, const char *value, bool str)
+ 
+ }
+ 
++#define create_jwt_token_fields(algo, exp, iat, nbf, fields) \
++	create_jwt_token_fields_kid(algo, "default", exp, iat, nbf, fields)
+-static buffer_t *create_jwt_token_fields(const char *algo, time_t exp, time_t iat,
+-					 time_t nbf, ARRAY_TYPE(oauth2_field) *fields)
++static buffer_t *
++create_jwt_token_fields_kid(const char *algo, const char *kid, time_t exp, time_t iat,
++			    time_t nbf, ARRAY_TYPE(oauth2_field) *fields)
+ {
+ 	const struct oauth2_field *field;
+ 	buffer_t *tokenbuf = t_buffer_create(64);
+-	base64url_encode_str(t_strdup_printf(
+-				"{\"alg\":\"%s\",\"typ\":\"JWT\"}", algo), tokenbuf);
++	string_t *hdr = t_str_new(32);
++	str_printfa(hdr, "{\"alg\":\"%s\",\"typ\":\"JWT\"", algo);
++	if (kid != NULL && *kid != '\0') {
++		str_append(hdr, ",\"kid\":\"");
++		json_append_escaped(hdr, kid);
++		str_append_c(hdr, '"');
++	}
++	str_append(hdr, "}");
++	base64url_encode_str(str_c(hdr), tokenbuf);
+ 	buffer_append(tokenbuf, ".", 1);
++
+ 	string_t *bodybuf = t_str_new(64);
+@@ -210,8 +223,12 @@ static buffer_t *create_jwt_token_fields(const char *algo, time_t exp, time_t ia
+ static void save_key_to(const char *algo, const char *name, const char *keydata)
+ {
+ 	const char *error;
+-	struct dict_transaction_context *ctx = dict_transaction_begin(keys_dict);
+-	dict_set(ctx, t_strconcat(DICT_PATH_SHARED, "default/", algo, "/", name, NULL), keydata);
++	struct dict_transaction_context *ctx =
++		dict_transaction_begin(keys_dict);
++	algo = t_str_ucase(algo);
++	dict_set(ctx, t_strconcat(DICT_PATH_SHARED, "default/", algo, "/",
++				  name, NULL),
++		 keydata);
+ 	if (dict_transaction_commit(&ctx, &error) < 0)
+ 		i_error("dict_set(%s) failed: %s", name, error);
+ }
+@@ -298,6 +305,50 @@ static void test_jwt_hs_token(void)
+ 	test_end();
+ }
+ 
++static void test_jwt_token_escape(void)
++{
++	struct test_case {
++		const char *alg;
++		const char *kid;
++		const char *esc_kid;
++	} test_cases[] = {
++		{ "hs256", "", "default" },
++		{ "hs256", "test", "test" },
++		{
++			"hs256",
++			"http://test.unit/local%key",
++			"http:%2f%2ftest%2eunit%2flocal%25key",
++		},
++		{ "hs256", "../", "%2e%2e%2f" },
++	};
++	buffer_t *b64_key =
++		t_base64_encode(0, SIZE_MAX, hs_sign_key->data, hs_sign_key->used);
++	ARRAY_TYPE(oauth2_field) fields;
++	t_array_init(&fields, 8);
++
++	for (size_t i = 0; i < N_ELEMENTS(test_cases); i++) {
++		const struct test_case *test_case = &test_cases[i];
++		array_clear(&fields);
++		struct oauth2_field *field = array_append_space(&fields);
++		field->name = "sub";
++		field->value = "testuser";
++		if (*test_case->kid != '\0') {
++			field = array_append_space(&fields);
++			field->name = "kid";
++			field->value = test_case->kid;
++		}
++		save_key_to(test_case->alg, test_case->esc_kid,
++			    str_c(b64_key));
++		buffer_t *token = create_jwt_token_fields_kid(test_case->alg,
++							      test_case->kid,
++							      time(NULL)+500,
++							      time(NULL)-500,
++							      0, &fields);
++		sign_jwt_token_hs256(token, hs_sign_key);
++		test_jwt_token(str_c(token));
++	}
++}
++
+ static void test_jwt_broken_token(void)
+ {
+ 	struct test_cases {
+@@ -754,6 +805,7 @@ int main(void)
+ 	static void (*test_functions[])(void) = {
+ 		test_do_init,
+ 		test_jwt_hs_token,
++		test_jwt_token_escape,
+ 		test_jwt_bad_valid_token,
+ 		test_jwt_broken_token,
+ 		test_jwt_dates,
+--- a/src/lib-oauth2/oauth2-jwt.c
++++ b/src/lib-oauth2/oauth2-jwt.c
+@@ -408,6 +408,8 @@ oauth2_jwt_body_process(const struct oauth2_settings *set, const char *alg,
+ 	const char *azp = get_field(tree, "azp");
+ 	if (azp == NULL)
+ 		azp = "default";
++	else
++		azp = escape_identifier(azp);
+ 
+ 	if (oauth2_validate_signature(set, azp, alg, kid, blobs, error_r) < 0)
+ 		return -1;
+--- a/src/lib-oauth2/test-oauth2-jwt.c
++++ b/src/lib-oauth2/test-oauth2-jwt.c
+@@ -227,13 +227,15 @@ create_jwt_token_fields_kid(const char *algo, const char *kid, time_t exp, time_
+ }
+ 
+ #define save_key(algo, key) save_key_to(algo, "default", (key))
+-static void save_key_to(const char *algo, const char *name, const char *keydata)
++#define save_key_to(algo, name, key) save_key_azp_to(algo, "default", name, (key))
++static void save_key_azp_to(const char *algo, const char *azp,
++			    const char *name, const char *keydata)
+ {
+ 	const char *error;
+ 	struct dict_transaction_context *ctx =
+ 		dict_transaction_begin(keys_dict);
+ 	algo = t_str_ucase(algo);
+-	dict_set(ctx, t_strconcat(DICT_PATH_SHARED, "default/", algo, "/",
++	dict_set(ctx, t_strconcat(DICT_PATH_SHARED, azp, "/", algo, "/",
+ 				  name, NULL),
+ 		 keydata);
+ 	if (dict_transaction_commit(&ctx, &error) < 0)
+@@ -308,18 +310,23 @@ static void test_jwt_hs_token(void)
+ static void test_jwt_token_escape(void)
+ {
+ 	struct test_case {
++		const char *azp;
+ 		const char *alg;
+ 		const char *kid;
++		const char *esc_azp;
+ 		const char *esc_kid;
+ 	} test_cases[] = {
+-		{ "hs256", "", "default" },
+-		{ "hs256", "test", "test" },
++		{ "", "hs256", "", "default", "default" },
++		{ "", "hs256", "test", "default", "test" },
++		{ "test", "hs256", "test", "test", "test" },
+ 		{
++			"http://test.unit/local%key",
+ 			"hs256",
+ 			"http://test.unit/local%key",
+ 			"http:%2f%2ftest%2eunit%2flocal%25key",
++			"http:%2f%2ftest%2eunit%2flocal%25key"
+ 		},
+-		{ "hs256", "../", "%2e%2e%2f" },
++		{ "../", "hs256", "../", "%2e%2e%2f", "%2e%2e%2f" },
+ 	};
+ 	buffer_t *b64_key =
+ 		t_base64_encode(0, SIZE_MAX, hs_sign_key->data, hs_sign_key->used);
+@@ -332,13 +339,18 @@ static void test_jwt_token_escape(void)
+ 		struct oauth2_field *field = array_append_space(&fields);
+ 		field->name = "sub";
+ 		field->value = "testuser";
++		if (*test_case->azp != '\0') {
++			field = array_append_space(&fields);
++			field->name = "azp";
++			field->value = test_case->azp;
++		}
+ 		if (*test_case->kid != '\0') {
+ 			field = array_append_space(&fields);
+ 			field->name = "kid";
+ 			field->value = test_case->kid;
+ 		}
+-		save_key_to(test_case->alg, test_case->esc_kid,
+-			    str_c(b64_key));
++		save_key_azp_to(test_case->alg, test_case->esc_azp, test_case->esc_kid,
++				str_c(b64_key));
+ 		buffer_t *token = create_jwt_token_fields_kid(test_case->alg,
+ 							      test_case->kid,
+ 							      time(NULL)+500,

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, perl, pkgconfig, systemd, openssl
+{ stdenv, lib, fetchurl, fetchpatch, perl, pkgconfig, systemd, openssl
 , bzip2, zlib, lz4, inotify-tools, pam, libcap, coreutils
 , clucene_core_2, icu, openldap, libsodium, libstemmer, cyrus_sasl
 , nixosTests
@@ -58,6 +58,12 @@ stdenv.mkDerivation rec {
     # so we can symlink plugins from several packages there.
     # The symlinking needs to be done in NixOS.
     ./2.3.x-module_dir.patch
+    ./2.3.13-CVE-2021-29157.patch
+    (fetchpatch {
+      name = "CVE-2021-33515.patch";
+      url = "https://github.com/dovecot/core/commit/65bd1a27a361545c9ccf405b955c72a9c4d29b38.patch";
+      sha256 = "0f1lz6qkwb9cbqc4p40fasr6gcyxxxgx1sxcsbqdypkz099m4psc";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
https://security.archlinux.org/CVE-2021-29157
https://security.archlinux.org/CVE-2021-33515

This firstly enables the tests (in an ugly fashion) to give greater confidence about the validity of the patching. From the commit message:

> this is not how i would want to do it in master, but there's added
> usefulness in adding this here & now given we're about to add
> significant patches

Suggestions welcome as to how we could do this more neatly for `master` but I think this is good enough for a dead-end branch (the problem is that the test harness seems like it clear the test's `PATH` or otherwise does something weird that prevents it from finding utils without their absolute path).

CVE-2021-29157's fix required a little mangling, mostly to work around the results of a source-formatter run they did. Happily includes tests. Please do check up on me that the patch file largely is the combination of the 4 linked commits with minor formatting changes, plus a bit of the source-formatting commit that I needed.

CVE-2021-33515's fix applies cleanly.

Not included: fix for CVE-2020-28200 as it's "only" an excessive resource consumption bug and common opinion is that it's too architecturally significant to backport, looking at it I'm inclined to agree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
