### PR TITLE
cataclysm-dda: 0.E-3 -> 0.F, cataclysm-dda-git: 2020-12-09 -> 2021-07-03

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -13,17 +13,15 @@ let
   tilesDeps = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf freetype ]
     ++ optionals stdenv.isDarwin [ Cocoa ];
 
-  installXDGAppLauncher = ''
-    launcher="$out/share/applications/cataclysm-dda.desktop"
-    install -D -m 444 data/xdg/*cataclysm-dda.desktop -T "$launcher"
-    sed -i "$launcher" -e "s,\(Exec=\)\(cataclysm-tiles\),\1$out/bin/\2,"
-    install -D -m 444 data/xdg/cataclysm-dda.svg -t $out/share/icons/hicolor/scalable/apps
+  patchDesktopFile = ''
+    substituteInPlace $out/share/applications/org.cataclysmdda.CataclysmDDA.desktop \
+      --replace "Exec=cataclysm-tiles" "Exec=$out/bin/cataclysm-tiles"
   '';
 
   installMacOSAppLauncher = ''
     app=$out/Applications/Cataclysm.app
-    install -D -m 444 data/osx/Info.plist -t $app/Contents
-    install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources
+    install -D -m 444 build-data/osx/Info.plist -t $app/Contents
+    install -D -m 444 build-data/osx/AppIcon.icns -t $app/Contents/Resources
     mkdir $app/Contents/MacOS
     launcher=$app/Contents/MacOS/Cataclysm.sh
     cat << EOF > $launcher
@@ -58,21 +56,18 @@ stdenv.mkDerivation {
   ] ++ optionals tiles [
     "TILES=1" "SOUND=1"
   ] ++ optionals stdenv.isDarwin [
-    "NATIVE=osx" "CLANG=1"
+    "NATIVE=osx"
+    "CLANG=1"
+    "OSX_MIN=${stdenv.targetPlatform.darwinMinVersion}"
   ];
 
   postInstall = optionalString tiles
   ( if !stdenv.isDarwin
-    then installXDGAppLauncher
+    then patchDesktopFile
     else installMacOSAppLauncher
   );
 
   dontStrip = debug;
-
-  # https://hydra.nixos.org/build/65193254
-  # src/weather_data.cpp:203:1: fatal error: opening dependency file obj/tiles/weather_data.d: No such file or directory
-  # make: *** [Makefile:687: obj/tiles/weather_data.o] Error 1
-  enableParallelBuilding = false;
 
   passthru = {
     isTiles = tiles;

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -2,9 +2,9 @@
 , tiles ? true, Cocoa
 , debug ? false
 , useXdgDir ? false
-, version ? "2020-12-09"
-, rev ? "cb02195d9fb5ba71f35a105be4104c3d8883065c"
-, sha256 ? "108cs6vp99qmqqfnmczad0xjgcl82bypm5xszwnlfcswdsrfs4da"
+, version ? "2021-07-03"
+, rev ? "9017808252e1e149446c8f8bd7a6582ce0f95285"
+, sha256 ? "0qrvkbyg098jb9hv69sg5093b1vj8f4n75p73v01jnmyxlz3ax28"
 }:
 
 let

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -10,13 +10,13 @@ let
   };
 
   self = common.overrideAttrs (common: rec {
-    version = "0.E-3";
+    version = "0.F";
 
     src = fetchFromGitHub {
       owner = "CleverRaven";
       repo = "Cataclysm-DDA";
       rev = version;
-      sha256 = "qhHtsm5cM0ct/7qXev0SiLInO2jqs2odxhWndLfRDIE=";
+      sha256 = "1jid8lcl04y768b3psj1ifhx96lmd6fn1j2wzxhl4ic7ra66p2z3";
     };
 
     meta = common.meta // {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/0.F

Makefile now installs a .desktop file, so we can get rid of the script we had for that. 

Parallel builds seem to work for me locally, now, so I re-enabled them.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note that this might break cataclysm-dda-git, but at this point it's behind the stable release, so it could just be aliased to 0.F for now.