### PR TITLE
[21.05] sway: 1.6 -> 1.6.1, wlroots: 0.13.0 -> 0.14.0

### DIFF
--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -15,7 +15,10 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
       # For glinfo and wayland-info:
       systemPackages = with pkgs; [ mesa-demos wayland-utils ];
       # Use a fixed SWAYSOCK path (for swaymsg):
-      variables."SWAYSOCK" = "/tmp/sway-ipc.sock";
+      variables = {
+        "SWAYSOCK" = "/tmp/sway-ipc.sock";
+        "WLR_RENDERER_ALLOW_SOFTWARE" = "1";
+      };
       # For convenience:
       shellAliases = {
         test-x11 = "glinfo | head -n 3 | tee /tmp/test-x11.out && touch /tmp/test-x11-exit-ok";
@@ -101,6 +104,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
 
     # Exit Sway and verify process exit status 0:
     machine.succeed("su - alice -c 'swaymsg exit || true'")
-    machine.wait_for_file("/tmp/sway-exit-ok")
+    # TODO: Sway currently segfaults after "swaymsg exit" but only in this VM test:
+    # machine # [  104.090032] sway[921]: segfault at 3f800008 ip 00007f7dbdc25f10 sp 00007ffe282182f8 error 4 in libwayland-server.so.0.1.0[7f7dbdc1f000+8000]
+    # machine.wait_for_file("/tmp/sway-exit-ok")
   '';
 })

--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "0ixl45g0m8b75gvbjm3gf5qg0yplspgs0xpm2619wn5sygc47sb1";
   };
 
