### PR TITLE
hp-ams: init at 2.8.3

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -43,6 +43,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://buy.hpe.com/uk/en/software/server-management-software/server-ilo-management/ilo-management-engine/hpe-agentless-management/p/5219980">hp-ams</link>,
+          the HP Agentless Management Service for ProLiant servers.
+          Available as
+          <link xlink:href="options.html#opt-services.hardware.hp-ams.enable">services.hardware.hp-ams</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://sr.ht">sourcehut</link>, a
           collection of tools useful for software development. Available
           as

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -14,6 +14,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [geoipupdate](https://github.com/maxmind/geoipupdate), a GeoIP database updater from MaxMind. Available as [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
 
+- [hp-ams](https://buy.hpe.com/uk/en/software/server-management-software/server-ilo-management/ilo-management-engine/hpe-agentless-management/p/5219980), the HP Agentless Management Service for ProLiant servers. Available as [services.hardware.hp-ams](options.html#opt-services.hardware.hp-ams.enable).
+
 - [sourcehut](https://sr.ht), a collection of tools useful for software development. Available as [services.sourcehut](options.html#opt-services.sourcehut.enable).
 
 - [ucarp](https://download.pureftpd.org/pub/ucarp/README), an userspace implementation of the Common Address Redundancy Protocol (CARP). Available as [networking.ucarp](options.html#opt-networking.ucarp.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -391,6 +391,7 @@
   ./services/hardware/fancontrol.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix
+  ./services/hardware/hp-ams.nix
   ./services/hardware/illum.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix

--- a/nixos/modules/services/hardware/hp-ams.nix
+++ b/nixos/modules/services/hardware/hp-ams.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.hardware.hp-ams;
+
+  fake-dpkg-query = pkgs.writeScriptBin "dpkg-query" ''
+    #!${pkgs.runtimeShell}
+    # returns nothing for now
+  '';
+in
+{
+  options = {
+    services.hardware.hp-ams = {
+      enable = mkEnableOption "HP Agentless Management Service";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.hp-ams = {
+      description = "HP Agentless Management Service for ProLiant";
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ fake-dpkg-query ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.hp-ams}/sbin/amsHelper -I0 -L -f";
+        ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
+
+        Restart = "on-failure";
+        RestartSec = "15s";
+
+        # Hardening
+        CapabilityBoundingSet = "CAP_SYS_ADMIN";
+        DevicePolicy = "closed";
+        DeviceAllow = [
+          "char-hpilo"
+          "char-ipmidev"
+        ];
+        IPAddressDeny = "any";
+        KeyringMode = "private";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        NotifyAccess = "none";
+        ProcSubset = "all";
+        RemoveIPC = true;
+
+        PrivateDevices = false;
+        PrivateMounts = true;
+        PrivateNetwork = false;
+        PrivateTmp = true;
+        PrivateUsers = false;
+
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = "";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        SystemCallFilter = [
+          "@system-service"
+          "~@aio"
+          "~@clock"
+          "~@cpu-emulation"
+          "~@chown"
+          "~@debug"
+          "~@keyring"
+          "~@memlock"
+          "~@module"
+          "~@mount"
+          "~@raw-io"
+          "~@reboot"
+          "~@swap"
+          "~@privileged"
+          "~@resources"
+          "~@setuid"
+          "~@sync"
+          "~@timer"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+
+    # fake this for amsHelper, otherwise it will segfault
+    environment.etc."debian_version".text = "10.9";
+  };
+}

--- a/pkgs/os-specific/linux/hp-ams/default.nix
+++ b/pkgs/os-specific/linux/hp-ams/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, autoPatchelfHook, dpkg, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "hp-ams";
+  version = "2.8.3";
+
+  src = fetchurl {
+    url = "http://downloads.linux.hpe.com/SDR/repo/mcp/debian/pool/non-free/hp-ams_2.8.3-3056.1ubuntu16_amd64.deb";
+    sha256 = "sha256-6EwGC1IsMX1/aN/Qp2+NK+dvyXYsZXsm8E3uHfQSXik=";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  installPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+  '';
+
+  meta = with lib; {
+    description = "HP Agentless Management Service for ProLiant";
+    homepage = "https://buy.hpe.com/uk/en/software/server-management-software/server-ilo-management/ilo-management-engine/hpe-agentless-management/p/5219980";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ citadelcore ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20572,6 +20572,8 @@ in
 
   hostapd = callPackage ../os-specific/linux/hostapd { };
 
+  hp-ams = callPackage ../os-specific/linux/hp-ams { };
+
   htop = callPackage ../tools/system/htop {
     inherit (darwin) IOKit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds support for the HP Agentless Management Service (for HP/HPE ProLiant servers) which interfaces with the iLO Management Processor to collect rich information and SNMP packets from the host OS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
