### PR TITLE
kops: default to 1.21.0, drop 1.18

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -20,6 +20,12 @@
           PHP now defaults to PHP 8.0, updated from 7.4.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          kOps now defaults to 1.21.0, which uses containerd as the
+          default runtime.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-new-services">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -7,6 +7,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 ## Highlights {#sec-release-21.11-highlights}
 
 - PHP now defaults to PHP 8.0, updated from 7.4.
+- kOps now defaults to 1.21.0, which uses containerd as the default runtime.
 
 ## New Services {#sec-release-21.11-new-services}
 

--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -53,11 +53,6 @@ rec {
 
   mkKops = generic;
 
-  kops_1_18 = mkKops {
-    version = "1.18.2";
-    sha256 = "17na83j6sfhk69w9ssvicc0xd1904z952ad3zzbpha50lcy6nlhp";
-  };
-
   kops_1_19 = mkKops rec {
     version = "1.19.2";
     sha256 = "15csxih1xy8myky37n5dyzp5mc31pc4bq9asaw6zz51mgw8ad5r9";
@@ -67,6 +62,12 @@ rec {
   kops_1_20 = mkKops rec {
     version = "1.20.2";
     sha256 = "011ib3xkj6nn7qax8d0ns8y4jhkwwmry1qnzxklvzssaxhmzs557";
+    rev = "v${version}";
+  };
+
+  kops_1_21 = mkKops rec {
+    version = "1.21.0";
+    sha256 = "sha256-T2i3qpg3GC7yaYCGrN1V5XXrUyT+Ce9Q4aV00gQJ7gM=";
     rev = "v${version}";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30895,11 +30895,11 @@ in
   # Exceptions are versions that we need to keep to allow upgrades from older NixOS releases
   inherit (callPackage ../applications/networking/cluster/kops {})
     mkKops
-    kops_1_18
     kops_1_19
     kops_1_20
+    kops_1_21
     ;
-  kops = kops_1_20;
+  kops = kops_1_21;
 
   lguf-brightness = callPackage ../misc/lguf-brightness { };
 


### PR DESCRIPTION
###### Motivation for this change

Update to the latest release, and drop the oldest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Need to fix the hash probably (#129471).