### PR TITLE
zfsUnstable: 2.1.0-rc7 -> 2.1.0-rc8

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -205,12 +205,12 @@ in {
 
   zfsUnstable = common {
     # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.13";
+    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.14";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2.1.0-rc7";
+    version = "2.1.0-rc8";
 
-    sha256 = "11dvz8r5l7cbhbx2j02y6335i2vibh29dqrqk4kmw4lf87g1isni";
+    sha256 = "0c53ca6xd59c30h3b2hmvyy63yqyk745x1kdfypnfqj3lnsj1pac";
 
     isUnstable = true;
   };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/openzfs/zfs/releases/tag/zfs-2.1.0-rc8

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).