### PR TITLE
psi-plus: backport bugfix for missing gstreamer dependencies to release-21.05

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -3,6 +3,10 @@
 , libidn, qca-qt5, libXScrnSaver, hunspell
 , libsecret, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
 , usrsctp
+
+# Voice messages
+, voiceMessagesSupport ? true
+, gst_all_1
 }:
 
 mkDerivation rec {
@@ -27,7 +31,16 @@ mkDerivation rec {
     libidn qca-qt5 libXScrnSaver hunspell
     libsecret libgcrypt libotr html-tidy libgpgerror libsignal-protocol-c
     usrsctp
+  ] ++ lib.optionals voiceMessagesSupport [
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
   ];
+
+  preFixup = lib.optionalString voiceMessagesSupport ''
+    qtWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    )
+  '';
 
   meta = with lib; {
     homepage = "https://psi-plus.com";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Voice messages don’t work without gstreamer “base” and “good” plugins. This change adds a an override for `GST_PLUGIN_SYSTEM_PATH_1_0` environment variable providing necessary dependencies.

(cherry picked from commit 20d4e8bd392ac12a9942fe6a21d2d73ed39231ea)

See also #129393

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
