### PR TITLE
wayland-scanner: use for nativeBuildInputs

### DIFF
--- a/pkgs/applications/networking/remote/wayvnc/default.nix
+++ b/pkgs/applications/networking/remote/wayvnc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, meson, pkg-config, ninja, scdoc
+{ lib, stdenv, fetchFromGitHub, meson, pkg-config, ninja, scdoc, wayland-scanner
 , pixman, libxkbcommon, wayland, neatvnc, libdrm, libX11, aml, pam
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0q48fgh6gf3jicy4bk3kq18h9lhqfq9qz32ri6j9ffvbb8mcw64s";
   };
 
-  nativeBuildInputs = [ meson pkg-config ninja scdoc wayland ];
+  nativeBuildInputs = [ meson pkg-config ninja scdoc wayland-scanner ];
   buildInputs = [ pixman libxkbcommon wayland neatvnc libdrm libX11 aml pam ];
 
   meta = with lib; {

--- a/pkgs/applications/video/wf-recorder/default.nix
+++ b/pkgs/applications/video/wf-recorder/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland, scdoc
-, wayland-protocols, ffmpeg, x264, libpulseaudio, ocl-icd, opencl-headers
+{ lib, stdenv, fetchFromGitHub
+, meson, ninja, pkg-config, scdoc, wayland-scanner
+, wayland, wayland-protocols, ffmpeg, x264, libpulseaudio, ocl-icd, opencl-headers
 }:
 
 stdenv.mkDerivation rec {
@@ -13,9 +14,9 @@ stdenv.mkDerivation rec {
     sha256 = "1cw6kpcbl33wh95pvy32xrsrm6kkk1awccr3phyh885xjs3b3iim";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config wayland scdoc ];
+  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner scdoc ];
   buildInputs = [
-    wayland-protocols ffmpeg x264 libpulseaudio ocl-icd opencl-headers
+    wayland wayland-protocols ffmpeg x264 libpulseaudio ocl-icd opencl-headers
   ];
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub
-, meson, ninja, pkg-config, wayland, scdoc, makeWrapper
-, wlroots, wayland-protocols, pixman, libxkbcommon
+, meson, ninja, pkg-config, wayland-scanner, scdoc, makeWrapper
+, wlroots, wayland, wayland-protocols, pixman, libxkbcommon
 , systemd, libGL, libX11, mesa
 , xwayland ? null
 , nixosTests
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vm96gxinhy48m3x9p1sfldyd03w3gk6iflb7n9kn06j1vqyswr6";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config wayland scdoc makeWrapper ];
+  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner scdoc makeWrapper ];
 
   buildInputs = [
     wlroots wayland wayland-protocols pixman libxkbcommon

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, substituteAll, swaybg
-, meson, ninja, pkg-config, wayland, scdoc
-, libxkbcommon, pcre, json_c, dbus, libevdev
+, meson, ninja, pkg-config, wayland-scanner, scdoc
+, wayland, libxkbcommon, pcre, json_c, dbus, libevdev
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
 , wlroots, wayland-protocols, libdrm
 , nixosTests
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    meson ninja pkg-config wayland scdoc
+    meson ninja pkg-config wayland-scanner scdoc
   ];
 
   buildInputs = [

--- a/pkgs/applications/window-managers/tinywl/default.nix
+++ b/pkgs/applications/window-managers/tinywl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, wlroots, pkg-config
+{ lib, stdenv, wlroots, pkg-config, wayland-scanner
 , libxkbcommon, pixman, udev, wayland, wayland-protocols
 }:
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   sourceRoot = "source/tinywl";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config wayland-scanner ];
   buildInputs = [ libxkbcommon pixman udev wayland wayland-protocols wlroots ];
 
   installPhase = ''
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://github.com/swaywm/wlroots/tree/master/tinywl";
-    description = ''"minimum viable product" Wayland compositor based on wlroots.'';
+    description = ''A "minimum viable product" Wayland compositor based on wlroots'';
     maintainers = with maintainers; [ qyliss ];
     license = licenses.cc0;
     inherit (wlroots.meta) platforms;

