### PR TITLE
nixos/duplicati: add parameters-file option

### DIFF
--- a/nixos/modules/services/backup/duplicati.nix
+++ b/nixos/modules/services/backup/duplicati.nix
@@ -35,10 +35,25 @@ in
           Run as root with special care.
         '';
       };
+
+      parameters = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          This option can be used to store some or all of the options given to the
+          commandline client.
+          Each line in this option should be of the format --option=value.
+          The options in this file take precedence over the options provided
+          through command line arguments.
+          <link xlink:href="https://duplicati.readthedocs.io/en/latest/06-advanced-options/#parameters-file">Duplicati docs: parameters-file</link>
+        '';
+      };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = let
+    parametersFile = pkgs.writeText "duplicati-parameters" cfg.parameters;
+  in mkIf cfg.enable {
     environment.systemPackages = [ pkgs.duplicati ];
 
     systemd.services.duplicati = {
@@ -49,7 +64,7 @@ in
         User = cfg.user;
         Group = "duplicati";
         StateDirectory = "duplicati";
-        ExecStart = "${pkgs.duplicati}/bin/duplicati-server --webservice-interface=${cfg.interface} --webservice-port=${toString cfg.port} --server-datafolder=/var/lib/duplicati";
+        ExecStart = "${pkgs.duplicati}/bin/duplicati-server --webservice-interface=${cfg.interface} --webservice-port=${toString cfg.port} --server-datafolder=/var/lib/duplicati --parameters-file=${parametersFile}";
         Restart = "on-failure";
       };
     };
@@ -66,4 +81,3 @@ in
 
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Adding `parameters` allows the consumer to specify any command line argument to the duplicati command ran in the service.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
    - Not significant enough
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
