### PR TITLE
Fix GHC not building with musl

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -68,8 +68,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl ];
   propagatedBuildInputs = lib.optionals useLLVM [ llvmPackages.llvm ];
 
+  # Set LD_LIBRARY_PATH or equivalent so that the programs running as part
+  # of the bindist installer can find the libraries they expect.
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
-  # the final install location/
+  # the final install location.
   ${libEnvVar} = libPath;
 
   postUnpack =
@@ -133,6 +135,7 @@ stdenv.mkDerivation rec {
     "--with-gmp-libraries=${lib.getLib gmp}/lib"
     "--with-gmp-includes=${lib.getDev gmp}/include"
   ] ++ lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    # From: https://github.com/NixOS/nixpkgs/pull/43369/commits
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
 
   # No building is necessary, but calling make without flags ironically

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation rec {
     '' +
     # Rename needed libraries and binaries, fix interpreter
     lib.optionalString stdenv.isLinux ''
-      find . -type f -perm -0100 -exec patchelf \
+      find . -type f -executable -exec patchelf \
           --interpreter ${stdenv.cc.bintools.dynamicLinker} {} \;
     '';
 

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -204,9 +204,6 @@ stdenv.mkDerivation rec {
     lib.optionalString stdenv.isLinux ''
       find . -type f -perm -0100 -exec patchelf \
           --interpreter ${glibcDynLinker} {} \;
-
-      sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
-      sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
     '' +
     # We're kludging a glibc bindist into working with non-glibc...
     # Here we patch up the use of `__strdup` (part of glibc binary ABI)

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -244,11 +244,9 @@ stdenv.mkDerivation rec {
 
   configurePlatforms = [ ];
   configureFlags = [
-    # Note that musl-based bindists seem to do nothing with the
-    # `--with-gmp-libraries` flag, see:
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/20073#note_363231
-    "--with-gmp-libraries=${lib.getLib gmp}/lib"
     "--with-gmp-includes=${lib.getDev gmp}/include"
+    # Note `--with-gmp-libraries` does nothing for GHC bindists:
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6124
   ] ++ lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
     # From: https://github.com/NixOS/nixpkgs/pull/43369/commits
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -36,82 +36,86 @@ let
   # * To skip file checking for a specific arch specfic library,
   #   set `fileToCheckFor = null`.
   ghcBinDists = {
-    i686-linux = {
-      src = {
-        url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
-        sha256 = "0bvwisl4w0z5z8z0da10m9sv0mhm9na2qm43qxr8zl23mn32mblx";
+    # Binary distributions for the default libc (e.g. glibc, or libSystem on Darwin)
+    # nixpkgs uses for the respective system.
+    defaultLibc = {
+      i686-linux = {
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
+          sha256 = "0bvwisl4w0z5z8z0da10m9sv0mhm9na2qm43qxr8zl23mn32mblx";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          # The i686-linux bindist provided by GHC HQ is currently built on Debian 9,
+          # which link it against `libtinfo.so.5` (ncurses 5).
+          # Other bindists are linked `libtinfo.so.6` (ncurses 6).
+          { nixPackage = ncurses5; fileToCheckFor = "libtinfo.so.5"; }
+        ];
       };
-      exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
-      archSpecificLibraries = [
-        # The i686-linux bindist provided by GHC HQ is currently built on Debian 9,
-        # which link it against `libtinfo.so.5` (ncurses 5).
-        # Other bindists are linked `libtinfo.so.6` (ncurses 6).
-        { nixPackage = ncurses5; fileToCheckFor = "libtinfo.so.5"; }
-      ];
+      x86_64-linux = {
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb10-linux.tar.xz";
+          sha256 = "0chnzy9j23b2wa8clx5arwz8wnjfxyjmz9qkj548z14cqf13slcl";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          { nixPackage = ncurses6; fileToCheckFor = "libtinfo.so.6"; }
+        ];
+      };
+      armv7l-linux = {
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-armv7-deb10-linux.tar.xz";
+          sha256 = "1j41cq5d3rmlgz7hzw8f908fs79gc5mn3q5wz277lk8zdf19g75v";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          { nixPackage = ncurses6; fileToCheckFor = "libtinfo.so.6"; }
+        ];
+      };
+      aarch64-linux = {
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb10-linux.tar.xz";
+          sha256 = "14smwl3741ixnbgi0l51a7kh7xjkiannfqx15b72svky0y4l3wjw";
+        };
+        exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
+        archSpecificLibraries = [
+          { nixPackage = ncurses6; fileToCheckFor = "libtinfo.so.6"; }
+          { nixPackage = numactl; fileToCheckFor = null; }
+        ];
+      };
+      x86_64-darwin = {
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+          sha256 = "1hngyq14l4f950hzhh2d204ca2gfc98pc9xdasxihzqd1jq75dzd";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          { nixPackage = ncurses6; fileToCheckFor = null; }
+          { nixPackage = libiconv; fileToCheckFor = null; }
+        ];
+      };
     };
-    x86_64-linux =
-      if stdenv.hostPlatform.isMusl
-        then
-          { # musl-bindist (referred to below)
-            src = {
-              url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3.10-linux-integer-simple.tar.xz";
-              sha256 = "0xpcbyaxqyhbl6f0i3s4rp2jm67nqpkfh2qlbj3i2fiaix89ml0l";
-            };
-            exePathForLibraryCheck = "bin/ghc";
-            archSpecificLibraries = [
-              # In contrast to glibc builds, the musl-bindist uses `libncursesw.so.*`
-              # instead of `libtinfo.so.*.`
-              { nixPackage = ncurses6; fileToCheckFor = "libncursesw.so.6"; }
-            ];
-          }
-        else
-          { # normal glibc based bindist
-            src = {
-              url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb10-linux.tar.xz";
-              sha256 = "0chnzy9j23b2wa8clx5arwz8wnjfxyjmz9qkj548z14cqf13slcl";
-            };
-            exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
-            archSpecificLibraries = [
-              { nixPackage = ncurses6; fileToCheckFor = "libtinfo.so.6"; }
-            ];
-          }
-        ;
-    armv7l-linux = {
-      src = {
-        url = "${downloadsUrl}/${version}/ghc-${version}-armv7-deb10-linux.tar.xz";
-        sha256 = "1j41cq5d3rmlgz7hzw8f908fs79gc5mn3q5wz277lk8zdf19g75v";
+    # Binary distributions for the musl libc for the respective system.
+    musl = {
+      x86_64-linux = {
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3.10-linux-integer-simple.tar.xz";
+          sha256 = "0xpcbyaxqyhbl6f0i3s4rp2jm67nqpkfh2qlbj3i2fiaix89ml0l";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          # In contrast to glibc builds, the musl-bindist uses `libncursesw.so.*`
+          # instead of `libtinfo.so.*.`
+          { nixPackage = ncurses6; fileToCheckFor = "libncursesw.so.6"; }
+        ];
       };
-      exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
-      archSpecificLibraries = [
-        { nixPackage = ncurses6; fileToCheckFor = "libtinfo.so.6"; }
-      ];
-    };
-    aarch64-linux = {
-      src = {
-        url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb10-linux.tar.xz";
-        sha256 = "14smwl3741ixnbgi0l51a7kh7xjkiannfqx15b72svky0y4l3wjw";
-      };
-      exePathForLibraryCheck = "ghc/stage2/build/tmp/ghc-stage2";
-      archSpecificLibraries = [
-        { nixPackage = ncurses6; fileToCheckFor = "libtinfo.so.6"; }
-        { nixPackage = numactl; fileToCheckFor = null; }
-      ];
-    };
-    x86_64-darwin = {
-      src = {
-        url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
-        sha256 = "1hngyq14l4f950hzhh2d204ca2gfc98pc9xdasxihzqd1jq75dzd";
-      };
-      exePathForLibraryCheck = null; # we don't have a library check for darwin yet
-      archSpecificLibraries = [
-        { nixPackage = ncurses6; fileToCheckFor = null; }
-        { nixPackage = libiconv; fileToCheckFor = null; }
-      ];
     };
   };
 
-  binDistUsed = ghcBinDists.${stdenv.hostPlatform.system}
-    or (throw "cannot bootstrap GHC on this platform");
+  distSetName = if stdenv.hostPlatform.isMusl then "musl" else "defaultLibc";
+
+  binDistUsed = ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform ('${stdenv.hostPlatform.system}' with libc '${distSetName}')");
 
   useLLVM = !stdenv.targetPlatform.isx86;
 
@@ -361,7 +365,16 @@ stdenv.mkDerivation rec {
     homepage = "http://haskell.org/ghc";
     description = "The Glasgow Haskell Compiler";
     license = lib.licenses.bsd3;
-    platforms = ["x86_64-linux" "armv7l-linux" "aarch64-linux" "i686-linux" "x86_64-darwin"];
+    # HACK: since we can't encode the libc / abi in platforms, we need
+    # to make the platform list dependent on the evaluation platform
+    # in order to avoid eval errors with musl which supports less
+    # platforms than the default libcs (i. e. glibc / libSystem).
+    # This is done for the benefit of Hydra, so `packagePlatforms`
+    # won't return any platforms that would cause an evaluation
+    # failure for `pkgsMusl.haskell.compiler.ghc8102Binary`, as
+    # long as the evaluator runs on a platform that supports
+    # `pkgsMusl`.
+    platforms = builtins.attrNames ghcBinDists.${distSetName};
     hydraPlatforms = builtins.filter (p: minimal || p != "aarch64-linux") platforms;
     maintainers = with lib.maintainers; [ lostnet ];
   };

--- a/pkgs/development/compilers/ghc/8.10.4.nix
+++ b/pkgs/development/compilers/ghc/8.10.4.nix
@@ -238,7 +238,16 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable =
+    [ "format" ]
+    # In nixpkgs, musl based builds currently enable `pie` hardening by default
+    # (see `defaultHardeningFlags` in `make-derivation.nix`).
+    # But GHC cannot currently produce outputs that are ready for `-pie` linking.
+    # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/issues/129247
+    # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
+    ++ lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/8.10.4.nix
+++ b/pkgs/development/compilers/ghc/8.10.4.nix
@@ -38,12 +38,30 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, #  Whether to build sphinx documentation.
+  enableDocs ? (
+    # Docs disabled for musl and cross because it's a large task to keep
+    # all `sphinx` dependencies building in those environments.
+    # `sphinx` pulls in among others:
+    # Ruby, Python, Perl, Rust, OpenGL, Xorg, gtk, LLVM.
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+    && !stdenv.hostPlatform.isMusl
+  )
+
+, enableHaddockProgram ?
+    # Disabled for cross; see note [HADDOCK_DOCS].
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+
 , # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
   disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+
+# Cross cannot currently build the `haddock` program for silly reasons,
+# see note [HADDOCK_DOCS].
+assert (stdenv.targetPlatform != stdenv.hostPlatform) -> !enableHaddockProgram;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -60,14 +78,26 @@ let
     ifneq \"\$(BuildFlavour)\" \"\"
     include mk/flavours/\$(BuildFlavour).mk
     endif
+    BUILD_SPHINX_HTML = ${if enableDocs then "YES" else "NO"}
+    BUILD_SPHINX_PDF = NO
+  '' +
+  # Note [HADDOCK_DOCS]:
+  # Unfortunately currently `HADDOCK_DOCS` controls both whether the `haddock`
+  # program is built (which we generally always want to have a complete GHC install)
+  # and whether it is run on the GHC sources to generate hyperlinked source code
+  # (which is impossible for cross-compilation); see:
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/20077
+  # This implies that currently a cross-compiled GHC will never have a `haddock`
+  # program, so it can never generate haddocks for any packages.
+  # If this is solved in the future, we'd like to unconditionally
+  # build the haddock program (removing the `enableHaddockProgram` option).
+  ''
+    HADDOCK_DOCS = ${if enableHaddockProgram then "YES" else "NO"}
     DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
     INTEGER_LIBRARY = ${if enableIntegerSimple then "integer-simple" else "integer-gmp"}
   '' + lib.optionalString (targetPlatform != hostPlatform) ''
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
-    HADDOCK_DOCS = NO
-    BUILD_SPHINX_HTML = NO
-    BUILD_SPHINX_PDF = NO
   '' + lib.optionalString (!enableProfiledLibs) ''
     GhcLibWays = "v dyn"
   '' + lib.optionalString enableRelocatedStaticLibs ''
@@ -217,8 +247,10 @@ stdenv.mkDerivation (rec {
   dontAddExtraLibs = true;
 
   nativeBuildInputs = [
-    perl autoconf automake m4 python3 sphinx
+    perl autoconf automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+  ] ++ lib.optionals enableDocs [
+    sphinx
   ];
 
   # For building runtime libs

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -152,6 +152,15 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  # In nixpkgs, musl based builds currently enable `pie` hardening by default
+  # (see `defaultHardeningFlags` in `make-derivation.nix`).
+  # But GHC cannot currently produce outputs that are ready for `-pie` linking.
+  # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
+  # See:
+  # * https://github.com/NixOS/nixpkgs/issues/129247
+  # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
+  hardeningDisable = lib.optional stdenv.targetPlatform.isMusl "pie";
+
   doInstallCheck = true;
   installCheckPhase = ''
     unset ${libEnvVar}

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -121,8 +121,9 @@ stdenv.mkDerivation rec {
 
   configurePlatforms = [ ];
   configureFlags = [
-    "--with-gmp-libraries=${lib.getLib gmp}/lib"
     "--with-gmp-includes=${lib.getDev gmp}/include"
+    # Note `--with-gmp-libraries` does nothing for GHC bindists:
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6124
   ] ++ lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
 

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -38,12 +38,30 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, #  Whether to build sphinx documentation.
+  enableDocs ? (
+    # Docs disabled for musl and cross because it's a large task to keep
+    # all `sphinx` dependencies building in those environments.
+    # `sphinx` pullls in among others:
+    # Ruby, Python, Perl, Rust, OpenGL, Xorg, gtk, LLVM.
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+    && !stdenv.hostPlatform.isMusl
+  )
+
+, enableHaddockProgram ?
+    # Disabled for cross; see note [HADDOCK_DOCS].
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+
 , # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
   disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+
+# Cross cannot currently build the `haddock` program for silly reasons,
+# see note [HADDOCK_DOCS].
+assert (stdenv.targetPlatform != stdenv.hostPlatform) -> !enableHaddockProgram;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -60,6 +78,21 @@ let
     ifneq \"\$(BuildFlavour)\" \"\"
     include mk/flavours/\$(BuildFlavour).mk
     endif
+    BUILD_SPHINX_HTML = ${if enableDocs then "YES" else "NO"}
+    BUILD_SPHINX_PDF = NO
+  '' +
+  # Note [HADDOCK_DOCS]:
+  # Unfortunately currently `HADDOCK_DOCS` controls both whether the `haddock`
+  # program is built (which we generally always want to have a complete GHC install)
+  # and whether it is run on the GHC sources to generate hyperlinked source code
+  # (which is impossible for cross-compilation); see:
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/20077
+  # This implies that currently a cross-compiled GHC will never have a `haddock`
+  # program, so it can never generate haddocks for any packages.
+  # If this is solved in the future, we'd like to unconditionally
+  # build the haddock program (removing the `enableHaddockProgram` option).
+  ''
+    HADDOCK_DOCS = ${if enableHaddockProgram then "YES" else "NO"}
     DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
     INTEGER_LIBRARY = ${if enableIntegerSimple then "integer-simple" else "integer-gmp"}
   ''
@@ -72,9 +105,6 @@ let
   + lib.optionalString (targetPlatform != hostPlatform) ''
     Stage1Only = ${if (targetPlatform.system == hostPlatform.system && !targetPlatform.isiOS) then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
-    HADDOCK_DOCS = NO
-    BUILD_SPHINX_HTML = NO
-    BUILD_SPHINX_PDF = NO
   '' + lib.optionalString dontStrip ''
     STRIP_CMD = :
   '' + lib.optionalString (!enableProfiledLibs) ''
@@ -227,8 +257,10 @@ stdenv.mkDerivation (rec {
   dontAddExtraLibs = true;
 
   nativeBuildInputs = [
-    perl autoconf automake m4 python3 sphinx
+    perl autoconf automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+  ] ++ lib.optionals enableDocs [
+    sphinx
   ];
 
   # For building runtime libs

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -142,11 +142,14 @@ stdenv.mkDerivation (rec {
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.
-  preConfigure = lib.optionalString stdenv.isAarch64 ''
+  preConfigure =
     # Aarch64 allow backward bootstrapping since earlier versions are unstable.
-    find . -name \*\.cabal\* -exec sed -i -e 's/\(base.*\)4.14/\14.16/' {} \; \
-      -exec sed -i -e 's/\(prim.*\)0.6/\10.8/' {} \;
-  '' + ''
+    # Same for musl, as earlier versions do not provide a musl bindist for bootstrapping.
+    lib.optionalString (stdenv.isAarch64 || stdenv.hostPlatform.isMusl) ''
+      find . -name \*\.cabal\* -exec sed -i -e 's/\(base.*\)4.14/\14.16/' {} \; \
+        -exec sed -i -e 's/\(prim.*\)0.6/\10.8/' {} \;
+    ''
+  + ''
     for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
       export "''${env#TARGET_}=''${!env}"
     done

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -248,7 +248,16 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable =
+    [ "format" ]
+    # In nixpkgs, musl based builds currently enable `pie` hardening by default
+    # (see `defaultHardeningFlags` in `make-derivation.nix`).
+    # But GHC cannot currently produce outputs that are ready for `-pie` linking.
+    # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/issues/129247
+    # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
+    ++ lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -225,7 +225,16 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable =
+    [ "format" ]
+    # In nixpkgs, musl based builds currently enable `pie` hardening by default
+    # (see `defaultHardeningFlags` in `make-derivation.nix`).
+    # But GHC cannot currently produce outputs that are ready for `-pie` linking.
+    # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/issues/129247
+    # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
+    ++ lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -39,12 +39,30 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, #  Whether to build sphinx documentation.
+  enableDocs ? (
+    # Docs disabled for musl and cross because it's a large task to keep
+    # all `sphinx` dependencies building in those environments.
+    # `sphinx` pullls in among others:
+    # Ruby, Python, Perl, Rust, OpenGL, Xorg, gtk, LLVM.
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+    && !stdenv.hostPlatform.isMusl
+  )
+
+, enableHaddockProgram ?
+    # Disabled for cross; see note [HADDOCK_DOCS].
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+
 , # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
   disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+
+# Cross cannot currently build the `haddock` program for silly reasons,
+# see note [HADDOCK_DOCS].
+assert (stdenv.targetPlatform != stdenv.hostPlatform) -> !enableHaddockProgram;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -61,14 +79,26 @@ let
     ifneq \"\$(BuildFlavour)\" \"\"
     include mk/flavours/\$(BuildFlavour).mk
     endif
+    BUILD_SPHINX_HTML = ${if enableDocs then "YES" else "NO"}
+    BUILD_SPHINX_PDF = NO
+  '' +
+  # Note [HADDOCK_DOCS]:
+  # Unfortunately currently `HADDOCK_DOCS` controls both whether the `haddock`
+  # program is built (which we generally always want to have a complete GHC install)
+  # and whether it is run on the GHC sources to generate hyperlinked source code
+  # (which is impossible for cross-compilation); see:
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/20077
+  # This implies that currently a cross-compiled GHC will never have a `haddock`
+  # program, so it can never generate haddocks for any packages.
+  # If this is solved in the future, we'd like to unconditionally
+  # build the haddock program (removing the `enableHaddockProgram` option).
+  ''
+    HADDOCK_DOCS = ${if enableHaddockProgram then "YES" else "NO"}
     DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
     INTEGER_LIBRARY = ${if enableIntegerSimple then "integer-simple" else "integer-gmp"}
   '' + lib.optionalString (targetPlatform != hostPlatform) ''
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
-    HADDOCK_DOCS = NO
-    BUILD_SPHINX_HTML = NO
-    BUILD_SPHINX_PDF = NO
   '' + lib.optionalString (!enableProfiledLibs) ''
     GhcLibWays = "v dyn"
   '' + lib.optionalString enableRelocatedStaticLibs ''
@@ -204,8 +234,10 @@ stdenv.mkDerivation (rec {
   dontAddExtraLibs = true;
 
   nativeBuildInputs = [
-    perl autoconf automake m4 python3 sphinx
+    perl autoconf automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+  ] ++ lib.optionals enableDocs [
+    sphinx
   ];
 
   # For building runtime libs

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (rec {
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
-  '' + lib.optionalString (stdenv.isLinux) ''
+  '' + lib.optionalString (stdenv.isLinux && hostPlatform.libc == "glibc") ''
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
   '' + lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -242,7 +242,16 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable =
+    [ "format" ]
+    # In nixpkgs, musl based builds currently enable `pie` hardening by default
+    # (see `defaultHardeningFlags` in `make-derivation.nix`).
+    # But GHC cannot currently produce outputs that are ready for `-pie` linking.
+    # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/issues/129247
+    # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
+    ++ lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -46,12 +46,30 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, #  Whether to build sphinx documentation.
+  enableDocs ? (
+    # Docs disabled for musl and cross because it's a large task to keep
+    # all `sphinx` dependencies building in those environments.
+    # `sphinx` pullls in among others:
+    # Ruby, Python, Perl, Rust, OpenGL, Xorg, gtk, LLVM.
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+    && !stdenv.hostPlatform.isMusl
+  )
+
+, enableHaddockProgram ?
+    # Disabled for cross; see note [HADDOCK_DOCS].
+    (stdenv.targetPlatform == stdenv.hostPlatform)
+
 , # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
   disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
 }:
 
 assert !enableNativeBignum -> gmp != null;
+
+# Cross cannot currently build the `haddock` program for silly reasons,
+# see note [HADDOCK_DOCS].
+assert (stdenv.targetPlatform != stdenv.hostPlatform) -> !enableHaddockProgram;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -68,14 +86,26 @@ let
     ifneq \"\$(BuildFlavour)\" \"\"
     include mk/flavours/\$(BuildFlavour).mk
     endif
+    BUILD_SPHINX_HTML = ${if enableDocs then "YES" else "NO"}
+    BUILD_SPHINX_PDF = NO
+  '' +
+  # Note [HADDOCK_DOCS]:
+  # Unfortunately currently `HADDOCK_DOCS` controls both whether the `haddock`
+  # program is built (which we generally always want to have a complete GHC install)
+  # and whether it is run on the GHC sources to generate hyperlinked source code
+  # (which is impossible for cross-compilation); see:
+  # https://gitlab.haskell.org/ghc/ghc/-/issues/20077
+  # This implies that currently a cross-compiled GHC will never have a `haddock`
+  # program, so it can never generate haddocks for any packages.
+  # If this is solved in the future, we'd like to unconditionally
+  # build the haddock program (removing the `enableHaddockProgram` option).
+  ''
+    HADDOCK_DOCS = ${if enableHaddockProgram then "YES" else "NO"}
     DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
     BIGNUM_BACKEND = ${if enableNativeBignum then "native" else "gmp"}
   '' + lib.optionalString (targetPlatform != hostPlatform) ''
     Stage1Only = ${if (targetPlatform.system == hostPlatform.system && !targetPlatform.isiOS) then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
-    HADDOCK_DOCS = NO
-    BUILD_SPHINX_HTML = NO
-    BUILD_SPHINX_PDF = NO
   '' + lib.optionalString dontStrip ''
     STRIP_CMD = :
   '' + lib.optionalString (!enableProfiledLibs) ''
@@ -221,8 +251,10 @@ stdenv.mkDerivation (rec {
   dontAddExtraLibs = true;
 
   nativeBuildInputs = [
-    perl autoconf autoreconfHook automake m4 python3 sphinx
+    perl autoconf autoreconfHook automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+  ] ++ lib.optionals enableDocs [
+    sphinx
   ];
 
   # For building runtime libs

--- a/pkgs/development/libraries/argp-standalone/default.nix
+++ b/pkgs/development/libraries/argp-standalone/default.nix
@@ -33,7 +33,11 @@ stdenv.mkDerivation {
 
   patchFlags = lib.optional stdenv.hostPlatform.isDarwin "-p0";
 
-  preConfigure = lib.optionalString stdenv.hostPlatform.isLinux "export CFLAGS='-fgnu89-inline'";
+  # For currently unknown reason, `-fPIC` has to be passed explicitly, otherwise
+  # downstream software like `elfutils` will get `recompile errors like:
+  #     libargp.a(argp-help.o): relocation R_X86_64_PC32 against symbol `program_invocation_short_name' can not be used when making a shared object; recompile with -fPIC
+  # It seems that nixpkgs's on-by-default `-fPIC` is not in effect here.
+  preConfigure = lib.optionalString stdenv.hostPlatform.isLinux "export CFLAGS='-fgnu89-inline -fPIC'";
 
   postInstall = ''
     mkdir -p $out/lib $out/include

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -57,7 +57,8 @@ in {
 
     ghc884 = callPackage ../development/compilers/ghc/8.8.4.nix {
       # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
-      bootPkgs = if stdenv.isAarch64 then
+      # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
+      bootPkgs = if stdenv.isAarch64 || stdenv.targetPlatform.isMusl then
           packages.ghc8102BinaryMinimal
         else
           packages.ghc865Binary;
@@ -67,7 +68,8 @@ in {
     };
     ghc8104 = callPackage ../development/compilers/ghc/8.10.4.nix {
       # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
-      bootPkgs = if stdenv.isAarch64 || stdenv.isAarch32 then
+      # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
+      bootPkgs = if stdenv.isAarch64 || stdenv.isAarch32 || stdenv.targetPlatform.isMusl then
           packages.ghc8102BinaryMinimal
         else
           packages.ghc865Binary;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -96,6 +96,8 @@ let
         writers = testPlatforms.writers;
       };
 
+      pkgsMusl.haskell.compiler = packagePlatforms pkgs.pkgsMusl.haskell.compiler;
+
       # test some statically linked packages to catch regressions
       # and get some cache going for static compilation with GHC
       pkgsStatic.haskellPackages = {
@@ -306,6 +308,21 @@ let
           jobs.pkgsStatic.haskellPackages.lens.aarch64-linux
           jobs.pkgsStatic.haskellPackages.random.x86_64-linux
           jobs.pkgsStatic.haskellPackages.random.aarch64-linux
+        ];
+      };
+      muslGHCs = pkgs.releaseTools.aggregate {
+        name = "haskell-pkgsMusl-ghcs";
+        meta = {
+          description = "GHCs built with musl";
+          maintainers = with lib.maintainers; [
+            nh2
+          ];
+        };
+        constituents = accumulateDerivations [
+          jobs.pkgsMusl.haskell.compiler.ghc8102Binary
+          jobs.pkgsMusl.haskell.compiler.ghc884
+          jobs.pkgsMusl.haskell.compiler.ghc8104
+          jobs.pkgsMusl.haskell.compiler.ghc901
         ];
       };
     }


### PR DESCRIPTION
###### Motivation for this change

Fixes binary GHCs segfaulting on `pkgsMusl`. See #129247, #118731.

All Nix-built Haskell compilers build now on `pkgsMusl`:

```sh
NIX_PATH=nixpkgs=. nix-build --no-link --expr 'with import <nixpkgs> {}; { inherit (pkgsMusl.haskell.compiler) ghc884 ghc8104 ghc901 ghcHEAD; }'
```

Key changes included (see commits for details):

* Switch `ghc8102Binary` to use GHC HQ musl bindist instead of patching glibc bindist with musl.
* Use this better binary bindist to bootstrap all nix-built GHCs for `pkgsMusl`
* Add missing `hardeningDisable = [ "pie" ]` where needed.
* Swith to build GHC without sphinx by default for musl (cross already does this) to avoid huge amount of build dependencies, some of which may not work with musl yet (or break frequently). This will reduce maintenance burden for projects like [`static-haskell-nix`](https://github.com/nh2/static-haskell-nix/) significantly, and make it cheaper to build musl-based GHC on Hydra.
  * Add new options to control this.
* Add new structure to declare which `ncurses` version and similar dependencies the bindists have, and a `postUnpack` step to ensure at build time that those are actually correct.
  * The build now complains when your expectation is wrong regarding what `ncurses` a bindist needs.
* Fix i686 build of `ghc8102Binary` as a drive-by contribution.
* Lots of explanatory extra comments.

###### Extra review needed for

* My usage of `buildPlatform`, `targetPlatform` etc.
* There are some some cross options that I slightly touch. People who care about cross Haskell should ideally check out if everything remains working.

###### TODO

* [x] I need some help to make the Hydra evaluation correct, see top `WIP` commit.
  * provided by @sternenseemann in https://github.com/NixOS/nixpkgs/pull/129289#pullrequestreview-699418026

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

CC people who care about this and may want to try whether it breaks anything, and others qualified to review:

@NixOS/haskell @expipiplus1 @peti @bgamari @nomeata @domenkozar @cdepillabout @dtzWill @lunaris @NorfairKing @maralorn @sternenseemann @dtzWill @Ericson2314 @matthewbauer @aveltras