### PR TITLE
pythonPackages.dateutil: move to python-aliases.nix

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -439,7 +439,7 @@ The following example shows which arguments are given to `buildPythonPackage` in
 order to build [`datashape`](https://github.com/blaze/datashape).
 
 ```nix
-{ lib, buildPythonPackage, fetchPypi, numpy, multipledispatch, dateutil, pytest }:
+{ lib, buildPythonPackage, fetchPypi, numpy, multipledispatch, python-dateutil, pytest }:
 
 buildPythonPackage rec {
   pname = "datashape";
@@ -451,7 +451,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest ];
-  propagatedBuildInputs = [ numpy multipledispatch dateutil ];
+  propagatedBuildInputs = [ numpy multipledispatch python-dateutil ];
 
   meta = with lib; {
     homepage = "https://github.com/ContinuumIO/datashape";
@@ -463,7 +463,7 @@ buildPythonPackage rec {
 ```
 
 We can see several runtime dependencies, `numpy`, `multipledispatch`, and
-`dateutil`. Furthermore, we have one `checkInputs`, i.e. `pytest`. `pytest` is a
+`python-dateutil`. Furthermore, we have one `checkInputs`, i.e. `pytest`. `pytest` is a
 test runner and is only used during the `checkPhase` and is therefore not added
 to `propagatedBuildInputs`.
 

--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -40,7 +40,7 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = with pythonPackages; [
     chromaprint
-    dateutil
+    python-dateutil
     discid
     fasteners
     mutagen

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo proj
   readline ffmpeg_3 makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
   libLAS proj-datumgrid ]
-    ++ (with python2Packages; [ python dateutil wxPython30 numpy ]);
+    ++ (with python2Packages; [ python python-dateutil wxPython30 numpy ]);
 
   # On Darwin the installer tries to symlink the help files into a system
   # directory

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -12,7 +12,7 @@ let
     numpy
     psycopg2
     chardet
-    dateutil
+    python-dateutil
     pyyaml
     pytz
     requests

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -55,7 +55,7 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     psutil
     pyxdg
     arrow
-    dateutil
+    python-dateutil
     easygui
     colour
     pymediainfo

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -77,7 +77,7 @@ mkDerivation rec {
       cchardet
       css-parser
       cssselect
-      dateutil
+      python-dateutil
       dnspython
       feedparser
       html2text

--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -20,7 +20,7 @@ buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    dateutil gflags httplib2 parsedatetime six vobject
+    python-dateutil gflags httplib2 parsedatetime six vobject
     google-api-python-client oauth2client uritemplate
     libnotify
   ];

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -18,7 +18,7 @@ with python3.pkgs; buildPythonApplication rec {
     click
     click-log
     configobj
-    dateutil
+    python-dateutil
     icalendar
     lxml
     pkgs.vdirsyncer

--- a/pkgs/applications/misc/pdfarranger/default.nix
+++ b/pkgs/applications/misc/pdfarranger/default.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication rec {
     pikepdf
     img2pdf
     setuptools
-    dateutil
+    python-dateutil
   ];
 
   # incompatible with wrapGAppsHook

--- a/pkgs/applications/misc/termdown/default.nix
+++ b/pkgs/applications/misc/termdown/default.nix
@@ -3,7 +3,7 @@
 , buildPythonApplication
 , click
 , pyfiglet
-, dateutil
+, python-dateutil
 , setuptools
 }:
 
@@ -18,7 +18,7 @@ buildPythonApplication rec {
     owner = "trehn";
   };
 
-  propagatedBuildInputs = [ dateutil click pyfiglet setuptools ];
+  propagatedBuildInputs = [ python-dateutil click pyfiglet setuptools ];
 
   meta = with lib; {
     description = "Starts a countdown to or from TIMESPEC";

--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -2,7 +2,7 @@
 , lib
 , buildPythonApplication
 , fetchFromGitHub
-, dateutil
+, python-dateutil
 , pandas
 , requests
 , lxml
@@ -36,7 +36,7 @@ buildPythonApplication rec {
   propagatedBuildInputs = [
     # from visidata/requirements.txt
     # packages not (yet) present in nixpkgs are commented
-    dateutil
+    python-dateutil
     pandas
     requests
     lxml

--- a/pkgs/applications/misc/yokadi/default.nix
+++ b/pkgs/applications/misc/yokadi/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonApplication, dateutil,
+{ lib, fetchurl, buildPythonApplication, python-dateutil,
   sqlalchemy, setproctitle, icalendar }:
 
 buildPythonApplication rec {
@@ -11,7 +11,7 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     sqlalchemy
     setproctitle
     icalendar

--- a/pkgs/applications/networking/cluster/luigi/default.nix
+++ b/pkgs/applications/networking/cluster/luigi/default.nix
@@ -9,7 +9,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "b4b1ccf086586d041d7e91e68515d495c550f30e4d179d63863fea9ccdbb78eb";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [ dateutil tornado python-daemon boto3 ];
+  propagatedBuildInputs = with python3.pkgs; [ python-dateutil tornado python-daemon boto3 ];
 
   # Requires tox, hadoop, and google cloud
   doCheck = false;

--- a/pkgs/applications/networking/feedreaders/gnome-feeds/default.nix
+++ b/pkgs/applications/networking/feedreaders/gnome-feeds/default.nix
@@ -51,7 +51,7 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     beautifulsoup4
-    dateutil
+    python-dateutil
     feedparser
     html5lib
     listparser

--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -46,7 +46,7 @@ python3Packages.buildPythonApplication rec {
     pynzb
     pyparsing
     PyRSS2Gen
-    dateutil
+    python-dateutil
     pyyaml
     rebulk
     requests

--- a/pkgs/applications/networking/giara/default.nix
+++ b/pkgs/applications/networking/giara/default.nix
@@ -48,7 +48,7 @@ python3.pkgs.buildPythonApplication rec {
   pythonPath = with python3.pkgs; [
     pygobject3
     pycairo
-    dateutil
+    python-dateutil
     praw
     pillow
     mistune

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix
@@ -55,7 +55,7 @@ in {
       sha256 = "0rnshrzw8605x05mpd8ndrx3ri8h6cx713mp8sl4f04f4gcrz8ml";
     };
 
-    propagatedBuildInputs = with pythonPackages; [twisted dateutil];
+    propagatedBuildInputs = with pythonPackages; [twisted python-dateutil];
 
     meta = with lib; {
       description = "Some (mainly XMPP-related) additions to twisted";

--- a/pkgs/applications/networking/sync/acd_cli/default.nix
+++ b/pkgs/applications/networking/sync/acd_cli/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, buildPythonApplication, fuse
-, appdirs, colorama, dateutil, requests, requests_toolbelt
+, appdirs, colorama, python-dateutil, requests, requests_toolbelt
 , fusepy, sqlalchemy, setuptools }:
 
 buildPythonApplication rec {
@@ -15,7 +15,7 @@ buildPythonApplication rec {
     sha256 = "0a0fr632l24a3jmgla3b1vcm50ayfa9hdbp677ch1chwj5dq4zfp";
   };
 
-  propagatedBuildInputs = [ appdirs colorama dateutil fusepy requests
+  propagatedBuildInputs = [ appdirs colorama python-dateutil fusepy requests
                             requests_toolbelt setuptools sqlalchemy ];
 
   makeWrapperArgs = [ "--prefix LIBFUSE_PATH : ${fuse}/lib/libfuse.so" ];

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, fetchpatch, libnotify, librsvg, killall
 , gtk3, libappindicator-gtk3, substituteAll, syncthing, wrapGAppsHook
-, gnome, buildPythonApplication, dateutil, pyinotify, pygobject3
+, gnome, buildPythonApplication, python-dateutil, pyinotify, pygobject3
 , bcrypt, gobject-introspection, gsettings-desktop-schemas
 , pango, gdk-pixbuf, atk }:
 
@@ -30,7 +30,7 @@ buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
-    dateutil pyinotify pygobject3 bcrypt
+    python-dateutil pyinotify pygobject3 bcrypt
   ];
 
   patches = [

--- a/pkgs/applications/office/paperless/default.nix
+++ b/pkgs/applications/office/paperless/default.nix
@@ -122,7 +122,7 @@ let
 
   runtimePackages = with python.pkgs; [
     dateparser
-    dateutil
+    python-dateutil
     django
     django-cors-headers
     django-crispy-forms

--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -122,7 +122,7 @@ python3Packages.buildPythonApplication rec {
     openpaperwork-core
     pypillowfight
     pyxdg
-    dateutil
+    python-dateutil
     setuptools
   ];
 

--- a/pkgs/applications/office/pyspread/default.nix
+++ b/pkgs/applications/office/pyspread/default.nix
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    dateutil
+    python-dateutil
     markdown2
     matplotlib
     numpy

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3Packages; [
-    dateutil
+    python-dateutil
     pygobject3
     goocalendar
     pycairo

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     let pp = python.pkgs; in ([
       pp.numpy pp.scipy pp.scikitimage pp.h5py
       pp.matplotlib pp.ipython pp.networkx pp.nose
-      pp.pandas pp.dateutil pp.protobuf pp.gflags
+      pp.pandas pp.python-dateutil pp.protobuf pp.gflags
       pp.pyyaml pp.pillow pp.six
     ] ++ lib.optional leveldbSupport pp.leveldb)
   );

--- a/pkgs/applications/video/pyca/default.nix
+++ b/pkgs/applications/video/pyca/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub, pycurl, dateutil, configobj, sqlalchemy, sdnotify, flask }:
+{ lib, buildPythonApplication, fetchFromGitHub, pycurl, python-dateutil, configobj, sqlalchemy, sdnotify, flask }:
 
 buildPythonApplication rec {
   pname = "pyca";
@@ -13,7 +13,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     pycurl
-    dateutil
+    python-dateutil
     configobj
     sqlalchemy
     sdnotify

--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -39,7 +39,7 @@ python37Packages.buildPythonApplication rec {
     cairocffi-xcffib
     setuptools
     setuptools-scm
-    dateutil
+    python-dateutil
     dbus-python
     mpd2
     psutil

--- a/pkgs/development/python-modules/Nikola/default.nix
+++ b/pkgs/development/python-modules/Nikola/default.nix
@@ -3,7 +3,7 @@
 , Babel
 , blinker
 , buildPythonPackage
-, dateutil
+, python-dateutil
 , docutils
 , doit
 , fetchPypi
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     aiohttp
     Babel
     blinker
-    dateutil
+    python-dateutil
     docutils
     doit
     ghp-import

--- a/pkgs/development/python-modules/adal/default.nix
+++ b/pkgs/development/python-modules/adal/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, requests, pyjwt, dateutil }:
+, requests, pyjwt, python-dateutil }:
 
 buildPythonPackage rec {
   pname = "adal";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "d74f45b81317454d96e982fd1c50e6fb5c99ac2223728aea8764433a39f566f1";
   };
 
-  propagatedBuildInputs =  [ requests pyjwt dateutil ];
+  propagatedBuildInputs =  [ requests pyjwt python-dateutil ];
 
   meta = with lib; {
     description = "Library to make it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources";

--- a/pkgs/development/python-modules/alembic/default.nix
+++ b/pkgs/development/python-modules/alembic/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi
 , pytest, pytestcov, mock, coverage, setuptools
-, Mako, sqlalchemy, python-editor, dateutil
+, Mako, sqlalchemy, python-editor, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ pytest pytestcov mock coverage ];
-  propagatedBuildInputs = [ Mako sqlalchemy python-editor dateutil setuptools ];
+  propagatedBuildInputs = [ Mako sqlalchemy python-editor python-dateutil setuptools ];
 
   # no traditional test suite
   doCheck = false;

--- a/pkgs/development/python-modules/aniso8601/default.nix
+++ b/pkgs/development/python-modules/aniso8601/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, dateutil
+, python-dateutil
 , fetchPypi
 , isPy3k
 , mock
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/azure-storage/default.nix
+++ b/pkgs/development/python-modules/azure-storage/default.nix
@@ -5,7 +5,7 @@
 , azure-common
 , cryptography
 , futures ? null
-, dateutil
+, python-dateutil
 , requests
 , isPy3k
 }:
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "0pyasfxkin6j8j00qmky7d9cvpxgis4fi9bscgclj6yrpvf14qpv";
   };
 
-  propagatedBuildInputs = [ azure-common cryptography dateutil requests ]
+  propagatedBuildInputs = [ azure-common cryptography python-dateutil requests ]
                             ++ pkgs.lib.optionals (!isPy3k) [ futures ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/beancount/default.nix
+++ b/pkgs/development/python-modules/beancount/default.nix
@@ -5,7 +5,7 @@
 , beautifulsoup4
 , bottle
 , chardet
-, dateutil
+, python-dateutil
 , google-api-python-client
 , google-auth-oauthlib
 , lxml
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     beautifulsoup4
     bottle
     chardet
-    dateutil
+    python-dateutil
     google-api-python-client
     google-auth-oauthlib
     lxml

--- a/pkgs/development/python-modules/bitcoin-price-api/default.nix
+++ b/pkgs/development/python-modules/bitcoin-price-api/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, dateutil, requests }:
+, python-dateutil, requests }:
 
 buildPythonPackage rec {
   pname = "bitcoin-price-api";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "bc68076f9632aaa9a8009d916d67a709c1e045dd904cfc7a3e8be33960d32029";
   };
 
-  propagatedBuildInputs = [ dateutil requests ];
+  propagatedBuildInputs = [ python-dateutil requests ];
 
   # No tests in archive
   doCheck = false;

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, dateutil
+, python-dateutil
 , jmespath
 , docutils
 , ordereddict
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     jmespath
     docutils
     ordereddict

--- a/pkgs/development/python-modules/bugwarrior/default.nix
+++ b/pkgs/development/python-modules/bugwarrior/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, pythonOlder, setuptools
-, twiggy, requests, offtrac, bugzilla, taskw, dateutil, pytz, keyring, six
+, twiggy, requests, offtrac, bugzilla, taskw, python-dateutil, pytz, keyring, six
 , jinja2, pycurl, dogpile_cache, lockfile, click, pyxdg, future, jira }:
 
 buildPythonPackage rec {
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     setuptools
-    twiggy requests offtrac bugzilla taskw dateutil pytz keyring six
+    twiggy requests offtrac bugzilla taskw python-dateutil pytz keyring six
     jinja2 pycurl dogpile_cache lockfile click pyxdg future jira
   ];
 

--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildPythonPackage, fetchPypi, makeWrapper, isPy3k,
   python, twisted, jinja2, zope_interface, sqlalchemy,
-  sqlalchemy_migrate, dateutil, txaio, autobahn, pyjwt, pyyaml, unidiff, treq,
+  sqlalchemy_migrate, python-dateutil, txaio, autobahn, pyjwt, pyyaml, unidiff, treq,
   txrequests, pypugjs, boto3, moto, mock, python-lz4, setuptoolsTrial,
   isort, pylint, flake8, buildbot-worker, buildbot-pkg, buildbot-plugins,
   parameterized, git, openssh, glibcLocales, ldap3, nixosTests }:
@@ -39,7 +39,7 @@ let
       zope_interface
       sqlalchemy
       sqlalchemy_migrate
-      dateutil
+      python-dateutil
       txaio
       autobahn
       pyjwt

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , ConfigArgParse, acme, configobj, cryptography, distro, josepy, parsedatetime, pyRFC3339, pyopenssl, pytz, requests, six, zope_component, zope_interface
 , dialog, gnureadline
-, pytest_xdist, pytestCheckHook, dateutil
+, pytest_xdist, pytestCheckHook, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   buildInputs = [ dialog gnureadline ];
 
   checkInputs = [
-    dateutil
+    python-dateutil
     pytestCheckHook
     pytest_xdist
   ];

--- a/pkgs/development/python-modules/clize/default.nix
+++ b/pkgs/development/python-modules/clize/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, dateutil
+, python-dateutil
 , sigtools
 , six
 , attrs
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    dateutil
+    python-dateutil
     pygments
     repeated_test
     unittest2

--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -5,7 +5,7 @@
 , attrs
 , colorlog
 , csvw
-, dateutil
+, python-dateutil
 , tabulate
 , mock
 , postgresql
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     tabulate
     colorlog
     attrs

--- a/pkgs/development/python-modules/cloudsmith-api/default.nix
+++ b/pkgs/development/python-modules/cloudsmith-api/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , certifi
 , six
-, dateutil
+, python-dateutil
 , urllib3
 }:
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     certifi
     six
-    dateutil
+    python-dateutil
     urllib3
   ];
 

--- a/pkgs/development/python-modules/csvw/default.nix
+++ b/pkgs/development/python-modules/csvw/default.nix
@@ -4,7 +4,7 @@
 , pythonOlder
 , attrs
 , isodate
-, dateutil
+, python-dateutil
 , rfc3986
 , uritemplate
 , mock
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     attrs
     isodate
-    dateutil
+    python-dateutil
     rfc3986
     uritemplate
   ];

--- a/pkgs/development/python-modules/datashape/default.nix
+++ b/pkgs/development/python-modules/datashape/default.nix
@@ -5,7 +5,7 @@
 , mock
 , numpy
 , multipledispatch
-, dateutil
+, python-dateutil
 }:
 
 let
