### PR TITLE
strip-nondeterminism: file to propagatedBuildInput

### DIFF
--- a/pkgs/development/perl-modules/strip-nondeterminism/default.nix
+++ b/pkgs/development/perl-modules/strip-nondeterminism/default.nix
@@ -18,7 +18,8 @@ buildPerlPackage rec {
   doCheck = false;
 
   nativeBuildInputs = lib.optionals stdenv.isDarwin [ shortenPerlShebang ];
-  buildInputs = [ ArchiveZip ArchiveCpio file ];
+  buildInputs = [ ArchiveZip ArchiveCpio ];
+  propagatedNativeBuildInputs = [ file ];
 
   perlPostHook = ''
     # we don’t need the debhelper script


### PR DESCRIPTION
###### Motivation for this change
`file` is used by the _strip-nondeterminism_ perl script but is not propagated during builds.
```
Can't exec "file": No such file or directory at /nix/store/ysp4zbrp2m1b8sbi4bfdfd1v8xjpcbwv-perl5.32.1-strip-nondeterminism-1.0.0/lib/perl5/site_perl/5.32.1/File/StripNondeterminism.pm line 37.
can't exec file: No such file or directory at /nix/store/ysp4zbrp2m1b8sbi4bfdfd1v8xjpcbwv-perl5.32.1-strip-nondeterminism-1.0.0/lib/perl5/site_perl/5.32.1/File/StripNondeterminism.pm line 37.
Use of uninitialized value in pattern match (m//) at /nix/store/ysp4zbrp2m1b8sbi4bfdfd1v8xjpcbwv-perl5.32.1-strip-nondeterminism-1.0.0/lib/perl5/site_perl/5.32.1/File/StripNondeterminism.pm line 63.
```

Here is the snippet of where it's used
```
sub _get_file_type($) {
	my $file=shift;
	open(FILE, '-|') # handle all filenames safely
	  || exec('file', $file)
	  || die "can't exec file: $!";
	my $type=<FILE>;
	close FILE;
	return $type;
}
```

This script is very handy to run within a `nix-build` context, specifically during the _fixupPhase_.
Unfortunately, _file_ is not propagated, and does not exist causing the build to fail.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
