### PR TITLE
emacs.pkgs.ebuild-mode: init at 1.52

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/ebuild-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/ebuild-mode/default.nix
@@ -1,0 +1,17 @@
+{ lib, trivialBuild, fetchurl }:
+
+trivialBuild rec {
+  pname = "ebuild-mode";
+  version = "1.52";
+
+  src = fetchurl {
+    url = "https://dev.gentoo.org/~ulm/emacs/ebuild-mode-${version}.tar.xz";
+    sha256 = "10nikbbwh612qlnms2i31963a0h3ccyg85vrxlizdpsqs4cjpg6h";
+  };
+
+  meta = with lib; {
+    description = "Major modes for Gentoo package files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -199,6 +199,8 @@
 
   # Packages made the classical callPackage way
 
+  ebuild-mode = callPackage ./ebuild-mode { };
+
   emacspeak = callPackage ./emacspeak { };
 
   ess-R-object-popup = callPackage ./ess-R-object-popup { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
