### PR TITLE
WIP: haskell/generic-builder: add benchmarkPhase

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -24,6 +24,8 @@ in
 , description ? null
 , doCheck ? !isCross && lib.versionOlder "7.4" ghc.version
 , doBenchmark ? false
+, benchmarkPhase ? null, preBenchmark ? null, postBenchmark ? null
+, benchTarget ? "", benchFlags ? ""
 , doHoogle ? true
 , doHaddockQuickjump ? doHoogle && lib.versionAtLeast ghc.version "8.6"
 , editedCabalFile ? null
@@ -301,7 +303,7 @@ stdenv.mkDerivation ({
 
   prePhases = ["setupCompilerEnvironmentPhase"];
   preConfigurePhases = ["compileBuildDriverPhase"];
-  preInstallPhases = ["haddockPhase"];
+  preInstallPhases = ["benchmarkPhase" "haddockPhase"];
 
   inherit src;
 
@@ -462,6 +464,12 @@ stdenv.mkDerivation ({
     checkFlagsArray+=(${lib.escapeShellArgs (builtins.map (opt: "--test-option=${opt}") testFlags)})
     ${setupCommand} test ${testTarget} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}
     runHook postCheck
+  '';
+
+  benchmarkPhase = ''
+    runHook preBenchmark
+    ${setupCommand} bench ${benchTarget} ${benchFlags}
+    runHook postBenchmark
   '';
 
   haddockPhase = ''
@@ -677,7 +685,9 @@ stdenv.mkDerivation ({
 // optionalAttrs (args ? postConfigure)          { inherit postConfigure; }
 // optionalAttrs (args ? preBuild)               { inherit preBuild; }
 // optionalAttrs (args ? postBuild)              { inherit postBuild; }
-// optionalAttrs (args ? doBenchmark)            { inherit doBenchmark; }
+// optionalAttrs (args ? benchmarkPhase)         { inherit benchmarkPhase; }
+// optionalAttrs (args ? preBenchmark)           { inherit preBenchmark; }
+// optionalAttrs (args ? postBenchmark)          { inherit postBenchmark; }
 // optionalAttrs (args ? checkPhase)             { inherit checkPhase; }
 // optionalAttrs (args ? preCheck)               { inherit preCheck; }
 // optionalAttrs (args ? postCheck)              { inherit postCheck; }


### PR DESCRIPTION
###### Motivation for this change
I should be able to run haskell benchmarks as part of my nix-build (similarly to how i can run tests)
###### Things done
Added a benchmarkPhase to the generic-builder

This is currently WIP/Draft for two reasons: 
 1) I need to make the benchmark flags a bit more fine-grained (I'll probably just end up mimicking what `checkPhase` does)
 2) I am a bit concerned about the following scenario and wanted to discuss: 
 I'd imagine that there are codebases that have worked around this current limitation by enabling `doBenchmark` to add the `enable-benchmarks` flag to configuration, but then have their own custom benchmark phase (probably as a `postBuildPhase`. Upgrading nixpkgs would suddenly (and silently) run the benchmark 2x. So i guess my question is: How has haskell nixpkgs traditionally dealt with something like this in the past?

@cdepillabout : this is the pr we were talking about yesterday

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
