### PR TITLE
ibus-engines.rime: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/data/misc/rime-data/default.nix
+++ b/pkgs/data/misc/rime-data/default.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, fetchFromGitHub, librime }:
+
+stdenv.mkDerivation {
+  pname = "rime-data";
+  version = "0.38.20210628";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "plum";
+    rev = "0b835e347cad9c2d7038cfe82df5b5d1fe1c0327";
+    sha256 = "0mja4wyazxdc6fr7pzij5ah4rzwxv4s12s64vfn5ikx1ias1f8ib";
+  };
+
+  buildInputs = [ librime ];
+
+  buildFlags = [ "all" ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preBuild = import ./fetchSchema.nix fetchFromGitHub;
+
+  postPatch = ''
+    # Disable git operations.
+    sed -i /fetch_or_update_package$/d scripts/install-packages.sh
+  '';
+
+  meta = with lib; {
+    description = "Schema data of Rime Input Method Engine";
+    longDescription = ''
+      Rime-data provides schema data for Rime Input Method Engine.
+    '';
+    homepage = "https://rime.im";
+    license = with licenses; [
+      # rime-array
+      # rime-combo-pinyin
+      # rime-double-pinyin
+      # rime-middle-chinese
+      # rime-scj
+      # rime-soutzoe
+      # rime-stenotype
+      # rime-wugniu
+      gpl3Only
+
+      # plum
+      # rime-bopomofo
+      # rime-cangjie
+      # rime-emoji
+      # rime-essay
+      # rime-ipa
+      # rime-jyutping
+      # rime-luna-pinyin
+      # rime-prelude
+      # rime-quick
+      # rime-stroke
+      # rime-terra-pinyin
+      # rime-wubi
+      lgpl3Only
+
+      # rime-pinyin-simp
+      asl20
+
+      # rime-cantonese
+      cc-by-40
+    ];
+    maintainers = [ maintainers.pengmeiyu ];
+  };
+}

