### PR TITLE
lightwalletd: init at 0.4.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1731,6 +1731,12 @@
     githubId = 977929;
     name = "Cody Allen";
   };
+  centromere = {
+    email = "nix@centromere.net";
+    github = "centromere";
+    githubId = 543423;
+    name = "Alex Wied";
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/applications/blockchains/lightwalletd/default.nix
+++ b/pkgs/applications/blockchains/lightwalletd/default.nix
@@ -1,0 +1,37 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "lightwalletd";
+  version = "0.4.7";
+
+  src = fetchFromGitHub {
+    owner = "zcash";
+    repo  = "lightwalletd";
+    rev = "v${version}";
+    sha256 = "0dwam3fhc4caga7kjg6cc06sz47g4ii7n3sa4j2ac4aiy21hsbjk";
+  };
+
+  vendorSha256 = null;
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/zcash/lightwalletd/common.Version=v${version}"
+    "-X github.com/zcash/lightwalletd/common.GitCommit=v${version}"
+    "-X github.com/zcash/lightwalletd/common.BuildDate=1970-01-01"
+    "-X github.com/zcash/lightwalletd/common.BuildUser=nixbld"
+  ];
+
+  postFixup = ''
+    shopt -s extglob
+    cd $out/bin
+    rm !(lightwalletd)
+  '';
+
+  meta = with lib; {
+    description = "A backend service that provides a bandwidth-efficient interface to the Zcash blockchain";
+    homepage = "https://github.com/zcash/lightwalletd";
+    maintainers = with maintainers; [ centromere ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28403,6 +28403,8 @@ in
 
   zcash = callPackage ../applications/blockchains/zcash { stdenv = llvmPackages_11.stdenv; };
 
+  lightwalletd = callPackage ../applications/blockchains/lightwalletd { };
+
   openethereum = callPackage ../applications/blockchains/openethereum { };
 
   parity-ui = callPackage ../applications/blockchains/parity-ui { };


### PR DESCRIPTION
###### Motivation for this change
Add lightwalletd to nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
