### PR TITLE
gupnp: revert #128538

### DIFF
--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -20,14 +20,22 @@
 
 stdenv.mkDerivation rec {
   pname = "gupnp";
-  version = "1.2.7";
+  version = "1.2.4";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-hEEnbxr9AXbm9ZUCajpQfu0YCav6BAJrrT8hYis1I+w=";
+    sha256 = "sha256-96AwfqUfXkTRuDL0k92QRURKOk4hHvhd/Zql3W6up9E=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-33516.patch";
+      url = "https://gitlab.gnome.org/GNOME/gupnp/-/commit/ca6ec9dcb26fd7a2a630eb6a68118659b589afac.patch";
+      sha256 = "sha256-G7e/xNQB7Kp2fPzqVeD/cH3h1co9hZXh55QOUBnAnvU=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
Reverts NixOS/nixpkgs#128448 since it causes issues building the linuxKernel (5.12.13; in https://github.com/NixOS/nixpkgs/pull/128538 ) and author commented that the merge request wasn't ready. ( https://github.com/NixOS/nixpkgs/pull/128448#issuecomment-869854683 )