### PR TITLE
mixxx: 2.2.4 -> 2.3.0

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -1,48 +1,116 @@
-{ lib, mkDerivation, fetchurl, fetchFromGitHub, chromaprint
-, fftw, flac, faad2, glibcLocales, mp4v2
-, libid3tag, libmad, libopus, libshout, libsndfile, libusb1, libvorbis
-, libGLU, libxcb, lilv, lv2, opusfile
-, pkg-config, portaudio, portmidi, protobuf, qtbase, qtscript, qtsvg
-, qtx11extras, rubberband, sconsPackages, sqlite, taglib, upower, vamp-plugin-sdk
+{ lib
+, mkDerivation
+, fetchurl
+, fetchFromGitHub
+, chromaprint
+, cmake
+, faad2
+, ffmpeg
+, fftw
+, flac
+, glibcLocales
+, hidapi
+, lame
+, libebur128
+, libGLU
+, libid3tag
+, libkeyfinder
+, libmad
+, libmodplug
+, libopus
+, libsecret
+, libshout
+, libsndfile
+, libusb1
+, libvorbis
+, libxcb
+, lilv
+, lv2
+, mp4v2
+, opusfile
+, pcre
+, pkg-config
+, portaudio
+, portmidi
+, protobuf
+, qtbase
+, qtkeychain
+, qtscript
+, qtsvg
+, qtx11extras
+, rubberband
+, serd
+, sord
+, soundtouch
+, sratom
+, sqlite
+, taglib
+, upower
+, vamp-plugin-sdk
+, wavpack
 }:
 
-let
-  # Because libshout 2.4.2 and newer seem to break streaming in mixxx, build it
-  # with 2.4.1 instead.
-  libshout241 = libshout.overrideAttrs (o: rec {
-    name = "libshout-2.4.1";
-    src = fetchurl {
-      url = "http://downloads.xiph.org/releases/libshout/${name}.tar.gz";
-      sha256 = "0kgjpf8jkgyclw11nilxi8vyjk4s8878x23qyxnvybbgqbgbib7k";
-    };
-  });
-in
 mkDerivation rec {
   pname = "mixxx";
-  version = "2.2.4";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "mixxxdj";
     repo = "mixxx";
-    rev = "release-${version}";
-    sha256 = "1dj9li8av9b2kbm76jvvbdmihy1pyrw0s4xd7dd524wfhwr1llxr";
+    rev = version;
+    sha256 = "18sx4l3zzbn5142xfv5bp0crdd615a5728fkprqacnx3zpa144x6";
   };
 
-  nativeBuildInputs = [ sconsPackages.scons_3_1_2 ];
+  nativeBuildInputs = [ cmake pkg-config ];
+
   buildInputs = [
-    chromaprint fftw flac faad2 glibcLocales mp4v2 libid3tag libmad libopus libshout241 libsndfile
-    libusb1 libvorbis libxcb libGLU lilv lv2 opusfile pkg-config portaudio portmidi protobuf qtbase qtscript qtsvg
-    qtx11extras rubberband sqlite taglib upower vamp-plugin-sdk
+    chromaprint
+    faad2
+    ffmpeg
+    fftw
+    flac
+    glibcLocales
+    hidapi
+    lame
+    libebur128
+    libGLU
+    libid3tag
+    libkeyfinder
+    libmad
+    libmodplug
+    libopus
+    libsecret
+    libshout
+    libsndfile
+    libusb1
+    libvorbis
+    libxcb
+    lilv
+    lv2
+    mp4v2
+    opusfile
+    pcre
+    portaudio
+    portmidi
+    protobuf
+    qtbase
+    qtkeychain
+    qtscript
+    qtsvg
+    qtx11extras
+    rubberband
+    serd
+    sord
+    soundtouch
+    sratom
+    sqlite
+    taglib
+    upower
+    vamp-plugin-sdk
+    wavpack
   ];
 
   enableParallelBuilding = true;
-
-  sconsFlags = [
-    "build=release"
-    "qtdir=${qtbase}"
-    "faad=1"
-    "opus=1"
-  ];
 
   qtWrapperArgs = [
     "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
@@ -52,7 +120,7 @@ mkDerivation rec {
     homepage = "https://mixxx.org";
     description = "Digital DJ mixing software";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.goibhniu maintainers.bfortz ];
+    maintainers = with maintainers; [ goibhniu bfortz ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* version update
* replace scons with cmake
* add new dependencies:
  - hidapi, lame, libebur128, libkeyfinder, libmodplug, libsecret, qtkeychain, serd, sord, soundtouch, sratom, wavpack
* use latest libshout again - streaming issues have been fixed

// cc @goibhniu @bfortz for testing

* supersedes https://github.com/NixOS/nixpkgs/pull/92854


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
