### PR TITLE
twurl: init at 0.9.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1512,6 +1512,12 @@
     githubId = 1111035;
     name = "Break Yang";
   };
+  brecht = {
+    email = "brecht.savelkoul@alumni.lse.ac.uk";
+    github = "brechtcs";
+    githubId = 6107054;
+    name = "Brecht Savelkoul";
+  };
   brettlyons = {
     email = "blyons@fastmail.com";
     github = "brettlyons";

--- a/pkgs/tools/misc/twurl/Gemfile
+++ b/pkgs/tools/misc/twurl/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'twurl'

--- a/pkgs/tools/misc/twurl/Gemfile.lock
+++ b/pkgs/tools/misc/twurl/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    oauth (0.5.6)
+    twurl (0.9.6)
+      oauth (~> 0.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  twurl
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/tools/misc/twurl/default.nix
+++ b/pkgs/tools/misc/twurl/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerApp, bundlerUpdateScript }:
+
+bundlerApp {
+  pname = "twurl";
+  gemdir = ./.;
+  exes = [ "twurl" ];
+
+  passthru.updateScript = bundlerUpdateScript "twurl";
+
+  meta = with lib; {
+    description = "OAuth-enabled curl for the Twitter API";
+    homepage    = "https://github.com/twitter/twurl";
+    license     = "MIT";
+    maintainers = with maintainers; [ brecht ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/twurl/gemset.nix
+++ b/pkgs/tools/misc/twurl/gemset.nix
@@ -1,0 +1,23 @@
+{
+  oauth = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zwd6v39yqfdrpg1p3d9jvzs9ljg55ana2p06m0l7qn5w0lgx1a0";
+      type = "gem";
+    };
+    version = "0.5.6";
+  };
+  twurl = {
+    dependencies = ["oauth"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jgsxa0cnkajnsxxlsrgl2wq3m7khaxvr0rcir4vwbc1hx210700";
+      type = "gem";
+    };
+    version = "0.9.6";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9441,6 +9441,8 @@ in
 
   twtxt = python3Packages.callPackage ../applications/networking/twtxt { };
 
+  twurl = callPackage ../tools/misc/twurl { };
+
   txr = callPackage ../tools/misc/txr { stdenv = clangStdenv; };
 
   txt2man = callPackage ../tools/misc/txt2man { };


### PR DESCRIPTION
###### Motivation for this change

Twurl gives more low-level access to the Twitter API (and is more up-to-date with the latest features) than the `t` tool that's already available in nixpkgs right now.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions: Ubuntu on WSL
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
