### PR TITLE
scli: pass python dependencies directly

### DIFF
--- a/pkgs/applications/misc/scli/default.nix
+++ b/pkgs/applications/misc/scli/default.nix
@@ -1,12 +1,15 @@
 { lib
-, python3
+, pyqrcode
+, urwid
+, urwid-readline
 , fetchFromGitHub
 , dbus
 , signal-cli
 , xclip
+, buildPythonApplication
 }:
 
-python3.pkgs.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "scli";
   version = "0.6.3";
 
@@ -17,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-QGVBJKTBo2RckGwW1deM2toRPT73PYDLvr7YVepkQvg=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     pyqrcode
     urwid
     urwid-readline

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26610,7 +26610,7 @@ in
 
   scite = callPackage ../applications/editors/scite { };
 
-  scli = callPackage ../applications/misc/scli { };
+  scli = with python3Packages; callPackage ../applications/misc/scli { };
 
   scribus = callPackage ../applications/office/scribus {
     inherit (gnome2) libart_lgpl;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is the pattern recommended by @jonringer when I added the package, was changed by @dotlambda in a recent update PR and I think it should stay in line with Jon's recommendations.

See:
- https://github.com/NixOS/nixpkgs/pull/127797
- https://github.com/NixOS/nixpkgs/pull/122315

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
