### PR TITLE
discordchatexporter-cli: init at 2.28

### DIFF
--- a/pkgs/tools/backup/discordchatexporter-cli/default.nix
+++ b/pkgs/tools/backup/discordchatexporter-cli/default.nix
@@ -1,0 +1,87 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, linkFarmFromDrvs, makeWrapper, autoPatchelfHook
+, dotnet-sdk_5, dotnetPackages, dotnetCorePackages, cacert
+}:
+
+let
+  projectFile = "DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj";
+in
+stdenv.mkDerivation rec {
+  pname = "discordchatexporter-cli";
+  version = "2.28";
+
+  src = fetchFromGitHub {
+    owner = "tyrrrz";
+    repo = "discordchatexporter";
+    rev = version;
+    sha256 = "1bcq8mwjr8635g8mkgbxnszk20hnwf0zk672glrxjqga6f6fnykg";
+  };
+
+  nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget cacert makeWrapper autoPatchelfHook ];
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  nugetDeps = linkFarmFromDrvs "${pname}-nuget-deps" (import ./deps.nix {
+    fetchNuGet = { name, version, sha256 }: fetchurl {
+      name = "nuget-${name}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+      inherit sha256;
+    };
+  });
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_NOLOGO=1
+
+    nuget sources Add -Name nixos -Source "$PWD/nixos"
+    nuget init "$nugetDeps" "$PWD/nixos"
+
+    # FIXME: https://github.com/NuGet/Home/issues/4413
+    mkdir -p $HOME/.nuget/NuGet
+    cp $HOME/.config/NuGet/NuGet.Config $HOME/.nuget/NuGet
+
+    dotnet restore --source "$PWD/nixos" ${projectFile}
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    dotnet build ${projectFile} \
+      --no-restore \
+      --configuration Release \
+      -p:Version=${version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dotnet publish ${projectFile} \
+      --no-build \
+      --configuration Release \
+      --no-self-contained \
+      --output $out/lib/${pname}
+    shopt -s extglob
+
+    makeWrapper $out/lib/${pname}/DiscordChatExporter.Cli $out/bin/discordchatexporter-cli \
+      --set DOTNET_ROOT "${dotnetCorePackages.sdk_3_1}"
+
+    runHook postInstall
+  '';
+
+  # Strip breaks the executable.
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "A tool to export Discord chat logs to a file";
+    homepage = "https://github.com/Tyrrrz/DiscordChatExporter";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.ivar ];
+    platforms = [ "x86_64-linux" ];
+  };
+  passthru.updateScript = ./updater.sh;
+}

