### PR TITLE
prompt to set root password has changed

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -446,8 +446,8 @@
      password for the <literal>root</literal> user, e.g.
 <screen>
 setting root password...
-Enter new UNIX password: ***
-Retype new UNIX password: ***</screen>
+New password: ***
+Retype new password: ***</screen>
      <note>
       <para>
        For unattended installations, it is possible to use


### PR DESCRIPTION
This is a change in the installation manual.

The manual mentions in
https://nixos.org/manual/nixos/stable/index.html#sec-installation-installing:
```
setting root password...
Enter new UNIX password: ***
Retype new UNIX password: ***
```

However, in the terminal I got:
```
setting root password...
New password: ***
Retype new password: ***
```