### PR TITLE
bento: 1.6.0-637 -> 1.6.0-638

### DIFF
--- a/pkgs/tools/video/bento4/default.nix
+++ b/pkgs/tools/video/bento4/default.nix
@@ -3,13 +3,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "bento4";
-  version = "1.6.0-637";
+  version = "1.6.0-638";
 
   src = fetchFromGitHub {
     owner = "axiomatic-systems";
     repo = "Bento4";
     rev = "v${version}";
-    sha256 = "0iwqi71nj0iczffvpxmz0prvmmnyiqypfwvzivkh38wl0br82bkp";
+    sha256 = "1hxr4lds4dl46advshk7azg28fcpcjaa5pzk2zzpsc9l69s0bnxk";
   };
 
   patches = [ ./libap4.patch ];

--- a/pkgs/tools/video/bento4/default.nix
+++ b/pkgs/tools/video/bento4/default.nix
@@ -12,16 +12,20 @@ stdenv.mkDerivation rec {
     sha256 = "1hxr4lds4dl46advshk7azg28fcpcjaa5pzk2zzpsc9l69s0bnxk";
   };
 
-  patches = [ ./libap4.patch ];
+  patches = [
+    ./libap4.patch # include all libraries as shared, not static
+  ];
 
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/{lib,bin}
     find -iname '*.so' -exec mv --target-directory="$out/lib" {} \;
     find -maxdepth 1 -executable -type f -exec mv --target-directory="$out/bin" {} \;
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
security update for bento4

#128341 #124609

backporting is recommended

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

closes #128341 #124609