### PR TITLE
[Backport release-21.05] matomo: 4.2.1 -> 4.3.1 

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,16 +3,16 @@
 let
   versions = {
     matomo = {
-      version = "4.2.1";
-      sha256 = "d3ea7572c5b42f2636da89b9c15dd7ae16da1d06dab0cea2ed93304a960277ac";
+      version = "4.3.1";
+      sha256 = "Ve4P1cVV/uZ59BcQaUZLTTOwpjX7veof9jR0l3Y9xOQ=";
     };
 
     matomo-beta = {
-      version = "4.2.1";
+      version = "4.3.1";
       # `beta` examples: "b1", "rc1", null
       # TOOD when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "d3ea7572c5b42f2636da89b9c15dd7ae16da1d06dab0cea2ed93304a960277ac";
+      sha256 = "Ve4P1cVV/uZ59BcQaUZLTTOwpjX7veof9jR0l3Y9xOQ=";
     };
   };
   common = pname: { version, sha256, beta ? null }:


### PR DESCRIPTION
(cherry picked from commit 41ebb21aa46045d02fb8e7240c5f3fb01f7b1581)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
