### PR TITLE
ocamlPackages.alcotest-mirage: init at 1.2.3

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/mirage.nix
+++ b/pkgs/development/ocaml-modules/alcotest/mirage.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, alcotest, lwt, logs, mirage-clock, duration }:
+
+buildDunePackage {
+  pname = "alcotest-mirage";
+
+  inherit (alcotest) version src;
+
+  propagatedBuildInputs = [ alcotest lwt logs mirage-clock duration ];
+
+  doCheck = true;
+
+  meta = alcotest.meta // {
+    description = "Mirage implementation for Alcotest";
+    maintainers = with lib.maintainers; [ ulrikstrid anmonteiro ];
+  };
+}

--- a/pkgs/development/ocaml-modules/alcotest/mirage.nix
+++ b/pkgs/development/ocaml-modules/alcotest/mirage.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "alcotest-mirage";
 
-  inherit (alcotest) version src;
+  inherit (alcotest) version src useDune2;
 
   propagatedBuildInputs = [ alcotest lwt logs mirage-clock duration ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -22,6 +22,8 @@ let
 
     alcotest-lwt = callPackage ../development/ocaml-modules/alcotest/lwt.nix {};
 
+    alcotest-mirage = callPackage ../development/ocaml-modules/alcotest/mirage.nix {};
+
     angstrom = callPackage ../development/ocaml-modules/angstrom { };
 
     angstrom-async = callPackage ../development/ocaml-modules/angstrom-async { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstreaming packages from overlays

@anmonteiro added to maintainers with his concent

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
