### PR TITLE
weechatScripts.highmon: init at 2.7

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -24,4 +24,6 @@
   weechat-go = callPackage ./weechat-go { };
 
   buffer_autoset = callPackage ./buffer_autoset { };
+
+  highmon = callPackage ./highmon { };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/highmon/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/highmon/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchurl, weechat }:
+
+stdenv.mkDerivation {
+  pname = "highmon";
+  version = "2.7";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/KenjiE20/highmon/182e67d070c75efc81999e68c2ac7fdfe44d2872/highmon.pl";
+    sha256 = "1vvgzscb12l3cp2nq954fx6j3awvpjsb0nqylal51ps9cq9a3wir";
+  };
+
+  dontUnpack = true;
+
+  passthru.scripts = [ "highmon.pl" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/share/highmon.pl
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    homepage = "https://github.com/KenjiE20/highmon/";
+    description = "highmon.pl is a weechat script that adds 'Highlight Monitor'.";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ govanify ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This adds one of the featured scripts of weechat to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
