### PR TITLE
qcelemental: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -1,33 +1,18 @@
-{ buildPythonPackage, lib, fetchPypi, fetchpatch, numpy
+{ buildPythonPackage, lib, fetchPypi, numpy
 , pydantic, pint,  networkx, pytestrunner, pytestcov, pytest
 } :
 
 buildPythonPackage rec {
   pname = "qcelemental";
-  version = "0.20.0";
+  version = "0.21.0";
 
   checkInputs = [ pytestrunner pytestcov pytest ];
   propagatedBuildInputs = [ numpy pydantic pint networkx ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "141vw36fmacj897q26kq2bl9l0d23lyqjfry6q46aa9087dcs7ni";
+    sha256 = "1b3c78fxbpnddrm1fnbvv4x2840jcfjg2l5cb5w4p38vzksiv238";
   };
-
-  # FIXME: Fixed upstream but not released yet. Nevertheless critical for correct behaviour.
-  # See https://github.com/MolSSI/QCElemental/pull/265
-  patches = [
-    (fetchpatch {
-      name = "SearchPath1.patch";
-      url = "https://github.com/MolSSI/QCElemental/commit/2211a4e59690bcb14265a60f199a5efe74fe44db.diff";
-      sha256 = "1ibjvmdrc103jdj79xrr11y5yji5hc966rm4ihfhfzgbvfkbjg2l";
-    })
-    (fetchpatch {
-      name = "SearchPath2.patch";
-      url = "https://github.com/MolSSI/QCElemental/commit/5a32ce33e8142047b0a00d0036621fe2750e872a.diff";
-      sha256 = "0gmg70vdps7k6alqclwdlxkli9d8s1fphbdvyl8wy8xrh46jw6rk";
-    })
-  ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change
Version upgrade. Contains the fixes, that required fetching extra patches for the previous version.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
