### PR TITLE
siril: 0.99.8.1 -> 0.99.10.1

### DIFF
--- a/pkgs/applications/science/astronomy/siril/default.nix
+++ b/pkgs/applications/science/astronomy/siril/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, fetchpatch, pkg-config, meson, ninja
+{ lib, stdenv, fetchFromGitLab, pkg-config, meson, ninja
 , git, criterion, gtk3, libconfig, gnuplot, opencv, json-glib
 , fftwFloat, cfitsio, gsl, exiv2, librtprocess, wcslib, ffmpeg
 , libraw, libtiff, libpng, libjpeg, libheif, ffms, wrapGAppsHook
@@ -6,22 +6,14 @@
 
 stdenv.mkDerivation rec {
   pname = "siril";
-  version = "0.99.8.1";
+  version = "0.99.10.1";
 
   src = fetchFromGitLab {
     owner = "free-astro";
     repo = pname;
     rev = version;
-    sha256 = "0h3slgpj6zdc0rwmyr9zb0vgf53283hpwb7h26skdswmggsk90i5";
+    sha256 = "sha256-gqV+pJNaU+GnYiUo/imofgNdeM+AtDg/pSH7aoqhkYA=";
   };
-
-  patches = [
-    # Backport fix for broken build on glib-2.68
-    (fetchpatch {
-      url = "https://gitlab.com/free-astro/siril/-/commit/d319fceca5b00f156e1c5e3512d3ac1f41beb16a.diff";
-      sha256 = "00lq9wq8z48ly3hmkgzfqbdjaxr0hzyl2qwbj45bdnxfwqragh5m";
-    })
-  ];
 
   nativeBuildInputs = [
     meson ninja pkg-config git criterion wrapGAppsHook
@@ -47,7 +39,8 @@ stdenv.mkDerivation rec {
     homepage = "https://www.siril.org/";
     description = "Astrophotographic image processing tool";
     license = licenses.gpl3Plus;
+    changelog = "https://gitlab.com/free-astro/siril/-/blob/HEAD/ChangeLog";
     maintainers = with maintainers; [ hjones2199 ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update siril to 0.99.10, and support aarch64 builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
