### PR TITLE
pythonPackages.micloud: init at 0.3

### DIFF
--- a/pkgs/development/python-modules/micloud/default.nix
+++ b/pkgs/development/python-modules/micloud/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, click
+, requests
+, tzlocal
+}:
+
+buildPythonPackage rec {
+  pname = "micloud";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "Squachen";
+    repo = "micloud";
+    rev = "v_${version}";
+    sha256 = "0267zyr79nfb5f9rwdwq3ym258yrpxx1b71xiqmszyz5s83mcixm";
+  };
+
+  propagatedBuildInputs = [
+    click
+    requests
+    tzlocal
+  ];
+
+  # tests require credentials
+  doCheck = false;
+
+  pythonImportsCheck = [ "micloud" ];
+
+  meta = with lib; {
+    description = "Xiaomi cloud connect library";
+    homepage = "https://github.com/Squachen/micloud";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5235,6 +5235,8 @@ in {
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };
 
+  micloud = callPackage ../development/python-modules/micloud { };
+
   netmap = callPackage ../development/python-modules/netmap { };
 
   openapi-core = callPackage ../development/python-modules/openapi-core { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This will become a Home Assistant dependency in the next release: https://github.com/home-assistant/core/pull/47955

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
