### PR TITLE
ocamlPackages.routes: init at 0.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10776,6 +10776,12 @@
     githubId = 347983;
     name = "Udo Spallek";
   };
+  ulrikstrid = {
+    email = "ulrik.strid@outlook.com";
+    github = "ulrikstrid";
+    githubId = 1607770;
+    name = "Ulrik Strid";
+  };
   unode = {
     email = "alves.rjc@gmail.com";
     github = "unode";

--- a/pkgs/development/ocaml-modules/routes/default.nix
+++ b/pkgs/development/ocaml-modules/routes/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "routes";
+  version = "0.9.1";
+
+  useDune2 = true;
+  minimalOCamlVersion = "4.05";
+
+  src = fetchurl {
+    url = "https://github.com/anuragsoni/routes/releases/download/${version}/routes-${version}.tbz";
+    sha256 = "0h2c1p5w6237c1lmsl5c8q2dj5dq20gf2cmb12nbmlfn12sfmcrl";
+  };
+
+  meta = with lib; {
+    description = "Typed routing for OCaml applications";
+    license = licenses.bsd3;
+    homepage = "https://anuragsoni.github.io/routes";
+    maintainers = with maintainers; [ ulrikstrid anmonteiro ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1155,6 +1155,8 @@ let
 
     rope = callPackage ../development/ocaml-modules/rope { };
 
+    routes = callPackage ../development/ocaml-modules/routes { };
+
     rpclib = callPackage ../development/ocaml-modules/rpclib { };
 
     rpclib-lwt = callPackage ../development/ocaml-modules/rpclib/lwt.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstreaming packages from overlays

@anmonteiro is added as a maintaner with his concent

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
