### PR TITLE
arduino-cli: add zlib to the fhsenv

### DIFF
--- a/pkgs/development/arduino/arduino-cli/default.nix
+++ b/pkgs/development/arduino/arduino-cli/default.nix
@@ -46,6 +46,10 @@ if stdenv.isLinux then
     extraInstallCommands = ''
       mv $out/bin/$name $out/bin/arduino-cli
     '';
+
+    targetPkgs = pkgs: with pkgs; [
+      zlib
+    ];
   }
 else
   pkg


### PR DESCRIPTION
fixes #128604

zlib is needed for the espressif toolchain

###### Motivation for this change

make arduino-cli work with the esp32-toolchain

###### Things done

added zlib to targetPkgs of buildFHSUserEnv

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
