### PR TITLE
ibus-engines.mozc: 2.23.4206.102 -> 2.26.4423.100

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -1,70 +1,64 @@
 { lib, stdenv, fetchFromGitHub, which, ninja, pkg-config, protobuf
 , ibus, gtk2, zinnia, qt5, libxcb, tegaki-zinnia-japanese, python3Packages }:
 
-let
-  japanese_usage_dictionary = fetchFromGitHub {
-    owner  = "hiroyuki-komatsu";
-    repo   = "japanese-usage-dictionary";
-    rev    = "e5b3425575734c323e1d947009dd74709437b684";
-    sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
-  };
-in stdenv.mkDerivation rec {
-  name = "ibus-mozc-${version}";
-  version = "2.23.4206.102";
-
-  meta = with lib; {
-    isIbusEngine = true;
-    description  = "Japanese input method from Google";
-    homepage     = "https://github.com/google/mozc";
-    license      = licenses.free;
-    platforms    = platforms.linux;
-    maintainers  = with maintainers; [ gebner ericsagnes ];
-  };
-
-  nativeBuildInputs = [ which ninja python3Packages.python python3Packages.six
-                        python3Packages.gyp pkg-config qt5.wrapQtAppsHook ];
-  buildInputs = [ protobuf ibus gtk2 zinnia qt5.qtbase libxcb ];
+stdenv.mkDerivation rec {
+  pname = "ibus-mozc";
+  version = "2.26.4423.100";
 
   src = fetchFromGitHub {
-    owner  = "google";
-    repo   = "mozc";
-    rev    = "91cc1e19ef34aeb12888b697fefa52907f1a834d";
-    sha256 = "1fyy9g1pnaq6s5nkf56aqmp5mgyibbmp1ylc64fqc6g1plg90zk2";
+    owner = "google";
+    repo = "mozc";
+    rev = "7654223979067e3c5ae52ea238d43880c5508f85";
+    sha256 = "aZVuhj4I9ZCsVR9dOplOd9zinYMgYw5SF5wG3IxBTO0=";
     fetchSubmodules = true;
   };
 
-  postUnpack = ''
-    rm -rf $sourceRoot/src/third_party/japanese_usage_dictionary/
-    ln -s ${japanese_usage_dictionary} $sourceRoot/src/third_party/japanese_usage_dictionary
-  '' + lib.optionalString stdenv.isLinux ''
+  nativeBuildInputs = [
+    which ninja python3Packages.python python3Packages.six
+    python3Packages.gyp pkg-config qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [ protobuf ibus gtk2 zinnia qt5.qtbase libxcb ];
+
+  postUnpack = lib.optionalString stdenv.isLinux ''
     sed -i 's/-lc++/-lstdc++/g' $sourceRoot/src/gyp/common.gypi
   '';
 
   configurePhase = ''
+    runHook preConfigure
+
     export GYP_DEFINES="document_dir=$out/share/doc/mozc use_libzinnia=1 use_libprotobuf=1 ibus_mozc_path=$out/lib/ibus-mozc/ibus-engine-mozc zinnia_model_file=${tegaki-zinnia-japanese}/share/tegaki/models/zinnia/handwriting-ja.model"
     cd src && python build_mozc.py gyp --gypdir=${python3Packages.gyp}/bin --server_dir=$out/lib/mozc
+
+    runHook postConfigure
   '';
 
   buildPhase = ''
+    runHook preBuild
+
     PYTHONPATH="$PWD:$PYTHONPATH" python build_mozc.py build -c Release \
       unix/ibus/ibus.gyp:ibus_mozc \
       unix/emacs/emacs.gyp:mozc_emacs_helper \
       server/server.gyp:mozc_server \
       gui/gui.gyp:mozc_tool \
       renderer/renderer.gyp:mozc_renderer
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -d        $out/share/licenses/mozc
     head -n 29 server/mozc_server.cc > $out/share/licenses/mozc/LICENSE
-    install -m 644    data/installer/*.html     $out/share/licenses/mozc/
+    install -m 644    data/installer/*.html $out/share/licenses/mozc/
 
     install -D -m 755 out_linux/Release/mozc_server $out/lib/mozc/mozc_server
     install    -m 755 out_linux/Release/mozc_tool   $out/lib/mozc/mozc_tool
     wrapQtApp $out/lib/mozc/mozc_tool
 
     install -d        $out/share/doc/mozc
-    install -m 644    data/installer/*.html         $out/share/doc/mozc/
+    install -m 644    data/installer/*.html $out/share/doc/mozc/
 
     install -D -m 755 out_linux/Release/ibus_mozc           $out/lib/ibus-mozc/ibus-engine-mozc
     install -D -m 644 out_linux/Release/gen/unix/ibus/mozc.xml $out/share/ibus/component/mozc.xml
@@ -79,5 +73,16 @@ in stdenv.mkDerivation rec {
     install    -m 644 data/images/unix/ui-alpha_half.png    $out/share/ibus-mozc/alpha_half.png
     install    -m 644 data/images/unix/ui-alpha_full.png    $out/share/ibus-mozc/alpha_full.png
     install -D -m 755 out_linux/Release/mozc_renderer       $out/lib/mozc/mozc_renderer
+
+    runHook postInstall
   '';
+
+  meta = with lib; {
+    isIbusEngine = true;
+    description = "Japanese input method from Google";
+    homepage = "https://github.com/google/mozc";
+    license = licenses.free;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ gebner ericsagnes ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Updating to the latest build because I want https://github.com/google/mozc/commit/467a91c5b237ef9f519075b42e7c4585281e168f.

Note that the previous version (build 4206) was [already](https://github.com/google/mozc/blob/91cc1e19ef34aeb12888b697fefa52907f1a834d/src/data/version/mozc_version_template.bzl#L31-L36) 2.26 and not 2.23.

I removed the part where we fetch `japanese-usage-dictionary` ourselves and replace it in the source, because it's already a submodule upstream with the exact same revision, so I don't see the point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @gebner @ericsagnes 