+  patches = [
+    # To fix the build with wlroots 0.14.0:
+    ./wlroots-0_14.patch
+  ];
+
   nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];
 
   buildInputs = [

--- a/pkgs/applications/window-managers/cage/wlroots-0_14.patch
+++ b/pkgs/applications/window-managers/cage/wlroots-0_14.patch
@@ -1,0 +1,36 @@
+From 9a4523d47efeafd674d419169fe161e5a3b31cb3 Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Thu, 3 Jun 2021 17:53:11 +0000
+Subject: [PATCH 1/3] view: chase swaywm/wlroots@9e58301df7f0
+
+view.c:238:52: error: no member named 'subsurfaces' in 'struct wlr_surface'
+        wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces, parent_link) {
+                                       ~~~~~~~~~~~~~~~~~  ^
+/usr/include/wayland-util.h:443:30: note: expanded from macro 'wl_list_for_each'
+        for (pos = wl_container_of((head)->next, pos, member);  \
+                                    ^~~~
+/usr/include/wayland-util.h:409:32: note: expanded from macro 'wl_container_of'
+        (__typeof__(sample))((char *)(ptr) -                            \
+                                      ^~~
+
+Based on https://github.com/swaywm/sway/commit/3162766eef14
+---
+ view.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/view.c b/view.c
+index b9ba9c2..3f3b0ed 100644
+--- a/view.c
++++ b/view.c
+@@ -235,7 +235,10 @@ view_map(struct cg_view *view, struct wlr_surface *surface)
+ 	view->wlr_surface = surface;
+ 
+ 	struct wlr_subsurface *subsurface;
+-	wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces, parent_link) {
++	wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces_below, parent_link) {
++		subsurface_create(view, subsurface);
++	}
++	wl_list_for_each (subsurface, &view->wlr_surface->subsurfaces_above, parent_link) {
+ 		subsurface_create(view, subsurface);
+ 	}
+ 

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cairo
 , fontconfig
 , libxkbcommon
@@ -30,6 +31,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-1IztedN5/I/4TDKHLJ26fSrDsvJ5QAr+cbzS2PQITDE=";
   };
+
+  patches = [
+    # To fix the build with wlroots 0.14.0:
+    (fetchpatch {
+      # Add fixes for wlroots 0.14.0
+      url = "https://github.com/project-repo/cagebreak/commit/d57869d43add58331386fc8e89c14bb2b74afe17.patch";
+      sha256 = "0g6sl8y4kk0bm5x6pxqbxw2j0gyg3ybr2v9m70q2pxp70kms4lqg";
+    })
+  ];
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/applications/window-managers/labwc/default.nix
+++ b/pkgs/applications/window-managers/labwc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , meson
 , ninja
@@ -29,6 +30,15 @@ stdenv.mkDerivation rec {
     rev = "fddeb74527e5b860d9c1a91a237d390041c758b6";
     sha256 = "0rhniv5j4bypqxxj0nbpa3hclmn8znal9rldv0mrgbizn3wsbs54";
   };
+
+  patches = [
+    # To fix the build with wlroots 0.14:
+    (fetchpatch {
+      # output: access texture width/height directly
+      url = "https://github.com/johanmalm/labwc/commit/892e93dd84c514b4e6f34a0fab01c727edd2d8de.patch";
+      sha256 = "1p1pg1kd98727wlcspa2sffl7ijhvsfad6bj2rxsw322q0bz3yrh";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sway-unwrapped";
-  version = "1.6";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "0vnplva11yafhbijrk68wy7pw0psn9jm0caaymswq1s951xsn1c8";
+    sha256 = "0j4sdbsrlvky1agacc0pcz9bwmaxjmrapjnzscbd2i0cria2fc5j";
   };
 
   patches = [

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libdrm";
-  version = "2.4.105";
+  version = "2.4.106";
 
   src = fetchurl {
     url = "https://dri.freedesktop.org/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0iiamypwdfiz250ki120nh598r48yyacmnndb4mkximdgi5h478x";
+    sha256 = "1m3vwpabjg3az84vmyxi96jyd7rrqm6qkhk1gq41w5wv89aarn4j";
   };
 
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libdrm";
-  version = "2.4.106";
+  version = "2.4.105";
 
   src = fetchurl {
     url = "https://dri.freedesktop.org/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1m3vwpabjg3az84vmyxi96jyd7rrqm6qkhk1gq41w5wv89aarn4j";
+    sha256 = "0iiamypwdfiz250ki120nh598r48yyacmnndb4mkximdgi5h478x";
   };
 
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/wlroots/0.13.nix
+++ b/pkgs/development/libraries/wlroots/0.13.nix
@@ -1,18 +1,18 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland-scanner
 , libGL, wayland, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg, xcbutilrenderutil, xwayland, libseat
+, libpng, ffmpeg, libuuid, xcbutilrenderutil, xwayland
 }:
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.14.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "103sf9bsyqw18kmaih11mlxwqi9ddymm95w1lfxz06pf69xwhd39";
+    sha256 = "01plhbnsp5yg18arz0v8fr0pr9l4w4pdzwkg9px486qdvb3s1vgy";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -23,8 +23,10 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libGL wayland wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg xcbutilrenderutil xwayland libseat
+    libpng ffmpeg libuuid xcbutilrenderutil xwayland
   ];
+
+  mesonFlags = [ "-Dlogind-provider=systemd" "-Dlibseat=disabled" ];
 
   postFixup = ''
     # Install ALL example programs to $examples:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24188,8 +24188,11 @@ in
   };
 
   wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
+  wlroots_0_13 = callPackage ../development/libraries/wlroots/0.13.nix {};
 
-  sway-unwrapped = callPackage ../applications/window-managers/sway { };
+  sway-unwrapped = callPackage ../applications/window-managers/sway {
+    wlroots = wlroots_0_13;
+  };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
@@ -24209,7 +24212,9 @@ in
 
   wbg = callPackage ../applications/misc/wbg { };
 
-  hikari = callPackage ../applications/window-managers/hikari { };
+  hikari = callPackage ../applications/window-managers/hikari {
+    wlroots = wlroots_0_13;
+  };
 
   i3 = callPackage ../applications/window-managers/i3 {
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
@@ -27185,7 +27190,8 @@ in
   wayfireApplications = wayfireApplications-unwrapped.withPlugins (plugins: [ plugins.wf-shell ]);
   inherit (wayfireApplications) wayfire wcm;
   wayfireApplications-unwrapped = recurseIntoAttrs (
-    callPackage ../applications/window-managers/wayfire/applications.nix { }
+    (callPackage ../applications/window-managers/wayfire/applications.nix { }).
+    extend (_: _: { wlroots = wlroots_0_13; })
   );
   wayfirePlugins = recurseIntoAttrs (
     callPackage ../applications/window-managers/wayfire/plugins.nix {
@@ -27235,7 +27241,9 @@ in
 
   weston = callPackage ../applications/window-managers/weston { pipewire = pipewire_0_2; };
 
-  wio = callPackage ../applications/window-managers/wio { };
+  wio = callPackage ../applications/window-managers/wio {
+    wlroots = wlroots_0_13;
+  };
 
   whitebox-tools = callPackage ../applications/gis/whitebox-tools {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24190,9 +24190,7 @@ in
   wlroots_0_12 = callPackage ../development/libraries/wlroots/0.12.nix {};
   wlroots_0_13 = callPackage ../development/libraries/wlroots/0.13.nix {};
 
-  sway-unwrapped = callPackage ../applications/window-managers/sway {
-    wlroots = wlroots_0_13;
-  };
+  sway-unwrapped = callPackage ../applications/window-managers/sway { };
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };


### PR DESCRIPTION
###### Motivation for this change

Backport PR for #128036, #127897 and #123519 (not so sure about the last one, I decided to update it as well to hopefully fix #127413 locally).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
