### PR TITLE
python3Packages.netmap: init at 0.7.0.2

### DIFF
--- a/pkgs/development/python-modules/netmap/default.nix
+++ b/pkgs/development/python-modules/netmap/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, substituteAll
+, nmap
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "netmap";
+  version = "0.7.0.2";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "python-nmap";
+    rev = version;
+    sha256 = "1a44zz9zsxy48ahlpjjrddpyfi7cnfknicfcp35hi588qm430mag";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./nmap-path.patch;
+      nmap = "${lib.getBin nmap}/bin/nmap";
+    })
+  ];
+
+  # upstream tests require sudo
+  # make sure nmap is found instead
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -c 'import nmap; nmap.PortScanner()'
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "nmap" ];
+
+  meta = with lib; {
+    description = "Python class to use nmap and access scan results from python3";
+    homepage = "https://github.com/home-assistant-libs/python-nmap";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/netmap/nmap-path.patch
+++ b/pkgs/development/python-modules/netmap/nmap-path.patch
@@ -1,0 +1,17 @@
+diff --git a/nmap/nmap.py b/nmap/nmap.py
+index 91c460d..8c5ff0a 100755
+--- a/nmap/nmap.py
++++ b/nmap/nmap.py
+@@ -77,11 +77,7 @@ class PortScanner(object):
+     def __init__(
+         self,
+         nmap_search_path=(
+-            "nmap",
+-            "/usr/bin/nmap",
+-            "/usr/local/bin/nmap",
+-            "/sw/bin/nmap",
+-            "/opt/local/bin/nmap",
++            "@nmap@",
+         ),
+     ):
+         """

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5233,6 +5233,8 @@ in {
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };
 
+  netmap = callPackage ../development/python-modules/netmap { };
+
   openapi-core = callPackage ../development/python-modules/openapi-core { };
 
   pdunehd = callPackage ../development/python-modules/pdunehd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This will be required by Home Assistant: https://github.com/home-assistant/core/pull/52300

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@fabaff I believe a patch is preferred over adding `nmap` to `propagatedBuildInputs`, as you did for `pythonPackages.python-nmap`.