### PR TITLE
qjournalctl: init at 0.6.3

### DIFF
--- a/pkgs/applications/system/qjournalctl/default.nix
+++ b/pkgs/applications/system/qjournalctl/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtbase
+, qmake
+, pkg-config
+, libssh
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qjournalctl";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "pentix";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j27cmfq29mwrbjfrrwi6m1grcamhbfhk47xzlfsx5wr2q9m6qkz";
+  };
+
+  postPatch = ''
+    substituteInPlace qjournalctl.pro --replace /usr/ $out/
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libssh
+    qtbase
+  ];
+
+  meta = with lib; {
+    description = "Qt-based graphical user interface for systemd's journalctl command";
+    homepage = "https://github.com/pentix/qjournalctl";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dtzWill srgom romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8204,6 +8204,8 @@ in
 
   qhull = callPackage ../development/libraries/qhull { };
 
+  qjournalctl = libsForQt5.callPackage ../applications/system/qjournalctl { };
+
   qjoypad = callPackage ../tools/misc/qjoypad { };
 
   qmk = callPackage ../tools/misc/qmk { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Continuation of https://github.com/NixOS/nixpkgs/pull/78815 (submitted by @SRGOM) and https://github.com/NixOS/nixpkgs/pull/55762 (submitted by @dtzWill)

- version bump
- quoted URL
- moved `wrapQtAppsHook` to `nativeBuildInputs`
- `pkg-config` is used instead of `pkgconfig`
- moved `libssh` to `buildInputs`
- format with `nixpkgs-fmt`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
