### PR TITLE
cm-rgb: 0.3.4 -> 0.3.6

### DIFF
--- a/pkgs/tools/system/cm-rgb/default.nix
+++ b/pkgs/tools/system/cm-rgb/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonApplication rec {
   pname = "cm-rgb";
-  version = "0.3.4";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "gfduszynski";
     repo = pname;
     rev = "v${version}";
-    sha256 = "04brldaa2zpvzkcg43i5hpbj03d1nqrgiplm5nh4shn12cif19ag";
+    sha256 = "sha256-m0ZAjSLRzcjzygLEbvCiDd7krc1gRqTg1ZV4H/o2c68=";
   };
 
   nativeBuildInputs = [
@@ -37,10 +37,6 @@ buildPythonApplication rec {
   ];
 
   postInstall = ''
-    # Remove this line when/if this PR gets merged:
-    # https://github.com/gfduszynski/cm-rgb/pull/43
-    install -m0755 scripts/cm-rgb-gui $out/bin/cm-rgb-gui
-
     mkdir -p $out/etc/udev/rules.d
     echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="2516", ATTR{idProduct}=="0051", TAG+="uaccess"' \
       > $out/etc/udev/rules.d/60-cm-rgb.rules
@@ -51,7 +47,7 @@ buildPythonApplication rec {
     longDescription = ''
       cm-rgb controls AMD Wraith Prism RGB LEDS.
 
-      To permit non-root accounts to change use this utility on
+      To permit non-root accounts to use this utility on
       NixOS, add this package to <literal>services.udev.packages</literal>
       in <filename>configuration.nix</filename>.
     '';


### PR DESCRIPTION
###### Motivation for this change
https://github.com/gfduszynski/cm-rgb/releases/tag/v0.3.6

Executing cm-rgb-gui fails but this is also the case for 0.3.4.
I reviewed all the code changes between the two versions and it looks fine with only one small change to the actual code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).