### PR TITLE
 bmake: 20210420 -> 20210621

### DIFF
--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bmake";
-  version = "20210420";
+  version = "20210621";
 
   src = fetchurl {
     url    = "http://www.crufty.net/ftp/pub/sjg/${pname}-${version}.tar.gz";
-    sha256 = "1ajq8v5rq3pl5y9h1hlscs83007fsyk3lhcp87z09ma370lm3ra7";
+    sha256 = "0gpzv75ibzqz1j1h0hdjgx1v7hkl3i5cb5yf6q9sfcgx0bvb55xa";
   };
 
   # Make tests work with musl

--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch
-, getopt, tzdata
+, getopt, tzdata, ksh
 , pkgsMusl # for passthru.tests
 }:
 
@@ -14,9 +14,12 @@ stdenv.mkDerivation rec {
 
   # Make tests work with musl
   # * Disable deptgt-delete_on_error test (alpine does this too)
+  # * Disable shell-ksh test (ksh doesn't compile with musl)
   # * Fix test failing due to different strerror(3) output for musl and glibc
   postPatch = lib.optionalString (stdenv.hostPlatform.libc == "musl") ''
-    sed -i unit-tests/Makefile -e '/deptgt-delete_on_error/d'
+    sed -i unit-tests/Makefile \
+      -e '/deptgt-delete_on_error/d' \
+      -e '/shell-ksh/d'
     substituteInPlace unit-tests/opt-chdir.exp --replace "File name" "Filename"
   '';
 
@@ -29,6 +32,8 @@ stdenv.mkDerivation rec {
     ./fix-unexport-env-test.patch
     # Fix localtime tests without global /etc/zoneinfo directory
     ./fix-localtime-test.patch
+    # Always enable ksh test since it checks in a impure location /bin/ksh
+    ./unconditional-ksh-test.patch
     # decouple tests from build phase
     (fetchpatch {
       name = "separate-tests.patch";
@@ -69,7 +74,11 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
-  checkInputs = [ tzdata ];
+  checkInputs = [
+    tzdata
+  ] ++ lib.optionals (stdenv.hostPlatform.libc != "musl") [
+    ksh
+  ];
   checkPhase = ''
     runHook preCheck
 

--- a/pkgs/development/tools/build-managers/bmake/default.nix
+++ b/pkgs/development/tools/build-managers/bmake/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch
 , getopt, tzdata
+, pkgsMusl # for passthru.tests
 }:
 
 stdenv.mkDerivation rec {
@@ -78,6 +79,10 @@ stdenv.mkDerivation rec {
   '';
 
   setupHook = ./setup-hook.sh;
+
+  passthru.tests = {
+    bmakeMusl = pkgsMusl.bmake;
+  };
 
   meta = with lib; {
     description = "Portable version of NetBSD 'make'";

--- a/pkgs/development/tools/build-managers/bmake/unconditional-ksh-test.patch
+++ b/pkgs/development/tools/build-managers/bmake/unconditional-ksh-test.patch
@@ -1,0 +1,12 @@
+--- bmake/unit-tests/Makefile.orig	2021-07-04 19:13:09.068094922 +0200
++++ bmake/unit-tests/Makefile	2021-07-04 19:13:14.630080696 +0200
+@@ -295,9 +295,7 @@
+ TESTS+=		sh-single-line
+ TESTS+=		shell-csh
+ TESTS+=		shell-custom
+-.if exists(/bin/ksh)
+ TESTS+=		shell-ksh
+-.endif
+ TESTS+=		shell-sh
+ TESTS+=		suff-add-later
+ TESTS+=		suff-clear-regular


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
