### PR TITLE
pythonPackages.fontmath: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/fontmath/default.nix
+++ b/pkgs/development/python-modules/fontmath/default.nix
@@ -1,17 +1,20 @@
-{ lib, buildPythonPackage, fetchPypi
-, fonttools
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, fonttools, setuptools-scm
 , pytest, pytestrunner
 }:
 
 buildPythonPackage rec {
   pname = "fontMath";
-  version = "0.6.0";
+  version = "0.8.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09xdqdjyjlx5k9ymi36d7hkgvn55zzjzd65l2yqidkfazlmh14ss";
+    sha256 = "0m2z2wwbxwljfcrg8hx4xq538adzcjpc352yqbfw0czbgs5ixmrr";
     extension = "zip";
   };
+
+  nativeBuildInputs = [ setuptools-scm ];
 
   propagatedBuildInputs = [ fonttools ];
   checkInputs = [ pytest pytestrunner ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tested on `x86_64-linux`:

```
/nix/store/bcgvapk6hyiiakjzfk5pcn9ggvjiwssd-liberation-fonts-2.1.0
/nix/store/k4wir8q8v5pnjcsxrqjbxviv1n5dimn9-liberation-fonts-1.07.5
/nix/store/vpxxkph3999n79n2wgm1r308cv22p4yl-noto-fonts-emoji-2020-09-16-unicode13.1
/nix/store/0jj8ipa3knks45qsw3difpf34am94dg2-scfbuild-1.0.3
/nix/store/c2i6a9aqxkcmbnwgfl5l75qbzyy552v7-twitter-color-emoji-13.0.2
/nix/store/w08sgvf77fhirc2vf9afdsn013y7a97n-rictydiminished-with-firacode-1.2.2
/nix/store/gwirzkqdwms39ga1rqk09fjjj8fi4lyr-liberation-sans-narrow-1.07.6
/nix/store/7m8yv390xzya1x487cz5aivn0pg8y5j4-visidata-2.4
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
