### PR TITLE
nixos/lighthouse: initial lighthouse ethereum service

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -381,6 +381,18 @@
           <link xlink:href="options.html#opt-services.seafile.enable">services.seafile</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/sigp/lighthouse">lighthouse</link>,
+          a Ethereum 2.0 client. Available as
+          <link xlink:href="options.html#opt-services.lighthouse">services.lighthouse</link>.
+          Can be used together with the
+          <link xlink:href="https://geth.ethereum.org/">geth</link>,
+          available as
+          <link xlink:href="options.html#opt-services.geth">services.geth</link>,
+          to run a node for staking ETH2.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -116,6 +116,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [seafile](https://www.seafile.com/en/home/), an open source file syncing & sharing software. Available as [services.seafile](options.html#opt-services.seafile.enable).
 
+- [lighthouse](https://github.com/sigp/lighthouse), a Ethereum 2.0 client. Available as [services.lighthouse](options.html#opt-services.lighthouse). Can be used together with the [geth](https://geth.ethereum.org/), available as [services.geth](options.html#opt-services.geth), to run a node for staking ETH2.
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `services.wakeonlan` option was removed, and replaced with `networking.interfaces.<name>.wakeOnLan`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -288,6 +288,7 @@
   ./services/backup/zfs-replication.nix
   ./services/backup/znapzend.nix
   ./services/blockchain/ethereum/geth.nix
+  ./services/blockchain/ethereum/lighthouse.nix
   ./services/backup/zrepl.nix
   ./services/cluster/hadoop/default.nix
   ./services/cluster/k3s/default.nix

--- a/nixos/modules/services/blockchain/ethereum/lighthouse.nix
+++ b/nixos/modules/services/blockchain/ethereum/lighthouse.nix
@@ -1,0 +1,283 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  eachLighthouse = config.services.lighthouse;
+
+  lighthouseOpts = { config, lib, name, ...}: {
+
+    options = {
+
+      beacon = mkOption {
+        description = "Beacon node";
+        type = types.submodule {
+          options = {
+            enable = lib.mkEnableOption  "Lightouse Beacon node";
+
+            address = mkOption {
+              type = types.str;
+              default = "0.0.0.0";
+              description = ''
+                Listen address of Beacon node.
+              '';
+            };
+
+            port = mkOption {
+              type = types.port;
+              default = 9000;
+              description = ''
+                Port number the Beacon node will be listening on.
+              '';
+            };
+
+            http = {
+              port = mkOption {
+                type = types.port;
+                default = 5052;
+                description = ''
+                  Port number of Beacon node RPC service.
+                '';
+              };
+
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = ''
+                  Listen address of Beacon node RPC service.
+                '';
+              };
+            };
+
+            metrics = {
+              enable = lib.mkEnableOption "Beacon node prometheus metrics";
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = ''
+                  Listen address of Beacon node metrics service.
+                '';
+              };
+
+              port = mkOption {
+                type = types.port;
+                default = 5054;
+                description = ''
+                  Port number of Beacon node metrics service.
+                '';
+              };
+            };
+
+            eth1Endpoints = mkOption {
+              type = types.listOf types.str;
+              default = ["http://localhost:8545"];
+              description = ''
+                List of ETH1 nodes to connect to.
+              '';
+            };
+
+            extraArgs = mkOption {
+              type = types.str;
+              description = ''
+                Additional arguments passed to the lighthouse beacon command.
+              '';
+              default = "";
+              example = "";
+            };
+          };
+        };
+      };
+
+      validator = mkOption {
+        description = "Validator node";
+        type = types.submodule {
+          options = {
+            enable = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Enable Lightouse Validator node.";
+            };
+
+            beaconNodes = mkOption {
+              type = types.listOf types.str;
+              default = ["http://localhost:5052"];
+              description = ''
+                Beacon nodes to connect to.
+              '';
+            };
+
+            metrics = {
+              enable = lib.mkEnableOption "Validator node prometheus metrics";
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = ''
+                  Listen address of Validator node metrics service.
+                '';
+              };
+
+              port = mkOption {
+                type = types.port;
+                default = 5056;
+                description = ''
+                  Port number of Validator node metrics service.
+                '';
+              };
+            };
+
+            extraArgs = mkOption {
+              type = types.str;
+              description = ''
+                Additional arguments passed to the lighthouse validator command.
+              '';
+              default = "";
+              example = "";
+            };
+          };
+        };
+      };
+
+      network = mkOption {
+        type = types.enum [ "prater" "pyrmont" "mainnet" ];
+        default = "mainnet";
+        description = ''
+          The network to connect to. Mainnet is the default ethereum network.
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = types.str;
+        description = ''
+          Additional arguments passed to every lighthouse command.
+        '';
+        default = "";
+        example = "";
+      };
+
+      package = mkOption {
+        default = pkgs.lighthouse-ethereum;
+        type = types.package;
+        description = ''
+          Package to use as Lighthouse node.
+        '';
+      };
+    };
+  };
+
+  lighthouse-wrapper = (lighthouseName: cfg:
+    pkgs.writeScriptBin "lh-${lighthouseName}" ''
+      #! ${pkgs.runtimeShell}
+      cd ${cfg.package}
+      sudo=exec
+      if [[ "$USER" != lighthouse-${lighthouseName}-validator ]]; then
+        sudo='exec /run/wrappers/bin/sudo -u lighthouse-${lighthouseName}-validator'
+      fi
+      $sudo \
+        ${cfg.package}/bin/lighthouse --network ${cfg.network} --datadir /var/lib/lighthouse-validator/${lighthouseName}/${cfg.network} $*
+    ''
+  );
+
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+    services.lighthouse = mkOption {
+      type = types.attrsOf (types.submodule lighthouseOpts);
+      default = {};
+      description = "Specification of one or more lighthouse instances.";
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf (eachLighthouse != {}) {
+
+    # Create a real user for the validator so we can interact with it
+    users.users = mapAttrs' (lighthouseName: cfg: (
+      nameValuePair "lighthouse-${lighthouseName}-validator" {
+      group = "lighthouse";
+      createHome = false;
+      description = "Lighthouse Validator User (${lighthouseName})";
+      home = "/var/lib/lighthouse-validator/${lighthouseName}";
+      isSystemUser = true;
+      packages = [ cfg.package ];
+    })) eachLighthouse;
+
+    users.groups.lighthouse = {};
+
+    # Create a wrapper script for each instance that has the proper data directory set
+    environment.systemPackages = flatten (mapAttrsToList lighthouse-wrapper eachLighthouse);
+
+    systemd.tmpfiles.rules = [
+       "d '/var/lib/lighthouse-validator' 0770 root lighthouse - -"
+    ] ++ flatten (mapAttrsToList (lighthouseName: cfg: [
+       "d '/var/lib/lighthouse-validator/${lighthouseName}' 0700 lighthouse-${lighthouseName}-validator lighthouse - -"
+    ]) eachLighthouse);
+
+    systemd.services = mapAttrs' (lighthouseName: cfg: (
+      nameValuePair "lighthouse-${lighthouseName}-beacon" (mkIf cfg.beacon.enable {
+        description = "Lighthouse Beacon node (${lighthouseName})";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          DynamicUser = true;
+          Restart = "always";
+          StateDirectory = "lighthouse-beacon/${lighthouseName}/${cfg.network}";
+
+          # Hardening measures
+          PrivateTmp = "true";
+          ProtectSystem = "full";
+          NoNewPrivileges = "true";
+          PrivateDevices = "true";
+          MemoryDenyWriteExecute = "true";
+        };
+
+        script = ''
+          ${cfg.package}/bin/lighthouse beacon \
+            --disable-upnp \
+            --http --http-address ${cfg.beacon.http.address} --http-port ${toString cfg.beacon.http.port} \
+            --network ${cfg.network} \
+            --eth1-endpoints ${lib.concatStringsSep "," cfg.beacon.eth1Endpoints} \
+            --port ${toString cfg.beacon.port} --listen-address ${cfg.beacon.address} \
+            ${optionalString cfg.beacon.metrics.enable ''--metrics --metrics-address ${cfg.beacon.metrics.address} --metrics-port ${toString cfg.beacon.metrics.port}''} \
+            ${cfg.extraArgs} ${cfg.beacon.extraArgs} \
+            --datadir /var/lib/lighthouse-beacon/${lighthouseName}/${cfg.network}
+        '';
+      }))) eachLighthouse // mapAttrs' (lighthouseName: cfg: (
+      nameValuePair "lighthouse-${lighthouseName}-validator" (mkIf cfg.validator.enable {
+        description = "Lighthouse Validator node (${lighthouseName})";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          User = "lighthouse-${lighthouseName}-validator";
+          Group = "lighthouse";
+          Restart = "always";
+          StateDirectory = "lighthouse-validator/${lighthouseName}/${cfg.network}";
+
+          # Hardening measures
+          PrivateTmp = "true";
+          ProtectSystem = "full";
+          NoNewPrivileges = "true";
+          PrivateDevices = "true";
+          MemoryDenyWriteExecute = "true";
+        };
+
+        script = ''
+          ${cfg.package}/bin/lighthouse validator \
+            --network ${cfg.network} \
+            --beacon-nodes ${lib.concatStringsSep "," cfg.validator.beaconNodes} \
+            ${optionalString cfg.validator.metrics.enable ''--metrics --metrics-address ${cfg.validator.metrics.address} --metrics-port ${toString cfg.validator.metrics.port}''} \
+            ${cfg.extraArgs} ${cfg.validator.extraArgs} \
+            --datadir /var/lib/lighthouse-validator/${lighthouseName}/${cfg.network}
+        '';
+      }))) eachLighthouse;
+
+  };
+
+}

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -28,13 +28,13 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "lighthouse";
-  version = "2.0.0";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "sigp";
     repo = "lighthouse";
