### PR TITLE
data/misc/svi: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4633,6 +4633,10 @@
     githubId = 2179419;
     name = "Arseniy Seroka";
   };
+  jake-gillberg = {
+    name = "Jake Gillberg";
+    email = "jake.gillberg@protonmail.com";
+  };
   jakeisnt = {
     name = "Jacob Chvatal";
     email = "jake@isnt.online";

--- a/pkgs/data/misc/svi/.gitignore
+++ b/pkgs/data/misc/svi/.gitignore
@@ -1,0 +1,1 @@
+source-files.nix.new

--- a/pkgs/data/misc/svi/Makefile
+++ b/pkgs/data/misc/svi/Makefile
@@ -1,0 +1,2 @@
+generate:
+	runhaskell generateSourceFiles.hs > source-files.nix.new

--- a/pkgs/data/misc/svi/Regions.hs
+++ b/pkgs/data/misc/svi/Regions.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Regions where
+
+import qualified Data.Text as T
+
+data US_State = US_State {
+  name :: T.Text
+, statefp :: T.Text
+}
+
+us_states =
+  [ US_State {name="American Samoa"                              , statefp="60"}
+  , US_State {name="Commonwealth of the Northern Mariana Islands", statefp="69"}
+  , US_State {name="District of Columbia"                        , statefp="11"}
+  , US_State {name="Guam"                                        , statefp="66"}
+  , US_State {name="Puerto Rico"                                 , statefp="72"}
+  , US_State {name="United States Virgin Islands"                , statefp="78"}
+  , US_State {name="Alabama"                                     , statefp="01"}
+  , US_State {name="Alaska"                                      , statefp="02"}
+  , US_State {name="Arizona"                                     , statefp="04"}
+  , US_State {name="Arkansas"                                    , statefp="05"}
+  , US_State {name="California"                                  , statefp="06"}
+  , US_State {name="Colorado"                                    , statefp="08"}
+  , US_State {name="Connecticut"                                 , statefp="09"}
+  , US_State {name="Delaware"                                    , statefp="10"}
+  , US_State {name="Florida"                                     , statefp="12"}
+  , US_State {name="Georgia"                                     , statefp="13"}
+  , US_State {name="Hawaii"                                      , statefp="15"}
+  , US_State {name="Idaho"                                       , statefp="16"}
+  , US_State {name="Illinois"                                    , statefp="17"}
+  , US_State {name="Indiana"                                     , statefp="18"}
+  , US_State {name="Iowa"                                        , statefp="19"}
+  , US_State {name="Kansas"                                      , statefp="20"}
+  , US_State {name="Kentucky"                                    , statefp="21"}
+  , US_State {name="Louisiana"                                   , statefp="22"}
+  , US_State {name="Maine"                                       , statefp="23"}
+  , US_State {name="Maryland"                                    , statefp="24"}
+  , US_State {name="Massachusetts"                               , statefp="25"}
+  , US_State {name="Michigan"                                    , statefp="26"}
+  , US_State {name="Minnesota"                                   , statefp="27"}
+  , US_State {name="Mississippi"                                 , statefp="28"}
+  , US_State {name="Missouri"                                    , statefp="29"}
+  , US_State {name="Montana"                                     , statefp="30"}
+  , US_State {name="Nebraska"                                    , statefp="31"}
+  , US_State {name="Nevada"                                      , statefp="32"}
+  , US_State {name="New Hampshire"                               , statefp="33"}
+  , US_State {name="New Jersey"                                  , statefp="34"}
+  , US_State {name="New Mexico"                                  , statefp="35"}
+  , US_State {name="New York"                                    , statefp="36"}
+  , US_State {name="North Carolina"                              , statefp="37"}
+  , US_State {name="North Dakota"                                , statefp="38"}
+  , US_State {name="Ohio"                                        , statefp="39"}
+  , US_State {name="Oklahoma"                                    , statefp="40"}
+  , US_State {name="Oregon"                                      , statefp="41"}
+  , US_State {name="Pennsylvania"                                , statefp="42"}
+  , US_State {name="Rhode Island"                                , statefp="44"}
+  , US_State {name="South Carolina"                              , statefp="45"}
+  , US_State {name="South Dakota"                                , statefp="46"}
+  , US_State {name="Tennessee"                                   , statefp="47"}
+  , US_State {name="Texas"                                       , statefp="48"}
+  , US_State {name="Utah"                                        , statefp="49"}
+  , US_State {name="Vermont"                                     , statefp="50"}
+  , US_State {name="Virginia"                                    , statefp="51"}
+  , US_State {name="Washington"                                  , statefp="53"}
+  , US_State {name="West Virginia"                               , statefp="54"}
+  , US_State {name="Wisconsin"                                   , statefp="55"}
+  , US_State {name="Wyoming"                                     , statefp="56"} ]

--- a/pkgs/data/misc/svi/Utils.hs
+++ b/pkgs/data/misc/svi/Utils.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Utils where
+
+import System.Process
+import System.Exit
+import qualified Data.Text as T
+import qualified Data.Map as M
+
+data SourceFile = SourceFile {
+  name :: T.Text
+, url :: T.Text
+, extraAttrs :: M.Map T.Text T.Text
+}
+
+showNixSource :: SourceFile -> IO [T.Text]
+showNixSource SourceFile{name=n, url=u, extraAttrs=a} = do
+  (exitcode, stdout, stderr) <- readProcessWithExitCode ("nix-prefetch-url") ["--unpack", "--name", T.unpack n, T.unpack u] ""
+  return $
+    [ n <> " = {"
+    , "  url = \"" <> u <> "\";"
+    , "  sha256 = \""
+      <> case exitcode of
+           ExitSuccess -> (T.strip (T.pack stdout))
+           _ -> "0000000000000000000000000000000000000000000000000000000000000000"
+      <> "\";"
+    ]
+    ++
+    (map (\(k, v) -> "  " <> k <> " = \"" <> v <> "\";") (M.toList a))
+    ++
+    [ "};" ]
+
+showNixSourceFiles :: [SourceFile] -> IO ()
+showNixSourceFiles sources = do
+  putStrLn "# Do not modify manually, auto generated with `generateSourceFiles.hs`"
+  putStrLn "{"
+  mapM
+    (\sourceFile -> do
+      nixSource <- showNixSource sourceFile
+      putStr $ T.unpack $ T.unlines $ map (\x -> "  " <> x) nixSource
+    )
+    sources
+  putStrLn "}"

--- a/pkgs/data/misc/svi/default.nix
+++ b/pkgs/data/misc/svi/default.nix
@@ -33,7 +33,7 @@ in
       '';
     homepage = "https://www.atsdr.cdc.gov/placeandhealth/svi/index.html";
     license = licenses.publicDomain;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ jake-gillberg ];
     platforms = platforms.all;
   };
 })

