### PR TITLE
[staging] eigen: 3.3.7 -> 3.3.9

### DIFF
--- a/pkgs/development/libraries/eigen/default.nix
+++ b/pkgs/development/libraries/eigen/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "eigen";
-  version = "3.3.7";
+  version = "3.3.9";
 
   src = fetchFromGitLab {
     owner = "libeigen";
     repo = pname;
     rev = version;
-    hash = "sha256-oXJ4V5rakL9EPtQF0Geptl0HMR8700FdSrOB09DbbMQ=";
+    sha256 = "sha256-JMIG7CLMndUsECfbKpXE3BtVFuAjn+CZvf8GXZpLkFQ=";
   };
 
   patches = [

--- a/pkgs/development/libraries/eigen/include-dir.patch
+++ b/pkgs/development/libraries/eigen/include-dir.patch
@@ -8,7 +8,16 @@
  
  # guard against in-source builds
  
-@@ -408,13 +408,6 @@ install(FILES
+@@ -407,7 +407,7 @@ set(PKGCONFIG_INSTALL_DIR
+     CACHE STRING "The directory relative to CMAKE_PREFIX_PATH where eigen3.pc is installed"
+     )
+ 
+-foreach(var INCLUDE_INSTALL_DIR CMAKEPACKAGE_INSTALL_DIR PKGCONFIG_INSTALL_DIR)
++foreach(var CMAKEPACKAGE_INSTALL_DIR PKGCONFIG_INSTALL_DIR)
+   if(IS_ABSOLUTE "${${var}}")
+     message(FATAL_ERROR "${var} must be relative to CMAKE_PREFIX_PATH. Got: ${${var}}")
+   endif()
+@@ -429,13 +429,6 @@ install(FILES
    DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel
    )
  
@@ -22,7 +31,7 @@
  add_subdirectory(Eigen)
  
  add_subdirectory(doc EXCLUDE_FROM_ALL)
-@@ -510,8 +503,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
+@@ -531,8 +524,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
  set ( EIGEN_VERSION_MINOR  ${EIGEN_MAJOR_VERSION} )
  set ( EIGEN_VERSION_PATCH  ${EIGEN_MINOR_VERSION} )
  set ( EIGEN_DEFINITIONS "")


### PR DESCRIPTION
Patch needs a small update to also skip the relative includedir check.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
