### PR TITLE
manuals: Describe how to link NixOS tests from packages

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -537,7 +537,13 @@ Note that because the checksum is computed after applying these effects, using o
 
 Tests are important to ensure quality and make reviews and automatic updates easy.
 
-Nix package tests are a lightweight alternative to [NixOS module tests](https://nixos.org/manual/nixos/stable/#sec-nixos-tests). They can be used to create simple integration tests for packages while the module tests are used to test services or programs with a graphical user interface on a NixOS VM. Unittests that are included in the source code of a package should be executed in the `checkPhase`.
+The following types of tests exists:
+
+* [NixOS **module tests**](https://nixos.org/manual/nixos/stable/#sec-nixos-tests), which spawn one or more NixOS VMs. They exercise both NixOS modules and the packaged programs used within them. For example, a NixOS module test can start a web server VM running the `nginx` module, and a client VM running `curl` or a graphical `firefox`, and test that they can talk to each other and display the correct content.
+* Nix **package tests** are a lightweight alternative to NixOS module tests. They should be used to create simple integration tests for packages, but cannot test NixOS services, and some programs with graphical user interfaces may also be difficult to test with them.
+* The **`checkPhase` of a package**, which should execute the unit tests that are included in the source code of a package.
+
+Here in the nixpkgs manual we describe mostly _package tests_; for _module tests_ head over to the corresponding [section in the NixOS manual](https://nixos.org/manual/nixos/stable/#sec-nixos-tests).
 
 ### Writing package tests {#ssec-package-tests-writing}
 
@@ -602,3 +608,23 @@ Here are examples of package tests:
 - [Spacy annotation test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/spacy/annotation-test/default.nix)
 - [Libtorch test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/science/math/libtorch/test/default.nix)
 - [Multiple tests for nanopb](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/nanopb/default.nix)
+
+### Linking NixOS module tests to a package {#ssec-nixos-tests-linking}
+
+Like [package tests](#ssec-package-tests-writing) as shown above, [NixOS module tests](https://nixos.org/manual/nixos/stable/#sec-nixos-tests) can also be linked to a package, so that the tests can be easily run when changing the related package.
+
+For example, assuming we're packaging `nginx`, we can link its module test via `passthru.tests`:
+
+```nix
+{ stdenv, lib, nixosTests }:
+
+stdenv.mkDerivation {
+  ...
+
+  passthru.tests = {
+    nginx = nixosTests.nginx;
+  };
+
+  ...
+}
+```

--- a/nixos/doc/manual/development/linking-nixos-tests-to-packages.section.md
+++ b/nixos/doc/manual/development/linking-nixos-tests-to-packages.section.md
@@ -1,0 +1,6 @@
+# Linking NixOS tests to packages {#sec-linking-nixos-tests-to-packages}
+
+You can link NixOS module tests to the packages that they exercised,
+so that the tests can be run automatically during code review when the package gets changed.
+This is
+[described in the nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#ssec-nixos-tests-linking).

--- a/nixos/doc/manual/development/nixos-tests.xml
+++ b/nixos/doc/manual/development/nixos-tests.xml
@@ -16,4 +16,5 @@ xlink:href="https://github.com/NixOS/nixpkgs/tree/master/nixos/tests">nixos/test
  <xi:include href="../from_md/development/writing-nixos-tests.section.xml" />
  <xi:include href="../from_md/development/running-nixos-tests.section.xml" />
  <xi:include href="../from_md/development/running-nixos-tests-interactively.section.xml" />
+ <xi:include href="../from_md/development/linking-nixos-tests-to-packages.section.xml" />
 </chapter>

--- a/nixos/doc/manual/from_md/development/linking-nixos-tests-to-packages.section.xml
+++ b/nixos/doc/manual/from_md/development/linking-nixos-tests-to-packages.section.xml
@@ -1,0 +1,10 @@
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-linking-nixos-tests-to-packages">
+  <title>Linking NixOS tests to packages</title>
+  <para>
+    You can link NixOS module tests to the packages that they exercised,
+    so that the tests can be run automatically during code review when
+    the package gets changed. This is
+    <link xlink:href="https://nixos.org/manual/nixpkgs/stable/#ssec-nixos-tests-linking">described
+    in the nixpkgs manual</link>.
+  </para>
+</section>


### PR DESCRIPTION
###### Motivation for this change

Finally explains `passthru.tests` for NixOS tests!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Doc-only change