### PR TITLE
formats: use runCommandLocal

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -38,7 +38,7 @@ rec {
       };
     in valueType;
 
-    generate = name: value: pkgs.runCommandNoCC name {
+    generate = name: value: pkgs.runCommandLocal name {
       nativeBuildInputs = [ pkgs.jq ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
@@ -121,7 +121,7 @@ rec {
       };
     in valueType;
 
-    generate = name: value: pkgs.runCommandNoCC name {
+    generate = name: value: pkgs.runCommandLocal name {
       nativeBuildInputs = [ pkgs.remarshal ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];


### PR DESCRIPTION
###### Motivation for this change

Before `runCommandNoCC` was used, which does not include

    preferLocalBuild = true;
    allowSubstitutes = false;

causing a bit of network traffic for each instantiation. Since the files typically are trivial to build we may as well do them locally and thereby avoid the network round trip.

CC @Infinisil Perhaps there is a specific reason why you chose `runCommandNoCC`?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
