### PR TITLE
noweb: fix nawk binary name

### DIFF
--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -57,7 +57,7 @@ lib.fix (noweb: stdenv.mkDerivation rec {
         # NOTE: substituteInPlace breaks Icon binaries, so make sure the script
         #       uses (n)awk before calling.
         if grep -q nawk "$f"; then
-            substituteInPlace "$f" --replace "nawk" "${nawk}/bin/awk"
+            substituteInPlace "$f" --replace "nawk" "${nawk}/bin/nawk"
         fi
     done
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The package `nawk` seems to supply the binary `nawk` not `awk`, not sure if this was always thus, or if this is a new change.
```
$ tree `nix eval -f '<nixpkgs>' --raw nawk`
/nix/store/jji0m1by0nks2pdplk6xpwqq0dz8qy2s-nawk-unstable-2021-02-15
├── bin
│   └── nawk
└── share
    └── man
        └── man1
            └── nawk.1.gz

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
