### PR TITLE
kvmfr: init at $looking-glass-client.version

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4609,6 +4609,12 @@
     githubId = 6874204;
     name = "Jason Carr";
   };
+  j-brn = {
+    email = "me@bricker.io";
+    github = "j-brn";
+    githubId = 40566146;
+    name = "Jonas Braun";
+  };
   j-keck = {
     email = "jhyphenkeck@gmail.com";
     github = "j-keck";

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, kernel, kmod, looking-glass-client }:
+
+stdenv.mkDerivation rec {
+  pname = "kvmfr";
+  version = looking-glass-client.version;
+
+  src = looking-glass-client.src;
+  sourceRoot = "source/module";
+  hardeningDisable = [ "pic" "format" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KVER=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D kvmfr.ko -t "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/misc/"
+  '';
+
+  meta = with lib; {
+    description = "Optional kernel module for LookingGlass";
+    longDescription = ''
+      This kernel module implements a basic interface to the IVSHMEM device for LookingGlass when using LookingGlass in VM->VM mode
+      Additionally, in VM->host mode, it can be used to generate a shared memory device on the host machine that supports dmabuf
+    '';
+    homepage = "https://github.com/gnif/LookingGlass";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ j-brn ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20978,6 +20978,8 @@ in
 
     jool = callPackage ../os-specific/linux/jool { };
 
+    kvmfr = callPackage ../os-specific/linux/kvmfr { };
+
     mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
     mwprocapture = callPackage ../os-specific/linux/mwprocapture { };


### PR DESCRIPTION
###### Motivation for this change

Adds the kernel module 'kvmfr' which is necessary to use dmabuf support with looking-glass-client.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
