### PR TITLE
postgresql.pkgs.citus: init at 10.0.3

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, autoreconfHook
+, postgresql
+, curl
+, fetchFromGitHub
+, lz4
+, zstd
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "citus";
+  version = "10.0.3";
+
+  src = fetchFromGitHub {
+    owner = "citusdata";
+    repo = "citus";
+    rev = "v${version}";
+    sha256 = "hzR4tQnws5kYyLY8xzoIiOEJrCQFj0t2d+lJg2c8/AE=";
+    fetchSubmodules = false;
+  };
+
+  buildInputs = [
+    postgresql
+    curl
+    lz4
+    zstd.out
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    zstd.dev
+  ];
+
+  # dirty hack to give us a clean install tree
+  installPhase = ''
+    make install DESTDIR=/tmp/citus
+    mkdir -p $out
+    mv /tmp/citus/nix/store/*/* $out
+  '';
+
+  meta = with lib; {
+    description = "Postgres Clustering";
+    homepage = "https://www.citusdata.com/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mkg20001 ];
+    inherit (postgresql.meta) platforms;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -4,6 +4,8 @@ self: super: {
       bison = self.bison_3_5;
     };
 
+    citus = super.callPackage ./ext/citus.nix { };
+
     periods = super.callPackage ./ext/periods.nix { };
 
     postgis = super.callPackage ./ext/postgis.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add citus db

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
