### PR TITLE
ocamlPackages.stringext: 1.4.0 -> 1.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -19,7 +19,6 @@ buildDunePackage {
 
   meta = {
     homepage = "https://github.com/rgrinberg/stringext";
-    platforms = ocaml.meta.platforms or [];
     description = "Extra string functions for OCaml";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchurl, ocaml, buildDunePackage, ounit, qtest
+{ lib, fetchurl, ocaml, buildDunePackage, ounit, qtest
 # Optionally enable tests; test script use OCaml-4.01+ features
-, doCheck ? lib.versionAtLeast (lib.getVersion ocaml) "4.01"
+, doCheck ? lib.versionAtLeast ocaml.version "4.04"
 }:
 
 let version = "1.6.0"; in
@@ -8,7 +8,7 @@ let version = "1.6.0"; in
 buildDunePackage {
   pname = "stringext";
   version = version;
-
+  useDune2 = true;
   src = fetchurl {
     url = "https://github.com/rgrinberg/stringext/releases/download/${version}/stringext-${version}.tbz";
     sha256 = "1sh6nafi3i9773j5mlwwz3kxfzdjzsfqj2qibxhigawy5vazahfv";

--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -1,28 +1,21 @@
-{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, ounit, qcheck
+{ stdenv, lib, fetchurl, ocaml, buildDunePackage, ounit, qtest
 # Optionally enable tests; test script use OCaml-4.01+ features
 , doCheck ? lib.versionAtLeast (lib.getVersion ocaml) "4.01"
 }:
 
-let version = "1.4.3"; in
+let version = "1.6.0"; in
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-stringext-${version}";
+buildDunePackage {
+  pname = "stringext";
+  version = version;
 
-  src = fetchzip {
-    url = "https://github.com/rgrinberg/stringext/archive/v${version}.tar.gz";
-    sha256 = "121k79vjazvsd254yg391fp4spsd1p32amccrahd0g6hjhf5w6sl";
+  src = fetchurl {
+    url = "https://github.com/rgrinberg/stringext/releases/download/${version}/stringext-${version}.tbz";
+    sha256 = "1sh6nafi3i9773j5mlwwz3kxfzdjzsfqj2qibxhigawy5vazahfv";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ounit qcheck ];
-
-  configurePhase = "ocaml setup.ml -configure --prefix $out"
-  + lib.optionalString doCheck " --enable-tests";
-  buildPhase = "ocaml setup.ml -build";
+  checkInputs = [ ounit qtest ];
   inherit doCheck;
-  checkPhase = "ocaml setup.ml -test";
-  installPhase = "ocaml setup.ml -install";
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "https://github.com/rgrinberg/stringext";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstreaming packages from overlays

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
