### PR TITLE
svt-av1: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/tools/video/svt-av1/default.nix
+++ b/pkgs/tools/video/svt-av1/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, cmake, nasm }:
+{ lib, stdenv, fetchFromGitLab, cmake, nasm }:
 
 stdenv.mkDerivation rec {
   pname = "svt-av1";
-  version = "0.8.6";
+  version = "0.8.7";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "AOMediaCodec";
     repo = "SVT-AV1";
     rev = "v${version}";
-    sha256 = "1wzamg89azi1f93wxvdy7silsgklckc754ca066k33drvyacicyw";
+    sha256 = "1xlxb6kn6hqz9dxz0nd905m4i2mwjwq1330rbabwzmg4b66cdslg";
   };
 
   nativeBuildInputs = [ cmake nasm ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       activities.
     '';
     inherit (src.meta) homepage;
-    changelog = "https://github.com/AOMediaCodec/SVT-AV1/blob/v${version}/CHANGELOG.md";
+    changelog = "https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v${version}/CHANGELOG.md";
     license = with licenses; [
       bsd2
       {


### PR DESCRIPTION


###### Motivation for this change

Updated and upstream moved from github to gitlab

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
