### PR TITLE
knockpy: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/tools/security/knockpy/default.nix
+++ b/pkgs/tools/security/knockpy/default.nix
@@ -5,30 +5,28 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "knockpy";
-  version = "5.0.0";
+  version = "5.1.0";
   disabled = python3.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "guelfoweb";
     repo = "knock";
     rev = version;
-    sha256 = "1h7sibdxx8y53xm1wydyng418n4j6baiys257msq03cs04jlm7h9";
+    sha256 = "sha256-4W6/omGPmQFuZ/2AVNgCs2q0ti/P8OY4o7b4/g9q+Rc=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
     beautifulsoup4
     colorama
+    matplotlib
+    networkx
+    pyqt5
     requests
   ];
 
-  postPatch = ''
-    # https://github.com/guelfoweb/knock/pull/95
-    substituteInPlace setup.py \
-      --replace "bs4" "beautifulsoup4"
-  '';
-
   # Project has no tests
   doCheck = false;
+
   pythonImportsCheck = [ "knockpy" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.1.0

Change log: https://github.com/guelfoweb/knock/releases/tag/5.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
