### PR TITLE
services.tor.settings.ORPort: Set a default to `auto` to avoid fatal …

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -125,6 +125,7 @@ let
     default = [];
   };
   optionORPort = optionName: mkOption {
+    # NOTE(Krey): Set as `auto` if relaying is enable by default to avoid failure (https://github.com/NixOS/nixpkgs/pull/128713)
     default = if (services.tor.relay.enable == true)
       then "auto"
       else 0;

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -125,7 +125,9 @@ let
     default = [];
   };
   optionORPort = optionName: mkOption {
-    default = [];
+    default = if (services.tor.relay.enable == true)
+      then "auto"
+      else 0;
     example = 443;
     type = with types; oneOf [port (enum ["auto"]) (listOf (oneOf [
       port


### PR DESCRIPTION
…failure if relaying is enabled

```
[root@leonid:/home/kreyren]# /nix/store/725d1mm915f4qxxq03i08dyhyh6gyz4z-tor-0.4.5.7/bin/tor -f /nix/store/fdnf3gw73zcrkwsxajcya5lpqv6x4xmb-torrc --verify-config
Jun 30 04:00:52.107 [notice] Tor 0.4.5.7 running on Linux with Libevent 2.1.12-stable, OpenSSL 1.1.1k, Zlib 1.2.11, Liblzma 5.2.5, Libzstd 1.4.9 and Glibc 2.32 as libc.
Jun 30 04:00:52.107 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://www.torproject.org/download/download#warning
Jun 30 04:00:52.107 [notice] Read configuration file "/nix/store/fdnf3gw73zcrkwsxajcya5lpqv6x4xmb-torrc".
Jun 30 04:00:52.108 [warn] Failed to parse/validate config: BridgeRelay is 1, ORPort is not set. This is an invalid combination.
Jun 30 04:00:52.108 [err] Reading config failed--see warnings above.
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
