### PR TITLE
udevil: refactor and fix #35650

### DIFF
--- a/nixos/modules/programs/udevil.nix
+++ b/nixos/modules/programs/udevil.nix
@@ -10,5 +10,8 @@ in {
 
   config = mkIf cfg.enable {
     security.wrappers.udevil.source = "${lib.getBin pkgs.udevil}/bin/udevil";
+
+    systemd.packages = [ pkgs.udevil ];
+    systemd.services."devmon@".wantedBy = [ "multi-user.target" ];
   };
 }

--- a/pkgs/applications/misc/udevil/default.nix
+++ b/pkgs/applications/misc/udevil/default.nix
@@ -1,12 +1,20 @@
-{ lib, stdenv, fetchurl, intltool, glib, pkg-config, udev, util-linux, acl }:
-stdenv.mkDerivation {
-  name = "udevil-0.4.4";
-  src = fetchurl {
-    url = "https://github.com/IgnorantGuru/udevil/archive/0.4.4.tar.gz";
-    sha256 = "0z1bhaayambrcn7bgnrqk445k50ifabmw8q4i9qj49nnbcvxhbxd";
+{ lib, stdenv, fetchFromGitHub, intltool, glib, pkg-config, udev, util-linux, acl }:
+
+stdenv.mkDerivation rec {
+  pname = "udevil";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "IgnorantGuru";
+    repo = "udevil";
+    rev = version;
+    sha256 = "0nd44r8rbxifx4x4m24z5aji1c6k1fhw8cmf5s43wd5qys0bcdad";
   };
+
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ intltool glib udev ];
+
   configurePhase = ''
     substituteInPlace src/Makefile.in --replace "-o root -g root" ""
     # do not set setuid bit in nix store
@@ -19,11 +27,18 @@ stdenv.mkDerivation {
       --with-setfacl-prog=${acl.bin}/bin/setfacl \
       --sysconfdir=$prefix/etc
   '';
+
+  postInstall = ''
+    substituteInPlace $out/lib/systemd/system/devmon@.service \
+      --replace /usr/bin/devmon "$out/bin/devmon"
+  '';
+
   patches = [ ./device-info-sys-stat.patch ];
-  meta = {
+
+  meta = with lib; {
     description = "A command line Linux program which mounts and unmounts removable devices without a password, shows device info, and monitors device changes";
     homepage = "https://ignorantguru.github.io/udevil/";
-    platforms = lib.platforms.linux;
-    license = lib.licenses.gpl3;
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #35650

~~i also updated it to the same commit that arch uses https://github.com/archlinux/svntogit-community/blob/7c87c0d9707926dd679acf30e4624ec181687331/trunk/PKGBUILD~~
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
