### PR TITLE
python3Packages.asyncssh: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -1,17 +1,48 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
 , cryptography
-, bcrypt, gssapi, libnacl, libsodium, nettle, pyopenssl
-, openssl, openssh, pytestCheckHook }:
+, bcrypt
+, gssapi
+, fido2
+, libnacl
+, libsodium
+, nettle
+, python-pkcs11
+, pyopenssl
+, openssl
+, openssh
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "asyncssh";
-  version = "2.6.0";
-  disabled = pythonOlder "3.4";
+  version = "2.7.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "20f0ef553a1e64a7d38db86ba3a2f3907e72f1e81f3dfec5edb191383783c7d1";
+    sha256 = "sha256-GFAT2OZ3R8PA8BtyQWuL14QX2h30jHH3baU8YH71QbY=";
   };
+
+  propagatedBuildInputs = [
+    bcrypt
+    cryptography
+    fido2
+    gssapi
+    libnacl
+    libsodium
+    nettle
+    python-pkcs11
+    pyopenssl
+  ];
+
+  checkInputs = [
+    openssh
+    openssl
+    pytestCheckHook
+  ];
 
   patches = [
     # Reverts https://github.com/ronf/asyncssh/commit/4b3dec994b3aa821dba4db507030b569c3a32730
@@ -23,32 +54,16 @@ buildPythonPackage rec {
     ./fix-sftp-chmod-test-nixos.patch
   ];
 
-  # Disables windows specific test (specifically the GSSAPI wrapper for Windows)
-  postPatch = ''
-    rm tests/sspi_stub.py
-  '';
-
-  propagatedBuildInputs = [
-    bcrypt
-    cryptography
-    gssapi
-    libnacl
-    libsodium
-    nettle
-    pyopenssl
+  disabledTestPaths = [
+    # Disables windows specific test (specifically the GSSAPI wrapper for Windows)
+    "tests/sspi_stub.py"
   ];
 
-  checkInputs = [
-    openssh
-    openssl
-    pytestCheckHook
-  ];
-
-  disabledTests = [ "test_expired_root" "test_confirm" ];
+  pythonImportsCheck = [ "asyncssh" ];
 
   meta = with lib; {
-    description = "Provides an asynchronous client and server implementation of the SSHv2 protocol on top of the Python asyncio framework";
-    homepage = "https://asyncssh.readthedocs.io/en/latest";
+    description = "Asynchronous SSHv2 Python client and server library";
+    homepage = "https://asyncssh.readthedocs.io/";
     license = licenses.epl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/python-pkcs11/default.nix
+++ b/pkgs/development/python-modules/python-pkcs11/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, asn1crypto
+, buildPythonPackage
+, cached-property
+, cython
+, fetchFromGitHub
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "python-pkcs11";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "danni";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0kncbipfpsb7m7mhv5s5b9wk604h1j08i2j26fn90pklgqll0xhv";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    cython
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    cached-property
+    asn1crypto
+  ];
+
+  # Test require additional setup
+  doCheck = false;
+
+  pythonImportsCheck = [ "pkcs11" ];
+
+  meta = with lib; {
+    description = "PKCS#11/Cryptoki support for Python";
+    homepage = "https://github.com/danni/python-pkcs11";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7061,6 +7061,8 @@ in {
 
   python-pipedrive = callPackage ../development/python-modules/python-pipedrive { };
 
+  python-pkcs11 = callPackage ../development/python-modules/python-pkcs11 { };
+
   python-prctl = callPackage ../development/python-modules/python-prctl { };
 
   python-ptrace = callPackage ../development/python-modules/python-ptrace { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.7.0

Change log: https://github.com/ronf/asyncssh/blob/master/docs/changes.rst#release-270-19-jun-2021

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
