### PR TITLE
[21.05] exfatprogs: init at 1.1.2

### DIFF
--- a/pkgs/tools/filesystems/exfatprogs/default.nix
+++ b/pkgs/tools/filesystems/exfatprogs/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, file }:
+
+stdenv.mkDerivation rec {
+  pname = "exfatprogs";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "19pbybgbfnvjb3n944ihrn1r8ch4dm8dr0d44d6w7p63dcp372xy";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook file ];
+
+  meta = with lib; {
+    description = "exFAT filesystem userspace utilities";
+    homepage = "https://github.com/exfatprogs/exfatprogs";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ zane ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4822,6 +4822,8 @@ in
 
   exfat = callPackage ../tools/filesystems/exfat { };
 
+  exfatprogs = callPackage ../tools/filesystems/exfatprogs { };
+
   dos2unix = callPackage ../tools/text/dos2unix { };
 
   uni2ascii = callPackage ../tools/text/uni2ascii { };


### PR DESCRIPTION
(cherry picked from commit 67641dc31a098e7e2a6defcdbceea18d0cf38c3e)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
