### PR TITLE
weechatScripts.buffer_autoset: init at 1.2

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/buffer_autoset/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/buffer_autoset/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, weechat }:
+
+stdenv.mkDerivation {
+  pname = "buffer_autoset";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/weechat/scripts/2b308b44df39ba6563d02b2bcd40c384ec2777dc/python/buffer_autoset.py";
+    sha256 = "0csl3sfpijdbq1j6wabx347lvn91a24a2jfx5b5pspfxz7gixli1";
+  };
+
+  dontUnpack = true;
+
+  passthru.scripts = [ "buffer_autoset.py" ];
+
+  installPhase = ''
+    install -D $src $out/share/buffer_autoset.py
+  '';
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "buffer_autoset.py is a weechat script which auto-set buffer properties when a buffer is opened.";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ govanify ];
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -22,4 +22,6 @@
   weechat-otr = callPackage ./weechat-otr { };
 
   weechat-go = callPackage ./weechat-go { };
+
+  buffer_autoset = callPackage ./buffer_autoset { };
 }


### PR DESCRIPTION
###### Motivation for this change

Adding a weechat script to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
