### PR TITLE
nomad-autoscaler: init at 0.3.3

### DIFF
--- a/pkgs/applications/networking/cluster/nomad-autoscaler/default.nix
+++ b/pkgs/applications/networking/cluster/nomad-autoscaler/default.nix
@@ -1,0 +1,112 @@
+{ lib, fetchFromGitHub, buildGoModule, go, removeReferencesTo, buildEnv }:
+
+let
+  package = buildGoModule rec {
+    pname = "nomad-autoscaler";
+    version = "0.3.3";
+
+    outputs = [
+      "out"
+      "bin"
+      "aws_asg"
+      "azure_vmss"
+      "datadog"
+      "fixed_value"
+      "gce_mig"
+      "nomad_apm"
+      "nomad_target"
+      "pass_through"
+      "prometheus"
+      "target_value"
+      "threshold"
+    ];
+
+    src = fetchFromGitHub {
+      owner = "hashicorp";
+      repo = "nomad-autoscaler";
+      rev = "v${version}";
+      sha256 = "sha256-bN/U6aCf33B88ouQwTGG8CqARzWmIvXNr5JPr3l8cVI=";
+    };
+
+    vendorSha256 = "sha256-Ls8gkfLyxfQD8krvxjAPnZhf1r1s2MhtQfMMfp8hJII=";
+
+    subPackages = [ "." ];
+
+    nativeBuildInputs = [ removeReferencesTo ];
+
+    # buildGoModule overrides normal buildPhase, can't use makeTargets
+    postBuild = ''
+      make build plugins
+    '';
+
+    # tries to pull tests from network, and fails silently anyway
+    doCheck = false;
+
+    postInstall = ''
+      mkdir -p $bin/bin
+      mv $out/bin/nomad-autoscaler $bin/bin/nomad-autoscaler
+      ln -s $bin/bin/nomad-autoscaler $out/bin/nomad-autoscaler
+
+      for d in $outputs; do
+        mkdir -p ''${!d}/share
+      done
+      rmdir $bin/share
+
+      # have out contain all of the plugins
+      for plugin in bin/plugins/*; do
+        remove-references-to -t ${go} "$plugin"
+        cp "$plugin" $out/share/
+      done
+
+      # populate the outputs as individual plugins
+      # can't think of a more generic way to handle this
+      # bash doesn't allow for dashes '-' to be in a variable name
+      # this means that the output names will need to differ slightly from the binary
+      mv bin/plugins/aws-asg $aws_asg/share/
+      mv bin/plugins/azure-vmss $azure_vmss/share/
+      mv bin/plugins/datadog $datadog/share/
+      mv bin/plugins/fixed-value $fixed_value/share/
+      mv bin/plugins/gce-mig $gce_mig/share/
+      mv bin/plugins/nomad-apm $nomad_apm/share/
+      mv bin/plugins/nomad-target $nomad_target/share/
+      mv bin/plugins/pass-through $pass_through/share/
+      mv bin/plugins/prometheus $prometheus/share/
+      mv bin/plugins/target-value $target_value/share/
+      mv bin/plugins/threshold $threshold/share/
+    '';
+
+    # make toggle-able, so that overrided versions can disable this check if
+    # they want newer versions of the plugins without having to modify
+    # the output logic
+    doInstallCheck = true;
+    installCheckPhase = ''
+      rmdir bin/plugins || {
+        echo "Not all plugins were extracted"
+        echo "Please move the following to their related output: $(ls bin/plugins)"
+        exit 1
+      }
+    '';
+
+    passthru = {
+      inherit plugins withPlugins;
+    };
+
+    meta = with lib; {
+      description = "Autoscaling daemon for Nomad";
+      homepage = "https://github.com/hashicorp/nomad-autoscaler";
+      license = licenses.mpl20;
+      maintainers = with maintainers; [ jonringer ];
+    };
+  };
+
+  plugins = let
+      plugins = builtins.filter (n: !(lib.elem n [ "out" "bin" ])) package.outputs;
+    in lib.genAttrs plugins (output: package.${output});
+
+  # Intended to be used as: (nomad-autoscaler.withPlugins (ps: [ ps.aws_asg ps.nomad_target ])
+  withPlugins = f: buildEnv {
+    name = "nomad-autoscaler-env";
+    paths = [ package.bin ] ++ f plugins;
+  };
+in
+  package

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7265,6 +7265,8 @@ in
     nvidiaGpuSupport = config.cudaSupport or false;
   };
 
+  nomad-autoscaler = callPackage ../applications/networking/cluster/nomad-autoscaler { };
+
   nomad-driver-podman = callPackage ../applications/networking/cluster/nomad-driver-podman { };
 
   notable = callPackage ../applications/misc/notable { };


### PR DESCRIPTION
###### Motivation for this change
Autoscaling plugins for nomad

Added the `withPlugins` so that people didn't have to install all of the plugins which are about ~185MB.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
