### PR TITLE
shared-mime-info: strictdeps

### DIFF
--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -39,10 +39,8 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     itstool
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     libxml2
-    shared-mime-info
-  ];
+  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) shared-mime-info;
 
   buildInputs = [
     libxml2

--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
     glib
   ];
 
+  strictDeps = true;
+
   mesonFlags = [
     "-Dupdate-mimedb=true"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The second commit of #128553 felt a little dirty because it specified an incomplete dependency list in order to avoid triggering rebuilds when not cross-compiling. This reverts the change and also sets `strictDeps` now because we can.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
