### PR TITLE
apio: init at 0.7.4

### DIFF
--- a/pkgs/development/tools/misc/apio/default.nix
+++ b/pkgs/development/tools/misc/apio/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, click
+, semantic-version
+, requests
+, colorama
+, pyserial
+, wheel
+, setuptools
+, tinyprog
+, pytestCheckHook
+}:
+
+buildPythonApplication rec {
+  pname = "apio";
+  version = "0.7.5";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "FPGAwars";
+    repo = "apio";
+    rev = "v${version}";
+    sha256 = "sha256-9f0q6tELUDo6FdjPG708d7BY3O5ZiZ0FwNFzBBiLQp4=";
+  };
+
+  postPatch = ''
+    substituteInPlace apio/managers/scons.py --replace \
+      'return "tinyprog --libusb --program"' \
+      'return "${tinyprog}/bin/tinyprog --libusb --program"'
+    substituteInPlace apio/util.py --replace \
+      '_command = join(get_bin_dir(), "tinyprog")' \
+      '_command = "${tinyprog}/bin/tinyprog"'
+
+    # semantic-version seems to not support version numbers like the one of tinyprog in Nixpkgs (1.0.24.dev114+gxxxxxxx).
+    # See https://github.com/rbarrois/python-semanticversion/issues/47.
+    # This leads to an error like "Error: Invalid version string: '1.0.24.dev114+g97f6353'"
+    # when executing "apio upload" for a TinyFPGA.
+    # Replace the dot with a dash to work around this problem.
+    substituteInPlace apio/managers/scons.py --replace \
+        'version = semantic_version.Version(pkg_version)' \
+        'version = semantic_version.Version(pkg_version.replace(".dev", "-dev"))'
+  '';
+
+  propagatedBuildInputs = [
+    click
+    semantic-version
+    requests
+    colorama
+    pyserial
+    wheel
+    setuptools # needs pkg_resources at runtime (technically not needed when tinyprog is also in this list because of the propagatedBuildInputs of tinyprog)
+
+    tinyprog # needed for upload to TinyFPGA
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "--offline" ];
+
+  meta = with lib; {
+    description = "Open source ecosystem for open FPGA boards";
+    homepage = "https://github.com/FPGAwars/apio";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1147,6 +1147,8 @@ in
 
   arduino-mk = callPackage ../development/arduino/arduino-mk {};
 
+  apio = python3Packages.callPackage ../development/tools/misc/apio { };
+
   apitrace = libsForQt514.callPackage ../applications/graphics/apitrace {};
 
   argtable = callPackage ../development/libraries/argtable { };


### PR DESCRIPTION
###### Motivation for this change
Add apio, so people can program their TinyFPGA boards without installing the package via pip.

I use this package for programming a TinyFPGA BX. It will probably not work with FPGAs which are not TinyFPGA boards, without modification.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).