### PR TITLE
flat-remix-gnome: init at 20210623

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10872,6 +10872,12 @@
     githubId = 608417;
     name = "Jos van den Oever";
   };
+  vanilla = {
+    email = "neko@hydev.org";
+    github = "VergeDX";
+    githubId = 25173827;
+    name = "Vanilla";
+  };
   vanschelven = {
     email = "klaas@vanschelven.com";
     github = "vanschelven";

--- a/pkgs/data/themes/flat-remix-gnome/default.nix
+++ b/pkgs/data/themes/flat-remix-gnome/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, glib
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flat-remix-gnome";
+  version = "20210623";
+
+  src = fetchFromGitHub {
+    owner = "daniruiz";
+    repo = pname;
+    rev = version;
+    hash = "sha256-FKsbAvjhXb2ipe3XqACM6OwGYwbBbzvDjsUQYCIQ8NM=";
+  };
+
+  nativeBuildInputs = [ glib ];
+  makeFlags = [ "PREFIX=$(out)" ];
+  preInstall = ''
+    # make install will back up this file, it will fail if the file doesn't exist.
+    # https://github.com/daniruiz/flat-remix-gnome/blob/20210623/Makefile#L50
+    mkdir -p $out/share/gnome-shell/
+    touch $out/share/gnome-shell/gnome-shell-theme.gresource
+  '';
+
+  postInstall = ''
+    rm $out/share/gnome-shell/gnome-shell-theme.gresource.old
+  '';
+
+  meta = with lib; {
+    description = "GNOME Shell theme inspired by material design.";
+    homepage = "https://drasite.com/flat-remix-gnome";
+    license = licenses.cc-by-sa-40;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.vanilla ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22058,6 +22058,7 @@ in
     inherit (plasma5Packages) breeze-icons;
   };
   flat-remix-gtk = callPackage ../data/themes/flat-remix-gtk { };
+  flat-remix-gnome = callPackage ../data/themes/flat-remix-gnome { };
 
   font-awesome_4 = (callPackage ../data/fonts/font-awesome-5 { }).v4;
   font-awesome_5 = (callPackage ../data/fonts/font-awesome-5 { }).v5;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
