### PR TITLE
apt-offline: 1.8.1 -> unstable-2021-04-11

### DIFF
--- a/pkgs/tools/misc/apt-offline/default.nix
+++ b/pkgs/tools/misc/apt-offline/default.nix
@@ -1,22 +1,39 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib, fetchFromGitHub, python3Packages, unstableGitUpdater, gnupg }:
 
 python3Packages.buildPythonApplication rec {
-  version = "1.8.1";
   pname = "apt-offline";
+  version = "unstable-2021-04-11";
 
   src = fetchFromGitHub {
     owner = "rickysarraf";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0k79d1d8jiwg1s684r05njmk1dz8gsb8a9bl4agz7m31snc11j84";
+    rev = "4e4b3281d004d1ece4833b7680e2b5b091402a03";
+    sha256 = "1lk4186h2wc8fphd592rhq7yj4kgc7jjawx4pjrs6pg4n0q32pl6";
   };
+
+  postPatch = ''
+    substituteInPlace org.debian.apt.aptoffline.policy \
+      --replace /usr/bin/ "$out/bin"
+
+    substituteInPlace apt_offline_core/AptOfflineCoreLib.py \
+      --replace /usr/bin/gpgv "${gnupg}/bin/gpgv"
+  '';
+
+  preFixup = ''
+    rm "$out/bin/apt-offline-gui"
+    rm "$out/bin/apt-offline-gui-pkexec"
+  '';
 
   doCheck = false;
 
-  # Requires python-qt4 (feel free to get it working).
-  preFixup = ''rm "$out/bin/apt-offline-gui"'';
+  pythonimportsCheck = [ "apt-offline" ];
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/rickysarraf/apt-offline.git";
+  };
 
   meta = with lib; {
+    homepage = "https://github.com/rickysarraf/apt-offline";
     description = "Offline APT package manager";
     license = licenses.gpl3;
     maintainers = [ ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#90298

###### Things done

```
./result/bin/apt-offline --help
usage: apt-offline [-h] [--verbose] [-v] {set,get,install} ...

Offline APT Package Manager - 1.8.2

positional arguments:
  {set,get,install}

optional arguments:
  -h, --help         show this help message and exit
  --verbose          Enable verbose messages
  -v, --version      show program's version number and exit

(C) 2005 - 2020 Ritesh Raj Sarraf - This program comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to
redistribute it under the GNU GPL Version 3 (or later) License
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
