### PR TITLE
nixos/zsh: change default prompt theme to 'suse'

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -91,7 +91,7 @@ in
           # before setting your PS1 and etc. Otherwise this will likely to interact with
           # your ~/.zshrc configuration in unexpected ways as the default prompt sets
           # a lot of different prompt variables.
-          autoload -U promptinit && promptinit && prompt walters && setopt prompt_sp
+          autoload -U promptinit && promptinit && prompt suse && setopt prompt_sp
         '';
         description = ''
           Shell script code used to initialise the zsh prompt.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The 'walters' prompt theme sets `RPS1`, which deviates from expected behavior, as `RPS1` is not set by default in ZSH or most other shells.  Given that the main reason a prompt theme is being set is to provide a more useful default, switching to a less-opinionated prompt seems like a reasonable compromise, and is also in-line with what at least two other distributions have opted to do in the past.

Walters theme (`RPS1` on far right):
![image](https://user-images.githubusercontent.com/630909/123511063-29f9e180-d64d-11eb-9fe2-b7eb9cc1da5c.png)

Suse theme:
![image](https://user-images.githubusercontent.com/630909/123511086-5150ae80-d64d-11eb-9cba-3081e343a185.png)

The suse theme is similar to what someone would find as a default on other shells (bash, fish):
![image](https://user-images.githubusercontent.com/630909/123511177-f8354a80-d64d-11eb-8bea-4601a3178c92.png)
![image](https://user-images.githubusercontent.com/630909/123511190-0edba180-d64e-11eb-8fe9-b3eea7e2ab3a.png)

See #38535 for earlier discussion.  I'd have proposed this as a change on the previous PR, but it appears that OP has been inactive on GitHub for quite some time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