-    rev = "v${version}";
-    sha256 = "01p24xcxf8z0d3krpx6k1q1gp25yvqh2pcq9q197fd09vw4bh0pl";
+    rev = "1790010260a7ce90a29af7267831d28ca3f7a576";
+    sha256 = "11k9dfinfjffwqvhz2jfpjbxhma0ac3r0w2cv5k64d1n5d1gilpk";
   };
 
   postPatch = ''
@@ -69,7 +69,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "--features" "${lib.optionalString portable "portable,"}" ];
 
-  cargoSha256 = "1ihxrjrxv8ipjis9i20hcd1xaspblxw3rh5phpfzgbgbkhpaqn35";
+  cargoSha256 = "19n12cz9cnmhlqim4f92l8nhnylz7ha7jxl4w5yh6lqqva5lg8li";
 
   checkFlags = [
     # these want internet access, disable them

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -3,7 +3,7 @@
 , rustPlatform
 , pkg-config, cmake, protobuf
 , zlib, bzip2, openssl, leveldb
-, nodePackages, curl, gnumake, git
+, nodePackages, curl, git
 , libredirect
 , portable ? true
 }:
@@ -28,20 +28,25 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "lighthouse";
-  version = "1.5.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "sigp";
     repo = "lighthouse";
     rev = "v${version}";
