### PR TITLE
unetbootin: 681 -> 702

### DIFF
--- a/pkgs/tools/cd-dvd/unetbootin/default.nix
+++ b/pkgs/tools/cd-dvd/unetbootin/default.nix
@@ -1,23 +1,39 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, qt4, util-linux, coreutils, which, qmake4Hook
-, p7zip, mtools, syslinux }:
+{ lib
+, stdenv
+, coreutils
+, fetchFromGitHub
+, libsForQt5
+, mtools
+, p7zip
+, qt5
+, syslinux
+, util-linux
+, which
+}:
 
 stdenv.mkDerivation rec {
   pname = "unetbootin";
-  version = "681";
+  version = "702";
 
   src = fetchFromGitHub {
-    owner  = "unetbootin";
-    repo   = "unetbootin";
-    rev    = version;
-    sha256 = "0ppqb7ywh4cpcjr5nw6f65dx4s8kx09gnhihnby3zjhxdf4l99fm";
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-psX15XicPXAsd36BhuvK0G3GQS8hV/hazzO0HByCqV4=";
   };
 
   setSourceRoot = ''
     sourceRoot=$(echo */src/unetbootin)
   '';
 
-  buildInputs = [ qt4 ];
-  nativeBuildInputs = [ makeWrapper qmake4Hook ];
+  buildInputs = [
+    qt5.qtbase
+    qt5.qttools
+    libsForQt5.qmake
+  ];
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
   enableParallelBuilding = true;
 
   # Lots of nice hard-coded paths...
@@ -50,18 +66,19 @@ stdenv.mkDerivation rec {
     install -Dm644 -t $out/share/unetbootin   unetbootin_*.qm
     install -Dm644 -t $out/share/applications unetbootin.desktop
 
-    wrapProgram $out/bin/unetbootin \
-      --prefix PATH : ${lib.makeBinPath [ mtools p7zip which ]} \
-      --set QT_X11_NO_MITSHM 1
-
     runHook postInstall
   '';
 
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ mtools p7zip which ]}"
+    "--set QT_X11_NO_MITSHM 1"
+  ];
+
   meta = with lib; {
-    homepage    = "http://unetbootin.sourceforge.net/";
     description = "A tool to create bootable live USB drives from ISO images";
-    license     = licenses.gpl2Plus;
-    platforms   = platforms.linux;
+    homepage = "http://unetbootin.github.io/";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ebzzry ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 702

Change log:
- https://github.com/unetbootin/unetbootin/releases/tag/702
- https://github.com/unetbootin/unetbootin/releases/tag/700

`unetbootin` now requires QT5. GUI is coming up but I get some errors.

```bash
$ sudo ./result/bin/unetbootin 
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
```

I would appreciate if somebody with proper knowledge about QT/qmake could take a look. Thanks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
