### PR TITLE
gnomeExtensions: rename extensionUuid to uuid

### DIFF
--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -50,7 +50,7 @@ let
     passthru = {
       extensionPortalSlug = pname;
       # Store the extension's UUID, because we might need it at some places
-      extensionUuid = uuid;
+      inherit uuid;
     };
   };
 in

--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -32,7 +32,7 @@ let
   # Map the list of extensions to an attrset based on the UUID as key
   mapUuidNames = extensions:
     lib.trivial.pipe extensions [
-      (map (extension: lib.nameValuePair extension.extensionUuid extension))
+      (map (extension: lib.nameValuePair extension.uuid extension))
       builtins.listToAttrs
     ];
 
@@ -42,13 +42,13 @@ let
     # Filter out all extensions that map to null
     (lib.filter (extension:
       !(
-        (builtins.hasAttr extension.extensionUuid extensionRenames)
-        && ((builtins.getAttr extension.extensionUuid extensionRenames) == null)
+        (builtins.hasAttr extension.uuid extensionRenames)
+        && ((builtins.getAttr extension.uuid extensionRenames) == null)
       )
     ))
     # Map all extensions to their pname, with potential overwrites
     (map (extension:
-      lib.nameValuePair (extensionRenames.${extension.extensionUuid} or extension.extensionPortalSlug) extension
+      lib.nameValuePair (extensionRenames.${extension.uuid} or extension.extensionPortalSlug) extension
     ))
     builtins.listToAttrs
   ];


### PR DESCRIPTION
###### Motivation for this change

If you take a look at some manual packaged extensions they all have a variable called `uuid`, some examples:
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix#L28
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/desktops/gnome/extensions/appindicator/default.nix#L19
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/desktops/gnome/extensions/arcmenu/default.nix#L27
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/desktops/gnome/extensions/caffeine/default.nix#L14

Current usage since all packages had a `uuid`:

```
let
  extensions = [
    pkgs.gnomeExtensions.appindicator
    pkgs.gnomeExtensions.caffeine
    pkgs.gnomeExtensions.clock-override
    pkgs.gnomeExtensions.dash-to-dock
    pkgs.gnomeExtensions.dynamic-panel-transparency
    pkgs.gnomeExtensions.fuzzy-app-search
    pkgs.gnomeExtensions.unite
    pkgs.gnomeExtensions.window-is-ready-remover
  ];
in {
  home-manager.users.rhoriguchi.dconf.settings."org/gnome/shell".enabled-extensions = map (extension: extension.uuid) extensions;
}
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
