### PR TITLE
p4est, p4est-sc: mpi/pthread additions

### DIFF
--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -1,13 +1,14 @@
 { lib, stdenv, fetchFromGitHub
 , autoreconfHook, pkg-config
 , p4est-sc-debugEnable ? true, p4est-sc-mpiSupport ? true
-, mpi, openmpi, openssh, zlib
+, mpi, openssh, zlib
 }:
 
 let
   dbg = if debugEnable then "-dbg" else "";
   debugEnable = p4est-sc-debugEnable;
   mpiSupport = p4est-sc-mpiSupport;
+  isOpenmpi = mpiSupport && mpi.pname == "openmpi";
 in
 stdenv.mkDerivation {
   pname = "p4est-sc${dbg}";
@@ -24,7 +25,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   propagatedBuildInputs = [ zlib ]
     ++ lib.optional mpiSupport mpi
-    ++ lib.optional (mpiSupport && mpi == openmpi) openssh
+    ++ lib.optional isOpenmpi openssh
   ;
   inherit debugEnable mpiSupport;
 
@@ -36,15 +37,17 @@ stdenv.mkDerivation {
     ${if mpiSupport then "unset CC" else ""}
   '';
 
-  configureFlags = lib.optional debugEnable "--enable-debug"
+  configureFlags = [ "--enable-pthread=-pthread" ]
+    ++ lib.optional debugEnable "--enable-debug"
     ++ lib.optional mpiSupport "--enable-mpi"
   ;
 
   makeFlags = [ "V=0" ];
+  checkFlags = lib.optional isOpenmpi "-j1";
 
   dontDisableStatic = true;
   enableParallelBuilding = true;
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = !stdenv.isAarch64 && stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = {
     branch = "prev3-develop";

--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -35,13 +35,12 @@ stdenv.mkDerivation {
     ${if mpiSupport then "unset CC" else ""}
   '';
 
-  configureFlags = [ "--with-sc=${p4est-sc}" ]
+  configureFlags = p4est-sc.configureFlags
+    ++ [ "--with-sc=${p4est-sc}" ]
     ++ lib.optional withMetis "--with-metis"
-    ++ lib.optional debugEnable "--enable-debug"
-    ++ lib.optional mpiSupport "--enable-mpi"
   ;
 
-  inherit (p4est-sc) makeFlags dontDisableStatic enableParallelBuilding doCheck;
+  inherit (p4est-sc) makeFlags checkFlags dontDisableStatic enableParallelBuilding doCheck;
 
   meta = {
     branch = "prev3-develop";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Disabling MPI on aarch64, since the tests won't run there.
Also adding -pthread compiler flag consistently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
