### PR TITLE
python3Packages.coloredlogs: 15.0 -> 15.0.1

### DIFF
--- a/pkgs/development/python-modules/coloredlogs/default.nix
+++ b/pkgs/development/python-modules/coloredlogs/default.nix
@@ -5,14 +5,14 @@
 , humanfriendly
 , verboselogs
 , capturer
-, pytest
+, pytestCheckHook
 , mock
 , util-linux
 }:
 
 buildPythonPackage rec {
   pname = "coloredlogs";
-  version = "15.0";
+  version = "15.0.1";
 
   src = fetchFromGitHub {
     owner = "xolox";
@@ -21,18 +21,33 @@ buildPythonPackage rec {
     sha256 = "sha256-C1Eo+XrrL3bwhT49KyOE6xjbAHJxn9Qy4s1RR5ERVtA=";
   };
 
+  propagatedBuildInputs = [
+    humanfriendly
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    mock
+    util-linux
+    verboselogs
+    capturer
+  ];
+
   # capturer is broken on darwin / py38, so we skip the test until a fix for
   # https://github.com/xolox/python-capturer/issues/10 is released.
   doCheck = !stdenv.isDarwin;
-  checkPhase = ''
-    PATH=$PATH:$out/bin pytest . -k "not test_plain_text_output_format \
-                                     and not test_auto_install"
+
+  preCheck = ''
+    # Required for the CLI test
+    PATH=$PATH:$out/bin
   '';
-  checkInputs = [ pytest mock util-linux verboselogs capturer ];
+
+  disabledTests = [
+    "test_plain_text_output_format"
+    "test_auto_install"
+  ];
 
   pythonImportsCheck = [ "coloredlogs" ];
-
-  propagatedBuildInputs = [ humanfriendly ];
 
   meta = with lib; {
     description = "Colored stream handler for Python's logging module";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 15.0.1

Change log: https://coloredlogs.readthedocs.io/en/latest/changelog.html#release-15-0-1-2021-06-11

Switch to `pytestCheckHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
