### PR TITLE
pidgin-plugins/purple-mm-sms: init at 0.1.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-mm-sms/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-mm-sms/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, glibmm, pidgin, pkg-config, modemmanager, fetchFromGitLab } :
+
+stdenv.mkDerivation rec {
+  pname = "purple-mm-sms";
+  version = "0.1.7";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "Librem5";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0917gjig35hmi6isqb62vhxd3lkc2nwdn13ym2gvzgcjfgjzjajr";
+  };
+
+  makeFlags = [
+    "DATA_ROOT_DIR_PURPLE=$(out)/share"
+    "PLUGIN_DIR_PURPLE=$(out)/lib/purple-2"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ glibmm pidgin modemmanager ];
+
+  meta = with lib; {
+    homepage = "https://source.puri.sm/Librem5/purple-mm-sms";
+    description = "A libpurple plugin for sending and receiving SMS via Modemmanager";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tomfitzhenry ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26264,6 +26264,8 @@ in
 
   purple-matrix = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-matrix { };
 
+  purple-mm-sms = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-mm-sms { };
+
   purple-plugin-pack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack { };
 
   purple-slack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-slack { };


### PR DESCRIPTION
###### Motivation for this change
Send/receive SMSs from libpurple clients such as Pidgin.

Tested with `finch`, an ncurses libpurple client.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
