### PR TITLE
python3Packages.pyls-spyder: fix build

### DIFF
--- a/pkgs/development/python-modules/pyls-spyder/default.nix
+++ b/pkgs/development/python-modules/pyls-spyder/default.nix
@@ -1,18 +1,29 @@
-{ lib, buildPythonPackage, fetchPypi, python-language-server }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python-lsp-server
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pyls-spyder";
   version = "0.4.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "45a321c83f64267d82907492c55199fccabda45bc872dd23bf1efd08edac1b0b";
+  src = fetchFromGitHub {
+    owner = "spyder-ide";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11ajbsia60d4c9s6m6rbvaqp1d69fcdbq6a98lkzkkzv2b9pdhkk";
   };
 
-  propagatedBuildInputs = [ python-language-server ];
+  propagatedBuildInputs = [
+    python-lsp-server
+  ];
 
-  # no tests
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [ "pyls_spyder" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/python-lsp-jsonrpc/default.nix
+++ b/pkgs/development/python-modules/python-lsp-jsonrpc/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, ujson
+}:
+
+buildPythonPackage rec {
+  pname = "python-lsp-jsonrpc";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "python-lsp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0h4bs8s4axcm0p02v59amz9sq3nr4zhzdgwq7iaw6awl27v1hd0i";
+  };
+
+  propagatedBuildInputs = [
+    ujson
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
+      --replace "--cov pylsp_jsonrpc --cov test" ""
+  '';
+
+  pythonImportsCheck = [ "pylsp_jsonrpc" ];
+
+  meta = with lib; {
+    description = "Python server implementation of the JSON RPC 2.0 protocol.";
+    homepage = "https://github.com/python-lsp/python-lsp-jsonrpc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, autopep8
+, buildPythonPackage
+, fetchFromGitHub
+, flake8
+, flaky
+, jedi
+, matplotlib
+, mccabe
+, numpy
+, pandas
+, pluggy
+, pycodestyle
+, pydocstyle
+, pyflakes
+, pylint
+, pyqt5
+, pytestCheckHook
+, python-lsp-jsonrpc
+, pythonOlder
+, rope
+, ujson
+, yapf
+}:
+
+buildPythonPackage rec {
+  pname = "python-lsp-server";
+  version = "1.1.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "python-lsp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1akdpfnylqg2mcwpkqmdwcg6j6hab23slp5rfjfidhphig2f2yjv";
+  };
+
+  propagatedBuildInputs = [
+    autopep8
+    flake8
+    jedi
+    mccabe
+    pluggy
+    pycodestyle
+    pydocstyle
+    pyflakes
+    pylint
+    python-lsp-jsonrpc
+    rope
+    ujson
+    yapf
+  ];
+
+  checkInputs = [
+    flaky
+    matplotlib
+    numpy
+    pandas
+    pyqt5
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
+      --replace "--cov pylsp --cov test" ""
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
+  '';
+
+  pythonImportsCheck = [ "pylsp" ];
+
+  meta = with lib; {
+    description = "Python implementation of the Language Server Protocol";
+    homepage = "https://github.com/python-lsp/python-lsp-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6998,6 +6998,8 @@ in {
 
   python-louvain = callPackage ../development/python-modules/python-louvain { };
 
+  python-lsp-jsonrpc = callPackage ../development/python-modules/python-lsp-jsonrpc { };
+
   python-ly = callPackage ../development/python-modules/python-ly { };
 
   python-lz4 = callPackage ../development/python-modules/python-lz4 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7000,6 +7000,8 @@ in {
 
   python-lsp-jsonrpc = callPackage ../development/python-modules/python-lsp-jsonrpc { };
 
+  python-lsp-server = callPackage ../development/python-modules/python-lsp-server { };
+
   python-ly = callPackage ../development/python-modules/python-ly { };
 
   python-lz4 = callPackage ../development/python-modules/python-lz4 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Starting with the last [release](https://github.com/spyder-ide/pyls-spyder/blob/master/CHANGELOG.md#version-040-20210429) `pyls-spyder` requires `python-lsp-server` instead of `python-language-server`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
