### PR TITLE
python3Packages.pytest-order: 0.10.0 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-order";
-  version = "0.10.0";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2da32cb95e63fac6972d34f5ddb53997fc66305355425be0f55f4092d666293d";
+    sha256 = "sha256-WZeiYrMSNO67Rh+anvJGh79zICm0mYRaQ5i2nttawyE=";
   };
 
   buildInputs = [ pytest ];
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Pytest plugin that allows you to customize the order in which your tests are run";
-    homepage = "https://github.com/mrbean-bremen/pytest-order";
+    homepage = "https://github.com/pytest-dev/pytest-order";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.jacg ];
   };


### PR DESCRIPTION
###### Motivation for this change
New release.

The PyPI project website links to https://github.com/pytest-dev/pytest-order as the repository, so change the homepage link.

ipfshttpclient fails to build because it is currently broken, with or without this change. I'll fix that in a different PR.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).