### PR TITLE
fishPlugins.pure: 3.4.2 -> 4.1.1

### DIFF
--- a/pkgs/shells/fish/plugins/pure.nix
+++ b/pkgs/shells/fish/plugins/pure.nix
@@ -2,14 +2,22 @@
 
 buildFishPlugin rec {
   pname = "pure";
-  version = "3.4.2";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
-    owner = "rafaelrinaldi";
+    owner = "pure-fish";
     repo = "pure";
     rev = "v${version}";
-    sha256 = "134sz3f98gb6z2vgd5kkm6dd8pka5gijk843c32s616w35y07sga";
+    sha256 = "1x1h65l8582p7h7w5986sc9vfd7b88a7hsi68dbikm090gz8nlxx";
   };
+
+  # The tests aren't passing either on the project's CI.
+  # The release notes of the program for v3.5.0 say:
+  # > Tests are going crazy at the moment, should be fixed once fishtape 3.0
+  # > is released, and we do the switch.
+  # This is tracked in https://github.com/pure-fish/pure/issues/272
+  # and https://github.com/pure-fish/pure/pull/275.
+  doCheck = false;
 
   checkInputs = [ git ];
   checkPlugins = [ fishtape ];


### PR DESCRIPTION
###### Motivation for this change

The repository of the project has been transferred to a GitHub organisation.
See https://github.com/pure-fish/pure/issues/249.

The tests of this package are also failing upstream, so they have been
temporarily disabled here too.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
