### PR TITLE
why3: 1.3.3 → 1.4.0; framac: 22.0 → 23.0-rc1

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     # Documentation
     rubber hevea
     # GUI
-    lablgtk
+    lablgtk3-sourceview3
     # WebIDE
     js_of_ocaml js_of_ocaml-ppx
     # S-expression output for why3pp

--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -3,16 +3,15 @@
 
 stdenv.mkDerivation {
   pname = "why3";
-  version = "1.3.3";
+  version = "1.4.0";
 
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/38367/why3-1.3.3.tar.gz";
-    sha256 = "1n0a2nn1gnk0zg339lh698g4wpk7m8m1vyi2yvifd5adqvk4milw";
+    url = "https://gforge.inria.fr/frs/download.php/file/38425/why3-1.4.0.tar.gz";
+    sha256 = "0lw0cpx347zz9vvwqibmbxgs80fsd16scgk3isscvwxnajpc3rv8";
   };
 
   buildInputs = with ocamlPackages; [
     ocaml findlib ocamlgraph zarith menhir menhirLib
-    # Compressed Sessions
     # Emacs compilation of why3.el
     emacs
     # Documentation
@@ -21,17 +20,15 @@ stdenv.mkDerivation {
     lablgtk
     # WebIDE
     js_of_ocaml js_of_ocaml-ppx
+    # S-expression output for why3pp
+    ppx_deriving ppx_sexp_conv
     # Coq Support
     coqPackages.coq coqPackages.flocq ocamlPackages.camlp5
   ];
 
-  propagatedBuildInputs = with ocamlPackages; [ camlzip num ];
+  propagatedBuildInputs = with ocamlPackages; [ camlzip num re sexplib ];
 
   enableParallelBuilding = true;
-
-  postPatch = ''
-    substituteInPlace Makefile.in --replace js_of_ocaml.ppx js_of_ocaml-ppx
-  '';
 
   configureFlags = [ "--enable-verbose-make" ];
 

--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -17,6 +17,12 @@ let
     ocamlgraph
     stdlib-shims
     why3
+    re
+    seq
+    sexplib
+    sexplib0
+    parsexp
+    base
     yojson
     zarith
   ];
@@ -25,12 +31,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "frama-c";
-  version = "22.0";
-  slang   = "Titanium";
+  version = "23.0-rc1";
+  slang   = "Vanadium";
 
   src = fetchurl {
     url    = "http://frama-c.com/download/frama-c-${version}-${slang}.tar.gz";
-    sha256 = "1mq1fijka95ydrla486yr4w6wdl9l7vmp512s1q00b0p6lmfwmkh";
+    sha256 = "1z9f9a217bav3vfc99kq57d5rza6j7hr91ndviwkgcaib6wc5hcv";
   };
 
   preConfigure = lib.optionalString stdenv.cc.isClang "configureFlagsArray=(\"--with-cpp=clang -E -C\")";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements:
  - https://gitlab.inria.fr/why3/why3/-/blob/1.4.0/CHANGES.md 
  - https://frama-c.com/html/changelog.html#Vanadium-23.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
