### PR TITLE
ocamlPackages.json-data-encdoing: init at 0.8, ocamlPackages.data-encdoing: init at 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/data-encoding/default.nix
+++ b/pkgs/development/ocaml-modules/data-encoding/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitLab
+, buildDunePackage
+, ezjsonm
+, zarith
+, hex
+, json-data-encoding
+, json-data-encoding-bson
+, alcotest
+, crowbar
+}:
+
+buildDunePackage {
+  pname = "data-encoding";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "nomadic-labs";
+    repo = "data-encoding";
+    rev = "0.2";
+    sha256 = "0d9c2ix2imqk4r0jfhnwak9laarlbsq9kmswvbnjzdm2g0hwin1d";
+  };
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    ezjsonm
+    zarith
+    hex
+    json-data-encoding
+    json-data-encoding-bson
+  ];
+
+  checkInputs = [
+    alcotest
+    crowbar
+  ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://gitlab.com/nomadic-labs/data-encoding";
+    description = "Library of JSON and binary encoding combinators";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/development/ocaml-modules/json-data-encoding/bson.nix
+++ b/pkgs/development/ocaml-modules/json-data-encoding/bson.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, json-data-encoding, ocplib-endian, crowbar }:
+
+buildDunePackage {
+  pname = "json-data-encoding-bson";
+
+  inherit (json-data-encoding) version src useDune2 doCheck;
+
+  propagatedBuildInputs = [
+    json-data-encoding
+    ocplib-endian
+  ];
+
+  checkInputs = [
+    crowbar
+  ];
+
+  meta = {
+    homepage = "https://gitlab.com/nomadic-labs/json-data-encoding";
+    description = "Type-safe encoding to and decoding from JSON (bson support)";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/development/ocaml-modules/json-data-encoding/bson.nix
+++ b/pkgs/development/ocaml-modules/json-data-encoding/bson.nix
@@ -14,10 +14,7 @@ buildDunePackage {
     crowbar
   ];
 
-  meta = {
-    homepage = "https://gitlab.com/nomadic-labs/json-data-encoding";
+  meta = json-data-encoding.meta // {
     description = "Type-safe encoding to and decoding from JSON (bson support)";
-    license = lib.licenses.lgpl3;
-    maintainers = [ lib.maintainers.ulrikstrid ];
   };
 }

--- a/pkgs/development/ocaml-modules/json-data-encoding/default.nix
+++ b/pkgs/development/ocaml-modules/json-data-encoding/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitLab, buildDunePackage, uri, crowbar }:
+
+buildDunePackage rec {
+  pname = "json-data-encoding";
+  version = "0.8";
+
+  src = fetchFromGitLab {
+    owner = "nomadic-labs";
+    repo = "json-data-encoding";
+    rev = "v${version}";
+    sha256 = "1c6m2qvi9bm6qjxc38p6cia1f66r0rb9xf6b8svlj3jjymvqw889";
+  };
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    uri
+  ];
+
+  checkInputs = [
+    crowbar
+  ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://gitlab.com/nomadic-labs/json-data-encoding";
+    description = "Type-safe encoding to and decoding from JSON";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -242,6 +242,8 @@ let
 
     dap =  callPackage ../development/ocaml-modules/dap { };
 
+    data-encoding = callPackage ../development/ocaml-modules/data-encoding { };
+
     decompress =  callPackage ../development/ocaml-modules/decompress { };
 
     diet =  callPackage ../development/ocaml-modules/diet { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -548,6 +548,10 @@ let
 
     jsonm = callPackage ../development/ocaml-modules/jsonm { };
 
+    json-data-encoding = callPackage ../development/ocaml-modules/json-data-encoding { };
+
+    json-data-encoding-bson = callPackage ../development/ocaml-modules/json-data-encoding/bson.nix { };
+
     junit = callPackage ../development/ocaml-modules/junit { };
     junit_ounit = callPackage ../development/ocaml-modules/junit/ounit.nix { };
     junit_alcotest = callPackage ../development/ocaml-modules/junit/alcotest.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These packages (and specifically these versions) are some of the prerequisites to get LIGO building.
Since the versions are old maybe we want to figure out how to have multiple versions, but that is out of the scope of this PR I think.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
