### PR TITLE
[21.05] php73: 7.3.28 -> 7.3.29, php74: 7.4.20 -> 7.4.21, php80: 8.0.7 -> 8.0.8

### DIFF
--- a/pkgs/development/interpreters/php/7.3.nix
+++ b/pkgs/development/interpreters/php/7.3.nix
@@ -4,8 +4,8 @@ let
   generic = (import ./generic.nix) _args;
 
   base = callPackage generic (_args // {
-    version = "7.3.28";
-    sha256 = "0r4r8famg3a8x6ch24y1370nsphkxg4k9zq5x8v88f4l8mj6wqwg";
+    version = "7.3.29";
+    sha256 = "1l74brhbkmmd0jbwyk5yixlapj3j4vlvysq4y0snkn0b2iw2hfm8";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = lib.optional stdenv.isDarwin ./php73-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/7.4.nix
+++ b/pkgs/development/interpreters/php/7.4.nix
@@ -4,8 +4,8 @@ let
   generic = (import ./generic.nix) _args;
 
   base = callPackage generic (_args // {
-    version = "7.4.20";
-    sha256 = "0d5ncz97y0271dsmz269wl4721vhq2fn6pmm9rxglc756p36pnha";
+    version = "7.4.21";
+    sha256 = "0al2697d5hwq0f39rgncl1pwfxzzpc0afmr0fjvw5qjpww163v1n";
   });
 
 in base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -4,8 +4,8 @@ let
   generic = (import ./generic.nix) _args;
 
   base = callPackage generic (_args // {
-    version = "8.0.7";
-    sha256 = "0yazcc9x66xg1gmi3rpgk891g6s3mm7aywcadqfqnx1mdz4z5ckj";
+    version = "8.0.8";
+    sha256 = "0vyi9hhy7yl4l589dniwb3gq29sp3giq7ni4nca3x54q3bbpgg8l";
   });
 
 in base.withExtensions ({ all, ... }: with all; ([

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -270,7 +270,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       { name = "dba"; }
       { name = "dom";
         buildInputs = [ libxml2 ];
-        patches = [
+        patches = lib.optionals (lib.versionOlder php.version "7.4") [
           # https://github.com/php/php-src/pull/7030
           (fetchpatch {
             url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
@@ -280,7 +280,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         ];
         # For some reason `patch` fails to remove these files correctly.
         # Since `postPatch` is already used in `mkExtension`, we have to make it here.
-        preCheck = ''
+        preCheck = lib.optionals (lib.versionOlder php.version "7.4") ''
           rm tests/bug43364.phpt
           rm tests/bug80268.phpt
         '';


### PR DESCRIPTION
###### Motivation for this change
Manual backport of #128881, since patches needed changing and nothing applied automatically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
