### PR TITLE
python3Packages.dugong: 3.7.5 -> 3.8.1

### DIFF
--- a/pkgs/development/python-modules/dugong/default.nix
+++ b/pkgs/development/python-modules/dugong/default.nix
@@ -1,14 +1,32 @@
-{ buildPythonPackage, fetchPypi, pythonOlder }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "dugong";
-  version = "3.7.5";
+  version = "3.8.1";
+  disabled = pythonOlder "3.3";
 
-  disabled = pythonOlder "3.3"; # Library does not support versions older than 3.3
+  src = fetchFromGitHub {
+    owner = "python-dugong";
+    repo = "python-dugong";
+    rev = "release-${version}";
+    sha256 = "1063c1779idc5nrjzfv5w1xqvyy3crapb2a2xll9y6xphxclnkjc";
+  };
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "tar.bz2";
-    sha256 = "10vjdp21m0gzm096lgl84z184s5l9iz69ppj6acgsc125037dl6h";
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "dugong" ];
+
+  meta = with lib; {
+    description = "HTTP 1.1 client designed for REST-ful APIs";
+    homepage = "https://github.com/python-dugong/python-dugong/";
+    license = with licenses; [ psfl asl20 ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.8.1

Change log: https://github.com/python-dugong/python-dugong/blob/master/Changes.rst#release-381-2021-01-10

Enable tests and add meta.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