--- a/pkgs/data/misc/rime-data/fetchSchema.nix
+++ b/pkgs/data/misc/rime-data/fetchSchema.nix
@@ -1,0 +1,137 @@
+# Generated using generateFetchSchema.sh
+fetchFromGitHub:
+''
+mkdir -p package/rime
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-array";
+  rev = "8514193da939bc8888ad6a744f5e5921d4baebc7";
+  sha256 = "1fy7pcq7d8m0wzkkhklmv6p370ms9lqc1zpndyy2xjamzrbb9l83";
+}} package/rime/array
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-bopomofo";
+  rev = "c7618f4f5728e1634417e9d02ea50d82b71956ab";
+  sha256 = "0g77nv0jrwqnbqqna0ib0kqcy6l5zl62kh49ny67d6bjwnwz9186";
+}} package/rime/bopomofo
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-cangjie";
+  rev = "8dfad9e537f18821b71ba28773315d9c670ae245";
+  sha256 = "029kw9nx6x0acg4f0m8wj1ziqffffhy9yyj51nlx17cnia0qcrby";
+}} package/rime/cangjie
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-cantonese";
+  rev = "b6f800c74eb639816d56d0d5601aaa96c8963178";
+  sha256 = "1a4ksacbz8l30y3y5c017d0hzwik8knplglb3yswy7l4hsvaanyh";
+}} package/rime/cantonese
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-combo-pinyin";
+  rev = "a84065a86b272c76215215bd6f03c506b6e7097c";
+  sha256 = "1f0b4kakw0x26gmx7xi4f94nbjlb8lvi9bks4f92jswa045vnd87";
+}} package/rime/combo-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-double-pinyin";
+  rev = "69bf85d4dfe8bac139c36abbd68d530b8b6622ea";
+  sha256 = "093wif5avvvw45fqbwj5wkbxrychy4pagl4mwsmbrayc8jkp69ak";
+}} package/rime/double-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-emoji";
+  rev = "4c8c51f4a3bc7298c99376eda9bbd86070fc4fa1";
+  sha256 = "0175jqh210fncafqckr9zzaw55qpswmqjrykwms1apmc68l43122";
+}} package/rime/emoji
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-essay";
+  rev = "9db2e77305e75798baf3ec8dcf1f82785b5e1be9";
+  sha256 = "03ypkkaadd5qmyg26n24a66cll90xvcimgbmiyv4d33jradiqg22";
+}} package/rime/essay
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-ipa";
+  rev = "22b71710e029bcb412e9197192a638ab11bc2abf";
+  sha256 = "0zdk4f9qkfj3q5hmjnairj1lv6f6y27mic12k886n6sxywwbwr2k";
+}} package/rime/ipa
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-jyutping";
+  rev = "1e24baa6998815c716c581effe8ec65ee87c4e8c";
+  sha256 = "0s2rckpwlrm3n7w1csnqyi5p9mkpp3z87s7mrm2vc9sv06rpv7zl";
+}} package/rime/jyutping
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-luna-pinyin";
+  rev = "623adb022b094d540218b287c2e601509eee3347";
+  sha256 = "06pcwp09l5wkqv7792gbsl31xnlb3gr9q6bgbp94vvq6m2ycahqz";
+}} package/rime/luna-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-middle-chinese";
+  rev = "9fad7a7c0c26167d5e6e85db8df48a15c7f7d4f0";
+  sha256 = "0a0bqrlzg0k692xblqnh1rh1fwwqqb205xwxlihgji85n8ibcgph";
+}} package/rime/middle-chinese
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-pinyin-simp";
+  rev = "b0e84cda02c613ebdedc127a26131b3800f45a8e";
+  sha256 = "05v804qr3a9xvjzp9yid7231fi2l2yrl47ybbvql61z9k36ab094";
+}} package/rime/pinyin-simp
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-prelude";
+  rev = "3de303ffaa731dba07b0462ce59f4767e1219ad2";
+  sha256 = "0g7a0bla58rh1v3md59k6adk185pilb4z8i2i0pqdl4nwqp40n2p";
+}} package/rime/prelude
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-quick";
+  rev = "3fe5911ba608cb2df1b6301b76ad1573bd482a76";
+  sha256 = "08bh87ym5qvw55lyw20l3m7jd4c2z5rvil8h5q8790r7z6j6ijy9";
+}} package/rime/quick
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-scj";
+  rev = "cab5a0858765eff0553dd685a2d61d5536e9149c";
+  sha256 = "0ard2bjp4896a8dimmcwyjwgmp9kl4rz92yc92jnd3y4rgwl6fvk";
+}} package/rime/scj
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-soutzoe";
+  rev = "beeaeca72d8e17dfd1e9af58680439e9012987dc";
+  sha256 = "0jyqx0q9s0qxn168l5n8zav8jcl2g5ppr7pa8jm1vwrllf20slcc";
+}} package/rime/soutzoe
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-stenotype";
+  rev = "f3e9189d5ce33c55d3936cc58e39d0c88b3f0c88";
+  sha256 = "0dl6px7lrh3xa87knjzwzdcwjj1k1dg4l72q7lb48an4s9f1cy5d";
+}} package/rime/stenotype
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-stroke";
+  rev = "ea8576d1accd6fda339e96b415caadb56e2a07d1";
+  sha256 = "07h6nq9867hjrd2v3h1pnr940sdrw4mqrzj43siz1rzjxz3s904r";
+}} package/rime/stroke
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-terra-pinyin";
+  rev = "ce7b9249612f575d2f43d51fcacd31d1b4e0ef1b";
+  sha256 = "0vm303f4lrdmdmif5klrp6w29vn9z2vzw33cw0y83pcnz39wiads";
+}} package/rime/terra-pinyin
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-wubi";
+  rev = "f1876f08f1d4a9696395be0070c0e8e4353c44cb";
+  sha256 = "1d9y9rqssacria9d0hla96czsqv2wkfm6z926m1x269ryv96zxvk";
+}} package/rime/wubi
+ln -sv ${fetchFromGitHub {
+  owner = "rime";
+  repo = "rime-wugniu";
+  rev = "abd1ee98efbf170258fcf43875c21a4259e00b61";
+  sha256 = "0qn54d3cclny106ixdw08r5n6wn52ffs1hgrma3k0j4pv0kr9nlq";
+}} package/rime/wugniu
+''

