### PR TITLE
rr-unstable: 2020-10-04 -> 2021-07-06

### DIFF
--- a/pkgs/development/tools/analysis/rr/unstable.nix
+++ b/pkgs/development/tools/analysis/rr/unstable.nix
@@ -1,9 +1,8 @@
-# This is a temporary copy of the default.nix in this folder, with the version updated to the current tip of rr's master branch.
-# This exists because rr has not had a release in a long time, but there have been a lot of improvements including UX.
-# Some of the UX improvements help prevent foot shooting.
-# Upstream has stated that it should be fine to use master.
-# This file, and its attribute in all-packages, can be removed once rr makes a release.
-# For further information, please see https://github.com/NixOS/nixpkgs/issues/99535 "Improve support for the rr debugger in nixos containers"
+# This is a temporary copy of the default.nix in this folder, with the version
+# updated to the current tip of rr's master branch. This exists because rr has
+# not had a release in a long time. Upstream has stated that it should be fine
+# to use master. This file, and its attribute in all-packages, can be removed
+# once rr makes a release.
 
 { callPackage, fetchFromGitHub }:
 
@@ -12,12 +11,12 @@ let
 in
 
   rr.overrideAttrs (old: {
-    version = "unstable-2020-10-04";
+    version = "unstable-2021-07-06";
 
     src = fetchFromGitHub {
       owner = "mozilla";
       repo = "rr";
-      rev = "9ff375813a740a0a6ebcdfcebc58bd61ab68c667";
-      sha256 = "0raifs6cg5ckpi2445inhy3hfhp4p89s1lkx9z17mcc2g1c1phf5";
+      rev = "0fc21a8d654dabc7fb1991d76343824cb7951ea0";
+      sha256 = "0s851rflxmvxcfw97zmplcwzhv86xmd3my78pi4c7gkj18d621i5";
     };
   })


### PR DESCRIPTION
It seems like the original reason for the rr-unstable package has gone stale, and there has been a proper release (5.4.0) since it was made. However, it has now been over 8 months since a release again, so I figured I would repurpose rr-unstable.

I personally need [this unreleased commit] to be able to use rr at all on an AMD Ryzen 5900X CPU.

[this unreleased commit]: https://github.com/rr-debugger/rr/pull/2762/commits/854b51effa25c7be3d6687ac0d6ef8afe9b3e3bb

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
