### PR TITLE
zsh: fix nixUnstable completions

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -53,7 +53,7 @@ in
       };
 
       shellAliases = mkOption {
-        default = {};
+        default = { };
         description = ''
           Set of aliases for zsh shell, which overrides <option>environment.shellAliases</option>.
           See <option>environment.shellAliases</option> for an option format description.
@@ -118,7 +118,9 @@ in
       setOptions = mkOption {
         type = types.listOf types.str;
         default = [
-          "HIST_IGNORE_DUPS" "SHARE_HISTORY" "HIST_FCNTL_LOCK"
+          "HIST_IGNORE_DUPS"
+          "SHARE_HISTORY"
+          "HIST_FCNTL_LOCK"
         ];
         example = [ "EXTENDED_HISTORY" "RM_STAR_WAIT" ];
         description = ''
@@ -279,14 +281,18 @@ in
     environment.etc.zinputrc.source = ./zinputrc;
 
     environment.systemPackages = [ pkgs.zsh ]
-      ++ optional (cfg.enableCompletion && ! lib.versionAtLeast (lib.getVersion config.nix.package) "2.4pre") pkgs.nix-zsh-completions;
+      ++ optional
+      (cfg.enableCompletion
+        && !lib.versionAtLeast (lib.getVersion config.nix.package) "2.4pre")
+      pkgs.nix-zsh-completions;
 
     environment.pathsToLink = optional cfg.enableCompletion "/share/zsh";
 
     #users.defaultUserShell = mkDefault "/run/current-system/sw/bin/zsh";
 
     environment.shells =
-      [ "/run/current-system/sw/bin/zsh"
+      [
+        "/run/current-system/sw/bin/zsh"
         "${pkgs.zsh}/bin/zsh"
       ];
 

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -280,11 +280,21 @@ in
 
     environment.etc.zinputrc.source = ./zinputrc;
 
-    environment.systemPackages = [ pkgs.zsh ]
-      ++ optional
-      (cfg.enableCompletion
-        && !lib.versionAtLeast (lib.getVersion config.nix.package) "2.4pre")
-      pkgs.nix-zsh-completions;
+    environment.systemPackages =
+      let
+        completions =
+          if lib.versionAtLeast (lib.getVersion config.nix.package) "2.4pre"
+          then
+            pkgs.nix-zsh-completions.overrideAttrs
+              (_: {
+                postInstall = ''
+                  rm $out/share/zsh/site-functions/_nix
+                '';
+              })
+          else pkgs.nix-zsh-completions;
+      in
+      [ pkgs.zsh ]
+      ++ optional cfg.enableCompletion completions;
 
     environment.pathsToLink = optional cfg.enableCompletion "/share/zsh";
 

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -279,7 +279,7 @@ in
     environment.etc.zinputrc.source = ./zinputrc;
 
     environment.systemPackages = [ pkgs.zsh ]
-      ++ optional cfg.enableCompletion pkgs.nix-zsh-completions;
+      ++ optional (cfg.enableCompletion && ! lib.versionAtLeast (lib.getVersion config.nix.package) "2.4pre") pkgs.nix-zsh-completions;
 
     environment.pathsToLink = optional cfg.enableCompletion "/share/zsh";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The unstable nix completions work very well. Unfortunately, zsh users have so far been left to fend for themselves when it comes to getting them working. This fixes the situation by ~~bumping `nixUnstable` to a commit with the working zsh completion script, and~~ cleaning up a conflict with `nixStable` and `nix-zsh-completions`.


###### Things done

Tested on my local NixOS machine and it works