### PR TITLE
python3Packages.identify: 1.6.1 -> 2.2.10

### DIFF
--- a/pkgs/development/python-modules/editdistance-s/default.nix
+++ b/pkgs/development/python-modules/editdistance-s/default.nix
@@ -9,7 +9,6 @@ buildPythonPackage rec {
   pname = "editdistance-s";
   version = "1.0.0";
 
-
   src = fetchFromGitHub {
     owner = "asottile";
     repo = pname;

--- a/pkgs/development/python-modules/editdistance-s/default.nix
+++ b/pkgs/development/python-modules/editdistance-s/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, cffi
+}:
+
+buildPythonPackage rec {
+  pname = "editdistance-s";
+  version = "1.0.0";
+
+
+  src = fetchFromGitHub {
+    owner = "asottile";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0w2qd5b6a3c3ahd0xy9ykq4wzqk0byqwdqrr26dyn8j2425j46lg";
+  };
+
+  propagatedBuildInputs = [ cffi ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "editdistance_s" ];
+
+  meta = with lib; {
+    description = "Fast implementation of the edit distance (Levenshtein distance)";
+    homepage = "https://github.com/asottile/editdistance-s";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ austinbutler ];
+  };
+}

--- a/pkgs/development/python-modules/identify/default.nix
+++ b/pkgs/development/python-modules/identify/default.nix
@@ -2,23 +2,23 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
-, editdistance
+, editdistance-s
 }:
 
 buildPythonPackage rec {
   pname = "identify";
-  version = "1.6.1";
+  version = "2.2.10";
 
 
   src = fetchFromGitHub {
     owner = "pre-commit";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1sqhqqjp53dwm8yq4nrgggxbvzs3szbg49z5sj2ss9xzlgmimclm";
+    sha256 = "017xcwm8m42a1v3v0fs8v3m2sga97rx9a7vk0cb2g14777f4w4si";
   };
 
   checkInputs = [
-    editdistance
+    editdistance-s
     pytestCheckHook
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2245,6 +2245,8 @@ in {
 
   editdistance = callPackage ../development/python-modules/editdistance { };
 
+  editdistance-s = callPackage ../development/python-modules/editdistance-s { };
+
   editorconfig = callPackage ../development/python-modules/editorconfig { };
 
   edward = callPackage ../development/python-modules/edward { };


### PR DESCRIPTION
###### Motivation for this change

Update package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).