### PR TITLE
sfm: 0.1 → 0.2

### DIFF
--- a/pkgs/applications/misc/sfm/default.nix
+++ b/pkgs/applications/misc/sfm/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sfm";
-  version = "0.1";
+  version = "0.2";
 
   src = fetchFromGitHub {
     owner = "afify";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-i4WzYaJKityIt+LPWCbd6UsPBaYoaS397l5BInOXQQA=";
+    hash = "sha256-DwXKrSqcebNI5N9REXyMV16W2kr72IH9+sKSVehc5zw=";
   };
 
   configFile = lib.optionalString (conf!=null) (lib.writeText "config.def.h" conf);


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/afify/sfm/compare/v0.1...v0.2)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
