### PR TITLE
dprint: init at 0.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5422,6 +5422,16 @@
     githubId = 788813;
     name = "Bryan Gardiner";
   };
+  khushraj = {
+    email = "khushraj.rathod@gmail.com";
+    github = "KhushrajRathod";
+    githubId = 44947946;
+    name = "Khushraj Rathod";
+    keys = [{
+      longkeyid = "rsa2048/0xB77B2A40E7702F19";
+      fingerprint = "1988 3FD8 EA2E B4EC 0A93  1E22 B77B 2A40 E770 2F19";
+    }];
+  };
   KibaFox = {
     email = "kiba.fox@foxypossibilities.com";
     github = "KibaFox";

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchCrate, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dprint";
+  version = "0.15.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-1DUGp+HiiY03fyZ+b8hNUBIfuQV5Z/gEcOxc/vG3YiA=";
+  };
+
+  cargoSha256 = "sha256-twFXA8A+vP1n6IFJO78fKNs+FC2ui46rj1JmJ/eq3wc=";
+
+  # Tests fail because they expect a test WASM plugin. Tests already run for
+  # every commit upstream on GitHub Actions
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Code formatting platform written in Rust";
+    longDescription = ''
+      dprint is a pluggable and configurable code formatting platform written in Rust.
+      It offers multiple WASM plugins to support various languages. It's written in
+      Rust, so it’s small, fast, and portable.
+    '';
+    changelog = "https://github.com/dprint/dprint/releases/tag/${version}";
+    homepage = "https://dprint.dev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ khushraj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13299,6 +13299,8 @@ in
     inherit (llvmPackages_11) llvm libclang;
   };
 
+  dprint = callPackage ../development/tools/dprint { };
+
   libcxx = llvmPackages.libcxx;
   libcxxabi = llvmPackages.libcxxabi;
 


### PR DESCRIPTION
###### Motivation for this change

Adds new package for https://github.com/dprint/dprint

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
