### PR TITLE
nixos/nix-daemon: set build machine scheme to SSH

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -466,13 +466,20 @@
         </itemizedlist>
       </listitem>
     </itemizedlist>
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>
           <literal>yggdrasil</literal> was upgraded to a new major
           release with breaking changes, see
           <link xlink:href="https://github.com/yggdrasil-network/yggdrasil-go/releases/tag/v0.4.0">upstream
           changelog</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nix.buildMachines</literal> now ensures remote build
+          machines are configured to use SSH. Previously, it was
+          possible to accidentally use special store types.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -117,6 +117,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `yggdrasil` was upgraded to a new major release with breaking changes, see [upstream changelog](https://github.com/yggdrasil-network/yggdrasil-go/releases/tag/v0.4.0).
 
+- `nix.buildMachines` now ensures remote build machines are configured to use SSH. Previously, it was possible to accidentally use special store types.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -518,12 +518,12 @@ in
     };
 
     # List of machines for distributed Nix builds in the format
-    # expected by build-remote.pl.
+    # expected by libstore/machines.cc.
     environment.etc."nix/machines" =
       { enable = cfg.buildMachines != [];
         text =
           concatMapStrings (machine:
-            "${if machine.sshUser != null then "${machine.sshUser}@" else ""}${machine.hostName} "
+            "ssh://${if machine.sshUser != null then "${machine.sshUser}@" else ""}${machine.hostName} "
             + (if machine.system != null then machine.system else concatStringsSep "," machine.systems)
             + " ${if machine.sshKey != null then machine.sshKey else "-"} ${toString machine.maxJobs} "
             + toString (machine.speedFactor)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently in NixOS's `nix.buildMachines` if a remote builder is set up such that its URI starts with `remote`, `local`, or `auto`, trying to use it as remote builder fails, giving a message like the following:

```
cannot build on 'remote-builder@castor': error: don't know how to open Nix store 'remote-builder@castor'
```

I encountered this when trying to set up a remote builder like this: `nix.buildMachines = [{ hostName = "castor"; sshUser = "remote-builder"; system = "x86_64-linux"; }];`.

Digging deeper I found [Nix expects machine URIs to have a scheme](https://github.com/NixOS/nix/blob/323e5450a1a6e4eb97ba1c9aeba195187cfaff37/src/libstore/machines.cc#L18-L27), with Nix using a heuristic-based fallback that causes the mentioned prefixes to fail here.

As the docs for `nix.buildMachines` indicate it is intended specifically for SSH, the fix is to add the `ssh://` scheme. This technically is a breaking change, as e.g. `nix.buildMachines = [{ hostName = "ssh-ng://example.com"; }, { hostName = "local?root=/tmp/nix"; }];` currently works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
