### PR TITLE
[Backport release-21.05] tdesktop: 2.7.5 -> 2.8.0 -> 2.8.1 -> 2.8.3 -> 2.8.4 -> 2.8.11

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -11,7 +11,7 @@
 with lib;
 
 let
-  tg_owt = callPackage ../tdesktop/tg_owt.nix {};
+  tg_owt = callPackage ./tg_owt.nix {};
 in mkDerivation rec {
   pname = "kotatogram-desktop";
   version = "1.4.1";

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, ninja, yasm
+, libjpeg, openssl, libopus, ffmpeg, alsaLib, libpulseaudio, protobuf
+, xorg, libXtst
+}:
+
+let
+  rev = "2d804d2c9c5d05324c8ab22f2e6ff8306521b3c3";
+  sha256 = "0kz0i381iwsgcc3yzsq7njx3gkqja4bb9fsgc24vhg0md540qhyn";
+
+in stdenv.mkDerivation {
+  pname = "tg_owt";
+  version = "git-${rev}";
+
+  src = fetchFromGitHub {
+    owner = "desktop-app";
+    repo = "tg_owt";
+    inherit rev sha256;
+    fetchSubmodules = true;
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkg-config cmake ninja yasm ];
+
+  buildInputs = [
+    libjpeg openssl libopus ffmpeg alsaLib libpulseaudio protobuf
+    xorg.libX11 libXtst
+  ];
+
+  cmakeFlags = [
+    # Building as a shared library isn't officially supported and currently broken:
+    "-DBUILD_SHARED_LIBS=OFF"
+  ];
+
+  meta.license = lib.licenses.bsd3;
+}

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -23,7 +23,8 @@ let
   tg_owt = callPackage ./tg_owt.nix {};
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.8.1";
+  version = "2.8.3";
+  # Note: Update via pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
   # Telegram-Desktop with submodules
   src = fetchFromGitHub {
@@ -31,7 +32,7 @@ in mkDerivation rec {
     repo = "tdesktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "1wf9806al6mzyd8nr37cdk6q2r354acixdqyjchi4r58drm99yv0";
+    sha256 = "1ywxsy3a99sdibipriblbzskmkqbnxwrz3lavfdr134wq8w8rjf7";
   };
 
   postPatch = ''
@@ -97,6 +98,7 @@ in mkDerivation rec {
 
   passthru = {
     inherit tg_owt;
+    updateScript = ./update.py;
   };
 
   meta = {

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -23,7 +23,7 @@ let
   tg_owt = callPackage ./tg_owt.nix {};
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.8.3";
+  version = "2.8.4";
   # Note: Update via pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
   # Telegram-Desktop with submodules
@@ -32,7 +32,7 @@ in mkDerivation rec {
     repo = "tdesktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "1ywxsy3a99sdibipriblbzskmkqbnxwrz3lavfdr134wq8w8rjf7";
+    sha256 = "sha256-IN3GQgdNM66/GxKa5EGKB/LIkgBxS8Y4mkPBaSEphmw=";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, callPackage
+{ mkDerivation, lib, fetchFromGitHub, callPackage
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
 , qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
@@ -23,12 +23,15 @@ let
   tg_owt = callPackage ./tg_owt.nix {};
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.8.0";
+  version = "2.8.1";
 
   # Telegram-Desktop with submodules
-  src = fetchurl {
-    url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "0689bmdpsj8qmv9ih6ckay23mivhlps8c081qljb8wqplmf2c4ds";
+  src = fetchFromGitHub {
+    owner = "telegramdesktop";
+    repo = "tdesktop";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "1wf9806al6mzyd8nr37cdk6q2r354acixdqyjchi4r58drm99yv0";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,8 +1,8 @@
-{ mkDerivation, lib, fetchFromGitHub, callPackage
+{ mkDerivation, lib, fetchFromGitHub, callPackage, fetchpatch
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
-, qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
-, dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
-, tl-expected, hunspell, glibmm, webkitgtk
+, qtbase, qtimageformats, gtk3, libsForQt5, lz4, xxHash
+, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
+, tl-expected, hunspell, glibmm, webkitgtk, jemalloc
 , libtgvoip, rnnoise, abseil-cpp, extra-cmake-modules
 # Transitive dependencies:
 , pcre, xorg, util-linux, libselinux, libsepol, epoxy
@@ -23,7 +23,7 @@ let
   tg_owt = callPackage ./tg_owt.nix {};
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.8.4";
+  version = "2.8.11";
   # Note: Update via pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
   # Telegram-Desktop with submodules
@@ -32,8 +32,16 @@ in mkDerivation rec {
     repo = "tdesktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-IN3GQgdNM66/GxKa5EGKB/LIkgBxS8Y4mkPBaSEphmw=";
+    sha256 = "020ycgb77vx7rza590i3csrvq1zgm15rvpxqqcp0xkb4yh71i3hb";
   };
+
+  patches = [(fetchpatch {
+    # ref: https://github.com/desktop-app/lib_webview/pull/9
+    url = "https://github.com/desktop-app/lib_webview/commit/75e924934eee8624020befbef1f3cb5b865d3b86.patch";
+    sha256 = "sha256-rN4FVK4KT+xNf9IVdcpbxMqT0+t3SINJPRRQPyMiDP0=";
+    stripLen = 1;
+    extraPrefix = "Telegram/lib_webview/";
+  })];
 
   postPatch = ''
     substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
@@ -49,9 +57,9 @@ in mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake ninja python3 wrapGAppsHook wrapQtAppsHook removeReferencesTo ];
 
   buildInputs = [
-    qtbase qtimageformats gtk3 libsForQt5.kwayland libsForQt5.libdbusmenu enchant2 lz4 xxHash
-    dee ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
-    tl-expected hunspell glibmm webkitgtk
+    qtbase qtimageformats gtk3 libsForQt5.kwayland libsForQt5.libdbusmenu lz4 xxHash
+    ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
+    tl-expected hunspell glibmm webkitgtk jemalloc
     libtgvoip rnnoise abseil-cpp extra-cmake-modules
     tg_owt
     # Transitive dependencies:

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -2,7 +2,7 @@
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
 , qtbase, qtimageformats, gtk3, libsForQt5, lz4, xxHash
 , ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
-, tl-expected, hunspell, glibmm, webkitgtk, jemalloc
+, tl-expected, hunspell, glibmm, webkitgtk
 , libtgvoip, rnnoise, abseil-cpp, extra-cmake-modules
 # Transitive dependencies:
 , pcre, xorg, util-linux, libselinux, libsepol, epoxy
@@ -44,8 +44,6 @@ in mkDerivation rec {
   })];
 
   postPatch = ''
-    substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
-      --replace '"libenchant-2.so.2"' '"${enchant2}/lib/libenchant-2.so.2"'
     substituteInPlace Telegram/CMakeLists.txt \
       --replace '"''${TDESKTOP_LAUNCHER_BASENAME}.appdata.xml"' '"''${TDESKTOP_LAUNCHER_BASENAME}.metainfo.xml"'
   '';
@@ -59,7 +57,7 @@ in mkDerivation rec {
   buildInputs = [
     qtbase qtimageformats gtk3 libsForQt5.kwayland libsForQt5.libdbusmenu lz4 xxHash
     ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
-    tl-expected hunspell glibmm webkitgtk jemalloc
+    tl-expected hunspell glibmm webkitgtk
     libtgvoip rnnoise abseil-cpp extra-cmake-modules
     tg_owt
     # Transitive dependencies:

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -1,8 +1,9 @@
-{ mkDerivation, lib, fetchurl, fetchpatch, callPackage
+{ mkDerivation, lib, fetchurl, callPackage
 , pkg-config, cmake, ninja, python3, wrapGAppsHook, wrapQtAppsHook, removeReferencesTo
 , qtbase, qtimageformats, gtk3, libsForQt5, enchant2, lz4, xxHash
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
-, tl-expected, hunspell, glibmm, webkitgtk, libtgvoip
+, tl-expected, hunspell, glibmm, webkitgtk
+, libtgvoip, rnnoise, abseil-cpp, extra-cmake-modules
 # Transitive dependencies:
 , pcre, xorg, util-linux, libselinux, libsepol, epoxy
 , at-spi2-core, libXtst, libthai, libdatrie
@@ -22,25 +23,13 @@ let
   tg_owt = callPackage ./tg_owt.nix {};
 in mkDerivation rec {
   pname = "telegram-desktop";
-  version = "2.7.5";
+  version = "2.8.0";
 
   # Telegram-Desktop with submodules
   src = fetchurl {
     url = "https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tdesktop-${version}-full.tar.gz";
-    sha256 = "sha256-9GxBw5ii9Musjq7D3KMf/P5BA4h690EgXRbhynHwO98=";
+    sha256 = "0689bmdpsj8qmv9ih6ckay23mivhlps8c081qljb8wqplmf2c4ds";
   };
-
-  patches = [
-    # fixes issue with ffmpeg>=4.4 crashes, hasn't been upstreamed yet
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/gentoo/1c91884873968997be4b0c954169d04dc839f1db/net-im/telegram-desktop/files/tdesktop-2.7.4-voice-crash.patch";
-      sha256 = "sha256-inLXcP70yJlkkmdeXlc3HRL7Vt+Sf00LLJG33gwBKdY=";
-    })
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/gentoo/1c91884873968997be4b0c954169d04dc839f1db/net-im/telegram-desktop/files/tdesktop-2.7.4-voice-ffmpeg44.patch";
-      sha256 = "sha256-p57LipNf7BDhVvNKRuicVqx0vU6IBL/Cvr5BAfLF4Hs=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
@@ -59,7 +48,8 @@ in mkDerivation rec {
     qtbase qtimageformats gtk3 libsForQt5.kwayland libsForQt5.libdbusmenu enchant2 lz4 xxHash
     dee ffmpeg openalSoft minizip libopus alsaLib libpulseaudio range-v3
     tl-expected hunspell glibmm webkitgtk
-    tg_owt libtgvoip
+    libtgvoip rnnoise abseil-cpp extra-cmake-modules
+    tg_owt
     # Transitive dependencies:
     pcre xorg.libpthreadstubs xorg.libXdmcp util-linux libselinux libsepol epoxy
     at-spi2-core libXtst libthai libdatrie libsysprof-capture libpsl brotli

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
@@ -3,31 +3,20 @@
 , libjpeg, openssl, libopus, ffmpeg, alsaLib, libpulseaudio, protobuf
 , xorg, libXtst, libXcomposite, libXdamage, libXext, libXrender, libXrandr
 , glib, abseil-cpp, pcre, util-linuxMinimal, libselinux, libsepol, pipewire
+, libXi
 }:
 
 stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "unstable-2021-06-17";
+  version = "unstable-2021-06-27";
 
   src = fetchFromGitHub {
     owner = "desktop-app";
     repo = "tg_owt";
-    rev = "f03ef05abf665437649a4f71886db1343590e862";
-    sha256 = "0s6ajw52b95lcq4mn6lv8gj6lhv62bvwjh43w7az2k5pbm14v7vv";
+    rev = "91d836dc84a16584c6ac52b36c04c0de504d9c34";
+    sha256 = "1ir4svv5mijpzr0rmx65088iikck83vhcdqrpf9dnk6yp4j9v4v2";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # Our libXtst seems broken:
-    # /nix/store/rd3swxwmzjgjvwhz8svyc8ghc0brq293-libXtst-1.2.3/include/X11/extensions/XTest.h:32:10: fatal error: X11/extensions/XInput.h: No such file or directory
-    (fetchpatch {
-      # Copy updated source files.
-      url = "https://github.com/desktop-app/tg_owt/commit/2c0fbe4d3d1c33d0cc9ff7c112b4db1963bea535.patch";
-      sha256 = "0apd6hfv3a1s3qy10kjwk4z8bg835cpk0ql9qxjnxf4gq183bhif";
-      revert = true;
-      includes = [ "src/modules/desktop_capture/linux/shared_x_display.cc" ];
-    })
-  ];
 
   outputs = [ "out" "dev" ];
 
@@ -37,6 +26,7 @@ stdenv.mkDerivation {
     libjpeg openssl libopus ffmpeg alsaLib libpulseaudio protobuf
     xorg.libX11 libXtst libXcomposite libXdamage libXext libXrender libXrandr
     glib abseil-cpp pcre util-linuxMinimal libselinux libsepol pipewire
+    libXi
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
@@ -1,22 +1,33 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, ninja, yasm
+{ lib, stdenv, fetchFromGitHub, fetchpatch
+, pkg-config, cmake, ninja, yasm
 , libjpeg, openssl, libopus, ffmpeg, alsaLib, libpulseaudio, protobuf
-, xorg, libXtst
+, xorg, libXtst, libXcomposite, libXdamage, libXext, libXrender, libXrandr
+, glib, abseil-cpp, pcre, util-linuxMinimal, libselinux, libsepol, pipewire
 }:
 
-let
-  rev = "2d804d2c9c5d05324c8ab22f2e6ff8306521b3c3";
-  sha256 = "0kz0i381iwsgcc3yzsq7njx3gkqja4bb9fsgc24vhg0md540qhyn";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "git-${rev}";
+  version = "unstable-2021-06-17";
 
   src = fetchFromGitHub {
     owner = "desktop-app";
     repo = "tg_owt";
-    inherit rev sha256;
+    rev = "f03ef05abf665437649a4f71886db1343590e862";
+    sha256 = "0s6ajw52b95lcq4mn6lv8gj6lhv62bvwjh43w7az2k5pbm14v7vv";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Our libXtst seems broken:
+    # /nix/store/rd3swxwmzjgjvwhz8svyc8ghc0brq293-libXtst-1.2.3/include/X11/extensions/XTest.h:32:10: fatal error: X11/extensions/XInput.h: No such file or directory
+    (fetchpatch {
+      # Copy updated source files.
+      url = "https://github.com/desktop-app/tg_owt/commit/2c0fbe4d3d1c33d0cc9ff7c112b4db1963bea535.patch";
+      sha256 = "0apd6hfv3a1s3qy10kjwk4z8bg835cpk0ql9qxjnxf4gq183bhif";
+      revert = true;
+      includes = [ "src/modules/desktop_capture/linux/shared_x_display.cc" ];
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 
@@ -24,7 +35,8 @@ in stdenv.mkDerivation {
 
   buildInputs = [
     libjpeg openssl libopus ffmpeg alsaLib libpulseaudio protobuf
-    xorg.libX11 libXtst
+    xorg.libX11 libXtst libXcomposite libXdamage libXext libXrender libXrandr
+    glib abseil-cpp pcre util-linuxMinimal libselinux libsepol pipewire
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/libtgvoip/default.nix
+++ b/pkgs/development/libraries/libtgvoip/default.nix
@@ -7,13 +7,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "libtgvoip";
-  version = "unstable-2021-01-01";
+  version = "unstable-2021-07-13";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "libtgvoip";
-    rev = "13a5fcb16b04472d808ce122abd695dbf5d206cd";
-    sha256 = "12p6s7vxkf1gh1spdckkdxrx7bjzw881ds9bky7l5fw751cwb3xd";
+    rev = "f321e7c8cc086bac6ae06fa0934aac7d9833a310";
+    sha256 = "1gk5nsqhbnn1cdh83b70qr3d3v2c1bncylvgn77vvj8vnyjlmnfq";
   };
 
   # To fix the build without external webrtc:

--- a/pkgs/development/libraries/libtgvoip/default.nix
+++ b/pkgs/development/libraries/libtgvoip/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, autoreconfHook
+{ stdenv, lib, fetchFromGitHub, fetchpatch
+, pkg-config, autoreconfHook
 , openssl, libopus, alsaLib, libpulseaudio
 }:
 
@@ -6,14 +7,30 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "libtgvoip";
-  version = "unstable-2020-03-02";
+  version = "unstable-2021-01-01";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "libtgvoip";
-    rev = "e422d2a80546a32ab7166a9b1058bacfc5daeefc";
-    sha256 = "0n6f7215k74039j0zmicjzhj6f45mq6fvkrwzyzibcrv87ib17fc";
+    rev = "13a5fcb16b04472d808ce122abd695dbf5d206cd";
+    sha256 = "12p6s7vxkf1gh1spdckkdxrx7bjzw881ds9bky7l5fw751cwb3xd";
   };
+
+  # To fix the build without external webrtc:
+  patches = [
+    (fetchpatch {
+      # Use methods from updated webrtc.
+      url = "https://github.com/telegramdesktop/libtgvoip/commit/13a5fcb16b04472d808ce122abd695dbf5d206cd.patch";
+      sha256 = "0wapqvml3yyv5dlp2q8iih5rfvfnkngll69krhnw5xsdjy22sp7r";
+      revert = true;
+    })
+    (fetchpatch {
+      # Allow working with external webrtc.
+      url = "https://github.com/telegramdesktop/libtgvoip/commit/6e82b6e45664c1f80b9039256c99bebc76d34672.patch";
+      sha256 = "0m87ixja70vnm80a9z4gxk0yl7n64y59smczxb88lxnj6kdgih7x";
+      revert = true;
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
This PR:

- [x] Is a backport of https://github.com/NixOS/nixpkgs/pull/128219
- [x] Does not include the changes from https://github.com/NixOS/nixpkgs/commit/e9e5f5f84dedea81605e493ea6cec41275a9a8fd (As I didn't know if those changes were supposed to be backported, I didn't included it and manually changed `alsa-lib` into `alsaLib` when cherry-picking commits.

For each cherry-picked commits, I had merge conflicts because of the change in the `alsaLib` name (_from `alsaLib` to `alsa-lib`_).

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
