### PR TITLE
python3Packages.adblock: 0.4.4 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -12,12 +12,11 @@
 , Security
 , pytestCheckHook
 , toml
-, python
 }:
 
 buildPythonPackage rec {
   pname = "adblock";
-  version = "0.4.4";
+  version = "0.5.0";
   disabled = isPy27;
 
   # Pypi only has binary releases
@@ -25,13 +24,13 @@ buildPythonPackage rec {
     owner = "ArniDagur";
     repo = "python-adblock";
     rev = version;
-    sha256 = "sha256-zNQ8zEpTLzyU5AnFBNpOGDJ02Ogu2+xl85LA+ia7Si4=";
+    sha256 = "sha256-JjmMfL24778T6LCuElXsD7cJxQ+RkqbNEnEqwoN24WE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-ajVZ0xPxC31hM1gQr3DC1HWdpIYBCSmqm0z2cflcClg=";
+    hash = "sha256-w+/W4T3ukRHNpCPjhlHZLPn6sgCpz4QHVD8VW+Rw5BI=";
   };
 
   format = "pyproject";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ArniDagur/python-adblock/releases/tag/0.5.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
