### PR TITLE
gnuradio3_8: 3.8.3.0 -> 3.8.3.1

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -42,14 +42,14 @@
 , versionAttr ? {
   major = "3.8";
   minor = "3";
-  patch = "0";
+  patch = "1";
 }
 # We use our build of volk and not the one bundled with the release
 , fetchSubmodules ? false
 }:
 
 let
-  sourceSha256 = "0lwbj3slhc8bjjvfw7yz45if21hajydgy2vsjvj2barzmhfb37fd";
+  sourceSha256 = "0vd39azp8n576dbqsanax7bgsnxwc80riaxid2ihxs4xzyjmbw9r";
   featuresInfo = {
     # Needed always
     basic = {
@@ -242,6 +242,7 @@ stdenv.mkDerivation rec {
     # From some reason, if these are not set, libcodec2 and gsm are not
     # detected properly. The issue is reported upstream:
     # https://github.com/gnuradio/gnuradio/issues/4278
+    # The above issue was fixed for GR3.9 without a backporting patch.
     #
     # NOTE: qradiolink needs libcodec2 to be detected in
     # order to build, see https://github.com/qradiolink/qradiolink/issues/67


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
