### PR TITLE
p4est, p4est-sc: fix checks with OpenMPI

### DIFF
--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -42,12 +42,18 @@ stdenv.mkDerivation {
     ++ lib.optional mpiSupport "--enable-mpi"
   ;
 
-  makeFlags = [ "V=0" ];
-  checkFlags = lib.optional isOpenmpi "-j1";
-
   dontDisableStatic = true;
   enableParallelBuilding = true;
-  doCheck = !stdenv.isAarch64 && stdenv.hostPlatform == stdenv.buildPlatform;
+  makeFlags = [ "V=0" ];
+
+  preCheck = ''
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+    export HYDRA_IFACE=lo
+  '';
+
+  # disallow Darwin checks due to prototype incompatibility of qsort_r
+  # to be fixed in a future version of the source code
+  doCheck = !stdenv.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = {
     branch = "prev3-develop";

--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     ++ lib.optional withMetis "--with-metis"
   ;
 
-  inherit (p4est-sc) makeFlags checkFlags dontDisableStatic enableParallelBuilding doCheck;
+  inherit (p4est-sc) makeFlags dontDisableStatic enableParallelBuilding preCheck doCheck;
 
   meta = {
     branch = "prev3-develop";


### PR DESCRIPTION
Setting environment variables in preCheck to make MPI tests run.
This is one commit for two packages in order not to break the dependency.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The linux checks so far require -j1, and aarch64 and darwin checks fail.
Hoping to fix linux and aarch64 by setting `preCheck` MPI environment variables.
The Darwin checks are disabled until the source is fixed (known incompatibility).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
