### PR TITLE
avro-cpp: 1.8.2 -> 1.10.2

### DIFF
--- a/pkgs/development/libraries/avro-c++/default.nix
+++ b/pkgs/development/libraries/avro-c++/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "avro-c++";
-  version = "1.8.2";
+  version = "1.10.2";
 
   src = fetchurl {
     url = "mirror://apache/avro/avro-${version}/cpp/avro-cpp-${version}.tar.gz";
-    sha256 = "1ars58bfw83s8f1iqbhnqp4n9wc9cxsph0gs2a8k7r9fi09vja2k";
+    sha256 = "1qv2wxh5q2iq48m5g3xci9p05znzcl0v3314bhcsyr5bkpdjvzs1";
   };
 
   nativeBuildInputs = [ cmake python3 ];

--- a/pkgs/development/libraries/libserdes/default.nix
+++ b/pkgs/development/libraries/libserdes/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , perl
 , boost
 , rdkafka
@@ -27,6 +28,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost rdkafka jansson curl avro-c avro-cpp ];
 
   makeFlags = [ "GEN_PKG_CONFIG=y" ];
+
+  patches = [
+    # Fix compatibility with Avro master branch
+    (fetchpatch {
+      url = "https://github.com/confluentinc/libserdes/commit/d7a355e712ab63ec77f6722fb5a9e8056e7416a2.patch";
+      sha256 = "14bdx075n4lxah63kp7phld9xqlz3pzs03yf3wbq4nmkgwac10dh";
+    })
+  ];
 
   postPatch = ''
     patchShebangs configure lds-gen.pl


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
