### PR TITLE
psi-plus: bugfix for missing gstreamer dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -3,6 +3,10 @@
 , libidn, qca-qt5, libXScrnSaver, hunspell
 , libsecret, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
 , usrsctp
+
+# Voice messages
+, voiceMessagesSupport ? true
+, gst_all_1
 }:
 
 mkDerivation rec {
@@ -27,7 +31,16 @@ mkDerivation rec {
     libidn qca-qt5 libXScrnSaver hunspell
     libsecret libgcrypt libotr html-tidy libgpgerror libsignal-protocol-c
     usrsctp
+  ] ++ lib.optionals voiceMessagesSupport [
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
   ];
+
+  preFixup = lib.optionalString voiceMessagesSupport ''
+    qtWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    )
+  '';
 
   meta = with lib; {
     homepage = "https://psi-plus.com";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Voice messages don’t work without gstreamer “base” and “good” plugins. This change adds a an override for `GST_PLUGIN_SYSTEM_PATH_1_0` environment variable providing necessary dependencies.

I figured out minimal requirements for making it work during a discussion with **psi-plus** maintainers (maintainers of the original program). With this command voice messages also work:

``` sh
nix-shell -p gst_all_1.gst-plugins-base -p gst_all_1.gst-plugins-good --run psi-plus
```

If you press voice message recording button in currently released version of `psi-plus` on GUI side it does nothing but writes this to stderr:

> [20210706 0:40:43] W:QMediaRecorder::FormatError : Not compatible codecs and container format. (unknown:0, unknown)
[20210706 0:40:43] W:QMediaRecorder::FormatError : Not compatible codecs and container format. (unknown:0, unknown)
[20210706 0:40:43] W:Could not create a media muxer element: "" (unknown:0, unknown)
[20210706 0:40:43] W:QMediaRecorder::FormatError : Failed to build media capture pipeline. (unknown:0, unknown)

With this introduced change it records voice messages as expected. When you hold recording button a countdown with 30 seconds limit is shown on the screen and after you release the button it shows a dialog to send the file that contains recording you just made.

`psi-plus` Nix package maintainers ping:
1. @orivej 
2. @misuzu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
