### PR TITLE
home-assistant: support smart_meter_texas component

### DIFF
--- a/pkgs/development/python-modules/smart-meter-texas/default.nix
+++ b/pkgs/development/python-modules/smart-meter-texas/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, aiohttp
+, python-dateutil
+, tenacity
+}:
+
+buildPythonPackage rec {
+  pname = "smart-meter-texas";
+  version = "0.4.3";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "grahamwetzler";
+    repo = "smart-meter-texas";
+    rev = "v${version}";
+    sha256 = "09n03wbyjh1b1gsiibf17fg86x7k1i1r1kpp94p7w1lcdbmn8v5c";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner" ""
+  '';
+
+  propagatedBuildInputs = [
+    aiohttp
+    python-dateutil
+    tenacity
+  ];
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Connect to and retrieve data from the unofficial Smart Meter Texas API";
+    homepage = "https://github.com/grahamwetzler/smart-meter-texas";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -767,7 +767,7 @@
     "slide" = ps: with ps; [ ]; # missing inputs: goslide-api
     "sma" = ps: with ps; [ pysma ];
     "smappee" = ps: with ps; [ aiohttp-cors pysmappee ];
-    "smart_meter_texas" = ps: with ps; [ ]; # missing inputs: smart-meter-texas
+    "smart_meter_texas" = ps: with ps; [ smart-meter-texas ];
     "smarthab" = ps: with ps; [ smarthab ];
     "smartthings" = ps: with ps; [ aiohttp-cors hass-nabucasa pysmartapp pysmartthings ];
     "smarttub" = ps: with ps; [ python-smarttub ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -657,6 +657,7 @@ in with py.pkgs; buildPythonApplication rec {
     "sleepiq"
     "sma"
     "smappee"
+    "smart_meter_texas"
     "smarthab"
     "smartthings"
     "smarttub"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7984,6 +7984,8 @@ in {
 
   sly = callPackage ../development/python-modules/sly { };
 
+  smart-meter-texas = callPackage ../development/python-modules/smart-meter-texas { };
+
   smart-open = callPackage ../development/python-modules/smart-open { };
 
   smarthab = callPackage ../development/python-modules/smarthab { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
