### PR TITLE
chromedriver: 91.0.4472.101 -> 92.0.4515.43 and aarch64-darwin support

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -68,7 +68,8 @@ def get_matching_chromedriver(version):
         return {
             'version': chromedriver_version,
             'sha256_linux': nix_prefetch_url(get_chromedriver_url('linux64')),
-            'sha256_darwin': nix_prefetch_url(get_chromedriver_url('mac64'))
+            'sha256_darwin': nix_prefetch_url(get_chromedriver_url('mac64')),
+            'sha256_darwin_m1': nix_prefetch_url(get_chromedriver_url('mac64_m1'))
         }
 
 

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -14,7 +14,8 @@
     "chromedriver": {
       "version": "96.0.4664.45",
       "sha256_linux": "15wybxlh38sw7f2bzalf9ivfp8262cpcvhq08nw9d2cj3j39f13m",
-      "sha256_darwin": "0r3b8wgbd8xjb09f4vc402gp77y2aqjk9hpqvvr6xgdr7nqym20f"
+      "sha256_darwin": "0r3b8wgbd8xjb09f4vc402gp77y2aqjk9hpqvvr6xgdr7nqym20f",
+      "sha256_darwin_m1": "NR/ayEn03gNNNvTttrx6nPZFXcpGB2fpKsUI/Szi1vs="
     }
   },
   "beta": {

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -17,6 +17,11 @@ let
       system = "mac64";
       sha256 = upstream-info.sha256_darwin;
     };
+
+    aarch64-darwin = {
+      system = "mac64_m1";
+      sha256 = upstream-info.sha256_darwin_m1;
+    };
   };
 
   spec = allSpecs.${stdenv.hostPlatform.system}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I need to develop selenium tests, and the chrome team are already release aarch64-darwin binaries.


###### Things done

1. bumped the version, called nix-prefetch-url to get the sha256 for linux and x86_64-darwin.
2. Added aarch64-darwin

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
