### PR TITLE
python3Packages.dill: 0.3.1.1 -> 0.3.4

### DIFF
--- a/pkgs/development/python-modules/dill/default.nix
+++ b/pkgs/development/python-modules/dill/default.nix
@@ -1,37 +1,47 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , isPy27
-, nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "dill";
-  version = "0.3.1.1";
+  version = "0.3.4";
+  doCheck = !isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "42d8ef819367516592a825746a18073ced42ca169ab1f5f4044134703e7a049c";
+  src = fetchFromGitHub {
+    owner = "uqfoundation";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0x702gh50wb3n820p2p9w49cn4a354y207pllwc7snfxprv6hypm";
   };
 
-  # python2 can't import a test fixture
-  doCheck = !isPy27;
-  checkInputs = [ nose ];
-  checkPhase = ''
-    PYTHONPATH=$PWD/tests:$PYTHONPATH
-    nosetests \
-      --ignore-files="test_classdef" \
-      --ignore-files="test_objects" \
-      --ignore-files="test_selected" \
-      --exclude="test_the_rest" \
-      --exclude="test_importable"
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   # Tests seem to fail because of import pathing and referencing items/classes in modules.
   # Seems to be a Nix/pathing related issue, not the codebase, so disabling failing tests.
+  disabledTestPaths = [
+    "tests/test_diff.py"
+    "tests/test_module.py"
+    "tests/test_objects.py"
+  ];
 
-  meta = {
+  disabledTests = [
+    "test_class_objects"
+    "test_method_decorator"
+    "test_importable"
+    "test_the_rest"
+  ];
+
+  pythonImportsCheck = [ "dill" ];
+
+  meta = with lib; {
     description = "Serialize all of python (almost)";
     homepage = "https://github.com/uqfoundation/dill/";
-    license = lib.licenses.bsd3;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.4

Change log: https://github.com/uqfoundation/dill/releases/tag/dill-0.3.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
