### PR TITLE
jquake: discard debug messages by default

### DIFF
--- a/pkgs/applications/misc/jquake/default.nix
+++ b/pkgs/applications/misc/jquake/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchurl, copyDesktopItems, makeDesktopItem, unzip, jre8 }:
+{ lib, stdenv, fetchurl, copyDesktopItems, makeDesktopItem, unzip, jre8
+, logOutput ? false
+}:
 
 stdenv.mkDerivation rec {
   pname = "jquake";
@@ -14,10 +16,9 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   postPatch = ''
-    # JQuake emits a lot of debug-like messages in console, but I
-    # don't think it's in our interest to void them by default. Log them at
-    # the appropriate level.
-    sed -i "/^java/ s/$/\ | logger -p user.debug/" JQuake.sh
+    # JQuake emits a lot of debug-like messages on stdout. Either drop the output
+    # stream entirely or log them at 'user.debug' level.
+    sed -i "/^java/ s/$/ ${if logOutput then "| logger -p user.debug" else "> \\/dev\\/null"}/" JQuake.sh
 
     # By default, an 'errors.log' file is created in the current directory.
     # cd into a temporary directory and let it be created there.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The amount of log messages sent over stdout by JQuake is noticeable, with a few lines written every second. This can quickly saturate the system logs, if the logger is not configured to not persist `user.debug` messages.

Give users the choice between logging these messages, like before, or discarding them directly. By default, all messages are discarded to avoid unintended storage space exhaustion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
