### PR TITLE
home-assistant: support syncthru component

### DIFF
--- a/pkgs/development/python-modules/pysyncthru/default.nix
+++ b/pkgs/development/python-modules/pysyncthru/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, isPy27
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, demjson
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "pysyncthru";
+  version = "0.7.3";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    pname = "PySyncThru";
+    inherit version;
+    sha256 = "13564018a7de4fe013e195e19d7bae92aa224e0f3a32373576682722d3dbee52";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    demjson
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest
+  '';
+
+  # no tests on PyPI, no tags on GitHub
+  doCheck = false;
+
+  pythonImportsCheck = [ "pysyncthru" ];
+
+  meta = with lib; {
+    description = "Automated JSON API based communication with Samsung SyncThru Web Service";
+    homepage = "https://github.com/nielstron/pysyncthru";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -826,7 +826,7 @@
     "switcher_kis" = ps: with ps; [ aioswitcher ];
     "switchmate" = ps: with ps; [ ]; # missing inputs: pySwitchmate
     "syncthing" = ps: with ps; [ aiosyncthing ];
-    "syncthru" = ps: with ps; [ url-normalize ]; # missing inputs: pysyncthru
+    "syncthru" = ps: with ps; [ pysyncthru url-normalize ];
     "synology_chat" = ps: with ps; [ ];
     "synology_dsm" = ps: with ps; [ synologydsm-api ];
     "synology_srm" = ps: with ps; [ ]; # missing inputs: synology-srm

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -685,6 +685,7 @@ in with py.pkgs; buildPythonApplication rec {
     "switch"
     "switcher_kis"
     "syncthing"
+    "syncthru"
     "synology_dsm"
     "system_health"
     "system_log"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5347,6 +5347,8 @@ in {
 
   pysiaalarm = callPackage ../development/python-modules/pysiaalarm { };
 
+  pysyncthru = callPackage ../development/python-modules/pysyncthru { };
+
   pytest-subprocess = callPackage ../development/python-modules/pytest-subprocess { };
 
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
