### PR TITLE
nixos/nixos-install: build system using local nix store first

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -147,6 +147,14 @@ if [[ -z $system ]]; then
     outLink="$tmpdir/system"
     if [[ -z $flake ]]; then
         echo "building the configuration in $NIXOS_CONFIG..."
+
+        # We build the flake twice to populate the local nix store with
+        # all of the paths needed to do installation.
+        # This is to avoid situations where `nix-build --store <path> --extra-substitutres auto?trusted=1`
+        # errors on paths not being found in the local nix store.
+        # See https://github.com/NixOS/nixpkgs/issues/126141 for more details.
+        nix-build --no-out-link "${extraBuildFlags[@]}" \
+            '<nixpkgs/nixos>' -A system -I "nixos-config=$NIXOS_CONFIG" "${verbosity[@]}"
         nix-build --out-link "$outLink" --store "$mountPoint" "${extraBuildFlags[@]}" \
             --extra-substituters "$sub" \
             '<nixpkgs/nixos>' -A system -I "nixos-config=$NIXOS_CONFIG" "${verbosity[@]}"


### PR DESCRIPTION
###### Motivation for this change
Essentially apply current work-around described in #126141
closes: #126141

Commit message:
> We build the flake twice to populate the local nix store with
all of the paths needed to do installation.
This is to avoid situations where `nix-build --store <path> --extra-substitutres auto?trusted=1`
errors on paths not being found in the local nix store.
See https://github.com/NixOS/nixpkgs/issues/126141 for more details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
