### PR TITLE
pscale: Init at 0.51.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8192,6 +8192,12 @@
     githubId = 1179566;
     name = "Nicolas B. Pierron";
   };
+  pimeys = {
+    email = "julius@nauk.io";
+    github = "pimeys";
+    githubId = 34967;
+    name = "Julius de Bruijn";
+  };
   pingiun = {
     email = "nixos@pingiun.com";
     github = "pingiun";

--- a/pkgs/development/tools/pscale/default.nix
+++ b/pkgs/development/tools/pscale/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "pscale";
+  version = "0.51.0";
+
+  src = fetchFromGitHub {
+    owner = "planetscale";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "sha256-ykHwDVwL30uXeCEP4EcM8TPYqZmCDDAUUpfinpYipHE=";
+  };
+
+  vendorSha256 = "sha256-3VP2fluQLZs4nWT3O6NmCFxrqKw0/j3ASNxtbXHlZEA=";
+
+  meta = with lib; {
+    homepage = "https://www.planetscale.com/";
+    changelog = "https://github.com/planetscale/cli/releases/tag/v${version}";
+    description = "The CLI for PlanetScale Database";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pimeys ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3149,6 +3149,8 @@ in
 
   ps_mem = callPackage ../tools/system/ps_mem { };
 
+  pscale = callPackage ../development/tools/pscale { };
+
   psstop = callPackage ../tools/system/psstop { };
 
   precice = callPackage ../development/libraries/precice { };


### PR DESCRIPTION
Introducing the PlanetScale CLI, a tool to manage PlanetScale databases.

###### Motivation for this change

To be able to manage PlanetScale databases conveniently from NixOS.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
