### PR TITLE
ocamlPackages.irmin: 2.6.0 -> 2.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -1,16 +1,16 @@
 { lib, fetchurl, buildDunePackage
 , repr, ppx_repr, fmt, logs, mtime, stdlib-shims
-, cmdliner, progress, semaphore-compat
+, cmdliner, progress, semaphore-compat, optint
 , alcotest, crowbar, re
 }:
 
 buildDunePackage rec {
   pname = "index";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/index/releases/download/${version}/index-${version}.tbz";
-    sha256 = "sha256-ycZi/TFLoGRloSpjYqH5FCHWP3eyiTCIDLESEn5inuI=";
+    sha256 = "13xd858c50fs651p1y8x70323ff0gzbf6zgc0a25f6xh3rsmkn4c";
   };
 
   minimumOCamlVersion = "4.08";
@@ -28,6 +28,7 @@ buildDunePackage rec {
     progress
     repr
     semaphore-compat
+    optint
   ];
 
   checkInputs = [

--- a/pkgs/development/ocaml-modules/irmin/pack.nix
+++ b/pkgs/development/ocaml-modules/irmin/pack.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage
-, alcotest-lwt, index, irmin, irmin-layers, irmin-test, ocaml_lwt, fpath
+, alcotest-lwt, index, irmin, irmin-layers, irmin-test, ocaml_lwt, fpath, optint
 }:
 
 buildDunePackage rec {
@@ -12,7 +12,7 @@ buildDunePackage rec {
   useDune2 = true;
 
   buildInputs = [ fpath ];
-  propagatedBuildInputs = [ index irmin irmin-layers ocaml_lwt ];
+  propagatedBuildInputs = [ index irmin irmin-layers ocaml_lwt optint ];
 
   checkInputs = [ alcotest-lwt irmin-test ];
 

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "ppx_irmin";
-  version = "2.6.0";
+  version = "2.7.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
-    sha256 = "1db134221e82c424260a0e206b640fcb82902be35eea4137af2bcd9c98d3ac0f";
+    sha256 = "fac7c032f472fb369378ad2d8fe77e7cd3b3c1c6a0d7bf59980b69528891b399";
   };
 
   minimumOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/repr/default.nix
+++ b/pkgs/development/ocaml-modules/repr/default.nix
@@ -2,11 +2,11 @@
 
 buildDunePackage rec {
   pname = "repr";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/${version}/${pname}-fuzz-${version}.tbz";
-    sha256 = "sha256-2b0v5RwutvyidzEDTEb5p33IvJ+3t2IW+KVxYD1ufXQ=";
+    sha256 = "1kpwgncyxcrq90dn7ilja7c5i88whc3fz4fmq1lwr0ar95d7d48p";
   };
 
   minimumOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/repr/ppx.nix
+++ b/pkgs/development/ocaml-modules/repr/ppx.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, ppx_deriving, ppxlib, repr, alcotest, hex }:
+{ lib, buildDunePackage, ppx_deriving, ppxlib, repr, alcotest, hex }:
 
 buildDunePackage {
   pname = "ppx_repr";


### PR DESCRIPTION
https://github.com/mirage/irmin/releases/tag/2.7.1

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The Tezos codebase depends on this latest version of Irmin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
