### PR TITLE
usb-reset: init at 0.3

### DIFF
--- a/pkgs/applications/misc/usb-reset/default.nix
+++ b/pkgs/applications/misc/usb-reset/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "usb-reset";
+  # not tagged, but changelog has this with the date of the e9a9d6c commit
+  # and no significant change occured between bumping the version in the Makefile and that
+  # and the changes since then (up to ff822d8) seem snap related
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "ralight";
+    repo = pname;
+    rev = "e9a9d6c4a533430e763e111a349efbba69e7a5bb";
+    sha256 = "0k9qmhqi206gcnv3z4vwya82g5nm225972ylf67zjiikk8pn8m0s";
+  };
+
+  buildInputs = [ libusb1 ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace /usr/include/libusb-1.0 \
+        ${libusb1.dev}/include/libusb-1.0
+  '';
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" "prefix=" ];
+
+  meta = with lib; {
+    description = "Perform a bus reset on a USB device using its vendor and product ID";
+    homepage = "https://github.com/ralight/usb-reset";
+    changelog = "https://github.com/ralight/usb-reset/blob/master/ChangeLog.txt";
+    license = licenses.mit;
+    maintainers = [ maintainers.evils ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/usb-reset/default.nix
+++ b/pkgs/applications/misc/usb-reset/default.nix
@@ -22,11 +22,13 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace /usr/include/libusb-1.0 \
-        ${libusb1.dev}/include/libusb-1.0
+      --replace /usr/include/libusb-1.0 ${libusb1.dev}/include/libusb-1.0
   '';
 
-  makeFlags = [ "DESTDIR=${placeholder "out"}" "prefix=" ];
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "prefix="
+  ];
 
   meta = with lib; {
     description = "Perform a bus reset on a USB device using its vendor and product ID";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31554,6 +31554,8 @@ in
 
   urbit = callPackage ../misc/urbit { };
 
+  usb-reset = callPackage ../applications/misc/usb-reset { };
+
   usql = callPackage ../applications/misc/usql { };
 
   utf8cpp = callPackage ../development/libraries/utf8cpp { };


### PR DESCRIPTION
###### Motivation for this change
i wanted to try out the utility

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - not a lot of devices seem to respond, but i got some serial interface reappearing after issuing a reset with this
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
