### PR TITLE
octoprint: add missing dependency to websocket-client

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -44,6 +44,7 @@ let
                   inherit version;
                   sha256 = "63509b41d158ae5b7f67eb4ad20fecbb4eee99434e73e140354dc3ff8e09716f";
                 };
+                propagatedBuildInputs = [ self.six ];
               }
             );
           }


### PR DESCRIPTION
###### Motivation for this change
The `six` dependency was removed from the websocket-client package when
it was upgraded to 1.1.0 in 600d787b9b7bb7b82ff4515cfb01925e121ae6ca.
Since we pin a different version for octoprint, we should re-add it
here.

Tested building with:
`nix-build -E "(import ./. {}).octoprint.python.withPackages (ps: [ps.octoprint ps.printtimegenius])"`

(Note, octoprint on nixpkgs master appears to have been broken because of an upgrade of flask. That is a separate problem from this: https://hydra.nixos.org/build/146420109  However, `nixpkgs-review` on this PR would not succeed for that reason.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
