### PR TITLE
openjdk: 11.0.10+11 -> 11.0.11+9

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -11,7 +11,7 @@
 let
   major = "11";
   minor = "0";
-  update = "10";
+  update = "11";
   build = "9";
 
   openjdk = stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ let
       owner = "openjdk";
       repo = "jdk${major}u";
       rev = "jdk-${version}";
-      sha256 = "06pm3hpz4ggiqwvkgzxr39y9kga7vk4flakfznz5979bvgb926vw";
+      sha256 = "0jncsj424340xjfwv6sx5hy9sas80qa3ymkx0ng3by3z01y5rgfx";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];


### PR DESCRIPTION
###### Motivation for this change
Updated to latest release version. Fixes #128407


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
asbachb@nixo-t14s  ~/dev/src/nix/nixpkgs   update/java/11  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 206, done.
remote: Counting objects: 100% (75/75), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 206 (delta 62), reused 55 (delta 55), pack-reused 131
Receiving objects: 100% (206/206), 275.90 KiB | 771.00 KiB/s, done.
Resolving deltas: 100% (70/70), completed with 42 local objects.
From https://github.com/NixOS/nixpkgs
   caeed722c23..a9a0ec04146  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-8c8b704c79b7cb4fc533a8d0004804a9e4136cdd-dirty-1/nixpkgs a9a0ec041468f65fbd5daf82d0471d65c6696118
Preparing worktree (detached HEAD a9a0ec04146)
Updating files: 100% (26808/26808), done.
HEAD is now at a9a0ec04146 Merge pull request #128077 from doronbehar/pkg/imagej
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-8c8b704c79b7cb4fc533a8d0004804a9e4136cdd-dirty-1/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
```
 asbachb@nixo-t14s  ~/dev/src/nix/nixpkgs/result/bin  ./java -version
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on
openjdk version "11.0.11" 2021-04-20
OpenJDK Runtime Environment (build 11.0.11+0-adhoc..source)
OpenJDK 64-Bit Server VM (build 11.0.11+0-adhoc..source, mixed mode)
 asbachb@nixo-t14s  ~/dev/src/nix/nixpkgs/result/bin 
```
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