@@ -29,7 +29,7 @@ in buildPythonPackage rec {
   };
 
   checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ numpy multipledispatch dateutil ];
+  propagatedBuildInputs = [ numpy multipledispatch python-dateutil ];
 
   # Disable several tests
   # https://github.com/blaze/datashape/issues/232

--- a/pkgs/development/python-modules/dateparser/0.x.nix
+++ b/pkgs/development/python-modules/dateparser/0.x.nix
@@ -4,7 +4,7 @@
 , mock
 , parameterized
 , pytestCheckHook
-, dateutil
+, python-dateutil
 , pytz
 , regex
 , tzlocal
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     # install_requires
-    dateutil pytz regex tzlocal
+    python-dateutil pytz regex tzlocal
     # extra_requires
     convertdate umalqurra jdatetime ruamel_yaml
   ];

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , isPy3k
 , fetchFromGitHub
-, dateutil
+, python-dateutil
 , pytz
 , regex
 , tzlocal
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     # install_requires
-    dateutil pytz regex tzlocal
+    python-dateutil pytz regex tzlocal
     # extra_requires
     hijri-converter convertdate
   ];

--- a/pkgs/development/python-modules/django-haystack/default.nix
+++ b/pkgs/development/python-modules/django-haystack/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, setuptools, setuptools-scm, django, dateutil, whoosh, pysolr
+, setuptools, setuptools-scm, django, python-dateutil, whoosh, pysolr
 , coverage, mock, nose, geopy, requests }:
 
 buildPythonPackage rec {
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "d490f920afa85471dd1fa5000bc8eff4b704daacbe09aee1a64e75cbc426f3be";
   };
 
