### PR TITLE
python3Packages.curio: 1.4 -> 1.5

### DIFF
--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , isPy3k
 , pytestCheckHook
 , sphinx
@@ -10,30 +9,18 @@
 
 buildPythonPackage rec {
   pname = "curio";
-  version = "1.4";
+  version = "1.5";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "57edce81c837f3c2cf42fbb346dee26e537d1659e6605269fb13bd179e068744";
+    sha256 = "sha256-rwghLlkLt9qOTMOcQgEnEUlNwg1iLxYhVbopbMLjvBA=";
   };
 
-  patches = [
-    # Fix the flaky test due to slow moving time on Apple Silicon chips.
-    # Remove when https://github.com/dabeaz/curio/pull/339 is in the next release.
-    (fetchpatch {
-      url = "https://github.com/dabeaz/curio/commit/132376724bbfaa0a52d3d63d0791aa4ac1eb6f5f.patch";
-      sha256 = "sha256-AxO0xRcR9l9/NKEJFwyZIoYcyZxpqOhpdNaeaYokVb4=";
-    })
-    # Same as above
-    (fetchpatch {
-      url = "https://github.com/dabeaz/curio/commit/8ac2f12a2cdacbc750b01fc7459cee8879bc1ee3.patch";
-      sha256 = "sha256-2Si3fuDLrI09QuzJd1TrE0QY02G9e9m+1eHFTB/MrWU=";
-    })
+  checkInputs = [
+    pytestCheckHook
+    sphinx
   ];
-
-  disabled = !isPy3k;
-
-  checkInputs = [ pytestCheckHook sphinx ];
 
   __darwinAllowLocalNetworking = true;
 
@@ -46,9 +33,11 @@ buildPythonPackage rec {
      "test_unix_ssl_server" # socket bind error on hydra when built with other packages
    ];
 
+  pythonImportsCheck = [ "curio" ];
+
   meta = with lib; {
     homepage = "https://github.com/dabeaz/curio";
-    description = "Library for performing concurrent I/O with coroutines in Python 3";
+    description = "Library for performing concurrent I/O with coroutines in Python";
     license = licenses.bsd3;
     maintainers = [ maintainers.marsam ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.5

Change log: https://github.com/dabeaz/curio/blob/master/CHANGES

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
