### PR TITLE
nixos/tests/zsh-history: Fix matching prompt

### DIFF
--- a/nixos/tests/zsh-history.nix
+++ b/nixos/tests/zsh-history.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     # Login
     default.wait_until_tty_matches(1, "login: ")
     default.send_chars("root\n")
-    default.wait_until_tty_matches(1, "root@default>")
+    default.wait_until_tty_matches(1, r"\nroot@default\b")
 
     # Generate some history
     default.send_chars("echo foobar\n")


### PR DESCRIPTION
In commit fbbaa4d40f73a5350671f286b07ab3dc58f07321, the Zsh default prompt has changed from `walters` to `suse`. So instead of:

```
root@default>
```

... we now have:

```
root@default:~/ >
```

However, in the NixOS VM test, we are matching `root@default>`, which doesn't include the current working directory and thus eventually leads to a test failure after timing out.

To fix this, I changed the regex to include a newline at the beginning and made sure that the hostname ends with a word boundary. This way it doesn't matter whether the prompt is `walters` or `suse`, because after all the test is not about the prompt but about whether the history mechanism works (or not).