### PR TITLE
Revert "writers: Allow string paths"

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -15,12 +15,12 @@ rec {
       name = last (builtins.split "/" nameOrPath);
     in
 
-    pkgs.runCommandLocal name (if types.path.check content then {
-      inherit interpreter;
-      contentPath = content;
-    } else {
+    pkgs.runCommandLocal name (if (types.str.check content) then {
       inherit content interpreter;
       passAsFile = [ "content" ];
+    } else {
+      inherit interpreter;
+      contentPath = content;
     }) ''
       # On darwin a script cannot be used as an interpreter in a shebang but
       # there doesn't seem to be a limit to the size of shebang and multiple


### PR DESCRIPTION
This reverts commit 33ffb05d390987802fe939f9c9a3d6a451076535.

###### Motivation for this change

#128097 broke the pleroma module, so I suggest reverting it. Alternative solutions are welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
