### PR TITLE
nixos/postgresql: add upgradeFrom option to upgrade from an old postgresql version

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -226,6 +226,15 @@ in
           By default, syscall groups (i.e. attribute names starting with `@`) are added
           _before_ negated groups (i.e. `~@` as prefix) _before_ syscall names
           and negations.
+          '';
+        };
+
+      upgradeFrom = mkOption {
+        type = types.nullOr types.package;
+        default = null;
+        example = literalExpression "pkgs.postgresql_11";
+        description = ''
+          PostgreSQL package that you're upgrading from (this will automatically call pg_upgrade)
         '';
       };
 
@@ -750,6 +759,15 @@ in
           # Initialise the database.
           initdb -U ${cfg.superUser} ${escapeShellArgs cfg.initdbArgs}
 
+          ${optionalString (cfg.upgradeFrom != null) ''
+            if [ -e "/var/lib/postgresql/${cfg.upgradeFrom.psqlSchema}" ]; then
+              mkdir -p /tmp/pg_upgrade
+              pushd /tmp/pg_upgrade
+              pg_upgrade -b "${cfg.upgradeFrom}/bin" -d "/var/lib/postgresql/${cfg.upgradeFrom.psqlSchema}/" -D "${cfg.dataDir}"
+              popd
+            fi
+          ''}
+
           # See postStart!
           touch "${cfg.dataDir}/.first_startup"
         fi
@@ -816,6 +834,7 @@ in
           # Give Postgres a decent amount of time to clean up after
           # receiving systemd's SIGINT.
           TimeoutSec = 120;
+          TimeoutStartSec = 3600;
 
           ExecStart = "${cfg.finalPackage}/bin/postgres";
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Allow upgrading easily

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
