### PR TITLE
janus-gateway: init at 0.11.3

### DIFF
--- a/pkgs/servers/janus-gateway/default.nix
+++ b/pkgs/servers/janus-gateway/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, gengetopt
+, glib, libconfig, libnice, jansson, boringssl, zlib, srtp, libuv
+, libmicrohttpd, curl, libwebsockets, sofia_sip, libogg, libopus
+, usrsctp, ffmpeg
+}:
+
+let
+  libwebsockets_janus = libwebsockets.overrideAttrs (_: {
+    configureFlags = [
+      "-DLWS_MAX_SMP=1"
+      "-DLWS_WITHOUT_EXTENSIONS=0"
+    ];
+  });
+in
+
+stdenv.mkDerivation rec {
+  pname = "janus-gateway";
+  version = "0.11.3";
+
+  src = fetchFromGitHub {
+    owner = "meetecho";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15nadpz67w24f4wz8ya0kx0a1jc4wxv1kl0d5fr7kckkdyijh7gz";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config gengetopt ];
+
+  buildInputs = [
+    glib libconfig libnice jansson boringssl zlib srtp libuv libmicrohttpd
+    curl libwebsockets_janus sofia_sip libogg libopus usrsctp ffmpeg
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-boringssl=${boringssl}"
+    "--enable-libsrtp2"
+    "--enable-turn-rest-api"
+    "--enable-json-logger"
+    "--enable-gelf-event-handler"
+    "--enable-post-processing"
+  ];
+
+  outputs = [ "out" "dev" "doc" "man" ];
+
+  postInstall = ''
+    moveToOutput share/janus "$doc"
+    moveToOutput etc "$doc"
+  '';
+
+  meta = with lib; {
+    description = "General purpose WebRTC server";
+    homepage = "https://janus.conf.meetecho.com/";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fpletz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19478,6 +19478,8 @@ in
 
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
+  janus-gateway = callPackage ../servers/janus-gateway { };
+
   jboss = callPackage ../servers/http/jboss { };
 
   jboss_mysql_jdbc = callPackage ../servers/http/jboss/jdbc/mysql { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
