### PR TITLE
pythonPackages.parsedatetime: skip impure tests

### DIFF
--- a/pkgs/development/python-modules/parsedatetime/default.nix
+++ b/pkgs/development/python-modules/parsedatetime/default.nix
@@ -2,9 +2,8 @@
 , buildPythonPackage
 , fetchPypi
 , isPy27
-, pytest
-, pytest-runner
 , future
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,13 +16,24 @@ buildPythonPackage rec {
     sha256 = "4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455";
   };
 
-  buildInputs = [ pytest pytest-runner ];
   propagatedBuildInputs = [ future ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "tests/Test*.py" ];
+
+  disabledTests = [
+    # https://github.com/bear/parsedatetime/issues/263
+    "testDate3ConfusedHourAndYear"
+    # https://github.com/bear/parsedatetime/issues/215
+    "testFloat"
+  ];
+
+  pythonImportChecks = [ "parsedatetime" ];
 
   meta = with lib; {
     description = "Parse human-readable date/time text";
     homepage = "https://github.com/bear/parsedatetime";
     license = licenses.asl20;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Building `pythonPackages.parsedatetime` fails today.  Looking through the upstream bug tracker, it also fails in the month of March.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
