### PR TITLE
generate-expr-from-tarballs.pl: use nix-shell as script interpreter

### DIFF
--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -1,10 +1,7 @@
-#! /usr/bin/env perl
+#!/usr/bin/env nix-shell
+#!nix-shell --pure --keep NIX_PATH -i perl -p cacert nix perl
 
-# Usage:
-#
-# manually update tarballs.list
-# then run: cat tarballs.list | perl ./generate-expr-from-tarballs.pl
-
+# Usage: manually update tarballs.list then run: ./generate-expr-from-tarballs.pl tarballs.list
 
 use strict;
 use warnings;


### PR DESCRIPTION
###### Things done
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).