### PR TITLE
doc: point out that nixos-21.05 has gnuradio 3.9

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2105.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2105.section.xml
@@ -101,16 +101,18 @@
       <listitem>
         <para>
           <link xlink:href="https://www.gnuradio.org/">GNURadio</link>
-          3.8 was
+          3.8 and 3.9 were
           <link xlink:href="https://github.com/NixOS/nixpkgs/issues/82263">finally</link>
           packaged, along with a rewrite to the Nix expressions,
           allowing users to override the features upstream supports
           selecting to compile or not to. Additionally, the attribute
-          <literal>gnuradio</literal> and <literal>gnuradio3_7</literal>
-          now point to an externally wrapped by default derivations,
-          that allow you to also add `extraPythonPackages` to the Python
-          interpreter used by GNURadio. Missing environmental variables
-          needed for operational GUI were also added
+          <literal>gnuradio</literal> (3.9),
+          <literal>gnuradio3_8</literal> and
+          <literal>gnuradio3_7</literal> now point to an externally
+          wrapped by default derivations, that allow you to also add
+          `extraPythonPackages` to the Python interpreter used by
+          GNURadio. Missing environmental variables needed for
+          operational GUI were also added
           (<link xlink:href="https://github.com/NixOS/nixpkgs/issues/75478">#75478</link>).
         </para>
       </listitem>

--- a/nixos/doc/manual/release-notes/rl-2105.section.md
+++ b/nixos/doc/manual/release-notes/rl-2105.section.md
@@ -36,7 +36,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 The following new services were added since the last release:
 
-- [GNURadio](https://www.gnuradio.org/) 3.8 was [finally](https://github.com/NixOS/nixpkgs/issues/82263) packaged, along with a rewrite to the Nix expressions, allowing users to override the features upstream supports selecting to compile or not to. Additionally, the attribute `gnuradio` and `gnuradio3_7` now point to an externally wrapped by default derivations, that allow you to also add \`extraPythonPackages\` to the Python interpreter used by GNURadio. Missing environmental variables needed for operational GUI were also added ([\#75478](https://github.com/NixOS/nixpkgs/issues/75478)).
+- [GNURadio](https://www.gnuradio.org/) 3.8 and 3.9 were [finally](https://github.com/NixOS/nixpkgs/issues/82263) packaged, along with a rewrite to the Nix expressions, allowing users to override the features upstream supports selecting to compile or not to. Additionally, the attribute `gnuradio` (3.9), `gnuradio3_8` and `gnuradio3_7` now point to an externally wrapped by default derivations, that allow you to also add \`extraPythonPackages\` to the Python interpreter used by GNURadio. Missing environmental variables needed for operational GUI were also added ([\#75478](https://github.com/NixOS/nixpkgs/issues/75478)).
 
 - [Keycloak](https://www.keycloak.org/), an open source identity and access management server with support for [OpenID Connect](https://openid.net/connect/), [OAUTH 2.0](https://oauth.net/2/) and [SAML 2.0](https://en.wikipedia.org/wiki/SAML_2.0).
 


### PR DESCRIPTION
###### Motivation for this change
Logically re-apply 64c70a8c4c ("doc: point out that nixos-21.05 has gnuradio
3.9"), because it was lost in the conversion from docbook to markdown, in
commit 32c2dd304d ("docs: nixos release notes to CommonMark (2105)").


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
