### PR TITLE
networking/eg25-manager: init at 0.3.0

### DIFF
--- a/pkgs/applications/networking/eg25-manager/default.nix
+++ b/pkgs/applications/networking/eg25-manager/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, glib
+, glibmm
+, libgpiod
+, libgudev
+, libusb
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eg25-manager";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    group = "mobian1";
+    owner = "devices";
+    repo = pname;
+    rev = version;
+    sha256 = "077i4z0w8589m5r0ffvwa13p7c1vvqdwcs2gkrlbx40yiv6x2wnr";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    glibmm
+    libgpiod
+    libgudev
+    libusb
+  ];
+
+  meta = with lib; {
+    description = "Manager daemon for the Quectel EG25 mobile broadband modem";
+    homepage = "https://gitlab.com/mobian1/devices/eg25-manager";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2564,6 +2564,8 @@ in
 
   eddy = libsForQt5.callPackage ../applications/graphics/eddy { };
 
+  eg25-manager = callPackage ../applications/networking/eg25-manager { };
+
   eggdrop = callPackage ../tools/networking/eggdrop { };
 
   eksctl = callPackage ../tools/admin/eksctl { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/mobile-nixos/issues/348

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