--- a/pkgs/tools/backup/discordchatexporter-cli/deps.nix
+++ b/pkgs/tools/backup/discordchatexporter-cli/deps.nix
@@ -1,0 +1,67 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    name = "CliFx";
+    version = "2.0.4";
+    sha256 = "1wwpjli4y2545yi6k17mvjqy994wl3wm6nngszk87rbdwhkbncaj";
+  })
+  (fetchNuGet {
+    name = "Gress";
+    version = "1.2.0";
+    sha256 = "0aidc9whi0718gh896j7xkyndki9x7rifd8n1n681afb2zbxw4bn";
+  })
+  (fetchNuGet {
+    name = "JsonExtensions";
+    version = "1.1.0";
+    sha256 = "1fqxb2jdbvjgg135wmy890qf63r056dq16jy7wgzkgp21m3j0lgy";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.App.Ref";
+    version = "3.1.10";
+    sha256 = "0xn4zh7shvijqlr03fqsmps6gz856isd9bg9rk4z2c4599ggal77";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Host.linux-x64";
+    version = "3.1.14";
+    sha256 = "11rqnascx9asfyxgxzwgxgr9gxxndm552k4dn4p1s57ciz7vkg9h";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.App.Ref";
+    version = "3.1.0";
+    sha256 = "08svsiilx9spvjamcnjswv0dlpdrgryhr3asdz7cvnl914gjzq4y";
+  })
+  (fetchNuGet {
+    name = "MiniRazor.CodeGen";
+    version = "2.1.2";
+    sha256 = "0mg4zy4zq0ccrc9wchy796ln1znkmn3k1aax0kd2gha4fwa1d1fb";
+  })
+  (fetchNuGet {
+    name = "MiniRazor.Runtime";
+    version = "2.1.2";
+    sha256 = "1a6cm7j1f5n1bfzhg8w60xwa7cps2i82418k57dm2hgqla6p3rsp";
+  })
+  (fetchNuGet {
+    name = "Polly";
+    version = "7.2.2";
+    sha256 = "0s15n5zwj44i6sw3v40ca8l6j0ijydxcakvad49j52rp49iwrmkn";
+  })
+  (fetchNuGet {
+    name = "Spectre.Console";
+    version = "0.40.0";
+    sha256 = "17bb31nsvfk7m337zwqcz4v6cvayhfx51ri4yrv5i8nbp7f4rpb1";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.0";
+    sha256 = "1layqpcx1q4l805fdnj2dfqp6ncx2z42ca06rgsr6ikq4jjgbv30";
+  })
+  (fetchNuGet {
+    name = "Tyrrrz.Extensions";
+    version = "1.6.5";
+    sha256 = "1yzsii1pbp6b066wxwwws310p7h809apl81bhb8ad55hqlzy1rg3";
+  })
+  (fetchNuGet {
+    name = "Wcwidth";
+    version = "0.2.0";
+    sha256 = "0p7zaisix9ql4v5nyl9gfc93xcyj74j01rwvgm7jw29js3wlj10s";
+  })
+]

--- a/pkgs/tools/backup/discordchatexporter-cli/updater.sh
+++ b/pkgs/tools/backup/discordchatexporter-cli/updater.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts dotnet-sdk_5
+set -eo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+deps_file="$(realpath "./deps.nix")"
+
+new_version="$(curl -s "https://api.github.com/repos/tyrrrz/DiscordChatExporter/releases?per_page=1" | jq -r '.[0].name')"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "Up to date"
+  exit 0
+fi
+
+cd ../../../..
+update-source-version discordchatexporter-cli "$new_version"
+store_src="$(nix-build . -A discordchatexporter-cli.src --no-out-link)"
+src="$(mktemp -d /tmp/discordexporter-src.XXX)"
+cp -rT "$store_src" "$src"
+chmod -R +w "$src"
+
+pushd "$src"
+
+mkdir ./nuget_tmp.packages
+dotnet restore DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj --packages ./nuget_tmp.packages
+
+echo "{ fetchNuGet }: [" >"$deps_file"
+while read pkg_spec; do
+  { read pkg_name; read pkg_version; } < <(
+    # Build version part should be ignored: `3.0.0-beta2.20059.3+77df2220` -> `3.0.0-beta2.20059.3`
+    sed -nE 's/.*<id>([^<]*).*/\1/p; s/.*<version>([^<+]*).*/\1/p' "$pkg_spec")
+  pkg_sha256="$(nix-hash --type sha256 --flat --base32 "$(dirname "$pkg_spec")"/*.nupkg)"
+  cat >>"$deps_file" <<EOF
+  (fetchNuGet {
+    name = "$pkg_name";
+    version = "$pkg_version";
+    sha256 = "$pkg_sha256";
+  })
+EOF
+done < <(find ./nuget_tmp.packages -name '*.nuspec' | sort)
+echo "]" >>"$deps_file"
+
+popd
+rm -r "$src"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14844,6 +14844,8 @@ in
 
   directfb = callPackage ../development/libraries/directfb { };
 
+  discordchatexporter-cli = callPackage ../tools/backup/discordchatexporter-cli { };
+
   discord-rpc = callPackage ../development/libraries/discord-rpc {
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };


### PR DESCRIPTION
cc @jonringer, I think you are interested in C# stuff?

###### Motivation for this change

Seems to be working perfectly. Note that only the CLI is packaged, as the GUI is windows-only.

The updater script seems to error out when running `update-source-version`:
```
error: undefined variable 'outPath' at (string):1:86
```
All files are still generated as expected, i think we can safely ignore this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
