### PR TITLE
zstd: Add pzstd to compiled binaries

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     (name: value: "-DZSTD_${name}:BOOL=${if value then "ON" else "OFF"}") {
       BUILD_SHARED = !static;
       BUILD_STATIC = static;
+      BUILD_CONTRIB = true;
       PROGRAMS_LINK_SHARED = !static;
       LEGACY_SUPPORT = legacySupport;
       BUILD_TESTS = doCheck;
@@ -62,12 +63,16 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = ''
+    mkdir -p $bin/bin
+    cp contrib/pzstd/pzstd $bin/bin/pzstd
     substituteInPlace ../programs/zstdgrep \
       --replace ":-grep" ":-${gnugrep}/bin/grep" \
       --replace ":-zstdcat" ":-$bin/bin/zstdcat"
 
     substituteInPlace ../programs/zstdless \
       --replace "zstdcat" "$bin/bin/zstdcat"
+  '' + lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change @rpath/libzstd.1.dylib $out/lib/libzstd.1.dylib $bin/bin/pzstd
   '';
 
   outputs = [ "bin" "dev" ]


### PR DESCRIPTION
###### Motivation for this change

pzstd is not part of the default zstd package, but it seems nice to have and gets usually packages by other distributions as well.
This PR enables the compilation of pzstd and copies it into. the default bin/ folder.

This will also fix https://github.com/NixOS/nixpkgs/issues/22218

This is very similar to what e.g. Arch does: https://github.com/archlinux/svntogit-packages/blob/packages/zstd/trunk/PKGBUILD#L39

(build contrib, copy over pzstd binary)


###### Test
```
% /nix/store/21nyj1larh5ff140fwzjpyb1nrlg10sd-zstd-1.5.0-bin/bin/pzstd --help
Usage:
  pzstd [args] [FILE(s)]
Parallel ZSTD options:
  -p, --processes   #    : number of threads to use for (de)compression (default:<numcpus>)
ZSTD options:
  -#                     : # compression level (1-19, default:3)
  -d, --decompress       : decompression
  -o                file : result stored into `file` (only if 1 input file)
  -f, --force            : overwrite output without prompting, (de)compress links
      --rm               : remove source file(s) after successful (de)compression
  -k, --keep             : preserve source file(s) (default)
  -h, --help             : display help and exit
  -V, --version          : display version number and exit
  -v, --verbose          : verbose mode; specify multiple times to increase log level (default:2)
  -q, --quiet            : suppress warnings; specify twice to suppress errors too
  -c, --stdout           : force write to standard output, even if it is the console
  -r                     : operate recursively on directories
      --ultra            : enable levels beyond 19, up to 22 (requires more memory)
  -C, --check            : integrity check (default)
      --no-check         : no integrity check
  -t, --test             : test compressed file integrity
  --                     : all arguments after "--" are treated as files
mseeger@mseeger-mbp nixpkgs % 
```


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
