### PR TITLE
home-assistant: support rflink component

### DIFF
--- a/pkgs/development/python-modules/rflink/default.nix
+++ b/pkgs/development/python-modules/rflink/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, async-timeout
+, docopt
+, pyserial
+, pyserial-asyncio
+, setuptools
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "rflink";
+  version = "0.0.58";
+
+  src = fetchFromGitHub {
+    owner = "aequitas";
+    repo = "python-rflink";
+    rev = version;
+    sha256 = "1zab55lsw419gg0jfrl69ap6128vbi3wdmg5z7qin65ijpjdhasc";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "version=version_from_git()" "version='${version}'"
+  '';
+
+  propagatedBuildInputs = [
+    async-timeout
+    docopt
+    pyserial
+    pyserial-asyncio
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "rflink.protocol" ];
+
+  meta = with lib; {
+    description = "Library and CLI tools for interacting with RFlink 433MHz transceiver";
+    homepage = "https://github.com/aequitas/python-rflink";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -695,7 +695,7 @@
     "repetier" = ps: with ps; [ ]; # missing inputs: pyrepetier
     "rest" = ps: with ps; [ jsonpath xmltodict ];
     "rest_command" = ps: with ps; [ ];
-    "rflink" = ps: with ps; [ ]; # missing inputs: rflink
+    "rflink" = ps: with ps; [ rflink ];
     "rfxtrx" = ps: with ps; [ ]; # missing inputs: pyRFXtrx
     "ring" = ps: with ps; [ ha-ffmpeg ring-doorbell ];
     "ripple" = ps: with ps; [ ]; # missing inputs: python-ripple-api

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -602,6 +602,7 @@ in with py.pkgs; buildPythonApplication rec {
     "remote"
     "rest"
     "rest_command"
+    "rflink"
     "ring"
     "risco"
     "rituals_perfume_genie"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7498,6 +7498,8 @@ in {
 
   rfcat = callPackage ../development/python-modules/rfcat { };
 
+  rflink = callPackage ../development/python-modules/rflink { };
+
   rich = callPackage ../development/python-modules/rich { };
 
   rig = callPackage ../development/python-modules/rig { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
