### PR TITLE
hikari: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/applications/window-managers/hikari/default.nix
+++ b/pkgs/applications/window-managers/hikari/default.nix
@@ -12,7 +12,7 @@
 
 let
   pname = "hikari";
-  version = "2.3.0";
+  version = "2.3.1";
 in
 
 stdenv.mkDerivation {
@@ -20,17 +20,8 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://hikari.acmelabs.space/releases/${pname}-${version}.tar.gz";
-    sha256 = "0vxwma2r9mb2h0c3dkpvf8dbrc2x2ykhc5bb0vd72sl9pwj4jxmy";
+    sha256 = "sha256-o6YsUATcWHSuAEfU7WnwxKNxRNuBt069qCv0FKDWStg=";
   };
-
-  patches = [
-    # To fix the build with wlroots 0.14.0:
-    (fetchpatch {
-      url = "https://cgit.freebsd.org/ports/plain/x11-wm/hikari/files/patch-wlroots-0.14?id=f2820b6cc2170feef17989c422f2cf46644a5b57";
-      sha256 = "1kpbcmgdm4clmf2ryrs5pv3ghycnq4glvs3d3ll6zr244ks5yf43";
-      extraPrefix = "";
-    })
-  ];
 
   nativeBuildInputs = [ pkg-config bmake ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates Hikari to the latest revision. 

Hikari has merged the patches that made https://github.com/NixOS/nixpkgs/commit/7e0e95b7763440bfdb9b1897f034fe02ce63e7dc necessary. This PR effectively reverts this commit and updates the version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
