### PR TITLE
protonvpn-gui, protonvpn-cli: init at 1.0.1, 3.7.2

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli-official/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli-official/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, dialog
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "protonvpn-linux-cli-official";
+  version = "3.7.2";
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "linux-cli";
+    rev = version;
+    sha256 = "0n6qn1pqpx4q533h4yz4gz86kzs5hw7hisgazpj7fjirl66f0mlr";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    protonvpn-nm-lib
+    pythondialog
+  ] ++ [
+    dialog
+  ];
+
+  strictDeps = false;
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  # HOME is exported to mitigate issues with permissions
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = with lib; {
+    description = "ProtonVPN Linux CLI";
+    homepage = "https://github.com/ProtonVPN/linux-cli";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ nkje ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/protonvpn-cli/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli/default.nix
@@ -6,7 +6,7 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "protonvpn";
-    repo = "linux-cli";
+    repo = "linux-cli-community";
     rev = "v${version}";
     sha256 = "0y7v9ikrmy5dbjlpbpacp08gy838i8z54m8m4ps7ldk1j6kyia3n";
   };
@@ -28,9 +28,9 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Linux command-line client for ProtonVPN";
-    homepage = "https://github.com/protonvpn/linux-cli";
+    homepage = "https://github.com/ProtonVPN/linux-cli-community";
     maintainers = with maintainers; [ jtcoolen jefflabonte shamilton ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/protonvpn-gui-official/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui-official/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, wrapGAppsHook
+, gobject-introspection
+, imagemagick
+, gtk3
+, withIndicator ? true
+, libappindicator-gtk3
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "protonvpn-linux-gui-official";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "linux-app";
+    rev = version;
+    sha256 = "081f7bdbi1j3nkm0kf3flpaj0xvfwgnn0svbqpqgnqc1bjycag5y";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection imagemagick ];
+
+  buildInputs = [ gtk3 ]
+    ++ lib.optionals withIndicator [ libappindicator-gtk3 ];
+
+  propagatedBuildInputs = with python3Packages; [
+    protonvpn-nm-lib
+    pygobject3
+    psutil
+  ];
+
+  strictDeps = false;
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  # Fails loading tests even though project has no tests
+  # Disabled until tests are added upstream
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp protonvpn.desktop $out/share/applications
+
+    for size in 16 32 48 64 72 96 128 192 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" \
+        protonvpn_gui/assets/icons/protonvpn-logo.png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/protonvpn-logo.png
+    done
+  '';
+
+  meta = with lib; {
+    description = "ProtonVPN Linux App";
+    homepage = "https://github.com/ProtonVPN/linux-app";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ nkje ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -11,8 +11,8 @@ in python3Packages.buildPythonApplication rec {
   version = "2.1.1";
 
   src = fetchFromGitHub {
-    owner = "protonvpn";
-    repo = "linux-gui";
+    owner = "calexandru2018";
+    repo = "linux-gui-legacy";
     rev = "v${version}";
     sha256 = "avo5/2eq53HSHCnnjtxrsmpURtHvxmLZn2BxActImGY=";
   };
@@ -81,9 +81,9 @@ in python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Linux GUI for ProtonVPN, written in Python";
-    homepage = "https://github.com/ProtonVPN/linux-gui";
+    homepage = "https://github.com/calexandru2018/linux-gui-legacy";
     maintainers = with maintainers; [ offline ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/proton-client/default.nix
+++ b/pkgs/development/python-modules/proton-client/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, substituteAll
+, openssl
+, stdenv
+, requests
+, bcrypt
+, python-gnupg
+, pyopenssl
+}:
+
+buildPythonPackage rec {
+  pname = "proton-client";
+  version = "0.5.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "ProtonMail";
+    repo = "proton-python-client";
+    rev = version;
+    sha256 = "1wm73c9dr5cmw7gm8w36byvaqvhzb6ybvb4g4kx9j1l39h28zdpz";
+  };
+
+  patches = [
+    # Patches the openssl library path where openssl is loaded
+    (substituteAll {
+      src = ./openssl-path.patch;
+      openssl = openssl.out;
+      ext = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ];
+
+  propagatedBuildInputs = [ requests bcrypt python-gnupg pyopenssl ];
+
+  pythonImportsCheck = [ "proton.api" ];
+
+  meta = with lib; {
+    description = "Proton API Python Client";
+    homepage = "https://github.com/ProtonMail/proton-python-client";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ nkje ];
+  };
+}

--- a/pkgs/development/python-modules/proton-client/openssl-path.patch
+++ b/pkgs/development/python-modules/proton-client/openssl-path.patch
@@ -1,0 +1,27 @@
+--- a/proton/srp/_ctsrp.py
++++ b/proton/srp/_ctsrp.py
+@@ -24,22 +24,14 @@
+ dlls = list()
+ 
+ platform = sys.platform
+-if platform == 'darwin':
+-    dlls.append(ctypes.cdll.LoadLibrary('libssl.dylib'))
+-elif 'win' in platform:
++if 'win' in platform:
+     for d in ('libeay32.dll', 'libssl32.dll', 'ssleay32.dll'):
+         try:
+             dlls.append(ctypes.cdll.LoadLibrary(d))
+         except Exception:
+             pass
+ else:
+-    try:
+-        dlls.append(ctypes.cdll.LoadLibrary('libssl.so.10'))
+-    except OSError:
+-        try:
+-            dlls.append(ctypes.cdll.LoadLibrary('libssl.so.1.0.0'))
+-        except OSError:
+-            dlls.append(ctypes.cdll.LoadLibrary('libssl.so'))
++    dlls.append(ctypes.cdll.LoadLibrary('@openssl@/lib/libssl@ext@'))
+ 
+ 
+ class BIGNUM_Struct(ctypes.Structure):

--- a/pkgs/development/python-modules/protonvpn-nm-lib/binary-paths.patch
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/binary-paths.patch
@@ -1,0 +1,25 @@
+--- a/protonvpn_nm_lib/core/subprocess_wrapper.py
++++ b/protonvpn_nm_lib/core/subprocess_wrapper.py
+@@ -44,11 +44,9 @@
+         binary_short_name => full secure path.
+         """
+         # Look for root-owned directories in the system path in order
+-        for path in os.environ.get('PATH', '').split(os.path.pathsep):
++        for path in "@path@".split(os.path.pathsep):
+             if not os.path.isdir(path):
+                 continue
+-            if not self.is_root_owned(path):
+-                continue
+ 
+             # Check for all the binaries that we haven't matched yet
+             for binary in self._acceptable_binaries.difference(
+@@ -58,9 +56,6 @@
+                 if not os.path.isfile(binary_path_candidate):
+                     continue
+ 
+-                if not self.is_root_owned(binary_path_candidate):
+-                    continue
+-
+                 # We're happy with that one, store it
+                 self._path_to_binaries[binary] = binary_path_candidate
+ 

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, substituteAll
+, networkmanager
+, pkgs
+, ncurses
+, xdg-utils
+, proton-client
+, pyxdg
+, keyring
+, pygobject3
+, jinja2
+, distro
+, systemd
+}:
+
+buildPythonPackage rec {
+  pname = "protonvpn-nm-lib";
+  version = "3.3.2";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "protonvpn-nm-lib";
+    rev = version;
+    sha256 = "1izb9bnvdw36iwmg7mlm7706pk8jg74qh9mcjwvl7vsfvn92jc4j";
+  };
+
+  patches = [
+    # Patches binary paths, also removes two if conditions
+    # that check if the binaries are owned by root
+    (substituteAll {
+      src = ./binary-paths.patch;
+      path = lib.makeBinPath [ networkmanager pkgs.systemd ncurses xdg-utils ];
+    })
+    # Patches the gi repository path of networkmanager
+    # into the search path used in the library
+    (substituteAll {
+      src = ./gi-path-patch.patch;
+      networkmanager_path = "${networkmanager}/lib/girepository-1.0";
+    })
+  ];
+
+  # Fails because it attempts to connect to DBUS
+  doCheck = false;
+
+  # Disabled because importing creates a log folder
+  # pythonImportsCheck = [ "protonvpn_nm_lib.api" ];
+
+  propagatedBuildInputs = [
+    proton-client
+    pyxdg
+    keyring
+    pygobject3
+    jinja2
+    distro
+    systemd
+  ];
+
+  meta = with lib; {
+    description = "ProtonVPN NM Library";
+    homepage = "https://github.com/ProtonVPN/protonvpn-nm-lib";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ nkje ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/protonvpn-nm-lib/gi-path-patch.patch
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/gi-path-patch.patch
@@ -1,0 +1,8 @@
+--- a/protonvpn_nm_lib/__init__.py
++++ b/protonvpn_nm_lib/__init__.py
+@@ -0,0 +1,5 @@
++import gi
++gi.require_version('GIRepository', '2.0')
++from gi.repository import GIRepository
++repo = GIRepository.Repository.get_default()
++repo.prepend_search_path('@networkmanager_path@')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26443,6 +26443,8 @@ in
 
   protonvpn-gui = callPackage ../applications/networking/protonvpn-gui { };
 
+  protonvpn-gui-official = callPackage ../applications/networking/protonvpn-gui-official { };
+
   ps2client = callPackage ../applications/networking/ps2client { };
 
   psi = libsForQt5.callPackage ../applications/networking/instant-messengers/psi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26439,6 +26439,8 @@ in
 
   protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
 
+  protonvpn-cli-official = callPackage ../applications/networking/protonvpn-cli-official { };
+
   protonvpn-gui = callPackage ../applications/networking/protonvpn-gui { };
 
   ps2client = callPackage ../applications/networking/ps2client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5589,6 +5589,8 @@ in {
 
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
 
+  proton-client = callPackage ../development/python-modules/proton-client { };
+
   prov = callPackage ../development/python-modules/prov { };
 
   prox-tv = callPackage ../development/python-modules/prox-tv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5591,6 +5591,8 @@ in {
 
   proton-client = callPackage ../development/python-modules/proton-client { };
 
+  protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib { };
+
   prov = callPackage ../development/python-modules/prov { };
 
   prox-tv = callPackage ../development/python-modules/prox-tv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ProtonVPN has release two new interfaces for using their VPN service. This PR includes both, however, if requested it can be split. Furthermore it includes a suggestion for renaming the old packages protonvpn packages. This is suboptimal, but so are the alternatives. Solutions:
- The aforementioned solution: this results in users being forced to update their packages to this (possibly breaking), but allow them to used the old packages
- Make this PR a version bump to the old packages: this results in users being forced to update their packages to this (possibly breaking)
- Give these packages a new name possibly adding `official`, however this could still possibly confuse new users.

I will update the PR according to the wishes of the community. I've not currently added myself as maintainer, as the maintainers of the old packages might wish to continue to maintain this.

The PR also includes two direct dependencies, which are common for both packages. Hopefully this PR can act as a foundation for getting these packages in to nixpkgs.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
