### PR TITLE
pythonPackages.google-i18n-address: fix compatibility with Python 3.9

### DIFF
--- a/pkgs/development/python-modules/google-i18n-address/default.nix
+++ b/pkgs/development/python-modules/google-i18n-address/default.nix
@@ -1,14 +1,21 @@
-{ buildPythonPackage, fetchPypi, pythonAtLeast, lib, requests, pytestCheckHook, mock }:
+{ buildPythonPackage, fetchPypi, fetchpatch, lib, requests, pytestCheckHook, mock }:
 
 buildPythonPackage rec {
   pname = "google-i18n-address";
   version = "2.4.0";
-  disabled = pythonAtLeast "3.9";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "8454a58f254a29988b8d1ca9ab663fd28a1f392a3d29b844d8824807db6333d7";
   };
+
+  patches = [
+    # fix compatibility with Python 3.9
+    (fetchpatch {
+      url = "https://github.com/mirumee/google-i18n-address/commit/b1d63d980e8b1a666e312e1c05c9037e2920685b.patch";
+      sha256 = "0lhsvkcgwz3i4az5hj8irbn8mj4b8yffq03isa18qp3z616adlrp";
+    })
+  ];
 
   propagatedBuildInputs = [ requests ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Not having to wait until https://github.com/mirumee/google-i18n-address/issues/60 is resolved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
