### PR TITLE
[21.05] libgcrypt: add patch for CVE-2021-33560

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gettext, libgpgerror, enableCapabilities ? false, libcap, buildPackages }:
+{ lib, stdenv, fetchurl, fetchpatch, gettext, libgpgerror, enableCapabilities ? false, libcap, buildPackages }:
 
 assert enableCapabilities -> stdenv.isLinux;
 
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     url = "mirror://gnupg/libgcrypt/${pname}-${version}.tar.bz2";
     sha256 = "sha256-ssENCRUTsnHkcXcnRgex/7o9lbGIu/qHl/lIrskFPFo=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-33560.patch";
+      url = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blobdiff_plain;f=cipher/elgamal.c;h=eead45022abc9d367563f065071afbbf9b5e3e55;hp=9835122fb18c615f58ad1ea580682dfb48970bf1;hb=3462280f2e23e16adf3ed5176e0f2413d8861320;hpb=8d3db6add149696bd777c6969442d771e9efdecf";
+      sha256 = "01kxy41bddhphizjyha5nwh9k6np7s4b1cfljxgwywc5hvdsz0zx";
+    })
+  ];
 
   outputs = [ "out" "dev" "info" ];
   outputBin = "dev";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-33560

Same cherry-pick as used by debian here. (See https://sources.debian.org/src/libgcrypt20/1.8.7-6/debian/patches/30_10-cipher-Fix-ElGamal-encryption-for-other-implementati.patch/)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
