### PR TITLE
ytfzf: 1.1.6 -> 1.2.0

### DIFF
--- a/pkgs/tools/misc/ytfzf/default.nix
+++ b/pkgs/tools/misc/ytfzf/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ytfzf";
-  version = "1.1.6";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "pystardust";
     repo = "ytfzf";
     rev = "v${version}";
-    sha256 = "sha256-HXn/8Lrt6tNZWW1AeKMArOiW9t1v7MzlynSLryNdI5Y=";
+    sha256 = "sha256-3wbjCtRmnd9tm8kqKaIF6VmMdKsWznhOvQkEsrAJpAE=";
   };
 
   patches = [

--- a/pkgs/tools/misc/ytfzf/no-update.patch
+++ b/pkgs/tools/misc/ytfzf/no-update.patch
@@ -1,8 +1,8 @@
 diff --git a/ytfzf b/ytfzf
-index d5ff8c9..96f9c8f 100755
+index f4d2e0d..7a3b4b6 100755
 --- a/ytfzf
 +++ b/ytfzf
-@@ -934,23 +934,8 @@ send_notify () {
+@@ -1260,22 +1260,8 @@ EOF
  }
  
  update_ytfzf () {
@@ -12,19 +12,18 @@ index d5ff8c9..96f9c8f 100755
 -
 -	if sed -n '1p' < "$updatefile" | grep -q '#!/bin/sh'; then
 -		chmod 755 "$updatefile"
--		if [ "$(uname)" = "Darwin" ]; then
--			sudo cp "$updatefile" "/usr/local/bin/ytfzf"
--		else
--			sudo cp "$updatefile" "/usr/bin/ytfzf"
--		fi
+-		[ "$(uname)" = "Darwin" ] && prefix="/usr/local/bin" || prefix="/usr/bin"
+-		function_exists "sudo" && doasroot="sudo" || doasroot="doas"
+-		$doasroot cp "$updatefile" "$prefix/ytfzf"
+-		unset prefix doasroot
 -	else
 -		printf "%bFailed to update ytfzf. Try again later.%b" "$c_red" "$c_reset"
 -	fi
 -
 -	rm "$updatefile"
--	exit
+-	exit 0
 +	printf "%bUpdates have to be installed through Nix.%b\n" "$c_red" "$c_reset"
 +	exit 1
  }
  
- sort_video_data_date () {
+ #gives a value to sort by (this will give the unix time the video was uploaded)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/pystardust/ytfzf/releases/tag/v1.2.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
