### PR TITLE
llvm_12: disable failing 'DebugInfo/X86/vla-multi.ll' on armv7l

### DIFF
--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -96,6 +96,7 @@ in stdenv.mkDerivation (rec {
     rm test/DebugInfo/X86/convert-debugloc.ll
     rm test/DebugInfo/X86/convert-inlined.ll
     rm test/DebugInfo/X86/convert-linked.ll
+    rm test/DebugInfo/X86/vla-multi.ll
     rm test/tools/dsymutil/X86/op-convert.test
   '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     # Seems to require certain floating point hardware (NEON?)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`DebugInfo/X86/vla-multi.ll` is broken on armv7l
```
100% [===========================================================(B](B ETA: 00:00:00
********************
Failed Tests (1):
  LLVM :: DebugInfo/X86/vla-multi.ll


Testing Time: 6753.07s
  Unsupported      :  1376
  Passed           : 40521
  Expectedly Failed:   154
  Failed           :     1

1 warning(s) in tests
make[3]: *** [CMakeFiles/check-all.dir/build.make:77: CMakeFiles/check-all] Error 1
make[3]: Leaving directory '/build/llvm/build'
make[2]: *** [CMakeFiles/Makefile2:9556: CMakeFiles/check-all.dir/all] Error 2
make[2]: Leaving directory '/build/llvm/build'
make[1]: *** [CMakeFiles/Makefile2:9563: CMakeFiles/check-all.dir/rule] Error 2
make[1]: Leaving directory '/build/llvm/build'
make: *** [Makefile:244: check-all] Error 2
builder for '/nix/store/sg30s09wmzc81q2mmj9pm9q5abpbp8ps-llvm-12.0.0.drv' failed with exit code 2
```
Related: https://github.com/NixOS/nixpkgs/pull/121693

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
