### PR TITLE
php: Run nixpkgs-fmt on all php related files

### DIFF
--- a/nixos/tests/php/default.nix
+++ b/nixos/tests/php/default.nix
@@ -1,5 +1,5 @@
 { system ? builtins.currentSystem
-, config ? {}
+, config ? { }
 , pkgs ? import ../../.. { inherit system config; }
 , php ? pkgs.php
 }:
@@ -8,7 +8,8 @@ let
   php' = php.buildEnv {
     extensions = { enabled, all }: with all; enabled ++ [ apcu ];
   };
-in {
+in
+{
   fpm = import ./fpm.nix { inherit system pkgs; php = php'; };
   httpd = import ./httpd.nix { inherit system pkgs; php = php'; };
   pcre = import ./pcre.nix { inherit system pkgs; php = php'; };

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({pkgs, lib, php, ...}: {
+import ../make-test-python.nix ({ pkgs, lib, php, ... }: {
   name = "php-${php.version}-fpm-nginx-test";
   meta.maintainers = lib.teams.php.members;
 
@@ -8,21 +8,23 @@ import ../make-test-python.nix ({pkgs, lib, php, ...}: {
     services.nginx = {
       enable = true;
 
-      virtualHosts."phpfpm" = let
-        testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
-      in {
-        root = "${testdir}/web";
-        locations."~ \\.php$".extraConfig = ''
-          fastcgi_pass unix:${config.services.phpfpm.pools.foobar.socket};
-          fastcgi_index index.php;
-          include ${pkgs.nginx}/conf/fastcgi_params;
-          include ${pkgs.nginx}/conf/fastcgi.conf;
-        '';
-        locations."/" = {
-          tryFiles = "$uri $uri/ index.php";
-          index = "index.php index.html index.htm";
+      virtualHosts."phpfpm" =
+        let
+          testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
+        in
+        {
+          root = "${testdir}/web";
+          locations."~ \\.php$".extraConfig = ''
+            fastcgi_pass unix:${config.services.phpfpm.pools.foobar.socket};
+            fastcgi_index index.php;
+            include ${pkgs.nginx}/conf/fastcgi_params;
+            include ${pkgs.nginx}/conf/fastcgi.conf;
+          '';
+          locations."/" = {
+            tryFiles = "$uri $uri/ index.php";
+            index = "index.php index.html index.htm";
+          };
         };
-      };
     };
 
     services.phpfpm.pools."foobar" = {

--- a/nixos/tests/php/httpd.nix
+++ b/nixos/tests/php/httpd.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({pkgs, lib, php, ...}: {
+import ../make-test-python.nix ({ pkgs, lib, php, ... }: {
   name = "php-${php.version}-httpd-test";
   meta.maintainers = lib.teams.php.members;
 
@@ -6,14 +6,16 @@ import ../make-test-python.nix ({pkgs, lib, php, ...}: {
     services.httpd = {
       enable = true;
       adminAddr = "admin@phpfpm";
-      virtualHosts."phpfpm" = let
-        testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
-      in {
-        documentRoot = "${testdir}/web";
-        locations."/" = {
-          index = "index.php index.html";
+      virtualHosts."phpfpm" =
+        let
+          testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
+        in
+        {
+          documentRoot = "${testdir}/web";
+          locations."/" = {
+            index = "index.php index.html";
+          };
         };
-      };
       phpPackage = php;
       enablePHP = true;
     };

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -1,6 +1,7 @@
 let
   testString = "can-use-subgroups";
-in import ../make-test-python.nix ({lib, php, ...}: {
+in
+import ../make-test-python.nix ({ lib, php, ... }: {
   name = "php-${php.version}-httpd-pcre-jit-test";
   meta.maintainers = lib.teams.php.members;
 
@@ -12,14 +13,15 @@ in import ../make-test-python.nix ({lib, php, ...}: {
       phpPackage = php;
       enablePHP = true;
       phpOptions = "pcre.jit = true";
-      extraConfig = let
-        testRoot = pkgs.writeText "index.php"
-          ''
-            <?php
-            preg_match('/(${testString})/', '${testString}', $result);
-            var_dump($result);
-          '';
-      in
+      extraConfig =
+        let
+          testRoot = pkgs.writeText "index.php"
+            ''
+              <?php
+              preg_match('/(${testString})/', '${testString}', $result);
+              var_dump($result);
+            '';
+        in
         ''
           Alias / ${testRoot}/
 

--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -2,12 +2,12 @@
 
 { pname
 , version
-, internalDeps ? []
-, peclDeps ? []
-, buildInputs ? []
-, nativeBuildInputs ? []
+, internalDeps ? [ ]
+, peclDeps ? [ ]
+, buildInputs ? [ ]
+, nativeBuildInputs ? [ ]
 , postPhpize ? ""
-, makeFlags ? []
+, makeFlags ? [ ]
 , src ? fetchurl {
     url = "http://pecl.php.net/get/${pname}-${version}.tgz";
     inherit (args) sha256;

--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -6,10 +6,47 @@ let
     sha256 = "0d5ncz97y0271dsmz269wl4721vhq2fn6pmm9rxglc756p36pnha";
   });
 
-in base.withExtensions ({ all, ... }: with all; ([
-  bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-  gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
-  openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
-  posix readline session simplexml sockets soap sodium sqlite3
-  tokenizer xmlreader xmlwriter zip zlib
+in
+base.withExtensions ({ all, ... }: with all; ([
+  bcmath
+  calendar
+  curl
+  ctype
+  dom
+  exif
+  fileinfo
+  filter
+  ftp
+  gd
+  gettext
+  gmp
+  iconv
+  intl
+  json
+  ldap
+  mbstring
+  mysqli
+  mysqlnd
+  opcache
+  openssl
+  pcntl
+  pdo
+  pdo_mysql
+  pdo_odbc
+  pdo_pgsql
+  pdo_sqlite
+  pgsql
+  posix
+  readline
+  session
+  simplexml
+  sockets
+  soap
+  sodium
+  sqlite3
+  tokenizer
+  xmlreader
+  xmlwriter
+  zip
+  zlib
 ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -6,10 +6,46 @@ let
     sha256 = "0yazcc9x66xg1gmi3rpgk891g6s3mm7aywcadqfqnx1mdz4z5ckj";
   });
 
-in base.withExtensions ({ all, ... }: with all; ([
-  bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-  gettext gmp iconv intl ldap mbstring mysqli mysqlnd opcache
-  openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
-  posix readline session simplexml sockets soap sodium sqlite3
-  tokenizer xmlreader xmlwriter zip zlib
+in
+base.withExtensions ({ all, ... }: with all; ([
+  bcmath
+  calendar
+  curl
+  ctype
+  dom
+  exif
+  fileinfo
+  filter
+  ftp
+  gd
+  gettext
+  gmp
+  iconv
+  intl
+  ldap
+  mbstring
+  mysqli
+  mysqlnd
+  opcache
+  openssl
+  pcntl
+  pdo
+  pdo_mysql
+  pdo_odbc
+  pdo_pgsql
+  pdo_sqlite
+  pgsql
+  posix
+  readline
+  session
+  simplexml
+  sockets
+  soap
+  sodium
+  sqlite3
+  tokenizer
+  xmlreader
+  xmlwriter
+  zip
+  zlib
 ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -3,17 +3,36 @@
 
 let
   generic =
-    { callPackage, lib, stdenv, nixosTests, fetchurl, makeWrapper
-    , symlinkJoin, writeText, autoconf, automake, bison, flex, libtool
-    , pkg-config, re2c, apacheHttpd, libargon2, libxml2, pcre2
-    , systemd, system-sendmail, valgrind, xcbuild
+    { callPackage
+    , lib
+    , stdenv
+    , nixosTests
+    , fetchurl
+    , makeWrapper
+    , symlinkJoin
+    , writeText
+    , autoconf
+    , automake
+    , bison
+    , flex
+    , libtool
+    , pkg-config
+    , re2c
+    , apacheHttpd
+    , libargon2
+    , libxml2
+    , pcre2
+    , systemd
+    , system-sendmail
+    , valgrind
+    , xcbuild
 
     , version
     , sha256
-    , extraPatches ? []
-    , packageOverrides ? (final: prev: {})
+    , extraPatches ? [ ]
+    , packageOverrides ? (final: prev: { })
 
-    # Sapi flags
+      # Sapi flags
     , cgiSupport ? true
     , cliSupport ? true
     , fpmSupport ? true
@@ -21,7 +40,7 @@ let
     , pharSupport ? true
     , phpdbgSupport ? true
 
-    # Misc flags
+      # Misc flags
     , apxs2Support ? !stdenv.isDarwin
     , argon2Support ? true
     , cgotoSupport ? false
@@ -43,101 +62,103 @@ let
       # expected.
       mkBuildEnv = prevArgs: prevExtensionFunctions: lib.makeOverridable (
         { extensions ? ({ enabled, ... }: enabled), extraConfig ? "", ... }@innerArgs:
-          let
-            allArgs = args // prevArgs // innerArgs;
-            filteredArgs = builtins.removeAttrs allArgs [ "extensions" "extraConfig" ];
-            php = generic filteredArgs;
+        let
+          allArgs = args // prevArgs // innerArgs;
+          filteredArgs = builtins.removeAttrs allArgs [ "extensions" "extraConfig" ];
+          php = generic filteredArgs;
 
-            php-packages = (callPackage ../../../top-level/php-packages.nix {
-              phpPackage = phpWithExtensions;
-            }).overrideScope' packageOverrides;
+          php-packages = (callPackage ../../../top-level/php-packages.nix {
+            phpPackage = phpWithExtensions;
+          }).overrideScope' packageOverrides;
 
-            allExtensionFunctions = prevExtensionFunctions ++ [ extensions ];
-            enabledExtensions =
-              builtins.foldl'
-                (enabled: f:
-                  f { inherit enabled; all = php-packages.extensions; })
-                []
-                allExtensionFunctions;
+          allExtensionFunctions = prevExtensionFunctions ++ [ extensions ];
+          enabledExtensions =
+            builtins.foldl'
+              (enabled: f:
+                f { inherit enabled; all = php-packages.extensions; })
+              [ ]
+              allExtensionFunctions;
 
-            getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
+          getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
 
-            # Recursively get a list of all internal dependencies
-            # for a list of extensions.
-            getDepsRecursively = extensions:
-              let
-                deps = lib.concatMap
-                         (ext: (ext.internalDeps or []) ++ (ext.peclDeps or []))
-                         extensions;
-              in
-                if ! (deps == []) then
-                  deps ++ (getDepsRecursively deps)
-                else
-                  deps;
+          # Recursively get a list of all internal dependencies
+          # for a list of extensions.
+          getDepsRecursively = extensions:
+            let
+              deps = lib.concatMap
+                (ext: (ext.internalDeps or [ ]) ++ (ext.peclDeps or [ ]))
+                extensions;
+            in
+            if ! (deps == [ ]) then
+              deps ++ (getDepsRecursively deps)
+            else
+              deps;
 
-            # Generate extension load configuration snippets from the
-            # extension parameter. This is an attrset suitable for use
-            # with textClosureList, which is used to put the strings in
-            # the right order - if a plugin which is dependent on
-            # another plugin is placed before its dependency, it will
-            # fail to load.
-            extensionTexts =
-              lib.listToAttrs
-                (map (ext:
+          # Generate extension load configuration snippets from the
+          # extension parameter. This is an attrset suitable for use
+          # with textClosureList, which is used to put the strings in
+          # the right order - if a plugin which is dependent on
+          # another plugin is placed before its dependency, it will
+          # fail to load.
+          extensionTexts =
+            lib.listToAttrs
+              (map
+                (ext:
                   let
                     extName = getExtName ext;
-                    phpDeps = (ext.internalDeps or []) ++ (ext.peclDeps or []);
+                    phpDeps = (ext.internalDeps or [ ]) ++ (ext.peclDeps or [ ]);
                     type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
                   in
-                    lib.nameValuePair extName {
-                      text = "${type}=${ext}/lib/php/extensions/${extName}.so";
-                      deps = map getExtName phpDeps;
-                    })
-                  (enabledExtensions ++ (getDepsRecursively enabledExtensions)));
+                  lib.nameValuePair extName {
+                    text = "${type}=${ext}/lib/php/extensions/${extName}.so";
+                    deps = map getExtName phpDeps;
+                  })
+                (enabledExtensions ++ (getDepsRecursively enabledExtensions)));
 
-            extNames = map getExtName enabledExtensions;
-            extraInit = writeText "php-extra-init-${version}.ini" ''
-              ${lib.concatStringsSep "\n"
-                (lib.textClosureList extensionTexts extNames)}
-              ${extraConfig}
-            '';
+          extNames = map getExtName enabledExtensions;
+          extraInit = writeText "php-extra-init-${version}.ini" ''
+            ${lib.concatStringsSep "\n"
+              (lib.textClosureList extensionTexts extNames)}
+            ${extraConfig}
+          '';
 
-            phpWithExtensions = symlinkJoin {
-              name = "php-with-extensions-${version}";
-              inherit (php) version;
-              nativeBuildInputs = [ makeWrapper ];
-              passthru = php.passthru // {
-                buildEnv = mkBuildEnv allArgs allExtensionFunctions;
-                withExtensions = mkWithExtensions allArgs allExtensionFunctions;
-                phpIni = "${phpWithExtensions}/lib/php.ini";
-                unwrapped = php;
-                # Select the right php tests for the php version
-                tests = nixosTests."php${lib.strings.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor php.version)}";
-                inherit (php-packages) extensions buildPecl;
-                packages = php-packages.tools;
-                meta = php.meta // {
-                  outputsToInstall = [ "out" ];
-                };
+          phpWithExtensions = symlinkJoin {
+            name = "php-with-extensions-${version}";
+            inherit (php) version;
+            nativeBuildInputs = [ makeWrapper ];
+            passthru = php.passthru // {
+              buildEnv = mkBuildEnv allArgs allExtensionFunctions;
+              withExtensions = mkWithExtensions allArgs allExtensionFunctions;
+              phpIni = "${phpWithExtensions}/lib/php.ini";
+              unwrapped = php;
+              # Select the right php tests for the php version
+              tests = nixosTests."php${lib.strings.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor php.version)}";
+              inherit (php-packages) extensions buildPecl;
+              packages = php-packages.tools;
+              meta = php.meta // {
+                outputsToInstall = [ "out" ];
               };
-              paths = [ php ];
-              postBuild = ''
-                ln -s ${extraInit} $out/lib/php.ini
-
-                if test -e $out/bin/php; then
-                  wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
-                fi
-
-                if test -e $out/bin/php-fpm; then
-                  wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
-                fi
-
-                if test -e $out/bin/phpdbg; then
-                  wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
-                fi
-              '';
             };
-          in
-            phpWithExtensions);
+            paths = [ php ];
+            postBuild = ''
+              ln -s ${extraInit} $out/lib/php.ini
+
+              if test -e $out/bin/php; then
+                wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
+              fi
+
+              if test -e $out/bin/php-fpm; then
+                wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
+              fi
+
+              if test -e $out/bin/phpdbg; then
+                wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
+              fi
+            '';
+          };
+        in
+        phpWithExtensions
+      );
 
       mkWithExtensions = prevArgs: prevExtensionFunctions: extensions:
         mkBuildEnv prevArgs prevExtensionFunctions { inherit extensions; };
@@ -182,13 +203,13 @@ let
         # Enable sapis
         ++ lib.optional (!cgiSupport) "--disable-cgi"
         ++ lib.optional (!cliSupport) "--disable-cli"
-        ++ lib.optional fpmSupport    "--enable-fpm"
+        ++ lib.optional fpmSupport "--enable-fpm"
         ++ lib.optional pearSupport [ "--with-pear" "--enable-xml" "--with-libxml" ]
         ++ lib.optionals (pearSupport && (lib.versionOlder version "7.4")) [
           "--enable-libxml"
           "--with-libxml-dir=${libxml2.dev}"
         ]
-        ++ lib.optional pharSupport   "--enable-phar"
+        ++ lib.optional pharSupport "--enable-phar"
         ++ lib.optional (!phpdbgSupport) "--disable-phpdbg"
 
 
@@ -211,33 +232,33 @@ let
       hardeningDisable = [ "bindnow" ];
 
       preConfigure =
-      # Don't record the configure flags since this causes unnecessary
-      # runtime dependencies
-      ''
-        for i in main/build-defs.h.in scripts/php-config.in; do
-          substituteInPlace $i \
-            --replace '@CONFIGURE_COMMAND@' '(omitted)' \
-            --replace '@CONFIGURE_OPTIONS@' "" \
-            --replace '@PHP_LDFLAGS@' ""
-        done
+        # Don't record the configure flags since this causes unnecessary
+        # runtime dependencies
+        ''
+          for i in main/build-defs.h.in scripts/php-config.in; do
+            substituteInPlace $i \
+              --replace '@CONFIGURE_COMMAND@' '(omitted)' \
+              --replace '@CONFIGURE_OPTIONS@' "" \
+              --replace '@PHP_LDFLAGS@' ""
+          done
 
-        export EXTENSION_DIR=$out/lib/php/extensions
-      ''
-      # PKG_CONFIG need not be a relative path
-      + lib.optionalString (! lib.versionAtLeast version "7.4") ''
-        for i in $(find . -type f -name "*.m4"); do
-          substituteInPlace $i \
-            --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
-        done
-      '' + ''
-        ./buildconf --copy --force
+          export EXTENSION_DIR=$out/lib/php/extensions
+        ''
+        # PKG_CONFIG need not be a relative path
+        + lib.optionalString (!lib.versionAtLeast version "7.4") ''
+          for i in $(find . -type f -name "*.m4"); do
+            substituteInPlace $i \
+              --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
+          done
+        '' + ''
+          ./buildconf --copy --force
 
-        if test -f $src/genfiles; then
-          ./genfiles
-        fi
-      '' + lib.optionalString stdenv.isDarwin ''
-        substituteInPlace configure --replace "-lstdc++" "-lc++"
-      '';
+          if test -f $src/genfiles; then
+            ./genfiles
+          fi
+        '' + lib.optionalString stdenv.isDarwin ''
+          substituteInPlace configure --replace "-lstdc++" "-lc++"
+        '';
 
       postInstall = ''
         test -d $out/etc || mkdir $out/etc
@@ -264,8 +285,8 @@ let
       outputs = [ "out" "dev" ];
 
       passthru = {
-        buildEnv = mkBuildEnv {} [];
-        withExtensions = mkWithExtensions {} [];
+        buildEnv = mkBuildEnv { } [ ];
+        withExtensions = mkWithExtensions { } [ ];
         inherit ztsSupport;
       };
 
@@ -278,4 +299,5 @@ let
         outputsToInstall = [ "out" "dev" ];
       };
     };
-in generic
+in
+generic

--- a/pkgs/development/php-packages/mongodb/default.nix
+++ b/pkgs/development/php-packages/mongodb/default.nix
@@ -1,5 +1,15 @@
-{ stdenv, buildPecl, lib, pcre2, pkg-config, cyrus_sasl, icu64
-, openssl, snappy, zlib, darwin }:
+{ stdenv
+, buildPecl
+, lib
+, pcre2
+, pkg-config
+, cyrus_sasl
+, icu64
+, openssl
+, snappy
+, zlib
+, darwin
+}:
 
 buildPecl {
   pname = "mongodb";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,9 +1,49 @@
-{ stdenv, lib, pkgs, fetchgit, phpPackage, autoconf, pkg-config, re2c
-, gettext, bzip2, curl, libxml2, openssl, gmp, icu64, oniguruma, libsodium
-, html-tidy, libzip, zlib, pcre2, libxslt, aspell, openldap, cyrus_sasl
-, uwimap, pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng
-, freetype, libffi, freetds, postgresql, sqlite, net-snmp, unixODBC, libedit
-, readline, rsync, fetchpatch, valgrind
+{ stdenv
+, lib
+, pkgs
+, fetchgit
+, phpPackage
+, autoconf
+, pkg-config
+, aspell
+, bzip2
+, curl
+, cyrus_sasl
+, enchant1
+, fetchpatch
+, freetds
+, freetype
+, gd
+, gettext
+, gmp
+, html-tidy
+, icu64
+, libXpm
+, libedit
+, libffi
+, libiconv
+, libjpeg
+, libpng
+, libsodium
+, libwebp
+, libxml2
+, libxslt
+, libzip
+, net-snmp
+, oniguruma
+, openldap
+, openssl
+, pam
+, pcre2
+, postgresql
+, re2c
+, readline
+, rsync
+, sqlite
+, unixODBC
+, uwimap
+, valgrind
+, zlib
 }:
 
 lib.makeScope pkgs.newScope (self: with self; {
@@ -129,401 +169,475 @@ lib.makeScope pkgs.newScope (self: with self; {
     xdebug = callPackage ../development/php-packages/xdebug { };
 
     yaml = callPackage ../development/php-packages/yaml { };
-  } // (let
-    # Function to build a single php extension based on the php version.
-    #
-    # Name passed is the name of the extension and is automatically used
-    # to add the configureFlag "--enable-${name}", which can be overriden.
-    #
-    # Build inputs is used for extra deps that may be needed. And zendExtension
-    # will mark the extension as a zend extension or not.
-    mkExtension = {
-      name
-      , configureFlags ? [ "--enable-${name}" ]
-      , internalDeps ? []
-      , postPhpize ? ""
-      , buildInputs ? []
-      , zendExtension ? false
-      , doCheck ? true
-      , ...
-    }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
-      pname = "php-${name}";
-      extensionName = name;
+  } // (
+    let
+      # Function to build a single php extension based on the php version.
+      #
+      # Name passed is the name of the extension and is automatically used
+      # to add the configureFlag "--enable-${name}", which can be overriden.
+      #
+      # Build inputs is used for extra deps that may be needed. And zendExtension
+      # will mark the extension as a zend extension or not.
+      mkExtension =
+        { name
+        , configureFlags ? [ "--enable-${name}" ]
+        , internalDeps ? [ ]
+        , postPhpize ? ""
+        , buildInputs ? [ ]
+        , zendExtension ? false
+        , doCheck ? true
+        , ...
+        }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
+          pname = "php-${name}";
+          extensionName = name;
 
-      inherit (php.unwrapped) version src;
-      sourceRoot = "php-${php.version}/ext/${name}";
+          inherit (php.unwrapped) version src;
+          sourceRoot = "php-${php.version}/ext/${name}";
 
-      enableParallelBuilding = true;
-      nativeBuildInputs = [ php.unwrapped autoconf pkg-config re2c ];
-      inherit configureFlags internalDeps buildInputs
-        zendExtension doCheck;
+          enableParallelBuilding = true;
+          nativeBuildInputs = [ php.unwrapped autoconf pkg-config re2c ];
+          inherit configureFlags internalDeps buildInputs
+            zendExtension doCheck;
 
-      prePatch = "pushd ../..";
-      postPatch = "popd";
+          prePatch = "pushd ../..";
+          postPatch = "popd";
 
-      preConfigure = ''
-        nullglobRestore=$(shopt -p nullglob)
-        shopt -u nullglob   # To make ?-globbing work
+          preConfigure = ''
+            nullglobRestore=$(shopt -p nullglob)
+            shopt -u nullglob   # To make ?-globbing work
 
-        # Some extensions have a config0.m4 or config9.m4
-        if [ -f config?.m4 ]; then
-          mv config?.m4 config.m4
-        fi
+            # Some extensions have a config0.m4 or config9.m4
+            if [ -f config?.m4 ]; then
+              mv config?.m4 config.m4
+            fi
 
-        $nullglobRestore
-        phpize
-        ${postPhpize}
-        ${lib.concatMapStringsSep "\n"
-          (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
-          internalDeps}
-      '';
-      checkPhase = "runHook preCheck; NO_INTERACTON=yes make test; runHook postCheck";
-      outputs = [ "out" "dev" ];
-      installPhase = ''
-        mkdir -p $out/lib/php/extensions
-        cp modules/${name}.so $out/lib/php/extensions/${name}.so
-        mkdir -p $dev/include
-        ${rsync}/bin/rsync -r --filter="+ */" \
-                              --filter="+ *.h" \
-                              --filter="- *" \
-                              --prune-empty-dirs \
-                              . $dev/include/
-      '';
+            $nullglobRestore
+            phpize
+            ${postPhpize}
+            ${lib.concatMapStringsSep "\n"
+              (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
+              internalDeps}
+          '';
+          checkPhase = "runHook preCheck; NO_INTERACTON=yes make test; runHook postCheck";
+          outputs = [ "out" "dev" ];
+          installPhase = ''
+            mkdir -p $out/lib/php/extensions
+            cp modules/${name}.so $out/lib/php/extensions/${name}.so
+            mkdir -p $dev/include
+            ${rsync}/bin/rsync -r --filter="+ */" \
+                                  --filter="+ *.h" \
+                                  --filter="- *" \
+                                  --prune-empty-dirs \
+                                  . $dev/include/
+          '';
 
-      meta = {
-        description = "PHP upstream extension: ${name}";
-        inherit (php.meta) maintainers homepage license;
-      };
-    });
+          meta = {
+            description = "PHP upstream extension: ${name}";
+            inherit (php.meta) maintainers homepage license;
+          };
+        });
 
-    # This list contains build instructions for different modules that one may
-    # want to build.
-    #
-    # These will be passed as arguments to mkExtension above.
-    extensionData = [
-      { name = "bcmath"; }
-      { name = "bz2"; buildInputs = [ bzip2 ]; configureFlags = [ "--with-bz2=${bzip2.dev}" ]; }
-      { name = "calendar"; }
-      { name = "ctype"; }
-      { name = "curl";
-        buildInputs = [ curl ];
-        configureFlags = [ "--with-curl=${curl.dev}" ];
-        doCheck = false; }
-      { name = "dba"; }
-      { name = "dom";
-        buildInputs = [ libxml2 ];
-        patches = [
-          # https://github.com/php/php-src/pull/7030
-          (fetchpatch {
-            url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
-            sha256 = "11qsdiwj1zmpfc2pgh6nr0sn7qa1nyjg4jwf69cgwnd57qfjcy4k";
-            excludes = [ "ext/dom/tests/bug43364.phpt" "ext/dom/tests/bug80268.phpt" ];
-          })
-        ];
-        # For some reason `patch` fails to remove these files correctly.
-        # Since `postPatch` is already used in `mkExtension`, we have to make it here.
-        preCheck = ''
-          rm tests/bug43364.phpt
-          rm tests/bug80268.phpt
-        '';
-        configureFlags = [ "--enable-dom" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
-      { name = "enchant";
-        buildInputs = [ enchant1 ];
-        configureFlags = [ "--with-enchant=${enchant1}" ];
-        # enchant1 doesn't build on darwin.
-        enable = (!stdenv.isDarwin);
-        doCheck = false; }
-      { name = "exif"; doCheck = false; }
-      { name = "ffi"; buildInputs = [ libffi ]; enable = lib.versionAtLeast php.version "7.4"; }
-      { name = "fileinfo"; buildInputs = [ pcre2 ]; }
-      { name = "filter"; buildInputs = [ pcre2 ]; }
-      { name = "ftp"; buildInputs = [ openssl ]; }
-      { name = "gd";
-        buildInputs = [ zlib gd ];
-        configureFlags = [
-          "--enable-gd"
-          "--with-external-gd=${gd.dev}"
-          "--enable-gd-jis-conv"
-        ];
-        doCheck = false;
-        enable = lib.versionAtLeast php.version "7.4"; }
-      { name = "gd";
-        buildInputs = [ zlib gd libXpm ];
-        configureFlags = [
-          "--with-gd=${gd.dev}"
-          "--with-freetype-dir=${freetype.dev}"
-          "--with-jpeg-dir=${libjpeg.dev}"
-          "--with-png-dir=${libpng.dev}"
-          "--with-webp-dir=${libwebp}"
-          "--with-xpm-dir=${libXpm.dev}"
-          "--with-zlib-dir=${zlib.dev}"
-          "--enable-gd-jis-conv"
-        ];
-        doCheck = false;
-        enable = lib.versionOlder php.version "7.4"; }
-      { name = "gettext";
-        buildInputs = [ gettext ];
-        patches = lib.optionals (lib.versionOlder php.version "7.4") [
-          (fetchpatch {
-            url = "https://github.com/php/php-src/commit/632b6e7aac207194adc3d0b41615bfb610757f41.patch";
-            sha256 = "0xn3ivhc4p070vbk5yx0mzj2n7p04drz3f98i77amr51w0vzv046";
-          })
-        ];
-        postPhpize = ''substituteInPlace configure --replace 'as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5' ':' '';
-        configureFlags = [ "--with-gettext=${gettext}" ]; }
-      { name = "gmp";
-        buildInputs = [ gmp ];
-        configureFlags = [ "--with-gmp=${gmp.dev}" ]; }
-      { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
-      { name = "iconv";
-        configureFlags = [
-          "--with-iconv${lib.optionalString stdenv.isDarwin "=${libiconv}"}"
-        ];
-        patches = lib.optionals (lib.versionOlder php.version "8.0") [
-          # Header path defaults to FHS location, preventing the configure script from detecting errno support.
-          (fetchpatch {
-            url = "https://github.com/fossar/nix-phps/raw/263861a8c9bdafd7abe44db6db4ef0179643680c/pkgs/iconv-header-path.patch";
-            sha256 = "7GHnEUu+hcsQ4h3itDwk6p46ZKfib9JZ2XpWlXrdn6E=";
-          })
-        ];
-        doCheck = false; }
-      { name = "imap";
-        buildInputs = [ uwimap openssl pam pcre2 ];
-        configureFlags = [ "--with-imap=${uwimap}" "--with-imap-ssl" ];
-        # uwimap doesn't build on darwin.
-        enable = (!stdenv.isDarwin); }
-      { name = "intl";
-        buildInputs = [ icu64 ];
-        patches = lib.optionals (lib.versionOlder php.version "7.4") [
-          (fetchpatch {
-            url = "https://github.com/php/php-src/commit/93a9b56c90c334896e977721bfb3f38b1721cec6.patch";
-            sha256 = "055l40lpyhb0rbjn6y23qkzdhvpp7inbnn6x13cpn4inmhjqfpg4";
-          })
-        ];
-      }
-      { name = "json"; enable = lib.versionOlder php.version "8.0"; }
-      { name = "ldap";
-        buildInputs = [ openldap cyrus_sasl ];
-        configureFlags = [
-          "--with-ldap"
-          "LDAP_DIR=${openldap.dev}"
-          "LDAP_INCDIR=${openldap.dev}/include"
-          "LDAP_LIBDIR=${openldap.out}/lib"
-        ] ++ lib.optionals stdenv.isLinux [
-          "--with-ldap-sasl=${cyrus_sasl.dev}"
-        ];
-        doCheck = false; }
-      { name = "mbstring"; buildInputs = [ oniguruma ] ++ lib.optionals (lib.versionAtLeast php.version "8.0") [
-          pcre2
-        ]; doCheck = false; }
-      { name = "mysqli";
-        internalDeps = [ php.extensions.mysqlnd ];
-        configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ];
-        doCheck = false; }
-      { name = "mysqlnd";
-        buildInputs = [ zlib openssl ];
-        # The configure script doesn't correctly add library link
-        # flags, so we add them to the variable used by the Makefile
-        # when linking.
-        MYSQLND_SHARED_LIBADD = "-lssl -lcrypto";
-        # The configure script builds a config.h which is never
-        # included. Let's include it in the main header file
-        # included by all .c-files.
-        patches = [
-          (pkgs.writeText "mysqlnd_config.patch" ''
-            --- a/ext/mysqlnd/mysqlnd.h
-            +++ b/ext/mysqlnd/mysqlnd.h
-            @@ -1,3 +1,6 @@
-            +#ifdef HAVE_CONFIG_H
-            +#include "config.h"
-            +#endif
-             /*
-               +----------------------------------------------------------------------+
-               | Copyright (c) The PHP Group                                          |
-          '')
-        ] ++ lib.optionals (lib.versionOlder php.version "7.4.8") [
-          (pkgs.writeText "mysqlnd_fix_compression.patch" ''
-            --- a/ext/mysqlnd/mysqlnd.h
-            +++ b/ext/mysqlnd/mysqlnd.h
-            @@ -48,7 +48,7 @@
-             #define MYSQLND_DBG_ENABLED 0
-             #endif
+      # This list contains build instructions for different modules that one may
+      # want to build.
+      #
+      # These will be passed as arguments to mkExtension above.
+      extensionData = [
+        { name = "bcmath"; }
+        { name = "bz2"; buildInputs = [ bzip2 ]; configureFlags = [ "--with-bz2=${bzip2.dev}" ]; }
+        { name = "calendar"; }
+        { name = "ctype"; }
+        {
+          name = "curl";
+          buildInputs = [ curl ];
+          configureFlags = [ "--with-curl=${curl.dev}" ];
+          doCheck = false;
+        }
+        { name = "dba"; }
+        {
+          name = "dom";
+          buildInputs = [ libxml2 ];
+          patches = [
+            # https://github.com/php/php-src/pull/7030
+            (fetchpatch {
+              url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
+              sha256 = "11qsdiwj1zmpfc2pgh6nr0sn7qa1nyjg4jwf69cgwnd57qfjcy4k";
+              excludes = [ "ext/dom/tests/bug43364.phpt" "ext/dom/tests/bug80268.phpt" ];
+            })
+          ];
+          # For some reason `patch` fails to remove these files correctly.
+          # Since `postPatch` is already used in `mkExtension`, we have to make it here.
+          preCheck = ''
+            rm tests/bug43364.phpt
+            rm tests/bug80268.phpt
+          '';
+          configureFlags = [ "--enable-dom" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        }
+        {
+          name = "enchant";
+          buildInputs = [ enchant1 ];
+          configureFlags = [ "--with-enchant=${enchant1}" ];
+          # enchant1 doesn't build on darwin.
+          enable = (!stdenv.isDarwin);
+          doCheck = false;
+        }
+        { name = "exif"; doCheck = false; }
+        { name = "ffi"; buildInputs = [ libffi ]; enable = lib.versionAtLeast php.version "7.4"; }
+        { name = "fileinfo"; buildInputs = [ pcre2 ]; }
+        { name = "filter"; buildInputs = [ pcre2 ]; }
+        { name = "ftp"; buildInputs = [ openssl ]; }
+        {
+          name = "gd";
+          buildInputs = [ zlib gd ];
+          configureFlags = [
+            "--enable-gd"
+            "--with-external-gd=${gd.dev}"
+            "--enable-gd-jis-conv"
+          ];
+          doCheck = false;
+          enable = lib.versionAtLeast php.version "7.4";
+        }
+        {
+          name = "gd";
+          buildInputs = [ zlib gd libXpm ];
+          configureFlags = [
+            "--with-gd=${gd.dev}"
+            "--with-freetype-dir=${freetype.dev}"
+            "--with-jpeg-dir=${libjpeg.dev}"
+            "--with-png-dir=${libpng.dev}"
+            "--with-webp-dir=${libwebp}"
+            "--with-xpm-dir=${libXpm.dev}"
+            "--with-zlib-dir=${zlib.dev}"
+            "--enable-gd-jis-conv"
+          ];
+          doCheck = false;
+          enable = lib.versionOlder php.version "7.4";
+        }
+        {
+          name = "gettext";
+          buildInputs = [ gettext ];
+          patches = lib.optionals (lib.versionOlder php.version "7.4") [
+            (fetchpatch {
+              url = "https://github.com/php/php-src/commit/632b6e7aac207194adc3d0b41615bfb610757f41.patch";
+              sha256 = "0xn3ivhc4p070vbk5yx0mzj2n7p04drz3f98i77amr51w0vzv046";
+            })
+          ];
+          postPhpize = ''substituteInPlace configure --replace 'as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5' ':' '';
+          configureFlags = [ "--with-gettext=${gettext}" ];
+        }
+        {
+          name = "gmp";
+          buildInputs = [ gmp ];
+          configureFlags = [ "--with-gmp=${gmp.dev}" ];
+        }
+        { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
+        {
+          name = "iconv";
+          configureFlags = [
+            "--with-iconv${lib.optionalString stdenv.isDarwin "=${libiconv}"}"
+          ];
+          patches = lib.optionals (lib.versionOlder php.version "8.0") [
+            # Header path defaults to FHS location, preventing the configure script from detecting errno support.
+            (fetchpatch {
+              url = "https://github.com/fossar/nix-phps/raw/263861a8c9bdafd7abe44db6db4ef0179643680c/pkgs/iconv-header-path.patch";
+              sha256 = "7GHnEUu+hcsQ4h3itDwk6p46ZKfib9JZ2XpWlXrdn6E=";
+            })
+          ];
+          doCheck = false;
+        }
+        {
+          name = "imap";
+          buildInputs = [ uwimap openssl pam pcre2 ];
+          configureFlags = [ "--with-imap=${uwimap}" "--with-imap-ssl" ];
+          # uwimap doesn't build on darwin.
+          enable = (!stdenv.isDarwin);
+        }
+        {
+          name = "intl";
+          buildInputs = [ icu64 ];
+          patches = lib.optionals (lib.versionOlder php.version "7.4") [
+            (fetchpatch {
+              url = "https://github.com/php/php-src/commit/93a9b56c90c334896e977721bfb3f38b1721cec6.patch";
+              sha256 = "055l40lpyhb0rbjn6y23qkzdhvpp7inbnn6x13cpn4inmhjqfpg4";
+            })
+          ];
+        }
+        { name = "json"; enable = lib.versionOlder php.version "8.0"; }
+        {
+          name = "ldap";
+          buildInputs = [ openldap cyrus_sasl ];
+          configureFlags = [
+            "--with-ldap"
+            "LDAP_DIR=${openldap.dev}"
+            "LDAP_INCDIR=${openldap.dev}/include"
+            "LDAP_LIBDIR=${openldap.out}/lib"
+          ] ++ lib.optionals stdenv.isLinux [
+            "--with-ldap-sasl=${cyrus_sasl.dev}"
+          ];
+          doCheck = false;
+        }
+        {
+          name = "mbstring";
+          buildInputs = [ oniguruma ] ++ lib.optionals (lib.versionAtLeast php.version "8.0") [
+            pcre2
+          ];
+          doCheck = false;
+        }
+        {
+          name = "mysqli";
+          internalDeps = [ php.extensions.mysqlnd ];
+          configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ];
+          doCheck = false;
+        }
+        {
+          name = "mysqlnd";
+          buildInputs = [ zlib openssl ];
+          # The configure script doesn't correctly add library link
+          # flags, so we add them to the variable used by the Makefile
+          # when linking.
+          MYSQLND_SHARED_LIBADD = "-lssl -lcrypto";
+          # The configure script builds a config.h which is never
+          # included. Let's include it in the main header file
+          # included by all .c-files.
+          patches = [
+            (pkgs.writeText "mysqlnd_config.patch" ''
+              --- a/ext/mysqlnd/mysqlnd.h
+              +++ b/ext/mysqlnd/mysqlnd.h
+              @@ -1,3 +1,6 @@
+              +#ifdef HAVE_CONFIG_H
+              +#include "config.h"
+              +#endif
+               /*
+                 +----------------------------------------------------------------------+
+                 | Copyright (c) The PHP Group                                          |
+            '')
+          ] ++ lib.optionals (lib.versionOlder php.version "7.4.8") [
+            (pkgs.writeText "mysqlnd_fix_compression.patch" ''
+              --- a/ext/mysqlnd/mysqlnd.h
+              +++ b/ext/mysqlnd/mysqlnd.h
+              @@ -48,7 +48,7 @@
+               #define MYSQLND_DBG_ENABLED 0
+               #endif
 
-            -#if defined(MYSQLND_COMPRESSION_WANTED) && defined(HAVE_ZLIB)
-            +#if defined(MYSQLND_COMPRESSION_WANTED)
-             #define MYSQLND_COMPRESSION_ENABLED 1
-             #endif
-          '')
-        ];
-        postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
-          substituteInPlace configure --replace '$OPENSSL_LIBDIR' '${openssl}/lib' \
-                                      --replace '$OPENSSL_INCDIR' '${openssl.dev}/include'
-        ''; }
-      # oci8 (7.4, 7.3, 7.2)
-      # odbc (7.4, 7.3, 7.2)
-      { name = "opcache";
-        buildInputs = [ pcre2 ] ++ lib.optionals (lib.versionAtLeast php.version "8.0" && !stdenv.isDarwin && lib.meta.availableOn stdenv.hostPlatform valgrind) [
-          valgrind.dev
-        ];
-        patches = lib.optionals (lib.versionOlder php.version "7.4") [
-          (pkgs.writeText "zend_file_cache_config.patch" ''
-            --- a/ext/opcache/zend_file_cache.c
-            +++ b/ext/opcache/zend_file_cache.c
-            @@ -27,9 +27,9 @@
-             #include "ext/standard/md5.h"
-             #endif
+              -#if defined(MYSQLND_COMPRESSION_WANTED) && defined(HAVE_ZLIB)
+              +#if defined(MYSQLND_COMPRESSION_WANTED)
+               #define MYSQLND_COMPRESSION_ENABLED 1
+               #endif
+            '')
+          ];
+          postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
+            substituteInPlace configure --replace '$OPENSSL_LIBDIR' '${openssl}/lib' \
+                                        --replace '$OPENSSL_INCDIR' '${openssl.dev}/include'
+          '';
+        }
+        # oci8 (7.4, 7.3, 7.2)
+        # odbc (7.4, 7.3, 7.2)
+        {
+          name = "opcache";
+          buildInputs = [ pcre2 ] ++ lib.optionals (!stdenv.isDarwin && lib.versionAtLeast php.version "8.0") [
+            valgrind.dev
+          ];
+          patches = lib.optionals (lib.versionOlder php.version "7.4") [
+            (pkgs.writeText "zend_file_cache_config.patch" ''
+              --- a/ext/opcache/zend_file_cache.c
+              +++ b/ext/opcache/zend_file_cache.c
+              @@ -27,9 +27,9 @@
+               #include "ext/standard/md5.h"
+               #endif
 
-            +#include "ZendAccelerator.h"
-             #ifdef HAVE_OPCACHE_FILE_CACHE
+              +#include "ZendAccelerator.h"
+               #ifdef HAVE_OPCACHE_FILE_CACHE
 
-            -#include "ZendAccelerator.h"
-             #include "zend_file_cache.h"
-             #include "zend_shared_alloc.h"
-             #include "zend_accelerator_util_funcs.h"
-          '') ];
-        zendExtension = true;
-        doCheck = !(lib.versionOlder php.version "7.4");
-        # Tests launch the builtin webserver.
-        __darwinAllowLocalNetworking = true; }
-      { name = "openssl";
-        buildInputs = [ openssl ];
-        configureFlags = [ "--with-openssl" ];
-        doCheck = false; }
-      { name = "pcntl"; }
-      { name = "pdo"; doCheck = false; }
-      { name = "pdo_dblib";
-        internalDeps = [ php.extensions.pdo ];
-        configureFlags = [ "--with-pdo-dblib=${freetds}" ];
-        # Doesn't seem to work on darwin.
-        enable = (!stdenv.isDarwin);
-        doCheck = false; }
-      # pdo_firebird (7.4, 7.3, 7.2)
-      { name = "pdo_mysql";
-        internalDeps = with php.extensions; [ pdo mysqlnd ];
-        configureFlags = [ "--with-pdo-mysql=mysqlnd" "PHP_MYSQL_SOCK=/run/mysqld/mysqld.sock" ];
-        doCheck = false; }
-      # pdo_oci (7.4, 7.3, 7.2)
-      { name = "pdo_odbc";
-        internalDeps = [ php.extensions.pdo ];
-        configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ];
-        doCheck = false; }
-      { name = "pdo_pgsql";
-        internalDeps = [ php.extensions.pdo ];
-        configureFlags = [ "--with-pdo-pgsql=${postgresql}" ];
-        doCheck = false; }
-      { name = "pdo_sqlite";
-        internalDeps = [ php.extensions.pdo ];
-        buildInputs = [ sqlite ];
-        configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ];
-        doCheck = false; }
-      { name = "pgsql";
-        buildInputs = [ pcre2 ];
-        configureFlags = [ "--with-pgsql=${postgresql}" ];
-        doCheck = false; }
-      { name = "posix"; doCheck = false; }
-      { name = "pspell"; configureFlags = [ "--with-pspell=${aspell}" ]; }
-      { name = "readline";
-        buildInputs = [ libedit readline ];
-        configureFlags = [ "--with-readline=${readline.dev}" ];
-        postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
-          substituteInPlace configure --replace 'as_fn_error $? "Please reinstall libedit - I cannot find readline.h" "$LINENO" 5' ':'
-        '';
-        doCheck = false;
-      }
-      { name = "session"; doCheck = !(lib.versionAtLeast php.version "8.0"); }
-      { name = "shmop"; }
-      { name = "simplexml";
-        buildInputs = [ libxml2 pcre2 ];
-        configureFlags = [ "--enable-simplexml" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
-      { name = "snmp";
-        buildInputs = [ net-snmp openssl ];
-        configureFlags = [ "--with-snmp" ];
-        # net-snmp doesn't build on darwin.
-        enable = (!stdenv.isDarwin);
-        doCheck = false; }
-      { name = "soap";
-        buildInputs = [ libxml2 ];
-        configureFlags = [ "--enable-soap" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
-        doCheck = false; }
-      { name = "sockets"; doCheck = false; }
-      { name = "sodium"; buildInputs = [ libsodium ]; }
-      { name = "sqlite3"; buildInputs = [ sqlite ]; }
-      { name = "sysvmsg"; }
-      { name = "sysvsem"; }
-      { name = "sysvshm"; }
-      { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; doCheck = false; }
-      { name = "tokenizer"; }
-      { name = "wddx";
-        buildInputs = [ libxml2 ];
-        internalDeps = [ php.extensions.session ];
-        configureFlags = [ "--enable-wddx" "--with-libxml-dir=${libxml2.dev}" ];
-        # Removed in php 7.4.
-        enable = lib.versionOlder php.version "7.4"; }
-      { name = "xml";
-        buildInputs = [ libxml2 ];
-        configureFlags = [ "--enable-xml" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
-        doCheck = false; }
-      { name = "xmlreader";
-        buildInputs = [ libxml2 ];
-        internalDeps = [ php.extensions.dom ];
-        NIX_CFLAGS_COMPILE = [ "-I../.." "-DHAVE_DOM" ];
-        configureFlags = [ "--enable-xmlreader" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
-      { name = "xmlrpc";
-        buildInputs = [ libxml2 libiconv ];
-        # xmlrpc was unbundled in 8.0 https://php.watch/versions/8.0/xmlrpc
-        enable = lib.versionOlder php.version "8.0";
-        configureFlags = [ "--with-xmlrpc" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
-      { name = "xmlwriter";
-        buildInputs = [ libxml2 ];
-        configureFlags = [ "--enable-xmlwriter" ]
-          # Required to build on darwin.
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
-      { name = "xsl";
-        buildInputs = [ libxslt libxml2 ];
-        doCheck = lib.versionOlder php.version "8.0";
-        configureFlags = [ "--with-xsl=${libxslt.dev}" ]; }
-      { name = "zend_test"; }
-      { name = "zip";
-        buildInputs = [ libzip pcre2 ];
-        configureFlags = [ "--with-zip" ]
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
-          ++ lib.optionals (lib.versionOlder php.version "7.3") [ "--with-libzip" ];
-        doCheck = false; }
-      { name = "zlib";
-        buildInputs = [ zlib ];
-        patches = lib.optionals (lib.versionOlder php.version "7.4") [
-          # Derived from https://github.com/php/php-src/commit/f16b012116d6c015632741a3caada5b30ef8a699
-          ../development/interpreters/php/zlib-darwin-tests.patch
-        ];
-        configureFlags = [ "--with-zlib" ]
-          ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]; }
-    ];
+              -#include "ZendAccelerator.h"
+               #include "zend_file_cache.h"
+               #include "zend_shared_alloc.h"
+               #include "zend_accelerator_util_funcs.h"
+            '')
+          ];
+          zendExtension = true;
+          doCheck = !(lib.versionOlder php.version "7.4");
+          # Tests launch the builtin webserver.
+          __darwinAllowLocalNetworking = true;
+        }
+        {
+          name = "openssl";
+          buildInputs = [ openssl ];
+          configureFlags = [ "--with-openssl" ];
+          doCheck = false;
+        }
+        { name = "pcntl"; }
+        { name = "pdo"; doCheck = false; }
+        {
+          name = "pdo_dblib";
+          internalDeps = [ php.extensions.pdo ];
+          configureFlags = [ "--with-pdo-dblib=${freetds}" ];
+          # Doesn't seem to work on darwin.
+          enable = (!stdenv.isDarwin);
+          doCheck = false;
+        }
+        # pdo_firebird (7.4, 7.3, 7.2)
+        {
+          name = "pdo_mysql";
+          internalDeps = with php.extensions; [ pdo mysqlnd ];
+          configureFlags = [ "--with-pdo-mysql=mysqlnd" "PHP_MYSQL_SOCK=/run/mysqld/mysqld.sock" ];
+          doCheck = false;
+        }
+        # pdo_oci (7.4, 7.3, 7.2)
+        {
+          name = "pdo_odbc";
+          internalDeps = [ php.extensions.pdo ];
+          configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ];
+          doCheck = false;
+        }
+        {
+          name = "pdo_pgsql";
+          internalDeps = [ php.extensions.pdo ];
+          configureFlags = [ "--with-pdo-pgsql=${postgresql}" ];
+          doCheck = false;
+        }
+        {
+          name = "pdo_sqlite";
+          internalDeps = [ php.extensions.pdo ];
+          buildInputs = [ sqlite ];
+          configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ];
+          doCheck = false;
+        }
+        {
+          name = "pgsql";
+          buildInputs = [ pcre2 ];
+          configureFlags = [ "--with-pgsql=${postgresql}" ];
+          doCheck = false;
+        }
+        { name = "posix"; doCheck = false; }
+        { name = "pspell"; configureFlags = [ "--with-pspell=${aspell}" ]; }
+        {
+          name = "readline";
+          buildInputs = [ libedit readline ];
+          configureFlags = [ "--with-readline=${readline.dev}" ];
+          postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
+            substituteInPlace configure --replace 'as_fn_error $? "Please reinstall libedit - I cannot find readline.h" "$LINENO" 5' ':'
+          '';
+          doCheck = false;
+        }
+        { name = "session"; doCheck = !(lib.versionAtLeast php.version "8.0"); }
+        { name = "shmop"; }
+        {
+          name = "simplexml";
+          buildInputs = [ libxml2 pcre2 ];
+          configureFlags = [ "--enable-simplexml" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        }
+        {
+          name = "snmp";
+          buildInputs = [ net-snmp openssl ];
+          configureFlags = [ "--with-snmp" ];
+          # net-snmp doesn't build on darwin.
+          enable = (!stdenv.isDarwin);
+          doCheck = false;
+        }
+        {
+          name = "soap";
+          buildInputs = [ libxml2 ];
+          configureFlags = [ "--enable-soap" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+          doCheck = false;
+        }
+        { name = "sockets"; doCheck = false; }
+        { name = "sodium"; buildInputs = [ libsodium ]; }
+        { name = "sqlite3"; buildInputs = [ sqlite ]; }
+        { name = "sysvmsg"; }
+        { name = "sysvsem"; }
+        { name = "sysvshm"; }
+        { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; doCheck = false; }
+        { name = "tokenizer"; }
+        {
+          name = "wddx";
+          buildInputs = [ libxml2 ];
+          internalDeps = [ php.extensions.session ];
+          configureFlags = [ "--enable-wddx" "--with-libxml-dir=${libxml2.dev}" ];
+          # Removed in php 7.4.
+          enable = lib.versionOlder php.version "7.4";
+        }
+        {
+          name = "xml";
+          buildInputs = [ libxml2 ];
+          configureFlags = [ "--enable-xml" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+          doCheck = false;
+        }
+        {
+          name = "xmlreader";
+          buildInputs = [ libxml2 ];
+          internalDeps = [ php.extensions.dom ];
+          NIX_CFLAGS_COMPILE = [ "-I../.." "-DHAVE_DOM" ];
+          configureFlags = [ "--enable-xmlreader" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        }
+        {
+          name = "xmlrpc";
+          buildInputs = [ libxml2 libiconv ];
+          # xmlrpc was unbundled in 8.0 https://php.watch/versions/8.0/xmlrpc
+          enable = lib.versionOlder php.version "8.0";
+          configureFlags = [ "--with-xmlrpc" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        }
+        {
+          name = "xmlwriter";
+          buildInputs = [ libxml2 ];
+          configureFlags = [ "--enable-xmlwriter" ]
+            # Required to build on darwin.
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        }
+        {
+          name = "xsl";
+          buildInputs = [ libxslt libxml2 ];
+          doCheck = lib.versionOlder php.version "8.0";
+          configureFlags = [ "--with-xsl=${libxslt.dev}" ];
+        }
+        { name = "zend_test"; }
+        {
+          name = "zip";
+          buildInputs = [ libzip pcre2 ];
+          configureFlags = [ "--with-zip" ]
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
+            ++ lib.optionals (lib.versionOlder php.version "7.3") [ "--with-libzip" ];
+          doCheck = false;
+        }
+        {
+          name = "zlib";
+          buildInputs = [ zlib ];
+          patches = lib.optionals (lib.versionOlder php.version "7.4") [
+            # Derived from https://github.com/php/php-src/commit/f16b012116d6c015632741a3caada5b30ef8a699
+            ../development/interpreters/php/zlib-darwin-tests.patch
+          ];
+          configureFlags = [ "--with-zlib" ]
+            ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ];
+        }
+      ];
 
-    # Convert the list of attrs:
-    # [ { name = <name>; ... } ... ]
-    # to a list of
-    # [ { name = <name>; value = <extension drv>; } ... ]
-    #
-    # which we later use listToAttrs to make all attrs available by name.
-    #
-    # Also filter out extensions based on the enable property.
-    namedExtensions = builtins.map (drv: {
-      name = drv.name;
-      value = mkExtension drv;
-    }) (builtins.filter (i: i.enable or true) extensionData);
+      # Convert the list of attrs:
+      # [ { name = <name>; ... } ... ]
+      # to a list of
+      # [ { name = <name>; value = <extension drv>; } ... ]
+      #
+      # which we later use listToAttrs to make all attrs available by name.
+      #
+      # Also filter out extensions based on the enable property.
+      namedExtensions = builtins.map
+        (drv: {
+          name = drv.name;
+          value = mkExtension drv;
+        })
+        (builtins.filter (i: i.enable or true) extensionData);
 
-    # Produce the final attribute set of all extensions defined.
-  in builtins.listToAttrs namedExtensions);
+      # Produce the final attribute set of all extensions defined.
+    in
+    builtins.listToAttrs namedExtensions
+  );
 })


### PR DESCRIPTION
###### Motivation for this change
Just reformatting all the files for consistency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
