### PR TITLE
php: expose mkExtension

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -133,7 +133,7 @@ let
               unwrapped = php;
               # Select the right php tests for the php version
               tests = nixosTests."php${lib.strings.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor php.version)}";
-              inherit (php-packages) extensions buildPecl;
+              inherit (php-packages) extensions buildPecl mkExtension;
               packages = php-packages.tools;
               meta = php.meta // {
                 outputsToInstall = [ "out" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -59,6 +59,73 @@ lib.makeScope pkgs.newScope (self: with self; {
     pname = "php-${pname}";
   });
 
+  # Function to build an extension which is shipped as part of the php
+  # source, based on the php version.
+  #
+  # Name passed is the name of the extension and is automatically used
+  # to add the configureFlag "--enable-${name}", which can be overriden.
+  #
+  # Build inputs is used for extra deps that may be needed. And zendExtension
+  # will mark the extension as a zend extension or not.
+  mkExtension =
+    { name
+    , configureFlags ? [ "--enable-${name}" ]
+    , internalDeps ? [ ]
+    , postPhpize ? ""
+    , buildInputs ? [ ]
+    , zendExtension ? false
+    , doCheck ? true
+    , ...
+    }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
+      pname = "php-${name}";
+      extensionName = name;
+
+      inherit (php.unwrapped) version src;
+      sourceRoot = "php-${php.version}/ext/${name}";
+
+      enableParallelBuilding = true;
+      nativeBuildInputs = [ php.unwrapped autoconf pkg-config re2c ];
+      inherit configureFlags internalDeps buildInputs
+        zendExtension doCheck;
+
+      prePatch = "pushd ../..";
+      postPatch = "popd";
+
+      preConfigure = ''
+        nullglobRestore=$(shopt -p nullglob)
+        shopt -u nullglob   # To make ?-globbing work
+
+        # Some extensions have a config0.m4 or config9.m4
+        if [ -f config?.m4 ]; then
+          mv config?.m4 config.m4
+        fi
+
+        $nullglobRestore
+        phpize
+        ${postPhpize}
+        ${lib.concatMapStringsSep "\n"
+          (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
+          internalDeps}
+      '';
+      checkPhase = "runHook preCheck; NO_INTERACTON=yes make test; runHook postCheck";
+      outputs = [ "out" "dev" ];
+      installPhase = ''
+        mkdir -p $out/lib/php/extensions
+        cp modules/${name}.so $out/lib/php/extensions/${name}.so
+        mkdir -p $dev/include
+        ${rsync}/bin/rsync -r --filter="+ */" \
+                              --filter="+ *.h" \
+                              --filter="- *" \
+                              --prune-empty-dirs \
+                              . $dev/include/
+      '';
+
+      meta = {
+        description = "PHP upstream extension: ${name}";
+        inherit (php.meta) maintainers homepage license;
+      };
+    });
+
   php = phpPackage;
 
   # This is a set of interactive tools based on PHP.
@@ -171,72 +238,6 @@ lib.makeScope pkgs.newScope (self: with self; {
     yaml = callPackage ../development/php-packages/yaml { };
   } // (
     let
-      # Function to build a single php extension based on the php version.
-      #
-      # Name passed is the name of the extension and is automatically used
-      # to add the configureFlag "--enable-${name}", which can be overriden.
-      #
-      # Build inputs is used for extra deps that may be needed. And zendExtension
-      # will mark the extension as a zend extension or not.
-      mkExtension =
-        { name
-        , configureFlags ? [ "--enable-${name}" ]
-        , internalDeps ? [ ]
-        , postPhpize ? ""
-        , buildInputs ? [ ]
-        , zendExtension ? false
-        , doCheck ? true
-        , ...
-        }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
-          pname = "php-${name}";
-          extensionName = name;
-
-          inherit (php.unwrapped) version src;
-          sourceRoot = "php-${php.version}/ext/${name}";
-
-          enableParallelBuilding = true;
-          nativeBuildInputs = [ php.unwrapped autoconf pkg-config re2c ];
-          inherit configureFlags internalDeps buildInputs
-            zendExtension doCheck;
-
-          prePatch = "pushd ../..";
-          postPatch = "popd";
-
-          preConfigure = ''
-            nullglobRestore=$(shopt -p nullglob)
-            shopt -u nullglob   # To make ?-globbing work
-
-            # Some extensions have a config0.m4 or config9.m4
-            if [ -f config?.m4 ]; then
-              mv config?.m4 config.m4
-            fi
-
-            $nullglobRestore
-            phpize
-            ${postPhpize}
-            ${lib.concatMapStringsSep "\n"
-              (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
-              internalDeps}
-          '';
-          checkPhase = "runHook preCheck; NO_INTERACTON=yes make test; runHook postCheck";
-          outputs = [ "out" "dev" ];
-          installPhase = ''
-            mkdir -p $out/lib/php/extensions
-            cp modules/${name}.so $out/lib/php/extensions/${name}.so
-            mkdir -p $dev/include
-            ${rsync}/bin/rsync -r --filter="+ */" \
-                                  --filter="+ *.h" \
-                                  --filter="- *" \
-                                  --prune-empty-dirs \
-                                  . $dev/include/
-          '';
-
-          meta = {
-            description = "PHP upstream extension: ${name}";
-            inherit (php.meta) maintainers homepage license;
-          };
-        });
-
       # This list contains build instructions for different modules that one may
       # want to build.
       #


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- make it easier to build extensions using `nix-phps`, as mentioned in https://github.com/fossar/nix-phps/issues/27#issuecomment-869742250

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
