### PR TITLE
epson-escpr2: 1.1.25 -> 1.1.34

### DIFF
--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, cups, busybox }:
+{ lib, stdenv, fetchurl, cups }:
 
 stdenv.mkDerivation rec {
   pname = "epson-inkjet-printer-escpr2";
-  version = "1.1.25";
+  version = "1.1.34";
 
   src = fetchurl {
     # To find new versions, visit
@@ -11,22 +11,15 @@ stdenv.mkDerivation rec {
     # version.
     # NOTE: Don't forget to update the webarchive link too!
     urls = [
-      "https://download3.ebz.epson.net/dsc/f/03/00/12/46/43/e233a3fefeb49723ba4b0a2f357527e3b45bf53a/epson-inkjet-printer-escpr2-1.1.25-1lsb3.2.src.rpm"
-      "https://web.archive.org/web/20210212220538if_/https://download3.ebz.epson.net/dsc/f/03/00/12/46/43/e233a3fefeb49723ba4b0a2f357527e3b45bf53a/epson-inkjet-printer-escpr2-1.1.25-1lsb3.2.src.rpm"
+      "https://download3.ebz.epson.net/dsc/f/03/00/12/85/48/fd5de1ecd7270b0398399355e265c99dfd1dbafb/epson-inkjet-printer-escpr2-1.1.34.tar.gz"
+      "https://web.archive.org/web/20210627160654/https://download3.ebz.epson.net/dsc/f/03/00/12/85/48/fd5de1ecd7270b0398399355e265c99dfd1dbafb/epson-inkjet-printer-escpr2-1.1.34.tar.gz"
     ];
-    sha256 = "sha256-8hgafO/1qOTVdfAdx7FpOOSLqfTl0sBFunuN/2q7KHw=";
+    sha256 = "sha256-sHBGWbkZ+zolHehyXQR8U2AyKSrgDSPmrkrcfcx/bAs=";
   };
 
   patches = [ ./cups-filter-ppd-dirs.patch ];
 
-  buildInputs = [ cups busybox ];
-
-  unpackPhase = ''
-    rpm2cpio $src | cpio -idmv
-
-    tar xvf ${pname}-${version}-1lsb3.2.tar.gz
-    cd ${pname}-${version}
-  '';
+  buildInputs = [ cups ];
 
   meta = with lib; {
     homepage = "http://download.ebz.epson.net/dsc/search/01/search/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
