### PR TITLE
[21.05] openmpt123: 0.5.8 -> 0.5.11

### DIFF
--- a/pkgs/applications/audio/openmpt123/default.nix
+++ b/pkgs/applications/audio/openmpt123/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "openmpt123";
-  version = "0.5.9";
+  version = "0.5.10";
 
   src = fetchurl {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz";
-    sha256 = "0h86p8mnpm98vc4v6jbvrmm02fch7dnn332i26fg3a2s1738m04d";
+    sha256 = "sha256-Waj6KNi432nLf6WXK9+TEIHatOHhFWxpoaU7ZcK+n/o=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/openmpt123/default.nix
+++ b/pkgs/applications/audio/openmpt123/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "openmpt123";
-  version = "0.5.10";
+  version = "0.5.11";
 
   src = fetchurl {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz";
-    sha256 = "sha256-Waj6KNi432nLf6WXK9+TEIHatOHhFWxpoaU7ZcK+n/o=";
+    sha256 = "1c54lldr2imjzhlhq5lvwhj7d5794xm97cby9pznr5wdjjay0sa4";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/openmpt123/default.nix
+++ b/pkgs/applications/audio/openmpt123/default.nix
@@ -1,19 +1,16 @@
 { config, lib, stdenv, fetchurl, zlib, pkg-config, mpg123, libogg, libvorbis, portaudio, libsndfile, flac
 , usePulseAudio ? config.pulseaudio or false, libpulseaudio }:
 
-let
-  version = "0.5.8";
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "openmpt123";
-  inherit version;
+  version = "0.5.9";
 
   src = fetchurl {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz";
-    sha256 = "sha256-KeLCEXS3P2fyul7naAjWLxgrEw5PcE7i2a6Cg5gtis0=";
+    sha256 = "0h86p8mnpm98vc4v6jbvrmm02fch7dnn332i26fg3a2s1738m04d";
   };
 
   enableParallelBuilding = true;
-  doCheck = true;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ zlib mpg123 libogg libvorbis portaudio libsndfile flac ]
@@ -21,11 +18,13 @@ in stdenv.mkDerivation {
 
   configureFlags = lib.optional (!usePulseAudio) "--without-pulseaudio";
 
+  doCheck = true;
+
   meta = with lib; {
     description = "A cross-platform command-line based module file player";
     homepage = "https://lib.openmpt.org/libopenmpt/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Backporting bugfix updates to stable.
0.5.8 -> 0.5.9 [(CHANGELOG)](https://lib.openmpt.org/libopenmpt/2021/05/16/releases-0.5.9-0.4.21-0.3.30/) from #126599
0.5.9 -> 0.5.10 [(CHANGELOG)](https://lib.openmpt.org/libopenmpt/2021/07/04/releases-0.5.10-0.4.22-0.3.31/) from #129414
0.5.10 -> 0.5.11 [(CHANGELOG)](https://lib.openmpt.org/libopenmpt/2021/08/22/security-updates-0.5.11-0.4.23-0.3.32/) from #137093

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
