### PR TITLE
ricochet-refresh: init at 3.0.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9052,6 +9052,12 @@
     github = "ribose-jeffreylau";
     githubId = 2649467;
   };
+  richard-blueprint = {
+    name = "Richard Pospesel";
+    email = "richard@blueprintforfreespeech.net";
+    github = "pospeselr";
+    githubId = 2148104;
+  };
   richardipsum = {
     email = "richardipsum@fastmail.co.uk";
     github = "richardipsum";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -41,6 +41,13 @@ with lib.maintainers; {
     scope = "Maintain BEAM-related packages and modules.";
   };
 
+  blueprint-freespeech = {
+    members = [
+      richard-blueprint
+    ];
+    scope = "Maintain ricochet-refresh";
+  };
+
   cinnamon = {
     members = [
       mkg20001

--- a/pkgs/applications/networking/instant-messengers/ricochet-refresh/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ricochet-refresh/default.nix
@@ -1,0 +1,81 @@
+{ makeDesktopItem
+, copyDesktopItems
+, lib
+, stdenv
+, fetchurl
+, fontconfig
+, freetype
+, libxcb
+, libxkbcommon
+, xorg
+}:
+
+let
+  rpath = lib.makeLibraryPath [
+    fontconfig
+    freetype
+    libxcb
+    libxkbcommon
+    stdenv.cc.cc.lib
+    xorg.xcbutilimage
+    xorg.xcbutilkeysyms
+    xorg.xcbutilrenderutil
+    xorg.xcbutilwm
+    xorg.libX11
+    xorg.libXext
+  ];
+
+in stdenv.mkDerivation rec {
+  pname = "ricochet-refresh";
+  version = "3.0.10";
+
+  # stripping breaks if rpath is set to a longer value using patchelf prior
+  # see: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = true;
+
+  src = fetchurl {
+    url = "https://github.com/blueprint-freespeech/ricochet-refresh/releases/download/v${version}-release/ricochet-refresh-${version}-linux-x86_64.tar.gz";
+    sha256 = "32eca517e0d20e5b427c6d9beafa4f18373b7417907c89e01beebe3934caf32e";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ricochet-refresh";
+      exec = "ricochet-refresh";
+      icon = "ricochet-refresh";
+      desktopName = "Ricochet Refresh";
+      genericName = "Ricochet Refresh";
+      categories = "Network;InstantMessaging;";
+    })
+  ];
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  unpackPhase = ''
+    echo "unpacking $src..."
+    tar -xvf $src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/pixmaps
+    mv ricochet-refresh/ricochet-refresh.png $out/share/pixmaps/ricochet-refresh.png
+    mv ricochet-refresh $out/bin
+
+    pushd $out/bin
+    for file in ricochet-refresh tor; do
+      patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} --set-rpath ${rpath} $file
+    done
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Private, anonymous, and metadata resistant instant messaging using Tor onion services";
+    homepage = "https://www.ricochetrefresh.net";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = teams.blueprint-freespeech.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27133,6 +27133,8 @@ with pkgs;
 
   ricochet = libsForQt5.callPackage ../applications/networking/instant-messengers/ricochet { };
 
+  ricochet-refresh = callPackage ../applications/networking/instant-messengers/ricochet-refresh { };
+
   ries = callPackage ../applications/science/math/ries { };
 
   ripcord = qt5.callPackage ../applications/networking/instant-messengers/ripcord { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Initial package for Ricochet Refresh v3.0.10 ( https://github.com/blueprint-freespeech/ricochet-refresh/releases/tag/v3.0.10-release )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
