### PR TITLE
git-branchless: init at 0.3.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
@@ -1,0 +1,49 @@
+{ lib, fetchFromGitHub
+
+, coreutils
+, git
+, ncurses
+, rustPlatform
+, sqlite
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-branchless";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "arxanas";
+    repo = "git-branchless";
+    rev = "v${version}";
+    sha256 = "0pfiyb23ah1h6risrhjr8ky7b1k1f3yfc3z70s92q3czdlrk6k07";
+  };
+
+  cargoSha256 = "0gplx80xhpz8kwry7l4nv4rlj9z02jg0sgb6zy1y3vd9s2j5wals";
+
+  # Remove path hardcodes patching if they get fixed upstream, see:
+  # https://github.com/arxanas/git-branchless/issues/26
+  postPatch = ''
+    # Inline test hardcodes `echo` location.
+    substituteInPlace ./src/commands/wrap.rs --replace '/bin/echo' '${coreutils}/bin/echo'
+
+    # Tests in general hardcode `git` location.
+    substituteInPlace ./src/testing.rs --replace '/usr/bin/git' '${git}/bin/git'
+  '';
+
+  buildInputs = [
+    ncurses
+    sqlite
+  ];
+
+  preCheck = ''
+    # Tests require path to git.
+    export PATH_TO_GIT=${git}/bin/git
+  '';
+
+  meta = with lib; {
+    description = "A suite of tools to help you visualize, navigate, manipulate, and repair your commit history";
+    homepage = "https://github.com/arxanas/git-branchless";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5075,6 +5075,8 @@ in
 
   git-big-picture = callPackage ../applications/version-management/git-and-tools/git-big-picture { };
 
+  git-branchless = callPackage ../applications/version-management/git-and-tools/git-branchless { };
+
   inherit (haskellPackages) git-brunch;
 
   git-bug = callPackage ../applications/version-management/git-and-tools/git-bug { };


### PR DESCRIPTION
###### Motivation for this change

[`git-branchless`](https://github.com/arxanas/git-branchless/issues/26) provides useful commands such as

* `git undo` ([blog post](https://blog.waleedkhan.name/git-undo/) about it)
* `git restack` to automatically restack stacked PRs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Co-maintainers wanted! :eyes: 