### PR TITLE
python3Packages.diff_cover: 5.2.0 -> 5.4.0

### DIFF
--- a/pkgs/development/python-modules/diff-cover/default.nix
+++ b/pkgs/development/python-modules/diff-cover/default.nix
@@ -15,12 +15,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "diff_cover";
+  pname = "diff-cover";
   version = "5.4.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "diff_cover";
+    inherit version;
     sha256 = "sha256-4iQ9/QcXh/lW8HE6wFZWc6Y57xhAEWu2TQnIUZJNAMs=";
   };
 

--- a/pkgs/development/python-modules/diff_cover/default.nix
+++ b/pkgs/development/python-modules/diff_cover/default.nix
@@ -1,41 +1,51 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib
+, buildPythonPackage
 , chardet
+, fetchPypi
 , inflect
 , jinja2
 , jinja2_pluralize
-, pygments
-, six
-# test dependencies
-, coverage
-, mock
-, nose
 , pycodestyle
 , pyflakes
+, pygments
 , pylint
-, pytest
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "diff_cover";
-  version = "5.2.0";
-
-  preCheck = ''
-    export LC_ALL=en_US.UTF-8;
-  '';
+  version = "5.4.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a1cd54232d2e48bd4c1eabc96cfe4a8727a9a92fd2556b52ff8f65bb8adf8768";
+    sha256 = "sha256-4iQ9/QcXh/lW8HE6wFZWc6Y57xhAEWu2TQnIUZJNAMs=";
   };
 
-  propagatedBuildInputs = [ chardet jinja2 jinja2_pluralize pygments six inflect ];
+  propagatedBuildInputs = [
+    chardet
+    inflect
+    jinja2
+    jinja2_pluralize
+    pygments
+  ];
 
-  checkInputs = [ mock coverage pytest nose pylint pyflakes pycodestyle ];
+  checkInputs = [
+    pycodestyle
+    pyflakes
+    pylint
+    pytest-mock
+    pytestCheckHook
+  ];
 
-  # ignore tests which try to write files
-  checkPhase = ''
-    pytest -k 'not added_file_pylint_console and not file_does_not_exist'
-  '';
+  disabledTests = [
+    "added_file_pylint_console"
+    "file_does_not_exist"
+  ];
+
+  pythonImportsCheck = [ "diff_cover" ];
 
   meta = with lib; {
     description = "Automatically find diff lines that need test coverage";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -36,6 +36,7 @@ mapAliases ({
   blockdiagcontrib-cisco = throw "blockdiagcontrib-cisco is not compatible with blockdiag 2.0.0 and has been removed."; # Added 2020-11-29
   bugseverywhere = throw "bugseverywhere has been removed: Abandoned by upstream."; # Added 2019-11-27
   detox = throw "detox is no longer maintained, and was broken since may 2019"; # added 2020-07-04
+  diff_cover = diff-cover; # added 2021-07-02
   dns = dnspython; # Alias for compatibility, 2017-12-10
   faulthandler = throw "faulthandler is built into ${python.executable}";
   gitdb2 = throw "gitdb2 has been deprecated, use gitdb instead."; # added 2020-03-14

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1921,7 +1921,7 @@ in {
 
   dicttoxml = callPackage ../development/python-modules/dicttoxml { };
 
-  diff_cover = callPackage ../development/python-modules/diff_cover { };
+  diff-cover = callPackage ../development/python-modules/diff-cover { };
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.4.0

Change log: https://github.com/Bachmann1234/diff_cover/releases/tag/v5.4.0

Rename from `diff_cover`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
