### PR TITLE
kustomize_3: init at 3.10.0

### DIFF
--- a/pkgs/development/tools/kustomize/3.nix
+++ b/pkgs/development/tools/kustomize/3.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kustomize_3";
+  version = "3.10.0";
+  # rev is the commit of the tag, mainly for kustomize version command output
+  rev = "602ad8aa98e2e17f6c9119e027a09757e63c8bec";
+
+  ldflags = let t = "sigs.k8s.io/kustomize/api/provenance"; in [
+    "-s -w"
+    "-X ${t}.version=${version}"
+    "-X ${t}.gitCommit=${rev}"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "kustomize";
+    rev = "kustomize/v${version}";
+    sha256 = "sha256-ESIykbAKXdv8zM9be0zEJ71rBAzZby0aTg25NlCsIOM=";
+  };
+
+  doCheck = true;
+
+  # avoid finding test and development commands
+  sourceRoot = "source/kustomize";
+
+  vendorSha256 = "sha256-xLeetcmzvpILLLMhMx7oahWLxguFjG3qbYpeeWpFUlw=";
+
+  meta = with lib; {
+    description = "Customization of kubernetes YAML configurations";
+    longDescription = ''
+      kustomize lets you customize raw, template-free YAML files for
+      multiple purposes, leaving the original YAML untouched and usable
+      as is.
+    '';
+    homepage = "https://github.com/kubernetes-sigs/kustomize";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ carlosdagos vdemeester zaninime Chili-Man saschagrunert ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13718,6 +13718,8 @@ in
 
   kustomize = callPackage ../development/tools/kustomize { };
 
+  kustomize_3 = callPackage ../development/tools/kustomize/3.nix { };
+
   kustomize-sops = callPackage ../development/tools/kustomize/kustomize-sops.nix { };
 
   ktlint = callPackage ../development/tools/ktlint { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Kustomize 4 has a lot of breaking changes so it is desirable to keep the last version of Kustomize 3 available for installation in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
