### PR TITLE
vscode: fix source name

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -10,6 +10,9 @@
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot
 , executableName, longName, shortName, pname, updateScript
+# sourceExecutableName is the name of the binary in the source archive, over
+# which we have no control
+, sourceExecutableName ? executableName
 }:
 
 let
@@ -77,12 +80,12 @@ let
     '' + (if system == "x86_64-darwin" then ''
       mkdir -p "$out/Applications/${longName}.app" $out/bin
       cp -r ./* "$out/Applications/${longName}.app"
-      ln -s "$out/Applications/${longName}.app/Contents/Resources/app/bin/${executableName}" $out/bin/${executableName}
+      ln -s "$out/Applications/${longName}.app/Contents/Resources/app/bin/${sourceExecutableName}" $out/bin/${executableName}
     '' else ''
       mkdir -p $out/lib/vscode $out/bin
       cp -r ./* $out/lib/vscode
 
-      ln -s $out/lib/vscode/bin/${executableName} $out/bin
+      ln -s $out/lib/vscode/bin/${sourceExecutableName} $out/bin/${executableName}
 
       mkdir -p $out/share/applications
       ln -s $desktopItem/share/applications/${executableName}.desktop $out/share/applications/${executableName}.desktop

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -25,6 +25,7 @@ in
     version = "1.57.1";
     pname = "vscode";
 
+    sourceExecutableName = "code";
     executableName = "code" + lib.optionalString isInsiders "-insiders";
     longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
     shortName = "Code" + lib.optionalString isInsiders " - Insiders";


### PR DESCRIPTION
###### Motivation for this change

This is an attempt at fixing https://github.com/NixOS/nixpkgs/issues/126272

I assume that the source executable name was always kinda buggy depending on how specifically you configured your VSCode installation in Nix. What I've gathered is that there are only ever two possible executable names in the source archive, `code` and `codium`. This commit introduces a `sourceExecutableName` to the `generic.nix` derivation, which is set to the correct executables.

The target executable name is the same as before. I just added one line to a symlink call so that we use our `executableName` instead of keeping the original name from the archive. That way no change is required in `with-extensions`, which is already inheriting `executableName`. It's probably easier to just check the diff than understand this paragraph, sorry.

I tested this on NixOS and Darwin with

```
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -E '{ ... }: let pkgs = import ./default.nix {}; in pkgs.vscode'
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -E '{ ... }: let pkgs = import ./default.nix {}; in pkgs.vscode.override { isInsiders = true; }'
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -E '{ ... }: let pkgs = import ./default.nix {}; in let foo = pkgs.vscode.override { isInsiders = true; }; in (pkgs.vscode-with-extensions.override { vscode = foo; }).overrideAttrs (old: { inherit (foo) pname version; })'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
