### PR TITLE
nixos/rl-notes/21.11: add python3 default bump entry

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -14,10 +14,16 @@
   </itemizedlist>
   <section xml:id="sec-release-21.11-highlights">
     <title>Highlights</title>
-    <itemizedlist spacing="compact">
+    <itemizedlist>
       <listitem>
         <para>
           PHP now defaults to PHP 8.0, updated from 7.4.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>python3</literal> now defaults to Python 3.9, updated
+          from Python 3.8.
         </para>
       </listitem>
     </itemizedlist>
@@ -364,6 +370,14 @@
           soon <literal>foot</literal>) so this is only an issue when
           using a customized configuration and not installing
           <literal>rxvt-unicode</literal> explicitly.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>python3</literal> now defaults to Python 3.9. Python
+          3.9 introduces many deprecation warnings, please look at the
+          <link xlink:href="https://docs.python.org/3/whatsnew/3.9.html">What’s
+          New In Python 3.9 post</link> for more information.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -8,6 +8,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - PHP now defaults to PHP 8.0, updated from 7.4.
 
+- `python3` now defaults to Python 3.9, updated from Python 3.8.
+
 ## New Services {#sec-release-21.11-new-services}
 
 - [geoipupdate](https://github.com/maxmind/geoipupdate), a GeoIP database updater from MaxMind. Available as [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
@@ -90,3 +92,5 @@ In addition to numerous new and upgraded packages, this release has the followin
   However, if [`services.fail2ban.enable`](options.html#opt-services.fail2ban.enable) is `true`, the `fail2ban` will override the verbosity to `"VERBOSE"`, so that `fail2ban` can observe the failed login attempts from the SSH logs.
 
 - Sway: The terminal emulator `rxvt-unicode` is no longer installed by default via `programs.sway.extraPackages`. The current default configuration uses `alacritty` (and soon `foot`) so this is only an issue when using a customized configuration and not installing `rxvt-unicode` explicitly.
+
+- `python3` now defaults to Python 3.9. Python 3.9 introduces many deprecation warnings, please look at the [What's New In Python 3.9 post](https://docs.python.org/3/whatsnew/3.9.html) for more information.


### PR DESCRIPTION
###### Motivation for this change
Add rl notes bump entry

related: #128634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
