### PR TITLE
nixos/security/vault: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -64,6 +64,17 @@
           templating for Vault secrets. Available as
           <link xlink:href="options.html#opt-services.security.vault-agent.enable">services.security.vault-agent</link>.
         </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              A convenience module has been added to automatically issue
+              and renew different types of Vault secrets to machines.
+              This requires vault-agent to be enabled, and is available
+              as
+              <link xlink:href="options.html#opt-security.vault-keys">security.vault-keys</link>.
+            </para>
+          </listitem>
+        </itemizedlist>
       </listitem>
       <listitem>
         <para>

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -59,6 +59,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://www.vaultproject.io/docs/agent">vault-agent</link>,
+          a client daemon that handles auto-auth, caching, and
+          templating for Vault secrets. Available as
+          <link xlink:href="options.html#opt-services.security.vault-agent.enable">services.security.vault-agent</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           Users of flashrom should migrate to
           <link xlink:href="options.html#opt-programs.flashrom.enable">programs.flashrom.enable</link>
           and add themselves to the <literal>flashrom</literal> group to

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -19,6 +19,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 - [ucarp](https://download.pureftpd.org/pub/ucarp/README), an userspace implementation of the Common Address Redundancy Protocol (CARP). Available as [networking.ucarp](options.html#opt-networking.ucarp.enable).
 
 - [vault-agent](https://www.vaultproject.io/docs/agent), a client daemon that handles auto-auth, caching, and templating for Vault secrets. Available as [services.security.vault-agent](options.html#opt-services.security.vault-agent.enable).
+  - A convenience module has been added to automatically issue and renew different types of Vault secrets to machines. This requires vault-agent to be enabled, and is available as [security.vault-keys](options.html#opt-security.vault-keys).
 
 - Users of flashrom should migrate to [programs.flashrom.enable](options.html#opt-programs.flashrom.enable) and add themselves to the `flashrom` group to be able to access programmers supported by flashrom.
 

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -18,6 +18,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [ucarp](https://download.pureftpd.org/pub/ucarp/README), an userspace implementation of the Common Address Redundancy Protocol (CARP). Available as [networking.ucarp](options.html#opt-networking.ucarp.enable).
 
+- [vault-agent](https://www.vaultproject.io/docs/agent), a client daemon that handles auto-auth, caching, and templating for Vault secrets. Available as [services.security.vault-agent](options.html#opt-services.security.vault-agent.enable).
+
 - Users of flashrom should migrate to [programs.flashrom.enable](options.html#opt-programs.flashrom.enable) and add themselves to the `flashrom` group to be able to access programmers supported by flashrom.
 
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -215,6 +215,7 @@
   ./rename.nix
   ./security/acme.nix
   ./security/apparmor.nix
+  ./security/vault/keys.nix
   ./security/audit.nix
   ./security/auditd.nix
   ./security/ca.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -900,6 +900,7 @@
   ./services/security/torsocks.nix
   ./services/security/usbguard.nix
   ./services/security/vault.nix
+  ./services/security/vault-agent.nix
   ./services/security/vaultwarden/default.nix
   ./services/security/yubikey-agent.nix
   ./services/system/cloud-init.nix

--- a/nixos/modules/security/vault/key-render-wait.py
+++ b/nixos/modules/security/vault/key-render-wait.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Waits for the specified keys to be created or modified
+
+import sys
+import argparse
+import inotify_simple
+from typing import List
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-t", "--temp-files", type=str, help="Temporary key filenames to watch", default="")
+parser.add_argument("-s", "--sink-files", type=str, help="Sink key filenames to watch", default="")
+parser.add_argument("-d", "--keydir", type=str, help="The location of the keys", default="/run/vault-keys")
+parser.add_argument("-m", "--modify", action="store_true", help="Tracks modification rather than creation or deletion", default=False)
+args = parser.parse_args()
+
+EXIST_FLAGS = inotify_simple.flags.CREATE | inotify_simple.flags.MOVED_TO
+MODIFY_FLAGS = EXIST_FLAGS | inotify_simple.flags.MODIFY | inotify_simple.flags.DELETE
+
+# Wait for all keys to come into existence
+def wait_for_existence(files: List[str]):
+    root = Path(args.keydir)
+    inotify = inotify_simple.INotify()
+    inotify.add_watch(root, EXIST_FLAGS)
+
+    exist_map = dict((k, root.joinpath(k).exists()) for k in files)
+
+    while True:
+        if all(exist_map.values()):
+            break
+        for event in inotify.read():
+            if event.name in exist_map:
+                exist_map[event.name] = True
+
+    print("All keys now confirmed to be present.")
+
+def wait_for_modification(files: List[str]):
+    root = Path(args.keydir)
+    inotify = inotify_simple.INotify()
+    inotify.add_watch(root, MODIFY_FLAGS)
+
+    while True:
+        exit = False
+        for event in inotify.read():
+            if event.name in files:
+                exit = True
+        if exit:
+            break
+
+    print("Key modified or deleted. Process will now exit.")
+
+# temporary key names are i.e ".sso-site-private.tmp"
+temp_files = args.temp_files.split(",")
+sink_files = args.sink_files.split(",")
+
+root = Path(args.keydir)
+
+if args.modify:
+    wait_for_modification(temp_files)
+else:
+    if all(list(map(lambda f: root.joinpath(f).exists(), sink_files))):
+        print("All sink files already present. Skipping existence check.")
+        exit(0)
+    wait_for_existence(temp_files)

--- a/nixos/modules/security/vault/keys.nix
+++ b/nixos/modules/security/vault/keys.nix
@@ -1,0 +1,420 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  formatConsulParams = attrs: (concatStringsSep " " (
+    flip mapAttrsToList attrs (key: value: ("\"${key}=${value}\""))
+  ));
+
+  backendToDefName = backend: if (backend == "kv") then "secret" else backend;
+
+  createConsulTemplates = key:
+    let
+      # figure out what backend we're going to use
+      backendFilter = filterAttrs (n: v: v != null) key.backends;
+      backendCount = length (attrNames backendFilter);
+      backendName = if (backendCount > 0) then (head (attrNames backendFilter)) else null;
+      backend = if (backendCount > 0) then (head (attrValues backendFilter)) else null;
+
+      type = backendName;
+      name = if (key.backendName != null) then key.backendName else backendToDefName backendName;
+
+      # info shared between all templates
+      keyInfo =
+        if type == "kv" then {
+          addr = "${name}/data/${backend.path}";
+          params = { };
+        } else if type == "pki" then {
+          addr = "${name}/issue/${backend.policy}";
+          params = { "common_name" = backend.commonName; };
+        } else null;
+
+      # template outputs for each type
+      keyTmpls =
+        if key.template != null then [{
+          body = key.template;
+        }] else if type == "kv" then [{
+          body = [ "{{ .Data.data | toJSON }}" ];
+        }] else if type == "pki" then
+          (
+            let
+              # repr of the certificate
+              certLines = [
+                "{{- .Data.certificate }}"
+              ] ++ (optional backend.fullChain [
+                "{{- if index .Data \"ca_chain\" }}"
+                "{{- range $cert := .Data.ca_chain }}\n{{ $cert }}{{ end }}"
+                "{{- end }}"
+              ]);
+
+              # repr of the private key
+              keyLines = [
+                "{{- .Data.private_key }}"
+              ];
+            in
+            # whether to split or bundle them together
+            if backend.bundle then [{
+              body = certLines ++ [ "" ] ++ keyLines;
+            }] else [
+              {
+                suffix = "public";
+                body = certLines;
+              }
+              {
+                suffix = "private";
+                body = keyLines;
+              }]
+          ) else null;
+
+      # final template generator
+    in
+    assert (assertMsg (backendCount == 1)) "vault key ${key.name}: exactly one backend must be specified";
+
+    forEach keyTmpls (template: rec {
+      suffix = if template ? suffix then template.suffix else null;
+      id = if (suffix != null) then "${key.name}-${template.suffix}" else key.name;
+
+      text = concatStringsSep "\n" (flatten [
+        "{{- with secret \"${keyInfo.addr}\" ${formatConsulParams keyInfo.params} }}"
+        template.body
+        "{{- end }}"
+      ]);
+    });
+
+  backendTypes = {
+    kv = types.submodule ({ config, ... }: {
+      options = {
+        path = mkOption {
+          default = null;
+          type = types.nullOr types.str;
+          description = "Path to the key/value key in Vault.";
+        };
+
+        field = mkOption {
+          default = null;
+          type = types.nullOr types.str;
+          description = "Default key/value field to use.";
+        };
+      };
+    });
+
+    pki = types.submodule ({ config, ... }: {
+      options = {
+        policy = mkOption {
+          type = types.str;
+          description = "Name of the PKI policy in Vault.";
+        };
+
+        bundle = mkOption {
+          default = false;
+          type = types.bool;
+          description = "Whether to bundle both the certificate and private key into one file.";
+        };
+
+        commonName = mkOption {
+          type = types.str;
+          description = "Common name of the certificate.";
+        };
+
+        fullChain = mkOption {
+          default = true;
+          type = types.bool;
+          description = "Includes the full certificate chain.";
+        };
+      };
+    });
+  };
+
+  sinkType = types.submodule ({ config, name, ... }: {
+    options = {
+      name = mkOption {
+        default = name;
+        type = types.str;
+        description = "Name of the destination file. Default is to use the sink name.";
+      };
+
+      user = mkOption {
+        default = "root";
+        type = types.str;
+        description = "The user which will be the owner of the key file.";
+      };
+
+      group = mkOption {
+        default = "root";
+        type = types.str;
+        description = "The group that will be set for the key file.";
+      };
+
+      permissions = mkOption {
+        default = "0600";
+        example = "0640";
+        type = types.str;
+        description = ''
+          The default permissions to set for the key file, needs to be in the
+          format accepted by ``chmod(1)``.
+        '';
+      };
+
+      kv = {
+        field = mkOption {
+          default = null;
+          type = types.nullOr types.str;
+          description = "The key/value field that this sink should pull from.";
+        };
+      };
+    };
+  });
+
+  keyType = types.submodule ({ config, name, ... }: {
+    options = {
+      name = mkOption {
+        example = "secret-123";
+        default = name;
+        type = types.str;
+        description = "The name of the key.";
+      };
+
+      folder = mkOption {
+        default = "/run/vault-keys";
+        type = types.str;
+        description = "The location to render the key to.";
+      };
+
+      template = mkOption {
+        default = null;
+        type = types.nullOr types.lines;
+        description = "Specifies a custom HCL template to render the key. Overrides built-in sink renderers.";
+      };
+
+      backends = {
+        kv = mkOption {
+          default = null;
+          type = types.nullOr backendTypes.kv;
+          description = "Configuration for the KeyValues backend.";
+        };
+
+        pki = mkOption {
+          default = null;
+          type = types.nullOr backendTypes.pki;
+          description = "Configuration for the PKI backend.";
+        };
+      };
+
+      backendName = mkOption {
+        default = null;
+        example = "pki_int";
+        type = types.nullOr types.str;
+        description = "The name of the Vault backend. Default is to use the default name for the backend type.";
+      };
+
+      # TODO: We need to get vault-agent to reload whenever this changes, how?
+      sinks = mkOption {
+        default = { "${name}" = { }; };
+        type = types.attrsOf sinkType;
+        description = "List of sink configurations that describe how to render this key to a file. If not set, the key name will be used.";
+      };
+
+      postRenew = {
+        command = mkOption {
+          default = "";
+          type = types.str;
+          description = "Optional command to run after the key is renewed.";
+        };
+
+        restart = mkOption {
+          default = false;
+          type = types.bool;
+          description = "Whether to automatically restart or reload systemd units when the key is renewed.";
+        };
+      };
+
+      dependency = {
+        units = mkOption {
+          default = [ ];
+          example = "[ \"nginx\" ]";
+          type = types.listOf types.str;
+          description = "Dependent systemd units for the key.";
+        };
+      };
+
+      external = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Specifies that this key will be pushed externally by a tool rather than being pulled by the host's agent.";
+      };
+    };
+  });
+
+  # build all the vault agent templates for a key
+  buildAgentTemplates = key:
+    let
+      defaults = {
+        createDestDirs = false;
+        sandboxPath = key.folder;
+      };
+    in
+    (forEach key.templates (template: ({
+      sourceFile = pkgs.writeText "vault-key-${template.id}.ctmpl" template.text;
+      destFile = "${key.folder}/.${template.id}.tmp";
+    } // defaults)));
+
+  # builds the final set of keys
+  finalKeys = (flip mapAttrs config.security.vault-keys (_: key: key // { templates = createConsulTemplates key; }));
+in
+{
+  options = {
+    security.vault-keys = mkOption {
+      default = { };
+      type = types.attrsOf keyType;
+      description = "Attributes of vault keys to deploy.";
+    };
+
+    reflection.vault-keys = mkOption {
+      default = finalKeys;
+      type = types.attrs;
+      description = "Allows extration of template values by an external script.";
+    };
+  };
+
+  config = mkIf (length (attrNames config.security.vault-keys) > 0) {
+    services.vault-agent.templates =
+      let
+        # exclude keys marked as external as they do not use the agent
+        keys = filterAttrs (k: v: v.external == false) finalKeys;
+      in
+      flatten (flip mapAttrsToList keys (_: key: buildAgentTemplates key));
+
+    users.users = (listToAttrs (flatten (flip mapAttrsToList finalKeys (_: key:
+      (flip mapAttrsToList (flip filterAttrs key.sinks (_: sink: sink.user != "root")) (_: sink: (nameValuePair sink.user { extraGroups = [ "keys" ]; })))
+    ))));
+
+    systemd.services = # create a service for every key
+      (listToAttrs (flip mapAttrsToList finalKeys (_: key: {
+        name = "vault-key-${key.name}";
+        value =
+          let
+            # the default template
+            default = head key.templates;
+
+            keyRenderWait = pkgs.writeScriptBin "key-render-wait" (builtins.readFile ./key-render-wait.py);
+
+            # filenames for the temporary files and target sink files
+            tempFileNames = concatStringsSep "," (map (template: ".${template.id}.tmp") key.templates);
+            sinkFileNames = concatStringsSep "," (flatten (flip mapAttrsToList key.sinks (_: sink:
+              if (key.template == null && ((length key.templates) > 1)) then (map (t: "${sink.name}-${t.suffix}") key.templates) else sink.name
+            )));
+          in
+          {
+            description = "Vault key activation service";
+
+            before = key.dependency.units;
+            after = [ "vault-agent.target" ];
+            wants = [ "vault-agent.target" ];
+            wantedBy = [ "multi-user.target" ] ++ key.dependency.units;
+
+            path = with pkgs; [
+              (python3.withPackages (p: with p; [
+                inotify-simple
+              ]))
+            ];
+
+            serviceConfig = {
+              Restart = "always";
+              RestartSec = "100ms";
+              TimeoutStartSec = "infinity";
+            };
+
+            preStart = ''
+              # Wait for create/move if any keys don't exist here
+              ${keyRenderWait}/bin/key-render-wait -t "${tempFileNames}" -s "${sinkFileNames}" -d "${key.folder}"
+            '';
+
+            script = ''
+              set -euo pipefail
+
+              # if the key's folder does not exist, create it
+              if [[ ! -d "${key.folder}" ]]; then
+                  mkdir -p "${key.folder}"
+                  chmod -R 0600 "${key.folder}"
+              fi
+
+              # we are now DONE waiting for all the keys
+              # finally render them
+            ${concatStringsSep "\n" (flatten ([
+              (flip mapAttrsToList key.sinks (_: sink:
+              let
+              buildKey = render: dest: id:
+              let
+                  tempFile = "${key.folder}/.${id}.tmp";
+              in
+              # if the temp file doesn't exist, don't attempt to render and instead use the old version
+              ''
+                if [[ -f "${tempFile}" ]]; then
+                    rm -rf "${dest}"
+                    ${render}
+                    chmod ${sink.permissions} "${dest}"
+                    chown "${sink.user}:${sink.group}" "${dest}"
+                fi
+              '';
+
+              buildStandaloneKey =
+              let
+                  dest = "${key.folder}/${sink.name}";
+              in
+              buildKey ''cp "${key.folder}/.${default.id}.tmp" "${dest}"'' dest default.id;
+              in
+              # we're always standalone if the parent key is overriding with a custom template
+              if key.template != null then buildStandaloneKey
+
+              # composite keys (suffixed with template suffix)
+              else if (length key.templates) > 1 then
+              (forEach key.templates (template:
+              let
+                  dest = "${key.folder}/${sink.name}-${template.suffix}";
+              in
+              buildKey ''cp "${key.folder}/.${template.id}.tmp" "${dest}"'' dest template.id))
+
+              # special for key/value keys (file per field)
+              else if (key.backends.kv != null) then
+              let
+                  dest = "${key.folder}/${sink.name}";
+              in
+                  buildKey ''cat "${key.folder}/.${default.id}.tmp" | ${pkgs.jq}/bin/jq -j -r '.["${sink.kv.field}"]' > "${dest}"'' dest default.id
+
+                  # fallback to regular
+                  else buildStandaloneKey))
+
+                  # remove the temporary files, but not for external keys as we might need to re-render them
+                  # TODO: could we actually just do this for all keys, i.e. not remove the tempfiles?
+                  (optional (key.external == false) (forEach key.templates (template: ''rm -f "${key.folder}/.${template.id}.tmp"'')))
+              ]))}
+
+              # perform actions on dependent units
+              ${concatStrings (if key.postRenew.restart then
+              (forEach key.dependency.units (unit: (
+              ''
+                systemctl reload-or-restart ${unit} --no-block
+              ''
+              ))) else [ ])}
+
+              ${key.postRenew.command}
+
+              # Wait for key modification and exit if so
+              ${keyRenderWait}/bin/key-render-wait -m -t "${tempFileNames}" -d "${key.folder}"
+            '';
+          };
+      }))) //
+
+      # default systemd options
+      {
+        vault-agent.serviceConfig.ReadWritePaths = "/run/vault-keys";
+      };
+
+    system.activationScripts.vault-keys =
+      let script = ''
+        mkdir -p /run/vault-keys -m 0770
+        chown root:keys /run/vault-keys
+      '';
+      in stringAfter [ "users" "groups" ] "source ${pkgs.writeText "setup-vault-keys.sh" script}";
+  };
+}

--- a/nixos/modules/services/security/vault-agent.nix
+++ b/nixos/modules/services/security/vault-agent.nix
@@ -1,0 +1,340 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  cfg = config.services.vault-agent;
+
+  configFile = pkgs.writeText "vault-agent.hcl" ''
+    auto_auth {
+      ${optionalString cfg.autoAuth.methods.appRole.enable ''
+      method "approle" {
+          config = {
+              role_id_file_path = "${cfg.autoAuth.methods.appRole.roleIdFile}"
+              secret_id_file_path = "${cfg.autoAuth.methods.appRole.secretIdFile}"
+              remove_secret_id_file_after_reading = false
+          }
+      }
+      ''}
+
+      ${optionalString cfg.autoAuth.sinks.file.enable ''
+      sink "file" {
+          config = {
+              path = "${cfg.autoAuth.sinks.file.path}"
+          }
+      }
+      ''}
+    }
+
+    ${optionalString cfg.cache.enable ''
+    cache {
+        use_auto_auth_token = ${toString cfg.cache.useAutoAuthToken}
+    }
+    ''}
+
+    vault {
+        address = "${cfg.address}"
+        ${if (cfg.caCertFile != null) then ''ca_cert = "${cfg.caCertFile}"'' else ''''}
+    }
+
+    ${concatStringsSep "\n" (forEach cfg.listeners (listener: ''
+    listener "${listener.type}" {
+        address = "${listener.address}"
+        ${if (listener.tlsCertFile != null && listener.tlsKeyFile != null) then ''
+        tls_cert_file = "${listener.tlsCertFile}"
+        tls_key_file = "${listener.tlsKeyFile}"
+        '' else ''
+        tls_disable = true
+        ''}
+    }
+    ''))}
+
+    ${concatStringsSep "\n" (forEach cfg.templates (template:
+    let sourceFile =
+        if template.sourceFile != null then template.sourceFile
+        else pkgs.writeText "template.ctmpl" template.sourceText;
+    in
+    ''
+      template {
+          source = "${sourceFile}"
+          destination = "${template.destFile}"
+
+          ${optionalString (template.createDestDirs == false) ''
+          create_dest_dirs = false
+          ''}
+
+          ${optionalString (template.command != null) ''
+          command = "${template.command}"
+          command_timeout = "${toString template.commandTimeout}s"
+          ''}
+
+          error_on_missing_key = true
+          perms = "${template.perms}"
+
+          ${optionalString template.backup ''
+          backup = true
+          ''}
+
+          ${optionalString (template.sandboxPath != null) ''
+          sandbox_path = "${template.sandboxPath}"
+          ''}
+      }
+      ''))}
+
+      ${cfg.extraConfig}
+  '';
+
+  listenerSubmodule = { ... }:
+    {
+      options = {
+        type = mkOption {
+          type = types.enum [ "tcp" "unix" ];
+          default = "tcp";
+          description = "Type of the listener to use";
+        };
+
+        address = mkOption {
+          type = types.str;
+          default = "127.0.0.1:8200";
+          description = "Address of the listener to listen to";
+        };
+
+        tlsKeyFile = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Path to the TLS private key";
+        };
+
+        tlsCertFile = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Path to the TLS certificate";
+        };
+      };
+    };
+
+  templateSubmodule = { ... }:
+    {
+      options = {
+        sourceFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = "The source template to use, as a file.";
+        };
+
+        sourceText = mkOption {
+          type = types.nullOr types.lines;
+          default = null;
+          description = "The source template to use.";
+        };
+
+        destFile = mkOption {
+          type = types.str;
+          description = "The destination path to render the template.";
+        };
+
+        createDestDirs = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Whether to create the destination directories automatically if they do not exist.";
+        };
+
+        command = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Optional command to run after the template is rendered.";
+        };
+
+        commandTimeout = mkOption {
+          type = types.int;
+          default = 30;
+          description = "Maximum amount of time to wait for the optional command, in seconds.";
+        };
+
+        perms = mkOption {
+          type = types.str;
+          default = "0600";
+          example = "0640";
+          description = "The permissions to render the file.";
+        };
+
+        backup = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to back up the previously rendered template.";
+        };
+
+        sandboxPath = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Checks to ensure the path is within this path.";
+        };
+      };
+    };
+in
+rec {
+  options = {
+    services.vault-agent = {
+      enable = mkEnableOption "Vault agent";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.vault;
+        defaultText = "pkgs.vault";
+        description = "This option specifies the vault package to use.";
+      };
+
+      address = mkOption {
+        type = types.str;
+        default = "http://127.0.0.1:8200";
+        description = "Address of the Vault instance to connect to.";
+      };
+
+      caCertFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Path to the certificate authority to use to verify the Vault certificate.";
+      };
+
+      autoAuth = {
+        methods = {
+          appRole = {
+            enable = mkEnableOption "AppRole";
+
+            name = mkOption {
+              type = types.str;
+              description = "The name of the Role. Used for role pushing and response wrapping.";
+            };
+
+            roleIdFile = mkOption {
+              type = types.str;
+              default = "/var/lib/vault-agent/role-id";
+              description = "The path to the file containing the Role ID.";
+            };
+
+            secretIdFile = mkOption {
+              type = types.str;
+              default = "/var/lib/vault-agent/secret-id";
+              description = "The path to the file containing the Secret ID.";
+            };
+          };
+        };
+
+        sinks = {
+          file = {
+            enable = mkEnableOption "File";
+            path = mkOption {
+              type = types.str;
+              description = "The destination path for the File sink";
+            };
+          };
+        };
+      };
+
+      cache = {
+        enable = mkEnableOption "Cache";
+        useAutoAuthToken = mkOption {
+          type = types.either types.bool (types.enum [ "force" ]);
+          default = false;
+          description = "Whether to forward requests with the auto auth token";
+        };
+      };
+
+      listeners = mkOption {
+        type = types.listOf (types.submodule listenerSubmodule);
+        default = [ ];
+        description = "List of listeners for the agent to create";
+      };
+
+      templates = mkOption {
+        type = types.listOf (types.submodule templateSubmodule);
+        default = [ ];
+        description = "List of templates for the agent to create";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra text appended to <filename>vault-agent.hcl</filename>.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      users.vault-agent = {
+        name = "vault-agent";
+        group = "vault-agent";
+        isSystemUser = true;
+        description = "Vault agent user";
+        extraGroups = [ "keys" ];
+      };
+
+      groups.vault-agent = { };
+    };
+
+    systemd.services.vault-agent = {
+      description = "Vault agent daemon";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "vault-agent";
+        Group = "vault-agent";
+        ExecStart = "${cfg.package}/bin/vault agent -config ${configFile}";
+        ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
+        KillSignal = "SIGINT";
+        TimeoutStopSec = "30s";
+        Restart = "always";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        DeviceAllow = "";
+        IPAddressDeny = [ "" ];
+        KeyringMode = "private";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        NotifyAccess = "none";
+        ProcSubset = "pid";
+        RemoveIPC = true;
+
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateNetwork = false;
+        PrivateTmp = true;
+        PrivateUsers = true;
+
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        # requires the ipc and sync syscalls in order to not crash
+        SystemCallFilter = [
+            "@system-service"
+            "~@aio" "~@clock" "~@cpu-emulation" "~@chown" "~@debug" "~@keyring"
+            "~@memlock" "~@module" "~@mount" "~@raw-io" "~@reboot" "~@swap"
+            "~@privileged" "~@resources" "~@setuid" "~@timer"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+      };
+
+      unitConfig = {
+        StartLimitInterval = "60s";
+        StartLimitBurst = 3;
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This pull request adds a module for dynamic declarative deployment of HashiCorp Vault keys as well as a module to configure and start `vault-agent` as a service. Keys are configured as templates in the agent which allows for automatic renewal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
