### PR TITLE
llvm: move libxml2 to propagatedBuildInputs

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -51,10 +51,10 @@ in stdenv.mkDerivation (rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     ./gnu-install-dirs.patch

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -51,10 +51,10 @@ in stdenv.mkDerivation (rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     ./gnu-install-dirs.patch

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -51,10 +51,10 @@ in stdenv.mkDerivation (rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     ./gnu-install-dirs.patch

--- a/pkgs/development/compilers/llvm/5/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/5/llvm/default.nix
@@ -48,9 +48,9 @@ stdenv.mkDerivation ({
   nativeBuildInputs = [ cmake python3 ]
     ++ optional enableManpages python3.pkgs.sphinx;
 
-  buildInputs = [ libxml2 libffi ];
+  buildInputs = [ libffi ];
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/compilers/llvm/6/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/6/llvm/default.nix
@@ -48,9 +48,9 @@ stdenv.mkDerivation ({
   nativeBuildInputs = [ cmake python3 ]
     ++ optional enableManpages python3.pkgs.sphinx;
 
-  buildInputs = [ libxml2 libffi ];
+  buildInputs = [ libffi ];
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     # Patches to fix tests, included in llvm_7

--- a/pkgs/development/compilers/llvm/7/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/7/llvm/default.nix
@@ -52,10 +52,10 @@ in stdenv.mkDerivation ({
   nativeBuildInputs = [ cmake python3 ]
     ++ optional enableManpages python3.pkgs.sphinx;
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     # backport, fix building rust crates with lto

--- a/pkgs/development/compilers/llvm/8/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/8/llvm/default.nix
@@ -51,10 +51,10 @@ in stdenv.mkDerivation ({
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     # Fix missing includes for GCC 10

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -50,10 +50,10 @@ in stdenv.mkDerivation (rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   patches = [
     ./gnu-install-dirs.patch

--- a/pkgs/development/compilers/llvm/git/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/git/llvm/default.nix
@@ -43,10 +43,10 @@ in stdenv.mkDerivation (rec {
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
-  buildInputs = [ libxml2 libffi ]
+  buildInputs = [ libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   checkInputs = [ which ];
 

--- a/pkgs/development/compilers/llvm/rocm/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm/default.nix
@@ -30,9 +30,9 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python3 ];
 
-  buildInputs = [ libxml2 libffi ];
+  buildInputs = [ libffi ];
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = [ ncurses zlib libxml2 ];
 
   cmakeFlags = with stdenv; [
     "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"


### PR DESCRIPTION
###### Motivation for this change

The library is included in the output of `llvm-config --link-static
--system-libs` but since it is not propagated, dependents that statically
link to LLVM fail to link (unless they otherwise bring in libxml2)

For example:

```
$ nix shell nixpkgs#llvm_10.dev -c llvm-config --link-static --system-libs all
-lz -lrt -ldl -ltinfo -lpthread -lm -lxml2
```

###### Things done

Unfortunately I have not done any testing of this since llvm takes so long to compiler. This also will trigger a whole bunch of rebuilds I'm sure. That said, this change seems quite unlikely to cause any breakage.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
