### PR TITLE
linux_xanmod: match features on homepage

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-xanmod.nix
+++ b/pkgs/os-specific/linux/kernel/linux-xanmod.nix
@@ -19,6 +19,7 @@ buildLinux (args // rec {
     PREEMPT = lib.mkForce yes;
     PREEMPT_VOLUNTARY = lib.mkForce no;
     NO_HZ_FULL = yes;
+    HZ_500 = yes;
   };
 
   extraMeta = {

--- a/pkgs/os-specific/linux/kernel/linux-xanmod.nix
+++ b/pkgs/os-specific/linux/kernel/linux-xanmod.nix
@@ -18,6 +18,7 @@ buildLinux (args // rec {
   structuredExtraConfig = with lib.kernel; {
     PREEMPT = lib.mkForce yes;
     PREEMPT_VOLUNTARY = lib.mkForce no;
+    NO_HZ_FULL = yes;
   };
 
   extraMeta = {

--- a/pkgs/os-specific/linux/kernel/linux-xanmod.nix
+++ b/pkgs/os-specific/linux/kernel/linux-xanmod.nix
@@ -15,6 +15,11 @@ buildLinux (args // rec {
     sha256 = "sha256-eFIWlguU1hnkAgTbRxSMTStq0X7XW4IT1/9XlQSgdMQ=";
   };
 
+  structuredExtraConfig = with lib.kernel; {
+    PREEMPT = lib.mkForce yes;
+    PREEMPT_VOLUNTARY = lib.mkForce no;
+  };
+
   extraMeta = {
     branch = "5.12-cacule";
     maintainers = with lib.maintainers; [ fortuneteller2k ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Looking at the kernel config, some things that xanmod users would expect aren't present, such as having `PREEMPT` enabled.

This PR aims to match the claims of the website, specifically:

- [x] Enabling preemption (`PREEMPT`)
- [x] Allow kernel to be tickless when possible (`NO_HZ_FULL`)
- [x] Have a 500 Hz tick rate (`HZ_500`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
