### PR TITLE
home-assistant: support upb component

### DIFF
--- a/pkgs/development/python-modules/upb-lib/default.nix
+++ b/pkgs/development/python-modules/upb-lib/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, pyserial-asyncio
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "upb-lib";
+  version = "0.4.12";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e668055d9c389aefd09203afb96a950a320095f225ef0a1aa611e592db92a71b";
+  };
+
+  propagatedBuildInputs = [
+    pyserial-asyncio
+    pytz
+  ];
+
+  # no tests on PyPI, no tags on GitHub
+  doCheck = false;
+
+  pythonImportsCheck = [ "upb_lib" ];
+
+  meta = with lib; {
+    description = "Library for interacting with UPB PIM";
+    homepage = "https://github.com/gwww/upb-lib";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -903,7 +903,7 @@
     "unifi_direct" = ps: with ps; [ pexpect ];
     "unifiled" = ps: with ps; [ unifiled ];
     "universal" = ps: with ps; [ ];
-    "upb" = ps: with ps; [ ]; # missing inputs: upb_lib
+    "upb" = ps: with ps; [ upb-lib ];
     "upc_connect" = ps: with ps; [ connect-box ];
     "upcloud" = ps: with ps; [ ]; # missing inputs: upcloud-api
     "updater" = ps: with ps; [ distro ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -697,6 +697,7 @@ in with py.pkgs; buildPythonApplication rec {
     "unifi"
     "unifi_direct"
     "universal"
+    "upb"
     "updater"
     "upnp"
     "uptime"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8837,6 +8837,8 @@ in {
 
   upass = callPackage ../development/python-modules/upass { };
 
+  upb-lib = callPackage ../development/python-modules/upb-lib { };
+
   update_checker = callPackage ../development/python-modules/update_checker { };
 
   update-copyright = callPackage ../development/python-modules/update-copyright { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
