### PR TITLE
python3Packages.faker: 6.6.3 -> 8.9.1

### DIFF
--- a/pkgs/development/python-modules/faker/default.nix
+++ b/pkgs/development/python-modules/faker/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "Faker";
-  version = "6.6.3";
+  version = "8.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c2852cadc99a4ebdbf06934e4c15e30f2307d414ead21d15605759602645f152";
+    sha256 = "160gi8f8v8xys9q881lhfi3pr1z62kahi3xhc69aa4zgacck4v0m";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
It didn't build anymore, probably since python update
(bisected into vicinity of 3898eb189).  Error:
https://hydra.nixos.org/build/146936942

I suspect it's 7.0.1 that brought the fix we need here,
but I can't see any breaking changes at a glance:
https://github.com/joke2k/faker/blob/v8.9.1/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
