### PR TITLE
tfswitch: init at 0.12.1119

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8476,7 +8476,7 @@
     email = "sibi@psibi.in";
     github = "psibi";
     githubId = 737477;
-    name = "Sibi";
+    name = "Sibi Prabakaran";
   };
   pstn = {
     email = "philipp@xndr.de";

--- a/pkgs/applications/networking/cluster/tfswitch/default.nix
+++ b/pkgs/applications/networking/cluster/tfswitch/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, lib, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "tfswitch";
+  version = "0.12.1119";
+
+  src = fetchFromGitHub {
+    owner = "warrensbox";
+    repo = "terraform-switcher";
+    rev = version;
+    sha256 = "1xsmr4hnmdg2il3rp39cyhv55ha4qcilcsr00iiija3bzxsm4rya";
+  };
+
+  vendorSha256 = "0mpm4m07v8w02g95cnj73m5gvd118id4ag2pym8d9r2svkyz5n70";
+
+  # Disable tests since it requires network access and relies on the
+  # presence of release.hashicorp.com
+  doCheck = false;
+
+  runVend = true;
+
+  postInstall = ''
+    # The binary is named tfswitch
+    mv $out/bin/terraform-switcher $out/bin/tfswitch
+  '';
+
+  meta = with lib; {
+    description = "A command line tool to switch between different versions of terraform";
+    homepage = "https://github.com/warrensbox/terraform-switcher";
+    license = licenses.mit;
+    maintainers = with maintainers; [ psibi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31513,6 +31513,8 @@ in
 
   terranix = callPackage ../applications/networking/cluster/terranix {};
 
+  tfswitch = callPackage ../applications/networking/cluster/tfswitch {};
+
   tilt = callPackage ../applications/networking/cluster/tilt {};
 
   timeular = callPackage ../applications/office/timeular {};


### PR DESCRIPTION



###### Motivation for this change

Add tfswitch which allows to easily manage different terraform
versions for different projects.

Tested it locally on a NixOS machine:

```
$ tfswitch --bin=/home/sibi/bin/terraform
Reading required version from terraform file
Reading required version from constraint: ~> 0.13.0
Matched version: 0.13.7
Switched terraform to version "0.13.7"
$ terraform version
Terraform v0.13.7
+ provider registry.terraform.io/hashicorp/aws v2.70.0

Your version of Terraform is out of date! The latest version
is 1.0.1. You can update by downloading from https://www.terraform.io/downloads.html
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


