### PR TITLE
shellhub-agent: 0.7.1 -> 0.7.2, gitRepo: 2.15.4 -> 2.16 

### DIFF
--- a/pkgs/applications/networking/shellhub-agent/default.nix
+++ b/pkgs/applications/networking/shellhub-agent/default.nix
@@ -9,18 +9,18 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    sha256 = "0fgkjv7p2p0k58ifs77qfy0ni2yhrmk8rqyysjxq0im6j3f3az11";
+    sha256 = "02ka7acynkwkml2pavlv4j5vkm6x5aq5sfxgydv26qzs39f1wdgc";
   };
 
   modRoot = "./agent";
 
-  vendorSha256 = "1avl5xvav9y2vni5w3ksvrcz67x2kkadqw9p1cfq5rkjny1c2jrg";
+  vendorSha256 = "18z3vwcwkyj6hcvl35qmj034237h9l18dvcbx1hxry7qdwv807c9";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.AgentVersion=v${version}" ];
 

--- a/pkgs/applications/version-management/git-repo/default.nix
+++ b/pkgs/applications/version-management/git-repo/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "git-repo";
-  version = "2.15.4";
+  version = "2.16";
 
   src = fetchFromGitHub {
     owner = "android";
     repo = "tools_repo";
     rev = "v${version}";
-    sha256 = "1ayw2pz9falcsi528q63z3w7npzkk7y8z258danqh41j6q9871js";
+    sha256 = "sha256-F36MuqgVkKM2RCIGEGJmL3/KpZy3eDRZ7WWUE15mTfU=";
   };
 
   # Fix 'NameError: name 'ssl' is not defined'


### PR DESCRIPTION


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