-  checkInputs = [ pysolr whoosh dateutil geopy coverage nose mock coverage requests ];
+  checkInputs = [ pysolr whoosh python-dateutil geopy coverage nose mock coverage requests ];
   propagatedBuildInputs = [ django setuptools ];
   nativeBuildInputs = [ setuptools-scm ];
 

--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -7,7 +7,7 @@
 , django
 , pygments
 , simplejson
-, dateutil
+, python-dateutil
 , requests
 , setuptools-scm
 , sqlparse
@@ -56,7 +56,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools-scm ];
   buildInputs = [ mock ];
   propagatedBuildInputs = [
-    django pygments simplejson dateutil requests
+    django pygments simplejson python-dateutil requests
     sqlparse jinja2 autopep8 pytz pillow gprof2dot
   ];
 

--- a/pkgs/development/python-modules/fake_factory/default.nix
+++ b/pkgs/development/python-modules/fake_factory/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , python
 , six
-, dateutil
+, python-dateutil
 , ipaddress
 , mock
 }:
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "f5bd18deb22ad8cb4402513c025877bc6b50de58902d686b6b21ba8981dce260";
   };
 
-  propagatedBuildInputs = [ six dateutil ipaddress mock ];
+  propagatedBuildInputs = [ six python-dateutil ipaddress mock ];
 
   # fake-factory is depreciated and single test will always fail
   doCheck = false;

--- a/pkgs/development/python-modules/faker/default.nix
+++ b/pkgs/development/python-modules/faker/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, dateutil
+, python-dateutil
 , text-unidecode
 , freezegun
 , pytestCheckHook
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     text-unidecode
   ];
 

--- a/pkgs/development/python-modules/feedgen/default.nix
+++ b/pkgs/development/python-modules/feedgen/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, dateutil, lxml }:
+{ lib, buildPythonPackage, fetchPypi, python-dateutil, lxml }:
 
 buildPythonPackage rec {
   pname = "feedgen";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "0jl0b87l7v6c0f1nx6k81skjhdj5i11kmchdjls00mynpvdip0cf";
   };
 
