### PR TITLE
[Backport release-21.05] seafile-shared: 8.0.1 -> 8.0.3, seafile-client: 8.0.1 -> 8.0.3

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -10,7 +10,7 @@ mkDerivation rec {
     owner = "haiwen";
     repo = "seafile-client";
     rev = "v${version}";
-    sha256 = "lhdKbR19ScNeezICf7vwZaeJikPjwbqrz42bo4lhxJs=";
+    sha256 = "cG3OSqRhYnxlzfauQia6pM/1gu+iE5mtHTGk3kGMFH0=";
   };
 
   nativeBuildInputs = [ pkg-config cmake ];

--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -1,26 +1,17 @@
-{ mkDerivation, lib, fetchFromGitHub, fetchpatch, pkg-config, cmake, qtbase, qttools
+{ mkDerivation, lib, fetchFromGitHub, pkg-config, cmake, qtbase, qttools
 , seafile-shared, jansson, libsearpc
 , withShibboleth ? true, qtwebengine }:
 
 mkDerivation rec {
   pname = "seafile-client";
-  version = "8.0.1";
+  version = "8.0.3";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-client";
-    rev = "b4b944921c7efef13a93d693c45c997943899dec";
-    sha256 = "2vV+6ZXjVg81JVLfWeD0UK+RdmpBxBU2Ozx790WFSyw=";
+    rev = "v${version}";
+    sha256 = "lhdKbR19ScNeezICf7vwZaeJikPjwbqrz42bo4lhxJs=";
   };
-
-  patches = [
-    # Fix compilation failure with "error: template with C linkage", fixes #122505
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/fix_build_with_glib2.diff?h=seafile-client&id=7be253aaa2bdb6771721f45aa08bc875c8001c5a";
-      name = "fix_build_with_glib2.diff";
-      sha256 = "0hl7rcqfr8k62c1pr133bp3j63b905izaaggmgvr1af4jibal05v";
-    })
-  ];
 
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ qtbase qttools seafile-shared jansson libsearpc ]

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "seafile-shared";
-  version = "8.0.1";
+  version = "8.0.3";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile";
-    rev = "d34499a2aafa024623a4210fe7f663cef13fe9a6";
-    sha256 = "VKoGr3CTDFg3Q0X+MTlwa4BbfLB+28FeTyTJRCq37RA=";
+    rev = "v${version}";
+    sha256 = "F6kLPWZb7FttyAP7pNEn+aRcAjvZlMNXrmuHMYa0Xig=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "haiwen";
     repo = "seafile";
     rev = "v${version}";
-    sha256 = "F6kLPWZb7FttyAP7pNEn+aRcAjvZlMNXrmuHMYa0Xig=";
+    sha256 = "QflLh3fj+jOq/8etr9aG8LGrvtIlB/htVkWbdO+GIbM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Backports https://github.com/NixOS/nixpkgs/pull/128776 and https://github.com/NixOS/nixpkgs/pull/129111.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
