### PR TITLE
python3Packages.pytest-rerunfailures: 9.1.1 -> 10.1

### DIFF
--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pytest-rerunfailures";
-  version = "9.1.1";
+  version = "10.1";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cb11a17fc121b3918414eb5eaf314ee325f2e693ac7cb3f6abf7560790827f2";
+    sha256 = "7617c06de13ee6dd2df9add7e275bfb2bcebbaaf3e450f5937cd0200df824273";
   };
 
   buildInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change

upstream release 10.1 ([on PyPI](https://pypi.org/project/pytest-rerunfailures/10.1/),  [on GitHub](https://github.com/pytest-dev/pytest-rerunfailures/releases/tag/10.1))
- [Changelog](https://github.com/pytest-dev/pytest-rerunfailures/blob/10.1/CHANGES.rst#101-2021-07-02)
- [all changes since 9.1.1](https://github.com/pytest-dev/pytest-rerunfailures/compare/9.1.1...10.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are none) 
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