-  propagatedBuildInputs = [ dateutil lxml ];
+  propagatedBuildInputs = [ python-dateutil lxml ];
 
   # No tests in archive
   doCheck = false;

--- a/pkgs/development/python-modules/fitbit/default.nix
+++ b/pkgs/development/python-modules/fitbit/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , coverage
-, dateutil
+, python-dateutil
 , freezegun
 , mock
 , requests-mock
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   version = "0.3.1";
 
   checkInputs = [ coverage freezegun mock requests-mock sphinx ];
-  propagatedBuildInputs = [ dateutil requests_oauthlib ];
+  propagatedBuildInputs = [ python-dateutil requests_oauthlib ];
 
   # The source package on PyPi is missing files required for unit testing.
   # https://github.com/orcasgit/python-fitbit/issues/148

--- a/pkgs/development/python-modules/flask-jwt-extended/default.nix
+++ b/pkgs/development/python-modules/flask-jwt-extended/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, dateutil, flask, pyjwt, werkzeug, pytest }:
+{ lib, buildPythonPackage, fetchPypi, python-dateutil, flask, pyjwt, werkzeug, pytest }:
 
 buildPythonPackage rec {
   pname = "Flask-JWT-Extended";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "76461f2dbdf502261c69ddecd858eaf4164fbcfbf05aa456f3927fc2ab0315de";
   };
 
-  propagatedBuildInputs = [ dateutil flask pyjwt werkzeug ];
+  propagatedBuildInputs = [ python-dateutil flask pyjwt werkzeug ];
   checkInputs = [ pytest ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/freezegun/0.3.nix
+++ b/pkgs/development/python-modules/freezegun/0.3.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , isPy27
-, dateutil
+, python-dateutil
 , six
 , mock
 , nose
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b";
   };
 
-  propagatedBuildInputs = [ dateutil six ];
+  propagatedBuildInputs = [ python-dateutil six ];
   checkInputs = [ mock nose pytest ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/freezegun/default.nix
+++ b/pkgs/development/python-modules/freezegun/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
-, dateutil
+, python-dateutil
 , pytestCheckHook
 }:
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3";
   };
 
-  propagatedBuildInputs = [ dateutil ];
+  propagatedBuildInputs = [ python-dateutil ];
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/gdrivefs/default.nix
+++ b/pkgs/development/python-modules/gdrivefs/default.nix
@@ -6,7 +6,7 @@
 , greenlet
 , httplib2
 , six
-, dateutil
+, python-dateutil
 , fusepy
 , google-api-python-client
 }:
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ gipc greenlet httplib2 six ];
-  propagatedBuildInputs = [ dateutil fusepy google-api-python-client ];
+  propagatedBuildInputs = [ python-dateutil fusepy google-api-python-client ];
 
   patchPhase = ''
     substituteInPlace gdrivefs/resources/requirements.txt \

--- a/pkgs/development/python-modules/ghp-import/default.nix
+++ b/pkgs/development/python-modules/ghp-import/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, dateutil
+, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     hash = "sha256-wiqc4Qw3dT4miNFk12WnANrkuNefptsKLDEyuniBiU8=";
   };
 
-  propagatedBuildInputs = [ dateutil ];
+  propagatedBuildInputs = [ python-dateutil ];
 
   # Does not include any unit tests
   doCheck = false;

--- a/pkgs/development/python-modules/github3_py/default.nix
+++ b/pkgs/development/python-modules/github3_py/default.nix
@@ -9,7 +9,7 @@
 , mock
 , requests
 , uritemplate
-, dateutil
+, python-dateutil
 , jwcrypto
 , pyopenssl
 , ndg-httpsclient
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   checkInputs = [ betamax pytest betamax-matchers ]
     ++ lib.optional (pythonOlder "3") unittest2
     ++ lib.optional (pythonOlder "3.3") mock;
-  propagatedBuildInputs = [ requests uritemplate dateutil jwcrypto pyopenssl ndg-httpsclient pyasn1 ];
+  propagatedBuildInputs = [ requests uritemplate python-dateutil jwcrypto pyopenssl ndg-httpsclient pyasn1 ];
 
   postPatch = ''
     sed -i -e 's/unittest2 ==0.5.1/unittest2>=0.5.1/' setup.py

--- a/pkgs/development/python-modules/google-apputils/default.nix
+++ b/pkgs/development/python-modules/google-apputils/default.nix
@@ -4,7 +4,7 @@
 , isPy3k
 , pytz
 , gflags
-, dateutil
+, python-dateutil
 , mox
 , python
 }:
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     sed -i '/ez_setup/d' setup.py
   '';
 
-  propagatedBuildInputs = [ pytz gflags dateutil mox ];
+  propagatedBuildInputs = [ pytz gflags python-dateutil mox ];
 
   checkPhase = ''
     ${python.executable} setup.py google_test

--- a/pkgs/development/python-modules/guessit/default.nix
+++ b/pkgs/development/python-modules/guessit/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pytestrunner
-, dateutil
+, python-dateutil
 , babelfish
 , rebulk
 }:
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   doCheck = false;
   buildInputs = [ pytestrunner ];
   propagatedBuildInputs = [
-    dateutil babelfish rebulk
+    python-dateutil babelfish rebulk
   ];
 
   meta = {

--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , convertdate
-, dateutil
+, python-dateutil
 , fetchPypi
 , hijri-converter
 , korean-lunar-calendar
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     convertdate
-    dateutil
+    python-dateutil
     hijri-converter
     korean-lunar-calendar
     six

--- a/pkgs/development/python-modules/hypchat/default.nix
+++ b/pkgs/development/python-modules/hypchat/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage, fetchPypi
-, requests, six, dateutil }:
+, requests, six, python-dateutil }:
 
 buildPythonPackage rec {
   pname = "hypchat";
@@ -10,5 +10,5 @@ buildPythonPackage rec {
     sha256 = "1sd8f3gihagaqd848dqy6xw457fa4f9bla1bfyni7fq3h76sjdzg";
   };
 
-  propagatedBuildInputs = [ requests six dateutil ];
+  propagatedBuildInputs = [ requests six python-dateutil ];
 }

