### PR TITLE
python3Packages.python-pidfile: init at 3.0.0

### DIFF
--- a/pkgs/development/python-modules/python-pidfile/default.nix
+++ b/pkgs/development/python-modules/python-pidfile/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  psutil,
+}:
+
+buildPythonPackage rec {
+  pname = "python-pidfile";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-HhCX30G8dfV0WZ/++J6LIO/xvfyRkdPtJkzC2ulUKdA=";
+  };
+
+  propagatedBuildInputs = [
+    psutil
+  ];
+
+  pythonImportsCheck = [ "pidfile" ];
+
+  # no tests on the github mirror of the source code
+  # see this: https://github.com/mosquito/python-pidfile/issues/7
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python context manager for managing pid files";
+    homepage = "https://github.com/mosquito/python-pidfile";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ legendofmiracles ];
+  };
+}

--- a/pkgs/development/python-modules/python-pidfile/default.nix
+++ b/pkgs/development/python-modules/python-pidfile/default.nix
@@ -1,8 +1,7 @@
-{
-  lib,
-  buildPythonPackage,
-  fetchPypi,
-  psutil,
+{ lib
+, buildPythonPackage
+, fetchPypi
+, psutil
 }:
 
 buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7061,6 +7061,8 @@ in {
 
   python-picnic-api = callPackage ../development/python-modules/python-picnic-api { };
 
+  python-pidfile = callPackage ../development/python-modules/python-pidfile { };
+
   python-pipedrive = callPackage ../development/python-modules/python-pipedrive { };
 
   python-prctl = callPackage ../development/python-modules/python-prctl { };


### PR DESCRIPTION
###### Motivation for this change
library needed for other program that i'd like to package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).