### PR TITLE
hplip: hardcode ppdc path to fix #44230 and add -n to gzip to improve reproducibility

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -102,6 +102,10 @@ python3Packages.buildPythonApplication {
   ];
 
   prePatch = ''
+    # https://github.com/NixOS/nixpkgs/issues/44230
+    substituteInPlace createPPD.sh \
+    --replace ppdc "${cups}/bin/ppdc"
+
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
     find . -type f -exec sed -i \
       -e s,/etc/hp,$out/etc/hp,g \

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -101,10 +101,11 @@ python3Packages.buildPythonApplication {
     ./hplip-3.20.11-nixos-cups-ppd-search-path.patch
   ];
 
-  prePatch = ''
+  postPatch = ''
     # https://github.com/NixOS/nixpkgs/issues/44230
     substituteInPlace createPPD.sh \
-    --replace ppdc "${cups}/bin/ppdc"
+      --replace ppdc "${cups}/bin/ppdc" \
+      --replace "gzip -c" "gzip -cn"
 
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
     find . -type f -exec sed -i \
@@ -151,6 +152,12 @@ python3Packages.buildPythonApplication {
     # This seems to be a 'ppdc' issue when the tool is run in a hermetic sandbox.
     # Could not find how to fix the problem in 'ppdc' so this is a workaround.
     export CUPS_DATADIR="${cups}/share/cups"
+  '';
+
+  postConfigure = ''
+    # don't save timestamp, in order to improve reproducibility
+    substituteInPlace Makefile \
+      --replace "GZIP_ENV = --best" "GZIP_ENV = --best -n"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
the ppdc: Warning - overlapping filename can be ignored
https://bugs.launchpad.net/hplip/+bug/1756967
```
ppdc: Warning - overlapping filename "ppd/hpijs/hp-color_laserjet_3500-hpijs.ppd".
ppdc: Warning - overlapping filename "ppd/hpijs/hp-color_laserjet_3500n-hpijs.ppd".
ppdc: Warning - overlapping filename "ppd/hpijs/hp-color_laserjet_3550-hpijs.ppd".
ppdc: Warning - overlapping filename "ppd/hpijs/hp-color_laserjet_3550n-hpijs.ppd".
ppdc: Warning - overlapping filename "ppd/hpijs/hp-color_laserjet_3600-hpijs.ppd".
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #44230

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
