### PR TITLE
pythonPackages.python3-saml: Add patch to fix tests due to expired responses

### DIFF
--- a/pkgs/development/python-modules/python3-saml/default.nix
+++ b/pkgs/development/python-modules/python3-saml/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, fetchFromGitHub, buildPythonPackage, isPy3k,
+{ lib, fetchpatch, fetchFromGitHub, buildPythonPackage, isPy3k,
 isodate, lxml, xmlsec, freezegun }:
 
 buildPythonPackage rec {
@@ -13,14 +13,21 @@ buildPythonPackage rec {
     sha256 = "1yk02xq90bm7p6k091av6gapb5h2ccxzgrbm03sj2x8h0wff9s8k";
   };
 
+  # Remove both patches on update
   patches = [
     # Remove the dependency on defusedxml
     #
     # This patch is already merged upstream and does not introduce any
     # functionality changes.
-    (fetchurl {
+    (fetchpatch {
       url = "https://github.com/onelogin/python3-saml/commit/4b6c4b1f2ed3f6eab70ff4391e595b808ace168c.patch";
-      sha256 = "11gqn7ib2hmlx5wp4xhi375v5ajapwmj4lpw0y44bh5ww8cypvqy";
+      sha256 = "sha256-KHyAoX3our3Rz2z4xo0lTBB1XOGuC3Pe+lUDCzK5WQI=";
+    })
+
+    # Update expiry dates for test response XMLs
+    (fetchpatch {
+      url = "https://github.com/onelogin/python3-saml/commit/05611bbf6d7d8313adb9c77ff88a9210333ccc38.patch";
+      sha256 = "sha256-62TwgCXDFYsZIAeqAysJRziMvhUVhGzta/C2wS3v4HY=";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The tests were broken since June due to onelogin/python3-saml#269.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
