### PR TITLE
python3Packages.portalocker: 1.7.0 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/msal-extensions/default.nix
+++ b/pkgs/development/python-modules/msal-extensions/default.nix
@@ -25,12 +25,18 @@ buildPythonPackage rec {
     pathlib2
   ];
 
+  # upstream doesn't update this requirement probably because they use pip
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "portalocker~=1.0" "portalocker"
+  '';
+
   # No tests found
   doCheck = false;
 
   meta = with lib; {
     description = "The Microsoft Authentication Library Extensions (MSAL-Extensions) for Python";
-    homepage = "https://github.com/AzureAD/microsoft-authentication-library-for-python";
+    homepage = "https://github.com/AzureAD/microsoft-authentication-extensions-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [
       kamadorueda

--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -1,34 +1,27 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch
-, sphinx
-, pytest
+{ lib, buildPythonPackage, fetchPypi
+, pytestCheckHook
 , pytestcov
 , pytest-flake8
+, pytest-mypy
+, redis
 }:
 
 buildPythonPackage rec {
-  version = "1.7.0";
+  version = "2.3.0";
   pname = "portalocker";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p32v16va780mjjdbyp3v702aqg5s618khlila7bdyynis1n84q9";
+    sha256 = "0k08c0qg21mwz3iqbd20ab22nq705q7cal4a1qr8qnd6ga03v4af";
   };
 
-  patches = [
-    # remove pytest-flakes from test dependencies
-    # merged into master, remove > 1.7.0 release
-    (fetchpatch {
-      url = "https://github.com/WoLpH/portalocker/commit/42e4c0a16bbc987c7e33b5cbc7676a63a164ceb5.patch";
-      sha256 = "01mlr41nhh7mh3qhqy5fhp3br4nps745iy4ns9fjcnm5xhabg5rr";
-      excludes = [ "pytest.ini" ];
-    })
+  propagatedBuildInputs = [
+    redis
   ];
 
   checkInputs = [
-    sphinx
-    pytest
-    pytestcov
-    pytest-flake8
+    pytestCheckHook
+    pytest-mypy
   ];
 
   meta = with lib; {

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -6,7 +6,7 @@ let
     prePatch = (attrs.prePatch or "") + ''
       rm -f azure_bdist_wheel.py tox.ini
       substituteInPlace setup.py \
-        --replace "cryptography>=2.3.1,<3.0.0" "cryptography"
+        --replace "cryptography>=3.2,<3.4" "cryptography"
       sed -i "/azure-namespace-package/c\ " setup.cfg
     '';
 
@@ -118,6 +118,12 @@ let
           applicationinsights
           portalocker
         ];
+
+        # upstream doesn't update this requirement probably because they use pip
+        postPatch = ''
+          substituteInPlace setup.py \
+            --replace "portalocker~=1.6" "portalocker"
+        '';
 
         # ignore flaky test
         checkPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Supersedes #117444
@jonringer @dotlambda 

###### Things done
had to add substituteInPlace's because upstream doesn't update them
`az --version` worked fine but i haven't dont use azure so i didn't test more

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>chia</li>
  </ul>
</details>
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>azure-cli</li>
    <li>python38Packages.applicationinsights</li>
    <li>python38Packages.azure-identity</li>
    <li>python38Packages.concurrent-log-handler</li>
    <li>python38Packages.msal-extensions</li>
    <li>python38Packages.portalocker</li>
    <li>python39Packages.applicationinsights</li>
    <li>python39Packages.azure-identity</li>
    <li>python39Packages.concurrent-log-handler</li>
    <li>python39Packages.msal-extensions</li>
    <li>python39Packages.portalocker</li>
  </ul>
</details>
chia was already failing https://hydra.nixos.org/build/146518756 #128498


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
