### PR TITLE
weechatScripts.weechat-go: init at 2.7

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -20,4 +20,6 @@
   weechat-autosort = callPackage ./weechat-autosort { };
 
   weechat-otr = callPackage ./weechat-otr { };
+
+  weechat-go = callPackage ./weechat-go { };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-go/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-go/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, weechat }:
+
+stdenv.mkDerivation {
+  pname = "weechat-go";
+  version = "2.7";
+
+  src = fetchurl {
+    url = "https://github.com/weechat/scripts/raw/414cff3ee605ba204b607742430a21443c035b08/python/go.py";
+    sha256 = "0bnbfpj1qg4yzwbikh1aw5ajc8l44lkb0y0m6mz8grpf5bxk5cwm";
+  };
+
+  dontUnpack = true;
+
+  passthru.scripts = [ "go.py" ];
+
+  installPhase = ''
+    install -D $src $out/share/go.py
+  '';
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "go.py is a weechat script to quickly jump to different buffers";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ govanify ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This is one of the featured scripts of weechat and an actually useful one, wouldn't hurt to have it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
