### PR TITLE
DO NOT MERGE: Test to understand ofBorgs review requests for teams on nixos modules/tests.

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -64,6 +64,7 @@ let
 
 in {
   meta.maintainers = teams.home-assistant.members;
+  # We are the maintainers, does ofBorg request our review for module changes?
 
   options.services.home-assistant = {
     # Running home-assistant on NixOS is considered an installation method that is unsupported by the upstream project.

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -63,7 +63,7 @@ let
   };
 
 in {
-  meta.maintainers = teams.home-assistant.members;
+  meta.maintainers = maintainers.hexa;
   # We are the maintainers, does ofBorg request our review for module changes?
 
   options.services.home-assistant = {

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -6,7 +6,7 @@ let
   mqttPassword = "secret";
 in {
   name = "home-assistant";
-  meta.maintainers = lib.teams.home-assistant.members;
+  meta.maintainers = lib.maintainers.hexa;
 
   nodes.hass = { pkgs, ... }: {
     environment.systemPackages = with pkgs; [ mosquitto ];

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -24,7 +24,7 @@ in {
       inherit configDir;
       enable = true;
       # includes the package with all tests enabled
-      package = pkgs.home-assistant;
+      #package = pkgs.home-assistant;
       config = {
         homeassistant = {
           name = "Home";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a test to check if ofBorg would request reviews for meta.maintainers on NixOS modules and tests.

```
  meta.maintainers = lib.teams.home-assistant.members;
```

### Test 1: Maintainer teams in NixOS tests :x: 

```diff
From a4d120bf5b462db6d93e077242d2a3ca467f61f4 Mon Sep 17 00:00:00 2001
From: Martin Weinelt <hexa@darmstadt.ccc.de>
Date: Sun, 27 Jun 2021 16:20:51 +0200
Subject: [PATCH] nixos/tests/home-assistant: disable package tests

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>
---
 nixos/tests/home-assistant.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/nixos/tests/home-assistant.nix b/nixos/tests/home-assistant.nix
index f8f8e9fd183f1..4813fe863bfaa 100644
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -24,7 +24,7 @@ in {
       inherit configDir;
       enable = true;
       # includes the package with all tests enabled
-      package = pkgs.home-assistant;
+      #package = pkgs.home-assistant;
       config = {
         homeassistant = {
           name = "Home";
```


### Test 2: Maintainer teams in NixOS modules :x: 

```diff
commit 425bd5aa540d52211562d01ca6dda2e06ef23907
Author: Martin Weinelt <hexa@darmstadt.ccc.de>
Date:   Sun Jun 27 20:53:45 2021 +0200

    nixos/home-assistant: silly comment change

diff --git a/nixos/modules/services/misc/home-assistant.nix b/nixos/modules/services/misc/home-assistant.nix
index d68d7b05c17..cc4770dc480 100644
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -64,6 +64,7 @@ let
 
 in {
   meta.maintainers = teams.home-assistant.members;
+  # We are the maintainers, does ofBorg request our review for module changes?
 
   options.services.home-assistant = {
     # Running home-assistant on NixOS is considered an installation method that is unsupported by the upstream project.
```

### Test 3: Personal maintainer in NixOS test :x:

```diff
commit 28b7753922f0b878e6d284dd736d364628886e3d
Author: Martin Weinelt <hexa@darmstadt.ccc.de>
Date:   Sun Jun 27 21:26:24 2021 +0200

    nixos/tests/home-assistant: take ultimate control!

diff --git a/nixos/tests/home-assistant.nix b/nixos/tests/home-assistant.nix
index 4813fe863bf..de7dc50a897 100644
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -6,7 +6,7 @@ let
   mqttPassword = "secret";
 in {
   name = "home-assistant";
-  meta.maintainers = lib.teams.home-assistant.members;
+  meta.maintainers = lib.maintainers.hexa;
 
   nodes.hass = { pkgs, ... }: {
     environment.systemPackages = with pkgs; [ mosquitto ];
```

### Test 4: Personal maintainer in NixOS module :x:

```diff
commit 63ac5ae8e83b190973689fb2a0bb98a86671f0ea
Author: Martin Weinelt <hexa@darmstadt.ccc.de>
Date:   Sun Jun 27 23:57:27 2021 +0200

    nixos/home-assistant: MYYY PRECIOUS!

diff --git a/nixos/modules/services/misc/home-assistant.nix b/nixos/modules/services/misc/home-assistant.nix
index cc4770dc480..bdc8b68b480 100644
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -63,7 +63,7 @@ let
   };
 
 in {
-  meta.maintainers = teams.home-assistant.members;
+  meta.maintainers = maintainers.hexa;
   # We are the maintainers, does ofBorg request our review for module changes?
 
   options.services.home-assistant = {
```