### PR TITLE
sfm: fix build with custom config

### DIFF
--- a/pkgs/applications/misc/sfm/default.nix
+++ b/pkgs/applications/misc/sfm/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, conf ? null }:
+{ lib, stdenv, fetchFromGitHub, writeText, conf ? null }:
 
 stdenv.mkDerivation rec {
   pname = "sfm";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-DwXKrSqcebNI5N9REXyMV16W2kr72IH9+sKSVehc5zw=";
   };
 
-  configFile = lib.optionalString (conf!=null) (lib.writeText "config.def.h" conf);
+  configFile = lib.optionalString (conf!=null) (writeText "config.def.h" conf);
 
   postPatch = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
 


### PR DESCRIPTION
###### Motivation for this change
Trying to build with custom config:
```nix
(sfm.override { conf = builtins.readFile ./sfm-conf.h; })
```
Got:
```
error: attribute 'writeText' missing

       at /nix/store/1iblaav6dxrc5b39b3gbdnbl47sfjxrq-source/pkgs/applications/misc/sfm/default.nix:14:49:

           13|
           14|   configFile = lib.optionalString (conf!=null) (lib.writeText "config.def.h" conf);
             |                                                 ^
           15|
```

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
