### PR TITLE
protege-distribution: refactor patching process and icon generation

### DIFF
--- a/pkgs/development/web/protege-distribution/default.nix
+++ b/pkgs/development/web/protege-distribution/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
       desktopName = "Protege Desktop";
       icon = "protege";
       comment = "OWL2 ontology editor";
+      categories = "Development";
       exec = "run-protege";
     })
   ];

--- a/pkgs/development/web/protege-distribution/default.nix
+++ b/pkgs/development/web/protege-distribution/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl, unzip, jre8, copyDesktopItems, makeDesktopItem }:
+{ lib, stdenv, fetchurl, unzip, jre8
+, copyDesktopItems
+, makeDesktopItem
+, iconConvTools
+}:
 
 stdenv.mkDerivation rec {
   pname = "protege-distribution";
@@ -9,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "092x22wyisdnhccx817mqq15sxqdfc7iz4whr4mbvzrd9di6ipjq";
   };
 
-  nativeBuildInputs = [ unzip copyDesktopItems ];
+  nativeBuildInputs = [ unzip copyDesktopItems iconConvTools ];
 
   patches = [
     # Replace logic for searching the install directory with a static cd into $out
@@ -40,8 +44,8 @@ stdenv.mkDerivation rec {
     # Move launch script into /bin, giving it a recognizable name
     install -D run.sh $out/bin/run-protege
 
-    # Copy icon to where it can be found
-    install -D app/Protege.ico $out/share/icons/hicolor/128x128/apps/protege.ico
+    # Generate and copy icons to where they can be found
+    icoFileToHiColorTheme app/Protege.ico protege $out
 
     # Move everything else under protege/
     mkdir $out/protege
@@ -54,7 +58,7 @@ stdenv.mkDerivation rec {
     (makeDesktopItem {
       name = "Protege";
       desktopName = "Protege Desktop";
-      icon = "protege.ico";
+      icon = "protege";
       comment = "OWL2 ontology editor";
       exec = "run-protege";
     })

--- a/pkgs/development/web/protege-distribution/disable-console-log.patch
+++ b/pkgs/development/web/protege-distribution/disable-console-log.patch
@@ -1,0 +1,28 @@
+--- a/conf/logback.xml	2021-06-25 00:49:10.446416341 +0900
++++ b/conf/logback.xml	2021-06-25 00:50:32.889120465 +0900
+@@ -1,13 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <configuration scan="true" scanPeriod="10 seconds">
+ 
+-    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+-            <Pattern>%highlight(%msg) %n</Pattern>
+-        </encoder>
+-    </appender>
+-
+-
+     <appender name="files" class="ch.qos.logback.core.FileAppender">
+         <file>${user.home}/.Protege/logs/protege.log</file>
+         <append>true</append>
+@@ -18,9 +11,8 @@
+ 
+ 
+     <root level="info">
+-        <appender-ref ref="stdout" />
+         <appender-ref ref="files"/>
+     </root>
+ 
+ 
+-</configuration>
+\ No newline at end of file
++</configuration>

--- a/pkgs/development/web/protege-distribution/static-path.patch
+++ b/pkgs/development/web/protege-distribution/static-path.patch
@@ -1,0 +1,16 @@
+--- a/run.sh	2021-06-24 22:30:20.764897745 +0900
++++ b/run.sh	2021-06-24 22:29:47.211210142 +0900
+@@ -1,12 +1,6 @@
+ #!/usr/bin/env bash
+ 
+-SOURCE="${BASH_SOURCE[0]}"
+-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+-  SOURCE="$(readlink "$SOURCE")"
+-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+-done
+-cd "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
++cd @out@/protege
+ 
+ java -Xmx500M -Xms200M \
+      -Xss16M \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Following the discussion stimulated by the merge of https://github.com/NixOS/nixpkgs/pull/127396 in place of https://github.com/NixOS/nixpkgs/pull/97365, I included in this PR the following suggested improvements:
- more stable and self-documenting patching process
- automatic production of icon images from the upstream `.ico` file

Refer to https://github.com/NixOS/nixpkgs/pull/127396#issuecomment-864947179, https://github.com/NixOS/nixpkgs/pull/127396#issuecomment-865119400 and https://github.com/NixOS/nixpkgs/pull/127396#issuecomment-865365527 for the full rationale.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
