### PR TITLE
python3Packages.ibm-watson: 5.2.0 -> 5.2.1

### DIFF
--- a/pkgs/development/python-modules/ibm-cloud-sdk-core/default.nix
+++ b/pkgs/development/python-modules/ibm-cloud-sdk-core/default.nix
@@ -38,9 +38,17 @@ buildPythonPackage rec {
 
   # Various tests try to access credential files which are not included with the source distribution
   disabledTests = [
-    "test_iam" "test_cwd" "test_configure_service" "test_get_authenticator"
-    "test_read_external_sources_2" "test_files_duplicate_parts" "test_files_list"
-    "test_files_dict" "test_retry_config_external" "test_gzip_compression_external"
+    "test_configure_service"
+    "test_cp4d_authenticator"
+    "test_cwd"
+    "test_files_dict"
+    "test_files_duplicate_parts"
+    "test_files_list"
+    "test_get_authenticator"
+    "test_gzip_compression_external"
+    "test_iam"
+    "test_read_external_sources_2"
+    "test_retry_config_external"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/ibm-watson/default.nix
+++ b/pkgs/development/python-modules/ibm-watson/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "ibm-watson";
-  version = "5.2.0";
+  version = "5.2.1";
 
   src = fetchFromGitHub {
     owner = "watson-developer-cloud";
     repo = "python-sdk";
     rev = "v${version}";
-    sha256 = "1abink5mv9nw506nwm9hlvnr1lq6dkxxj2j12iwphcyd7xs63n2s";
+    sha256 = "sha256-0F4BZf0D0dqGm0OkJaSgmH5RxEA8KCzOlbnhIQVsgzQ=";
   };
 
   checkInputs = [
@@ -40,8 +40,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace websocket-client==0.48.0 websocket-client>=0.48.0 \
-      --replace ibm_cloud_sdk_core==3.3.6 ibm_cloud_sdk_core>=3.3.6
+      --replace websocket-client==1.1.0 websocket-client>=1.1.0
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.2.1

Change log: https://github.com/watson-developer-cloud/python-sdk/releases/tag/v5.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
