### PR TITLE
p4est, p4est-sc: init at current prev3-develop tip

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1701,6 +1701,18 @@
     githubId = 3471749;
     name = "Claudio Bley";
   };
+  cburstedde = {
+    email = "burstedde@ins.uni-bonn.de";
+    github = "cburstedde";
+    githubId = 109908;
+    name = "Carsten Burstedde";
+    keys = [
+      {
+        longkeyid = "rsa2048/0x0704CD9E550A6BCD";
+        fingerprint = "1127 A432 6524 BF02 737B  544E 0704 CD9E 550A 6BCD";
+      }
+    ];
+  };
   cdepillabout = {
     email = "cdep.illabout@gmail.com";
     github = "cdepillabout";

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -36,8 +36,7 @@ stdenv.mkDerivation {
     ${if mpiSupport then "unset CC" else ""}
   '';
 
-  configureFlags = [ ]
-    ++ lib.optional debugEnable "--enable-debug"
+  configureFlags = lib.optional debugEnable "--enable-debug"
     ++ lib.optional mpiSupport "--enable-mpi"
   ;
 

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -1,0 +1,63 @@
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook, pkg-config
+, p4est-sc-debugEnable ? true, p4est-sc-mpiSupport ? true
+, mpi, openmpi, openssh, zlib
+}:
+
+let
+  dbg = if debugEnable then "-dbg" else "";
+  debugEnable = p4est-sc-debugEnable;
+  mpiSupport = p4est-sc-mpiSupport;
+in
+stdenv.mkDerivation {
+  pname = "p4est-sc${dbg}";
+  version = "unstable-2021-06-14";
+
+  # fetch an untagged snapshot of the prev3-develop branch
+  src = fetchFromGitHub {
+    owner = "cburstedde";
+    repo = "libsc";
+    rev = "1ae814e3fb1cc5456652e0d77550386842cb9bfb";
+    sha256 = "14vm0b162jh8399pgpsikbwq4z5lkrw9vfzy3drqykw09n6nc53z";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  propagatedBuildInputs = [ zlib ]
+    ++ lib.optional mpiSupport mpi
+    ++ lib.optional (mpiSupport && mpi == openmpi) openssh
+  ;
+  inherit debugEnable mpiSupport;
+
+  postPatch = ''
+    echo "dist_scaclocal_DATA += config/sc_v4l2.m4" >> Makefile.am
+  '';
+  preConfigure = ''
+    echo "2.8.0" > .tarball-version
+    ${if mpiSupport then "unset CC" else ""}
+  '';
+
+  configureFlags = [ ]
+    ++ lib.optional debugEnable "--enable-debug"
+    ++ lib.optional mpiSupport "--enable-mpi"
+  ;
+
+  makeFlags = [ "V=0" ];
+
+  dontDisableStatic = true;
+  enableParallelBuilding = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+
+  meta = {
+    branch = "prev3-develop";
+    description = "Support for parallel scientific applications";
+    longDescription = ''
+      The SC library provides support for parallel scientific applications.
+      Its main purpose is to support the p4est software library, hence
+      this package is called p4est-sc, but it works standalone, too.
+    '';
+    homepage = "https://www.p4est.org/";
+    downloadPage = "https://github.com/cburstedde/libsc.git";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.cburstedde ];
+  };
+}

--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook, pkg-config
+, p4est-withMetis ? true, metis
+, p4est-sc
+}:
+
+let
+  inherit (p4est-sc) debugEnable mpiSupport;
+  dbg = if debugEnable then "-dbg" else "";
+  withMetis = p4est-withMetis;
+in
+stdenv.mkDerivation {
+  pname = "p4est${dbg}";
+  version = "unstable-2021-06-22";
+
+  # fetch an untagged snapshot of the prev3-develop branch
+  src = fetchFromGitHub {
+    owner = "cburstedde";
+    repo = "p4est";
+    rev = "7423ac5f2b2b64490a7a92e5ddcbd251053c4dee";
+    sha256 = "0vffnf48rzw6d0as4c3x1f31b4kapmdzr1hfj5rz5ngah72gqrph";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  propagatedBuildInputs = [ p4est-sc ];
+  buildInputs = lib.optional withMetis metis;
+  inherit debugEnable mpiSupport withMetis;
+
+  patches = [ ./p4est-metis.patch ];
+  postPatch = ''
+    sed -i -e "s:\(^\s*ACLOCAL_AMFLAGS.*\)\s@P4EST_SC_AMFLAGS@\s*$:\1 -I ${p4est-sc}/share/aclocal:" Makefile.am
+  '';
+  preConfigure = ''
+    echo "2.8.0" > .tarball-version
+    ${if mpiSupport then "unset CC" else ""}
+  '';
+
+  configureFlags = [ "--with-sc=${p4est-sc}" ]
+    ++ lib.optional withMetis "--with-metis"
+    ++ lib.optional debugEnable "--enable-debug"
+    ++ lib.optional mpiSupport "--enable-mpi"
+  ;
+
+  inherit (p4est-sc) makeFlags dontDisableStatic enableParallelBuilding doCheck;
+
+  meta = {
+    branch = "prev3-develop";
+    description = "Parallel AMR on Forests of Octrees";
+    longDescription = ''
+      The p4est software library provides algorithms for parallel AMR.
+      AMR refers to Adaptive Mesh Refinement, a technique in scientific
+      computing to cover the domain of a simulation with an adaptive mesh.
+    '';
+    homepage = "https://www.p4est.org/";
+    downloadPage = "https://github.com/cburstedde/p4est.git";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.cburstedde ];
+  };
+}

