### PR TITLE
[21.05] entr: fix segfault on darwin

### DIFF
--- a/pkgs/tools/misc/entr/default.nix
+++ b/pkgs/tools/misc/entr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, coreutils, ncurses }:
+{ lib, stdenv, fetchurl, coreutils, ncurses, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "entr";
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     url = "https://eradman.com/entrproject/code/${pname}-${version}.tar.gz";
     sha256 = "sha256-4lak0vvkb2EyRggzukR+ZdfzW6nQsmXnxBUDl8xEBaI=";
   };
+
+  patches = lib.optionals stdenv.isDarwin [
+    # Fix v4.9 segfault on Darwin. remove with the next update
+    # https://github.com/eradman/entr/issues/74
+    (fetchpatch {
+      url = "https://github.com/eradman/entr/commit/468d77d45925abba826bb1dcda01487dbe37eb33.patch";
+      sha256 = "17kkcrsnac0pb930sf2kix71h4c7krzsrvz8pskx0vm39n1c9xfi";
+      includes = [ "entr.c" ];
+    })
+  ];
 
   postPatch = ''
     substituteInPlace Makefile.bsd --replace /bin/echo echo


### PR DESCRIPTION
(cherry picked from commit 23e36778a13ca70c16535fbbd47590ec4205178d)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Entr is broken on MacOS.

Please note that this is my first backport pull-request. I'm sorry if I missed some step.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
