### PR TITLE
ocamlPackages.{camlpdf,cpdf}: 2.3.1 → 2.4

### DIFF
--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -5,26 +5,16 @@ then throw "camlpdf is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "2.3.1";
+  version = "2.4";
   name = "ocaml${ocaml.version}-camlpdf-${version}";
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "camlpdf";
     rev = "v${version}";
-    sha256 = "1q69hhk63z836jbkv4wsng27w35w0qpz01c7ax0mqm8d8kmnr0v4";
+    sha256 = "09kzrgmlxb567315p3fy59ba0kv7xhp548n9i3l4wf9n06p0ww9m";
   };
 
   buildInputs = [ which ocaml findlib ];
-
-  # Version number in META file is wrong
-  patchPhase = ''
-    patch -p 0 META <<EOF
-    3c3
-    < version="1.7.1"
-    ---
-    > version="${version}"
-    EOF
-  '';
 
   preInstall = ''
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -1,6 +1,10 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, camlpdf, ncurses }:
 
-let version = "2.3.1"; in
+if !lib.versionAtLeast ocaml.version "4.10"
+then throw "cpdf is not available for OCaml ${ocaml.version}"
+else
+
+let version = "2.4"; in
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-cpdf-${version}";
@@ -9,19 +13,14 @@ stdenv.mkDerivation {
     owner = "johnwhitington";
     repo = "cpdf-source";
     rev = "v${version}";
-    sha256 = "1gwz0iy28f67kbqap2q10nf98dalwbi03vv5j893z2an7pb4w68z";
+    sha256 = "1a8lmfc76dr8x6pxgm4aypbys02pfma9yh4z3l1qxp2q1909na5l";
   };
-
-  prePatch = ''
-    substituteInPlace META --replace 'version="1.7"' 'version="${version}"'
-  '';
 
   buildInputs = [ ocaml findlib ncurses ];
   propagatedBuildInputs = [ camlpdf ];
 
-  createFindlibDestdir = true;
-
-  postInstall = ''
+  preInstall = ''
+    mkdir -p $OCAMLFIND_DESTDIR
     mkdir -p $out/bin
     cp cpdf $out/bin
     mkdir -p $out/share/


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/johnwhitington/camlpdf/blob/v2.4/Changes

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
