### PR TITLE
llvm_12: fix cross

### DIFF
--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -48,6 +48,10 @@ in stdenv.mkDerivation (rec {
 
   outputs = [ "out" "lib" "dev" "python" ];
 
+  "NIX_LDFLAGS_${pkgsBuildBuild.stdenv.cc.bintools.suffixSalt}" = [
+    "-L${lib.getLib pkgsBuildBuild.ncurses}/lib"
+  ];
+
   nativeBuildInputs = [ cmake python3 ]
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
@@ -58,6 +62,7 @@ in stdenv.mkDerivation (rec {
 
   patches = [
     ./gnu-install-dirs.patch
+    ./llvm-config-libtinfo-cross.patch
     # On older CPUs (e.g. Hydra/wendy) we'd be getting an error in this test.
     (fetchpatch {
       name = "uops-CMOV16rm-noreg.diff";

--- a/pkgs/development/compilers/llvm/12/llvm/llvm-config-libtinfo-cross.patch
+++ b/pkgs/development/compilers/llvm/12/llvm/llvm-config-libtinfo-cross.patch
@@ -1,0 +1,49 @@
+From 6dbc1c9e2069d30e6e7c5d2f79e447b8b1090dd1 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Thu, 1 Jul 2021 10:20:37 +0000
+Subject: [PATCH llvm] [CMake] Don't link to libtinfo by absolute path
+
+TERMINFO_LIB is the absolute path to the libtinfo library for the
+target system.  Since llvm-config is built for the host system, not
+the target, this would try to link llvm-config with the libtinfo for
+the wrong system.  Instead, just give the linker the name of the
+library, and let it figure it out, the same as for zlib.
+---
+ lib/Support/CMakeLists.txt | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Support/CMakeLists.txt b/lib/Support/CMakeLists.txt
+index cdee11412eb5..d4f34b549e10 100644
+--- a/lib/Support/CMakeLists.txt
++++ b/lib/Support/CMakeLists.txt
+@@ -4,6 +4,10 @@ if(LLVM_ENABLE_ZLIB)
+   set(imported_libs ZLIB::ZLIB)
+ endif()
+ 
++if(LLVM_ENABLE_TERMINFO)
++  get_library_name(${TERMINFO_LIB} terminfo_library)
++endif()
++
+ if( MSVC OR MINGW )
+   # libuuid required for FOLDERID_Profile usage in lib/Support/Windows/Path.inc.
+   # advapi32 required for CryptAcquireContextW in lib/Support/Windows/Path.inc.
+@@ -24,7 +28,7 @@ elseif( CMAKE_HOST_UNIX )
+     set(system_libs ${system_libs} ${Backtrace_LIBFILE})
+   endif()
+   if( LLVM_ENABLE_TERMINFO )
+-    set(imported_libs ${imported_libs} "${TERMINFO_LIB}")
++    set(imported_libs ${imported_libs} "${terminfo_library}")
+   endif()
+   if( LLVM_ENABLE_THREADS AND (HAVE_LIBATOMIC OR HAVE_CXX_LIBATOMICS64) )
+     set(system_libs ${system_libs} atomic)
+@@ -249,7 +253,6 @@ if(LLVM_ENABLE_ZLIB)
+ endif()
+ 
+ if(LLVM_ENABLE_TERMINFO)
+-  get_library_name(${TERMINFO_LIB} terminfo_library)
+   set(llvm_system_libs ${llvm_system_libs} "${terminfo_library}")
+ endif()
+ 
+-- 
+2.31.1
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Previously, the linker would be asked to link llvm-config (which is built for the build system\*) against the host system's ncurses, by absolute path, resulting in a failed build.  I've added a patch to fix LLVM and have it link against the appropriate curses library by name instead, so that it'll use the normal Nixpkgs logic for library discovery.

But unfortunately, that's not the whole story, because I couldn't get the linker to actually look in the right place using normal Nixpkgs ways of specifying dependencies.  The build cc wrapper doesn't add the -L flag for the build ncurses if it's in nativeBuildInputs of pkgsBuildBuild.  So in addition to my LLVM patch, I've also had to use the rather obscure platform-specific `NIX_LDFLAGS_*` override variable, to get the build system linker to look in the right place for ncurses.

I'm opening this PR as a draft because I'm not happy with my solution here.  I don't like that it requires both a patch to LLVM _and_ the use of an override mechanism that is only used in one other place in Nixpkgs.  I wouldn't feel confident trying to upstream my LLVM patch when even after the patch we still need weird hacks like this, so I'm hoping somebody can help me figure out how to get rid of them.  I don't understand why `depsBuildBuild = [ ncurses ]` isn't all we need (in conjunction with my LLVM patch).

\* I'm using Nixpkgs/GNU terminology here, not LLVM terminology.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
