### PR TITLE
expat: Fix cmake config files

### DIFF
--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -27,6 +27,13 @@ stdenv.mkDerivation rec {
     patchShebangs ./configure ./run.sh ./test-driver-wrapper.sh
   '';
 
+  # CMake files incorrectly calculate library path from dev prefix
+  # https://github.com/libexpat/libexpat/issues/501
+  postFixup = ''
+    substituteInPlace $dev/lib/cmake/expat-${version}/expat-noconfig.cmake \
+      --replace "$"'{_IMPORT_PREFIX}' $out
+  '';
+
   meta = with lib; {
     homepage = "https://libexpat.github.io/";
     description = "A stream-oriented XML parser library written in C";

--- a/pkgs/development/libraries/opencolorio/default.nix
+++ b/pkgs/development/libraries/opencolorio/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, lib, fetchFromGitHub, symlinkJoin,
+  stdenv, lib, fetchFromGitHub,
   cmake, expat, libyamlcpp, ilmbase, pystring, # Base dependencies
 
   glew, freeglut, # Only required on Linux
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
     sha256 = "194j9jp5c8ws0fryiz936wyinphnpzwpqnzvw9ryx6rbiwrba487";
   };
 
-  nativeBuildInputs = [ cmake (symlinkJoin { name = "expat"; paths = [ expat.out expat.dev ]; }) ];
-  buildInputs = [ expat.out libyamlcpp ilmbase pystring ]
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ expat libyamlcpp ilmbase pystring ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ glew freeglut ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Carbon GLUT Cocoa ]
     ++ lib.optionals pythonBindings [ python3Packages.python python3Packages.pybind11 ]


### PR DESCRIPTION
Closes #128808
This is a universal fix for what the above PR was trying to implement locally.

###### Motivation for this change

As mentioned in #128808, the expat bump from #124212 introduced new, currently broken CMake files. This broke the freshly introduced opencolorio 2.x (part of #127522) and in turn our Blender package. This patches those files so everything works again.

Why are they broken?

`expat.cmake`:
```cmake
# Compute the installation prefix relative to this file.
get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
if(_IMPORT_PREFIX STREQUAL "/")
  set(_IMPORT_PREFIX "") 
endif()

# Create imported target expat::expat
add_library(expat::expat SHARED IMPORTED)

set_target_properties(expat::expat PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
)

# Load information for each installed configuration.
get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
file(GLOB CONFIG_FILES "${_DIR}/expat-*.cmake")
foreach(f ${CONFIG_FILES})
  include(${f})
endforeach()
```

`expat-noconfig.cmake`:
```cmake
# Import target "expat::expat" for configuration ""
set_property(TARGET expat::expat APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
set_target_properties(expat::expat PROPERTIES
  IMPORTED_LOCATION_NOCONFIG "${_IMPORT_PREFIX}/lib/libexpat.so.1.8.1"
  IMPORTED_SONAME_NOCONFIG "libexpat.so.1"
  )

list(APPEND _IMPORT_CHECK_TARGETS expat::expat )
list(APPEND _IMPORT_CHECK_FILES_FOR_expat::expat "${_IMPORT_PREFIX}/lib/libexpat.so.1.8.1" )
```

Since `_IMPORT_PREFIX` is calculated from the `dev` output that has the cmake files but the libraries are in the `out` output, the later check can never find the libraries. We'll replace the `${_IMPORT_PREFIX}` usage in the library path with the correct output variable.

CC @hartwork, upstream expat developer & committer of the bump that introduced these files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
