### PR TITLE
emacs.pkgs.melpaBuild: package-build: 2018-10-05 -> 2021-04-13

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
@@ -67,8 +67,7 @@ in {
         lib.nameValuePair ename (
           self.callPackage ({ melpaBuild, fetchurl, ... }@pkgargs:
           melpaBuild {
-            inherit pname;
-            ename = ename;
+            inherit pname ename commit;
             version = if isNull version then "" else
               lib.concatStringsSep "." (map toString version);
             # TODO: Broken should not result in src being null (hack to avoid eval errors)

--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -38,8 +38,8 @@ import ./generic.nix { inherit lib stdenv emacs texinfo writeText; } ({
   packageBuild = fetchFromGitHub {
     owner = "melpa";
     repo = "package-build";
-    rev = "0a22c3fbbf661822ec1791739953b937a12fa623";
-    sha256 = "0dpy5p34il600sc8ic5jdgb3glya9si3lrvhxab0swks8fdydjgs";
+    rev = "047801d301a73d4932f33f768d94a8ed26b8d524";
+    sha256 = "0ygzkpg7xc3mjjbxg1kcyz6fwbkb0prvca499f0ffmhfaiv28h59";
   };
 
   elpa2nix = ./elpa2nix.el;
@@ -70,7 +70,7 @@ import ./generic.nix { inherit lib stdenv emacs texinfo writeText; } ({
         -L "$NIX_BUILD_TOP/package-build" \
         -l "$melpa2nix" \
         -f melpa2nix-build-package \
-        $ename $version
+        $ename $version $commit
 
     runHook postBuild
     '';

--- a/pkgs/build-support/emacs/melpa2nix.el
+++ b/pkgs/build-support/emacs/melpa2nix.el
@@ -12,5 +12,8 @@
   (if (not noninteractive)
       (error "`melpa2nix-build-package' is to be used only with -batch"))
   (pcase command-line-args-left
-    (`(,package ,version)
+    (`(,package ,version ,commit)
+     ;; Monkey-patch package-build so it doesn't shell out to git/hg.
+     (defun package-build--get-commit (&rest _)
+       commit)
      (package-build--package (package-recipe-lookup package) version))))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I think this is due an update.  I've chosen to update to the latest
version that has been merged into Melpa.

Unfortunately we now need to hack around it trying to run VCS
commands.

My Emacs configuration with thirty-something leaf packages seems fine
after the rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
