### PR TITLE
mangohud: 0.6.3 → 0.6.4

### DIFF
--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -46,14 +46,14 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "mangohud";
-  version = "0.6.3";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "flightlessmango";
     repo = "MangoHud";
     rev = "v${version}";
-    sha256 = "wL+/wAqvVFph1QzuXPBbSEFjs33VA0S6euNWr/1J1Mk=";
     fetchSubmodules = true;
+    sha256 = "S7FtO/VLZp6Al13i6IrEbIzsgP3kZ3VSNBLhwReZLqM=";
   };
 
   outputs = [ "out" "doc" "man" ];


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/flightlessmango/MangoHud/releases/tag/v0.6.4

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).