### PR TITLE
chromiumDev: Fix build errors due to the older system FFmpeg

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -175,6 +175,18 @@ let
         sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
         revert = true;
       })
+      # To fix build errors with the older system FFmpeg:
+      (githubPatch {
+        # unbundle: add libavcodec/packet.h to shim headers
+        commit = "e4d228ec30607b06bf3fed77497abef89c29966a";
+        sha256 = "02jg2bdmgjcpmk6alb72jc93wy3nf2fpa72hb4aarq337i2mwn4v";
+      })
+      (githubPatch {
+        # Roll src/third_party/ffmpeg/ 7e1d53a09..cf7ee6598 (1000 commits)
+        commit = "3ec3b2992238d4b4764f99f04605e154688c7990";
+        sha256 = "1fwb154s5qcis490rvcvm14zrmaj59g5lg9zg8ada36vw9hycbrf";
+        revert = true;
+      })
     ];
 
     postPatch = ''


### PR DESCRIPTION
The final linking still fails though, even with llvm-git.
We might have to diable use_thin_lto for now:
ld.lld: error: undefined symbol: snappy::Compress(char const*, unsigned long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)
>>> referenced by compression_module.cc
>>>               thinlto-cache/Thin-ed5ed5.tmp.o:(reporting::CompressionModule::CompressRecord(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, base::OnceCallback<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, absl::optional<reporting::CompressionInformation>)>) const)
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
