### PR TITLE
vlang: 0.1.21 -> weekly.2021.25

### DIFF
--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -4,13 +4,13 @@ assert stdenv.hostPlatform.isUnix -> upx != null;
 
 stdenv.mkDerivation rec {
   pname = "vlang";
-  version = "0.1.21";
+  version = "weekly.2021.25";
 
   src = fetchFromGitHub {
     owner = "vlang";
     repo = "v";
     rev = version;
-    sha256 = "0npd7a7nhd6r9mr99naib9scqk30209hz18nxif27284ckjbl4fk";
+    sha256 = "0y4a5rmpcdqina32d6azbmsbi3zqqfl413sicg72x6a1pm2vg33j";
   };
 
   # V compiler source translated to C for bootstrap.
@@ -18,18 +18,19 @@ stdenv.mkDerivation rec {
   vc = fetchFromGitHub {
     owner = "vlang";
     repo = "vc";
-    rev = "950a90b6acaebad1c6ddec5486fc54307e38a9cd";
-    sha256 = "1dh5l2m207rip1xj677hvbp067inw28n70ddz5wxzfpmaim63c0l";
+    rev = "3201d2dd2faadfa370da0bad2a749a664ad5ade3";
+    sha256 = "0xzkjdph5wfjr3qfkihgc27vsbbjh2l31rp8z2avq9hc531hwvrz";
   };
 
-  enableParallelBuilding = true;
   propagatedBuildInputs = [ glfw freetype openssl ]
     ++ lib.optional stdenv.hostPlatform.isUnix upx;
 
   buildPhase = ''
     runHook preBuild
     cc -std=gnu11 $CFLAGS -w -o v $vc/v.c -lm $LDFLAGS
-    ./v -prod -cflags `$CFLAGS` -o v compiler
+    # vlang seems to want to write to $HOME/.vmodules,
+    # so lets give it a writable HOME
+    HOME=$PWD ./v -prod self
     # Exclude thirdparty/vschannel as it is windows-specific.
     find thirdparty -path thirdparty/vschannel -prune -o -type f -name "*.c" -execdir cc -std=gnu11 $CFLAGS -w -c {} $LDFLAGS ';'
     runHook postBuild
@@ -39,8 +40,8 @@ stdenv.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/{bin,lib,share}
     cp -r examples $out/share
-    cp -r {vlib,thirdparty} $out/lib
-    cp v $out/lib
+    cp -r {cmd,vlib,thirdparty} $out/lib
+    mv v $out/lib
     ln -s $out/lib/v $out/bin/v
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change
Addresses #128063 
Supersedes #74985

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
