### PR TITLE
adriconf: init at 2.4.1

### DIFF
--- a/pkgs/tools/graphics/adriconf/default.nix
+++ b/pkgs/tools/graphics/adriconf/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, cmake
+, pkg-config
+, libdrm
+, libGL
+, atkmm
+, pcre
+, gtkmm3
+, boost
+, libxmlxx3
+, mesa
+, pciutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "adriconf";
+  version = "2.4.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mesa";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "hZy+FpKKBKuho/fALu2O+44zzK6s/M8CTbhrO00ANgo=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libdrm libGL atkmm pcre gtkmm3 boost libxmlxx3 mesa pciutils ];
+
+  cmakeFlags = [ "-DENABLE_UNIT_TESTS=off" ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.freedesktop.org/mesa/adriconf/";
+    description = "A GUI tool used to configure open source graphics drivers";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ musfay ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -799,6 +799,8 @@ in
 
   acme-client = callPackage ../tools/networking/acme-client { stdenv = gccStdenv; };
 
+  adriconf = callPackage ../tools/graphics/adriconf { };
+
   amass = callPackage ../tools/networking/amass { };
 
   afew = callPackage ../applications/networking/mailreaders/afew { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A GUI tool used to configure open source graphics drivers. 

Disabled unittests because they are broken. Other distros disabled them as well.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
