### PR TITLE
fetchNodeModules: init

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -137,6 +137,47 @@ For more information about the generation process, consult the
 [README.md](https://github.com/svanderburg/node2nix) file of the `node2nix`
 tool.
 
+## Vendoring of dependencies {#nodejs-vendoring-of-dependencies}
+
+For projects that include a NPM lock file (`package-lock.json`), it's
+also possible to fetch a reproducible set of dependencies from NPM using
+the `fetchNodeModules` fetcher. `fetchNodeModules` can be used as follows:
+
+```nix
+nodeModules = nodePackages.fetchNodeModules {
+  inherit src;
+  hash = "sha256-TMsC8eEQ4whZtSoiVyjcEg72j9VEms82QeJrgl6zCsA=";
+}
+```
+
+The `src` attribute is required, as well as a hash specified through
+one of the `sha256` or `hash` attributes. The following optional
+attributes can also be used:
+
+* `name`: the name that is used for the dependencies tarball/directory.
+  If `name` is not specified, then one will be created from the name of
+  `src`.
+* `sourceRoot`: when `package.json` and `package-lock.json` are in a
+  subdirectory, `sourceRoot` specifies the relative path to these
+  files.
+* `makeTarball`: whether to create a tarball or a directory as the
+  output. By default, a tarball is created.
+* `runScripts`: whether to run NPM scripts bundled with the packages.
+  By default, scripts are not run as they may lead to non-deterministic
+  output.
+* `production`: whether to only install runtime dependencies or not.
+  By default, this is `true` so that dev dependencies will not be
+  installed.
+* `exposeBin`: whether to expose executables in `$out/bin`. This can
+  only be used when `makeTarball` is set to `false`.
+* `npmFlags`: additional flags to be passed to the `npm` command.
+
+Depending on whether `makeTarball` is set, the output of `fetchNodeModules`
+is either a tarball containing the `node_modules` directory, or a directory
+with the modules located in `lib/node_modules`. If the dependencies provide
+executable commands, a `bin` directory will also be created containing the
+executables.
+
 ## Tool specific instructions {#javascript-tool-specific}
 
 ### node2nix {#javascript-node2nix}

--- a/pkgs/build-support/fetchnodemodules/default.nix
+++ b/pkgs/build-support/fetchnodemodules/default.nix
@@ -1,0 +1,91 @@
+{ lib, stdenvNoCC, makeWrapper, nodejs }:
+
+{ src
+, hash ? ""
+, sha256 ? ""
+, name ? null
+, production ? true
+, runScripts ? false
+, makeTarball ? true
+, preferLocalBuild ? true
+, npmFlags ? ""
+, ...
+} @ args:
+
+let
+  suffix = if makeTarball then ".tar.gz" else "";
+  prodSuffix = if production then "-production" else "-dev";
+  name_ = if name == null then "${src.name}-node_modules${prodSuffix}${suffix}" else name;
+  nodejs_ = if args ? nodejs then args.nodejs else nodejs;
+
+  hash_ =
+    if hash != "" then { outputHashAlgo = null; outputHash = hash; }
+    else if sha256 != "" then { outputHashAlgo = "sha256"; outputHash = sha256; }
+    else throw "fetchNodeModules requires a hash for ${name_}";
+
+  customArgs = [ "name" "hash" "sha256" ];
+in stdenvNoCC.mkDerivation ({
+  inherit src production runScripts makeTarball preferLocalBuild;
+
+  name = name_;
+  nativeBuildInputs = [ nodejs_ makeWrapper ];
+
+  phases = "unpackPhase patchPhase buildPhase installPhase";
+
+  buildPhase = ''
+    if [[ ! -f package.json ]]; then
+        echo
+        echo "ERROR: The package.json file doesn't exist"
+        echo
+        exit 1
+    fi
+    if [[ ! -f package-lock.json ]]; then
+        echo
+        echo "ERROR: The package-lock.json file doesn't exist"
+        echo
+        echo "package-lock.json is required to make sure the node_modules"
+        echo "set we download never changes."
+        exit 1
+    fi
+
+    export SOURCE_DATE_EPOCH=1
+    export npm_config_cache=/tmp
+    NPM_FLAGS="--no-update-notifier $npmFlags"
+
+    # Scripts may result in non-deterministic behavior.
+    # Some packages (e.g., Puppeteer) use postinstall scripts to download extra data.
+    if [[ -z $runScripts ]]; then
+        NPM_FLAGS+=" --ignore-scripts"
+    fi
+
+    # Whether to install dev dependencies
+    if [[ -n $production ]]; then
+        NPM_FLAGS+=" --production"
+    fi
+
+    echo "Running npm ci $NPM_FLAGS"
+    npm ci $NPM_FLAGS
+
+    echo "Injecting package manifest into output"
+    cp package.json node_modules/
+    cp package-lock.json node_modules/
+  '';
+
+  installPhase = ''
+    if [[ -n $makeTarball ]]; then
+        # Produce a deterministic tarball
+        tar -czf $out --owner=0 --group=0 --numeric-owner --format=gnu \
+            --mtime="@$SOURCE_DATE_EPOCH" --sort=name \
+            node_modules
+    else
+        # Copy all modules into a directory
+        mkdir -p $out/lib
+        cp -r node_modules $out/lib
+    fi
+  '';
+
+  outputHashMode = if makeTarball then "flat" else "recursive";
+  inherit (hash_) outputHashAlgo outputHash;
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+} // (builtins.removeAttrs args customArgs))

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -8,6 +8,8 @@ let
     inherit (stdenv.hostPlatform) system;
   };
   self = super // {
+    fetchNodeModules = pkgs.callPackage ../../build-support/fetchnodemodules { };
+
     "@angular/cli" = super."@angular/cli".override {
       prePatch = ''
         export NG_CLI_ANALYTICS=false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds a new fetcher, `fetchNodeModules`, which can download deterministic dependency sets from the public NPM registry according to the NPM lock file (`package-lock.json`). This is useful for ensuring that Node.js packages are able to use dependencies at the exact versions specified by upstream, avoiding silent breakages caused by updates to the shared `nodePackages` package set which does not respect semantic versioning. The fetcher will also greatly simplify the work required to package Node.js projects with complex dependencies without sacrificing reproducibility.

###### Background

Currently, adding a package that makes use of the NPM ecosystem to Nixpkgs is done by adding all NPM dependencies it requires to one of the following places, both of which come with their own downsides:

<details>
<summary>Shared `nodePackages` package set</summary>

We keep a shared list of NPM packages in `pkgs/development/node-packages/node-packages.json`. When people add packages to this list, a script (`generate.sh`) is run which fetches the latest versions of *all* packages in the list from NPM, writing the URLs to retrieve the packages along with their hashes into `node-packages.nix`. This workflow has several major downsides:

- **Unrelated changes always get introduced.** When the generator script is run, all packages in the shared list are updated at once, regardless of whether they are necessary or not.
- **Semantic versioning is violated.** The generator always fetches the latest version of the packages (sans several manual exceptions), without taking compatibility into consideration.
- **Merge conflicts are a frequent occurrence.** PRs proposing changes to the shared package set (e.g., #126664, #115474) are often met with merge conflicts as the generator script often introduces large, unrelated changes to the shared `node-packages.nix`.
- **The package update process is slow.** Fetching all of the shared packages is often a slow process for maintainers. 

All of these inevitably lead to silent breakages of unrelated packages. An example of silent breakage can be found in a proposed addition of the BGPAlerter package (#115474). A major update to `js-yaml` (3.14.1 -> 4.0.0) was introduced in [a PR](https://github.com/NixOS/nixpkgs/pull/108596) that updates rust-analyzer package. Unfortunately, this release is not backwards-compatible (indicated by the increase of the major release number) and it removes several deprecated functions that were available in earlier versions (e.g., `safeLoad`). For BGPAlerter, the configuration wizard (run when there is no configuration) works without issue while actually starting the monitoring daemon will fail because of the removed `safeLoad` function. In other words, such breakages can be invisible even from those directly testing the packages.
</details>

<details>
<summary>Private dependency set</summary>

Alternatively, maintainers can also opt to separate their packages from the global shared package list. They work similarly to the global list, except at a smaller scale with changes affecting only the package itself. A tool like `node2nix` and `yarn2nix` is used to convert the NPM/Yarn dependencies (with version constraints, and in most cases, lock files) into Nix expressions containing a list of URLs and hashes corresponding to each dependency. Dependencies are downloaded according to the version constraints specified in the package's manifest (`package.json`), and in most cases, a lock file (`yarn.lock`, `package-lock.json`) will be used which specifies the exact version for each required dependency. Because of that, breakages do not occur for packages using their private dependency sets.

Due to the interconnected nature of the NPM ecosystem, the generated Nix expressions can be [extremely long](https://github.com/NixOS/nixpkgs/blob/cd3ed54f6ea1c13d45c6772b4752ae6d2ff35997/pkgs/applications/networking/cluster/spacegun/node-packages.nix), often with line counts in the thousands or even tens of thousands. As a result, reviewers can be [reluctant](https://github.com/NixOS/nixpkgs/pull/115474#discussion_r590050056) accepting new packages with their private dependency sets. The shared package set remains the preferred way for smaller leaf packages, and thus has to suffer from the issues listed above.

A list of packages that have their own dependency sets can be found by searching for `offline_cache =` and `generated by node2nix` in Nixpkgs.

</details>

###### `fetchNodeModules`

`fetchNodeModules` is similar to the `fetchCargoTarball` fetcher for Rust packages in that it relies on the native language-specific package manager (npm) to complete the entire process of resolving and downloading dependencies, resulting in a bundle of frozen packages. A fixed-output derivation is used to allow npm network access and the results are compared against a predetermined hash in the Nix expression.

The process is reproducible because like it relies on a lock file which specifies the exact version for each required dependency along with hashes created from the its contents, like `yarn2nix` and `node2nix` mentioned above. The difference is that the dependency list is not converted to Nix and only standard tools for the language are used. Reproducibility is enforced both in npm (lock file) and Nix (hash of final output).

It is important to note that the [original lock file](https://github.com/dvallin/spacegun/blob/86d42ae8dbfd5b76df1fc837b7a035c35e700b26/package-lock.json) and [the translated Nix expressions](https://github.com/NixOS/nixpkgs/blob/cd3ed54f6ea1c13d45c6772b4752ae6d2ff35997/pkgs/applications/networking/cluster/spacegun/node-packages.nix) from the aforementioned tools contain the same level of information. `fetchNodeModules` does not work with projects without a lock file.

###### Example

A tarball of all runtime dependencies of BGPAlerter can be created with the expression below:

```
pkgs.nodePackages.fetchNodeModules {
  src = fetchFromGitHub {
    owner = "nttgin";
    repo = "BGPalerter";
    rev = "v1.28.1";
    sha256 = "sha256-Y0atkJfZxjUOGPQ3goXS/YD5SsX9ZjpbM0Nc5IuaFP4=";
  };

  makeTarball = true;
  sha256 = "sha256-850tsQSYWECziz5qMoTUKRpIF7wKMuRj1e54VeWEOV4=";
}
```

###### See also

- https://github.com/NixOS/nixpkgs/pull/115474#issuecomment-870899532
- https://news.ycombinator.com/item?id=27371665

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
