### PR TITLE
Add easystroke to available packages

### DIFF
--- a/pkgs/applications/misc/easystroke/abs.patch
+++ b/pkgs/applications/misc/easystroke/abs.patch
@@ -1,0 +1,10 @@
+--- easystroke.orig/handler.cc	2017-06-10 18:29:45.785935113 +0200
++++ easystroke/handler.cc	2017-06-10 18:34:59.931032754 +0200
+@@ -533,7 +533,6 @@
+ 	virtual Grabber::State grab_mode() { return parent->grab_mode(); }
+ };
+ 
+-static inline float abs(float x) { return x > 0 ? x : -x; }
+ 
+ class AbstractScrollHandler : public Handler {
+ 	bool have_x, have_y;

--- a/pkgs/applications/misc/easystroke/add-toggle-option.patch
+++ b/pkgs/applications/misc/easystroke/add-toggle-option.patch
@@ -1,0 +1,21 @@
+Add option to toggle easystroke on/off.
+diff -Naur a/main.cc b/main.cc
+--- a/main.cc	2013-03-27 16:52:38.000000000 +0100
++++ b/main.cc	2015-05-10 17:31:00.223132604 +0200
+@@ -315,6 +315,8 @@
+ 			disabled.set(true);
+ 		} else if (!strcmp(arg[i], "enable")) {
+ 			disabled.set(false);
++		} else if (!strcmp(arg[i], "toggle")) {
++			disabled.set(!disabled.get());
+ 		} else if (!strcmp(arg[i], "about")) {
+ 			win->show_about();
+ 		} else if (!strcmp(arg[i], "quit")) {
+@@ -428,6 +430,7 @@
+ 	printf("  hide                   Hide configuration window\n");
+ 	printf("  disable                Disable easystroke\n");
+ 	printf("  enable                 Enable easystroke\n");
++	printf("  toggle                 Toggle easystroke\n");
+ 	printf("  about                  Show about dialog\n");
+ 	printf("  quit                   Quit easystroke\n");
+ 	printf("\n");

--- a/pkgs/applications/misc/easystroke/default.nix
+++ b/pkgs/applications/misc/easystroke/default.nix
@@ -1,0 +1,31 @@
+# based on easystroke-git from Arch AUR
+# as found on https://github.com/teu5us/easystroke-nix
+
+{ pkgs, ... }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "easystroke";
+  version = "patched-2018-12-05";
+  src = fetchTarball {
+    url = "https://github.com/thjaeger/easystroke/archive/refs/tags/0.6.0.tar.gz";
+    sha256 = "0kgzmwxqgbq3cgp2rvj09j9rk6h7ynbibim4mins3wzalgwy68dv";
+  };
+  nativeBuildInputs = [ gnutar bzip2 gnumake boost.dev gtkmm3.dev dbus-glib.dev pkg-config git xorg.xorgserver.dev ];
+  buildInputs = [ boost gtkmm3 xorg.libXtst intltool dbus-glib xorg.xorgserver ];
+  buildPhase = ''
+    # cd $src/easystroke
+    make
+  '';
+  patches = [
+    ./sigc.patch
+    ./dont-ignore-xshape-when-saving.patch
+    ./add-toggle-option.patch
+    ./abs.patch
+  ];
+  installPhase = ''
+    mkdir -p $out
+    make install PREFIX="$out"
+  '';
+}

--- a/pkgs/applications/misc/easystroke/dont-ignore-xshape-when-saving.patch
+++ b/pkgs/applications/misc/easystroke/dont-ignore-xshape-when-saving.patch
@@ -1,0 +1,14 @@
+DOn't ignore xshape setting when saving.
+diff -Naur a/prefdb.cc b/prefdb.cc
+--- a/prefdb.cc	2015-11-04 19:56:49.354441037 +0100
++++ b/prefdb.cc	2015-11-04 20:00:26.609473508 +0100
+@@ -72,8 +72,6 @@
+ 		ar & help;
+ 	}
+ 	ar & trace.unsafe_ref();
+-	if (trace.get() == TraceShape)
+-		trace.unsafe_ref() = TraceDefault;
+ 	if (version < 3) {
+ 		int delay;
+ 		ar & delay;
+

--- a/pkgs/applications/misc/easystroke/sigc.patch
+++ b/pkgs/applications/misc/easystroke/sigc.patch
@@ -1,0 +1,31 @@
+Fix build with libsigc++ 2.4+ (group was removed).
+diff -Naur a/actions.cc b/actions.cc
+--- a/actions.cc	2015-11-04 19:56:49.351107678 +0100
++++ b/actions.cc	2015-11-04 19:57:07.161246969 +0100
+@@ -51,10 +51,8 @@
+ 	context->set_icon(pb, pb->get_width(), pb->get_height());
+ }
+ 
+-bool negate(bool b) { return !b; }
+-
+ TreeViewMulti::TreeViewMulti() : Gtk::TreeView(), pending(false) {
+-	get_selection()->set_select_function(sigc::group(&negate, sigc::ref(pending)));
++    get_selection()->set_select_function(sigc::mem_fun(*this, &TreeViewMulti::negate_pending));
+ }
+ 
+ enum Type { COMMAND, KEY, TEXT, SCROLL, IGNORE, BUTTON, MISC };
+diff -Naur a/actions.h b/actions.h
+--- a/actions.h	2015-11-04 19:56:49.351107678 +0100
++++ b/actions.h	2015-11-04 19:57:07.161246969 +0100
+@@ -30,6 +30,11 @@
+ 	virtual void on_drag_begin(const Glib::RefPtr<Gdk::DragContext> &context);
+ public:
+ 	TreeViewMulti();
++    bool negate_pending(const Glib::RefPtr<Gtk::TreeModel>& model,
++                        const Gtk::TreeModel::Path& path,
++                        bool path_currently_selected) {
++        return !pending;
++    }
+ };
+ 
+ class Actions {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25847,6 +25847,8 @@ in
 
   sndpeek = callPackage ../applications/audio/sndpeek { };
 
+  easystroke = callPackage ../applications/misc/easystroke { };
+
   sxhkd = callPackage ../applications/window-managers/sxhkd { };
 
   mpop = callPackage ../applications/networking/mpop {


### PR DESCRIPTION
###### Motivation for this change
Package not yet in list of available packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
