### PR TITLE
rtw89: init at 2021-07-03

### DIFF
--- a/pkgs/os-specific/linux/firmware/rtw89-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtw89-firmware/default.nix
@@ -1,0 +1,25 @@
+{ stdenvNoCC, lib, linuxPackages }:
+
+stdenvNoCC.mkDerivation {
+  pname = "rtw89-firmware";
+  inherit (linuxPackages.rtw89) version src;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/firmware/rtw89
+    cp *.bin $out/lib/firmware/rtw89
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Driver for Realtek 8852AE, an 802.11ax device";
+    homepage = "https://github.com/lwfinger/rtw89";
+    license = licenses.unfreeRedistributableFirmware;
+    maintainers = with maintainers; [ tvorog ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/rtw89/default.nix
+++ b/pkgs/os-specific/linux/rtw89/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+let
+  modDestDir =
+    "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtw89";
+in
+stdenv.mkDerivation {
+  pname = "rtw89";
+  version = "unstable-2021-07-03";
+
+  src = fetchFromGitHub {
+    owner = "lwfinger";
+    repo = "rtw89";
+    rev = "cebafc6dc839e66c725b92c0fabf131bc908f607";
+    sha256 = "1vw67a423gajpzd5d51bxnja1qpppx9x5ii2vcfkj6cbnqwr83af";
+  };
+
+  makeFlags = [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p ${modDestDir}
+    find . -name '*.ko' -exec cp --parents {} ${modDestDir} \;
+    find ${modDestDir} -name '*.ko' -exec xz -f {} \;
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = " Driver for Realtek 8852AE, an 802.11ax device";
+    homepage = "https://github.com/lwfinger/rtw89";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ tvorog ];
+    platforms = platforms.linux;
+    broken = kernel.kernelOlder "5.4";
+    priority = -1;
+  };
+}

--- a/pkgs/os-specific/linux/rtw89/default.nix
+++ b/pkgs/os-specific/linux/rtw89/default.nix
@@ -1,8 +1,7 @@
 { stdenv, lib, fetchFromGitHub, kernel }:
 
 let
-  modDestDir =
-    "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtw89";
+  modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtw89";
 in
 stdenv.mkDerivation {
   pname = "rtw89";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20992,6 +20992,8 @@ in
     rtw88 = callPackage ../os-specific/linux/rtw88 { };
     rtlwifi_new = rtw88;
 
+    rtw89 = callPackage ../os-specific/linux/rtw89 { };
+
     openafs_1_8 = callPackage ../servers/openafs/1.8/module.nix { };
     openafs_1_9 = callPackage ../servers/openafs/1.9/module.nix { };
     # Current stable release; don't backport release updates!
@@ -21583,6 +21585,8 @@ in
   rtl8761b-firmware = callPackage ../os-specific/linux/firmware/rtl8761b-firmware { };
 
   rtw88-firmware = callPackage ../os-specific/linux/firmware/rtw88-firmware { };
+
+  rtw89-firmware = callPackage ../os-specific/linux/firmware/rtw89-firmware { };
 
   s3ql = callPackage ../tools/backup/s3ql { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add support for new WiFi chip. (closes #129098)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested on my notebook with Realtek 8852AE, the WiFi now works and seems quite stable. Kernel version: 5.12.9-zen1.

I'm not entirely sure about the metadata as this is mainly copied from the existing rtw88 code.
1. I'm not sure if the license information is correct. The rtw88 license information is bsd3 and gpl2 only although I cannot find this information on the GitHub repository. For rtw89, the license is gpl2 and I'm not sure if it is gpl2 only, and whether bsd3 would apply.
2. I'm not sure if I should be the maintainer of this package, I only copied the code from an existing package.
3. The version is written as `unstable-2021-07-03`, similar to the one in rtw88. I'm not sure what is the versioning convention for this.