--- a/pkgs/development/python-modules/icalendar/default.nix
+++ b/pkgs/development/python-modules/icalendar/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , setuptools
-, dateutil
+, python-dateutil
 , pytz
 }:
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ setuptools ];
-  propagatedBuildInputs = [ dateutil pytz ];
+  propagatedBuildInputs = [ python-dateutil pytz ];
 
   meta = with lib; {
     description = "A parser/generator of iCalendar files";

--- a/pkgs/development/python-modules/influxdb/default.nix
+++ b/pkgs/development/python-modules/influxdb/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, dateutil
+, python-dateutil
 , fetchFromGitHub
 , fetchpatch
 , mock
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     requests
-    dateutil
+    python-dateutil
     pytz
     six
     msgpack

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , nose
-, dateutil
+, python-dateutil
 , ipython_genutils
 , decorator
 , pyzmq
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   buildInputs = [ nose ];
 
-  propagatedBuildInputs = [ dateutil ipython_genutils decorator pyzmq ipython jupyter_client ipykernel tornado
+  propagatedBuildInputs = [ python-dateutil ipython_genutils decorator pyzmq ipython jupyter_client ipykernel tornado
   ] ++ lib.optionals (!isPy3k) [ futures ];
 
   # Requires access to cluster

--- a/pkgs/development/python-modules/javaproperties/default.nix
+++ b/pkgs/development/python-modules/javaproperties/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchFromGitHub
 , six
 , pytest
-, dateutil
+, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  checkInputs = [ dateutil pytest ];
+  checkInputs = [ python-dateutil pytest ];
   checkPhase = ''
     rm tox.ini
     pytest -k 'not dumps and not time' --ignore=test/test_propclass.py

--- a/pkgs/development/python-modules/jupyter_client/5.nix
+++ b/pkgs/development/python-modules/jupyter_client/5.nix
@@ -4,7 +4,7 @@
 , traitlets
 , jupyter_core
 , pyzmq
-, dateutil
+, python-dateutil
 , isPyPy
 , py
 , tornado
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     traitlets
     jupyter_core
     pyzmq
-    dateutil
+    python-dateutil
     tornado
   ] ++ lib.optional isPyPy py;
 

--- a/pkgs/development/python-modules/jupyter_client/default.nix
+++ b/pkgs/development/python-modules/jupyter_client/default.nix
@@ -4,7 +4,7 @@
 , traitlets
 , jupyter_core
 , pyzmq
-, dateutil
+, python-dateutil
 , isPyPy
 , py
 , tornado
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     traitlets
     jupyter_core
     pyzmq
-    dateutil
+    python-dateutil
     tornado
   ] ++ lib.optional isPyPy py;
 

--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -7,7 +7,7 @@
 , alembic
 , async_generator
 , certipy
-, dateutil
+, python-dateutil
 , entrypoints
 , jinja2
 , jupyter-telemetry
@@ -115,7 +115,7 @@ buildPythonPackage rec {
     alembic
     async_generator
     certipy
-    dateutil
+    python-dateutil
     entrypoints
     jinja2
     jupyter-telemetry

--- a/pkgs/development/python-modules/koji/default.nix
+++ b/pkgs/development/python-modules/koji/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonPackage, isPy3k, pycurl, six, rpm, dateutil }:
+{ lib, fetchurl, buildPythonPackage, isPy3k, pycurl, six, rpm, python-dateutil }:
 
 buildPythonPackage rec {
   pname = "koji";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "0a3kn3qvspvx15imgzzzjsbvw6bqmbk29apbliqwifa9cj7pvb40";
   };
 
-  propagatedBuildInputs = [ pycurl six rpm dateutil ];
+  propagatedBuildInputs = [ pycurl six rpm python-dateutil ];
 
   # Judging from SyntaxError
   disabled = isPy3k;

--- a/pkgs/development/python-modules/mailman-rss/default.nix
+++ b/pkgs/development/python-modules/mailman-rss/default.nix
@@ -9,7 +9,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1brrik70jyagxa9l0cfmlxvqpilwj1q655bphxnvjxyganxf4c00";
   };
 
-  propagatedBuildInputs = with python3Packages; [ dateutil future requests beautifulsoup4 ]
+  propagatedBuildInputs = with python3Packages; [ python-dateutil future requests beautifulsoup4 ]
     ++ lib.optional withTwitter python3Packages.twitter
   ;
 

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchPypi, writeText, python, buildPythonPackage, pycairo, backports_functools_lru_cache
-, which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
+, which, cycler, python-dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, libpng, pkg-config, mock, pytz, pygobject3, gobject-introspection, functools32, subprocess32
 , fetchpatch
 , enableGhostscript ? false, ghostscript, gtk3
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     ++ lib.optional stdenv.isDarwin [ Cocoa ];
 
   propagatedBuildInputs =
-    [ cycler dateutil nose numpy pyparsing tornado freetype kiwisolver
+    [ cycler python-dateutil nose numpy pyparsing tornado freetype kiwisolver
       libpng mock pytz ]
     ++ lib.optional (pythonOlder "3.3") backports_functools_lru_cache
     ++ lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchPypi, writeText, buildPythonPackage, isPy3k, pycairo
-, which, cycler, dateutil, numpy, pyparsing, sphinx, tornado, kiwisolver
+, which, cycler, python-dateutil, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, qhull, libpng, pkg-config, mock, pytz, pygobject3, gobject-introspection
 , certifi, pillow
 , enableGhostscript ? true, ghostscript, gtk3
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     ++ lib.optional stdenv.isDarwin [ Cocoa ];
 
   propagatedBuildInputs =
-    [ cycler dateutil numpy pyparsing tornado freetype qhull
+    [ cycler python-dateutil numpy pyparsing tornado freetype qhull
       kiwisolver certifi libpng mock pytz pillow ]
     ++ lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]
     ++ lib.optionals enableTk [ tcl tk tkinter libX11 ]

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -4,7 +4,7 @@
 , isPy27
 # python dependencies
 , click
-, dateutil
+, python-dateutil
 , etelemetry
 , filelock
 , funcsigs
@@ -68,7 +68,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     click
-    dateutil
+    python-dateutil
     etelemetry
     filelock
     funcsigs

--- a/pkgs/development/python-modules/oci/default.nix
+++ b/pkgs/development/python-modules/oci/default.nix
@@ -5,7 +5,7 @@
 , configparser
 , cryptography
 , pyopenssl
-, dateutil
+, python-dateutil
 , pytz
 }:
 
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    certifi configparser cryptography pyopenssl dateutil pytz
+    certifi configparser cryptography pyopenssl python-dateutil pytz
   ];
 
   # Tests fail: https://github.com/oracle/oci-python-sdk/issues/164

--- a/pkgs/development/python-modules/owslib/default.nix
+++ b/pkgs/development/python-modules/owslib/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, dateutil, requests, pytz, pyproj , pytest, pyyaml } :
+{ lib, buildPythonPackage, fetchPypi, python-dateutil, requests, pytz, pyproj , pytest, pyyaml } :
 buildPythonPackage rec {
   pname = "OWSLib";
   version = "0.24.1";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ pytest ];
-  propagatedBuildInputs = [ dateutil pyproj pytz requests pyyaml ];
+  propagatedBuildInputs = [ python-dateutil pyproj pytz requests pyyaml ];
 
   # 'tests' dir not included in pypy distribution archive.
   doCheck = false;

--- a/pkgs/development/python-modules/pandas/2.nix
+++ b/pkgs/development/python-modules/pandas/2.nix
@@ -8,7 +8,7 @@
 , pytest
 , glibcLocales
 , cython
-, dateutil
+, python-dateutil
 , scipy
 , moto
 , numexpr
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cython ];
   buildInputs = lib.optional stdenv.isDarwin libcxx;
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     scipy
     numexpr
     pytz
