### PR TITLE
python3Packages.async-dns: 1.1.9 -> 1.1.10

### DIFF
--- a/pkgs/development/python-modules/async-dns/default.nix
+++ b/pkgs/development/python-modules/async-dns/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , python
 , pythonOlder
@@ -9,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "async-dns";
-  version = "1.1.9";
+  version = "1.1.10";
   disabled = pythonOlder "3.6";
   format = "pyproject";
 
@@ -17,21 +16,11 @@ buildPythonPackage rec {
     owner = "gera2ld";
     repo = "async_dns";
     rev = "v${version}";
-    sha256 = "1z8j0s3dwcyavarhx41q75k1cmfzmwiqdh4svv3v15np26cywyag";
+    sha256 = "1yxmdlf2n66kp2mprsd4bvfsf63l4c4cfkjm2rm063pmlifz2fvj";
   };
 
   nativeBuildInputs = [
     poetry-core
-  ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/gera2ld/async_dns/pull/22
-    # Can be remove for async-dns>1.1.9
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/gera2ld/async_dns/commit/25fee497aae3bde0ddf9f8804d249a27edbe607e.patch";
-      sha256 = "0w4zlppnp1a2q1wasc95ymqx3djswl32y5nw6fvz3nn8jg4gc743";
-    })
   ];
 
   checkPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.153

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
