### PR TITLE
dhall: Use --base-import-url flag for documentation

### DIFF
--- a/pkgs/development/interpreters/dhall/build-dhall-github-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-github-package.nix
@@ -43,7 +43,7 @@ lib.makePackageOverridable
         "rev"
       ]);
 
-      prefix = lib.optionalString (directory != "") "${directory}/";
+      prefix = lib.optionalString (directory != "") "/${directory}";
 
     in
       buildDhallPackage
@@ -51,9 +51,12 @@ lib.makePackageOverridable
 
             name = versionedName;
 
-            code = "${src}/${prefix}${file}";
+            code = "${src}${prefix}/${file}";
           }
         // lib.optionalAttrs document
-          { documentationRoot = "${src}/${prefix}"; }
+          { documentationRoot = "${src}/${prefix}";
+
+            baseImportUrl = "https://raw.githubusercontent.com/${owner}/${repo}/${rev}${prefix}";
+          }
         )
   )

--- a/pkgs/development/interpreters/dhall/build-dhall-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-package.nix
@@ -37,6 +37,12 @@
   #
   # If `null`, then no documentation is generated.
 , documentationRoot ? null
+
+  # Base URL prepended to paths copied to the clipboard
+  #
+  # This is used in conjunction with `documentationRoot`, and is unused if
+  # `documentationRoot` is `null`.
+, baseImportUrl ? null
 }:
 
 let
@@ -85,6 +91,12 @@ in
     ${lib.optionalString (documentationRoot != null) ''
     mkdir -p $out/${dataDhall}
 
-    XDG_DATA_HOME=$out/${data} ${dhall-docs}/bin/dhall-docs --input '${documentationRoot}' --package-name '${name}' --output-link $out/docs
+    XDG_DATA_HOME=$out/${data} ${dhall-docs}/bin/dhall-docs --output-link $out/docs ${lib.cli.toGNUCommandLineShell { } {
+      base-import-url = baseImportUrl;
+
+      input = documentationRoot;
+
+      package-name = name;
+    }}
     ''}
   ''


### PR DESCRIPTION
This updates `pkgs.dhallPackages.buildDhallGitHubPackage` to use the
newly added `--base-import-url` `dhall-docs` flag.  This flag is used
by the generated documentation so that paths copied to the clipboard
represent complete URLs that can be imported instead of only the
relative path to the import.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