@@ -68,7 +68,7 @@ buildPythonPackage rec {
 
 
   disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) ([
-    # since dateutil 0.6.0 the following fails: test_fallback_plural, test_ambiguous_flags, test_ambiguous_compat
+    # since python-dateutil 0.6.0 the following fails: test_fallback_plural, test_ambiguous_flags, test_ambiguous_compat
     # was supposed to be solved by https://github.com/dateutil/dateutil/issues/321, but is not the case
     "test_fallback_plural"
     "test_ambiguous_flags"

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -7,7 +7,7 @@
 , beautifulsoup4
 , bottleneck
 , cython
-, dateutil
+, python-dateutil
 , html5lib
 , jinja2
 , lxml
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     beautifulsoup4
     bottleneck
-    dateutil
+    python-dateutil
     html5lib
     numexpr
     lxml

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchFromGitHub, isPy27
 , glibcLocales, git
 , mock, nose, markdown, lxml, typogrify
-, jinja2, pygments, docutils, pytz, unidecode, six, dateutil, feedgenerator
+, jinja2, pygments, docutils, pytz, unidecode, six, python-dateutil, feedgenerator
 , blinker, pillow, beautifulsoup4, markupsafe, pandoc }:
 
 buildPythonPackage rec {
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    jinja2 pygments docutils pytz unidecode six dateutil feedgenerator
+    jinja2 pygments docutils pytz unidecode six python-dateutil feedgenerator
     blinker pillow beautifulsoup4 markupsafe lxml
   ];
 

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchPypi, buildPythonPackage, pythonOlder
-, dateutil
+, python-dateutil
 , importlib-metadata
 , poetry
 , poetry-core
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [ poetry-core ];
-  propagatedBuildInputs = [ dateutil pytzdata ]
+  propagatedBuildInputs = [ python-dateutil pytzdata ]
   ++ lib.optional (pythonOlder "3.5") typing
   ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 

--- a/pkgs/development/python-modules/prov/default.nix
+++ b/pkgs/development/python-modules/prov/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , lxml
 , networkx
-, dateutil
+, python-dateutil
 , rdflib
 , pydot
 }:
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     lxml
     networkx
-    dateutil
+    python-dateutil
     rdflib
   ];
 

--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -14,7 +14,7 @@
 , psutil
 , pyelftools
 , pyserial
-, dateutil
+, python-dateutil
 , requests
 , rpyc
 , tox
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     psutil
     pyelftools
     pyserial
-    dateutil
+    python-dateutil
     requests
     rpyc
     tox

--- a/pkgs/development/python-modules/pycollada/default.nix
+++ b/pkgs/development/python-modules/pycollada/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, numpy, dateutil }:
+{ lib, fetchPypi, buildPythonPackage, numpy, python-dateutil }:
 
 buildPythonPackage rec {
   pname = "pycollada";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "1rp4wlvfywgk3v6l3hnhjx61x9yqawvvivpq4dig2jj71k3mpsyj";
   };
 
-  propagatedBuildInputs = [ numpy dateutil ];
+  propagatedBuildInputs = [ numpy python-dateutil ];
 
   # Some tests fail because they refer to test data files that don't exist
   # (upstream packaging issue)

--- a/pkgs/development/python-modules/pyflick/default.nix
+++ b/pkgs/development/python-modules/pyflick/default.nix
@@ -3,7 +3,7 @@
 , pythonOlder
 , fetchPypi
 , aiohttp
-, dateutil
+, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiohttp
-    dateutil
+    python-dateutil
   ];
 
   # no tests implemented

--- a/pkgs/development/python-modules/pykeepass/default.nix
+++ b/pkgs/development/python-modules/pykeepass/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, buildPythonPackage
 , lxml, pycryptodomex, construct
-, argon2_cffi, dateutil, future
+, argon2_cffi, python-dateutil, future
 , python
 }:
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     lxml pycryptodomex construct
-    argon2_cffi dateutil future
+    argon2_cffi python-dateutil future
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pykwalify/default.nix
+++ b/pkgs/development/python-modules/pykwalify/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, dateutil
+, python-dateutil
 , docopt
 , fetchPypi
 , pytestCheckHook
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     docopt
     pyyaml
     ruamel-yaml

--- a/pkgs/development/python-modules/pync/default.nix
+++ b/pkgs/development/python-modules/pync/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , isPy27
-, dateutil
+, python-dateutil
 , pkgs
 }:
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ pkgs.coreutils ];
-  propagatedBuildInputs = [ dateutil ];
+  propagatedBuildInputs = [ python-dateutil ];
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     sed -i 's|^\([ ]*\)self.bin_path.*$|\1self.bin_path = "${pkgs.terminal-notifier}/bin/terminal-notifier"|' build/lib/pync/TerminalNotifier.py

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , substituteAll
 , xmlsec
-, cryptography, defusedxml, pyopenssl, dateutil, pytz, requests, six
+, cryptography, defusedxml, pyopenssl, python-dateutil, pytz, requests, six
 , mock, pyasn1, pymongo, pytest, responses, xmlschema, importlib-resources
 }:
 
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cryptography
-    dateutil
+    python-dateutil
     defusedxml
     importlib-resources
     pyopenssl

--- a/pkgs/development/python-modules/pytomlpp/default.nix
+++ b/pkgs/development/python-modules/pytomlpp/default.nix
@@ -4,7 +4,7 @@
 , pythonOlder
 , pybind11
 , pytestCheckHook
-, dateutil
+, python-dateutil
 , doxygen
 , python
 , pelican
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
 
-    dateutil
+    python-dateutil
     doxygen
     python
     pelican

--- a/pkgs/development/python-modules/rainbowstream/default.nix
+++ b/pkgs/development/python-modules/rainbowstream/default.nix
@@ -8,7 +8,7 @@
 , pyfiglet
 , requests
 , arrow
-, dateutil
+, python-dateutil
 , pysocks
 , pocket
 }:
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     done
   '';
 
-  buildInputs =  [ pkgs.libjpeg pkgs.freetype pkgs.zlib pkgs.glibcLocales pillow twitter pyfiglet requests arrow dateutil pysocks pocket ];
+  buildInputs =  [ pkgs.libjpeg pkgs.freetype pkgs.zlib pkgs.glibcLocales pillow twitter pyfiglet requests arrow python-dateutil pysocks pocket ];
 
   meta = with lib; {
     description = "Streaming command-line twitter client";

--- a/pkgs/development/python-modules/sipsimple/default.nix
+++ b/pkgs/development/python-modules/sipsimple/default.nix
@@ -5,7 +5,7 @@
 , pkgs
 , cython
 , dnspython
-, dateutil
+, python-dateutil
 , xcaplib
 , msrplib
 , lxml
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkgs.pkg-config ];
   buildInputs = with pkgs; [ alsa-lib ffmpeg_3 libv4l sqlite libvpx ];
