### PR TITLE
realmd: init at 0.17.0

### DIFF
--- a/pkgs/os-specific/linux/realmd/default.nix
+++ b/pkgs/os-specific/linux/realmd/default.nix
@@ -1,0 +1,71 @@
+{ lib, stdenv
+, autoreconfHook
+, docbook_xml_dtd_412
+, docbook_xml_dtd_42
+, docbook_xml_dtd_43
+, docbook_xsl
+, fetchFromGitLab
+, glib
+, intltool
+, libkrb5
+, libtool
+, libxslt
+, openldap
+, pkg-config
+, polkit
+, systemd
+, xmlto
+}:
+# doc-related (--disable-doc): docbook_xml_dtd_412 docbook_xml_dtd_42 docbook_xml_dtd_43 docbook_xsl libxslt xmlto
+
+stdenv.mkDerivation rec {
+  pname = "realmd";
+  version = "0.17.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1c6q2a86kk2f1akzc36nh52hfwsmmc0mbp6ayyjxj4zsyk9zx5bf";
+  };
+
+  # service/Makefile.am expects to find the file "service/realmd-NixOS.conf", which:
+  # - isn't provided by upstream
+  # - doesn't make sense in this context and should rather be provided by a module configuring the realmd service
+  # don't install "/var/cache" and "/var/lib" which should be provided by the service unit at runtime
+  patches = [ ./remove-distro-and-fhs.patch ];
+
+  configureFlags = [
+    "--with-distro=NixOS"
+    "--with-systemd-unit-dir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook_xml_dtd_412
+    docbook_xml_dtd_42
+    docbook_xml_dtd_43
+    docbook_xsl
+  ];
+
+  buildInputs = [
+    glib
+    intltool
+    libkrb5
+    libxslt
+    openldap
+    pkg-config
+    polkit
+    systemd
+    xmlto
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.freedesktop.org/realmd/realmd";
+    description = "Service + helpers for configuring Kerberos, AD-membership and other online identities";
+    platforms = platforms.linux;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ eliasp ];
+  };
+}

--- a/pkgs/os-specific/linux/realmd/remove-distro-and-fhs.patch
+++ b/pkgs/os-specific/linux/realmd/remove-distro-and-fhs.patch
@@ -1,0 +1,14 @@
+diff --git a/service/Makefile.am b/service/Makefile.am
+index c17bf3b..954ce59 100644
+--- a/service/Makefile.am
++++ b/service/Makefile.am
+@@ -135,9 +135,6 @@ realmd_LDADD = \
+ # Install and uninstall the config for this distro
+ install-service:
+ 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(privatedir)
+-	$(INSTALL_PROGRAM) -d $(DESTDIR)$(localstatedir)/lib/realmd
+-	$(INSTALL_PROGRAM) -d $(DESTDIR)$(cachedir)
+-	$(INSTALL_DATA) $(srcdir)/service/realmd-$(DISTRO).conf $(DESTDIR)$(privatedir)/realmd-distro.conf
+ uninstall-service:
+ 	rm -f $(DESTDIR)$(privatedir)/realmd-distro.conf
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8722,6 +8722,8 @@ with pkgs;
 
   qt-box-editor = libsForQt5.callPackage ../applications/misc/qt-box-editor { };
 
+  realmd = callPackage ../os-specific/linux/realmd { };
+
   recutils = callPackage ../tools/misc/recutils { };
 
   recoll = libsForQt5.callPackage ../applications/search/recoll { };


### PR DESCRIPTION
###### Motivation for this change
To make it easier to join NixOS systems to ActiveDirectory, I want to make use of [realmd](https://gitlab.freedesktop.org/realmd/realmd/).
It consists of the CLI tool `realm` and the D-Bus activated systemd service `realmd`.

This PR is still a WIP and so far only provides the package, but no module to configure the service yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
