### PR TITLE
Fix default pager environment

### DIFF
--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -18,7 +18,8 @@ in
 
     environment.variables =
       { NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-        PAGER = mkDefault "less -R";
+        PAGER = mkDefault "less";
+        LESS = mkDefault "-R";
         EDITOR = mkDefault "nano";
         XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
       };


### PR DESCRIPTION
###### Motivation for this change

Causes `dmesg -H` (aka `dmesg --human`) to actually work.

see https://github.com/NixOS/nixpkgs/pull/13470#issuecomment-680702220