### PR TITLE
kanjidraw: init at 0.2.3

### DIFF
--- a/pkgs/applications/misc/kanjidraw/default.nix
+++ b/pkgs/applications/misc/kanjidraw/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, python3
+, bash
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "kanjidraw";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "obfusk";
+    repo = "kanjidraw";
+    rev = "v${version}";
+    sha256 = "03ag8vkbf85qww857ii8hcnn8bh5qa7rsmhka0v9vfxk272ifbyq";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ tkinter ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace /bin/bash ${bash}/bin/bash
+  '';
+
+  checkPhase = ''
+    make test
+  '';
+
+  meta = with lib; {
+    description = "Handwritten kanji recognition";
+    longDescription = ''
+      kanjidraw is a simple Python library + GUI for matching (the strokes of a)
+      handwritten kanji against its database.
+
+      You can use the GUI to draw and subsequently select a kanji from the list of
+      probable matches, which will then be copied to the clipboard.
+
+      The database is based on KanjiVG and the algorithms are based on the
+      Kanji draw Android app.
+    '';
+    homepage = "https://github.com/obfusk/kanjidraw";
+    license = with licenses; [
+      agpl3Plus     # code
+      cc-by-sa-30   # data.json
+    ];
+    maintainers = [ maintainers.obfusk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2891,6 +2891,8 @@ in
 
   jiten = callPackage ../applications/misc/jiten { };
 
+  kanjidraw = callPackage ../applications/misc/kanjidraw { };
+
   jotta-cli = callPackage ../applications/misc/jotta-cli { };
 
   joycond = callPackage ../os-specific/linux/joycond { };


### PR DESCRIPTION
###### Motivation for this change

* New package.
* Dependency of newer versions of `jiten` (which is already in `nixpkgs`, maintained by me, which I'd like to update soon).
* I'm the upstream author; and also working on an official Debian package.
* I'd also like to maintain it for NixOS :smile_cat:
* (It's also available on PyPI.)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Other

* [x] Seems to build reproducibly w/ `nix-build --check`.