### PR TITLE
[20.09] Staging

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/6.x.nix
+++ b/pkgs/applications/graphics/ImageMagick/6.x.nix
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "imagemagick";
-  version = "6.9.12-15";
+  version = "6.9.12-16";
 
   src = fetchFromGitHub {
     owner = "ImageMagick";
     repo = "ImageMagick6";
     rev = version;
-    sha256 = "sha256-bel4p45eQfQPIp5/sawhTYTfyuYRQ5nFuGh4qqt1zDs=";
+    sha256 = "sha256-kg8vt88G6huRbJlVYztKxHiFPhGz/QHuNKtbhmai790=";
   };
 
   outputs = [ "out" "dev" "doc" ]; # bin/ isn't really big

--- a/pkgs/applications/graphics/ImageMagick/6.x.nix
+++ b/pkgs/applications/graphics/ImageMagick/6.x.nix
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "imagemagick";
-  version = "6.9.12-16";
+  version = "6.9.12-17";
 
   src = fetchFromGitHub {
     owner = "ImageMagick";
     repo = "ImageMagick6";
     rev = version;
-    sha256 = "sha256-kg8vt88G6huRbJlVYztKxHiFPhGz/QHuNKtbhmai790=";
+    sha256 = "sha256-yZXvxl9Tbl3JRBmRcfsjbkaxywtD08SuUnJayKfwk9M=";
   };
 
   outputs = [ "out" "dev" "doc" ]; # bin/ isn't really big

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "dhcp";
-  version = "4.4.2";
+  version = "4.4.2-P1";
 
   src = fetchurl {
     url = "https://ftp.isc.org/isc/dhcp/${version}/${pname}-${version}.tar.gz";
-    sha256 = "08a5003zdxgl41b29zjkxa92h2i40zyjgxg0npvnhpkfl5jcsz0s";
+    sha256 = "06jsr0cg5rsmyibshrpcb9za0qgwvqccashdma7mlm1rflrh8pmh";
   };
 
   patches =


### PR DESCRIPTION
This is a smol staging run, and likely the last one for release-20.09.

https://hydra.nixos.org/job/nixpkgs/staging-20.09/unstable#tabs-constituents

Previous staging-20.09 run: https://github.com/NixOS/nixpkgs/pull/126555
