### PR TITLE
otpclient: init at 2.4.4

### DIFF
--- a/pkgs/applications/misc/otpclient/default.nix
+++ b/pkgs/applications/misc/otpclient/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, gtk3
+, wrapGAppsHook
+, jansson
+, libgcrypt
+, libzip
+, libpng
+, libcotp
+, zbar
+}:
+
+stdenv.mkDerivation rec {
+  pname = "otpclient";
+  version = "2.4.4";
+
+  src = fetchFromGitHub {
+    owner = "paolostivanin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zjvhcx9q8nsf97zikddxriky0kghi4j4i7312s94pl8c7kb4abr";
+  };
+
+  buildInputs = [ gtk3 jansson libgcrypt libzip libpng libcotp zbar ];
+  nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
+
+  meta = with lib; {
+    description = "Highly secure and easy to use OTP client written in C/GTK that supports both TOTP and HOTP";
+    homepage = "https://github.com/paolostivanin/OTPClient";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ alexbakker ];
+  };
+}

--- a/pkgs/development/libraries/libbaseencode/default.nix
+++ b/pkgs/development/libraries/libbaseencode/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "libbaseencode";
+  version = "1.0.11";
+
+  src = fetchFromGitHub {
+    owner = "paolostivanin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1f52yh052z8k90d1ag6nk01p1gf4i1zxp1daw8mashs8avqr2m7g";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Library written in C for encoding and decoding data using base32 or base64 (RFC-4648)";
+    homepage = "https://github.com/paolostivanin/libbaseencode";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ alexbakker ];
+  };
+}

--- a/pkgs/development/libraries/libcotp/default.nix
+++ b/pkgs/development/libraries/libcotp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, libgcrypt, libbaseencode }:
+
+stdenv.mkDerivation rec {
+  pname = "libcotp";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "paolostivanin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qq4shwiz1if9vys052dnsbm4dfw1ynlj6nsb0v4zjly3ndspfsk";
+  };
+
+  buildInputs = [ libbaseencode libgcrypt ];
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = with lib; {
+    description = "C library that generates TOTP and HOTP";
+    homepage = "https://github.com/paolostivanin/libcotp";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ alexbakker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7668,6 +7668,8 @@ in
 
   otfcc = callPackage ../tools/misc/otfcc { };
 
+  otpclient = callPackage ../applications/misc/otpclient { };
+
   otpw = callPackage ../os-specific/linux/otpw { };
 
   ovftool = callPackage ../tools/virtualization/ovftool { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16151,6 +16151,8 @@ in
 
   libctemplate = callPackage ../development/libraries/libctemplate { };
 
+  libcotp = callPackage ../development/libraries/libcotp { };
+
   libcouchbase = callPackage ../development/libraries/libcouchbase { };
 
   libcue = callPackage ../development/libraries/libcue { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16036,6 +16036,8 @@ in
     inherit (ocaml-ng.ocamlPackages) bap ocaml findlib ctypes;
   };
 
+  libbaseencode = callPackage ../development/libraries/libbaseencode { };
+
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;
   libbass_fx = (callPackage ../development/libraries/audio/libbass { }).bass_fx;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New package for OTPClient, and two other new packages for libraries that it depends on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
