### PR TITLE
tts: 0.0.15.1 -> 0.1.2

### DIFF
--- a/pkgs/development/python-modules/gruut-ipa/default.nix
+++ b/pkgs/development/python-modules/gruut-ipa/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pkgs
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "gruut-ipa";
+  version = "0.9.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = pname;
+    rev = "df74f7dff562d868ad8088b7251f9e7206271d37";
+    sha256 = "0b2znvjngffxc0mlmqmcai8l22ff09kc39bj6f0lkjw735vclnzh";
+  };
+
+  postPatch = ''
+    patchShebangs bin/speak-ipa
+    substituteInPlace bin/speak-ipa \
+      --replace '${"\${src_dir}:"}' "$out/lib/${python.libPrefix}/site-packages:" \
+      --replace "do espeak" "do ${pkgs.espeak}/bin/espeak"
+  '';
+
+  postInstall = ''
+    install -m0755 bin/speak-ipa $out/bin/speak-ipa
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "gruut_ipa"
+  ];
+
+  meta = with lib; {
+    description = "Library for manipulating pronunciations using the International Phonetic Alphabet (IPA)";
+    homepage = "https://github.com/rhasspy/gruut-ipa";
+    license = licenses.mit;
+    maintainers = teams.tts.members;
+  };
+}

--- a/pkgs/development/python-modules/gruut/default.nix
+++ b/pkgs/development/python-modules/gruut/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, buildPythonPackage
+, callPackage
+, pythonOlder
+, fetchFromGitHub
+, Babel
+, gruut-ipa
+, jsonlines
+, num2words
+, python-crfsuite
+, dataclasses
+, python
+}:
+
+let
+  langPkgs = [
+    "cs"
+    "de"
+    "es"
+    "fr"
+    "it"
+    "nl"
+    "pt"
+    "ru"
+    "sv"
+    "sw"
+  ];
+in
+buildPythonPackage rec {
+  pname = "gruut";
+  version = "1.2.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1763qmcd1gxap27jppqaywx03k5cagcl62z2p2qdiqigdksplm2g";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "Babel~=2.8.0" "Babel"
+  '';
+
+  propagatedBuildInputs = [
+    Babel
+    gruut-ipa
+    jsonlines
+    num2words
+    python-crfsuite
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    dataclasses
+  ] ++ (map (lang: callPackage ./language-pack.nix {
+    inherit lang version format src;
+  }) langPkgs);
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "gruut"
+  ];
+
+  meta = with lib; {
+    description = "A tokenizer, text cleaner, and phonemizer for many human languages";
+    homepage = "https://github.com/rhasspy/gruut";
+    license = licenses.mit;
+    maintainers = teams.tts.members;
+  };
+}

--- a/pkgs/development/python-modules/gruut/language-pack.nix
+++ b/pkgs/development/python-modules/gruut/language-pack.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+
+, lang
+, version
+, format
+, src
+}:
+
+buildPythonPackage rec {
+  pname = "gruut-lang-${lang}";
+  inherit version format src;
+
+  prePatch = ''
+    cd "${pname}"
+  '';
+
+  pythonImportsCheck = [
+    "gruut_lang_${lang}"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Language files for gruut tokenizer/phonemizer";
+    homepage = "https://github.com/rhasspy/gruut";
+    license = licenses.mit;
+    maintainers = teams.tts.members;
+  };
+}

--- a/pkgs/development/python-modules/python-crfsuite/default.nix
+++ b/pkgs/development/python-modules/python-crfsuite/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-crfsuite";
+  version = "0.9.7";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ryfcdfpqbrf8rcd2rlay2gfiba3px3q508543jf81shrv93hi9v";
+  };
+
+  preCheck = ''
+    # make sure import the built version, not the source one
+    rm -r pycrfsuite
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pycrfsuite"
+  ];
+
+  meta = with lib; {
+    description = "Python binding for CRFsuite";
+    homepage = "https://github.com/scrapinghub/python-crfsuite";
+    license = licenses.mit;
+    maintainers = teams.tts.members;
+  };
+}

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -12,25 +12,24 @@
 #
 # If you upgrade from an old version you may have to delete old models from ~/.local/share/tts
 # Also note that your tts version might not support all available models so check:
-#   https://github.com/coqui-ai/TTS/releases/tag/v0.0.15.1
+#   https://github.com/coqui-ai/TTS/releases/tag/v0.1.2
 #
 # For now, for deployment check the systemd unit in the pull request:
 #   https://github.com/NixOS/nixpkgs/pull/103851#issue-521121136
 
 python3Packages.buildPythonApplication rec {
   pname = "tts";
-  version = "0.0.15.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "TTS";
     rev = "v${version}";
-    sha256 = "0z6sbzspgmw5ja8r2zysyhdk4jzlv88a0ihkvxvvwxslkyncdb89";
+    sha256 = "1qgiaqn7iqxyf54qgnpmli69nw9s3gmi9qv874jsgycykc10hjg4";
   };
 
   postPatch = ''
     sed -i -e 's!librosa==[^"]*!librosa!' requirements.txt
-    sed -i -e 's!unidecode==[^"]*!unidecode!' requirements.txt
     sed -i -e 's!numba==[^"]*!numba!' requirements.txt
     sed -i -e 's!numpy==[^"]*!numpy!' requirements.txt
     sed -i -e 's!umap-learn==[^"]*!umap-learn!' requirements.txt
@@ -44,6 +43,7 @@ python3Packages.buildPythonApplication rec {
     anyascii
     coqpit
     flask
+    gruut
     gdown
     inflect
     jieba

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5562,6 +5562,8 @@ in
     stdenv = stdenv_32bit;
   };
 
+  gruut = with python3.pkgs; toPythonApplication gruut;
+
   gruut-ipa = with python3.pkgs; toPythonApplication gruut-ipa;
 
   gx = callPackage ../tools/package-management/gx { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5562,6 +5562,8 @@ in
     stdenv = stdenv_32bit;
   };
 
+  gruut-ipa = with python3.pkgs; toPythonApplication gruut-ipa;
+
   gx = callPackage ../tools/package-management/gx { };
   gx-go = callPackage ../tools/package-management/gx/go { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3131,6 +3131,8 @@ in {
 
   grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
 
+  gruut = callPackage ../development/python-modules/gruut { };
+
   gruut-ipa = callPackage ../development/python-modules/gruut-ipa { };
 
   gsd = callPackage ../development/python-modules/gsd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3131,6 +3131,8 @@ in {
 
   grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
 
+  gruut-ipa = callPackage ../development/python-modules/gruut-ipa { };
+
   gsd = callPackage ../development/python-modules/gsd { };
 
   gspread = callPackage ../development/python-modules/gspread { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5379,6 +5379,8 @@ in {
 
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
 
+  python-crfsuite = callPackage ../development/python-modules/python-crfsuite { };
+
   python-csxcad = callPackage ../development/python-modules/python-csxcad { };
 
   python-ecobee-api = callPackage ../development/python-modules/python-ecobee-api { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/coqui-ai/TTS/releases/tag/v0.1.0
https://github.com/coqui-ai/TTS/releases/tag/v0.1.1
https://github.com/coqui-ai/TTS/releases/tag/v0.1.2
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
