### PR TITLE
python3Packages.diofant: 0.10.0 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/diofant/default.nix
+++ b/pkgs/development/python-modules/diofant/default.nix
@@ -1,39 +1,42 @@
 { lib
-, isPy3k
 , buildPythonPackage
 , fetchPypi
-, pytestrunner
-, setuptools-scm
+, gmpy2
 , isort
 , mpmath
-, strategies
+, numpy
+, pythonOlder
+, scipy
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "diofant";
-  version = "0.10.0";
+  version = "0.12.0";
+  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit version;
     pname = "Diofant";
-    sha256 = "0qjg0mmz2cqxryr610mppx3virf1gslzrsk24304502588z53v8w";
+    sha256 = "sha256-G0CTSoDSduiWxlrk5XjnX5ldNZ9f7yxaJeUPO3ezJgo=";
   };
 
   nativeBuildInputs = [
     isort
-    pytestrunner
     setuptools-scm
   ];
 
   propagatedBuildInputs = [
+    gmpy2
     mpmath
-    strategies
+    numpy
+    scipy
   ];
 
   # tests take ~1h
   doCheck = false;
 
-  disabled = !isPy3k;
+  pythonImportsCheck = [ "diofant" ];
 
   meta = with lib; {
     description = "A Python CAS library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.12.0

Change log: https://diofant.readthedocs.io/en/latest/release/notes-0.12.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
