### PR TITLE
isomd5sum: support cross: move python to nativeBuildInputs

### DIFF
--- a/pkgs/tools/cd-dvd/isomd5sum/default.nix
+++ b/pkgs/tools/cd-dvd/isomd5sum/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
     sha256 = "1wjnh2hlp1hjjm4a8wzdhdrm73jq41lmpmy3ls0rh715p3j7z4q9";
   };
 
-  buildInputs = [ python3 popt ] ;
+  strictDeps = true;
+  nativeBuildInputs = [ python3 ];
+  buildInputs = [ popt ] ;
 
   postPatch = ''
     substituteInPlace Makefile --replace "#/usr/" "#"


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] implantisomd5 (with qemu-aarch64)
  - [x] checkisomd5 (with qemu-aarch64)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
