### PR TITLE
fancy-motd: unstable-2021-05-20 -> unstable-2021-06-26

### DIFF
--- a/pkgs/tools/system/fancy-motd/default.nix
+++ b/pkgs/tools/system/fancy-motd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fancy-motd";
-  version = "unstable-2021-05-20";
+  version = "unstable-2021-06-26";
 
   src = fetchFromGitHub {
     owner = "bcyran";
     repo = pname;
-    rev = "57978bdfa31179783c51c6f33e47063ec8641205";
-    sha256 = "0bkgd86721jw81jvliw3rv4p52qpjynsxb6hn81divd068l56prg";
+    rev = "dc3c8768affa6320050a141420b3ca80c687fce6";
+    sha256 = "1zs0i1cpn6dky2hqmdr2phycmjdk30ipvvdhrxg6z3bgizd502x0";
   };
 
   buildInputs = [ bc curl figlet fortune gawk iproute2 ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
