### PR TITLE
maestral-gui: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.4.4";
+  version = "1.4.5";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-4IrLwpdMepXBxjgR6euENuVKaPRU0dLiApJO45DB2C4=";
+    sha256 = "sha256-HaEQTmpyM1r/+rTkki93aStdzdnhNmkfNJTZRTPehTw=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.4.4";
+  version = "1.4.5";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "03scg4y13jbi8n454hc4vq8p02isbhppqx0zhbady639p7l3ggfg";
+    sha256 = "sha256-kyOBF+qsl/+9u0P+EmfxbuJNGMqPSLCWJUlcZMyKJH4=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Upstream update https://github.com/SamSchott/maestral/releases/tag/v1.4.5

###### Things done

```
$ NIXPKGS_ALLOW_UNFREE=1 nixpkgs-review rev maestral-1.4.5
[...]
4 packages updated:
maestral (1.4.4 → 1.4.5) maestral-gui (1.4.4 → 1.4.5) python38Packages.maestral (1.4.4 → 1.4.5) python39Packages.maestral (1.4.4 → 1.4.5)
[...]
3 packages built:
maestral maestral-gui python39Packages.maestral
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
