### PR TITLE
[20.09] privoxy: 3.0.28 -> 3.0.32

### DIFF
--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   pname = "privoxy";
-  version = "3.0.28";
+  version = "3.0.29";
 
   src = fetchurl {
     url = "mirror://sourceforge/ijbswa/Sources/${version}%20%28stable%29/${pname}-${version}-stable-src.tar.gz";
-    sha256 = "0jl2yav1qzqnaqnnx8i6i53ayckkimcrs3l6ryvv7bda6v08rmxm";
+    sha256 = "17a8fbdyb0ixc0wwq68fg7xn7l6n7jq67njpq93psmxgzng0dii5";
   };
 
   hardeningEnable = [ "pie" ];

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   pname = "privoxy";
-  version = "3.0.31";
+  version = "3.0.32";
 
   src = fetchurl {
     url = "mirror://sourceforge/ijbswa/Sources/${version}%20%28stable%29/${pname}-${version}-stable-src.tar.gz";
-    sha256 = "sha256-B3cpo6rHkiKk6NiKZQ2QKNFv1LDWA42o9fXkcSDQBOs=";
+    sha256 = "sha256-xh3kAIxiRF7Bjx8nBAfL8jcuq6k76szcnjI4uy3v7tc=";
   };
 
   hardeningEnable = [ "pie" ];

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   pname = "privoxy";
-  version = "3.0.29";
+  version = "3.0.30";
 
   src = fetchurl {
     url = "mirror://sourceforge/ijbswa/Sources/${version}%20%28stable%29/${pname}-${version}-stable-src.tar.gz";
-    sha256 = "17a8fbdyb0ixc0wwq68fg7xn7l6n7jq67njpq93psmxgzng0dii5";
+    sha256 = "sha256-pP4kHF2nAQsoS/ienp4xoyHx8+scx5ZVnT+6ublBXuE=";
   };
 
   hardeningEnable = [ "pie" ];

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
 
   pname = "privoxy";
-  version = "3.0.30";
+  version = "3.0.31";
 
   src = fetchurl {
     url = "mirror://sourceforge/ijbswa/Sources/${version}%20%28stable%29/${pname}-${version}-stable-src.tar.gz";
-    sha256 = "sha256-pP4kHF2nAQsoS/ienp4xoyHx8+scx5ZVnT+6ublBXuE=";
+    sha256 = "sha256-B3cpo6rHkiKk6NiKZQ2QKNFv1LDWA42o9fXkcSDQBOs=";
   };
 
   hardeningEnable = [ "pie" ];


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/128418

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via backporting `nixosTests.privoxy`
- [x] Tested compilation of all pkgs that depend on this change (`privoxy`)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
