### PR TITLE
makeself: try to finally solve issues with tests

### DIFF
--- a/pkgs/applications/misc/makeself/default.nix
+++ b/pkgs/applications/misc/makeself/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "07cq7q71bv3fwddkp2863ylry2ivds00f8sjy8npjpdbkailxm21";
   };
 
-  patchPhase = "patchShebangs test";
+  patches = [ ./tests-use-better-shell.patch ];
+  postPatch = "patchShebangs test";
 
   doCheck = true;
   checkTarget = "test";
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://megastep.org/makeself";
+    homepage = "https://makeself.io";
     description = "Utility to create self-extracting packages";
     license = licenses.gpl2;
     maintainers = [ maintainers.wmertens ];

--- a/pkgs/applications/misc/makeself/tests-use-better-shell.patch
+++ b/pkgs/applications/misc/makeself/tests-use-better-shell.patch
@@ -1,0 +1,10 @@
+Use full bash's sh in tests instead of /bin/sh, as that would be
+too minimalist in the build sandbox.  See issue:
+https://github.com/NixOS/nixpkgs/issues/110149#issuecomment-874258128
+diff --git a/test/extracttest b/test/extracttest
+--- a/test/extracttest
++++ b/test/extracttest
+@@ -9,2 +9,3 @@ setupTests() {
+   $SUT $* archive makeself-test.run "Test $*" echo Testing
++  sed "1s|/bin|$(dirname "$SHELL")|" -i ./makeself-test.run
+ }


### PR DESCRIPTION
Hopefully fixes #110149.  I'm really annoyed with this on 21.05 now:
https://hydra.nixos.org/build/147005675#tabs-buildsteps
and this isn't the first time it's caused significant issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
