### PR TITLE
xfce.xfce4-panel-profiles: init at 1.0.13

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-panel-profiles/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-panel-profiles/default.nix
@@ -1,0 +1,29 @@
+{ mkXfceDerivation, lib, python3, intltool, gettext,
+ gtk3, libxfce4ui, libxfce4util, pango, harfbuzz, gdk-pixbuf, atk }:
+
+let
+  pythonEnv = python3.withPackages(ps: [ ps.pygobject3 ]);
+  makeTypelibPath = lib.makeSearchPathOutput "lib/girepository-1.0" "lib/girepository-1.0";
+in mkXfceDerivation {
+  category = "apps";
+  pname = "xfce4-panel-profiles";
+  version = "1.0.13";
+
+  sha256 = "sha256-B3Q5d3KBN5m8wY82CIbIugJC8nNS+OcgKchn+TGrDhc=";
+
+  nativeBuildInputs = [ intltool gettext ];
+  propagatedBuildInputs = [ pythonEnv ];
+
+  configurePhase = ''
+    ./configure --prefix=$out
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/xfce4-panel-profiles \
+      --set GI_TYPELIB_PATH ${makeTypelibPath [ gtk3 libxfce4ui libxfce4util pango harfbuzz gdk-pixbuf atk ]}
+  '';
+
+  meta = {
+    description = "Simple application to manage Xfce panel layouts";
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -93,6 +93,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfburn = callPackage ./applications/xfburn { };
 
+  xfce4-panel-profiles = callPackage ./applications/xfce4-panel-profiles { };
+
   #### ART
 
   xfce4-icon-theme = callPackage ./art/xfce4-icon-theme { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool for backing up or applying xfce4-panel configs.

We need to override `configurePhase` because nix add path flags to configure script but the script doesn't support all of them so it fails.

cc @romildo for review
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
