### PR TITLE
yq: fix build

### DIFF
--- a/pkgs/development/python-modules/yq/jq-path.patch
+++ b/pkgs/development/python-modules/yq/jq-path.patch
@@ -1,26 +1,26 @@
 diff --git a/test/test.py b/test/test.py
-index a81f41b..9e80f04 100755
+index f25dced..cd308c8 100755
 --- a/test/test.py
 +++ b/test/test.py
-@@ -112,7 +112,7 @@ class TestYq(unittest.TestCase):
+@@ -105,7 +105,7 @@ class TestYq(unittest.TestCase):
                  tf2.seek(0)
                  self.assertEqual(self.run_yq("", ["-y", arg, tf.name, self.fd_path(tf2)]), '1\n...\n')
- 
+
 -    @unittest.skipIf(subprocess.check_output(["jq", "--version"]) < b"jq-1.6", "Test options introduced in jq 1.6")
 +    @unittest.skipIf(subprocess.check_output(["@jq@", "--version"]) < b"jq-1.6", "Test options introduced in jq 1.6")
      def test_jq16_arg_passthrough(self):
          self.assertEqual(self.run_yq("{}", ["--indentless", "-y", ".a=$ARGS.positional", "--args", "a", "b"]),
                           "a:\n- a\n- b\n")
 diff --git a/yq/__init__.py b/yq/__init__.py
-index afeb42c..a0d7970 100755
+index 91212d0..ee5a799 100755
 --- a/yq/__init__.py
 +++ b/yq/__init__.py
 @@ -146,7 +146,7 @@ def yq(input_streams=None, output_stream=None, input_format="yaml", output_forma
- 
      try:
-         # Note: universal_newlines is just a way to induce subprocess to make stdin a text buffer and encode it for us
+         # Notes: universal_newlines is just a way to induce subprocess to make stdin a text buffer and encode it for us;
+         # close_fds must be false for command substitution to work (yq . t.yml --slurpfile t <(yq . t.yml))
 -        jq = subprocess.Popen(["jq"] + list(jq_args),
 +        jq = subprocess.Popen(["@jq@"] + list(jq_args),
                                stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE if converting_output else None,
-                               universal_newlines=True)
+                               close_fds=False,


### PR DESCRIPTION
###### Motivation for this change

Build fails to apply patch:

```
unpacking source archive /nix/store/9s9pi3scf0q7naxh02dxvl1m45h4g65h-yq-2.12.2.tar.gz
source root is yq-2.12.2
setting SOURCE_DATE_EPOCH to timestamp 1623619990 of file yq-2.12.2/setup.cfg
patching sources
applying patch /nix/store/gl30lnglcs7q68839wv28xn3m04x2fjw-jq-path.patch
patching file test/test.py
Hunk #1 succeeded at 105 (offset -7 lines).
patching file yq/__init__.py
Hunk #1 FAILED at 146.
1 out of 1 hunk FAILED -- saving rejects to file yq/__init__.py.rej
builder for '/nix/store/jjzwbm6gjkwn1kld9xrvnfj7mnv5vgmx-python3.8-yq-2.12.2.drv' failed with exit code 1
error: build of '/nix/store/jjzwbm6gjkwn1kld9xrvnfj7mnv5vgmx-python3.8-yq-2.12.2.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
