### PR TITLE
startup-notification: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/startup-notification/default.nix
+++ b/pkgs/development/libraries/startup-notification/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation {
     sha256 = "3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a";
   };
 
+  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.targetPlatform) [
+    "lf_cv_sane_realloc=yes"
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libX11 libxcb xcbutil ];
 


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for this common desktop dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
