### PR TITLE
python3Packages.poppler-qt5: reduce the amount of patching done to `pyproject.toml`

### DIFF
--- a/pkgs/development/python-modules/poppler-qt5/default.nix
+++ b/pkgs/development/python-modules/poppler-qt5/default.nix
@@ -1,9 +1,7 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonPackage
 , isPy3k
 , fetchPypi
-, pythonPackages
 , sip
 , qtbase
 , qmake

--- a/pkgs/development/python-modules/poppler-qt5/default.nix
+++ b/pkgs/development/python-modules/poppler-qt5/default.nix
@@ -42,11 +42,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     cat <<EOF >> pyproject.toml
-    sip-include-dirs = ["${pyqt5}/share/sip/PyQt5"]
-
     [tool.sip.bindings.Poppler-Qt5]
     include-dirs = ["${poppler.dev}/include/poppler"]
-    tags = ["${sip.platform_tag}"]
     EOF
   '';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
