### PR TITLE
home-assistant: support sia component

### DIFF
--- a/pkgs/development/python-modules/dataclasses-json/default.nix
+++ b/pkgs/development/python-modules/dataclasses-json/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "dataclasses-json";
-  version = "0.5.2";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "lidatong";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1gcnm41rwg0jvq4vhr57vv9hyasws425zl8h4p05x2nzq86l0w1n";
+    sha256 = "193xklf1xrsin7fr24yqx5ckr4m5s9v1bdyr00qr51j74hiy8qsv";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pysiaalarm/default.nix
+++ b/pkgs/development/python-modules/pysiaalarm/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, dataclasses-json
+, pycryptodome
+, setuptools
+, pytest-asyncio
+, pytest-cases
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pysiaalarm";
+  version = "3.0.0";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b1c3a3d48d399bc91014167f59b23af601044d182db9267c23a9cf3559922122";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "==" ">="
+    substituteInPlace pytest.ini \
+      --replace "--cov pysiaalarm --cov-report term-missing" ""
+  '';
+
+  propagatedBuildInputs = [
+    dataclasses-json
+    pycryptodome
+    setuptools
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-cases
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pysiaalarm"
+    "pysiaalarm.aio"
+  ];
+
+  meta = with lib; {
+    description = "Python package for creating a client that talks with SIA-based alarm systems";
+    homepage = "https://github.com/eavanvalkenburg/pysiaalarm";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -750,7 +750,7 @@
     "shodan" = ps: with ps; [ shodan ];
     "shopping_list" = ps: with ps; [ aiohttp-cors ];
     "sht31" = ps: with ps; [ ]; # missing inputs: Adafruit-GPIO Adafruit-SHT31
-    "sia" = ps: with ps; [ ]; # missing inputs: pysiaalarm
+    "sia" = ps: with ps; [ pysiaalarm ];
     "sigfox" = ps: with ps; [ ];
     "sighthound" = ps: with ps; [ pillow simplehound ];
     "signal_messenger" = ps: with ps; [ ]; # missing inputs: pysignalclirestapi

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -627,6 +627,7 @@ in with py.pkgs; buildPythonApplication rec {
     "shell_command"
     "shelly"
     "shopping_list"
+    "sia"
     "sigfox"
     "sighthound"
     "simplisafe"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5325,6 +5325,8 @@ in {
 
   pyshark = callPackage ../development/python-modules/pyshark { };
 
+  pysiaalarm = callPackage ../development/python-modules/pysiaalarm { };
+
   pytest-subprocess = callPackage ../development/python-modules/pytest-subprocess { };
 
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Support all components introduced with the latest release: https://www.home-assistant.io/blog/2021/06/02/release-20216/#new-integrations

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
