### PR TITLE
whitesur-gtk-theme: init at 2021-06-23

### DIFF
--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, glib
+, gnome-themes-extra
+, libxml2
+, sassc
+, util-linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "whitesur-gtk-theme";
+  version = "2021-06-23";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "075fw57mv6zadq4dryn8bg2b3vq8inmisq18s758cv53pprxh9hw";
+  };
+
+  nativeBuildInputs = [
+    glib
+    libxml2
+    sassc
+    util-linux
+  ];
+
+  buildInputs = [
+    gnome-themes-extra # adwaita engine for Gtk2
+  ];
+
+  postPatch = ''
+    find -name "*.sh" -print0 | while IFS= read -r -d ''' file; do patchShebangs "$file"; done
+
+    # Do not provide `sudo`, as it is not needed in our use case of the install script
+    substituteInPlace lib-core.sh --replace '$(which sudo)' false
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes
+    ./install.sh --dest $out/share/themes --alt all --theme all
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "MacOS Big Sur like theme for Gnome desktops";
+    homepage = "https://github.com/vinceliuice/WhiteSur-gtk-theme";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22656,6 +22656,8 @@ in
 
   weather-icons = callPackage ../data/fonts/weather-icons { };
 
+  whitesur-gtk-theme = callPackage ../data/themes/whitesur { };
+
   whitesur-icon-theme = callPackage ../data/icons/whitesur-icon-theme { };
 
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [WhiteSur-gtk-theme](https://github.com/vinceliuice/WhiteSur-gtk-theme).

Closes https://github.com/NixOS/nixpkgs/issues/127234

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
