### PR TITLE
tinywl: init at 0.14.0

### DIFF
--- a/pkgs/applications/window-managers/tinywl/default.nix
+++ b/pkgs/applications/window-managers/tinywl/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, wlroots, pkg-config
+, libxkbcommon, pixman, udev, wayland, wayland-protocols
+}:
+
+stdenv.mkDerivation {
+  pname = "tinywl";
+  inherit (wlroots) version src;
+
+  sourceRoot = "source/tinywl";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libxkbcommon pixman udev wayland wayland-protocols wlroots ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp tinywl $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/swaywm/wlroots/tree/master/tinywl";
+    description = ''"minimum viable product" Wayland compositor based on wlroots.'';
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.cc0;
+    inherit (wlroots.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27192,6 +27192,8 @@ in
 
   trayer = callPackage ../applications/window-managers/trayer { };
 
+  tinywl = callPackage ../applications/window-managers/tinywl { };
+
   tinywm = callPackage ../applications/window-managers/tinywm { };
 
   tree-from-tags = callPackage ../applications/audio/tree-from-tags { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

tinywl is the wlroots reference compositor.  It's very useful when
debugging Wayland/wlroots problems as it helps with determining
whether an issue is the fault of a compositor or of wlroots.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
