### PR TITLE
 python3Packages.lmnotify: init at 0.0.4 

### DIFF
--- a/pkgs/development/python-modules/lmnotify/default.nix
+++ b/pkgs/development/python-modules/lmnotify/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, oauthlib
+, requests
+, requests_oauthlib
+}:
+
+buildPythonPackage rec {
+  pname = "lmnotify";
+  version = "0.0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1l0h4yab7ix8psf65iygc1wy5xwq3v2rwwjixvd8rwk46d2477dx";
+  };
+
+  propagatedBuildInputs = [ oauthlib requests requests_oauthlib ];
+
+  doCheck = false; # no tests exist
+
+  pythonImportsCheck = [ "lmnotify" ];
+
+  meta = with lib; {
+    description = "lmnotify is a package for sending notifications to LaMetric Time.";
+    homepage = "https://github.com/keans/lmnotify";
+    maintainers = with maintainers; [ rhoriguchi ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -436,7 +436,7 @@
     "kulersky" = ps: with ps; [ pykulersky ];
     "kwb" = ps: with ps; [ ]; # missing inputs: pykwb
     "lacrosse" = ps: with ps; [ pylacrosse ];
-    "lametric" = ps: with ps; [ ]; # missing inputs: lmnotify
+    "lametric" = ps: with ps; [ lmnotify ];
     "lannouncer" = ps: with ps; [ ];
     "lastfm" = ps: with ps; [ pylast ];
     "launch_library" = ps: with ps; [ ]; # missing inputs: pylaunches

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4171,6 +4171,8 @@ in {
 
   lml = callPackage ../development/python-modules/lml { };
 
+  lmnotify = callPackage ../development/python-modules/lmnotify { };
+
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
   localimport = callPackage ../development/python-modules/localimport { };


### PR DESCRIPTION
###### Motivation for this change

Add missing python package needed for [home-assistant LaMetric](https://github.com/home-assistant/core/blob/dev/homeassistant/components/lametric/manifest.json#L5) integration.

[This](https://github.com/keans/lmnotify) project has not tests.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
