### PR TITLE
cantata: 2.4.2 -> unstable-2021-06-14

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -78,13 +78,13 @@ let
 in
 mkDerivation rec {
   pname = "cantata";
-  version = "2.4.2";
+  version = "unstable-2021-06-14";
 
   src = fetchFromGitHub {
     owner = "CDrummond";
     repo = "cantata";
-    rev = "v${version}";
-    sha256 = "15qfx9bpfdplxxs08inwf2j8kvf7g5cln5sv1wj1l2l41vbf1mjr";
+    rev = "b5775c77578ea147b327fc6076751a392c8e27b1";
+    sha256 = "fkYxoPGfjk0wnvVEJmIps0k+C0BZ1HzDkJurzk7ObWs=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update version to latest commit/version at the time of making this PR.
The Cantata project has stopped making releases (for some reason which i do not know), though new features and bug fixes are still being added through the commits to its master branch.

Note: inside the Cantata program it does say "version: 2.5.0" and I can see that there are a couple of commits mentioning that version and a change log in the Cantata repo. https://github.com/CDrummond/cantata/commit/d61ca874081311844526ab13cd40348421f89097
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
