### PR TITLE
praat: 6.0.43 -> 6.1.50

### DIFF
--- a/pkgs/applications/audio/praat/default.nix
+++ b/pkgs/applications/audio/praat/default.nix
@@ -1,30 +1,34 @@
-{ lib, stdenv, fetchurl, alsa-lib, gtk2, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, wrapGAppsHook, alsa-lib, gtk3, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   pname = "praat";
-  version = "6.0.43";
+  version = "6.1.50";
 
-  src = fetchurl {
-    url = "https://github.com/praat/praat/archive/v${version}.tar.gz";
-    sha256 = "1l13bvnl7sv8v6s5z63201bhzavnj6bnqcj446akippsam13z4sf";
+  src = fetchFromGitHub {
+    owner = "praat";
+    repo = "praat";
+    rev = "v${version}";
+    sha256 = "11cw4292pml71hdnfy8y91blwyh45dyam1ywr09355zk44c5njpq";
   };
 
   configurePhase = ''
-    cp makefiles/makefile.defs.linux.alsa makefile.defs
+    cp makefiles/makefile.defs.linux.pulse makefile.defs
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp praat $out/bin
+    install -Dt $out/bin praat
   '';
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ alsa-lib gtk2 ];
+  nativeBuildInputs = [ pkg-config wrapGAppsHook ];
+  buildInputs = [ alsa-lib gtk3 libpulseaudio ];
 
-  meta = {
+  enableParallelBuilding = true;
+
+  meta = with lib; {
     description = "Doing phonetics by computer";
     homepage = "https://www.fon.hum.uva.nl/praat/";
-    license = lib.licenses.gpl2Plus; # Has some 3rd-party code in it though
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2Plus; # Has some 3rd-party code in it though
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix build, switch to GTK 3, enable pulseaudio (without it praat is silent until reconfigured).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
