### PR TITLE
hy: 0.19.0 -> 1.0a1 and improvements

### DIFF
--- a/doc/languages-frameworks/hy.section.md
+++ b/doc/languages-frameworks/hy.section.md
@@ -1,0 +1,31 @@
+# Hy {#sec-language-hy}
+
+## Installation {#ssec-hy-installation}
+
+### Installation without packages {#installation-without-packages}
+
+You can install `hy` via nix-env or by adding it to `configuration.nix` by reffering to it as a `hy` attribute. This kind of installation adds `hy` to your environment and it succesfully works with `python3`.
+
+::: {.caution}
+Packages that are installed with your python derivation, are not accesible by `hy` this way.
+:::
+
+### Installation with packages {#installation-with-packages}
+
+Creating `hy` derivation with custom `python` packages is really simple and similar to the way that python does it. Attribute `hy` provides function `withPackages` that creates custom `hy` derivation with specified packages.
+
+For example if you want to create shell with `matplotlib` and `numpy`, you can do it like so:
+
+```ShellSession
+$ nix-shell -p "hy.withPackages (ps: with ps; [ numpy matplotlib ])"
+```
+
+Or if you want to extend your `configuration.nix`:
+```nix
+{ # ...
+
+  environment.systemPackages = with pkgs; [
+    (hy.withPackages (py-packages: with py-packages; [ numpy matplotlib ]))
+  ];
+}
+```

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -16,6 +16,7 @@
  <xi:include href="gnome.section.xml" />
  <xi:include href="go.section.xml" />
  <xi:include href="haskell.section.xml" />
+ <xi:include href="hy.section.xml" />
  <xi:include href="idris.section.xml" />
  <xi:include href="ios.section.xml" />
  <xi:include href="java.section.xml" />

--- a/pkgs/development/interpreters/hy/builder.nix
+++ b/pkgs/development/interpreters/hy/builder.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3Packages
+, hyDefinedPythonPackages /* Packages like with python.withPackages */
+, ...
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "hy";
+  version = "1.0a1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-lCrbvbkeutSNmvvn/eHpTnJwPb5aEH7hWTXYSE+AJmU=";
+  };
+
+  checkInputs = with python3Packages; [ flake8 pytest ];
+
+  propagatedBuildInputs = with python3Packages; [
+    appdirs
+    astor
+    clint
+    colorama
+    fastentrypoints
+    funcparserlib
+    rply
+    pygments
+  ] ++ (hyDefinedPythonPackages python3Packages);
+
+  # Hy does not include tests in the source distribution from PyPI, so only test executable.
+  checkPhase = ''
+    $out/bin/hy --help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A LISP dialect embedded in Python";
+    homepage = "https://hylang.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nixy mazurel ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -1,37 +1,15 @@
-{ lib, python3Packages }:
-
-python3Packages.buildPythonApplication rec {
-  pname = "hy";
-  version = "0.19.0";
-
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "05k05qmiiysiwdc05sxmanwhv1crfwbb3l8swxfisbzbvmv1snis";
-  };
-
-  checkInputs = with python3Packages; [ flake8 pytest ];
-
-  propagatedBuildInputs = with python3Packages; [
-    appdirs
-    astor
-    clint
-    colorama
-    fastentrypoints
-    funcparserlib
-    rply
-    pygments
-  ];
-
-  # Hy does not include tests in the source distribution from PyPI, so only test executable.
-  checkPhase = ''
-    $out/bin/hy --help > /dev/null
-  '';
-
-  meta = with lib; {
-    description = "A LISP dialect embedded in Python";
-    homepage = "http://hylang.org/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ nixy ];
-    platforms = platforms.all;
-  };
+{ lib
+, callPackage
+, hyDefinedPythonPackages ? python-packages: [] /* Packages like with python.withPackages */
+}:
+let
+  withPackages = (
+    python-packages: callPackage ./builder.nix {
+      hyDefinedPythonPackages = python-packages;
+    }
+  );
+in
+(withPackages hyDefinedPythonPackages) // {
+  # Export withPackages function for hy customization
+  inherit withPackages;
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Hy version was outdated and there was no way for it to use python packages.

###### Things done

I have updated Hy version to the newest version and created a simple `withPackages` function that allows Hy to use Python3 packages.
I also wrote basic documentation for this package.

Also, I have added myself to the maintainers list.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
