### PR TITLE
python3Packages.aioesphomeapi: 2.9.0 -> 4.1.0; python3Packages.zeroconf: 0.31.0 -> 0.32.0

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -50,19 +50,25 @@ let
           }
         )
 
-        # Octoprint needs zeroconf >=0.24 <0.25. While this should be done in
-        # the mkOverride aboves, this package also has broken tests, so we need
-        # a proper override.
+        # Octoprint needs zeroconf >=0.24 <0.25. This can't be done via mkOverride, because in zeroconf 0.32
+        # the super package was migrated to fetchFromGitHub.
         (
           self: super: {
             zeroconf = super.zeroconf.overrideAttrs (oldAttrs: rec {
               version = "0.24.5";
-              src = oldAttrs.src.override {
+              src = super.fetchPypi {
+                inherit (oldAttrs) pname;
                 inherit version;
                 sha256 = "0jpgd0rk91si93857mjrizan5gc42kj1q4fi4160qgk68la88fl9";
               };
-              buildInputs = [ self.nose ];
-              checkPhase = "nosetests";
+              pythonImportsCheck = [
+                "zeroconf"
+              ];
+              buildInputs = with self; [
+                pytestCheckHook
+                nose
+              ];
+              pytestFlagsArray = [ "zeroconf/test.py" ];
             });
           }
         )

--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -1,22 +1,34 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, attrs, protobuf, zeroconf }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, protobuf
+, zeroconf
+}:
 
 buildPythonPackage rec {
   pname = "aioesphomeapi";
-  version = "2.9.0";
+  version = "4.1.0";
+  format = "setuptools";
 
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "11259cd1f115d31b91512a209779fa813dded747408100805bc8ecf7c1c1fa82";
+    sha256 = "0210l2d5g76pllr2vh990k9shfv3zrknx5d2dmgqb5y90142cp76";
   };
 
-  propagatedBuildInputs = [ attrs protobuf zeroconf ];
+  propagatedBuildInputs = [
+    protobuf
+    zeroconf
+  ];
 
   # no tests implemented
   doCheck = false;
 
-  pythonImportsCheck = [ "aioesphomeapi" ];
+  pythonImportsCheck = [
+    "aioesphomeapi"
+  ];
 
   meta = with lib; {
     description = "Python Client for ESPHome native API";

--- a/pkgs/development/python-modules/zeroconf/default.nix
+++ b/pkgs/development/python-modules/zeroconf/default.nix
@@ -1,32 +1,41 @@
 { stdenv
 , lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , ifaddr
+, pytest-asyncio
 , pythonOlder
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "zeroconf";
-  version = "0.31.0";
+  version = "0.32.0";
+  format = "setuptools";
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-U6GAJIRxxvgb0f/8vOA+2T19jq8QkFyRIaweqZbRmEQ=";
+  # no tests in pypi sdist
+  src = fetchFromGitHub {
+    owner = "jstasiak";
+    repo = "python-zeroconf";
+    rev = version;
+    sha256 = "08fnpc236v4n9vrxjj6y2xsm06ax0bnygxf294m6lhwmn1vygy7i";
   };
 
-  propagatedBuildInputs = [ ifaddr ];
+  propagatedBuildInputs = [
+    ifaddr
+  ];
 
-  checkInputs = [ pytestCheckHook ];
-
-  pytestFlagsArray = [ "zeroconf/test.py" ];
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
   disabledTests = [
-    # disable tests that expect some sort of networking in the build container
+    # tests that require network interaction
     "test_close_multiple_times"
     "test_launch_and_close"
+    "test_launch_and_close_context_manager"
     "test_launch_and_close_v4_v6"
     "test_launch_and_close_v6_only"
     "test_integration_with_listener_ipv6"
@@ -36,7 +45,10 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pythonImportsCheck = [ "zeroconf" ];
+  pythonImportsCheck = [
+    "zeroconf"
+    "zeroconf.asyncio"
+  ];
 
   meta = with lib; {
     description = "Python implementation of multicast DNS service discovery";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/esphome/aioesphomeapi/releases/tag/v4.1.0
https://github.com/jstasiak/python-zeroconf/releases/tag/0.32.0

Waiting for Home Assistant 2021.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
