### PR TITLE
pythonPackages.loguru: 0.5.3 -> unstable-2021-03-19

### DIFF
--- a/pkgs/development/python-modules/loguru/default.nix
+++ b/pkgs/development/python-modules/loguru/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
-, fetchPypi
-, fetchpatch
+, fetchFromGitHub
 , isPy27
 , colorama
 , pytestCheckHook
@@ -11,22 +10,15 @@
 
 buildPythonPackage rec {
   pname = "loguru";
-  version = "0.5.3";
+  version = "unstable-2021-03-19";
 
-  # python3.9 compatibility should be in the next release after 0.5.3
-  disabled = isPy27 || pythonAtLeast "3.9";
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319";
+  disabled = isPy27;
+  src = fetchFromGitHub {
+    owner = "Delgan";
+    repo = "loguru";
+    rev = "68616485f4f0decb5fced36a16040f5e05e2842f";
+    sha256 = "1gnn7hgs3c521kzlas7vs4js3ljbky6w7j61v650zrjdnas67zqd";
   };
-
-  patches = [
-    # Fixes tests with pytest>=6.2.2. Will be part of the next release after 0.5.3
-    (fetchpatch {
-      url = "https://github.com/Delgan/loguru/commit/31cf758ee9d22dbfa125f38153782fe20ac9dce5.patch";
-      sha256 = "1lzbs8akg1s7s6xjl3samf4c4bpssqvwg5fn3mwlm4ysr7jd5y67";
-    })
-  ];
 
   checkInputs = [ pytestCheckHook colorama ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* Use latest master for Python 3.9 support
* use `fetchFromGitHub` instead of `fetchPypi`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