-  propagatedBuildInputs = [ cython pkgs.openssl dnspython dateutil xcaplib msrplib lxml python-otr ];
+  propagatedBuildInputs = [ cython pkgs.openssl dnspython python-dateutil xcaplib msrplib lxml python-otr ];
 
   meta = with lib; {
     description = "SIP SIMPLE implementation for Python";

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchPypi, buildPythonPackage
 , six, sqlalchemy
-, mock, pytz, isort, flake8, jinja2, pg8000, pyodbc, pytest, pymysql, dateutil
+, mock, pytz, isort, flake8, jinja2, pg8000, pyodbc, pytest, pymysql, python-dateutil
 , docutils, flexmock, psycopg2, pygments }:
 
 buildPythonPackage rec {
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     pyodbc
     pytest
     pymysql
-    dateutil
+    python-dateutil
     docutils
     flexmock
     psycopg2

--- a/pkgs/development/python-modules/suseapi/default.nix
+++ b/pkgs/development/python-modules/suseapi/default.nix
@@ -7,7 +7,7 @@
 , mechanize
 , beautifulsoup4
 , pyxdg
-, dateutil
+, python-dateutil
 , requests
 , httpretty
 }:
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    django suds-jurko ldap mechanize beautifulsoup4 pyxdg dateutil requests
+    django suds-jurko ldap mechanize beautifulsoup4 pyxdg python-dateutil requests
   ];
 
   buildInputs = [ httpretty ];

--- a/pkgs/development/python-modules/taskw/default.nix
+++ b/pkgs/development/python-modules/taskw/default.nix
@@ -4,7 +4,7 @@
 , nose
 , tox
 , six
