### PR TITLE
Pipewire 0.3.31

### DIFF
--- a/nixos/modules/services/desktops/pipewire/bluez-hardware.conf.json
+++ b/nixos/modules/services/desktops/pipewire/bluez-hardware.conf.json
@@ -1,0 +1,197 @@
+{
+  "bluez5.features.device": [
+    {
+      "name": "Air 1 Plus",
+      "no-features": [
+        "hw-volume-mic"
+      ]
+    },
+    {
+      "name": "AirPods",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "name": "AirPods Pro",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "name": "AXLOIE Goin",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "name": "JBL Endurance RUN BT",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl",
+        "sbc-xq"
+      ]
+    },
+    {
+      "name": "JBL LIVE650BTNC"
+    },
+    {
+      "name": "Soundcore Life P2-L",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "name": "Urbanista Stockholm Plus",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "address": "~^94:16:25:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^9c:64:8b:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^a0:e9:db:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^0c:a6:94:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^00:14:02:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^44:5e:f3:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^d4:9c:28:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^00:18:6b:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^b8:ad:3e:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^a0:e9:db:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^00:24:1c:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^00:11:b1:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^a4:15:66:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^00:14:f1:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^00:26:7e:",
+      "no-features": [
+        "hw-volume"
+      ]
+    },
+    {
+      "address": "~^90:03:b7:",
+      "no-features": [
+        "hw-volume"
+      ]
+    }
+  ],
+  "bluez5.features.adapter": [
+    {
+      "bus-type": "usb",
+      "vendor-id": "usb:0bda"
+    },
+    {
+      "bus-type": "usb",
+      "no-features": [
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "no-features": [
+        "msbc-alt1-rtl"
+      ]
+    }
+  ],
+  "bluez5.features.kernel": [
+    {
+      "sysname": "Linux",
+      "release": "~^[0-4]\\.",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "sysname": "Linux",
+      "release": "~^5\\.[1-7]\\.",
+      "no-features": [
+        "msbc-alt1",
+        "msbc-alt1-rtl"
+      ]
+    },
+    {
+      "sysname": "Linux",
+      "release": "~^5\\.(8|9|10)\\.",
+      "no-features": [
+        "msbc-alt1"
+      ]
+    },
+    {
+      "no-features": []
+    }
+  ]
+}

