### PR TITLE
ocamlPackages.alcotest: 1.3.0 → 1.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname = "alcotest";
-  version = "1.3.0";
+  version = "1.4.0";
 
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-mirage-${version}.tbz";
-    sha256 = "sha256-efnevbyolTdNb91zr4pHDcvgaLQQSD01wEu2zMM+iaw=";
+    sha256 = "sha256:1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
   };
 
   propagatedBuildInputs = [ astring cmdliner fmt uuidm re stdlib-shims uutf ];

--- a/pkgs/development/ocaml-modules/fiat-p256/default.nix
+++ b/pkgs/development/ocaml-modules/fiat-p256/default.nix
@@ -12,6 +12,12 @@ buildDunePackage rec {
     sha256 = "0086h9qkvnqfm8acrxqbki54z619nj73x7f0d01v5vg2naznx7w9";
   };
 
+  # Make tests compatible with alcotest 1.4.0
+  postPatch = ''
+    substituteInPlace test/wycheproof/test.ml --replace \
+      'Printf.ksprintf Alcotest.fail' 'Printf.ksprintf (fun s -> Alcotest.fail s)'
+  '';
+
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ bigarray-compat cstruct eqaf hex ];
   checkInputs = [ alcotest asn1-combinators benchmark

--- a/pkgs/development/ocaml-modules/mirage-block-ramdisk/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block-ramdisk/default.nix
@@ -13,6 +13,11 @@ buildDunePackage rec {
     sha256 = "cc0e814fd54efe7a5b7a8c5eb1c04e2dece751b7d8dee2d95908a0768896e8af";
   };
 
+  # Make tests compatible with alcotest 1.4.0
+  postPatch = ''
+    substituteInPlace test/tests.ml --replace 'Fmt.kstrf Alcotest.fail' 'Fmt.kstrf (fun s -> Alcotest.fail s)'
+  '';
+
   minimumOCamlVersion = "4.06";
 
   propagatedBuildInputs = [ io-page mirage-block ];

--- a/pkgs/development/ocaml-modules/mirage-channel/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-channel/default.nix
@@ -14,6 +14,11 @@ buildDunePackage rec {
     sha256 = "0wmb2zhiyp8n78xgcspcsyd19bhcml3kyli2caw3778wc1gyvfpc";
   };
 
+  # Make tests compatible with alcotest 1.4.0
+  postPatch = ''
+    substituteInPlace test/test_channel.ml --replace 'Fmt.kstrf Alcotest.fail' 'Fmt.kstrf (fun s -> Alcotest.fail s)'
+  '';
+
   propagatedBuildInputs = [ cstruct logs lwt mirage-flow ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/mirage-flow/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/unix.nix
@@ -6,6 +6,11 @@ buildDunePackage {
 
   inherit (mirage-flow) version useDune2 src;
 
+  # Make tests compatible with alcotest 1.4.0
+  postPatch = ''
+    substituteInPlace test/test.ml --replace 'Fmt.kstrf Alcotest.fail' 'Fmt.kstrf (fun s -> Alcotest.fail s)'
+  '';
+
   propagatedBuildInputs = [ fmt logs mirage-flow ocaml_lwt cstruct ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/tcpip/default.nix
+++ b/pkgs/development/ocaml-modules/tcpip/default.nix
@@ -26,6 +26,14 @@ buildDunePackage rec {
     ./makefile-no-opam.patch
   ];
 
+  # Make tests compatible with alcotest 1.4.0
+  postPatch = ''
+    for p in common.ml test_tcp_options.ml
+    do
+      substituteInPlace test/$p --replace 'Fmt.kstrf Alcotest.fail' 'Fmt.kstrf (fun s -> Alcotest.fail s)'
+    done
+  '';
+
   nativeBuildInputs = [
     bisect_ppx
     ppx_cstruct


### PR DESCRIPTION
###### Motivation for this change

#129434

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @ericbmerritt 