--- a/pkgs/data/misc/rime-data/generateFetchSchema.sh
+++ b/pkgs/data/misc/rime-data/generateFetchSchema.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch-git -p jq
+
+imlist=(
+    array
+    bopomofo
+    cangjie
+    cantonese
+    combo-pinyin
+    double-pinyin
+    emoji
+    essay
+    ipa
+    jyutping
+    luna-pinyin
+    middle-chinese
+    pinyin-simp
+    prelude
+    quick
+    scj
+    soutzoe
+    stenotype
+    stroke
+    terra-pinyin
+    wubi
+    wugniu
+)
+
+echo "# Generated using generateFetchSchema.sh"
+echo "fetchFromGitHub:"
+echo \'\'
+echo "mkdir -p package/rime"
+for im in ${imlist[@]}; do
+    tempFile=$(mktemp)
+    echo "ln -sv \${fetchFromGitHub {"
+    echo "  owner = \"rime\";"
+    echo "  repo = \"rime-$im\";"
+    nix-prefetch-git --quiet https://github.com/rime/rime-$im \
+        | jq '{ rev: .rev, sha256: .sha256 }' \
+        | jq -r 'to_entries | map("  \(.key) = \"\(.value)\";") | .[]'
+    echo "}} package/rime/$im"
+done
+echo \'\'

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
@@ -1,36 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, gdk-pixbuf, glib, ibus, libnotify
-, librime, brise }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gdk-pixbuf
+, glib
+, ibus
+, libnotify
+, librime
+, pkg-config
+, rime-data
+}:
 
 stdenv.mkDerivation rec {
   pname = "ibus-rime";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "rime";
     repo = "ibus-rime";
     rev = version;
-    sha256 = "0zbajz7i18vrqwdyclzywvsjg6qzaih64jhi3pkxp7mbw8jc5vhy";
+    sha256 = "0gdxg6ia0i31jn3cvh1nrsjga1j31hf8a2zfgg8rzn25chrfr319";
   };
 
-  buildInputs = [ gdk-pixbuf glib ibus libnotify librime brise ];
+  buildInputs = [ gdk-pixbuf glib ibus libnotify librime rime-data ];
   nativeBuildInputs = [ cmake pkg-config ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
-  dontUseCmakeConfigure = true;
+  cmakeFlags = [ "-DRIME_DATA_DIR=${rime-data}/share/rime-data" ];
 
   prePatch = ''
-    substituteInPlace Makefile \
-       --replace 'cmake' 'cmake -DRIME_DATA_DIR=${brise}/share/rime-data'
-
-    substituteInPlace rime_config.h \
-       --replace '/usr' $out
-
-    substituteInPlace rime_config.h \
-       --replace 'IBUS_RIME_SHARED_DATA_DIR IBUS_RIME_INSTALL_PREFIX' \
-                 'IBUS_RIME_SHARED_DATA_DIR "${brise}"'
-
-    substituteInPlace rime.xml \
-       --replace '/usr' $out
+    substituteInPlace CMakeLists.txt \
+       --replace 'DESTINATION "''${RIME_DATA_DIR}"' \
+                 'DESTINATION "''${CMAKE_INSTALL_DATADIR}/rime-data"'
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22432,6 +22432,8 @@ in
 
   redhat-official-fonts = callPackage ../data/fonts/redhat-official { };
 
+  rime-data = callPackage ../data/misc/rime-data { };
+
   route159 = callPackage ../data/fonts/route159 { };
 
   sampradaya = callPackage ../data/fonts/sampradaya { };


### PR DESCRIPTION
###### Motivation for this change

Update ibus-engines.rime to 1.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
