### PR TITLE
home-assistant: support rfxtrx component

### DIFF
--- a/pkgs/development/python-modules/pyrfxtrx/default.nix
+++ b/pkgs/development/python-modules/pyrfxtrx/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyrfxtrx";
+  version = "0.27.0";
+
+  src = fetchFromGitHub {
+    owner = "Danielhiversen";
+    repo = "pyRFXtrx";
+    rev = version;
+    sha256 = "0nzgy56b2v3bnn9idlb67qkzj4cj5j9v1436ri1y305fqwjy48nm";
+  };
+
+  propagatedBuildInputs = [
+    pyserial
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Library to communicate with the RFXtrx family of devices";
+    homepage = "https://github.com/Danielhiversen/pyRFXtrx";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -696,7 +696,7 @@
     "rest" = ps: with ps; [ jsonpath xmltodict ];
     "rest_command" = ps: with ps; [ ];
     "rflink" = ps: with ps; [ rflink ];
-    "rfxtrx" = ps: with ps; [ ]; # missing inputs: pyRFXtrx
+    "rfxtrx" = ps: with ps; [ pyrfxtrx ];
     "ring" = ps: with ps; [ ha-ffmpeg ring-doorbell ];
     "ripple" = ps: with ps; [ ]; # missing inputs: python-ripple-api
     "risco" = ps: with ps; [ pyrisco ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -625,6 +625,7 @@ in with py.pkgs; buildPythonApplication rec {
     "rest"
     "rest_command"
     "rflink"
+    "rfxtrx"
     "ring"
     "risco"
     "rituals_perfume_genie"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5341,6 +5341,8 @@ in {
 
   pynx584 = callPackage ../development/python-modules/pynx584 { };
 
+  pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };
+
   pyrogram = callPackage ../development/python-modules/pyrogram { };
 
   pysbd = callPackage ../development/python-modules/pysbd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
