### PR TITLE
Remove danieldk as a maintainer for some packages

### DIFF
--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     homepage = "https://about.draw.io/";
     license = licenses.asl20;
     changelog = "https://github.com/jgraph/drawio-desktop/releases/tag/v${version}";
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     description = "Multi-platform password manager";
     homepage = "https://1password.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ danieldk timstott savannidgerinel ];
+    maintainers = with maintainers; [ timstott savannidgerinel ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -123,7 +123,7 @@ in stdenv.mkDerivation {
     description = "An office suite with a word processor, spreadsheet and presentation program";
     homepage = "https://www.softmaker.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -72,6 +72,6 @@ in mkDerivation {
     license = licenses.unfree;
     homepage = "http://makemkv.com";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ danieldk titanous ];
+    maintainers = with maintainers; [ titanous ];
   };
 }

--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -38,6 +38,6 @@ stdenvNoCC.mkDerivation {
     description = "A set of default and supplemental wallpapers for Fedora";
     license = licenses.cc-by-sa-40;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/compilers/llvm/rocm/clang.nix
+++ b/pkgs/development/compilers/llvm/rocm/clang.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     description = "ROCm fork of the clang C/C++/Objective-C/Objective-C++ LLVM compiler frontend";
     homepage = "https://llvm.org/";
     license = with licenses; [ ncsa ];
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/compilers/llvm/rocm/lld/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/lld/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "ROCm fork of the LLVM Linker";
     homepage = "https://github.com/RadeonOpenCompute/llvm-project";
     license = licenses.ncsa;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/compilers/llvm/rocm/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm/default.nix
@@ -91,7 +91,7 @@ in stdenv.mkDerivation rec {
     description = "ROCm fork of the LLVM compiler infrastructure";
     homepage = "https://github.com/RadeonOpenCompute/llvm-project";
     license = with licenses; [ ncsa ];
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -85,6 +85,6 @@ in stdenv.mkDerivation rec {
     changelog = "https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-${version}";
     license = licenses.mit;
     platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = with maintainers; [ danieldk Flakebi ];
+    maintainers = with maintainers; [ Flakebi ];
   };
 }

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     description = "Radeon Open Compute common language runtime";
     homepage = "https://github.com/ROCm-Developer-Tools/ROCclr";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     # rocclr seems to have some AArch64 ifdefs, but does not seem
     # to be supported yet by the build infrastructure. Recheck in
     # the future.

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     description = "APIs for compiling and inspecting AMDGPU code objects";
     homepage = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/tree/amd-stg-open/lib/comgr";
     license = licenses.ncsa;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Set of AMD-specific device-side language runtime libraries";
     homepage = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs";
     license = licenses.ncsa;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/rocm-opencl-icd/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-icd/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "OpenCL ICD definition for AMD GPUs using the ROCm stack";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     description = "OpenCL runtime for AMD GPUs, part of the ROCm stack";
     homepage = "https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime";
     license = with licenses; [ asl20 mit ];
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     description = "Platform runtime for ROCm";
     homepage = "https://github.com/RadeonOpenCompute/ROCR-Runtime";
     license = with licenses; [ ncsa ];
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "Radeon open compute thunk interface";
     homepage = "https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface";
     license = with licenses; [ bsd2 mit ];
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/build-managers/rocm-cmake/default.nix
+++ b/pkgs/development/tools/build-managers/rocm-cmake/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "CMake modules for common build tasks for the ROCm stack";
     homepage = "https://github.com/RadeonOpenCompute/rocm-cmake";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -75,7 +75,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "An interactive tree view, a fuzzy search, a balanced BFS descent and customizable commands";
     homepage = "https://dystroy.org/broot/";
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     license = with licenses; [ mit ];
   };
 }

--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "System management interface for AMD GPUs supported by ROCm";
     homepage = "https://github.com/RadeonOpenCompute/ROC-smi";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- AMD GPU packages: AMD removed support for the RX5x0 GPUs from ROCm, so
  I cannot test these packages anymore.
- A small number of GUI packages: I switched back to macOS on the
  desktop for work reasons, so I cannot easily test these.
- broot: I took over maintainership from someone in else, but do not
  really use broot.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
