### PR TITLE
obs-move-transition: fix patch path

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-move-transition-use-FindLibobs.cmake.patch
+++ b/pkgs/applications/video/obs-studio/plugins/obs-move-transition-use-FindLibobs.cmake.patch
@@ -18,6 +18,7 @@ index f6d8fa3..5f0657d 100644
 +	"${LIBOBS_INCLUDE_DIR}/../UI/obs-frontend-api")
 +
  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version.h)
+
  set(move-transition_HEADERS
 @@ -38,4 +49,10 @@ target_link_libraries(move-transition
  	libobs)

--- a/pkgs/applications/video/obs-studio/plugins/obs-move-transition.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-move-transition.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     cp ${obs-studio.src}/cmake/external/FindLibobs.cmake FindLibobs.cmake
   '';
 
-  patches = [ ./0001-Use-FindLibobs.cmake.patch ];
+  patches = [ ./obs-move-transition-use-FindLibobs.cmake.patch ];
 
   postPatch = ''
     substituteInPlace move-source-filter.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'


### PR DESCRIPTION
###### Motivation for this change

There was a mistake in the path for the patch in #128270  which caused `obs-move-transition` not to build. Additionally, changes to the actual patch file rendered it invalid. This PR fixes both those things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
