### PR TITLE
php80: 8.0.7 -> 8.0.8, php74: 7.4.20 -> 7.4.21

### DIFF
--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "7.4.20";
-    sha256 = "0d5ncz97y0271dsmz269wl4721vhq2fn6pmm9rxglc756p36pnha";
+    version = "7.4.21";
+    sha256 = "0al2697d5hwq0f39rgncl1pwfxzzpc0afmr0fjvw5qjpww163v1n";
   });
 
 in

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "8.0.7";
-    sha256 = "0yazcc9x66xg1gmi3rpgk891g6s3mm7aywcadqfqnx1mdz4z5ckj";
+    version = "8.0.8";
+    sha256 = "0vyi9hhy7yl4l589dniwb3gq29sp3giq7ni4nca3x54q3bbpgg8l";
   });
 
 in

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -195,8 +195,6 @@ let
 
         # PCRE
         ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre2.dev}" ]
-        ++ lib.optionals (lib.versions.majorMinor version == "7.3") [ "--with-pcre-regex=${pcre2.dev}" ]
-        ++ lib.optionals (lib.versionOlder version "7.3") [ "--with-pcre-regex=${pcre2.dev}" ]
         ++ [ "PCRE_LIBDIR=${pcre2}" ]
 
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -257,20 +257,6 @@ lib.makeScope pkgs.newScope (self: with self; {
         {
           name = "dom";
           buildInputs = [ libxml2 ];
-          patches = [
-            # https://github.com/php/php-src/pull/7030
-            (fetchpatch {
-              url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
-              sha256 = "11qsdiwj1zmpfc2pgh6nr0sn7qa1nyjg4jwf69cgwnd57qfjcy4k";
-              excludes = [ "ext/dom/tests/bug43364.phpt" "ext/dom/tests/bug80268.phpt" ];
-            })
-          ];
-          # For some reason `patch` fails to remove these files correctly.
-          # Since `postPatch` is already used in `mkExtension`, we have to make it here.
-          preCheck = ''
-            rm tests/bug43364.phpt
-            rm tests/bug80268.phpt
-          '';
           configureFlags = [ "--enable-dom" ]
             # Required to build on darwin.
             ++ lib.optionals (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];


### PR DESCRIPTION
###### Motivation for this change
fixes CVE-2021-21705 and CVE-2021-21704

Changelog for 7.4 has not been posted yet, only 8.0 and 7.3 (which we don't have anymore), so far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
