### PR TITLE
gemrb: vlc is only needed on mac

### DIFF
--- a/pkgs/games/gemrb/default.nix
+++ b/pkgs/games/gemrb/default.nix
@@ -20,6 +20,10 @@ let
   backend =
     if (stdenv.isx86_32 || stdenv.isx86_64) then "OpenGL" else "GLES";
 
+  withVLC = stdenv.isDarwin;
+
+  inherit (lib) optional optionalString;
+
 in
 stdenv.mkDerivation rec {
   pname = "gemrb";
@@ -39,19 +43,23 @@ stdenv.mkDerivation rec {
     libGL
     libiconv
     libpng
-    libvlc
     libvorbis
     openal
     python2
     zlib
-  ];
+  ]
+  ++ optional withVLC libvlc;
 
   nativeBuildInputs = [ cmake ];
 
-  LIBVLC_INCLUDE_PATH = "${lib.getDev libvlc}/include";
-  LIBVLC_LIBRARY_PATH = "${lib.getLib libvlc}/lib";
+  # libvlc isn't being detected properly as of 0.9.0, so set it
+  LIBVLC_INCLUDE_PATH = optionalString withVLC "${lib.getDev libvlc}/include";
+  LIBVLC_LIBRARY_PATH = optionalString withVLC "${lib.getLib libvlc}/lib";
 
   cmakeFlags = [
+    "-DDATA_DIR=${placeholder "out"}/share/gemrb"
+    "-DEXAMPLE_CONF_DIR=${placeholder "out"}/share/doc/gemrb/examples"
+    "-DSYSCONF_DIR=/etc"
     # use the Mesa drivers for video on ARM (harmless on x86)
     "-DDISABLE_VIDEOCORE=ON"
     "-DLAYOUT=opt"


### PR DESCRIPTION
###### Motivation for this change

We don't need libvlc on !mac.

Also, allow setting machine-wide defaults in /etc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
