### PR TITLE
complete-alias: init at 1.10.0

### DIFF
--- a/pkgs/tools/misc/complete-alias/default.nix
+++ b/pkgs/tools/misc/complete-alias/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "complete-alias";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "cykerway";
+    repo = pname;
+    rev = version;
+    sha256 = "1s0prdnmb2qnzc8d7ddldzqa53yc10qq0lbgx2l9dzmz8pdwylyc";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    # required for the patchShebangs setup hook
+    chmod +x complete_alias
+
+    patchShebangs complete_alias
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r complete_alias "$out"/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Automagical shell alias completion";
+    homepage = "https://github.com/cykerway/complete-alias";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ tuxinaut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23270,6 +23270,8 @@ in
 
   communi = libsForQt5.callPackage ../applications/networking/irc/communi { };
 
+  complete-alias = callPackage ../tools/misc/complete-alias { };
+
   confclerk = callPackage ../applications/misc/confclerk { };
 
   copyq = libsForQt514.callPackage ../applications/misc/copyq { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Have [complete-alias](https://github.com/cykerway/complete-alias) available as nix package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 128551"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
