### PR TITLE
libsForQt5.kimageformats: fix build after libavif update

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules,
   ilmbase, karchive, openexr, libavif, qtbase
 }:
@@ -8,6 +8,15 @@ let inherit (lib) getDev; in
 
 mkDerivation {
   name = "kimageformats";
+
+  patches = [
+    (fetchpatch { # included in kimageformats >= 5.83
+      name = "avif-0.9.2.diff";
+      url = "https://invent.kde.org/frameworks/kimageformats/-/commit/bf3f94da766d66a0470ab744dbe1ced4697b572d.diff";
+      sha256 = "18d67l5kj9sv88jdpi061k9rl3adzkx9l51ng7saylrkfddwc3ig";
+    })
+  ];
+
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive openexr libavif qtbase ];
   outputs = [ "out" ]; # plugins only


### PR DESCRIPTION
###### Motivation for this change

The channel is broken now.  See e.g. discussion on https://github.com/NixOS/nixpkgs/pull/128064

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
