### PR TITLE
cnijfilter_4_00: fix broken build

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
@@ -41,6 +41,7 @@ in stdenv.mkDerivation {
     ./patches/cnijfilter-4.00-4-ppd.patch
     ./patches/cnijfilter-4.00-5-abi_x86_32.patch
     ./patches/cnijfilter-4.00-6-headers.patch
+    ./patches/cnijfilter-4.00-7-sysctl.patch
   ];
 
   postPatch = ''

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-7-sysctl.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/patches/cnijfilter-4.00-7-sysctl.patch
@@ -1,0 +1,10 @@
+--- a/cnijnpr/src/cnijnpr.c
++++ b/cnijnpr/src/cnijnpr.c
+@@ -33,7 +33,6 @@
+ #include <signal.h>
+ #include <sys/ioctl.h>
+ #include <net/if.h>
+-#include <sys/sysctl.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <config.h>


### PR DESCRIPTION
###### Motivation for this change

30286ebcc178aec1fb3797ba3ec88cf75feb282b updated glibc to 2.32.
The update removed the deprecated <sys/sysctl.h> header, which caused a build
error on this package.
Since this header doesn't seem to be required it was removed with this
patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