--- a/pkgs/development/libraries/science/math/p4est/p4est-metis.patch
+++ b/pkgs/development/libraries/science/math/p4est/p4est-metis.patch
@@ -1,0 +1,26 @@
+diff --git a/src/p4est_connectivity.c b/src/p4est_connectivity.c
+index 95339136..c93528f2 100644
+--- a/src/p4est_connectivity.c
++++ b/src/p4est_connectivity.c
+@@ -3715,6 +3715,7 @@ p4est_connectivity_reorder_newid (sc_MPI_Comm comm, int k,
+                                   sc_array_t * newid)
+ {
+   const int           n = (int) conn->num_trees;
++  int                 metis_n;
+   int                *xadj;
+   int                *adjncy;
+   int                *part;
+@@ -3862,10 +3863,12 @@ p4est_connectivity_reorder_newid (sc_MPI_Comm comm, int k,
+ 
+     P4EST_GLOBAL_INFO ("Entering metis\n");
+     /* now call metis */
++    metis_n = n;
+     P4EST_EXECUTE_ASSERT_INT
+-      (METIS_PartGraphRecursive (&n, &ncon, xadj, adjncy, NULL, NULL,
++      (METIS_PartGraphRecursive (&metis_n, &ncon, xadj, adjncy, NULL, NULL,
+                                  NULL, &k, NULL, NULL, NULL, &volume, part),
+        METIS_OK);
++    P4EST_ASSERT (metis_n == n);
+     P4EST_GLOBAL_INFO ("Done metis\n");
+ 
+     P4EST_GLOBAL_STATISTICSF ("metis volume %d\n", volume);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29871,6 +29871,12 @@ in
 
   p4est-sc-dbg = callPackage ../development/libraries/science/math/p4est-sc { };
 
+  p4est = callPackage ../development/libraries/science/math/p4est { };
+
+  p4est-dbg = callPackage ../development/libraries/science/math/p4est {
+    p4est-sc = p4est-sc-dbg;
+  };
+
   petsc = callPackage ../development/libraries/science/math/petsc { };
 
   parmetis = callPackage ../development/libraries/science/math/parmetis { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29865,6 +29865,12 @@ in
 
   rubiks = callPackage ../development/libraries/science/math/rubiks { };
 
+  p4est-sc = callPackage ../development/libraries/science/math/p4est-sc {
+    p4est-sc-debugEnable = false;
+  };
+
+  p4est-sc-dbg = callPackage ../development/libraries/science/math/p4est-sc { };
+
   petsc = callPackage ../development/libraries/science/math/petsc { };
 
   parmetis = callPackage ../development/libraries/science/math/parmetis { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add new package p4est and its support package p4est-sc to nixpkgs.
Adding two versions of each, namely a production and a debug compile.
p4est is a software library used for scientific computing and solving partial differential equations.
It manages a forest of octrees representing a parallel adaptive mesh of a computational domain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).