### PR TITLE
Add txredisapi to matrix-synapse dependencies

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -161,6 +161,7 @@ with lib.maintainers; {
       ekleog
       ralith
       mjlbach
+      dandellion
     ];
     scope = "Maintain the ecosystem around Matrix, a decentralized messenger.";
   };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -431,6 +431,7 @@ in
   trezord = handleTest ./trezord.nix {};
   trickster = handleTest ./trickster.nix {};
   trilium-server = handleTestOn ["x86_64-linux"] ./trilium-server.nix {};
+  txredisapi = handleTest ./txredisapi.nix {};
   tuptime = handleTest ./tuptime.nix {};
   turbovnc-headless-server = handleTest ./turbovnc-headless-server.nix {};
   ucarp = handleTest ./ucarp.nix {};

--- a/nixos/tests/txredisapi.nix
+++ b/nixos/tests/txredisapi.nix
@@ -1,0 +1,27 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+{
+  name = "txredisapi";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ dandellion ];
+  };
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+
+      {
+        services.redis.enable = true;
+        services.redis.unixSocket = "/run/redis/redis.sock";
+
+        environment.systemPackages = with pkgs; [ (python38.withPackages (ps: [ ps.twisted ps.txredisapi ps.mock ]))];
+      };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("redis")
+    machine.wait_for_open_port("6379")
+
+    tests = machine.succeed("PYTHONPATH=\"${pkgs.python3Packages.txredisapi.src}\" python -m twisted.trial ${pkgs.python3Packages.txredisapi.src}/tests")
+  '';
+})

--- a/pkgs/development/python-modules/txredisapi/default.nix
+++ b/pkgs/development/python-modules/txredisapi/default.nix
@@ -16,6 +16,8 @@ buildPythonPackage rec {
   doCheck = false;
   pythonImportsCheck = [ "txredisapi" ];
 
+  passthru.tests.unit-tests = nixosTests.txredisapi;
+
   meta = with lib; {
     homepage = "https://github.com/IlyaSkriblovsky/txredisapi";
     description = "non-blocking redis client for python";

--- a/pkgs/development/python-modules/txredisapi/default.nix
+++ b/pkgs/development/python-modules/txredisapi/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, nixosTests, six, twisted }:
+
+buildPythonPackage rec {
+  pname = "txredisapi";
+  version = "1.4.7";
+
+  src = fetchFromGitHub {
+    owner = "IlyaSkriblovsky";
+    repo = "txredisapi";
+    rev = "1.4.7";
+    sha256 = "1f7j3c5l7jcfphvsk7nqmgyb4jaydbzq081m555kw0f9xxak0pgq";
+  };
+
+  propagatedBuildInputs = [ six twisted ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "txredisapi" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/IlyaSkriblovsky/txredisapi";
+    description = "non-blocking redis client for python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}
+

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -60,7 +60,7 @@ buildPythonApplication rec {
     typing-extensions
     unpaddedbase64
   ] ++ lib.optional enableSystemd systemd
-    ++ lib.optional enableRedis hiredis;
+    ++ lib.optionals enableRedis [ hiredis txredisapi ];
 
   checkInputs = [ mock parameterized openssl ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8699,6 +8699,8 @@ in {
 
   txgithub = callPackage ../development/python-modules/txgithub { };
 
+  txredisapi = callPackage ../development/python-modules/txredisapi { };
+
   txrequests = callPackage ../development/python-modules/txrequests { };
 
   txtorcon = callPackage ../development/python-modules/txtorcon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
When using workers with synapse txredisapi is required.

###### Things done

I've been using basically this for half a year+ with a module with worker support.

I'm not sure if it makes sense at all to do the unit testing like this for the txredisapi package. If someone has an opinion on keeping/improving/or removing I'm all ears.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
