### PR TITLE
apksigcopier: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/apksigcopier/default.nix
+++ b/pkgs/development/tools/apksigcopier/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, python3
+, installShellFiles
+, bash
+, pandoc
+}:
+
+# FIXME: how to "recommend" apksigner like the Debian package?
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "apksigcopier";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "obfusk";
+    repo = "apksigcopier";
+    rev = "v${version}";
+    sha256 = "1la1ml91jvqc1zakbqfpayjbs67pi3i18bsgz3mf11rxgphd3fpk";
+  };
+
+  nativeBuildInputs = [ installShellFiles pandoc ];
+  propagatedBuildInputs = with python3.pkgs; [ click ];
+  checkInputs = with python3.pkgs; [ flake8 mypy pylint ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace /bin/bash ${bash}/bin/bash \
+      --replace 'apksigcopier --version' '${python3.interpreter} apksigcopier --version'
+  '';
+
+  postBuild = ''
+    make ${pname}.1
+  '';
+
+  checkPhase = ''
+    make test
+  '';
+
+  postInstall = ''
+    installManPage ${pname}.1
+  '';
+
+  meta = with lib; {
+    description = "Copy/extract/patch apk signatures & compare apks";
+    longDescription = ''
+      apksigcopier is a tool for copying APK signatures from a signed APK
+      to an unsigned one (in order to verify reproducible builds).  It can
+      also be used to compare two APKs with different signatures.  Its
+      command-line tool offers four operations:
+
+      * copy signatures directly from a signed to an unsigned APK
+      * extract signatures from a signed APK to a directory
+      * patch previously extracted signatures onto an unsigned APK
+      * compare two APKs with different signatures (requires apksigner)
+    '';
+    homepage = "https://github.com/obfusk/apksigcopier";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = [ maintainers.obfusk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1082,6 +1082,8 @@ in
 
   apkid = callPackage ../development/tools/apkid { };
 
+  apksigcopier = callPackage ../development/tools/apksigcopier { };
+
   apktool = callPackage ../development/tools/apktool {
     inherit (androidenv.androidPkgs_9_0) build-tools;
   };


### PR DESCRIPTION
###### Motivation for this change

* New package; related to Reproducible Builds for Android; used by e.g. F-Droid.
* I'm the upstream author; and also the Debian maintainer.
* I'd also like to maintain it for NixOS :smile_cat:
* (It's also available on PyPI and someone has packaged it for Arch in the AUR.)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### FIXME

* [ ] On Debian, this package recommends `apksigner` (from the Android SDK; needed for 1 of the 4 subcommands). I don't see a separate package for that in NixOS. It might be in included in some Android SDK package, but that seems like a rather large dependency. So maybe it's best to just leave it up to the user to install `apksigner`?

###### Other

* [x] Seems to build reproducibly w/ `nix-build --check`.