### PR TITLE
lsp-plugins: 1.1.26 -> 1.1.30

### DIFF
--- a/pkgs/applications/audio/lsp-plugins/default.nix
+++ b/pkgs/applications/audio/lsp-plugins/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lsp-plugins";
-  version = "1.1.26";
+  version = "1.1.30";
 
   src = fetchFromGitHub {
     owner = "sadko4u";
     repo = pname;
-    rev = "${pname}-${version}";
-    sha256 = "1apw8zh3a3il4smkjji6bih4vbsymj0hjs10fgkrd4nazqkjvgyd";
+    rev = version;
+    sha256 = "0g0nx05dyjwz2149v3pj6sa9divr26jyqvg2kk1qk48s2n4najkz";
   };
 
   nativeBuildInputs = [ pkg-config php makeWrapper ];
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildFlags = [ "release" ];
+
+  enableParallelBuilding = true;
 
   meta = with lib;
     { description = "Collection of open-source audio plugins";
@@ -84,6 +86,8 @@ stdenv.mkDerivation rec {
         - Compressor MidSide - Kompressor MidSide
         - Compressor Mono - Kompressor Mono
         - Compressor Stereo - Kompressor Stereo
+        - Artistic Delay Mono - Künstlerische Verzögerung
+        - Artistic Delay Stereo - Künstlerische Verzögerung
         - Latency Meter - Latenzmessgerät
         - Loudness Compensator Mono - Lautstärke Kompensator Mono
         - Loudness Compensator Stereo - Lautstärke Kompensator Stereo
@@ -99,6 +103,9 @@ stdenv.mkDerivation rec {
         - Multiband Compressor MidSide x8 - Multi-band Kompressor MidSide x8
         - Multiband Compressor Mono x8 - Multi-band Kompressor Mono x8
         - Multiband Compressor Stereo x8 - Multi-band Kompressor Stereo x8
+        - Oscilloscope x1 - Oscilloscope x1
+        - Oscilloscope x2 - Oscilloscope x2
+        - Oscilloscope x4 - Oscilloscope x4
         - Oscillator Mono - Oszillator Mono
         - Parametric Equalizer x16 LeftRight - Parametrischer Entzerrer x16 LeftRight
         - Parametric Equalizer x16 MidSide - Parametrischer Entzerrer x16 MidSide


### PR DESCRIPTION
###### Motivation for this change

Regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Tested execution of some binary files (there is a lot)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

/cc maintainer @magnetophon