### PR TITLE
manual: Fix missing semicolon in custom keyboard layout example

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -241,11 +241,11 @@ xkb_symbols &quot;us-greek&quot;
   description = "US layout with alt-gr greek";
   languages   = [ "eng" ];
   symbolsFile = /yourpath/symbols/us-greek;
-}
+};
 </programlisting>
   <note>
   <para>
-   The name should match the one given to the
+   The name (after <literal>extraLayouts.</literal>) should match the one given to the
    <literal>xkb_symbols</literal> block.
   </para>
   </note>


### PR DESCRIPTION
###### Motivation for this change

Typos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Doc-only change.
