### PR TITLE
python3Packages.pyrituals: 0.0.3 -> 0.0.4

### DIFF
--- a/pkgs/development/python-modules/pyrituals/default.nix
+++ b/pkgs/development/python-modules/pyrituals/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyrituals";
-  version = "0.0.3";
+  version = "0.0.4";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     owner = "milanmeu";
     repo = pname;
     rev = version;
-    sha256 = "sha256-oAxQRGP6GxiidnGshSJZEh2RD3XsZ/7kFGwcqaYaBnM=";
+    sha256 = "sha256-XJoSKGGwLoHMWxPGfXHeLg8VlIH1/j0ktzWe/pjd//0=";
   };
 
   propagatedBuildInputs = [ aiohttp ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.4

Change log: https://github.com/milanmeu/pyrituals/releases/tag/0.0.4

- Related Home Assistant change: https://github.com/home-assistant/core/pull/52209
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
