### PR TITLE
linuxPackages.evdi: 2021-04-01 -> 2021-06-11, fix 5.13 build

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -2,14 +2,27 @@
 
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "unstable-20210401";
+  version = "unstable-2021-06-11";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = pname;
-    rev = "b0b3d131b26df62664ca33775679eea7b70c47b1";
-    sha256 = "09apbvdc78bbqzja9z3b1wrwmqkv3k7cn3lll5gsskxjnqbhxk9y";
+    rev = "65e12fca334f2f42396f4e8d16592d53cab34dd6";
+    sha256 = "sha256-81IfdYKadKT7vRdkmxzfGo4KHa4UJ8uJ0K6djQCr22U=";
   };
+
+  # Linux 5.13 support
+  # The patches break compilation for older kernels
+  patches = lib.optional (kernel.kernelAtLeast "5.13") [
+    (fetchpatch {
+      url = "https://github.com/DisplayLink/evdi/commit/c5f5441d0a115d2cfc8125b8bafaa05b2edc7938.patch";
+      sha256 = "sha256-tWYgBrRh3mXPebhUygOvJ07V87g9JU66hREriACfEVI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/DisplayLink/evdi/commit/5f04d2e2df4cfd21dc15d31f1152c6a66fa48a78.patch";
+      sha256 = "sha256-690/eUiEVWvnT/YAVgKcLo86dgolF9giWRuPxXpL+eQ=";
+    })
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
@@ -31,8 +44,8 @@ stdenv.mkDerivation rec {
     description = "Extensible Virtual Display Interface";
     maintainers = with maintainers; [ eyjhb ];
     platforms = platforms.linux;
-    license = with licenses; [ lgpl21 gpl2 ];
+    license = with licenses; [ lgpl21Only gpl2Only ];
     homepage = "https://www.displaylink.com/";
-    broken = versionOlder kernel.version "4.19" || stdenv.isAarch64;
+    broken = kernel.kernelOlder "4.19" || stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix 5.13 build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
