### PR TITLE
linux_xanmod: match all features on homepage

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-xanmod.nix
+++ b/pkgs/os-specific/linux/kernel/linux-xanmod.nix
@@ -16,10 +16,34 @@ buildLinux (args // rec {
   };
 
   structuredExtraConfig = with lib.kernel; {
-    PREEMPT = lib.mkForce yes;
+
+    # Preemptive Full Tickless Kernel at 500Hz
     PREEMPT_VOLUNTARY = lib.mkForce no;
+    PREEMPT = lib.mkForce yes;
     NO_HZ_FULL = yes;
     HZ_500 = yes;
+
+    # Google's Multigenerational LRU Framework
+    LRU_GEN = yes;
+    LRU_GEN_ENABLED = yes;
+
+    # Google's BBRv2 TCP congestion Control
+    TCP_CONG_BBR2 = yes;
+    DEFAULT_BBR2 = yes;
+
+    # FQ-PIE Packet Scheduling
+    NET_SCH_DEFAULT = yes;
+    DEFAULT_FQ_PIE = yes;
+
+    # Graysky's additional CPU optimizations
+    CC_OPTIMIZE_FOR_PERFORMANCE_O3 = yes;
+
+    # Android Ashmem and Binder IPC Driver as module for Anbox
+    ASHMEM = module;
+    ANDROID = yes;
+    ANDROID_BINDER_IPC = module;
+    ANDROID_BINDERFS = module;
+    ANDROID_BINDER_DEVICES = freeform "binder,hwbinder,vndbinder";
   };
 
   extraMeta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Looking at the kernel config, some features that xanmod users would expect aren't present.

This PR aims to match the claims on the [website](https://xanmod.org/), specifically:

- Google's Multigenerational LRU Framework
- Google's BBRv2 TCP congestion Control
- FQ-PIE Packet Scheduling
- Graysky's additional CPU optimizations
- Android Ashmem and Binder IPC Driver as module for Anbox

###### Things done
- Built and successfully booted with kernel.
- Verified that changes were applied, via `zcat /proc/config.gz`.
- Mounted ZFS dataset.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
