### PR TITLE
imapsync: 1.727 -> 2.140

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -613,6 +613,11 @@ in mkLicense lset) ({
     fullName  = "University of Illinois/NCSA Open Source License";
   };
 
+  nlpl = {
+    spdxId = "NLPL";
+    fullName = "No Limit Public License";
+  };
+
   nposl3 = {
     spdxId = "NPOSL-3.0";
     fullName = "Non-Profit Open Software License 3.0";

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -2,13 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "imapsync";
-  version = "1.727";
+  version = "2.140";
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "0ckd968aimrxr6w7p6y67xspjbc9yijv7s7pc2yaricxxg26pg3q";
+    sha256 = "1k4rf582c3434yxj9brsjz0awakd84xwikghyq0h54darqwfm23j";
   };
+
+  patches = [
+    ./patch-makefile.patch
+    ./patch-prerequisites.patch
+  ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
@@ -18,10 +23,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = with perlPackages; [ perl openssl MailIMAPClient TermReadKey
+  buildInputs = with perlPackages; [ perl openssl CGI EncodeIMAPUTF7 FileTail ModuleScanDeps PackageStashXS MailIMAPClient TermReadKey
     IOSocketSSL DigestHMAC URI FileCopyRecursive IOTee UnicodeString
     DataUniqid JSONWebToken TestMockGuard LWP CryptOpenSSLRSA
-    LWPProtocolHttps Readonly TestPod TestMockObject ParseRecDescent
+    LWPProtocolHttps Readonly RegexpCommon SysMemInfo TestDeep TestFatal TestPod TestRequires TestMockObject ParseRecDescent
     IOSocketInet6 NTLM
   ] ++ [ procps ];
 

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://imapsync.lamiral.info/";
     description = "Mail folder synchronizer between IMAP servers";
-    license = licenses.gpl2Plus;
+    license = licenses.nlpl;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];
   };

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, makeWrapper, fetchFromGitHub, perl, openssl, perlPackages, procps }:
+{ lib, stdenv, makeWrapper, fetchFromGitHub, perl, openssl, perlPackages, procps }:
 
 stdenv.mkDerivation rec {
   pname = "imapsync";
@@ -23,11 +23,39 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = with perlPackages; [ perl openssl CGI EncodeIMAPUTF7 FileTail ModuleScanDeps PackageStashXS MailIMAPClient TermReadKey
-    IOSocketSSL DigestHMAC URI FileCopyRecursive IOTee UnicodeString
-    DataUniqid JSONWebToken TestMockGuard LWP CryptOpenSSLRSA
-    LWPProtocolHttps Readonly RegexpCommon SysMemInfo TestDeep TestFatal TestPod TestRequires TestMockObject ParseRecDescent
-    IOSocketInet6 NTLM
+  buildInputs = with perlPackages; [
+    perl
+    openssl
+    CGI
+    EncodeIMAPUTF7
+    FileTail
+    ModuleScanDeps
+    PackageStashXS
+    MailIMAPClient
+    TermReadKey
+    IOSocketSSL
+    DigestHMAC
+    URI
+    FileCopyRecursive
+    IOTee
+    UnicodeString
+    DataUniqid
+    JSONWebToken
+    TestMockGuard
+    LWP
+    CryptOpenSSLRSA
+    LWPProtocolHttps
+    Readonly
+    RegexpCommon
+    SysMemInfo
+    TestDeep
+    TestFatal
+    TestPod
+    TestRequires
+    TestMockObject
+    ParseRecDescent
+    IOSocketInet6
+    NTLM
   ] ++ [ procps ];
 
   meta = with lib; {

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -10,9 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ckd968aimrxr6w7p6y67xspjbc9yijv7s7pc2yaricxxg26pg3q";
   };
 
-  patchPhase = ''
-    sed -i -e s@/usr@$out@ Makefile
-  '';
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postInstall = ''
     wrapProgram $out/bin/imapsync --set PERL5LIB $PERL5LIB

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, makeWrapper, fetchFromGitHub, perl, openssl, perlPackages }:
+{lib, stdenv, makeWrapper, fetchFromGitHub, perl, openssl, perlPackages, procps }:
 
 stdenv.mkDerivation rec {
   pname = "imapsync";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     DataUniqid JSONWebToken TestMockGuard LWP CryptOpenSSLRSA
     LWPProtocolHttps Readonly TestPod TestMockObject ParseRecDescent
     IOSocketInet6 NTLM
-  ];
+  ] ++ [ procps ];
 
   meta = with lib; {
     homepage = "https://imapsync.lamiral.info/";

--- a/pkgs/tools/networking/imapsync/default.nix
+++ b/pkgs/tools/networking/imapsync/default.nix
@@ -1,12 +1,13 @@
-{lib, stdenv, makeWrapper, fetchurl, perl, openssl, perlPackages }:
+{lib, stdenv, makeWrapper, fetchFromGitHub, perl, openssl, perlPackages }:
 
 stdenv.mkDerivation rec {
   pname = "imapsync";
   version = "1.727";
-
-  src = fetchurl {
-    url = "https://releases.pagure.org/imapsync/imapsync-${version}.tgz";
-    sha256 = "1axacjw2wyaphczfw3kfmi5cl83fyr8nb207nks40fxkbs8q5dlr";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0ckd968aimrxr6w7p6y67xspjbc9yijv7s7pc2yaricxxg26pg3q";
   };
 
   patchPhase = ''
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://www.linux-france.org/prj/imapsync/";
+    homepage = "https://imapsync.lamiral.info/";
     description = "Mail folder synchronizer between IMAP servers";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/tools/networking/imapsync/patch-makefile.patch
+++ b/pkgs/tools/networking/imapsync/patch-makefile.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 6046a6b..adc9a8d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -160,6 +160,7 @@ clean_man:
+ 	rm -f  W/imapsync.1
+ 
+ W/imapsync.1: imapsync
++	mkdir -p W
+ 	pod2man imapsync > W/imapsync.1
+ 
+ install: testp W/imapsync.1

--- a/pkgs/tools/networking/imapsync/patch-prerequisites.patch
+++ b/pkgs/tools/networking/imapsync/patch-prerequisites.patch
@@ -1,0 +1,26 @@
+diff --git a/INSTALL.d/prerequisites_imapsync b/INSTALL.d/prerequisites_imapsync
+index bbac1f4..46c72b8 100755
+--- a/INSTALL.d/prerequisites_imapsync
++++ b/INSTALL.d/prerequisites_imapsync
+@@ -3,7 +3,6 @@
+ # $Id: prerequisites_imapsync,v 1.35 2019/11/27 15:58:46 gilles Exp gilles $
+ 
+ MODULES_MANDATORY='
+-App::cpanminus
+ Authen::NTLM
+ CGI
+ Compress::Zlib
+@@ -36,7 +35,6 @@ Module::ScanDeps
+ Net::SSLeay
+ Package::Stash
+ Package::Stash::XS
+-PAR::Packer
+ Parse::RecDescent
+ Pod::Usage
+ Readonly
+@@ -285,5 +283,4 @@ then
+         search_modules_any "$@"
+ fi
+ 
+-test_cpanm
+ exit $EXIT

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7397,6 +7397,20 @@ let
     };
   };
 
+  EncodeIMAPUTF7 = buildPerlPackage {
+    pname = "Encode-IMAPUTF7";
+    version = "1.05";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PM/PMAKHOLM/Encode-IMAPUTF7-1.05.tar.gz";
+      sha256 = "1q9pgjckjxz0qfwaqmzm1dh1y09819vi6vf1sglcz0vlqgfha0s7";
+    };
+    buildInputs = [ TestNoWarnings ];
+    meta = {
+      description = "Modification of UTF-7 encoding for IMAP";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   EncodeJIS2K = buildPerlPackage {
     pname = "Encode-JIS2K";
     version = "0.03";


### PR DESCRIPTION
###### Motivation for this change
I wanted to update [imapsync](https://imapsync.lamiral.info/) from 1.727 to 2.140 as I ran into an issue with the older release during an IMAP migration.

###### Things done
- fixed a few smaller issues (homepage, license, dependency, src, ...) of the original pkg
- added some `perlPackages` required by the newer release
- bumped the release of `imapsync` to 2.140

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
