### PR TITLE
fix ssh kerberos by removing duplicate ::1 line in /etc/hosts

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -162,7 +162,7 @@ in
     in {
       "127.0.0.2" = hostnames;
     } // optionalAttrs cfg.enableIPv6 {
-      "::1" = hostnames;
+      "::1" = hostnames ++ [ "localhost" ];
     };
 
     networking.hostFiles = let
@@ -172,7 +172,6 @@ in
       # FQDN so that e.g. "hostname -f" works correctly.
       localhostHosts = pkgs.writeText "localhost-hosts" ''
         127.0.0.1 localhost
-        ${optionalString cfg.enableIPv6 "::1 localhost"}
       '';
       stringHosts =
         let

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -325,6 +325,7 @@ in
   opensmtpd = handleTest ./opensmtpd.nix {};
   opensmtpd-rspamd = handleTest ./opensmtpd-rspamd.nix {};
   openssh = handleTest ./openssh.nix {};
+  openssh-kerberos = handleTest ./openssh-kerberos.nix {};
   openstack-image-metadata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).metadata or {};
   openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).userdata or {};
   opentabletdriver = handleTest ./opentabletdriver.nix {};

--- a/nixos/tests/openssh-kerberos.nix
+++ b/nixos/tests/openssh-kerberos.nix
@@ -1,0 +1,85 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+let
+  krb5 =
+    { enable = true;
+      domain_realm."ssh.test"   = "SSH.TEST";
+      libdefaults.default_realm = "SSH.TEST";
+      realms."SSH.TEST" =
+        { admin_server = "server.ssh.test";
+          kdc = "server.ssh.test";
+        };
+    };
+
+in
+
+{
+  name = "ssh-with-kerberos";
+
+  nodes = {
+    client = { lib, ... }:
+      { inherit krb5;
+        networking.hostName = "client";
+        networking.domain = "ssh.test";
+
+        programs.ssh.extraConfig = ''
+            GSSAPIAuthentication yes
+        '';
+      };
+
+    server = { lib, config, ...}:
+      { inherit krb5;
+        networking.hostName = "server";
+        networking.domain = "ssh.test";
+
+        networking.firewall.allowedTCPPorts = [
+          88   # kerberos
+        ];
+
+        services.kerberos_server.enable = true;
+        services.kerberos_server.realms."SSH.TEST" = {};
+
+        services.openssh = {
+          enable = true;
+          passwordAuthentication = false;
+          challengeResponseAuthentication = false;
+          extraConfig = ''
+            GSSAPIAuthentication yes
+          '';
+        };
+      };
+  };
+
+  testScript =
+    ''
+      start_all()
+      # set up kerberos database
+      server.succeed(
+          "kdb5_util create -s -r SSH.TEST -P master_key",
+          "systemctl restart kadmind.service kdc.service",
+      )
+      server.wait_for_unit("kadmind.service")
+      server.wait_for_unit("kdc.service")
+
+      # create principals
+      server.succeed(
+          "kadmin.local add_principal -randkey host/server.ssh.test",
+          "kadmin.local add_principal -pw root_pw root",
+      )
+
+      # add principal to keytabs
+      server.succeed("kadmin.local ktadd host/server.ssh.test")
+
+      server.wait_for_unit("sshd.service")
+      server.succeed("cat /etc/ssh/ssh_host_ed25519_key.pub | sed -E 's/(.*) (.*) .*/server \\1 \\2/' > /tmp/shared/known_hosts")
+
+      with subtest("try ssh as root"):
+          client.succeed("mkdir ~/.ssh")
+          client.succeed("cp /tmp/shared/known_hosts /root/.ssh")
+          client.fail("ssh server ls -l /")
+          client.succeed("echo root_pw | kinit -l 00:10")
+          client.succeed("ssh server ls -l /")
+    '';
+})


### PR DESCRIPTION
###### Motivation for this change

currently, `/etc/hosts` is a bit faulty, because it contains 2 lines for `::1` (the IPv6 loopback address). One hard-coded for `localhost` and another line a bit below for the actual hostname of the system.

`openssh`'s `sshd` gets confused by this when using *kerberos* authentication. It will look at `/etc/hosts` to find out which kerberos principal name to use for itself. Finds localhost (which isn't a valid principal) and fails.

This change removes the hard coded localhost line and merges it with the other hostnames. I could not find a reason for adding logic to make sure it stays the second line. It appears the comment about `hostname -f` only applies to IPv4 localhost.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
