### PR TITLE
chickenPackages_5.chicken: check the binaryVersion

### DIFF
--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "https://call-cc.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ corngood ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin; # Maybe other Unix
+    platforms = lib.platforms.unix;
     description = "A portable compiler for the Scheme programming language";
     longDescription = ''
       CHICKEN is a compiler for the Scheme programming language.

--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchurl, makeWrapper, darwin, bootstrap-chicken ? null }:
 
 let
-  version = "5.2.0";
   platform = with stdenv;
     if isDarwin then "macosx"
     else if isCygwin then "cygwin"
@@ -9,9 +8,9 @@ let
     else if isSunOS then "solaris"
     else "linux"; # Should be a sane default
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "chicken";
-  inherit version;
+  version = "5.2.0";
 
   binaryVersion = 11;
 
@@ -46,10 +45,14 @@ stdenv.mkDerivation {
     done
   '';
 
-  # TODO: Assert csi -R files -p '(pathname-file (repository-path))' == binaryVersion
+  doCheck = true;
+  postCheck = ''
+    ./csi -R chicken.pathname -R chicken.platform \
+       -p "(assert (equal? \"${toString binaryVersion}\" (pathname-file (car (repository-path)))))"
+  '';
 
   meta = {
-    homepage = "http://www.call-cc.org/";
+    homepage = "https://call-cc.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ corngood ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin; # Maybe other Unix


### PR DESCRIPTION
###### Motivation for this change
This adds a new simple check during the building of the package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
