### PR TITLE
pycritty: init at 0.3.5

### DIFF
--- a/pkgs/development/python-modules/pycritty/default.nix
+++ b/pkgs/development/python-modules/pycritty/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "pycritty";
   version = "0.3.5";
-
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
@@ -11,18 +10,18 @@ buildPythonPackage rec {
     sha256 = "1lrmd4a1ps3h9z0pndfjfrd2qa7v3abd6np75fd2q2ffsqv7ar6x";
   };
 
-  # The package does not include any tests to run
-  doCheck = false;
-
-  pythonImportsCheck = [ "pycritty" ];
-
-  propagatedBuildInputs = [ pyyaml ];
-
   postPatch = ''
     # remove custom install
     substituteInPlace setup.py \
       --replace "'install': PostInstallHook," ""
   '';
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  # The package does not include any tests to run
+  doCheck = false;
+
+  pythonImportsCheck = [ "pycritty" ];
 
   meta = with lib; {
     description = "A CLI tool for changing your alacritty configuration on the fly";

--- a/pkgs/development/python-modules/pycritty/default.nix
+++ b/pkgs/development/python-modules/pycritty/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "pycritty";
+  version = "0.3.5";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1lrmd4a1ps3h9z0pndfjfrd2qa7v3abd6np75fd2q2ffsqv7ar6x";
+  };
+
+  # The package does not include any tests to run
+  doCheck = false;
+
+  pythonImportsCheck = [ "pycritty" ];
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  postPatch = ''
+    # remove custom install
+    substituteInPlace setup.py \
+      --replace "'install': PostInstallHook," ""
+  '';
+
+  meta = with lib; {
+    description = "A CLI tool for changing your alacritty configuration on the fly";
+    homepage = "https://github.com/antoniosarosi/pycritty";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jperras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13939,6 +13939,8 @@ in
 
   pyrseas = callPackage ../development/tools/database/pyrseas { };
 
+  pycritty = with python3Packages; toPythonApplication pycritty;
+
   qtcreator = libsForQt5.callPackage ../development/tools/qtcreator { };
 
   qxmledit = libsForQt5.callPackage ../applications/editors/qxmledit {} ;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5763,6 +5763,8 @@ in {
 
   pycrc = callPackage ../development/python-modules/pycrc { };
 
+  pycritty = callPackage ../development/python-modules/pycritty { };
+
   pycron = callPackage ../development/python-modules/pycron { };
 
   pycrypto = callPackage ../development/python-modules/pycrypto { };


### PR DESCRIPTION
###### Motivation for this change

Adds the Python package `pycritty`, which allows for dynamic changing of `alacritty` configuration.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