-    sha256 = "13pacp39splz6glinz0fy58fb0lsbqp54ndb2d4w9xb716yr1vnk";
+    sha256 = "01p24xcxf8z0d3krpx6k1q1gp25yvqh2pcq9q197fd09vw4bh0pl";
   };
 
-  # Patch version check to not rely on git
   postPatch = ''
+    # Patch version check to not rely on git
     substituteInPlace common/lighthouse_version/src/lib.rs \
       --replace 'fallback = "unknown"' 'fallback = "Lighthouse/v${version}"' \
       --replace 'r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?-[[:xdigit:]]{7}\+?$"' 'r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?$"'
+
+    # web3signer_tests requires internet access to build, and fetches the latest version from github
+    # remove it it is only used for testing
+    substituteInPlace Cargo.toml \
+      --replace '"testing/web3signer_tests",' '#"testing/web3signer_tests",' \
   '';
 
   # LevelDB can't be unvendored and it requires cmake to be built
@@ -64,7 +69,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "--features" "${lib.optionalString portable "portable,"}" ];
 
-  cargoSha256 = "1i84gf7as3hkk6x5ir9br2sfxrh490704sdiqp44an005hlbaiav";
+  cargoSha256 = "1ihxrjrxv8ipjis9i20hcd1xaspblxw3rh5phpfzgbgbkhpaqn35";
 
   checkFlags = [
     # these want internet access, disable them

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -1,0 +1,87 @@
+{ lib, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config, cmake, protobuf
+, zlib, bzip2, openssl, leveldb
+, nodePackages, curl, gnumake, git
+, libredirect
+, portable ? true
+}:
+
+let
+  # Contains the data required by the deposit_contract
+  # See `common/deposit_contract/build.rs` in the lighthous source for exact version
+  eth2specs = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "eth2.0-specs";
+    rev = "v0.12.1";
+    sha256 = "05irxnskcsdbp844hgk2hwkjmgfjxin99jr1fl5b5wg1v7v7gl4y";
+  };
+  eth2specs_unsafe = fetchFromGitHub {
+    owner = "sigp";
+    repo = "unsafe-eth2-deposit-contract";
+    # NOTE: the version of the unsafe contract lags the main tag, but the v0.9.2.1 code is compatible
+    # with the unmodified v0.12.1 contract. See `common/deposit_contract/build.rs` for details.
+    rev = "v0.9.2.1";
+    sha256 = "151ahdj5114xb5hbhzsx5rx4yyry832hhm0bkx36s2np3r8v883q";
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "lighthouse";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "sigp";
+    repo = "lighthouse";
+    rev = "v${version}";
+    sha256 = "13pacp39splz6glinz0fy58fb0lsbqp54ndb2d4w9xb716yr1vnk";
+  };
+
+  # Patch version check to not rely on git
+  postPatch = ''
+    substituteInPlace common/lighthouse_version/src/lib.rs \
+      --replace 'fallback = "unknown"' 'fallback = "Lighthouse/v${version}"' \
+      --replace 'r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?-[[:xdigit:]]{7}\+?$"' 'r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?$"'
+  '';
+
+  # LevelDB can't be unvendored and it requires cmake to be built
+  nativeBuildInputs = [ pkg-config cmake protobuf git ];
+  buildInputs = [ openssl zlib bzip2 leveldb ];
+  checkInputs = [ nodePackages.ganache-cli curl ];
+
+  preConfigure = ''
+    # Needed to get openssl-sys to use pkg-config.
+    export OPENSSL_NO_VENDOR=1
+
+    # Prost build needs this
+    export PROTOC="${protobuf}/bin/protoc"
+    export PROTOC_INCLUDE="${protobuf}/include"
+
+    # Use the pre fetched files instead of downloading them during build
+    export LIGHTHOUSE_DEPOSIT_CONTRACT_SPEC_URL="file://${eth2specs}/deposit_contract/contracts/validator_registration.json"
+    export LIGHTHOUSE_DEPOSIT_CONTRACT_TESTNET_URL="file://${eth2specs_unsafe}/unsafe_validator_registration.json"
+  '';
+
+  cargoBuildFlags = [ "--features" "${lib.optionalString portable "portable,"}" ];
+
+  cargoSha256 = "1i84gf7as3hkk6x5ir9br2sfxrh490704sdiqp44an005hlbaiav";
+
+  checkFlags = [
+    # these want internet access, disable them
+    "--skip=generated"
+  ];
+
+  # Make /etc/resolv.conf available in sandbox
+  preCheck = ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/resolv.conf=$(realpath resolv.conf)
+    export LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '';
+
+  meta = with lib; {
+    description = "An open-source Ethereum 2.0 client, written in Rust.";
+    homepage = "https://github.com/sigp/lighthouse";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29486,6 +29486,8 @@ with pkgs;
 
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };
 
+  lighthouse-ethereum = callPackage ../applications/blockchains/lighthouse { };
+
   lightning-loop = callPackage ../applications/blockchains/lightning-loop { };
 
   lightning-pool = callPackage ../applications/blockchains/lightning-pool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Allow running a lighthouse ETH2 client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