-, dateutil
+, python-dateutil
 , kitchen
 , pytz
 , pkgs
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   buildInputs = [ nose pkgs.taskwarrior tox ];
-  propagatedBuildInputs = [ six dateutil kitchen pytz ];
+  propagatedBuildInputs = [ six python-dateutil kitchen pytz ];
 
   meta = with lib; {
     homepage =  "https://github.com/ralphbean/taskw";

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -6,7 +6,7 @@
 , lxml
 , relatorio
 , genshi
-, dateutil
+, python-dateutil
 , polib
 , python-sql
 , werkzeug
@@ -41,7 +41,7 @@ buildPythonApplication rec {
     lxml
     relatorio
     genshi
-    dateutil
+    python-dateutil
     polib
     python-sql
     werkzeug

--- a/pkgs/development/python-modules/urllib3/2.nix
+++ b/pkgs/development/python-modules/urllib3/2.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , certifi
 , cryptography
-, dateutil
+, python-dateutil
 , fetchpatch
 , fetchPypi
 , idna
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    dateutil
+    python-dateutil
     mock
     pytest-freezegun
     pytest-timeout

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -2,7 +2,7 @@
 , brotli
 , buildPythonPackage
 , cryptography
-, dateutil
+, python-dateutil
 , fetchPypi
 , idna
 , isPy27
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    dateutil
+    python-dateutil
     mock
     pytest-freezegun
     pytest-timeout

--- a/pkgs/development/python-modules/vertica-python/default.nix
+++ b/pkgs/development/python-modules/vertica-python/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, future, dateutil, six, pytest, mock, parameterized }:
+{ lib, buildPythonPackage, fetchPypi, future, python-dateutil, six, pytest, mock, parameterized }:
 
 buildPythonPackage rec {
   pname = "vertica-python";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "94cff37e03f89fc4c5e4b2d4c913c7d5d7450f5a205d14f709b39e0a4202be95";
   };
 
-  propagatedBuildInputs = [ future dateutil six ];
+  propagatedBuildInputs = [ future python-dateutil six ];
 
   checkInputs = [ pytest mock parameterized ];
 

--- a/pkgs/development/python-modules/vobject/default.nix
+++ b/pkgs/development/python-modules/vobject/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, isPyPy, python, dateutil }:
+{ lib, buildPythonPackage, fetchPypi, isPyPy, python, python-dateutil }:
 
 buildPythonPackage rec {
   version = "0.9.6.1";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   disabled = isPyPy;
 
-  propagatedBuildInputs = [ dateutil ];
+  propagatedBuildInputs = [ python-dateutil ];
 
   checkPhase = "${python.interpreter} tests.py";
 

--- a/pkgs/development/python-modules/webdavclient3/default.nix
+++ b/pkgs/development/python-modules/webdavclient3/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, isPy27, lib, dateutil, lxml, requests
+{ buildPythonPackage, fetchPypi, isPy27, lib, python-dateutil, lxml, requests
 , pytestCheckHook }:
 
 buildPythonPackage rec {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     sha256 = "0yw3n5m70ysjn1ch48znpn4zr4a1bd0lsm7q2grqz7q5hfjzjwk0";
   };
 
-  propagatedBuildInputs = [ dateutil lxml requests ];
+  propagatedBuildInputs = [ python-dateutil lxml requests ];
 
   checkInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/weboob/default.nix
+++ b/pkgs/development/python-modules/weboob/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchPypi, isPy27
 , Babel
 , cssselect
-, dateutil
+, python-dateutil
 , feedparser
 , futures ? null
 , gdata
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     Babel
     cssselect
-    dateutil
+    python-dateutil
     feedparser
     gdata
     gnupg

--- a/pkgs/development/python-modules/woob/default.nix
+++ b/pkgs/development/python-modules/woob/default.nix
@@ -5,7 +5,7 @@
 , Babel
 , colorama
 , cssselect
-, dateutil
+, python-dateutil
 , feedparser
 , gdata
 , gnupg
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     Babel
     colorama
     cssselect
-    dateutil
+    python-dateutil
     feedparser
     gdata
     gnupg

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -56,7 +56,7 @@ in newPython.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with newPython.pkgs; [
     bottle
     colorama
-    dateutil
+    python-dateutil
     deprecation
     distro
     fasteners

--- a/pkgs/development/tools/remarshal/default.nix
+++ b/pkgs/development/tools/remarshal/default.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3Packages; [
-    pyyaml cbor2 dateutil tomlkit u-msgpack-python
+    pyyaml cbor2 python-dateutil tomlkit u-msgpack-python
   ];
 
   meta = with lib; {

--- a/pkgs/misc/pylode/default.nix
+++ b/pkgs/misc/pylode/default.nix
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3Packages; [
-    dateutil
+    python-dateutil
     falcon
     gunicorn
     isodate

--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
       six
       pyasn1
       pyasn1-modules
-      dateutil
+      python-dateutil
       argcomplete
       libselinux
     ]))

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k, isort, coverage, mock
 , robot-detection, django_extensions, rjsmin, cssmin, django-mailman3
-, django-haystack, flufl_lock, networkx, dateutil, defusedxml
+, django-haystack, flufl_lock, networkx, python-dateutil, defusedxml
 , django-paintstore, djangorestframework, django, django-q
 , django_compressor, beautifulsoup4, six, psycopg2, whoosh, elasticsearch
 }:
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ isort ];
   propagatedBuildInputs = [
     robot-detection django_extensions rjsmin cssmin django-mailman3
-    django-haystack flufl_lock networkx dateutil defusedxml
+    django-haystack flufl_lock networkx python-dateutil defusedxml
     django-paintstore djangorestframework django django-q
     django_compressor six psycopg2 isort
   ];

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -33,7 +33,7 @@ toPythonModule (buildPythonApplication rec {
   propagatedBuildInputs = [
     Babel
     certifi
-    dateutil
+    python-dateutil
     flask
     flaskbabel
     gevent

--- a/pkgs/tools/admin/awslogs/default.nix
+++ b/pkgs/tools/admin/awslogs/default.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3Packages; [
-    boto3 termcolor dateutil docutils setuptools jmespath
+    boto3 termcolor python-dateutil docutils setuptools jmespath
   ];
 
   checkInputs = [ python3Packages.pytestCheckHook ];

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -33,7 +33,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3Packages; [
-    oci arrow certifi pinned_click configparser cryptography jmespath dateutil
+    oci arrow certifi pinned_click configparser cryptography jmespath python-dateutil
     pytz retrying six terminaltables pyopenssl pyyaml
   ];
 

--- a/pkgs/tools/backup/tarsnapper/default.nix
+++ b/pkgs/tools/backup/tarsnapper/default.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication rec {
     py.test .
   '';
 
-  propagatedBuildInputs = with python3Packages; [ pyyaml dateutil pexpect ];
+  propagatedBuildInputs = with python3Packages; [ pyyaml python-dateutil pexpect ];
 
   patches = [ ./remove-argparse.patch ];
 

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -132,7 +132,7 @@ let
     ps.cherrypy
     ps.cmd2
     ps.colorama
-    ps.dateutil
+    ps.python-dateutil
     ps.jsonpatch
     ps.pecan
     ps.prettytable

--- a/pkgs/tools/misc/barman/default.nix
+++ b/pkgs/tools/misc/barman/default.nix
@@ -1,5 +1,5 @@
 { buildPythonApplication, fetchurl, lib
-, dateutil, argcomplete, argh, psycopg2, boto3
+, python-dateutil, argcomplete, argh, psycopg2, boto3
 }:
 
 buildPythonApplication rec {
@@ -12,7 +12,7 @@ buildPythonApplication rec {
     sha256 = "Ts8I6tlP2GRp90OIIKXy+cRWWvUO3Sm86zq2dtVP5YE=";
   };
 
-  propagatedBuildInputs = [ dateutil argh psycopg2 boto3 argcomplete ];
+  propagatedBuildInputs = [ python-dateutil argh psycopg2 boto3 argcomplete ];
 
   # Tests are not present in tarball
   checkPhase = ''

--- a/pkgs/tools/misc/pdd/default.nix
+++ b/pkgs/tools/misc/pdd/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication, dateutil }:
+{ lib, fetchFromGitHub, buildPythonApplication, python-dateutil }:
 
 buildPythonApplication rec {
   pname = "pdd";
@@ -13,7 +13,7 @@ buildPythonApplication rec {
 
   format = "other";
 
-  propagatedBuildInputs = [ dateutil ];
+  propagatedBuildInputs = [ python-dateutil ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/misc/pubs/default.nix
+++ b/pkgs/tools/misc/pubs/default.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3Packages; [
-    argcomplete dateutil configobj feedparser bibtexparser pyyaml requests six
+    argcomplete python-dateutil configobj feedparser bibtexparser pyyaml requests six
     beautifulsoup4
   ];
 

--- a/pkgs/tools/networking/cloud-custodian/default.nix
+++ b/pkgs/tools/networking/cloud-custodian/default.nix
@@ -3,7 +3,7 @@
 , boto3
 , botocore
 , certifi
-, dateutil
+, python-dateutil
 , jsonpatch
 , jsonschema
 , pyyaml
@@ -26,7 +26,7 @@ buildPythonApplication rec {
     boto3
     botocore
     certifi
-    dateutil
+    python-dateutil
     jsonpatch
     jsonschema
     pyyaml

--- a/pkgs/tools/networking/s3cmd/default.nix
+++ b/pkgs/tools/networking/s3cmd/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub, python_magic, dateutil }:
+{ lib, buildPythonApplication, fetchFromGitHub, python_magic, python-dateutil }:
 
 buildPythonApplication rec {
   pname = "s3cmd";
@@ -11,7 +11,7 @@ buildPythonApplication rec {
     sha256 = "0p6mbgai7f0c12pkw4s7d649gj1f8hywj60pscxvj9jsna3iifhs";
   };
 
-  propagatedBuildInputs = [ python_magic dateutil ];
+  propagatedBuildInputs = [ python_magic python-dateutil ];
 
   dontUseSetuptoolsCheck = true;
 

--- a/pkgs/tools/package-management/nixops/azure-storage/default.nix
+++ b/pkgs/tools/package-management/nixops/azure-storage/default.nix
@@ -4,7 +4,7 @@
 , python
 , azure-common
 , futures
-, dateutil
+, python-dateutil
 , requests
 , isPy3k
 }:
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "06bmw6k2000kln5jwk5r9bgcalqbyvqirmdh9gq4s6nb4fv3c0jb";
   };
 
-  propagatedBuildInputs = [ azure-common dateutil requests ]
+  propagatedBuildInputs = [ azure-common python-dateutil requests ]
                             ++ pkgs.lib.optionals (!isPy3k) [ futures ];
 
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22801,7 +22801,7 @@ in
 
   acd-cli = callPackage ../applications/networking/sync/acd_cli {
     inherit (python3Packages)
-      buildPythonApplication appdirs colorama dateutil
+      buildPythonApplication appdirs colorama python-dateutil
       requests requests_toolbelt setuptools sqlalchemy fusepy;
   };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -35,6 +35,7 @@ in
 mapAliases ({
   blockdiagcontrib-cisco = throw "blockdiagcontrib-cisco is not compatible with blockdiag 2.0.0 and has been removed."; # Added 2020-11-29
   bugseverywhere = throw "bugseverywhere has been removed: Abandoned by upstream."; # Added 2019-11-27
+  dateutil = python-dateutil; # added 2021-07-03
   detox = throw "detox is no longer maintained, and was broken since may 2019"; # added 2020-07-04
   dns = dnspython; # Alias for compatibility, 2017-12-10
   faulthandler = throw "faulthandler is built into ${python.executable}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6917,8 +6917,6 @@ in {
   python-daemon = callPackage ../development/python-modules/python-daemon { };
 
   python-dateutil = callPackage ../development/python-modules/dateutil { };
-  # Alias that we should deprecate
-  dateutil = self.python-dateutil;
 
   python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The command I ran is
```
rg '[^-_"/]dateutil\b' --files-with-matches --iglob '!pkgs/top-level/python*' --iglob '!pkgs/top-level/kodi-packages.nix' --iglob '!pkgs/applications/video/kodi-packages' | xargs sed -i 's/\([^-_"/]\)dateutil\(\b\)/\1python-dateutil\2/g'
```