--- a/nixos/modules/services/desktops/pipewire/jack.conf.json
+++ b/nixos/modules/services/desktops/pipewire/jack.conf.json
@@ -7,7 +7,7 @@
   },
   "context.modules": [
     {
-      "name": "libpipewire-module-rtkit",
+      "name": "libpipewire-module-rt",
       "args": {},
       "flags": [
         "ifexists",

--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -15,6 +15,7 @@ let
   defaults = {
     alsa-monitor = (builtins.fromJSON (builtins.readFile ./alsa-monitor.conf.json));
     bluez-monitor = (builtins.fromJSON (builtins.readFile ./bluez-monitor.conf.json));
+    bluez-hardware = (builtins.fromJSON (builtins.readFile ./bluez-hardware.conf.json));
     media-session = (builtins.fromJSON (builtins.readFile ./media-session.conf.json));
     v4l2-monitor = (builtins.fromJSON (builtins.readFile ./v4l2-monitor.conf.json));
   };
@@ -22,6 +23,7 @@ let
   configs = {
     alsa-monitor = recursiveUpdate defaults.alsa-monitor cfg.config.alsa-monitor;
     bluez-monitor = recursiveUpdate defaults.bluez-monitor cfg.config.bluez-monitor;
+    bluez-hardware = defaults.bluez-hardware;
     media-session = recursiveUpdate defaults.media-session cfg.config.media-session;
     v4l2-monitor = recursiveUpdate defaults.v4l2-monitor cfg.config.v4l2-monitor;
   };
@@ -119,6 +121,10 @@ in {
     environment.etc."pipewire/media-session.d/bluez-monitor.conf" =
       mkIf config.services.pipewire.pulse.enable {
         source = json.generate "bluez-monitor.conf" configs.bluez-monitor;
+      };
+    environment.etc."pipewire/media-session.d/bluez-hardware.conf" =
+      mkIf config.services.pipewire.pulse.enable {
+        source = json.generate "bluez-hardware.conf" configs.bluez-hardware;
       };
 
     environment.etc."pipewire/media-session.d/with-jack" =

--- a/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
+++ b/pkgs/development/libraries/pipewire/0055-pipewire-media-session-path.patch
@@ -2,16 +2,13 @@ diff --git a/meson_options.txt b/meson_options.txt
 index 93b5e2a9..1b915ac3 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -13,6 +13,9 @@ option('media-session',
-        description: 'Build and install pipewire-media-session',
+@@ -200,3 +200,6 @@ option('media-session',
         type: 'feature',
         value: 'auto')
 +option('media-session-prefix',
 +       description: 'Install directory for pipewire-media-session and its support files',
 +       type: 'string')
- option('man',
-        description: 'Build manpages',
-        type: 'feature',
+ option('session-managers',
 diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
 index 1edebb2d..251270eb 100644
 --- a/src/daemon/systemd/user/meson.build

--- a/pkgs/development/libraries/pipewire/0090-pipewire-config-template-paths.patch
+++ b/pkgs/development/libraries/pipewire/0090-pipewire-config-template-paths.patch
@@ -6,8 +6,8 @@ index bbafa134..227d3e06 100644
              # access.allowed to list an array of paths of allowed
              # apps.
              #access.allowed = [
--            #    @media_session_path@
-+            #    <media_session_path>
+-            #    @session_manager_path@
++            #    <session_manager_path>
              #]
  
              # An array of rejected paths.
@@ -15,8 +15,8 @@ index bbafa134..227d3e06 100644
      # but it is better to start it as a systemd service.
      # Run the session manager with -h for options.
      #
--    @comment@{ path = "@media_session_path@"  args = "" }
-+    @comment@{ path = "<media_session_path>"  args = "" }
+-    @comment@{ path = "@session_manager_path@"  args = "@session_manager_args@" }
++    @comment@{ path = "<session_manager_path>"  args = "@session_manager_args@" }
      #
      # You can optionally start the pulseaudio-server here as well
      # but it is better to start it as a systemd service.

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -192,6 +192,7 @@ let
           paths-out-media-session = [
             "nix-support/etc/pipewire/media-session.d/alsa-monitor.conf.json"
             "nix-support/etc/pipewire/media-session.d/bluez-monitor.conf.json"
+            "nix-support/etc/pipewire/media-session.d/bluez-hardware.conf.json"
             "nix-support/etc/pipewire/media-session.d/media-session.conf.json"
             "nix-support/etc/pipewire/media-session.d/v4l2-monitor.conf.json"
           ];

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -14,6 +14,7 @@
 , dbus
 , alsa-lib
 , libjack2
+, libusb1
 , udev
 , libva
 , libsndfile
@@ -43,10 +44,11 @@ let
   };
 
   mesonEnable = b: if b then "enabled" else "disabled";
+  mesonList = l: "[" + lib.concatStringsSep "," l + "]";
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.30";
+    version = "0.3.31";
 
     outputs = [
       "out"
@@ -64,7 +66,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-DnaPvZoDaegjtJNKBmCJEAZe5FQBnSER79FPnxiWQUE=";
+      sha256 = "1dirz69ami7bcgy6hhh0ffi9gzwcy9idg94nvknwvwkjw4zm8m79";
     };
 
     patches = [
@@ -96,6 +98,7 @@ let
       dbus
       glib
       libjack2
+      libusb1
       libsndfile
       ncurses
       udev
@@ -122,6 +125,7 @@ let
       "-Dmedia-session-prefix=${placeholder "mediaSession"}"
       "-Dlibjack-path=${placeholder "jack"}/lib"
       "-Dlibcamera=disabled"
+      "-Droc=disabled"
       "-Dlibpulse=${mesonEnable pulseTunnelSupport}"
       "-Davahi=${mesonEnable zeroconfSupport}"
       "-Dgstreamer=${mesonEnable gstreamerSupport}"
@@ -133,6 +137,7 @@ let
       "-Dbluez5-backend-hsphfpd=${mesonEnable hsphfpdSupport}"
       "-Dsysconfdir=/etc"
       "-Dpipewire_confdata_dir=${placeholder "lib"}/share/pipewire"
+      "-Dsession-managers=${mesonList (lib.optional withMediaSession "media-session")}"
     ];
 
     FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/0.3.31/NEWS

Updated, and added config file that update.sh complained about.

wireplumber is now an optional replacement session manager, but I've kept that out for now. Could be added later, though probably more appropriate as a separate derivation anyway?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
