### PR TITLE
smlnj: fix x86_64-darwin build

### DIFF
--- a/pkgs/development/compilers/smlnj/bootstrap.nix
+++ b/pkgs/development/compilers/smlnj/bootstrap.nix
@@ -1,3 +1,7 @@
+# This derivation should be redundant, now that regular smlnj works on Darwin,
+# and is preserved only for pre-existing direct usage. New use cases should
+# just use the regular smlnj derivation.
+
 { lib, stdenv, fetchurl, cpio, rsync, xar, makeWrapper }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -1,11 +1,9 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, Libsystem }:
 let
   version = "110.95";
   baseurl = "http://smlnj.cs.uchicago.edu/dist/working/${version}";
 
-  isArch64 = stdenv.system == "x86_64-linux";
-
-  arch = if isArch64
+  arch = if stdenv.is64bit
     then "64"
     else "32";
 
@@ -14,7 +12,7 @@ let
   boot64 = { url = "${baseurl}/boot.amd64-unix.tgz";
              sha256 = "1zn96a83kb6bn6228yfjsvb58m2qxw9k4j3qz0p9c8za479w4ch6"; };
 
-  bootBinary = if isArch64
+  bootBinary = if stdenv.is64bit
                then boot64
                else boot32;
 
@@ -53,6 +51,10 @@ in stdenv.mkDerivation {
     sed -i '/PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
     echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
     patch --verbose config/_heap2exec ${./heap2exec.diff}
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Locate standard headers like <unistd.h>
+    substituteInPlace base/runtime/config/gen-posix-names.sh \
+      --replace "\$SDK_PATH/usr" "${Libsystem}"
   '';
 
   unpackPhase = ''
@@ -83,7 +85,7 @@ in stdenv.mkDerivation {
     description = "Standard ML of New Jersey, a compiler";
     homepage    = "http://smlnj.org";
     license     = licenses.bsd3;
-    platforms   = [ "x86_64-linux" "i686-linux" ];
+    platforms   = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12055,6 +12055,7 @@ in
 
   shmig = callPackage ../development/tools/database/shmig { };
 
+  # smlnjBootstrap should be redundant, now that smlnj works on Darwin natively
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
   smlnj = callPackage ../development/compilers/smlnj {
     inherit (darwin) Libsystem;
@@ -30058,11 +30059,7 @@ in
 
   iprover = callPackage ../applications/science/logic/iprover { };
 
-  jonprl = callPackage ../applications/science/logic/jonprl {
-    smlnj = if stdenv.isDarwin
-      then smlnjBootstrap
-      else smlnj;
-  };
+  jonprl = callPackage ../applications/science/logic/jonprl { };
 
   key = callPackage ../applications/science/logic/key { };
 
@@ -30121,19 +30118,11 @@ in
 
   tptp = callPackage ../applications/science/logic/tptp {};
 
-  celf = callPackage ../applications/science/logic/celf {
-    smlnj = if stdenv.isDarwin
-      then smlnjBootstrap
-      else smlnj;
-  };
+  celf = callPackage ../applications/science/logic/celf { };
 
   fast-downward = callPackage ../applications/science/logic/fast-downward { };
 
-  twelf = callPackage ../applications/science/logic/twelf {
-    smlnj = if stdenv.isDarwin
-      then smlnjBootstrap
-      else smlnj;
-  };
+  twelf = callPackage ../applications/science/logic/twelf { };
 
   verifast = callPackage ../applications/science/logic/verifast {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12056,7 +12056,9 @@ in
   shmig = callPackage ../development/tools/database/shmig { };
 
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
-  smlnj = callPackage ../development/compilers/smlnj { };
+  smlnj = callPackage ../development/compilers/smlnj {
+    inherit (darwin) Libsystem;
+  };
 
   smlpkg = callPackage ../tools/package-management/smlpkg { };
 


### PR DESCRIPTION
###### Motivation for this change

Fix the `x86_64-darwin` build for Standard ML of New Jersey. I've confirmed that `x86_64-linux` isn't affected.

This entails two small changes: correcting the 32/64-bit input to the project's build scripts, and locating standard C headers in the nix store.

I thought the 32/64-bit fix might also enable `aarch64-linux`, but the project is sufficiently old that it needs additional updates to support ARM at all. Since the [latest README](http://www.smlnj.org/dist/working/110.99.1/110.99.1-README.html) says they are actively working on native Apple M1 support, I haven't gone any further here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