--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, wayland
-, libGL, mesa, libxkbcommon, cairo, libxcb
+{ lib, stdenv, fetchurl, meson, ninja, pkg-config, wayland-scanner
+, wayland, libGL, mesa, libxkbcommon, cairo, libxcb
 , libXcursor, xlibsWrapper, udev, libdrm, mtdev, libjpeg, pam, dbus, libinput, libevdev
 , colord, lcms2, pipewire ? null
 , pango ? null, libunwind ? null, freerdp ? null, vaapi ? null, libva ? null
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "1zlql0xgiqc3pvgbpnnvj4xvpd91pwva8qf83xfb23if377ddxaw";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config wayland ];
+  nativeBuildInputs = [ meson ninja pkg-config wayland-scanner ];
   buildInputs = [
     wayland libGL mesa libxkbcommon cairo libxcb libXcursor xlibsWrapper udev libdrm
     mtdev libjpeg pam dbus libinput libevdev pango libunwind freerdp vaapi libva

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, meson, pkg-config, ninja, wayland
+{ stdenv, lib, fetchFromGitHub, meson, pkg-config, ninja, wayland-scanner
 , libdrm
 , minimal ? false, libva-minimal
-, libX11, libXext, libXfixes, libffi, libGL
+, libX11, libXext, libXfixes, wayland, libffi, libGL
 , mesa
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "dev" "out" ];
 
-  nativeBuildInputs = [ meson pkg-config ninja wayland ];
+  nativeBuildInputs = [ meson pkg-config ninja wayland-scanner ];
 
   buildInputs = [ libdrm ]
     ++ lib.optionals (!minimal) [ libva-minimal libX11 libXext libXfixes wayland libffi libGL ];

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -16,6 +16,7 @@
 , withWaylandTools ? stdenv.isLinux
 , wayland
 , wayland-protocols
+, wayland-scanner
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja pkg-config bison doxygen ]
-    ++ lib.optional withWaylandTools wayland;
+    ++ lib.optional withWaylandTools wayland-scanner;
   buildInputs = [ xkeyboard_config libxcb libxml2 ]
     ++ lib.optionals withWaylandTools [ wayland wayland-protocols ];
   checkInputs = [ python3 ];

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, fetchpatch, buildPackages
 , meson, pkg-config, ninja
-, intltool, bison, flex, file, python3Packages
+, intltool, bison, flex, file, python3Packages, wayland-scanner
 , expat, libdrm, xorg, wayland, wayland-protocols, openssl
 , llvmPackages, libffi, libomxil-bellagio, libva-minimal
 , libelf, libvdpau
@@ -143,7 +143,7 @@ self = stdenv.mkDerivation {
     intltool bison flex file
     python3Packages.python python3Packages.Mako
   ] ++ lib.optionals (elem "wayland" eglPlatforms) [
-    wayland # For wayland-scanner during the build
+    wayland-scanner
   ];
 
   propagatedBuildInputs = with xorg; [

--- a/pkgs/tools/wayland/wayland-utils/default.nix
+++ b/pkgs/tools/wayland/wayland-utils/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl
-, meson, pkg-config, ninja
+, meson, pkg-config, ninja, wayland-scanner
 , wayland, wayland-protocols
 }:
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1h38l850ww6hxjb1l8iwa33nkbz8q88bw6lh0aryjyp8b16crzk4";
   };
 
-  nativeBuildInputs = [ meson pkg-config ninja wayland ];
+  nativeBuildInputs = [ meson pkg-config ninja wayland-scanner ];
   buildInputs = [ wayland wayland-protocols ];
 
   meta = with lib; {

--- a/pkgs/tools/wayland/wev/default.nix
+++ b/pkgs/tools/wayland/wev/default.nix
@@ -3,6 +3,7 @@
 , fetchFromSourcehut
 , pkg-config
 , scdoc
+, wayland-scanner
 , wayland
 , wayland-protocols
 , libxkbcommon
@@ -19,8 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l71v3fzgiiv6xkk365q1l08qvaymxd4kpaya6r2g8yzkr7i2hms";
   };
 
