### PR TITLE
wpa_supplicant: allow disabling pcsclite dependency

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,9 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, openssl, pkg-config, libnl
-
 , withDbus ? true, dbus
 , withReadline ? true, readline
 , withPcsclite ? true, pcsclite
-
 , readOnlyModeSSIDs ? false
 }:
 

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchurl, fetchpatch, openssl, pkg-config, libnl
-, dbus, readline ? null, pcsclite ? null
+
+, withDbus ? true, dbus
+, withReadline ? true, readline
+, withPcsclite ? true, pcsclite
 
 , readOnlyModeSSIDs ? false
 }:
@@ -87,16 +90,16 @@ stdenv.mkDerivation rec {
     CONFIG_TDLS=y
     CONFIG_BGSCAN_SIMPLE=y
     CONFIG_BGSCAN_LEARN=y
-  '' + optionalString (pcsclite != null) ''
+  '' + optionalString withPcsclite ''
     CONFIG_EAP_SIM=y
     CONFIG_EAP_AKA=y
     CONFIG_EAP_AKA_PRIME=y
     CONFIG_PCSC=y
-  '' + optionalString (dbus != null) ''
+  '' + optionalString withDbus ''
     CONFIG_CTRL_IFACE_DBUS=y
     CONFIG_CTRL_IFACE_DBUS_NEW=y
     CONFIG_CTRL_IFACE_DBUS_INTRO=y
-  '' + (if readline != null then ''
+  '' + (if withReadline then ''
     CONFIG_READLINE=y
   '' else ''
     CONFIG_WPA_CLI_EDIT=y
@@ -113,10 +116,13 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace /usr/local $out
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE \
       -I$(echo "${lib.getDev libnl}"/include/libnl*/) \
-      -I${lib.getDev pcsclite}/include/PCSC/"
+      ${optionalString withPcsclite "-I${lib.getDev pcsclite}/include/PCSC/"}"
   '';
 
-  buildInputs = [ openssl libnl dbus readline pcsclite ];
+  buildInputs = [ openssl libnl ]
+    ++ optional withDbus dbus
+    ++ optional withReadline readline
+    ++ optional withPcsclite pcsclite;
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This change fixes disabling `pcsclite` dependency in `wpa_supplicant`.
```nix
{
  nixpkgs.overlays = [
    (self: super:
    {
      wpa_supplicant = super.wpa_supplicant.override {
        withPcsclite = false;
      };
    })
  ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
