### PR TITLE
python3Packages.build: 0.3.0 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , filelock
 , flit-core
 , importlib-metadata
@@ -8,6 +8,7 @@
 , packaging
 , pep517
 , pytest-mock
+, pytest-rerunfailures
 , pytest-xdist
 , pytestCheckHook
 , pythonOlder
@@ -17,13 +18,14 @@
 
 buildPythonPackage rec {
   pname = "build";
-  version = "0.3.0";
-
+  version = "0.5.1";
   format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-DrlbLI13DXxMm5LGjCJ8NQu/ZfPsg1UazpCXwYzBX90=";
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = pname;
+    rev = version;
+    sha256 = "15hc9mbxsngfc9n805x8rk7yqbxnw12mpk6hfwcsldnfii1vg2ph";
   };
 
   nativeBuildInputs = [
@@ -42,20 +44,18 @@ buildPythonPackage rec {
 
   checkInputs = [
     filelock
-    pytestCheckHook
     pytest-mock
+    pytest-rerunfailures
     pytest-xdist
+    pytestCheckHook
   ];
 
   disabledTests = [
     "test_isolation"
     "test_isolated_environment_install"
     "test_default_pip_is_never_too_old"
-    "test_build_isolated - StopIteration"
-    "test_build_raises_build_exception"
-    "test_build_raises_build_backend_exception"
-    "test_projectbuilder.py"
-    "test_projectbuilder.py"
+    "test_build"
+    "test_init"
   ];
 
   pythonImportsCheck = [ "build" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.1

Change log: https://pypa-build.readthedocs.io/en/stable/changelog.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
