### PR TITLE
flawfinder: 2.0.15 -> 2.0.18

### DIFF
--- a/pkgs/development/tools/flawfinder/default.nix
+++ b/pkgs/development/tools/flawfinder/default.nix
@@ -1,30 +1,22 @@
 { lib
-, stdenv
 , fetchurl
 , installShellFiles
 , python3
 }:
 
-stdenv.mkDerivation rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "flawfinder";
-  version = "2.0.15";
+  version = "2.0.18";
 
   src = fetchurl {
     url = "https://dwheeler.com/flawfinder/flawfinder-${version}.tar.gz";
-    sha256 = "01j4szy8gwvikrfzfayfayjnc1za0jxsnxp5fsa6d06kn69wyr8a";
+    sha256 = "1hk2y13fd2a5gf42a1hk45hw6pbls715wi9k1yh3c3wyhvbyylba";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
+  # Project is using a combination of bash/Python for the tests
+  doCheck = false;
 
-  buildInputs = [ python3 ];
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp ${pname} $out/bin
-    installManPage flawfinder.1
-    runHook postInstall
-  '';
+  pythonImportsCheck = [ "flawfinder" ];
 
   meta = with lib; {
     description = "Tool to examines C/C++ source code for security flaws";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.18

Migrate it to `buildPythonApplication`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
