### PR TITLE
python3Packages.forecast-solar: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/forecast-solar/default.nix
+++ b/pkgs/development/python-modules/forecast-solar/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiodns
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "forecast-solar";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "forecast_solar";
+    rev = version;
+    sha256 = "1kqzr1ypvdjw0zvac4spb6xdd2qpms9h8nr6vf0w9qx756ir0f95";
+  };
+
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+  ];
+
+  # no unit tests implemented
+  doCheck = false;
+
+  pythonImportsCheck = [ "forecast_solar" ];
+
+  meta = with lib; {
+    description = "Asynchronous Python client for getting forecast solar information";
+    homepage = "https://github.com/home-assistant-libs/forecast_solar";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2684,6 +2684,8 @@ in {
 
   fordpass = callPackage ../development/python-modules/fordpass { };
 
+  forecast-solar = callPackage ../development/python-modules/forecast-solar { };
+
   fortiosapi = callPackage ../development/python-modules/fortiosapi { };
 
   FormEncode = callPackage ../development/python-modules/FormEncode { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This will become a Home Assistant dependency: https://github.com/home-assistant/core/pull/52158

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
