### PR TITLE
wio: 0.0.0+unstable=2021-06-01 -> 0.0.0+unstable=2021-06-27

### DIFF
--- a/pkgs/applications/window-managers/wio/default.nix
+++ b/pkgs/applications/window-managers/wio/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromBitbucket
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -20,22 +19,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wio";
-  version = "0.0.0+unstable=2021-06-01";
+  version = "0.0.0+unstable=2021-06-27";
 
   src = fetchFromBitbucket {
     owner = "anderson_torres";
     repo = pname;
-    rev = "ad57eb45ba0459cd0b16ba486cb6e01626079c29";
-    sha256 = "sha256-mCggAscQ+Ej3SNwhA6QxecV1nH6Rw8RDf8yAsbadqjE=";
+    rev = "e0b258777995055d69e61a0246a6a64985743f42";
+    sha256 = "sha256-8H9fOnZsNjjq9XvOv68F4RRglGNluxs5/jp/h4ROLiI=";
   };
-
-  patches = [
-    # Fix the build with wlroots 0.14:
-    (fetchpatch {
-      url = "https://git.sr.ht/~primeos/wio/commit/9d5093c019f6966b8ee0dba1da3361a761d04bcc.patch";
-      sha256 = "08hfmcs1fbz8pdxwcaidrhvydf19482i6wics75a41ilrdh0dpi1";
-    })
-  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
