### PR TITLE
hottext: fix

### DIFF
--- a/pkgs/tools/text/hottext/default.nix
+++ b/pkgs/tools/text/hottext/default.nix
@@ -67,7 +67,7 @@ in stdenv.mkDerivation rec {
 
   nimFlags = [ "-d:release" ] ++ map (lib: "--path:${lib}/src") nimLibs;
 
-  HOTTEXT_FONT_PATH = "${gentium}/share/fonts/truetype/GentiumPlus-R.ttf";
+  HOTTEXT_FONT_PATH = "${gentium}/share/fonts/truetype/GentiumPlus-Regular.ttf";
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
The default font is from Gentium, but the available font files in the current version of Gentium don't contain the requested one (`GentiumPlus-R.ttf`):

```
$ ls /nix/store/hyc050nq33gvxjrdxw1z8yc948q67xjp-gentium-6.000/share/fonts/truetype/
GentiumBookPlus-BoldItalic.ttf  GentiumBookPlus-Regular.ttf  GentiumPlus-Italic.ttf
GentiumBookPlus-Bold.ttf        GentiumPlus-BoldItalic.ttf   GentiumPlus-Regular.ttf
GentiumBookPlus-Italic.ttf      GentiumPlus-Bold.ttf
```

`GentiumPlus-Regular` seems more likely to be what was intended.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`hottext` is currently broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
