### PR TITLE
libint: init at 2.6.0

### DIFF
--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -72,6 +72,5 @@ stdenv.mkDerivation rec {
     license = with licenses; [ lgpl3Only gpl3Only ];
     maintainers = [ maintainers.markuskowa ];
     platforms = platforms.linux;
-    timeout = 3 * 3600; # Long build time, not parallelized.
   };
 }

--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -1,0 +1,77 @@
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool
+, python3, perl, gmpxx, mpfr, boost, eigen, gfortran
+, enableFMA ? false
+} :
+
+stdenv.mkDerivation rec {
+  pname = "libint2";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "evaleev";
+    repo = "libint";
+    rev = "v${version}";
+    sha256 = "0pbc2j928jyffhdp4x5bkw68mqmx610qqhnb223vdzr0n2yj5y19";
+  };
+
+  patches = [
+    ./fix-paths.patch
+  ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    gfortran
+    mpfr
+    python3
+    perl
+    gmpxx
+  ];
+
+  buildInputs = [ boost ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  configureFlags = [
+    "--enable-eri=2"
+    "--enable-eri3=2"
+    "--enable-eri2=2"
+    "--with-eri-max-am=7,5,4"
+    "--with-eri-opt-am=3"
+    "--with-eri3-max-am=7"
+    "--with-eri2-max-am=7"
+    "--with-g12-max-am=5"
+    "--with-g12-opt-am=3"
+    "--with-g12dkh-max-am=5"
+    "--with-g12dkh-opt-am=3"
+    "--enable-contracted-ints"
+    "--enable-shared"
+   ] ++ lib.optional enableFMA "--enable-fma";
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  postBuild = ''
+    # build the fortran interface file
+    cd export/fortran
+    make libint_f.o ENABLE_FORTRAN=yes
+    cd ../..
+  '';
+
+  postInstall = ''
+    cp export/fortran/libint_f.mod $out/include/
+  '';
+
+  meta = with lib; {
+    description = "Library for the evaluation of molecular integrals of many-body operators over Gaussian functions";
+    homepage = "https://github.com/evaleev/libint";
+    license = with licenses; [ lgpl3Only gpl3Only ];
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+    timeout = 3 * 3600; # Long build time, not parallelized.
+  };
+}

--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool
 , python3, perl, gmpxx, mpfr, boost, eigen, gfortran
 , enableFMA ? false
