### PR TITLE
cpython: fix permissions on venv activation scripts

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -190,6 +190,10 @@ in with passthru; stdenv.mkDerivation {
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
     (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
+    # Make sure that the virtualenv activation scripts are
+    # owner-writable, so venvs can be recreated without permission
+    # errors.
+    ./virtualenv-permissions.patch
   ] ++ optionals mimetypesSupport [
     # Make the mimetypes module refer to the right file
     ./mimetypes.patch

--- a/pkgs/development/interpreters/python/cpython/virtualenv-permissions.patch
+++ b/pkgs/development/interpreters/python/cpython/virtualenv-permissions.patch
@@ -1,0 +1,13 @@
+diff --git a/Lib/venv/__init__.py b/Lib/venv/__init__.py
+index caa7285..ad666ac 100644
+--- a/Lib/venv/__init__.py
++++ b/Lib/venv/__init__.py
+@@ -379,7 +379,7 @@ class EnvBuilder:
+                 if data is not None:
+                     with open(dstfile, 'wb') as f:
+                         f.write(data)
+-                    shutil.copymode(srcfile, dstfile)
++                    os.chmod(dstfile, 0o644)
+ 
+ 
+ def create(env_dir, system_site_packages=False, clear=False,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Previously these ended up without u+w permissions which meant they could
not be regenerated, which was hugely annoying when these venvs were for
example created and recreated in a nix-shell.

```
❯ python3 -m venv venv
❯ python3 -m venv venv
Error: [Errno 13] Permission denied: '/home/hexa/git/nixos/master/venv/bin/Activate.ps1' 
❯ ls -lah venv/bin/*ctivate*
Permissions Size User Date Modified Name
.r--r--r--  2.2k hexa  7 Mai 17:13  venv/bin/activate
.r--r--r--  1.2k hexa  7 Mai 17:13  venv/bin/activate.csh
.r--r--r--  2.4k hexa  7 Mai 17:13  venv/bin/activate.fish
.r--r--r--  8.8k hexa  7 Mai 17:13  venv/bin/Activate.ps1
```

Tested on python3{6,7,8,9,10}.

Best merged together with #127171.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
