### PR TITLE
conan: fix build after python3Packages updates

### DIFF
--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -39,6 +39,22 @@ let newPython = python3.override {
         "test_ec_verify_should_return_false_if_signature_invalid"
       ];
     });
+    # conan needs jinja2<3
+    jinja2 = super.jinja2.overridePythonAttrs (oldAttrs: rec {
+      version = "2.11.3";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6";
+      };
+    });
+    # old jinja2 needs old markupsafe
+    markupsafe = super.markupsafe.overridePythonAttrs (oldAttrs: rec {
+      version = "1.1.1";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b";
+      };
+    });
   };
 };
 
@@ -92,7 +108,8 @@ in newPython.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace conans/requirements.txt \
-      --replace "deprecation>=2.0, <2.1" "deprecation"
+      --replace "deprecation>=2.0, <2.1" "deprecation" \
+      --replace "six>=1.10.0,<=1.15.0" "six>=1.10.0,<=1.16.0"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
conan needs jinja2<3 and six<=1.15.0. Adding six to packageOverrides
results in this build error:

```
  $ nix-build -A conan
  ...
  Found duplicated packages in closure for dependency 'six':
    six 1.16.0 (/nix/store/zn4haxpv5j9ilccvw7vxxwbfb84vhl5i-python3.8-six-1.16.0/lib/python3.8/site-packages)
    six 1.15.0 (/nix/store/8nkfc88xal8g91hfjsxq93b6pfydq2d7-python3.8-six-1.15.0/lib/python3.8/site-packages)
```

As the changes in six-1.16.0 look harmless, work around the above issue
by allowing conan to use six-1.16.0.

Ref. https://github.com/NixOS/nixpkgs/pull/127419

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
