### PR TITLE
calibre-web: 0.6.11 -> 0.6.12

### DIFF
--- a/pkgs/development/python-modules/pypdf3/default.nix
+++ b/pkgs/development/python-modules/pypdf3/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, glibcLocales
+, python
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "pypdf3";
+  version = "1.0.5";
+
+  src = fetchPypi {
+    pname = "PyPDF3";
+    inherit version;
+    sha256 = "sha256-DGKpR4p3z8tw4gKi5Hmj09svysD3Hkn4NklhgROmEAU=";
+  };
+
+  LC_ALL = "en_US.UTF-8";
+  buildInputs = [ glibcLocales ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest tests/*.py
+  '';
+
+  propagatedBuildInputs = [
+    tqdm
+  ];
+
+  meta = with lib; {
+    description = "A Pure-Python library built as a PDF toolkit";
+    homepage = "https://github.com/sfneal/PyPDF3";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -7,22 +7,20 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "calibre-web";
-  version = "0.6.11";
+  version = "0.6.12";
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
     rev = version;
-    sha256 = "10sjllhhcamswpa1wlim4mbm2zl4g804bwly5p4nmklg7n1v226g";
+    sha256 = "sha256-IgS281qDxG302UznC63nZH8/ty4fgFtn+lLYdakGA4w=";
   };
 
   prePatch = ''
     substituteInPlace setup.cfg \
-        --replace "singledispatch>=3.4.0.0,<3.5.0.0" "" \
         --replace "requests>=2.11.1,<2.25.0" "requests>=2.11.1,<2.26.0" \
-        --replace "unidecode>=0.04.19,<1.2.0" "unidecode>=0.04.19" \
         --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
-        --replace "Babel>=1.3, <2.9" "Babel>=1.3, <=2.9"
+        --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0"
   '';
 
   patches = [
@@ -54,7 +52,7 @@ python3.pkgs.buildPythonApplication rec {
     flask_login
     flask_principal
     iso-639
-    pypdf2
+    pypdf3
     requests
     sqlalchemy
     tornado

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6305,6 +6305,8 @@ in {
 
   pypdf2 = callPackage ../development/python-modules/pypdf2 { };
 
+  pypdf3 = callPackage ../development/python-modules/pypdf3 { };
+
   pypeg2 = callPackage ../development/python-modules/pypeg2 { };
 
   pyperclip = callPackage ../development/python-modules/pyperclip { };


### PR DESCRIPTION
###### Motivation for this change

The current version fails to build, bumping the version updates the dependency requirements such that it builds now.

I am not sure about the packaging of PyPDF3, as it is mostly just a copy-paste of PyPDF2, notably I'm not sure why `glibclocales` is needed as a `buildInput`.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
