### PR TITLE
stern: 1.14.0 -> 1.19.0

### DIFF
--- a/pkgs/applications/networking/cluster/stern/default.nix
+++ b/pkgs/applications/networking/cluster/stern/default.nix
@@ -4,16 +4,18 @@ let isCrossBuild = stdenv.hostPlatform != stdenv.buildPlatform;
 in
 buildGoModule rec {
   pname = "stern";
-  version = "1.14.0";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "stern";
     repo = "stern";
     rev = "v${version}";
-    sha256 = "sha256-8l/Tr+IxR3yPmt9hI70XuUQ4YEYzRTMLbo8BsngoU60=";
+    sha256 = "sha256-jgmURvc1did3YgtqWlAzFbWxc3jHHylOfCVOLeAC7V8=";
   };
 
-  vendorSha256 = "sha256-pvFT4A7bDBvBf1odyv3z4inw1/IsvOA+++OPbfNjzxM=";
+  vendorSha256 = "sha256-p8WoFDwABXcO54WKP5bszoht2JdjHlRJjbG8cMyNo6A=";
+
+  subPackages = [ "." ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Update to the latest release

Note that I had to add `subPackages = [ "." ];` to the derivation to avoid encountering this build error:

```sh
error: builder for '/nix/store/h536lmc9sj2zfk2h004waxfzjadrkic1-stern-1.19.0.drv' failed with exit code 1;
       last 10 log lines:
       > github.com/google/btree
       > github.com/peterbourgon/diskv
       > github.com/gregjones/httpcache/diskcache
       > k8s.io/client-go/discovery/cached/disk
       > k8s.io/cli-runtime/pkg/genericclioptions
       > github.com/stern/stern/cmd
       > github.com/stern/stern
       > Building subPackage ./cmd
       > Building subPackage ./hack/tools
       > main module (github.com/stern/stern) does not contain package github.com/stern/stern/hack/tools
       For full logs, run 'nix log /nix/store/h536lmc9sj2zfk2h004waxfzjadrkic1-stern-1.19.0.drv'.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
