### PR TITLE
instant-messengers/chatty: init at 0.3.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatty/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatty/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, libhandy
+, libphonenumber
+, libgcrypt
+, pidgin
+, protobuf
+, modemmanager
+, folks
+, gtk3
+, gom
+, feedbackd
+, evolution-data-server
+, glib
+, desktop-file-utils
+, appstream-glib
+, libgdata
+, olm
+, dbus
+, vala
+, wrapGAppsHook
+, xvfb-run
+, python3
+, sqlite
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chatty";
+  version = "0.3.2";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "Librem5";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kznkcm1pdp9m21swwzzlpb44qmgvmc233k0ngdp56f1qz522pzy";
+  };
+
+  patches = [
+    # https://source.puri.sm/Librem5/chatty/-/issues/508
+    ./disable-accounts-test.patch
+  ];
+
+  postPatch = ''
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    desktop-file-utils
+    appstream-glib
+    vala
+    wrapGAppsHook
+    python3
+  ];
+
+  buildInputs = [
+    evolution-data-server
+    gom
+    feedbackd
+    gtk3
+    libgcrypt
+    libgdata # required by some dependency transitively
+    libhandy
+    libphonenumber
+    modemmanager
+    pidgin
+    protobuf
+    olm
+    sqlite
+  ];
+
+  checkInputs = [
+    dbus
+    xvfb-run
+  ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    NO_AT_BRIDGE=1 \
+    XDG_DATA_DIRS=${folks}/share/gsettings-schemas/${folks.name} \
+    xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+      --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      meson test --print-errorlogs
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "XMPP and SMS messaging via libpurple and Modemmanager";
+    homepage = "https://source.puri.sm/Librem5/chatty";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/chatty/disable-accounts-test.patch
+++ b/pkgs/applications/networking/instant-messengers/chatty/disable-accounts-test.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/meson.build b/tests/meson.build
+index e9a2f89..8848e7b 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -10,7 +10,6 @@ env.set('GSETTINGS_SCHEMA_DIR', join_paths(meson.build_root(), 'data'))
+ env.set('MALLOC_CHECK_', '2')
+ 
+ test_items = [
+-  'account',
+   'history',
+   'settings',
+   'utils',

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1355,6 +1355,8 @@ in
 
   catcli = python3Packages.callPackage ../tools/filesystems/catcli { };
 
+  chatty = callPackage ../applications/networking/instant-messengers/chatty { };
+
   chezmoi = callPackage ../tools/misc/chezmoi { };
 
   chipsec = callPackage ../tools/security/chipsec {


### PR DESCRIPTION
###### Motivation for this change
Chatty is a minimal UI for libpurple, suitable for small screens.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
