### PR TITLE
zfs: 2.0.5 -> 2.1.0

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -198,9 +198,9 @@ in {
     kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.13";
 
     # this package should point to the latest release.
-    version = "2.0.5";
+    version = "2.1.0";
 
-    sha256 = "0n0d8ab7ibxxa8znfsprh7jxwgighx5g291v7hi8272vfjrmk1mj";
+    sha256 = "16l7kva4i3xvzls7n8vi7gpjhxxsgxs37p81fi0n0r2p5d4kimk1";
   };
 
   zfsUnstable = common {
@@ -208,9 +208,9 @@ in {
     kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.14";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2.1.0-rc8";
+    version = "2.1.0";
 
-    sha256 = "0c53ca6xd59c30h3b2hmvyy63yqyk745x1kdfypnfqj3lnsj1pac";
+    sha256 = "16l7kva4i3xvzls7n8vi7gpjhxxsgxs37p81fi0n0r2p5d4kimk1";
 
     isUnstable = true;
   };


### PR DESCRIPTION
###### Motivation for this change

Updating zfs to the newest release.

Major New Features
Distributed Spare RAID (dRAID) - Create pools using a new distributed variant of RAIDZ which enables dramatically faster resilver times using integrated hot spares. Full redundancy can be restored to the pool in a fraction of the time normally required to do a full disk replacement.

Compatibility Property - The new compatibility property lets administrators specify the set of features which should be enabled on the pool. This fine grained control makes it easy to create portable pools and maintain pool compatibility between OpenZFS versions and across platforms.

InfluxDB Support - Collect pool statistics with the zpool influxdb command in an InfluxDB time-series database for analysis and monitoring.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
