### PR TITLE
sqlitebrowser: add wrapGAppsHook

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchFromGitHub, cmake
-, qtbase, qttools, sqlite }:
+, qtbase, qttools, sqlite, wrapGAppsHook }:
 
 mkDerivation rec {
   pname = "sqlitebrowser";
@@ -18,7 +18,7 @@ mkDerivation rec {
   # We *really* should get that cleaned up.
   buildInputs = [ qtbase sqlite ];
 
-  nativeBuildInputs = [ cmake qttools ];
+  nativeBuildInputs = [ cmake qttools wrapGAppsHook ];
 
   meta = with lib; {
     description = "DB Browser for SQLite";


### PR DESCRIPTION
###### Motivation for this change
Fixes opening file dialogs on non-NixOS:

```
$ ./result/bin/sqlitebrowser
[... try to open a file dialog: File -> Open Database ...]
(.sqlitebrowser-wrapped:7229): GLib-GIO-ERROR **: 11:27:46.197: Settings schema 'org.gtk.Settings.FileChooser' does not contain a key named 'show-type-column'
Trace/breakpoint trap (core dumped)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu 18.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
