### PR TITLE
darwin.apple_sdk.frameworks.CoreSymbolication: expose under SDK 11.0

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/private-frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/private-frameworks.nix
@@ -15,4 +15,7 @@
   SignpostMetrics = {};
   PassKitCore = {};
   SkyLight = {};
+
+  # Also expose CoreSymbolication; used by `root` package.
+  CoreSymbolication = {};
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is used by the `root` package, and otherwise prevents the nixpkgs.tarball build from succeeding (e.g. https://hydra.nixos.org/build/146838433) - because we need CoreSymbolication for aarch64-darwin builds.

I haven't actually tested to see if `root` will now _build_ on aarch64-darwin, but it does at least instantiate (and `nixpkgs.tarball` is part of `tested`, so it does need to evaluate)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
