### PR TITLE
xorg.xf86inputlibinput: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1847,11 +1847,11 @@ lib.makeScope newScope (self: with self; {
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86inputlibinput = callPackage ({ stdenv, pkg-config, fetchurl, xorgproto, libinput, xorgserver }: stdenv.mkDerivation {
-    name = "xf86-input-libinput-1.0.1";
+    name = "xf86-input-libinput-1.1.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/driver/xf86-input-libinput-1.0.1.tar.bz2";
-      sha256 = "0nr4r9x8c7y1l0ipivjch5zps093mxmg2nqmfn2934am26fc9ppx";
+      url = "mirror://xorg/individual/driver/xf86-input-libinput-1.1.0.tar.bz2";
+      sha256 = "05ldqr10f2rrnshyk3lc773rz0gp3ccdzwa8n7lsc94i850jl7g1";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -81,7 +81,7 @@ mirror://xorg/individual/doc/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.6.tar.bz2
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-keyboard-1.9.0.tar.bz2
-mirror://xorg/individual/driver/xf86-input-libinput-1.0.1.tar.bz2
+mirror://xorg/individual/driver/xf86-input-libinput-1.1.0.tar.bz2
 mirror://xorg/individual/driver/xf86-input-mouse-1.9.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-synaptics-1.9.1.tar.bz2
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.1.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-June/003094.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).