### PR TITLE
prometheus-mysqld-exporter: 0.12.1 -> 0.13.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
@@ -1,18 +1,21 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "mysqld_exporter";
-  version = "0.12.1";
+  version = "0.13.0";
   rev = "v${version}";
-
-  goPackagePath = "github.com/prometheus/mysqld_exporter";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "prometheus";
     repo = "mysqld_exporter";
-    sha256 = "0nzbfzx4dzs3cagdid1fqddrqimgr8x6r8gmmxglrss05c8srgs8";
+    sha256 = "05gb6p65a0ys356qnanwc40klz1izrib37rz5yzyg2ysvamlvmys";
   };
+
+  vendorSha256 = "19785rfzlx8h0h8vmg0ghd40h3p4y6ikhgf8rd2qfj5f6qxfhrgv";
+
+  # skips tests with external dependencies, e.g. on mysqld
+  checkFlags = [ "-short" ];
 
   meta = with lib; {
     description = "Prometheus exporter for MySQL server metrics";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/prometheus/mysqld_exporter/blob/master/CHANGELOG.md#0130--2021-05-18

Depends on #129286

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
