### PR TITLE
hydra-unstable: unbreak

### DIFF
--- a/pkgs/development/libraries/libpqxx/6.nix
+++ b/pkgs/development/libraries/libpqxx/6.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, postgresql, doxygen, xmlto, python2, gnused }:
+
+stdenv.mkDerivation rec {
+  pname = "libpqxx";
+  version = "6.4.5";
+
+  src = fetchFromGitHub {
+    owner = "jtv";
+    repo = pname;
+    rev = version;
+    sha256 = "0djmjr2b5x5nd2a4idv5j8s6w0kdmvil910iv1kyc7x94dirbrni";
+  };
+
+  nativeBuildInputs = [ gnused python2 ];
+  buildInputs = [ postgresql doxygen xmlto ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  configureFlags = [ "--enable-shared" ];
+
+  meta = {
+    description = "A C++ library to access PostgreSQL databases";
+    homepage = "http://pqxx.org/development/libpqxx/";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.eelco ];
+  };
+}

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -1,5 +1,5 @@
 { stdenv, nix, perlPackages, buildEnv
-, makeWrapper, autoconf, automake, libtool, unzip, pkg-config, sqlite, libpqxx
+, makeWrapper, autoconf, automake, libtool, unzip, pkg-config, sqlite, libpqxx_6
 , top-git, mercurial, darcs, subversion, breezy, openssl, bzip2, libxslt
 , perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
 , docbook_xsl, openssh, gnused, coreutils, findutils, gzip, xz, gnutar
@@ -82,7 +82,7 @@ in stdenv.mkDerivation rec {
   inherit stdenv src version patches;
 
   buildInputs =
-    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx
+    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx_6
       top-git mercurial /*darcs*/ subversion breezy openssl bzip2 libxslt
       perlDeps perl nix
       postgresql # for running the tests

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16804,6 +16804,7 @@ in
   libpfm = callPackage ../development/libraries/libpfm { };
 
   libpqxx = callPackage ../development/libraries/libpqxx { };
+  libpqxx_6 = callPackage ../development/libraries/libpqxx/6.nix { };
 
   inherit (callPackages ../development/libraries/prometheus-client-c {
     stdenv = gccStdenv; # Required for darwin


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/126996 broke the build

This is a temporary measure until https://github.com/NixOS/hydra/issues/978 gets resolved

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
