### PR TITLE
lethe: init at 0.5.1

### DIFF
--- a/pkgs/tools/security/lethe/default.nix
+++ b/pkgs/tools/security/lethe/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lethe";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "kostassoid";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "173ms4fd09iclm4v5zkmvc60l6iyyb5lzxc6dxd6q21zy0pvs35g";
+  };
+
+  cargoSha256 = "11l7wxadinidf0bsxv14j1kv8gdhq1d6ffnb76n54igxid8gza14";
+
+  buildInputs = lib.optional stdenv.isDarwin Security;
+
+  meta = with lib; {
+    description = "Tool to wipe drives in a secure way";
+    homepage = "https://github.com/kostassoid/lethe";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6576,6 +6576,10 @@ in
 
   leela = callPackage ../tools/graphics/leela { };
 
+  lethe = callPackage ../tools/security/lethe {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   lftp = callPackage ../tools/networking/lftp { };
 
   libck = callPackage ../development/libraries/libck { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to wipe drives in a secure way

https://github.com/kostassoid/lethe

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