-  nativeBuildInputs = [ pkg-config scdoc wayland ];
-  buildInputs = [ wayland-protocols libxkbcommon ];
+  nativeBuildInputs = [ pkg-config scdoc wayland-scanner ];
+  buildInputs = [ wayland wayland-protocols libxkbcommon ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/wayland/wlsunset/default.nix
+++ b/pkgs/tools/wayland/wlsunset/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, fetchFromSourcehut, meson, pkg-config, ninja, wayland, scdoc
-, wayland-protocols
+{ lib, stdenv, fetchFromSourcehut
+, meson, pkg-config, ninja, wayland-scanner, scdoc
+, wayland, wayland-protocols
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hhsddh3rs066rbsjksr8kcwg8lvglbvs67dq0r5wx5c1xcwb51w";
   };
 
-  nativeBuildInputs = [ meson pkg-config ninja wayland scdoc ];
+  nativeBuildInputs = [ meson pkg-config ninja wayland-scanner scdoc ];
   buildInputs = [ wayland wayland-protocols ];
 
   meta = with lib; {

--- a/pkgs/tools/wayland/wob/default.nix
+++ b/pkgs/tools/wayland/wob/default.nix
@@ -5,9 +5,10 @@
 , ninja
 , pkg-config
 , scdoc
-, libseccomp
-, wayland # wayland-scanner
+, wayland-scanner
+, wayland
 , wayland-protocols
+, libseccomp
 }:
 
 stdenv.mkDerivation rec {
@@ -21,8 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "13mx6nzab6msp57s9mv9ambz53a4zkafms9v97xv5zvd6xarnrya";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config scdoc wayland ];
-  buildInputs = [ wayland-protocols ]
+  nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
+  buildInputs = [ wayland wayland-protocols ]
     ++ lib.optional stdenv.isLinux libseccomp;
 
   mesonFlags = lib.optional stdenv.isLinux "-Dseccomp=enabled";

--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromSourcehut
-, meson, pkg-config, wayland, ninja
-, cairo, libinput, pango, wayland-protocols, libxkbcommon
+, meson, pkg-config, wayland-scanner, ninja
+, cairo, libinput, pango, wayland, wayland-protocols, libxkbcommon
 }:
 
 let
@@ -17,8 +17,8 @@ in stdenv.mkDerivation rec {
     sha256 = "10kafdja5cwbypspwhvaxjz3hvf51vqjzbgdasl977193cvxgmbs";
   };
 
-  nativeBuildInputs = [ meson pkg-config wayland ninja ];
-  buildInputs = [ cairo libinput pango wayland-protocols libxkbcommon ];
+  nativeBuildInputs = [ meson pkg-config wayland-scanner ninja ];
+  buildInputs = [ cairo libinput pango wayland wayland-protocols libxkbcommon ];
 
   meta = with lib; {
     description = "Displays keys being pressed on a Wayland session";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```console
$ nix-build -A wayvnc -A wf-recorder -A cage -A sway -A tinywl -A weston -A libva -A libxkbcommon -A mesa -A wayland-utils -A wev -A wlsunset -A wob -A wshowkeys
/nix/store/5q7zmgxcwizl69qwgcv5ncrniv1i3ncb-wayvnc-0.4.0
/nix/store/km93hm94zmsmrd10qi2jcn4wkq05zxk7-wf-recorder-0.2.1
/nix/store/g1mcvi0v0k545x0hxcg0br7b12cxm32a-cage-0.1.4
/nix/store/0q7n7caxp1jjzrr0phdnq3l3sya95bpi-sway-1.6.1
/nix/store/zp3hyb50plxrjsslsvwg84p9dzv413za-tinywl-0.14.0
/nix/store/qfvbc88yhdvclbhvk64zfn3h9npsbaiy-weston-9.0.0
/nix/store/yq20s5wx89g1bzdlq2w8ihd687fj4l30-libva-2.12.0-dev
/nix/store/g8y2qfg3b5w60kddvy5s0knxdg63pln2-libxkbcommon-1.3.0
/nix/store/b9cpils284zs6svqmk1xxlfx5c9sbw8q-mesa-21.1.3
/nix/store/2d0vvzkarisfy5p9y9818sy7v32q8v6g-wayland-utils-1.0.0
/nix/store/lqd3i1k5n72jrm4fara6lyfd232dy66g-wev-1.0.0
/nix/store/swy1nmnyccjwlb0zzhj1fvns59f5a57b-wlsunset-0.2.0
/nix/store/ficj19v3wvyrg2q2fxfk4wwmrv16mp0s-wob-0.11
/nix/store/v6sbfkbf746crd20hagmpd3hs8cq05b9-wshowkeys-unstable-2020-03-29
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
