### PR TITLE
janet: the nix sandbox doesn't have /usr/bin/env

### DIFF
--- a/pkgs/development/interpreters/janet/default.nix
+++ b/pkgs/development/interpreters/janet/default.nix
@@ -11,7 +11,20 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TzJbHmHIySlf3asQ02HOdehMR+s0KkPifBiaQ4FvFCg=";
   };
 
+  # we don't have /usr/bin/env in the sandbox, so substitute for a proper,
+  # absolute path to janet
+  postPatch = ''
+    substituteInPlace jpm \
+      --replace '/usr/bin/env janet' $out/bin/janet \
+      --replace /usr/local/lib/janet $out/lib \
+      --replace /usr/local           $out
+
+    substituteInPlace janet.1 \
+      --replace /usr/local/lib/janet $out/lib
+  '';
+
   nativeBuildInputs = [ meson ninja ];
+
   mesonFlags = [ "-Dgit_hash=release" ];
 
   doCheck = true;
@@ -20,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "Janet programming language";
     homepage = "https://janet-lang.org/";
     license = licenses.mit;
+    maintainers = with maintainers; [ andrewchambers peterhoeg ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ andrewchambers ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

jpm uses /usr/bin/env to find janet, which doesn't exist in a sandbox. With this
change it's possible to build in a proper sandbox.

Next step is proper build support, which should be very straight forward.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
