### PR TITLE
bintools: disable -pie when -r or -Ur are used

### DIFF
--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -37,7 +37,7 @@ fi
 for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
     pie)
-      if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static " || "$*" =~ " -r " || "$*" =~ " -Ur ") ]]; then
+      if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static " || "$*" =~ " -r " || "$*" =~ " -Ur " || "$*" =~ " -i ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
         hardeningLDFlags+=('-pie')
       fi

--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -37,7 +37,7 @@ fi
 for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
     pie)
-      if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static ") ]]; then
+      if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static " || "$*" =~ " -r " || "$*" =~ " -Ur ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
         hardeningLDFlags+=('-pie')
       fi


### PR DESCRIPTION
ld’s -r allows you to partially link object files. When -pie is passed with -r, though, we get:

  ld: -r and -pie may not be used together

Most build systems are intelligent enough to pass -no-pie before -r, but we might as well support those that
don’t.

Note: -pie is not enabled by default in Nixpkgs, but it is when you are using musl. So this solution is really
only useful for musl toolchains.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
