### PR TITLE
inkscape-extensions.applytransforms: 0.0.0+unstable=2021-05-11

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -4,6 +4,7 @@
 , cairo
 , cmake
 , fetchurl
+, fetchpatch
 , gettext
 , ghostscript
 , glib
@@ -70,6 +71,15 @@ stdenv.mkDerivation rec {
       # Python is used at run-time to execute scripts,
       # e.g., those from the "Effects" menu.
       python3 = "${python3Env}/bin/python";
+    })
+
+    # Fix parsing paths by Python extensions.
+    # https://gitlab.com/inkscape/extensions/-/merge_requests/342
+    (fetchpatch {
+      url = "https://gitlab.com/inkscape/extensions/-/commit/a82c382c610d37837c8f3f5b13224bab8fd3667e.patch";
+      sha256 = "YWrgjCnQ9q6BUsxSLQojIXnDzPxM/SgrIfj1gxQ/JKM=";
+      stripLen = 1;
+      extraPrefix = "share/extensions/";
     })
   ];
 

--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -2,9 +2,12 @@
 , fetchFromGitHub
 , runCommand
 , inkcut
+, callPackage
 }:
 
 {
+  applytransforms = callPackage ./extensions/applytransforms { };
+
   hexmap = stdenv.mkDerivation {
     name = "hexmap";
     version = "2020-06-06";

--- a/pkgs/applications/graphics/inkscape/extensions/applytransforms/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/applytransforms/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+}:
+
+stdenv.mkDerivation {
+  pname = "inkscape-applytransforms";
+  version = "0.0.0+unstable=2021-05-11";
+
+  src = fetchFromGitHub {
+    owner = "Klowner";
+    repo = "inkscape-applytransforms";
+    rev = "5b3ed4af0fb66e399e686fc2b649b56db84f6042";
+    sha256 = "XWwkuw+Um/cflRWjIeIgQUxJLrk2DLDmx7K+pMWvIlI=";
+  };
+
+  checkInputs = [
+    python3.pkgs.inkex
+    python3.pkgs.pytestCheckHook
+  ];
+
+  dontBuild = true;
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt "$out/share/inkscape/extensions" *.inx *.py
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Inkscape extension which removes all matrix transforms by applying them recursively to shapes";
+    homepage = "https://github.com/Klowner/inkscape-applytransforms";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/inkscape/with-extensions.nix
+++ b/pkgs/applications/graphics/inkscape/with-extensions.nix
@@ -2,13 +2,19 @@
 , inkscape
 , symlinkJoin
 , makeWrapper
-, inkscapeExtensions ? []
+, inkscapeExtensions ? [ ]
+, inkscape-extensions
 }:
+
+let
+  allExtensions = lib.filter (pkg: lib.isDerivation pkg && !pkg.meta.broken or false) (lib.attrValues inkscape-extensions);
+  selectedExtensions = if inkscapeExtensions == null then allExtensions else inkscapeExtensions;
+in
 
 symlinkJoin {
   name = "inkscape-with-extensions-${lib.getVersion inkscape}";
 
-  paths = [ inkscape ] ++ inkscapeExtensions;
+  paths = [ inkscape ] ++ selectedExtensions;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, inkscape
+, lxml
+, python
+}:
+
+buildPythonPackage {
+  pname = "inkex";
+  inherit (inkscape) version;
+
+  format = "other";
+
+  propagatedBuildInputs = [
+    lxml
+  ];
+
+  # We just copy the files.
+  dontUnpack = true;
+  dontBuild = true;
+
+  # No tests installed.
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/${python.sitePackages}"
+    cp -r "${inkscape}/share/inkscape/extensions/inkex" "$out/${python.sitePackages}"
+
+    runHook postInstall
+  '';
+
+  meta = inkscape.meta // {
+    description = "Inkscape Extensions Library";
+    longDescription = ''
+      This module provides support for inkscape extensions, it includes support for opening svg files and processing them.
+
+      Standalone, it is especially useful for running tests for Inkscape extensions.
+    '';
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3493,6 +3493,8 @@ in {
 
   injector = callPackage ../development/python-modules/injector { };
 
+  inkex = callPackage ../development/python-modules/inkex { };
+
   inotify-simple = callPackage ../development/python-modules/inotify-simple { };
 
   inquirer = callPackage ../development/python-modules/inquirer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
