### PR TITLE
kubernetes: make tests pass by fixing a conntrack-tools dep and a missing dir

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -189,6 +189,7 @@ in
         # manually paste it in place. Just symlink.
         # otherwise, create the target file, ready for users to insert the token
 
+        mkdir -p $(dirname ${certmgrAPITokenPath})
         if [ -f "${cfsslAPITokenPath}" ]; then
           ln -fs "${cfsslAPITokenPath}" "${certmgrAPITokenPath}"
         else

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -59,7 +59,7 @@ in
       description = "Kubernetes Proxy Service";
       wantedBy = [ "kubernetes.target" ];
       after = [ "kube-apiserver.service" ];
-      path = with pkgs; [ iptables conntrack_tools ];
+      path = with pkgs; [ iptables conntrack-tools ];
       serviceConfig = {
         Slice = "kubernetes.slice";
         ExecStart = ''${top.package}/bin/kube-proxy \

--- a/nixos/tests/kubernetes/base.nix
+++ b/nixos/tests/kubernetes/base.nix
@@ -40,7 +40,7 @@ let
                   allowedTCPPorts = [
                     10250 # kubelet
                   ];
-                  trustedInterfaces = ["docker0"];
+                  trustedInterfaces = ["mynet"];
 
                   extraCommands = concatMapStrings  (node: ''
                     iptables -A INPUT -s ${node.config.networking.primaryIPAddress} -j ACCEPT
@@ -61,6 +61,13 @@ let
                   advertiseAddress = master.ip;
                 };
                 masterAddress = "${masterName}.${config.networking.domain}";
+                # workaround for:
+                #   https://github.com/kubernetes/kubernetes/issues/102676
+                #   (workaround from) https://github.com/kubernetes/kubernetes/issues/95488
+                kubelet.extraOpts = ''\
+                  --cgroups-per-qos=false \
+                  --enforce-node-allocatable="" \
+                '';
               };
             }
             (optionalAttrs (any (role: role == "master") machine.roles) {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This PR fixes the kubernetes tests on master.  There are several unrelated changes, and unfortunately, all are necessary for the tests to actually succeed

Changes:
  - Change the dep in `proxy.nix` from `conntrack_tools` to `conntrack-tools`.  The former is an alias to the latter, but aliases have been disabled in tests since 3edde65.
  - Create the `certmgrAPITokenPath` dir in `pki.nix`.  Without that, the tests fail with an error like `kube-certmgr-bootstrap-start[698]: touch: cannot touch '/var/lib/kubernetes/secrets/apitoken.secret':No such file or directory`.
  - In `tests/kubernetes/base.nix`, the container network is now called `mynet` by default and not `docker0`.  This was changed during the switch to containerd in 7b5c38e973842.
  - Also there, add some extra options to `kubectl` to work around a runc bug introduced in kubernetes-1.21.1  ([kubernetes/102676](https://github.com/kubernetes/kubernetes/issues/102676)).  Weirdly enough, this doesn't affect my live cluster, but the tests seem to fail most of the time (but not always) due to this.

###### Motivation for this change

Fixes the kubernetes tests, for the most part.  Specifically, it fixes the `dns.nix` and `rbac.nix` tests as they're the only ones mentioned in `default.nix`.

Mind you, even with the changes here, the tests are still flaky and sometimes end up getting stuck in a loop logging `"Error getting node" err="node \"machine1.my.zyx\" not found"`, but we can fix that separately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