--- a/pkgs/data/misc/svi/default.nix
+++ b/pkgs/data/misc/svi/default.nix
@@ -1,0 +1,39 @@
+{ fetchzip
+, lib
+, linkFarmFromDrvs
+}:
+let
+  sourceFiles = import ./source-files.nix;
+  fetchSourceFile = name: sourceFile:
+    fetchzip {
+      inherit name;
+      stripRoot = false;
+      url = sourceFile.url;
+      sha256 = sourceFile.sha256;
+
+      passthru = removeAttrs sourceFile ["name" "url" "sha256"];
+    };
+in
+(linkFarmFromDrvs
+   "svi"
+   (lib.mapAttrsToList
+      fetchSourceFile
+      sourceFiles )
+).overrideAttrs (oldAttrs: rec {
+  meta = with lib; {
+    description = "CDC/ATSDR Social Vulnerability Index";
+    longDescription =
+      ''The CDC/ATSDR SVI uses U.S. Census data to determine the social
+        vulnerability of every census tract. Census tracts are subdivisions
+        of counties for which the Census collects statistical data. The
+        CDC/ATSDR SVI ranks each tract on 15 social factors, including
+        poverty, lack of vehicle access, and crowded housing, and groups
+        them into four related themes. Each tract receives a separate
+        ranking for each of the four themes, as well as an overall ranking.
+      '';
+    homepage = "https://www.atsdr.cdc.gov/placeandhealth/svi/index.html";
+    license = licenses.publicDomain;
+    maintainers = [ ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/data/misc/svi/generateSourceFiles.hs
+++ b/pkgs/data/misc/svi/generateSourceFiles.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Regions as Regions
+import Utils as Utils
+
+import qualified Data.Text as T
+import qualified Data.Map as M
+
+main = Utils.showNixSourceFiles sources
+
+sources =
+  let
+    states = filter
+      (\US_State{Regions.name=name, statefp=_} ->
+        name /= "American Samoa"
+        && name /= "Commonwealth of the Northern Mariana Islands"
+        && name /= "Guam"
+        && name /= "United States Virgin Islands"
+      )
+      us_states
+  in
+  concatMap
+    (\year ->
+      nationSources year
+      <> concatMap (stateSources year) states
+    )
+    [2014,2016..2018]
+
+nationSources year =
+  let
+    nation_geoms = 
+      [ "county"
+      , "tract"
+      , "ttract"
+      ]
+    s_year = T.pack $ show year
+    nationUrl :: T.Text -> T.Text
+    nationUrl geom =
+      "https://svi.cdc.gov/Documents/Data/"
+      <> s_year <> "_SVI_Data/"
+      <> case (geom, year) of
+           ("ttract", _) -> "States/Tribal_Tracts"
+           ("tract", _) -> "SVI" <> s_year <> "_US"
+           ("county", year) | year == 2014 -> "SVI" <> s_year <> "_US_cnty"
+           _ -> "SVI" <> s_year <> "_US_" <> geom
+      <> ".zip"
+   in
+    map (\geom ->
+      SourceFile {
+        Utils.name =
+          "svi-" <> s_year <> "-us-" <> geom,
+        url =
+          nationUrl geom,
+        extraAttrs = M.fromList
+          [ ("year", s_year)
+          , ("region", "US")
+          , ("geom", geom)
+          ]
+        }
+      )
+      nation_geoms
+
+sanatize = T.replace " " "_"
+
+stateSources year state = 
+  let
+    state_geoms :: [T.Text]
+    state_geoms =
+      [ "county"
+      , "tract"
+      ]
+    s_name = sanatize $ Regions.name state
+    u_name = T.replace " " "" $ Regions.name state
+    s_year = T.pack $ show year
+    stateName :: T.Text -> T.Text
+    stateName geom =
+      "svi-" <> s_year <> "-" <> (T.toLower s_name) <> "-" <> geom
+    stateUrl :: T.Text -> T.Text
+    stateUrl geom =
+      "https://svi.cdc.gov/Documents/Data/"
+      <> s_year <> "_SVI_Data/"
+      <> case (geom, year) of
+           ("tract", _) -> "States/" <> u_name
+           ("county", year) | year == 2014 -> "States_Counties/" <> u_name <> "_cnty"
+           ("county", _) -> "States_Counties/" <> u_name <> "_county"
+      <> ".zip"
+    stateSource :: T.Text -> SourceFile
+    stateSource geom =
+      SourceFile {
+        Utils.name = stateName geom,
+        url = stateUrl geom,
+        extraAttrs = M.fromList
+          [ ("year", s_year)
+          , ("region", s_name)
+          , ("geom", geom)
+          ]
+      }
+  in
+    map stateSource state_geoms

--- a/pkgs/data/misc/svi/generateSourceFiles.hs
+++ b/pkgs/data/misc/svi/generateSourceFiles.hs
@@ -29,7 +29,7 @@ sources =
 
 nationSources year =
   let
-    nation_geoms = 
+    nation_geoms =
       [ "county"
       , "tract"
       , "ttract"
@@ -63,7 +63,7 @@ nationSources year =
 
 sanatize = T.replace " " "_"
 
-stateSources year state = 
+stateSources year state =
   let
     state_geoms :: [T.Text]
     state_geoms =

--- a/pkgs/data/misc/svi/shell.nix
+++ b/pkgs/data/misc/svi/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import ../../../../. {} }: with pkgs;
+mkShell {
+  nativeBuildInputs = [
+    (haskellPackages.ghcWithPackages (ps: []))
+    unzip
+  ];
+}

--- a/pkgs/data/misc/svi/source-files.nix
+++ b/pkgs/data/misc/svi/source-files.nix
@@ -1,0 +1,2250 @@
+# Do not modify manually, auto generated with `generateSourceFiles.hs`
+{
+  svi-2014-us-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/SVI2014_US_cnty.zip";
+    sha256 = "0581g19klmwswj73gndpwgc9hh2idvg14277zzwvnq5py3rjhk9m";
+    geom = "county";
+    region = "US";
+    year = "2014";
+  };
+  svi-2014-us-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/SVI2014_US.zip";
+    sha256 = "0f373nz9ccgiq0aj3h1cipn15ag8654jj8600y2fi0254h3a072x";
+    geom = "tract";
+    region = "US";
+    year = "2014";
+  };
+  svi-2014-us-ttract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Tribal_Tracts.zip";
+    sha256 = "02bqin0sn9gcal5hzy63sibgs6arbilkl5qi4myla6c8knf4rvmv";
+    geom = "ttract";
+    region = "US";
+    year = "2014";
+  };
+  svi-2014-district_of_columbia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/DistrictofColumbia_cnty.zip";
+    sha256 = "07pvap4yqx85k7if7mqq6s4s7cs0jlzzwyc6bc91lfps6c8p2yq9";
+    geom = "county";
+    region = "District_of_Columbia";
+    year = "2014";
+  };
+  svi-2014-district_of_columbia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/DistrictofColumbia.zip";
+    sha256 = "0x6kkg1zrrwfizkvpwvvaqj13r9yjy8bh6g4s47bw6a5gr1qfhx6";
+    geom = "tract";
+    region = "District_of_Columbia";
+    year = "2014";
+  };
+  svi-2014-puerto_rico-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/PuertoRico_cnty.zip";
+    sha256 = "0wirw0rmsy5vr80ckblxp7s3f943qm97pq1a7aq34jp0h3hsn2n7";
+    geom = "county";
+    region = "Puerto_Rico";
+    year = "2014";
+  };
+  svi-2014-puerto_rico-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/PuertoRico.zip";
+    sha256 = "006bl98sy5mhyrxap9lr3ggq4xryybanxy84hch5j6r0zw0y5k7w";
+    geom = "tract";
+    region = "Puerto_Rico";
+    year = "2014";
+  };
+  svi-2014-alabama-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Alabama_cnty.zip";
+    sha256 = "1zzfzr7xdxmf15881vbg3di96z1cnc916889igniwdym8jhnk624";
+    geom = "county";
+    region = "Alabama";
+    year = "2014";
+  };
+  svi-2014-alabama-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Alabama.zip";
+    sha256 = "1w7ph2zj2av24748qhgzi8q2wijmnphnr1cd0nxlp7fl9ns6k4sg";
+    geom = "tract";
+    region = "Alabama";
+    year = "2014";
+  };
+  svi-2014-alaska-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Alaska_cnty.zip";
+    sha256 = "0hcyq2qjjilswrspn1yv37hyidlrc1gm0h9npjmnrk1c3p1yviqz";
+    geom = "county";
+    region = "Alaska";
+    year = "2014";
+  };
+  svi-2014-alaska-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Alaska.zip";
+    sha256 = "0gw7nznarjzxqa2307s83qq49wr3i20zzfxfkabbzwzczzzr663w";
+    geom = "tract";
+    region = "Alaska";
+    year = "2014";
+  };
+  svi-2014-arizona-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Arizona_cnty.zip";
+    sha256 = "128zmv8wy6hwb5gy7mbjgn2qj4fgp0awhdl52rlnxq1hqy1fzswf";
+    geom = "county";
+    region = "Arizona";
+    year = "2014";
+  };
+  svi-2014-arizona-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Arizona.zip";
+    sha256 = "1mfaarqjm1pdri9yhwyniiyb3bc7n0qbx3f73hqxiplvbgnmpvpz";
+    geom = "tract";
+    region = "Arizona";
+    year = "2014";
+  };
+  svi-2014-arkansas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Arkansas_cnty.zip";
+    sha256 = "1bscnjfdn449x8yggpcd1322c386wjyi7d561qxdv8f4swyx32gj";
+    geom = "county";
+    region = "Arkansas";
+    year = "2014";
+  };
+  svi-2014-arkansas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Arkansas.zip";
+    sha256 = "147n07l56q8n8k5djlix4jqhj1npc8nna86ry421z8ckc2fa2n5j";
+    geom = "tract";
+    region = "Arkansas";
+    year = "2014";
+  };
+  svi-2014-california-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/California_cnty.zip";
+    sha256 = "103v1fca273hv5knrcn7wbz9lpxfmpwa4a5s6j8z6iqkvaldpq37";
+    geom = "county";
+    region = "California";
+    year = "2014";
+  };
+  svi-2014-california-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/California.zip";
+    sha256 = "0wxgx8phqs0bnwzb1grslp496iy8l34flyy4r0rggh3kfb07l14x";
+    geom = "tract";
+    region = "California";
+    year = "2014";
+  };
+  svi-2014-colorado-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Colorado_cnty.zip";
+    sha256 = "09igmv9sn4hlm889qkhw1dm1qmln4qf0r8qr7mwnnai8xsn25zyi";
+    geom = "county";
+    region = "Colorado";
+    year = "2014";
+  };
+  svi-2014-colorado-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Colorado.zip";
+    sha256 = "0y5qwyiv9i7qzpqcfk18lk1w0l7m65hildbzrkrqqnbpwd9y4w4k";
+    geom = "tract";
+    region = "Colorado";
+    year = "2014";
+  };
+  svi-2014-connecticut-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Connecticut_cnty.zip";
+    sha256 = "0fbxys5lq0byjfsw6kim5jzgz4xb9gxgd15rwq2lb4q1hxhvj7s4";
+    geom = "county";
+    region = "Connecticut";
+    year = "2014";
+  };
+  svi-2014-connecticut-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Connecticut.zip";
+    sha256 = "1rdz6gidnfjk2wpdw8132k0yjn3wzm3g8f753ra4fcl6hss9cfp7";
+    geom = "tract";
+    region = "Connecticut";
+    year = "2014";
+  };
+  svi-2014-delaware-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Delaware_cnty.zip";
+    sha256 = "0rfqchkkll74m5j19l1d3fj0h0j9gbcfg2dn659a3jgs1waj45p1";
+    geom = "county";
+    region = "Delaware";
+    year = "2014";
+  };
+  svi-2014-delaware-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Delaware.zip";
+    sha256 = "00d5zd442knw7wvs6rf7kzw7bvab3rcr38a31fbia1ccmjkzdgpk";
+    geom = "tract";
+    region = "Delaware";
+    year = "2014";
+  };
+  svi-2014-florida-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Florida_cnty.zip";
+    sha256 = "0j1mbfp9v99nvyxvzk3ai7f0vwn0frw58mq5avznyrr0cqsz85bi";
+    geom = "county";
+    region = "Florida";
+    year = "2014";
+  };
+  svi-2014-florida-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Florida.zip";
+    sha256 = "1m33n877703x6m5zbq8cpp8b37da0b22ynkccr286si0az8n4ccd";
+    geom = "tract";
+    region = "Florida";
+    year = "2014";
+  };
+  svi-2014-georgia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Georgia_cnty.zip";
+    sha256 = "0lp0gr8acqk8056zj12prx1j85p7s3xphpfailgv0x3s12yjla4z";
+    geom = "county";
+    region = "Georgia";
+    year = "2014";
+  };
+  svi-2014-georgia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Georgia.zip";
+    sha256 = "09g57c751nbz7rzy7vm3m94yigwag8238nccf1fhj90yba6jgbi7";
+    geom = "tract";
+    region = "Georgia";
+    year = "2014";
+  };
+  svi-2014-hawaii-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Hawaii_cnty.zip";
+    sha256 = "0khgxibsdxm6gpga29mbcp7a13lk6jvsna3idjmla0p081apf21m";
+    geom = "county";
+    region = "Hawaii";
+    year = "2014";
+  };
+  svi-2014-hawaii-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Hawaii.zip";
+    sha256 = "15d4a2bj0v9bxcax056mcdm9dmyybslv0pyj19xsn94scgpaj6br";
+    geom = "tract";
+    region = "Hawaii";
+    year = "2014";
+  };
+  svi-2014-idaho-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Idaho_cnty.zip";
+    sha256 = "1v6sahjyhz2fnh3g31fhaxzl5xa5jjk63dbmfw6p50n7bbid95kc";
+    geom = "county";
+    region = "Idaho";
+    year = "2014";
+  };
+  svi-2014-idaho-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Idaho.zip";
+    sha256 = "1vgcxxynv0xv6ccnxdva9cgc322mg45fid1yqjlrbwa4c7g89mpl";
+    geom = "tract";
+    region = "Idaho";
+    year = "2014";
+  };
+  svi-2014-illinois-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Illinois_cnty.zip";
+    sha256 = "1fmgjnqv7lk5d1zjnsdxqc5wjg1bcfjcdmp1gj3k2c9c6j90h190";
+    geom = "county";
+    region = "Illinois";
+    year = "2014";
+  };
+  svi-2014-illinois-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Illinois.zip";
+    sha256 = "16qqgm0lmy7a1ccrhhvk6aycxf7n45z4bir6as0rcnidjl0jw7m8";
+    geom = "tract";
+    region = "Illinois";
+    year = "2014";
+  };
+  svi-2014-indiana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Indiana_cnty.zip";
+    sha256 = "10nl4452fak1m7jz2s6s2dywj77zdg7k27p5zdqilpk86cmfrz3w";
+    geom = "county";
+    region = "Indiana";
+    year = "2014";
+  };
+  svi-2014-indiana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Indiana.zip";
+    sha256 = "00v4ybipz56rpf93igm5hlr9yhfa1k6lfyjh8s5jd8sfsff703pf";
+    geom = "tract";
+    region = "Indiana";
+    year = "2014";
+  };
+  svi-2014-iowa-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Iowa_cnty.zip";
+    sha256 = "18xpw3gvz4sxgcjwhb2zsa65ym7b8k7b4xxq0yixzkfjghfv98g5";
+    geom = "county";
+    region = "Iowa";
+    year = "2014";
+  };
+  svi-2014-iowa-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Iowa.zip";
+    sha256 = "0459rjdhj4qcjnl05j280j0a7x243pkvc8m6063j3dfac7gymysh";
+    geom = "tract";
+    region = "Iowa";
+    year = "2014";
+  };
+  svi-2014-kansas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Kansas_cnty.zip";
+    sha256 = "02fqqg2fm7dynmq7j7vrh1lpapyi3ybgfbf2mw4wrl56ddy1r6y5";
+    geom = "county";
+    region = "Kansas";
+    year = "2014";
+  };
+  svi-2014-kansas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Kansas.zip";
+    sha256 = "045flz0ic41dz3yjcysxdjng0pdbji88p8rykdrhbi7pfzwiwjr2";
+    geom = "tract";
+    region = "Kansas";
+    year = "2014";
+  };
+  svi-2014-kentucky-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Kentucky_cnty.zip";
+    sha256 = "10imk76w5vsrg8cjqcr56dmimdajc7ngvg6h6a5zqw6rxrd4lzs5";
+    geom = "county";
+    region = "Kentucky";
+    year = "2014";
+  };
+  svi-2014-kentucky-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Kentucky.zip";
+    sha256 = "1scjj8hfd40flqczyrhd6bimyxj7qa3y7f57nh2g1c5grkvm2skw";
+    geom = "tract";
+    region = "Kentucky";
+    year = "2014";
+  };
+  svi-2014-louisiana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Louisiana_cnty.zip";
+    sha256 = "19qqvscgya2hpik6j9v15as46pyc7ffnai5q99d7kc2jcrd1w5hf";
+    geom = "county";
+    region = "Louisiana";
+    year = "2014";
+  };
+  svi-2014-louisiana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Louisiana.zip";
+    sha256 = "1hvyys5zmphdylzsc221h29myyp26vf2f9sjrkwi8gjrmd4r3l8k";
+    geom = "tract";
+    region = "Louisiana";
+    year = "2014";
+  };
+  svi-2014-maine-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Maine_cnty.zip";
+    sha256 = "1i08f7ynza8k59rhmxgw6vcvs8k23fmv7ls2qw9jqd75w19i186z";
+    geom = "county";
+    region = "Maine";
+    year = "2014";
+  };
+  svi-2014-maine-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Maine.zip";
+    sha256 = "17l36qxjq8n69i2d978lsl3jd8x1vav4aqb13q7nzjnk96qfr7k7";
+    geom = "tract";
+    region = "Maine";
+    year = "2014";
+  };
+  svi-2014-maryland-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Maryland_cnty.zip";
+    sha256 = "1yx2x86qmz5fpp6n6vcqx1jjfkd0jm63vbnwkd51g97jpfhcil46";
+    geom = "county";
+    region = "Maryland";
+    year = "2014";
+  };
+  svi-2014-maryland-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Maryland.zip";
+    sha256 = "0kia4mlzidzxpwi0bsx3gxm0ibyvv386ysfd8ibxzgwflc6ry5m8";
+    geom = "tract";
+    region = "Maryland";
+    year = "2014";
+  };
+  svi-2014-massachusetts-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Massachusetts_cnty.zip";
+    sha256 = "19vw76fqy9jsl8396ipd3bplyc78qy3fqjc2l41466xc22yw6fvi";
+    geom = "county";
+    region = "Massachusetts";
+    year = "2014";
+  };
+  svi-2014-massachusetts-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Massachusetts.zip";
+    sha256 = "02bz7a2h9fp7wsc6wchzqmrvl0m5hg7sj9jaskwz874s8dzjsys7";
+    geom = "tract";
+    region = "Massachusetts";
+    year = "2014";
+  };
+  svi-2014-michigan-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Michigan_cnty.zip";
+    sha256 = "1ckqqsnd2cdp04l54dqyzg973wl4nznhyd5s1jvv4p403c35p0f8";
+    geom = "county";
+    region = "Michigan";
+    year = "2014";
+  };
+  svi-2014-michigan-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Michigan.zip";
+    sha256 = "1flv99yj9y9458w0lamm8s8mccwfp3s5bkkxbbircrg41i1ivjn6";
+    geom = "tract";
+    region = "Michigan";
+    year = "2014";
+  };
+  svi-2014-minnesota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Minnesota_cnty.zip";
+    sha256 = "1f9nl47advf4376vw0gr4knby9yjws1s85m9cqh7yipl83lv9whz";
+    geom = "county";
+    region = "Minnesota";
+    year = "2014";
+  };
+  svi-2014-minnesota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Minnesota.zip";
+    sha256 = "00fddmfx5x91sxhknyivrbhpv6f6xn9a4h72kacmiii0v4l8a5n5";
+    geom = "tract";
+    region = "Minnesota";
+    year = "2014";
+  };
+  svi-2014-mississippi-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Mississippi_cnty.zip";
+    sha256 = "0c8a0slipxlb3ilffp3dgswxawy4prhqgfcds1y3519644yb5787";
+    geom = "county";
+    region = "Mississippi";
+    year = "2014";
+  };
+  svi-2014-mississippi-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Mississippi.zip";
+    sha256 = "0abk3jzxz2vi3vdgx201gqfg0ffnj07h80hvdi4n77mba3kspas3";
+    geom = "tract";
+    region = "Mississippi";
+    year = "2014";
+  };
+  svi-2014-missouri-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Missouri_cnty.zip";
+    sha256 = "1rxx96kyvdsr7hl0qgr8iy2ag77q88c7ivky6h935acadhbx5ir4";
+    geom = "county";
+    region = "Missouri";
+    year = "2014";
+  };
+  svi-2014-missouri-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Missouri.zip";
+    sha256 = "1n7kjr46kh7wjx2vkmpfjzlpf6z2dsxcp8j8cjl22d7lcixvdpm0";
+    geom = "tract";
+    region = "Missouri";
+    year = "2014";
+  };
+  svi-2014-montana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Montana_cnty.zip";
+    sha256 = "168qgcbcw7wsyr9834fjabyk2pgfh4fmaqc19y0xjp8liq0c9k90";
+    geom = "county";
+    region = "Montana";
+    year = "2014";
+  };
+  svi-2014-montana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Montana.zip";
+    sha256 = "0apsjhidxxxdhx05647h4g1xdsxmlrcmkl6qjfvmd81pv86dn20q";
+    geom = "tract";
+    region = "Montana";
+    year = "2014";
+  };
+  svi-2014-nebraska-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Nebraska_cnty.zip";
+    sha256 = "0vdsmzc5fc88k138rsksdgqd3adws3sa4bwblwxzihmsdwznxcl8";
+    geom = "county";
+    region = "Nebraska";
+    year = "2014";
+  };
+  svi-2014-nebraska-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Nebraska.zip";
+    sha256 = "0xmab72jsfgl7lc6kdpqwj62r7ag6g8r2i7i7rjgncwc8jcqn75z";
+    geom = "tract";
+    region = "Nebraska";
+    year = "2014";
+  };
+  svi-2014-nevada-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Nevada_cnty.zip";
+    sha256 = "1gnnx173rdxlsaixi7d0r3x737kgy0kp26amzz2ikmnmm77qlcdf";
+    geom = "county";
+    region = "Nevada";
+    year = "2014";
+  };
+  svi-2014-nevada-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Nevada.zip";
+    sha256 = "19zjripdg0685l7rkhhy9nm0dmlr24afynig8i4ac1zvyajhmz71";
+    geom = "tract";
+    region = "Nevada";
+    year = "2014";
+  };
+  svi-2014-new_hampshire-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/NewHampshire_cnty.zip";
+    sha256 = "1wnz3mq2y5rzflcs8zcrgdaacxydq904hy03i61yvpnk8krx7n0r";
+    geom = "county";
+    region = "New_Hampshire";
+    year = "2014";
+  };
+  svi-2014-new_hampshire-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/NewHampshire.zip";
+    sha256 = "1gmggs5slmq0q9i0mdllhbcj3rm46yvgpg36c1kg0nh4sw3iv9nv";
+    geom = "tract";
+    region = "New_Hampshire";
+    year = "2014";
+  };
+  svi-2014-new_jersey-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/NewJersey_cnty.zip";
+    sha256 = "0dbp1milk688x7b3s8klbaclxf3v1cjlbw6vfy3ssaxnayx351dr";
+    geom = "county";
+    region = "New_Jersey";
+    year = "2014";
+  };
+  svi-2014-new_jersey-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/NewJersey.zip";
+    sha256 = "12gy4gqcjlc5aiyx6z8kkl7151xvgcccz55xsbfncb6ppidpl08w";
+    geom = "tract";
+    region = "New_Jersey";
+    year = "2014";
+  };
+  svi-2014-new_mexico-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/NewMexico_cnty.zip";
+    sha256 = "1v3nacvsddram86z32ikfh022wl8l577phblf608jjx080cdal7d";
+    geom = "county";
+    region = "New_Mexico";
+    year = "2014";
+  };
+  svi-2014-new_mexico-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/NewMexico.zip";
+    sha256 = "0k0pcwbsq9vllil30x0n5b03gmsbj6cn6h1f5gg60qx8j9zgq2pq";
+    geom = "tract";
+    region = "New_Mexico";
+    year = "2014";
+  };
+  svi-2014-new_york-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/NewYork_cnty.zip";
+    sha256 = "1zm6129ws11w0wzwjdp1rnr9lqc8ni1qr4c9v40qnqaq21lc12mb";
+    geom = "county";
+    region = "New_York";
+    year = "2014";
+  };
+  svi-2014-new_york-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/NewYork.zip";
+    sha256 = "199cld6zvq0hmdx6pjq97sl4kar4rdkxldq533bhwygjqqgx2wim";
+    geom = "tract";
+    region = "New_York";
+    year = "2014";
+  };
+  svi-2014-north_carolina-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/NorthCarolina_cnty.zip";
+    sha256 = "0vpzy03lf0l1s2qh8dhvzf5ny29pafm1zyzad0wn5ghfjygij4vm";
+    geom = "county";
+    region = "North_Carolina";
+    year = "2014";
+  };
+  svi-2014-north_carolina-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/NorthCarolina.zip";
+    sha256 = "020v7kndxv0lq9d30xqrhbd2qp28qiv1mfy6r71lkdfqf0dsln4n";
+    geom = "tract";
+    region = "North_Carolina";
+    year = "2014";
+  };
+  svi-2014-north_dakota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/NorthDakota_cnty.zip";
+    sha256 = "0smmxsd2prl7wdi1l3f7m2r058fxn0fr26s0wzlmlp9bwvg1y2rf";
+    geom = "county";
+    region = "North_Dakota";
+    year = "2014";
+  };
+  svi-2014-north_dakota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/NorthDakota.zip";
+    sha256 = "05kxfpdbzmsd8hincf3i0jjyaqv43pzcwrmy9qx36x093wdr0m59";
+    geom = "tract";
+    region = "North_Dakota";
+    year = "2014";
+  };
+  svi-2014-ohio-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Ohio_cnty.zip";
+    sha256 = "11h9k0f2z6lckw6vg5sv2h35cgv77vw78q3rzld9bp3rkasnxgqz";
+    geom = "county";
+    region = "Ohio";
+    year = "2014";
+  };
+  svi-2014-ohio-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Ohio.zip";
+    sha256 = "137hn22b7wlascj42z1lfrf0zbllys212hcji412x0qyzwwf0144";
+    geom = "tract";
+    region = "Ohio";
+    year = "2014";
+  };
+  svi-2014-oklahoma-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Oklahoma_cnty.zip";
+    sha256 = "067kwibl26d0lsxnrl209pl8j8b02h1mkpf3w6v8l77sikrfbnwx";
+    geom = "county";
+    region = "Oklahoma";
+    year = "2014";
+  };
+  svi-2014-oklahoma-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Oklahoma.zip";
+    sha256 = "17z7ni4zpxbyy9mhgjiw6mbb842h6p2dvl71z41vg2bk09d737l7";
+    geom = "tract";
+    region = "Oklahoma";
+    year = "2014";
+  };
+  svi-2014-oregon-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Oregon_cnty.zip";
+    sha256 = "068dd3xl12b840ak6ysad2kbhx2jsw2h1xh915bh1rwhc81n8d4d";
+    geom = "county";
+    region = "Oregon";
+    year = "2014";
+  };
+  svi-2014-oregon-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Oregon.zip";
+    sha256 = "0ajgklyaqkdpdy121ykw50vwq3zrzbs2i8yk5mbqklyxyzix2id8";
+    geom = "tract";
+    region = "Oregon";
+    year = "2014";
+  };
+  svi-2014-pennsylvania-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Pennsylvania_cnty.zip";
+    sha256 = "0851maqmx0792hbxa7l3gnjx92klsl52jzx32wj1677pvx5kls3p";
+    geom = "county";
+    region = "Pennsylvania";
+    year = "2014";
+  };
+  svi-2014-pennsylvania-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Pennsylvania.zip";
+    sha256 = "17sv91n6ky29lrjxh3yz5wfm6d3f79k7b9xh42k0dfb1gdl56wcw";
+    geom = "tract";
+    region = "Pennsylvania";
+    year = "2014";
+  };
+  svi-2014-rhode_island-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/RhodeIsland_cnty.zip";
+    sha256 = "0aw0nxf8fx3d1gzhcha816kzfgmgm6akfzlfkc2ywz0zp8f5m8zn";
+    geom = "county";
+    region = "Rhode_Island";
+    year = "2014";
+  };
+  svi-2014-rhode_island-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/RhodeIsland.zip";
+    sha256 = "03c12yap7i6mk9ajp1g8hxw3haf08vhfkmyhar3ryygbmkz6jsba";
+    geom = "tract";
+    region = "Rhode_Island";
+    year = "2014";
+  };
+  svi-2014-south_carolina-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/SouthCarolina_cnty.zip";
+    sha256 = "091b6pwr6rq3fyc88m3xxsn5i64w6anjrp2gnm8nn2qpr18x0n6s";
+    geom = "county";
+    region = "South_Carolina";
+    year = "2014";
+  };
+  svi-2014-south_carolina-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/SouthCarolina.zip";
+    sha256 = "1r9p3b6azvhkcy27yvfwiql5l8f4yghlqr62fpnxa9rygi0lhmq6";
+    geom = "tract";
+    region = "South_Carolina";
+    year = "2014";
+  };
+  svi-2014-south_dakota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/SouthDakota_cnty.zip";
+    sha256 = "02gxbjlk6h5n4zv19mismpxgcr1wdp14x1ykk1lvf3p00s2qa5vz";
+    geom = "county";
+    region = "South_Dakota";
+    year = "2014";
+  };
+  svi-2014-south_dakota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/SouthDakota.zip";
+    sha256 = "149qnvm9lnjy2rklq43awz0hkhvx5sygwxw017dld84a5ag10kry";
+    geom = "tract";
+    region = "South_Dakota";
+    year = "2014";
+  };
+  svi-2014-tennessee-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Tennessee_cnty.zip";
+    sha256 = "0fc7sayqj0pwkh725965x10vak2qqm29c565qx8dm8h4bcc0rwp9";
+    geom = "county";
+    region = "Tennessee";
+    year = "2014";
+  };
+  svi-2014-tennessee-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Tennessee.zip";
+    sha256 = "0v42nyawdiq1mpwp8rxz922431ydgsn6s1lbhcnvjq3v4dhab242";
+    geom = "tract";
+    region = "Tennessee";
+    year = "2014";
+  };
+  svi-2014-texas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Texas_cnty.zip";
+    sha256 = "1l1bmvdgj1sxdx4grjvs34vcax87d3d84bxlhp56nj1h82kfargl";
+    geom = "county";
+    region = "Texas";
+    year = "2014";
+  };
+  svi-2014-texas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Texas.zip";
+    sha256 = "1hnzm570gsbz0gdydcpbj83ykwgkwhhxbpjxis8d66fypjacp4in";
+    geom = "tract";
+    region = "Texas";
+    year = "2014";
+  };
+  svi-2014-utah-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Utah_cnty.zip";
+    sha256 = "0vp4pc701p6ihzny8c5swwyyncmx3wln8p094rncwdsafhx665zw";
+    geom = "county";
+    region = "Utah";
+    year = "2014";
+  };
+  svi-2014-utah-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Utah.zip";
+    sha256 = "1v7b9j9wkirwhx4qs9hk84y706jz86dn0pmm1a6kzwida2dpjpi0";
+    geom = "tract";
+    region = "Utah";
+    year = "2014";
+  };
+  svi-2014-vermont-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Vermont_cnty.zip";
+    sha256 = "1281g96sdisvc9gany8z8kjp47izwbw3n7bzdnnzyihk4fqxb9nv";
+    geom = "county";
+    region = "Vermont";
+    year = "2014";
+  };
+  svi-2014-vermont-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Vermont.zip";
+    sha256 = "1f7y0q9jq2i1zlz3q9k498aw78sn6fsk6jqg99x6llcjsn83mgrk";
+    geom = "tract";
+    region = "Vermont";
+    year = "2014";
+  };
+  svi-2014-virginia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Virginia_cnty.zip";
+    sha256 = "12xby5j1ggynrv5n6z0yn74d9crag8r316akb103pyysnc1mv09d";
+    geom = "county";
+    region = "Virginia";
+    year = "2014";
+  };
+  svi-2014-virginia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Virginia.zip";
+    sha256 = "0w5p9h75zaqsak04cs0rmzzwilnyysg6fqs71d10v5bswbva6c68";
+    geom = "tract";
+    region = "Virginia";
+    year = "2014";
+  };
+  svi-2014-washington-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Washington_cnty.zip";
+    sha256 = "0f8xnnssdpwf3656x2a2rw895w52yf54i0yqp38ldrm52mm0ipm2";
+    geom = "county";
+    region = "Washington";
+    year = "2014";
+  };
+  svi-2014-washington-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Washington.zip";
+    sha256 = "0zlj92dgy6xzdzpwppcq4b4i8a1dmcqayq8da9ax6h6d0dybgldf";
+    geom = "tract";
+    region = "Washington";
+    year = "2014";
+  };
+  svi-2014-west_virginia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/WestVirginia_cnty.zip";
+    sha256 = "0bh0i63bqj6n41njjb2a5qdwbiz11fycc1lgka3ffnggh4bsl5zq";
+    geom = "county";
+    region = "West_Virginia";
+    year = "2014";
+  };
+  svi-2014-west_virginia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/WestVirginia.zip";
+    sha256 = "1kvrkwgna95gqaz1li5s4mr6fb34lsnwnvsralmaszk573j8qnc0";
+    geom = "tract";
+    region = "West_Virginia";
+    year = "2014";
+  };
+  svi-2014-wisconsin-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Wisconsin_cnty.zip";
+    sha256 = "0xii63fi2cnxxlph8y7nybscgm8hz0277qr3s5s8r8fhkzj4al4b";
+    geom = "county";
+    region = "Wisconsin";
+    year = "2014";
+  };
+  svi-2014-wisconsin-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Wisconsin.zip";
+    sha256 = "0mask08dkjjpz85qsmdgx9dmr1fq7ccg2adk2m4zbkrvdwwm65f2";
+    geom = "tract";
+    region = "Wisconsin";
+    year = "2014";
+  };
+  svi-2014-wyoming-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States_Counties/Wyoming_cnty.zip";
+    sha256 = "19fqwrfbg1xwfwvkis0j6hp2yvbmx7j7wpgiv7xkq8ayjpgfrb44";
+    geom = "county";
+    region = "Wyoming";
+    year = "2014";
+  };
+  svi-2014-wyoming-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2014_SVI_Data/States/Wyoming.zip";
+    sha256 = "1j8qr0jrks7w93h85h7xjdr7fvmzp2gqy8c5r1ygbrps4c75mzl9";
+    geom = "tract";
+    region = "Wyoming";
+    year = "2014";
+  };
+  svi-2016-us-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/SVI2016_US_county.zip";
+    sha256 = "1c6adiyy0xn9m1rglgswy4xzsag21v857dclc5d90hjm8makpsxn";
+    geom = "county";
+    region = "US";
+    year = "2016";
+  };
+  svi-2016-us-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/SVI2016_US.zip";
+    sha256 = "0vr1cda64lzvjxhx1kv2ny18v5653b0fwxji674rb9sj1x04b2vd";
+    geom = "tract";
+    region = "US";
+    year = "2016";
+  };
+  svi-2016-us-ttract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Tribal_Tracts.zip";
+    sha256 = "1izl1lnh9qi6l4ihay6glcmm2amj5d29f7n43rdqr9w0q585v95g";
+    geom = "ttract";
+    region = "US";
+    year = "2016";
+  };
+  svi-2016-district_of_columbia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/DistrictofColumbia_county.zip";
+    sha256 = "020wjv44r3km8wd4m44m1kazaazcasryi2z03xm8d0v2d80hng9l";
+    geom = "county";
+    region = "District_of_Columbia";
+    year = "2016";
+  };
+  svi-2016-district_of_columbia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/DistrictofColumbia.zip";
+    sha256 = "0fl3fmcbgxjvdnaqqkhcgmzdd3splc5dpyhk48sihyr5pzynddba";
+    geom = "tract";
+    region = "District_of_Columbia";
+    year = "2016";
+  };
+  svi-2016-puerto_rico-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/PuertoRico_county.zip";
+    sha256 = "1kfpj5xyvmhxa6mkdjvxk7brg4rx00xfybampnx18p92ydx155hh";
+    geom = "county";
+    region = "Puerto_Rico";
+    year = "2016";
+  };
+  svi-2016-puerto_rico-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/PuertoRico.zip";
+    sha256 = "0396dw8703i6vdi3nbgphawg5vnw18067248svbnqhwky796lica";
+    geom = "tract";
+    region = "Puerto_Rico";
+    year = "2016";
+  };
+  svi-2016-alabama-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Alabama_county.zip";
+    sha256 = "1bgjw065kkzzdsv15bdralmm3zyvchbhrhc4kmk4axhjjapngphg";
+    geom = "county";
+    region = "Alabama";
+    year = "2016";
+  };
+  svi-2016-alabama-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Alabama.zip";
+    sha256 = "0p20bps9mh0yqdvhgcc40xnnm94vw11kxpncgl0y3l1nh8xnnakm";
+    geom = "tract";
+    region = "Alabama";
+    year = "2016";
+  };
+  svi-2016-alaska-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Alaska_county.zip";
+    sha256 = "1rjnl8amp99jnv32m6mv6ad74c5imbzzihx5k8z6pgzbhaz74d1n";
+    geom = "county";
+    region = "Alaska";
+    year = "2016";
+  };
+  svi-2016-alaska-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Alaska.zip";
+    sha256 = "107klvnqhzyakz9ng0h6s25crqakjqzczx4bp5rqin6kldh9v2yx";
+    geom = "tract";
+    region = "Alaska";
+    year = "2016";
+  };
+  svi-2016-arizona-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Arizona_county.zip";
+    sha256 = "00bknbd9cfqg29zxiz8hlmlbdkla1fv59w5nxzyyq9gwn1w7xzfv";
+    geom = "county";
+    region = "Arizona";
+    year = "2016";
+  };
+  svi-2016-arizona-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Arizona.zip";
+    sha256 = "1npk19zvpifc8m0gkimajrjramg43a9rsh6j553184j02pk9cqaz";
+    geom = "tract";
+    region = "Arizona";
+    year = "2016";
+  };
+  svi-2016-arkansas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Arkansas_county.zip";
+    sha256 = "1gyfvvgff6cf2lxh2s3dwmhaz4aqqd9jrxa4m06vjaj2lbhdw6cq";
+    geom = "county";
+    region = "Arkansas";
+    year = "2016";
+  };
+  svi-2016-arkansas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Arkansas.zip";
+    sha256 = "0s6n5snlq787i02xnk91mh27r5q6hjf7zji5clxpm8l5bihilhf0";
+    geom = "tract";
+    region = "Arkansas";
+    year = "2016";
+  };
+  svi-2016-california-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/California_county.zip";
+    sha256 = "0hvpawqwz15f6dizh26gi4n1yj83imsq01jgwh3b7wif2515mdhy";
+    geom = "county";
+    region = "California";
+    year = "2016";
+  };
+  svi-2016-california-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/California.zip";
+    sha256 = "0fy1fshfhva7ccvpb5pz13n1qfmr620ss8gr5pwwq0571cc0bq4q";
+    geom = "tract";
+    region = "California";
+    year = "2016";
+  };
+  svi-2016-colorado-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Colorado_county.zip";
+    sha256 = "12x1sqxskifx3pvs5ci2srwk6p8ria6jwxqpi0v4ma9jj9b1n51v";
+    geom = "county";
+    region = "Colorado";
+    year = "2016";
+  };
+  svi-2016-colorado-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Colorado.zip";
+    sha256 = "09rlw8wn82i8m7r6cak3qy07q242d12ghfnxj6nlpd4isqf6wj29";
+    geom = "tract";
+    region = "Colorado";
+    year = "2016";
+  };
+  svi-2016-connecticut-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Connecticut_county.zip";
+    sha256 = "0j38kf844vgx7kla30kv8qbkwx09m0f01n7br3c394h0503alz6a";
+    geom = "county";
+    region = "Connecticut";
+    year = "2016";
+  };
+  svi-2016-connecticut-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Connecticut.zip";
+    sha256 = "1gaql1iw2jf5p2wagv2ahjgf12kaqxlar9ca91000jfwli3rv7kg";
+    geom = "tract";
+    region = "Connecticut";
+    year = "2016";
+  };
+  svi-2016-delaware-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Delaware_county.zip";
+    sha256 = "0g0i7bv8sj65rnip1krn4cghpb60j6lh9hxlnp566sy3xhim6zll";
+    geom = "county";
+    region = "Delaware";
+    year = "2016";
+  };
+  svi-2016-delaware-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Delaware.zip";
+    sha256 = "0al998p6fimxk0q4jlny1hcv6w2756jr1i0v0kkvi7334a40dmwh";
+    geom = "tract";
+    region = "Delaware";
+    year = "2016";
+  };
+  svi-2016-florida-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Florida_county.zip";
+    sha256 = "0yqhkyk8wls6pyfqddildjq7pzv80vwyizyg86ak48rj7vrgd1sa";
+    geom = "county";
+    region = "Florida";
+    year = "2016";
+  };
+  svi-2016-florida-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Florida.zip";
+    sha256 = "1wfardx7j2ly7d3vnj8l412d6l1cc4rwd23p65zk4sk4xwjjl2lb";
+    geom = "tract";
+    region = "Florida";
+    year = "2016";
+  };
+  svi-2016-georgia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Georgia_county.zip";
+    sha256 = "1ip2sb930krs8agwp4xxcn1xns44bik82q0njwmlqqh5wjzsqj1k";
+    geom = "county";
+    region = "Georgia";
+    year = "2016";
+  };
+  svi-2016-georgia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Georgia.zip";
+    sha256 = "0f5dg6za21hcric15y7frxw89xc9nqya2w25pwmh5s9n3b05xbqp";
+    geom = "tract";
+    region = "Georgia";
+    year = "2016";
+  };
+  svi-2016-hawaii-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Hawaii_county.zip";
+    sha256 = "1x1gjck8nnyf17l3whh7ylzi1nhgrvhqcs81aqjihjivp9n0cn3v";
+    geom = "county";
+    region = "Hawaii";
+    year = "2016";
+  };
+  svi-2016-hawaii-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Hawaii.zip";
+    sha256 = "1cg278b6ssvqd4ryyqkpp2pw8v6yqx29a3bv09i1xyy09qs5b7dm";
+    geom = "tract";
+    region = "Hawaii";
+    year = "2016";
+  };
+  svi-2016-idaho-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Idaho_county.zip";
+    sha256 = "08aksxxydbcaga3yg3c4qihcznjfk51qc9q35140cfjd1458c1x8";
+    geom = "county";
+    region = "Idaho";
+    year = "2016";
+  };
+  svi-2016-idaho-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Idaho.zip";
+    sha256 = "1b0h0gaic9pcaqshnrn90lhsv28mi37g4hlqhlaqcyydkkwyr32n";
+    geom = "tract";
+    region = "Idaho";
+    year = "2016";
+  };
+  svi-2016-illinois-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Illinois_county.zip";
+    sha256 = "115rhdw0k9jl4nwcq8lm0ixcrvlm3fla2qvpmn47kvv5rf4lnjcb";
+    geom = "county";
+    region = "Illinois";
+    year = "2016";
+  };
+  svi-2016-illinois-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Illinois.zip";
+    sha256 = "188y4lwm0cc7416nc7103w03n1pgm7hp58sh99s54cfvjw2pcksh";
+    geom = "tract";
+    region = "Illinois";
+    year = "2016";
+  };
+  svi-2016-indiana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Indiana_county.zip";
+    sha256 = "1yjvg7cr049yazrbvv6c0n8nbbghmixp6di68gyhpbprdh9pi3m4";
+    geom = "county";
+    region = "Indiana";
+    year = "2016";
+  };
+  svi-2016-indiana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Indiana.zip";
+    sha256 = "04y0kvhdgibhf7s94n7vds3qbc5axpi4kzj2737yzy6hnn9gsl9i";
+    geom = "tract";
+    region = "Indiana";
+    year = "2016";
+  };
+  svi-2016-iowa-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Iowa_county.zip";
+    sha256 = "13p88zbh1q42p2s00kiqy587vkvkmxi3n8jqrrvsblgyqz4kn03y";
+    geom = "county";
+    region = "Iowa";
+    year = "2016";
+  };
+  svi-2016-iowa-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Iowa.zip";
+    sha256 = "091816nrk4xab79916iz7jm6q2z9jj1lkg27d67kycyjz7m6zpfh";
+    geom = "tract";
+    region = "Iowa";
+    year = "2016";
+  };
+  svi-2016-kansas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Kansas_county.zip";
+    sha256 = "0x5hgllwfbanynxnmkm31qligw9236qxkl5mxbdpp5bb6xx0ms3q";
+    geom = "county";
+    region = "Kansas";
+    year = "2016";
+  };
+  svi-2016-kansas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Kansas.zip";
+    sha256 = "1904nvw1b7wq2v2f3n76dkh22dz97b41hjn6rgcbwj38j61cixp5";
+    geom = "tract";
+    region = "Kansas";
+    year = "2016";
+  };
+  svi-2016-kentucky-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Kentucky_county.zip";
+    sha256 = "18ccjb9x7yybc8iwwlayh7gd5x7s8xwk2dl1iz1ayvhhwbpdnmyk";
+    geom = "county";
+    region = "Kentucky";
+    year = "2016";
+  };
+  svi-2016-kentucky-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Kentucky.zip";
+    sha256 = "1d7hgq8vs553a8g96qasr2s1x4np6s2wfh6gzssym99mvzp75387";
+    geom = "tract";
+    region = "Kentucky";
+    year = "2016";
+  };
+  svi-2016-louisiana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Louisiana_county.zip";
+    sha256 = "1k95c3khs3fizi3ahgvvdsynicfq8nrznx1frq0xlf97jp9qw4a4";
+    geom = "county";
+    region = "Louisiana";
+    year = "2016";
+  };
+  svi-2016-louisiana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Louisiana.zip";
+    sha256 = "0mwfa1aapj3wahczs8y5y9a4j9ap4ij7vidrd3dwij1j48x6wqxz";
+    geom = "tract";
+    region = "Louisiana";
+    year = "2016";
+  };
+  svi-2016-maine-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Maine_county.zip";
+    sha256 = "1r5ksgib0730dr3h9c9c2s3sjm2jjcy0sdfxrk2fbkhbryh53531";
+    geom = "county";
+    region = "Maine";
+    year = "2016";
+  };
+  svi-2016-maine-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Maine.zip";
+    sha256 = "1pf071wr4kalnymss5by1n4dj41ykxh651xkqfjq2r5wpca53qb0";
+    geom = "tract";
+    region = "Maine";
+    year = "2016";
+  };
+  svi-2016-maryland-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Maryland_county.zip";
+    sha256 = "008nw9cf8lwg11a75ilp8bavpp0qmvx6cab2ivf766ahsszbkas6";
+    geom = "county";
+    region = "Maryland";
+    year = "2016";
+  };
+  svi-2016-maryland-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Maryland.zip";
+    sha256 = "1g3y8sciiawhgwlc4b4k5w2vv7g4jf0jvnfccbl22lzlrzl07wg9";
+    geom = "tract";
+    region = "Maryland";
+    year = "2016";
+  };
+  svi-2016-massachusetts-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Massachusetts_county.zip";
+    sha256 = "1p0msrlznnwmnv1spyyis0s0zisxy5w8jhb65jpyscqhiq8hcbzi";
+    geom = "county";
+    region = "Massachusetts";
+    year = "2016";
+  };
+  svi-2016-massachusetts-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Massachusetts.zip";
+    sha256 = "1cx6w9b288n78jcirlzxni8p7w8za4nh719n89l9zg7lp0n2kl6y";
+    geom = "tract";
+    region = "Massachusetts";
+    year = "2016";
+  };
+  svi-2016-michigan-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Michigan_county.zip";
+    sha256 = "1gaw3q6inbjir9hmpmhv715p8z97gxd6wffccnfx43n20vsjb792";
+    geom = "county";
+    region = "Michigan";
+    year = "2016";
+  };
+  svi-2016-michigan-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Michigan.zip";
+    sha256 = "0aa60cqjbdpq8p8mwshd9mdbvgcl36sarn1qifdwrjgzfwjm89wb";
+    geom = "tract";
+    region = "Michigan";
+    year = "2016";
+  };
+  svi-2016-minnesota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Minnesota_county.zip";
+    sha256 = "1gndx2kpaq4swhbnspjimbx6nczy2k928z3lq29h86q1mdpji85z";
+    geom = "county";
+    region = "Minnesota";
+    year = "2016";
+  };
+  svi-2016-minnesota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Minnesota.zip";
+    sha256 = "08mfq25wd15bjwkrdp5bycsld7vb8xa1wsazjd3xscsdhrs64v62";
+    geom = "tract";
+    region = "Minnesota";
+    year = "2016";
+  };
+  svi-2016-mississippi-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Mississippi_county.zip";
+    sha256 = "18s9s8c59x2041asyifgk4d0nqpzzmpv4fbndviwds6npsakd086";
+    geom = "county";
+    region = "Mississippi";
+    year = "2016";
+  };
+  svi-2016-mississippi-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Mississippi.zip";
+    sha256 = "170hnjzpp0866d3nshflzl1g72xiby4xccwjw1f1j3ja4j3xfx7p";
+    geom = "tract";
+    region = "Mississippi";
+    year = "2016";
+  };
+  svi-2016-missouri-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Missouri_county.zip";
+    sha256 = "02kjxdfn4rdq4jkia769mj3ysxjs6a6klvsnv58n6c314kfzxf00";
+    geom = "county";
+    region = "Missouri";
+    year = "2016";
+  };
+  svi-2016-missouri-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Missouri.zip";
+    sha256 = "1mn3qxl69cwdr6sw4xjmxq8apjia6xx80xllbl27lssybw0c05id";
+    geom = "tract";
+    region = "Missouri";
+    year = "2016";
+  };
+  svi-2016-montana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Montana_county.zip";
+    sha256 = "1hr0s7srmsbyg4mpxq9dk4dg9j1374swz8czgsd5m8v3b828vh6v";
+    geom = "county";
+    region = "Montana";
+    year = "2016";
+  };
+  svi-2016-montana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Montana.zip";
+    sha256 = "13gp5pb0kfah8llbz5yf951wvabg4p46c6rxdycma6pz2csrdnj7";
+    geom = "tract";
+    region = "Montana";
+    year = "2016";
+  };
+  svi-2016-nebraska-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Nebraska_county.zip";
+    sha256 = "0c4brqb4xrrdl7dxyjzckn3xsan8qj8jlbp705sk08kpqj2iq464";
+    geom = "county";
+    region = "Nebraska";
+    year = "2016";
+  };
+  svi-2016-nebraska-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Nebraska.zip";
+    sha256 = "0x4p82nyhga768vfyxds00z4gnxhs2nzfp22qy84n8prwc432bxp";
+    geom = "tract";
+    region = "Nebraska";
+    year = "2016";
+  };
+  svi-2016-nevada-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Nevada_county.zip";
+    sha256 = "1ypb9nn3dhg66f5warac5p7dgzssq3znnchsv9k2ffnmmiv3hkww";
+    geom = "county";
+    region = "Nevada";
+    year = "2016";
+  };
+  svi-2016-nevada-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Nevada.zip";
+    sha256 = "1ai8sskk24yf10rmbhmqa3x7npgchxgj6djwyij3c72x6al3l5wm";
+    geom = "tract";
+    region = "Nevada";
+    year = "2016";
+  };
+  svi-2016-new_hampshire-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/NewHampshire_county.zip";
+    sha256 = "0pablcak51amp557bvjcbyfi8ww0189bsqy0fmi97klvmdqbb8vq";
+    geom = "county";
+    region = "New_Hampshire";
+    year = "2016";
+  };
+  svi-2016-new_hampshire-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/NewHampshire.zip";
+    sha256 = "18n38r9vcn3aiqz65nshn2vv9gsxg4pfgxnp61vj7wkcr07ksn4m";
+    geom = "tract";
+    region = "New_Hampshire";
+    year = "2016";
+  };
+  svi-2016-new_jersey-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/NewJersey_county.zip";
+    sha256 = "0gi41m6amj0ywakyzmfb722rwwkyqyd9r57ky20z6aybqbg94jkv";
+    geom = "county";
+    region = "New_Jersey";
+    year = "2016";
+  };
+  svi-2016-new_jersey-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/NewJersey.zip";
+    sha256 = "0x6jg6d4bvi009kgrh14bgxmdf2fdn3q7ca3iis8nnwjf5lvfnwj";
+    geom = "tract";
+    region = "New_Jersey";
+    year = "2016";
+  };
+  svi-2016-new_mexico-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/NewMexico_county.zip";
+    sha256 = "0d34fripaxwd54cwq5vqv5lmybv9j0hm7kv613vzn7pi8dmrcsy6";
+    geom = "county";
+    region = "New_Mexico";
+    year = "2016";
+  };
+  svi-2016-new_mexico-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/NewMexico.zip";
+    sha256 = "0n9k8q5a0h7v0p8fcvwgpbnksx56awljci22b7jbm9vlgfpdry17";
+    geom = "tract";
+    region = "New_Mexico";
+    year = "2016";
+  };
+  svi-2016-new_york-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/NewYork_county.zip";
+    sha256 = "19hdr5ca7m2mnch40d7bcmsa22l5i2adky8pjcrnv3h5y81v2w2a";
+    geom = "county";
+    region = "New_York";
+    year = "2016";
+  };
+  svi-2016-new_york-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/NewYork.zip";
+    sha256 = "1bb54fhhnpdl0vwppf5kg19yc33b1hl8xpnga9ak3mv7vp2cymkg";
+    geom = "tract";
+    region = "New_York";
+    year = "2016";
+  };
+  svi-2016-north_carolina-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/NorthCarolina_county.zip";
+    sha256 = "13daajxppw5jl099s5zxp74n9vwzmhaigb0pq4gbb3726bdjk74q";
+    geom = "county";
+    region = "North_Carolina";
+    year = "2016";
+  };
+  svi-2016-north_carolina-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/NorthCarolina.zip";
+    sha256 = "0zj27vbhc6967fypcqikii4yy5xwlmxj7lpqrrcf1mlvfqyd3fcl";
+    geom = "tract";
+    region = "North_Carolina";
+    year = "2016";
+  };
+  svi-2016-north_dakota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/NorthDakota_county.zip";
+    sha256 = "1dnv2jfvsvp4y5zbixhm6mj4ib00nqac9whsv2azxny2r03dqjy7";
+    geom = "county";
+    region = "North_Dakota";
+    year = "2016";
+  };
+  svi-2016-north_dakota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/NorthDakota.zip";
+    sha256 = "0f9lpkbq5xlmfcr8p635f95b3v9452i8m9wgyk5qxr2jmnc1i6rm";
+    geom = "tract";
+    region = "North_Dakota";
+    year = "2016";
+  };
+  svi-2016-ohio-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Ohio_county.zip";
+    sha256 = "0lkbsp6kl3vvgc092c4p6np08ajb478s8jcichikdqjrksd5zqay";
+    geom = "county";
+    region = "Ohio";
+    year = "2016";
+  };
+  svi-2016-ohio-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Ohio.zip";
+    sha256 = "0y7a54x8yk4h9ycdb55alm9b2v2y6b0j2wxwfqq9hnm919d0c9nc";
+    geom = "tract";
+    region = "Ohio";
+    year = "2016";
+  };
+  svi-2016-oklahoma-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Oklahoma_county.zip";
+    sha256 = "0xfyabx8vbfnffzx7bkh4r9mxqrf4wjbkry12p19g7d12s4d3id5";
+    geom = "county";
+    region = "Oklahoma";
+    year = "2016";
+  };
+  svi-2016-oklahoma-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Oklahoma.zip";
+    sha256 = "1gxk3hglx7qxkhaldpxfddxa8hzcgy24pcfkqh2yw52446qjrazg";
+    geom = "tract";
+    region = "Oklahoma";
+    year = "2016";
+  };
+  svi-2016-oregon-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Oregon_county.zip";
+    sha256 = "0m9fcs8irdh7n06rvwbrpblcxw9512w9ggynbdalrzm9hczpx3bb";
+    geom = "county";
+    region = "Oregon";
+    year = "2016";
+  };
+  svi-2016-oregon-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Oregon.zip";
+    sha256 = "145x2rig5xxxjjllz0r20h2ijbf34ywy1vjqsx45y3n3pnl987ii";
+    geom = "tract";
+    region = "Oregon";
+    year = "2016";
+  };
+  svi-2016-pennsylvania-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Pennsylvania_county.zip";
+    sha256 = "0ghmi13qbrfyxi36jics4qnr7v2fl8ciplg8x3msdvhid1zkk6yx";
+    geom = "county";
+    region = "Pennsylvania";
+    year = "2016";
+  };
+  svi-2016-pennsylvania-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Pennsylvania.zip";
+    sha256 = "1layzg8lswdr0wqmf14x6jyvmgk7i6fm0gr9i0dxcnas79rjr0j4";
+    geom = "tract";
+    region = "Pennsylvania";
+    year = "2016";
+  };
+  svi-2016-rhode_island-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/RhodeIsland_county.zip";
+    sha256 = "1jvnir9iyanmvhz22rh1lp3yfpwbnx7vf6zb5v05wpmwn7bdqc4f";
+    geom = "county";
+    region = "Rhode_Island";
+    year = "2016";
+  };
+  svi-2016-rhode_island-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/RhodeIsland.zip";
+    sha256 = "1kmq6ybpz74g3lkjylbchlakzanlfqmw7bjhy6jb60x4jb4qhyvh";
+    geom = "tract";
+    region = "Rhode_Island";
+    year = "2016";
+  };
+  svi-2016-south_carolina-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/SouthCarolina_county.zip";
+    sha256 = "0s2szm6hgh0kqdlnc1ixjh4c15g15j7n9iwbij6q7yhz0smwdf05";
+    geom = "county";
+    region = "South_Carolina";
+    year = "2016";
+  };
+  svi-2016-south_carolina-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/SouthCarolina.zip";
+    sha256 = "0nibrhjg45pqjbgwhhhmpa9mxw7sbw7chwq8vl28m2a76rpgrbdc";
+    geom = "tract";
+    region = "South_Carolina";
+    year = "2016";
+  };
+  svi-2016-south_dakota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/SouthDakota_county.zip";
+    sha256 = "07allxi4pcx23kj4k06zyjfmrjq28b8lwfa6syzh8ljrdq8xywmw";
+    geom = "county";
+    region = "South_Dakota";
+    year = "2016";
+  };
+  svi-2016-south_dakota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/SouthDakota.zip";
+    sha256 = "04w274d2b1nrs6cji7cxmdpr26nf9zji1h42azsiy3mwcahi6m9v";
+    geom = "tract";
+    region = "South_Dakota";
+    year = "2016";
+  };
+  svi-2016-tennessee-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Tennessee_county.zip";
+    sha256 = "03jyiy06kkcwjj94vllb0pgjda2r0y11n2c2w3ysvwhy6dvjqryy";
+    geom = "county";
+    region = "Tennessee";
+    year = "2016";
+  };
+  svi-2016-tennessee-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Tennessee.zip";
+    sha256 = "0033z1p9zc41pg5z28kaf29ilzc7nb0xs8abnv9qpx128img1w46";
+    geom = "tract";
+    region = "Tennessee";
+    year = "2016";
+  };
+  svi-2016-texas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Texas_county.zip";
+    sha256 = "0x3q098f6b8i6z4bwz3bkvlh0rsggfj1rwnw8xbdxwp2715nw64m";
+    geom = "county";
+    region = "Texas";
+    year = "2016";
+  };
+  svi-2016-texas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Texas.zip";
+    sha256 = "038rs3zjlx4n72afxhhbndayj1vahd9942wzjfjrlpnicqj7kby9";
+    geom = "tract";
+    region = "Texas";
+    year = "2016";
+  };
+  svi-2016-utah-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Utah_county.zip";
+    sha256 = "10cmyglnp0ymbqhacp4320hxx9vq619ir07xn347jadga4yay225";
+    geom = "county";
+    region = "Utah";
+    year = "2016";
+  };
+  svi-2016-utah-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Utah.zip";
+    sha256 = "0g879pwbkgb1i7sxwlz3wbrsjbm559bhdx2hjsn5k0akhicbld1s";
+    geom = "tract";
+    region = "Utah";
+    year = "2016";
+  };
+  svi-2016-vermont-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Vermont_county.zip";
+    sha256 = "0h0db6d65isbv4vdhhyrav0mcsr9a6h62hkrsx0sfmpqhwwfz8w4";
+    geom = "county";
+    region = "Vermont";
+    year = "2016";
+  };
+  svi-2016-vermont-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Vermont.zip";
+    sha256 = "1z31baxp9bbb19fww1hzi1mbs1mrl05bgm9pi6n7dnad6bhij0wi";
+    geom = "tract";
+    region = "Vermont";
+    year = "2016";
+  };
+  svi-2016-virginia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Virginia_county.zip";
+    sha256 = "0dfchrm4840hbh6siab118r821iqanav5biknnlxfqlaj5f5p0na";
+    geom = "county";
+    region = "Virginia";
+    year = "2016";
+  };
+  svi-2016-virginia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Virginia.zip";
+    sha256 = "141pwpiij9v3nzv4jhpdqflawadvniid8b78fh693iwjzr4m4d27";
+    geom = "tract";
+    region = "Virginia";
+    year = "2016";
+  };
+  svi-2016-washington-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Washington_county.zip";
+    sha256 = "0w4m083mplgabqyvj8alirw8506v68inpfk6i92xz7vz7lx7j9zl";
+    geom = "county";
+    region = "Washington";
+    year = "2016";
+  };
+  svi-2016-washington-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Washington.zip";
+    sha256 = "1yq8jvp9p6m30rnv04x27ssaidlrgsnn92vmmhmzmnkf1m80as7j";
+    geom = "tract";
+    region = "Washington";
+    year = "2016";
+  };
+  svi-2016-west_virginia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/WestVirginia_county.zip";
+    sha256 = "1syps54byqblqf3ka114kryqirch6q69qmqsf0p5gsx3j0miq9zp";
+    geom = "county";
+    region = "West_Virginia";
+    year = "2016";
+  };
+  svi-2016-west_virginia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/WestVirginia.zip";
+    sha256 = "1m473faj9wswi2n4i6k0gsswhg1j208pfky40qy07k69vwql8drc";
+    geom = "tract";
+    region = "West_Virginia";
+    year = "2016";
+  };
+  svi-2016-wisconsin-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Wisconsin_county.zip";
+    sha256 = "07s0ww8kxihvrg9x1dl0xg6mxw6wgydyk6jms3zzns3njqnivx8j";
+    geom = "county";
+    region = "Wisconsin";
+    year = "2016";
+  };
+  svi-2016-wisconsin-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Wisconsin.zip";
+    sha256 = "1067a0bivgp74ilhb1das3q18hqwivn2c687qh8bl1kd9s6bj7mk";
+    geom = "tract";
+    region = "Wisconsin";
+    year = "2016";
+  };
+  svi-2016-wyoming-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States_Counties/Wyoming_county.zip";
+    sha256 = "1nkyaxwamqaibiwpwv1sm79asnlkfkrplh7jj76fqrcbvqcmqnsk";
+    geom = "county";
+    region = "Wyoming";
+    year = "2016";
+  };
+  svi-2016-wyoming-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2016_SVI_Data/States/Wyoming.zip";
+    sha256 = "1y8miaa9xb9djqgcnvamv3cr1c4dqygwsrlckqf0d1acv8hpdkj9";
+    geom = "tract";
+    region = "Wyoming";
+    year = "2016";
+  };
+  svi-2018-us-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/SVI2018_US_county.zip";
+    sha256 = "1f65n2r7qpbfqrnwp7mmmn9fpk9fgnvwxwlgl2ac2qwajhqpm64n";
+    geom = "county";
+    region = "US";
+    year = "2018";
+  };
+  svi-2018-us-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/SVI2018_US.zip";
+    sha256 = "0ixsfrfvwvgdk5id1fvcblxkq03w27k2dmgf12abs7mkrwlrny49";
+    geom = "tract";
+    region = "US";
+    year = "2018";
+  };
+  svi-2018-us-ttract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Tribal_Tracts.zip";
+    sha256 = "1xfb1q0lxrjh74pjjng29b7r7aq13v8qhyciwa8vdlxssyblq4bf";
+    geom = "ttract";
+    region = "US";
+    year = "2018";
+  };
+  svi-2018-district_of_columbia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/DistrictofColumbia_county.zip";
+    sha256 = "1j2fangjjyki6rlrgs5g0h3wxdvha5wj0flnpjn6mdms66c6zzc1";
+    geom = "county";
+    region = "District_of_Columbia";
+    year = "2018";
+  };
+  svi-2018-district_of_columbia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/DistrictofColumbia.zip";
+    sha256 = "0y6hi8x96day9c0w90qysb3hqxawxmyy9j5ij3bhsr9a0pnilrms";
+    geom = "tract";
+    region = "District_of_Columbia";
+    year = "2018";
+  };
+  svi-2018-puerto_rico-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/PuertoRico_county.zip";
+    sha256 = "1im6qx4d9sh8p5x2b7n6af07lxwgvdar8ckc7g8kyvz9m8qz3kgv";
+    geom = "county";
+    region = "Puerto_Rico";
+    year = "2018";
+  };
+  svi-2018-puerto_rico-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/PuertoRico.zip";
+    sha256 = "128d5j46yfw3w1z006icfvdnszcqz7hgfk5bglm9w9wrlvvbmigd";
+    geom = "tract";
+    region = "Puerto_Rico";
+    year = "2018";
+  };
+  svi-2018-alabama-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Alabama_county.zip";
+    sha256 = "163iinh8z5faw96zmd5mra6cr4p0dxfhrl5g6lgwsybizjasmw0k";
+    geom = "county";
+    region = "Alabama";
+    year = "2018";
+  };
+  svi-2018-alabama-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Alabama.zip";
+    sha256 = "193nr63fxc7y23nsbgm47pimm09p2f0jx5jd6hppnyyigbs18i3s";
+    geom = "tract";
+    region = "Alabama";
+    year = "2018";
+  };
+  svi-2018-alaska-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Alaska_county.zip";
+    sha256 = "09ir1fn9fj8ydzi3b20nv3vvdiv53qvybi7cfx4dk316467h2akh";
+    geom = "county";
+    region = "Alaska";
+    year = "2018";
+  };
+  svi-2018-alaska-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Alaska.zip";
+    sha256 = "09qjpymjrrvc5acxs3q1f0bl0xyr92prnsafbp3fj81xc17paf16";
+    geom = "tract";
+    region = "Alaska";
+    year = "2018";
+  };
+  svi-2018-arizona-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Arizona_county.zip";
+    sha256 = "1l5bk9581vzxaf8rj71xhs9x03mcrhr13294qchnmk335ph4igy4";
+    geom = "county";
+    region = "Arizona";
+    year = "2018";
+  };
+  svi-2018-arizona-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Arizona.zip";
+    sha256 = "16axv346agk21f2p0zmmpw7v334ghy83vdsc00f63q80yfiv77v2";
+    geom = "tract";
+    region = "Arizona";
+    year = "2018";
+  };
+  svi-2018-arkansas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Arkansas_county.zip";
+    sha256 = "1vaylin5j1i5f7xkc2apbsw4cppqa0d92m11xwcdqgz1wzxlj6yw";
+    geom = "county";
+    region = "Arkansas";
+    year = "2018";
+  };
+  svi-2018-arkansas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Arkansas.zip";
+    sha256 = "18dqzwa7pf5yssw7li0q14b3mv92n2kifyc8d7l25vlcykqzvndi";
+    geom = "tract";
+    region = "Arkansas";
+    year = "2018";
+  };
+  svi-2018-california-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/California_county.zip";
+    sha256 = "1jmyzpcai9ajbl9xk0a5m8hd1ry0x48vjw467np0w4ghi5bjjnsy";
+    geom = "county";
+    region = "California";
+    year = "2018";
+  };
+  svi-2018-california-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/California.zip";
+    sha256 = "1xzhnir1vj884h0vkkybx19rih7r2nj576vvapy7nd2j9aa295xj";
+    geom = "tract";
+    region = "California";
+    year = "2018";
+  };
+  svi-2018-colorado-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Colorado_county.zip";
+    sha256 = "1hh0bzivgm43swmqlvisb0dkbhfkfkq8d7lpkgn6lwj98bw938pl";
+    geom = "county";
+    region = "Colorado";
+    year = "2018";
+  };
+  svi-2018-colorado-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Colorado.zip";
+    sha256 = "1mrqpp47v8r1bgwpf3bljxmp1ybnx0rly78k2cli822xp0y60wc5";
+    geom = "tract";
+    region = "Colorado";
+    year = "2018";
+  };
+  svi-2018-connecticut-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Connecticut_county.zip";
+    sha256 = "14lw2g6chadp5wfh54lii7y9a7h0dqc3rk6y2qd1rhkkv8dli11b";
+    geom = "county";
+    region = "Connecticut";
+    year = "2018";
+  };
+  svi-2018-connecticut-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Connecticut.zip";
+    sha256 = "1ilkd0277lc602q2gf0j3rczcg7kn3ya1w24xbh6yyjvssvdaw1x";
+    geom = "tract";
+    region = "Connecticut";
+    year = "2018";
+  };
+  svi-2018-delaware-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Delaware_county.zip";
+    sha256 = "0kff1bymbb1im7wrdi5sii552x2xw2n2l77xfl7k4sm9lr06malr";
+    geom = "county";
+    region = "Delaware";
+    year = "2018";
+  };
+  svi-2018-delaware-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Delaware.zip";
+    sha256 = "0d2nhnwwa6yj2b4ndbwpwyrq24l7ia04g7jjbj08nz3lxkaqvl96";
+    geom = "tract";
+    region = "Delaware";
+    year = "2018";
+  };
+  svi-2018-florida-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Florida_county.zip";
+    sha256 = "1cyhw6g0cci9s3zrfw3f6cyny2bz5sd5nnyfnyhs5v4n2kwx5cwl";
+    geom = "county";
+    region = "Florida";
+    year = "2018";
+  };
+  svi-2018-florida-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Florida.zip";
+    sha256 = "1p5aahpcazfhfkpqi0hgx3p44660x29cfqwfb1xvklh9v7phfgr2";
+    geom = "tract";
+    region = "Florida";
+    year = "2018";
+  };
+  svi-2018-georgia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Georgia_county.zip";
+    sha256 = "1z0l1cpl2z5i3l8z2g8zgxwyzzs6rdq0gqbjwsd44ma3ghy8mlym";
+    geom = "county";
+    region = "Georgia";
+    year = "2018";
+  };
+  svi-2018-georgia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Georgia.zip";
+    sha256 = "06azqikffp7glbpjgnnfw0ywnzvibgksk6kygx6cawax4v48wz9s";
+    geom = "tract";
+    region = "Georgia";
+    year = "2018";
+  };
+  svi-2018-hawaii-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Hawaii_county.zip";
+    sha256 = "0x1hd7y8v056pqs10qglm2g8vjgd442m96m8k6fhcdsiasn4mchs";
+    geom = "county";
+    region = "Hawaii";
+    year = "2018";
+  };
+  svi-2018-hawaii-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Hawaii.zip";
+    sha256 = "0snmbv7zf23da978m4jplnzkny4hawbjjabw64l3z4kab08bx22l";
+    geom = "tract";
+    region = "Hawaii";
+    year = "2018";
+  };
+  svi-2018-idaho-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Idaho_county.zip";
+    sha256 = "1vq787sf253fw3sa42wsvdyyrc8kc7k33akb7ilq590n67bxln9j";
+    geom = "county";
+    region = "Idaho";
+    year = "2018";
+  };
+  svi-2018-idaho-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Idaho.zip";
+    sha256 = "0nxv0dr4aa2zsjpqinnw913ln0qlhibvg3pq2wkjnf79nwzzh8mi";
+    geom = "tract";
+    region = "Idaho";
+    year = "2018";
+  };
+  svi-2018-illinois-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Illinois_county.zip";
+    sha256 = "1pksmiqcfn01081gkbvk8l48a3kik9j8zdixymd1lfm1a45hgy6m";
+    geom = "county";
+    region = "Illinois";
+    year = "2018";
+  };
+  svi-2018-illinois-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Illinois.zip";
+    sha256 = "0fg9jcis35m5d0aqncvmhv7zgindiy7my4r64hmb0ys1lb3w85gb";
+    geom = "tract";
+    region = "Illinois";
+    year = "2018";
+  };
+  svi-2018-indiana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Indiana_county.zip";
+    sha256 = "1nnfnvgly1w46b30b9scd9wbkg858f81f4rlyhmajdvlngabrwx0";
+    geom = "county";
+    region = "Indiana";
+    year = "2018";
+  };
+  svi-2018-indiana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Indiana.zip";
+    sha256 = "150lydx5wak5ldww8nkciiacc7ndrx6sifcqihv09n9l75xziz3j";
+    geom = "tract";
+    region = "Indiana";
+    year = "2018";
+  };
+  svi-2018-iowa-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Iowa_county.zip";
+    sha256 = "0fidqvk0dr9r2p4qc7bdiz11brgxprwrd864nx1snmv2aajj6j5c";
+    geom = "county";
+    region = "Iowa";
+    year = "2018";
+  };
+  svi-2018-iowa-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Iowa.zip";
+    sha256 = "1r9ni5nz4jcq4vyqnj0y1b1qyfhwm8mmcjymzsh7c3g36s7j5c3i";
+    geom = "tract";
+    region = "Iowa";
+    year = "2018";
+  };
+  svi-2018-kansas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Kansas_county.zip";
+    sha256 = "10143698snci0yfjf7nw0mafwh3hcjxaj4n4rplpfbni3gcl21jq";
+    geom = "county";
+    region = "Kansas";
+    year = "2018";
+  };
+  svi-2018-kansas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Kansas.zip";
+    sha256 = "0cn25iwv9sv0906jvvn4icfbwpg2cq05yz96b0xmlik95invg0hv";
+    geom = "tract";
+    region = "Kansas";
+    year = "2018";
+  };
+  svi-2018-kentucky-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Kentucky_county.zip";
+    sha256 = "19wnkc0fpfidxavmjayn86dps4lzgql49r0h7lzdkp4d24hbkj3s";
+    geom = "county";
+    region = "Kentucky";
+    year = "2018";
+  };
+  svi-2018-kentucky-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Kentucky.zip";
+    sha256 = "02zxzfq1acilg7gknmcxf1vd8qr6i69yrqbly2jbkjkai2pg1ghs";
+    geom = "tract";
+    region = "Kentucky";
+    year = "2018";
+  };
+  svi-2018-louisiana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Louisiana_county.zip";
+    sha256 = "1r8dpmzwkwkw0dv6hxs9hwz8hr9c7n60b8i90k9ryzb8m3c2sfy0";
+    geom = "county";
+    region = "Louisiana";
+    year = "2018";
+  };
+  svi-2018-louisiana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Louisiana.zip";
+    sha256 = "0zrhxcczlsfh04w0gikb1r9v4pa3ksf9iglc5279d6nrc9qrhyh5";
+    geom = "tract";
+    region = "Louisiana";
+    year = "2018";
+  };
+  svi-2018-maine-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Maine_county.zip";
+    sha256 = "1g5mpgr55l9bahapyc9i6m5igg6yg8j5kg7j9qh63n9vlc7b2amh";
+    geom = "county";
+    region = "Maine";
+    year = "2018";
+  };
+  svi-2018-maine-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Maine.zip";
+    sha256 = "034abm8jg8p1g4zjz7f2vd2alxyzyzcm6yinpiysf2956ddgx25x";
+    geom = "tract";
+    region = "Maine";
+    year = "2018";
+  };
+  svi-2018-maryland-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Maryland_county.zip";
+    sha256 = "0pfrkybyh6q65p8wblyspqkxr8y7596s6347c9b62kxsygsi7bgv";
+    geom = "county";
+    region = "Maryland";
+    year = "2018";
+  };
+  svi-2018-maryland-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Maryland.zip";
+    sha256 = "1zk77ivd3h75fla286aqva92x76s40xqr50vmvfn8hzqq14c6mix";
+    geom = "tract";
+    region = "Maryland";
+    year = "2018";
+  };
+  svi-2018-massachusetts-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Massachusetts_county.zip";
+    sha256 = "1qki4pwx952b0ipdgf8kncfy3mkm8hwrxmnisbddw91awmhgjgzh";
+    geom = "county";
+    region = "Massachusetts";
+    year = "2018";
+  };
+  svi-2018-massachusetts-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Massachusetts.zip";
+    sha256 = "03pk6xypxk1isdii27kj87k6lak619lflznwp484ir75x5ynyfqx";
+    geom = "tract";
+    region = "Massachusetts";
+    year = "2018";
+  };
+  svi-2018-michigan-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Michigan_county.zip";
+    sha256 = "1r4xyhlz5vap0zbfmdbr5xhbf654v34y7vcp8nrpifn2yrwcasak";
+    geom = "county";
+    region = "Michigan";
+    year = "2018";
+  };
+  svi-2018-michigan-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Michigan.zip";
+    sha256 = "1cwcga43pq3xrr9avl6jizj653fln8xkhqvpwscbpy45qxb23zzq";
+    geom = "tract";
+    region = "Michigan";
+    year = "2018";
+  };
+  svi-2018-minnesota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Minnesota_county.zip";
+    sha256 = "01ghsd4f79ycnpa2f9cqdxmj62bxfd62dxid62ybqmkvp4kwiv5f";
+    geom = "county";
+    region = "Minnesota";
+    year = "2018";
+  };
+  svi-2018-minnesota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Minnesota.zip";
+    sha256 = "18kqlyvhqyhpkgxcr0glqhp8pdlmj9d6qahhkymp6knjjf03pl99";
+    geom = "tract";
+    region = "Minnesota";
+    year = "2018";
+  };
+  svi-2018-mississippi-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Mississippi_county.zip";
+    sha256 = "009jkpf793npps9nfpxn33z1qxrpc8bapgadhf6gzzw63vrv9l6y";
+    geom = "county";
+    region = "Mississippi";
+    year = "2018";
+  };
+  svi-2018-mississippi-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Mississippi.zip";
+    sha256 = "0ksapqlhbnfi3qxqfaxvwgjifbgkirn96v73pwy3h70msyi9axnc";
+    geom = "tract";
+    region = "Mississippi";
+    year = "2018";
+  };
+  svi-2018-missouri-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Missouri_county.zip";
+    sha256 = "1nafgbhs7nywml34h0xvfjgxx3ykidllmbbjrk5n2sj3zgcadl07";
+    geom = "county";
+    region = "Missouri";
+    year = "2018";
+  };
+  svi-2018-missouri-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Missouri.zip";
+    sha256 = "0mh97wz9395l75a668m1xwlmqkxlc4vh8b9w82qzzkqbkm9y2xdv";
+    geom = "tract";
+    region = "Missouri";
+    year = "2018";
+  };
+  svi-2018-montana-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Montana_county.zip";
+    sha256 = "19cgn3zwvmkfpixvia1n1smsvhqdg5i2xsj3vmsqgms55sp7glrm";
+    geom = "county";
+    region = "Montana";
+    year = "2018";
+  };
+  svi-2018-montana-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Montana.zip";
+    sha256 = "1dpa1smwdw71z0cl8r3s8wykjc9f6jkxjkb6q3mwszm77azj1fxb";
+    geom = "tract";
+    region = "Montana";
+    year = "2018";
+  };
+  svi-2018-nebraska-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Nebraska_county.zip";
+    sha256 = "1bn1dw18vpdd7ma6fzhdf1dnwkj2cfaimxlnfk58b00j0cz532il";
+    geom = "county";
+    region = "Nebraska";
+    year = "2018";
+  };
+  svi-2018-nebraska-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Nebraska.zip";
+    sha256 = "0h567s9fng2wp0fyqfx73s7sjwypfi0c0v3abny9qsisysy0zkx1";
+    geom = "tract";
+    region = "Nebraska";
+    year = "2018";
+  };
+  svi-2018-nevada-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Nevada_county.zip";
+    sha256 = "1nxbc1valc3xvq52xq5mcd6l0kv92fxk36wc0wvaxxgn4ihkwbdv";
+    geom = "county";
+    region = "Nevada";
+    year = "2018";
+  };
+  svi-2018-nevada-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Nevada.zip";
+    sha256 = "0k4i9d0ih12v3rc1z67sdvisvr2lh693nx8arz26bxr2g9207q5l";
+    geom = "tract";
+    region = "Nevada";
+    year = "2018";
+  };
+  svi-2018-new_hampshire-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/NewHampshire_county.zip";
+    sha256 = "06xnf3s9mvgraw763vazzv7rh9zl2xx7qvrbisbic5m04mkm7j3d";
+    geom = "county";
+    region = "New_Hampshire";
+    year = "2018";
+  };
+  svi-2018-new_hampshire-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/NewHampshire.zip";
+    sha256 = "181cgsbz18p5db1g0pknb2jxk07c489y96g724hwsaha5drql895";
+    geom = "tract";
+    region = "New_Hampshire";
+    year = "2018";
+  };
+  svi-2018-new_jersey-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/NewJersey_county.zip";
+    sha256 = "1bs5hxc9ii6f1ypdnh1j9d99bq8qkpqam4yrwqm5flvl5vgj5r4h";
+    geom = "county";
+    region = "New_Jersey";
+    year = "2018";
+  };
+  svi-2018-new_jersey-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/NewJersey.zip";
+    sha256 = "1s23l6qgv8mhkxvdzcvjx3zx741ws8xvqhcp9fxz7dcs3drm6332";
+    geom = "tract";
+    region = "New_Jersey";
+    year = "2018";
+  };
+  svi-2018-new_mexico-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/NewMexico_county.zip";
+    sha256 = "1cv12hf2qq978v0815v2iarclc3cffzrhl1zc2ak0xaf3kg69xi6";
+    geom = "county";
+    region = "New_Mexico";
+    year = "2018";
+  };
+  svi-2018-new_mexico-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/NewMexico.zip";
+    sha256 = "1acj9yd7lxxyc8rm02cx0hw99c5jm3qwdsd1j5ljv3si3ihl1dql";
+    geom = "tract";
+    region = "New_Mexico";
+    year = "2018";
+  };
+  svi-2018-new_york-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/NewYork_county.zip";
+    sha256 = "1arv0n1c4si8lk3402dpgf2z8bvypp5an6n65i07v9ggafjgs4a1";
+    geom = "county";
+    region = "New_York";
+    year = "2018";
+  };
+  svi-2018-new_york-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/NewYork.zip";
+    sha256 = "0qlwsxccvwkqs0qgy4wmlghvjllf5svw10z7jf5rhj0zq90j5rmg";
+    geom = "tract";
+    region = "New_York";
+    year = "2018";
+  };
+  svi-2018-north_carolina-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/NorthCarolina_county.zip";
+    sha256 = "1yixcbz5hh9z424zyjs96p5ndybdi7wzp82pm1r456z0crs88rdp";
+    geom = "county";
+    region = "North_Carolina";
+    year = "2018";
+  };
+  svi-2018-north_carolina-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/NorthCarolina.zip";
+    sha256 = "1jihzzfnbmddqn4xm13ssa7qx4714krq7q3hk6li81j9hx9r18pk";
+    geom = "tract";
+    region = "North_Carolina";
+    year = "2018";
+  };
+  svi-2018-north_dakota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/NorthDakota_county.zip";
+    sha256 = "0rfk3xijwgy4fvfq0y65xcsqj5vs307fm68jagpc5g063rjywdjx";
+    geom = "county";
+    region = "North_Dakota";
+    year = "2018";
+  };
+  svi-2018-north_dakota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/NorthDakota.zip";
+    sha256 = "170w0f0079clndv1rnqppcy4mljgx279dplfp8y52z3li9npvw0s";
+    geom = "tract";
+    region = "North_Dakota";
+    year = "2018";
+  };
+  svi-2018-ohio-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Ohio_county.zip";
+    sha256 = "16facmkw2k57lj920rp5anlb1dr9na97vqnr5rs9l8k80csn1p5f";
+    geom = "county";
+    region = "Ohio";
+    year = "2018";
+  };
+  svi-2018-ohio-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Ohio.zip";
+    sha256 = "0xq1l6lvn04nxm95ajf0x75z47zaccazayafwdkh5mvb4wxankd7";
+    geom = "tract";
+    region = "Ohio";
+    year = "2018";
+  };
+  svi-2018-oklahoma-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Oklahoma_county.zip";
+    sha256 = "025955bn9q7nl7w4hz290xgh6383gsqsj65y5wh3107wxda9ilwv";
+    geom = "county";
+    region = "Oklahoma";
+    year = "2018";
+  };
+  svi-2018-oklahoma-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Oklahoma.zip";
+    sha256 = "0djaxyqmhywlgjwd9css17g2dvz2ms7h4l24hmnjvxmkbxpm62hs";
+    geom = "tract";
+    region = "Oklahoma";
+    year = "2018";
+  };
+  svi-2018-oregon-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Oregon_county.zip";
+    sha256 = "0mcjlkvfsrvm63i7f6i5ynyhyavqj5wwwkvd6qhpjhl0k7261283";
+    geom = "county";
+    region = "Oregon";
+    year = "2018";
+  };
+  svi-2018-oregon-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Oregon.zip";
+    sha256 = "1lbxxyrvp8p7a9qlxh5v9q65z1bl0103b7asm2mhdla6fwq8cspp";
+    geom = "tract";
+    region = "Oregon";
+    year = "2018";
+  };
+  svi-2018-pennsylvania-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Pennsylvania_county.zip";
+    sha256 = "0ldaaishia77vxhvm1jshkm9ybarhavhsrx4jcis4w15h24kib40";
+    geom = "county";
+    region = "Pennsylvania";
+    year = "2018";
+  };
+  svi-2018-pennsylvania-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Pennsylvania.zip";
+    sha256 = "1yhzdjqygfi29496pf76xvad6j6jsr2nnq8gdb2vkd40nlb82rhq";
+    geom = "tract";
+    region = "Pennsylvania";
+    year = "2018";
+  };
+  svi-2018-rhode_island-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/RhodeIsland_county.zip";
+    sha256 = "0lna9dr2w8712h5c1hdix0ryfjsfkrqhj511bjiqmklw59gbcrvq";
+    geom = "county";
+    region = "Rhode_Island";
+    year = "2018";
+  };
+  svi-2018-rhode_island-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/RhodeIsland.zip";
+    sha256 = "1mn155xs91nvvsw5qc5324rjymqpnhxl54xnzm6zwskn4x2n8r99";
+    geom = "tract";
+    region = "Rhode_Island";
+    year = "2018";
+  };
+  svi-2018-south_carolina-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/SouthCarolina_county.zip";
+    sha256 = "0bj8f8mk1fa8a7b57qrml92crf3ibswic04kxi45z5j1fbps3x8r";
+    geom = "county";
+    region = "South_Carolina";
+    year = "2018";
+  };
+  svi-2018-south_carolina-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/SouthCarolina.zip";
+    sha256 = "1ai36dhnzw8dqz7wxl2nsrknswyl8z3bnvr7fjvhlbywrp3s5qb4";
+    geom = "tract";
+    region = "South_Carolina";
+    year = "2018";
+  };
+  svi-2018-south_dakota-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/SouthDakota_county.zip";
+    sha256 = "0824vqdag8kp3wj8mwvm9jrn210w2zy0w3yfcg3fwldjix2sgy5z";
+    geom = "county";
+    region = "South_Dakota";
+    year = "2018";
+  };
+  svi-2018-south_dakota-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/SouthDakota.zip";
+    sha256 = "09v7gfalw6zkpf7b0w0065jysrndmjk319kmiz06d87l4ydpgr5w";
+    geom = "tract";
+    region = "South_Dakota";
+    year = "2018";
+  };
+  svi-2018-tennessee-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Tennessee_county.zip";
+    sha256 = "0ab13gkjh681f2218maiy7yf7wmpajcfwx3a4102lhq63qfr6rqz";
+    geom = "county";
+    region = "Tennessee";
+    year = "2018";
+  };
+  svi-2018-tennessee-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Tennessee.zip";
+    sha256 = "16gsfk6rxsyn7gcc4kjdgimw0fjv77340k3mpwqlabdncs6rg8j4";
+    geom = "tract";
+    region = "Tennessee";
+    year = "2018";
+  };
+  svi-2018-texas-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Texas_county.zip";
+    sha256 = "09345k8sqlnah391jqk129nw9rf6x8f2rkns0pbm837csq3bxzl5";
+    geom = "county";
+    region = "Texas";
+    year = "2018";
+  };
+  svi-2018-texas-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Texas.zip";
+    sha256 = "1fjwflqnsar7c86rk78p33pimpnhi7xdkmsi07k17zixj24pkqwa";
+    geom = "tract";
+    region = "Texas";
+    year = "2018";
+  };
+  svi-2018-utah-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Utah_county.zip";
+    sha256 = "1vjg0inyyh0vclps4hymx3fqiygxmaq7a8baaj5ihgrsf3npplvn";
+    geom = "county";
+    region = "Utah";
+    year = "2018";
+  };
+  svi-2018-utah-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Utah.zip";
+    sha256 = "16ahrsmxxp4pza1c07xmx1pjyjfklz4mhwgwipjsmzqq244dlcc1";
+    geom = "tract";
+    region = "Utah";
+    year = "2018";
+  };
+  svi-2018-vermont-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Vermont_county.zip";
+    sha256 = "1p7a5qd7vzhgs4farj4q7i23gnwhpn9n7ppjbhyjkmwss4pjghpl";
+    geom = "county";
+    region = "Vermont";
+    year = "2018";
+  };
+  svi-2018-vermont-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Vermont.zip";
+    sha256 = "1cmypk0zhwmf126jjk01qppnij8v3n47ky5g24i2fhg9g95xzgpx";
+    geom = "tract";
+    region = "Vermont";
+    year = "2018";
+  };
+  svi-2018-virginia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Virginia_county.zip";
+    sha256 = "1i7ws3q4wsgbzvchkvr37s9v4lvnp0mg7cwhpm2v00rfi1s1fbny";
+    geom = "county";
+    region = "Virginia";
+    year = "2018";
+  };
+  svi-2018-virginia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Virginia.zip";
+    sha256 = "1xdlav4c8icf7cjx3jq32zg3yvc1mvv9k2hxmxzgzdbqs4z2hyxz";
+    geom = "tract";
+    region = "Virginia";
+    year = "2018";
+  };
+  svi-2018-washington-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Washington_county.zip";
+    sha256 = "07a2bmrbqwzlm4cf88g8b4hb7rjk8pd365ra47hbb940hrgsksg6";
+    geom = "county";
+    region = "Washington";
+    year = "2018";
+  };
+  svi-2018-washington-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Washington.zip";
+    sha256 = "0vikwz34bgqabszzqan98g23zbszgcs5ba180vvvjv4zi611q6a7";
+    geom = "tract";
+    region = "Washington";
+    year = "2018";
+  };
+  svi-2018-west_virginia-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/WestVirginia_county.zip";
+    sha256 = "1pijf4c5iw27w0ss6ri6hl7rda2jmyviikz70gwl2cmm0yka5awj";
+    geom = "county";
+    region = "West_Virginia";
+    year = "2018";
+  };
+  svi-2018-west_virginia-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/WestVirginia.zip";
+    sha256 = "0p2hxq3522fxhl9cgjj0l8xzq23mk6z88n298f6w55cpy2r99vp2";
+    geom = "tract";
+    region = "West_Virginia";
+    year = "2018";
+  };
+  svi-2018-wisconsin-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Wisconsin_county.zip";
+    sha256 = "11jj2kglplrs6ij5g5psvcn25c3fmz5fh6xn6x2dir2bigrqfnis";
+    geom = "county";
+    region = "Wisconsin";
+    year = "2018";
+  };
+  svi-2018-wisconsin-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Wisconsin.zip";
+    sha256 = "1xlg25hw4wacr08hyb6mdr7imhmc390r6c77g2ak90gxwb04bcvb";
+    geom = "tract";
+    region = "Wisconsin";
+    year = "2018";
+  };
+  svi-2018-wyoming-county = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States_Counties/Wyoming_county.zip";
+    sha256 = "0ss51njssfp703r53w2pwa5n7d69rkahbbzk8c6x8zj7vjdiz805";
+    geom = "county";
+    region = "Wyoming";
+    year = "2018";
+  };
+  svi-2018-wyoming-tract = {
+    url = "https://svi.cdc.gov/Documents/Data/2018_SVI_Data/States/Wyoming.zip";
+    sha256 = "1zlsn6nwxlc8m2agjsfizp4ckydk4qy3b5b7s72hi748bg85d1ki";
+    geom = "tract";
+    region = "Wyoming";
+    year = "2018";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22485,6 +22485,8 @@ in
 
   skeu = callPackage ../data/themes/skeu { };
 
+  svi = callPackage ../data/misc/svi { };
+
   sweet = callPackage ../data/themes/sweet { };
 
   mime-types = callPackage ../data/misc/mime-types { };


### PR DESCRIPTION
###### Motivation for this change

Adding CDC Social Vulnerability Index data to nixpkgs.

It would be awesome to use nixpkgs as a curated and standardized interface to public data sets. This has some precedence, for instance with the inclusion of [machine-learning datasets](https://github.com/NixOS/nixpkgs/tree/3a8d7958a610cd3fec3a6f424480f91a1b259185/pkgs/data/machine-learning/mnist).

I started thinking about this while working within [OHDSI](https://github.com/OHDSI/), a large open-source, open-science health-data initiative. I am a part of a group that is looking to create applications and analyses on top of publicly available datasets relevant to health data. With all the trouble that government has keeping APIs alive and standard, it would be awesome to draw on the open-source community to provide this standardization and stability for applications that build on top of it. This, for instance, would be great for the Postgis Tiger geocoder, which is required to maintain shell scripts stored in sql tables to fetch un-pinned urls. Yuck! nixpkgs to the rescue?

I tried to start a discussion [here](https://discourse.nixos.org/t/public-gis-data-in-pkgs-data/13606), but it didn't gain much (any) interest. I'm hoping that opening this pull request might kick things off.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
