### PR TITLE
rotate-backups: move out of pythonPackages

### DIFF
--- a/pkgs/tools/backup/rotate-backups/default.nix
+++ b/pkgs/tools/backup/rotate-backups/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "rotate-backups";
-  version = "6.0";
+  version = "8.1";
 
   src = fetchFromGitHub {
     owner = "xolox";
     repo = "python-rotate-backups";
     rev = version;
-    sha256 = "0i59qfv1cfm0ss63ab2nrkn5wr4rxpqqmvfd7pf9c3pl9dbfq20c";
+    sha256 = "0r4dyd7hj403rksgp3vh1azp9n4af75r3wq3x39wxcqizpms3vkx";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/backup/rotate-backups/default.nix
+++ b/pkgs/tools/backup/rotate-backups/default.nix
@@ -1,6 +1,9 @@
-{ lib, buildPythonPackage, fetchFromGitHub, update-dotdee, simpleeval, dateutil }:
+{ lib
+, python3
+, fetchFromGitHub
+}:
 
-buildPythonPackage rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "rotate-backups";
   version = "6.0";
 
@@ -11,7 +14,20 @@ buildPythonPackage rec {
     sha256 = "0i59qfv1cfm0ss63ab2nrkn5wr4rxpqqmvfd7pf9c3pl9dbfq20c";
   };
 
-  propagatedBuildInputs = [ update-dotdee simpleeval dateutil ];
+  propagatedBuildInputs = with python3.pkgs; [
+    python-dateutil
+    simpleeval
+    update-dotdee
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # https://github.com/xolox/python-rotate-backups/issues/33
+    "test_removal_command"
+  ];
 
   meta = with lib; {
     description = "Simple command line interface for backup rotation";
@@ -20,4 +36,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ eyjhb ];
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18077,7 +18077,7 @@ in
 
   rocksdb_lite = rocksdb.override { enableLite = true; };
 
-  rotate-backups = with python3Packages; toPythonApplication rotate-backups;
+  rotate-backups = callPackage ../tools/backup/rotate-backups { };
 
   rote = callPackage ../development/libraries/rote { };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -50,6 +50,7 @@ mapAliases ({
   pytest-pep8 = pytestpep8; # added 2021-01-04
   pytestpep8 = throw "pytestpep8 was removed because it is abandoned and no longer compatible with pytest v6.0"; # added 2020-12-10
   qasm2image = throw "qasm2image is no longer maintained (since November 2018), and is not compatible with the latest pythonPackages.qiskit versions."; # added 2020-12-09
+  rotate-backups = throw "pythonPackages.rotate-backups was removed in favor of the top-level rotate-backups"; # added 2021-07-01
   selectors34 = throw "selectors34 has been removed: functionality provided by Python itself; archived by upstream."; # Added 2021-06-10
   setuptools_scm = setuptools-scm; # added 2021-06-03
   smart_open = smart-open; # added 2021-03-14

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7624,8 +7624,6 @@ in {
 
   ropper = callPackage ../development/python-modules/ropper { };
 
-  rotate-backups = callPackage ../tools/backup/rotate-backups { };
-
   routes = callPackage ../development/python-modules/routes { };
 
   rpdb = callPackage ../development/python-modules/rpdb { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
It's only a command line tool and not supposed to be used through `import rotate_backups` as far as I can tell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
