### PR TITLE
usbredir: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -1,27 +1,50 @@
-{ lib, stdenv, fetchurl, pkg-config, libusb1 }:
+{ lib
+, stdenv
+, cmake
+, fetchFromGitLab
+, pkg-config
+, meson
+, ninja
+, glib
+, libusb1
+}:
 
 stdenv.mkDerivation rec {
   pname = "usbredir";
-  version = "0.8.0";
+  version = "0.10.0";
 
-  src = fetchurl {
-    url = "https://spice-space.org/download/usbredir/${pname}-${version}.tar.bz2";
-    sha256 = "002yik1x7kn0427xahvnhjby2np14a6xqw7c3dx530n9h5d9rg47";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "spice";
+    repo = "usbredir";
+    rev = "${pname}-${version}";
+    sha256 = "1dz8jms9l6gg2hw0k6p1p1lnchc9mcgmskgvm5gbdvw3j7wrhdbz";
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+  nativeBuildInputs = [
+    glib
+    meson
+    ninja
+    pkg-config
+  ];
 
-  nativeBuildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ libusb1 ];
+  propagatedBuildInputs = [
+    libusb1
+  ];
+
+  mesonFlags = [
+    "-Dgit_werror=disabled"
+    "-Dtools=enabled"
+    "-Dfuzzing=disabled"
+  ];
 
   outputs = [ "out" "dev" ];
 
   meta = with lib; {
     description = "USB traffic redirection protocol";
     homepage = "https://www.spice-space.org/usbredir.html";
-    license = licenses.lgpl21;
-
-    maintainers = [ maintainers.offline ];
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ offline ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.10.0

Change log: https://gitlab.freedesktop.org/spice/usbredir/-/blob/master/ChangeLog.md#usbredir-0100-27-may-2021

Upstream uses now `mason`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


CC @offline