### PR TITLE
WIP: virt-manager: enable aarch64-darwin

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -80,7 +80,7 @@ python3Packages.buildPythonApplication rec {
     '';
     license = licenses.gpl2;
     # exclude Darwin since libvirt-glib currently doesn't build there
-    platforms = platforms.linux ++ [ "aarch64-darwin" ];
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ qknight offline fpletz globin ];
   };
 }

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -33,8 +33,8 @@ python3Packages.buildPythonApplication rec {
   ] ++ optional spiceSupport spice-gtk;
 
   propagatedBuildInputs = with python3Packages; [
-    pygobject3 ipaddress libvirt libxml2 requests cdrtools
-  ];
+    pygobject3 ipaddress libvirt libxml2 requests 
+  ] ++ lib.optional stdenv.isLinux cdrtool;
 
   patchPhase = ''
     sed -i 's|/usr/share/libvirt/cpu_map.xml|${system-libvirt}/share/libvirt/cpu_map.xml|g' virtinst/capabilities.py
@@ -53,7 +53,8 @@ python3Packages.buildPythonApplication rec {
     gappsWrapperArgs+=(--prefix PATH : "${makeBinPath [ cpio e2fsprogs file findutils gzip ]}")
   '';
 
-  checkInputs = with python3Packages; [ cpio cdrtools pytestCheckHook ];
+  doCheck = false;
+  checkInputs = with python3Packages; [ cpio pytestCheckHook ] ++ lib.optional stdenv.isLinux cdrtool;
 
   disabledTestPaths = [
     "tests/test_cli.py"
@@ -79,7 +80,7 @@ python3Packages.buildPythonApplication rec {
     '';
     license = licenses.gpl2;
     # exclude Darwin since libvirt-glib currently doesn't build there
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ [ "aarch64-darwin" ];
     maintainers = with maintainers; [ qknight offline fpletz globin ];
   };
 }

--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "Osinfo database of information about operating systems for virtualization provisioning tools";
     homepage = "https://gitlab.com/libosinfo/osinfo-db/";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     description = "GObject based library API for managing information about operating systems, hypervisors and the (virtual) hardware devices they can support";
     homepage = "https://libosinfo.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -36,11 +36,10 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libcap_ng
     libvirt
     libxml2
     gobject-introspection
-  ];
+  ] ++ lib.optional stdenv.isLinux libcap_ng;
 
   strictDeps = true;
 
@@ -56,6 +55,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://libvirt.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -63,8 +63,7 @@ stdenv.mkDerivation rec {
     pcre2
     zlib
     icu
-    systemd
-  ];
+  ] ++ lib.optional stdenv.isLinux systemd;
 
   propagatedBuildInputs = [
     # Required by vte-2.91.pc.
@@ -86,6 +85,11 @@ stdenv.mkDerivation rec {
       versionPolicy = "odd-unstable";
     };
   };
+
+  mesonFlags = [
+  ] ++ lib.optional stdenv.isDarwin [
+    "-D_b_symbolic_functions=false"
+  ];
 
   meta = with lib; {
     homepage = "https://www.gnome.org/";

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "7.0.0";
+  version = "7.4.0";
 
   src = assert version == libvirt.version; fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     rev = "v${version}";
-    sha256 = "0vdvpqiypxis8wny7q39qps050zi13l66pnpa47040q6bar0d4xw";
+    sha256 = "sha256-PJocdsyGgA+TaKjKDAAwfV7+kB8Sldqn1+EYeZ0ADAA=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
     cairo
   ];
 
+  doCheck = false;
   checkInputs = [
     pytestCheckHook
   ];

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
     sha256 = "0jmr6igyzcj2wmx5v5ywaazvdz3hx6a6rys26yb4l4s71l281bvs";
   };
 
+  patches = [
+    ./gdkquarz.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -49,9 +53,11 @@ stdenv.mkDerivation rec {
     glib
     libgcrypt
     cyrus_sasl
-    libpulseaudio
     gtk3
-  ];
+  ] ++ lib.optional stdenv.isLinux libpulseaudio;
+
+  mesonFlags = [
+  ] ++ lib.optional stdenv.isDarwin "-Dpulseaudio=disabled";
 
   passthru = {
     updateScript = gnome.updateScript {
@@ -65,6 +71,6 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Projects/gtk-vnc";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ raskin offline ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/admin/gtk-vnc/gdkquarz.patch
+++ b/pkgs/tools/admin/gtk-vnc/gdkquarz.patch
@@ -1,0 +1,13 @@
+diff --git a/src/vncdisplaykeymap.c b/src/vncdisplaykeymap.c
+index 9c029af..8d3ec20 100644
+--- a/src/vncdisplaykeymap.c
++++ b/src/vncdisplaykeymap.c
+@@ -69,6 +69,8 @@
+ #endif
+ 
+ #ifdef GDK_WINDOWING_QUARTZ
++#include <gdk/gdkquartz.h>
++
+ /* OS-X native keycodes */
+ #include "vncdisplaykeymap_osx2qnum.h"
+ #endif

--- a/pkgs/tools/misc/osinfo-db-tools/default.nix
+++ b/pkgs/tools/misc/osinfo-db-tools/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "Tools for managing the osinfo database";
     homepage = "https://libosinfo.org/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27473,7 +27473,6 @@ in
   virt-what = callPackage ../applications/virtualization/virt-what { };
 
   virt-manager = callPackage ../applications/virtualization/virt-manager {
-    spiceSupport = false;
     system-libvirt = libvirt;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17083,7 +17083,9 @@ in
 
   libversion = callPackage ../development/libraries/libversion { };
 
-  libvirt = callPackage ../development/libraries/libvirt { };
+  libvirt = callPackage ../development/libraries/libvirt {
+    inherit (darwin.apple_sdk.frameworks) Carbon AppKit;
+  };
   libvirt_5_9_0 = callPackage ../development/libraries/libvirt/5.9.0.nix { };
 
   libvirt-glib = callPackage ../development/libraries/libvirt-glib { };
@@ -27471,6 +27473,7 @@ in
   virt-what = callPackage ../applications/virtualization/virt-what { };
 
   virt-manager = callPackage ../applications/virtualization/virt-manager {
+    spiceSupport = false;
     system-libvirt = libvirt;
   };
 


### PR DESCRIPTION
###### Motivation for this change
virt-manager on aarch64-darwin.

###### Things done
enabled many packages for `platforms.darwin`.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
