### PR TITLE
python3Packages.desktop-notifier: 3.2.3 -> 3.3.0

### DIFF
--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -10,11 +10,12 @@
 
 buildPythonPackage rec {
   pname = "desktop-notifier";
-  version = "3.2.3";
+  version = "3.3.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "cf359450efc0944ac4db3106e50faa9d49dcef072307c3531e6af2c8a10cd523";
+    sha256 = "sha256-ROSZorkA2wAp2Ubh3B3KWIUxM/4r7cv/1aSJqeKnPqg=";
   };
 
   propagatedBuildInputs = [
@@ -34,5 +35,6 @@ buildPythonPackage rec {
     description = "A Python library for cross-platform desktop notifications";
     license = licenses.mit;
     maintainers = with maintainers; [ sfrijters ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream update

###### Things done

```
$ nixpkgs-review rev desktop-notifier-3.3.0
[...]
6 packages updated:
maestral maestral-qt python38Packages.desktop-notifier (3.2.3 → 3.3.0) python3.8-maestral python39Packages.desktop-notifier (3.2.3 → 3.3.0) python3.9-maestral
[...]
5 packages built:
maestral maestral-gui python38Packages.desktop-notifier python39Packages.desktop-notifier python39Packages.maestral
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
