### PR TITLE
fort-validator: init at 1.5.0

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -36,6 +36,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://fortproject.net/en/validator">fort-validator</link>,
+          a RPKI validator and RTR server. Available as
+          <link xlink:href="options.html#opt-services.networking.fort-validator.enable">services.networking.fort-validator</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/maxmind/geoipupdate">geoipupdate</link>,
           a GeoIP database updater from MaxMind. Available as
           <link xlink:href="options.html#opt-services.geoipupdate.enable">services.geoipupdate</link>.

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -12,6 +12,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [btrbk](https://digint.ch/btrbk/index.html), a backup tool for btrfs subvolumes, taking advantage of btrfs specific capabilities to create atomic snapshots and transfer them incrementally to your backup locations. Available as [services.btrbk](options.html#opt-services.brtbk.instances).
 
+- [fort-validator](https://fortproject.net/en/validator), a RPKI validator and RTR server. Available as [services.networking.fort-validator](options.html#opt-services.networking.fort-validator.enable).
+
 - [geoipupdate](https://github.com/maxmind/geoipupdate), a GeoIP database updater from MaxMind. Available as [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
 
 - [sourcehut](https://sr.ht), a collection of tools useful for software development. Available as [services.sourcehut](options.html#opt-services.sourcehut.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -694,6 +694,7 @@
   ./services/networking/fireqos.nix
   ./services/networking/firewall.nix
   ./services/networking/flannel.nix
+  ./services/networking/fort-validator.nix
   ./services/networking/freenet.nix
   ./services/networking/freeradius.nix
   ./services/networking/gateone.nix

--- a/nixos/modules/services/networking/fort-validator.nix
+++ b/nixos/modules/services/networking/fort-validator.nix
@@ -1,0 +1,149 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.networking.fort-validator;
+in
+{
+  options = {
+    services.networking.fort-validator = {
+      enable = mkEnableOption "FORT Validator";
+
+      acceptArinRpa = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          By enabling this option you agree to be bound by
+          the <link xlink:href="https://www.arin.net/resources/manage/rpki/rpa.pdf">ARIN RPA</link>.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      users.fort-validator = {
+        name = "fort-validator";
+        group = "fort-validator";
+        isSystemUser = true;
+        description = "FORT Validator user";
+      };
+
+      groups.fort-validator = { };
+    };
+
+    systemd = {
+      services = {
+        init-fort-tals = {
+          description = "Create and download RPKI TALs for FORT.";
+
+          wantedBy = [ "multi-user.target" ];
+          wants = [ "network-online.target" ];
+          after = [ "network-online.target" ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            User = "fort-validator";
+            Group = "fort-validator";
+          };
+
+          script =
+            let
+              rpaResult = if cfg.acceptArinRpa then "yes" else "no";
+            in
+            ''
+              TALS_DIR="/var/lib/fort/tals"
+              if [ ! -d "$TALS_DIR" ]; then
+                  mkdir -p "$TALS_DIR"
+                  printf '${rpaResult}\n' | ${pkgs.fort-validator}/bin/fort --init-tals --tal "$TALS_DIR"
+              else
+                  echo "skipping: TALs already loaded"
+              fi
+            '';
+        };
+
+        fort-validator = {
+          description = "FORT Validator";
+
+          wantedBy = [ "multi-user.target" ];
+          wants = [ "network-online.target" ];
+          after = [ "network-online.target" ];
+
+          path = [ pkgs.rsync ];
+
+          serviceConfig = {
+            User = "fort-validator";
+            Group = "fort-validator";
+            ReadWritePaths = "/var/lib/fort";
+            ExecStart = "${pkgs.fort-validator}/bin/fort --tal /var/lib/fort/tals --local-repository /var/lib/fort/cache --server.address \"127.0.0.1,::1\" --server.port 3323";
+            ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
+            KillSignal = "SIGINT";
+            TimeoutStopSec = "30s";
+            Restart = "always";
+
+            # Hardening
+            CapabilityBoundingSet = "";
+            DeviceAllow = "";
+            IPAddressDeny = [ "" ];
+            KeyringMode = "private";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            NoNewPrivileges = true;
+            NotifyAccess = "none";
+            ProcSubset = "pid";
+            RemoveIPC = true;
+
+            PrivateDevices = true;
+            PrivateMounts = true;
+            PrivateNetwork = "no";
+            PrivateTmp = true;
+            PrivateUsers = true;
+
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectHome = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectHostname = true;
+            ProtectProc = "invisible";
+            ProtectSystem = "strict";
+            RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+
+            # requires the ipc syscall in order to not crash
+            SystemCallFilter = [
+              "@system-service"
+              "~@aio"
+              "~@clock"
+              "~@cpu-emulation"
+              "~@chown"
+              "~@debug"
+              "~@keyring"
+              "~@memlock"
+              "~@module"
+              "~@mount"
+              "~@raw-io"
+              "~@reboot"
+              "~@swap"
+              "~@privileged"
+              "~@resources"
+              "~@setuid"
+              "~@sync"
+              "~@timer"
+            ];
+            SystemCallArchitectures = "native";
+            SystemCallErrorNumber = "EPERM";
+          };
+        };
+      };
+
+      tmpfiles.rules = [
+        "d /var/lib/fort 0755 fort-validator fort-validator - -"
+        "z /var/lib/fort 0755 fort-validator fort-validator - -"
+      ];
+    };
+  };
+}

--- a/pkgs/tools/networking/fort-validator/default.nix
+++ b/pkgs/tools/networking/fort-validator/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, jansson
+, rsync
+, curl
+, libxml2
+, pkg-config
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fort-validator";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "NICMx";
+    repo = "FORT-validator";
+    rev = "v${version}";
+    sha256 = "sha256-sldN/xg+agdunTln2q03XEjSwyDtDJucv+9YizP4nw8=";
+  };
+
+  buildInputs = [
+    jansson
+    rsync
+    curl
+    libxml2
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  meta = with lib; {
+    description = "An RPKI Validator and RTR Server, part of the FORT project";
+    homepage = "https://fortproject.net/en/validator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ citadelcore ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4801,6 +4801,8 @@ in
 
   flvstreamer = callPackage ../tools/networking/flvstreamer { };
 
+  fort-validator = callPackage ../tools/networking/fort-validator { };
+
   hmetis = pkgsi686Linux.callPackage ../applications/science/math/hmetis { };
 
   libbsd = callPackage ../development/libraries/libbsd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds a package and module for the FORT RPKI validator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
