### PR TITLE
[20.09] python3Packages.pydantic: add patch for CVE-2021-29510

### DIFF
--- a/pkgs/development/python-modules/pydantic/1.5.1-CVE-2021-29510.patch
+++ b/pkgs/development/python-modules/pydantic/1.5.1-CVE-2021-29510.patch
@@ -1,0 +1,107 @@
+Based on upstream https://github.com/samuelcolvin/pydantic/commit/7e83fdd2563ffac081db7ecdf1affa65ef38c468.patch
+adapted by ris to apply to 1.5.1.
+
+Has side effect of adding negative timestamp support from
+https://github.com/samuelcolvin/pydantic/commit/113921c6c5d34c12de16d1ef0f83b6bc39097521
+as failing to do so would likely leave a hole in the fix.
+
+diff --git a/pydantic/datetime_parse.py b/pydantic/datetime_parse.py
+index d567c5c51..59466c15f 100644
+--- a/pydantic/datetime_parse.py
++++ b/pydantic/datetime_parse.py
+@@ -58,6 +58,8 @@
+ # if greater than this, the number is in ms, if less than or equal it's in seconds
+ # (in seconds this is 11th October 2603, in ms it's 20th August 1970)
+ MS_WATERSHED = int(2e10)
++# slightly more than datetime.max in ns - (datetime.max - EPOCH).total_seconds() * 1e9
++MAX_NUMBER = int(3e20)
+ StrBytesIntFloat = Union[str, bytes, int, float]
+ 
+ 
+@@ -73,6 +75,11 @@ def get_numeric(value: StrBytesIntFloat, native_expected_type: str) -> Union[Non
+ 
+ 
+ def from_unix_seconds(seconds: Union[int, float]) -> datetime:
+-    while seconds > MS_WATERSHED:
++    if seconds > MAX_NUMBER:
++        return datetime.max
++    elif seconds < -MAX_NUMBER:
++        return datetime.min
++
++    while abs(seconds) > MS_WATERSHED:
+         seconds /= 1000
+     dt = EPOCH + timedelta(seconds=seconds)
+diff --git a/tests/test_datetime_parse.py b/tests/test_datetime_parse.py
+index d629d9fb8..f714d6667 100644
+--- a/tests/test_datetime_parse.py
++++ b/tests/test_datetime_parse.py
+@@ -42,11 +42,20 @@ def create_tz(minutes):
+         (1_549_316_052_104, date(2019, 2, 4)),  # nowish in ms
+         (1_549_316_052_104_324, date(2019, 2, 4)),  # nowish in μs
+         (1_549_316_052_104_324_096, date(2019, 2, 4)),  # nowish in ns
++        ('infinity', date(9999, 12, 31)),
++        ('inf', date(9999, 12, 31)),
++        (float('inf'), date(9999, 12, 31)),
++        ('infinity ', date(9999, 12, 31)),
++        (int('1' + '0' * 100), date(9999, 12, 31)),
++        (1e1000, date(9999, 12, 31)),
++        ('-infinity', date(1, 1, 1)),
++        ('-inf', date(1, 1, 1)),
++        ('nan', ValueError),
+     ],
+ )
+ def test_date_parsing(value, result):
+-    if result == errors.DateError:
+-        with pytest.raises(errors.DateError):
++    if type(result) == type and issubclass(result, Exception):
++        with pytest.raises(result):
+             parse_date(value)
+     else:
+         assert parse_date(value) == result
+@@ -123,11 +132,19 @@ def test_time_parsing(value, result):
+         (1_549_316_052_104, datetime(2019, 2, 4, 21, 34, 12, 104_000, tzinfo=timezone.utc)),  # nowish in ms
+         (1_549_316_052_104_324, datetime(2019, 2, 4, 21, 34, 12, 104_324, tzinfo=timezone.utc)),  # nowish in μs
+         (1_549_316_052_104_324_096, datetime(2019, 2, 4, 21, 34, 12, 104_324, tzinfo=timezone.utc)),  # nowish in ns
++        ('infinity', datetime(9999, 12, 31, 23, 59, 59, 999999)),
++        ('inf', datetime(9999, 12, 31, 23, 59, 59, 999999)),
++        ('inf ', datetime(9999, 12, 31, 23, 59, 59, 999999)),
++        (1e50, datetime(9999, 12, 31, 23, 59, 59, 999999)),
++        (float('inf'), datetime(9999, 12, 31, 23, 59, 59, 999999)),
++        ('-infinity', datetime(1, 1, 1, 0, 0)),
++        ('-inf', datetime(1, 1, 1, 0, 0)),
++        ('nan', ValueError),
+     ],
+ )
+ def test_datetime_parsing(value, result):
+-    if result == errors.DateTimeError:
+-        with pytest.raises(errors.DateTimeError):
++    if type(result) == type and issubclass(result, Exception):
++        with pytest.raises(result):
+             parse_datetime(value)
+     else:
+         assert parse_datetime(value) == result
+@@ -251,3 +268,24 @@ class Model(BaseModel):
+         'type': 'value_error.unicodedecode',
+         'msg': "'utf-8' codec can't decode byte 0x81 in position 0: invalid start byte",
+     }
++
++
++def test_nan():
++    class Model(BaseModel):
++        dt: datetime
++        d: date
++
++    with pytest.raises(ValidationError) as exc_info:
++        Model(dt='nan', d='nan')
++    assert exc_info.value.errors() == [
++        {
++            'loc': ('dt',),
++            'msg': 'cannot convert float NaN to integer',
++            'type': 'value_error',
++        },
++        {
++            'loc': ('d',),
++            'msg': 'cannot convert float NaN to integer',
++            'type': 'value_error',
++        },
++    ]

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
       url = "https://github.com/samuelcolvin/pydantic/commit/a5b0e741e585040a0ab8b0be94dd9dc2dd3afcc7.patch";
       sha256 = "0v91ac3dw23rm73370s2ns84vi0xqbfzpvj84zb7xdiicx8fhmf1";
     })
+    ./1.5.1-CVE-2021-29510.patch
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-29510

Very simple patch, includes tests.

See #128133 for master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
