### PR TITLE
yajsv: init at 1.4.0

### DIFF
--- a/pkgs/tools/misc/yajsv/default.nix
+++ b/pkgs/tools/misc/yajsv/default.nix
@@ -1,0 +1,28 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+let version = "1.4.0";
+in buildGoModule {
+  pname = "yajsv";
+  version = version;
+
+  src = fetchFromGitHub {
+    owner = "neilpa";
+    repo = "yajsv";
+    rev = "v${version}";
+    sha256 = "0smaij3905fqgcjmnfs58r6silhp3hyv7ccshk7n13fmllmsm7v7";
+  };
+
+  vendorSha256 = "0rmc31i5jra2qcqhw1azflmhawxasrq0d6qwd6qp250sj1jr6ahq";
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/yajsv -v > /dev/null
+  '';
+
+  meta = {
+    description = "Yet Another JSON Schema Validator";
+    homepage = "https://github.com/neilpa/yajsv";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rycee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10168,6 +10168,8 @@ in
 
   yafaray-core = callPackage ../tools/graphics/yafaray-core { };
 
+  yajsv = callPackage ../tools/misc/yajsv { };
+
   yapf = with python3Packages; toPythonApplication yapf;
 
   yarn = callPackage ../development/tools/yarn  { };


### PR DESCRIPTION
###### Motivation for this change

Adds package yajsv "Yet Another JSON Schema Validator".

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
