### PR TITLE
ffmpeg_4: fix incorrect segment length in hls

### DIFF
--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -2,6 +2,7 @@
 # Darwin frameworks
 , Cocoa, CoreMedia, VideoToolbox
 , stdenv, lib
+, fetchpatch
 , ...
 }@args:
 
@@ -11,7 +12,18 @@ callPackage ./generic.nix (rec {
   sha256 = "03kxc29y8190k4y8s8qdpsghlbpmchv1m8iqygq2qn0vfm4ka2a2";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
 
-  /* Work around https://trac.ffmpeg.org/ticket/9242 */
-  patches = lib.optional stdenv.isDarwin
-    ./v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch;
+  patches = [
+    # Fix incorrect segment length in HLS child playlist with fmp4 segment format
+    # FIXME remove in version 4.5
+    # https://trac.ffmpeg.org/ticket/9193
+    # https://trac.ffmpeg.org/ticket/9205
+    (fetchpatch {
+      name = "ffmpeg_fix_incorrect_segment_length_in_hls.patch";
+      url = "https://git.videolan.org/?p=ffmpeg.git;a=commitdiff_plain;h=59032494e81a1a65c0b960aaae7ec4c2cc9db35a";
+      sha256 = "03zz1lw51kkc3g3vh47xa5hfiz3g3g1rbrll3kcnslvwylmrqmy3";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Work around https://trac.ffmpeg.org/ticket/9242
+    ./v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch
+  ];
 } // args)


### PR DESCRIPTION
###### Motivation for this change
Fixed error:
```
npm[240713]: [peertube.localhost:80] 2021-07-05 00:35:32.102 error: Error in controller. {
npm[240713]:   "err": "RangeNotSatisfiableError: Range Not Satisfiable\n    at SendStream.error (/nix/store/lvm95kwj2v8m7jwbr19dv15bsaphq41j-peertube-server-yarn-modules-3.2.1/node_modules/send/index.js:270:31)\n    at SendStream.send (/nix/store/lvm95kwj2v8m7jwbr19dv15bsaphq41j-peertube-server-yarn-modules-3.2.1/node_modules/send/index.js:670:19)\n    at onstat (/nix/store/lvm95kwj2v8m7jwbr19dv15bsaphq41j-peertube-server-yarn-modules-3.2.1/node_modules/send/index.js:729:10)\n    at FSReqCallback.oncomplete (fs.js:193:5)"
npm[240713]: }
```

Revert ffmpeg patch "avformat/hlsenc: compute video_keyframe_size after write keyframe"

cc @mohe2015

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
