### PR TITLE
coqPackages.itauto: init at 8.13+no

### DIFF
--- a/pkgs/development/coq-modules/itauto/default.nix
+++ b/pkgs/development/coq-modules/itauto/default.nix
@@ -1,0 +1,24 @@
+{ lib, mkCoqDerivation, coq, version ? null }:
+with lib;
+
+mkCoqDerivation rec {
+  pname = "itauto";
+  owner = "fbesson";
+  domain = "gitlab.inria.fr";
+
+  release."8.13+no".sha256 = "sha256-gXoxtLcHPoyjJkt7WqvzfCMCQlh6kL2KtCGe3N6RC/A=";
+  inherit version;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = isGe "8.13"; out = "8.13+no"; }
+  ] null;
+
+  mlPlugin = true;
+  extraBuildInputs = (with coq.ocamlPackages; [ ocamlbuild ]);
+  enableParallelBuilding = false;
+
+  meta = {
+    description = "A reflexive SAT solver parameterised by a leaf tactic and Nelson-Oppen support";
+    maintainers = with maintainers; [ siraben ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -49,6 +49,7 @@ let
       interval = callPackage ../development/coq-modules/interval {};
       InfSeqExt = callPackage ../development/coq-modules/InfSeqExt {};
       iris = callPackage ../development/coq-modules/iris {};
+      itauto = callPackage ../development/coq-modules/itauto { };
       ITree = callPackage ../development/coq-modules/ITree { };
       ltac2 = callPackage ../development/coq-modules/ltac2 {};
       math-classes = callPackage ../development/coq-modules/math-classes { };


### PR DESCRIPTION
###### Motivation for this change
Add [itauto](https://gitlab.inria.fr/fbesson/itauto) as seen at ITP 2021.

Example shell session:
```coq
$ coqtop
Welcome to Coq 8.13.2 (January 1980)

Coq < Require Import Cdcl.Itauto.
[Loading ML file ring_plugin.cmxs ... done]
[Loading ML file zify_plugin.cmxs ... done]
[Loading ML file micromega_plugin.cmxs ... done]
[Loading ML file omega_plugin.cmxs ... done]
[Loading ML file int63_syntax_plugin.cmxs ... done]
[Loading ML file cdcl_plugin.cmxs ... done]

Coq < Goal forall {A: Type} (x y z: A) (p: Prop), x = y -> y = z -> (x = z -> p) -> p.
1 subgoal
  
  ============================
  forall (A : Type) (x y z : A) (p : Prop),
  x = y -> y = z -> (x = z -> p) -> p

Unnamed_thm < intros. Fail intuition congruence.
1 subgoal
  
  A : Type
  x, y, z : A
  p : Prop
  H : x = y
  H0 : y = z
  H1 : x = z -> p
  ============================
  p

The command has indeed failed with message:
Tactic failure: congruence failed.

Unnamed_thm < Undo. Undo.

1 subgoal
  
  ============================
  forall (A : Type) (x y z : A) (p : Prop),
  x = y -> y = z -> (x = z -> p) -> p

Unnamed_thm < itauto congruence.
No more subgoals.

Unnamed_thm < Qed.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