-} :
+}:
 
 stdenv.mkDerivation rec {
   pname = "libint2";

--- a/pkgs/development/libraries/libint/fix-paths.patch
+++ b/pkgs/development/libraries/libint/fix-paths.patch
@@ -1,0 +1,96 @@
+diff --git a/export/fortran/Makefile b/export/fortran/Makefile
+index 62d8711..a83edc7 100644
+--- a/export/fortran/Makefile
++++ b/export/fortran/Makefile
+@@ -1,12 +1,14 @@
+-TOPDIR = ..
+-SRCDIR = ..
++TOPDIR = ../..
++SRCDIR = ../..
+ 
+--include ../MakeSuffixRules
+--include ../MakeVars
+--include ../MakeVars.features
++-include ../../lib/MakeSuffixRules
++-include ../../src/bin/MakeVars
++-include ../../src/lib/libint/MakeVars.features
+ 
+-FCFLAGS := -I../include -I../include/libint2 -D__COMPILING_LIBINT2=1 $(FCFLAGS)
+-COMPUTE_LIB = -L../lib -lint2
++FCFLAGS := -I../../include -I../../include/libint2 -D__COMPILING_LIBINT2=1 $(FCFLAGS)
++COMPUTE_LIB = -L../../lib -lint2
++
++CXXCPP = cc -E -I../../include/libint2
+ 
+ .PHONY: clean distclean default make_test check_test
+ 
+@@ -28,7 +30,7 @@ libint2_types_f.h: $(TOPDIR)/include/libint2.h.i
+ 
+ fortran_example.o: libint_f.o
+ 
+-fortran_incldefs.h: $(TOPDIR)/include/libint2_types.h
++fortran_incldefs.h: $(TOPDIR)/include/libint2/libint2_types.h
+ 	grep '^#' $< | grep -v '#include' > $@
+ 
+ fortran_example: fortran_example.o libint_f.o
+diff --git a/src/bin/libint/Makefile b/src/bin/libint/Makefile
+index 406306c..bd8a695 100644
+--- a/src/bin/libint/Makefile
++++ b/src/bin/libint/Makefile
+@@ -59,7 +59,7 @@ test: $(TESTCXXOBJ) $(LIBTARGET)
+ 	$(CXX) -o $@ $(CXXFLAGS) $(LDFLAGS) $^ $(SYSLIBS)
+ 
+ $(LIBTARGET): $(LIBOBJ)
+-	/bin/rm -f $@
++	rm -f $@
+ 	$(AR) $(ARFLAGS) $@ $(LIBOBJ)
+ 	$(RANLIB) $@
+ 
+@@ -102,7 +102,7 @@ ifneq ($(CXXDEPENDSUF),none)
+ %.d: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXFLAGS) $< > /dev/null
+ 	sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' < $(*F).$(CXXDEPENDSUF) > $(@F)
+-	/bin/rm -f $(*F).$(CXXDEPENDSUF)
++	rm -f $(*F).$(CXXDEPENDSUF)
+ else
+ %.d: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXFLAGS) $< | sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' > $(@F)
+diff --git a/tests/eri/Makefile b/tests/eri/Makefile
+index 6223e4f..05909dc 100644
+--- a/tests/eri/Makefile
++++ b/tests/eri/Makefile
+@@ -62,7 +62,7 @@ ifneq ($(CXXDEPENDSUF),none)
+ %.d: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXFLAGS) $< > /dev/null
+ 	sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' < $(*F).$(CXXDEPENDSUF) > $(@F)
+-	/bin/rm -f $(*F).$(CXXDEPENDSUF)
++	rm -f $(*F).$(CXXDEPENDSUF)
+ else
+ %.d: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXFLAGS) $< | sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' > $(@F)
+diff --git a/tests/hartree-fock/Makefile b/tests/hartree-fock/Makefile
+index aaebadc..4971472 100644
+--- a/tests/hartree-fock/Makefile
++++ b/tests/hartree-fock/Makefile
+@@ -95,7 +95,7 @@ ifneq ($(CXXDEPENDSUF),none)
+ %.d:: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXFLAGS) $< > /dev/null
+ 	sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' < $(*F).$(CXXDEPENDSUF) > $(@F)
+-	/bin/rm -f $(*F).$(CXXDEPENDSUF)
++	rm -f $(*F).$(CXXDEPENDSUF)
+ else
+ %.d:: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXFLAGS) $< | sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' > $(@F)
+diff --git a/tests/unit/Makefile b/tests/unit/Makefile
+index f2d9400..da9d82b 100644
+--- a/tests/unit/Makefile
++++ b/tests/unit/Makefile
+@@ -93,7 +93,7 @@ ifneq ($(CXXDEPENDSUF),none)
+ %.d:: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXGENFLAGS) $< > /dev/null
+ 	sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' < $(*F).$(CXXDEPENDSUF) > $(@F)
+-	/bin/rm -f $(*F).$(CXXDEPENDSUF)
++	rm -f $(*F).$(CXXDEPENDSUF)
+ else
+ %.d:: %.cc
+ 	$(CXXDEPEND) $(CXXDEPENDFLAGS) -c $(CPPFLAGS) $(CXXGENFLAGS) $< | sed 's/^$*.o/$*.$(OBJSUF) $*.d/g' > $(@F)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6614,6 +6614,8 @@ in
 
   libinsane = callPackage ../development/libraries/libinsane { };
 
+  libint = callPackage ../development/libraries/libint {};
+
   libipfix = callPackage ../development/libraries/libipfix { };
 
   libircclient = callPackage ../development/libraries/libircclient { };


### PR DESCRIPTION
###### Motivation for this change
Library for the evaluation of molecular integrals of many-body operators over Gaussian functions. Required by some quantum chemistry program packages. Has been tested extensively here: https://github.com/markuskowa/NixOS-QChem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
