### PR TITLE
subtitleeditor: cleanup using rec

### DIFF
--- a/pkgs/applications/video/subtitleeditor/default.nix
+++ b/pkgs/applications/video/subtitleeditor/default.nix
@@ -3,13 +3,9 @@
   libsigcxx, libxmlxx, xdg-utils, isocodes, wrapGAppsHook
 }:
 
-let
-  version = "0.54.0";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "subtitleeditor";
-  inherit version;
+  version = "0.54.0";
 
   src = fetchFromGitHub {
     owner = "kitone";


### PR DESCRIPTION
###### Motivation for this change
very little cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
