### PR TITLE
gentium: 5.000 → 6.000

### DIFF
--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "5.000";
+  version = "6.000";
 in fetchzip rec {
   name = "gentium-${version}";
 
@@ -10,12 +10,20 @@ in fetchzip rec {
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}
     unzip -l $downloadedFile
-    unzip -j $downloadedFile \*.ttf                                          -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt \*/README.txt -d $out/share/doc/${name}
-    unzip -j $downloadedFile \*/documentation/\*                             -d $out/share/doc/${name}/documentation
+    unzip -j $downloadedFile \*.ttf \
+      -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \
+      \*/FONTLOG.txt \
+      \*/README.txt \
+      -d $out/share/doc/${name}
+    unzip -j $downloadedFile \
+      \*/documentation/\*.html \
+      \*/documentation/\*.txt \
+      -x \*/documentation/source/\* \
+      -d $out/share/doc/${name}/documentation
   '';
 
-  sha256 = "1qr2wjdmm93167b0w9cidlf3wwsyjx4838ja9jmm4jkyian5whhp";
+  sha256 = "zhSpAYK3Lfzsx6Z1IA6aRFNNXdDGq/jWxsQ20c2HcxI=";
 
   meta = with lib; {
     homepage = "https://software.sil.org/gentium/";


### PR DESCRIPTION
###### Motivation for this change
https://software.sil.org/gentium/release-6-000/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
