### PR TITLE
libliftoff: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/libliftoff/default.nix
+++ b/pkgs/development/libraries/libliftoff/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub
+, meson, pkg-config, ninja
+, libdrm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libliftoff";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s53jsll3c7272bhmh4jr6k5m1nvn8i1ld704qmzsm852ilmgrla";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+
+  buildInputs = [ libdrm ];
+
+  meta = with lib; {
+    description = "A lightweight KMS plane library";
+    longDescription = ''
+      libliftoff eases the use of KMS planes from userspace without standing in
+      your way. Users create "virtual planes" called layers, set KMS properties
+      on them, and libliftoff will pick planes for these layers if possible.
+    '';
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/emersion/libliftoff/releases/tag/v${version}";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16507,6 +16507,8 @@ in
 
   liblcf = callPackage ../development/libraries/liblcf { };
 
+  libliftoff = callPackage ../development/libraries/libliftoff { };
+
   liblqr1 = callPackage ../development/libraries/liblqr-1 { };
 
   liblockfile = callPackage ../development/libraries/liblockfile { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should eventually become a dependency of wlroots (`https://github.com/swaywm/wlroots/pull/2760`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
