### PR TITLE
vlang: use shipped Makefile instead of custom buildPhase

### DIFF
--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -1,6 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, glfw, freetype, openssl, makeWrapper, upx ? null }:
-
-assert stdenv.hostPlatform.isUnix -> upx != null;
+{ lib, stdenv, fetchFromGitHub, glfw, freetype, openssl, makeWrapper, upx }:
 
 stdenv.mkDerivation rec {
   pname = "vlang";

--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     "VC=${vc}"
     # vlang seems to want to write to $HOME/.vmodules , so lets give
     # it a writable HOME
-    "HOME=/tmp"
+    "HOME=$TMPDIR"
   ];
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
The Makefile changes should make future updates smoother. Also, this prefixed the `v` binary with `stdenv.cc` because that is
needed to build v files.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
