### PR TITLE
python3Packages.ipfshttpclient: 0.7.0 -> 0.8.0a2

### DIFF
--- a/pkgs/development/python-modules/ipfshttpclient/default.nix
+++ b/pkgs/development/python-modules/ipfshttpclient/default.nix
@@ -20,15 +20,15 @@
 
 buildPythonPackage rec {
   pname = "ipfshttpclient";
-  version = "0.7.0";
+  version = "0.8.0a2";
   format = "flit";
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "ipfs-shipyard";
     repo = "py-ipfs-http-client";
     rev = version;
-    sha256 = "sha256-0lMoZo/9kZUXkaKvD9ZAZDQdGX7eNLzJVszZdlM/3Qs=";
+    sha256 = "sha256-OmC67pN2BbuGwM43xNDKlsLhwVeUbpvfOazyIDvoMEA=";
   };
 
   propagatedBuildInputs = [
@@ -51,11 +51,7 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    # Remove when the package supports the latest IPFS version by default
-    substituteInPlace ipfshttpclient/client/__init__.py \
-      --replace 'VERSION_MAXIMUM   = "0.8.0"' \
-                'VERSION_MAXIMUM   = "0.9.0"'
-
+    # This can be removed for the 0.8.0 release
     # Use pytest-order instead of pytest-ordering since the latter is unmaintained and broken
     substituteInPlace test/run-tests.py \
       --replace 'pytest_ordering' 'pytest_order'


### PR DESCRIPTION
###### Motivation for this change
https://github.com/ipfs-shipyard/py-ipfs-http-client/releases/tag/0.8.0a2
This fixes the build failure caused by updating the version of IPFS. This version of ipfshttpclient treats a newer IPFS version as a warning instead of an error and the tests pass just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).