### PR TITLE
scream: 3.6 -> 3.7

### DIFF
--- a/pkgs/applications/audio/scream/default.nix
+++ b/pkgs/applications/audio/scream/default.nix
@@ -1,26 +1,29 @@
 { stdenv, lib, config, fetchFromGitHub, cmake, pkg-config
 , alsaSupport ? stdenv.isLinux, alsa-lib
 , pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio
+, jackSupport ? false, libjack2
 }:
 
 stdenv.mkDerivation rec {
   pname = "scream";
-  version = "3.6";
+  version = "3.7";
 
   src = fetchFromGitHub {
     owner = "duncanthrax";
     repo = pname;
     rev = version;
-    sha256 = "01k2zhfb781gfj3apmcjqbm5m05m6pvnh7fb5k81zwvqibai000v";
+    sha256 = "0d9abrw62cd08lcg4il415b7ap89iggbljvbl5jqv2y23il0pvyz";
   };
 
   buildInputs = lib.optional pulseSupport libpulseaudio
+    ++ lib.optional jackSupport libjack2
     ++ lib.optional alsaSupport alsa-lib;
   nativeBuildInputs = [ cmake pkg-config ];
 
   cmakeFlags = [
     "-DPULSEAUDIO_ENABLE=${if pulseSupport then "ON" else "OFF"}"
     "-DALSA_ENABLE=${if alsaSupport then "ON" else "OFF"}"
+    "-DJACK_ENABLE=${if jackSupport then "ON" else "OFF"}"
   ];
 
   cmakeDir = "../Receivers/unix";


### PR DESCRIPTION
###### Motivation for this change

Updated, also Jack support added and stuff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
