### PR TITLE
fsearch: init at unstable-2021-06-23

### DIFF
--- a/pkgs/tools/misc/fsearch/default.nix
+++ b/pkgs/tools/misc/fsearch/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gtk3
+, pcre
+, glib
+, desktop-file-utils
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+, unstableGitUpdater
+, gettext
+}:
+
+stdenv.mkDerivation {
+  pname = "fsearch";
+  version = "unstable-2021-06-23";
+
+  src = fetchFromGitHub {
+    owner = "cboxdoerfer";
+    repo = "fsearch";
+    rev = "9300cc03ab2f0cea3a70abb5477bda8b52c4afd1";
+    sha256 = "16qh2si48j113yhay5wawr7dvldks6jb32za41j2sng7n4ryw221";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+    gettext
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    pcre
+  ];
+
+  preFixup = ''
+    substituteInPlace $out/share/applications/io.github.cboxdoerfer.FSearch.desktop \
+      --replace "Exec=fsearch" "Exec=$out/bin/fsearch"
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/cboxdoerfer/fsearch.git";
+  };
+
+  meta = with lib; {
+    description = "A fast file search utility for Unix-like systems based on GTK+3";
+    homepage = "https://github.com/cboxdoerfer/fsearch.git";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ artturin ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13434,6 +13434,8 @@ in
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  fsearch = callPackage ../tools/misc/fsearch { };
+
   fujprog = callPackage ../development/tools/misc/fujprog {
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
