### PR TITLE
python3Packages.pep8-naming: fix tests

### DIFF
--- a/pkgs/development/python-modules/pep8-naming/default.nix
+++ b/pkgs/development/python-modules/pep8-naming/default.nix
@@ -1,6 +1,10 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder
+{ lib
+, fetchPypi
+, fetchpatch
+, buildPythonPackage
+, flake8
 , flake8-polyfill
-, importlib-metadata
+, python
 }:
 
 buildPythonPackage rec {
@@ -12,10 +16,27 @@ buildPythonPackage rec {
     sha256 = "0937rnk3c2z1jkdmbw9hfm80p5k467q7rqhn6slfiprs4kflgpd1";
   };
 
+  patches = [
+    (fetchpatch {
+      # Fix tests by setting extended-default-ignore to an empty list
+      url = "https://github.com/PyCQA/pep8-naming/commit/6d62db81d7967e123e29673a4796fefec6f06d26.patch";
+      sha256 = "1jpr2dga8sphksik3izyzq9hiszyki691mwnh2rjzd2vpgnv8cxf";
+    })
+  ];
+
   propagatedBuildInputs = [
+    flake8
     flake8-polyfill
-  ] ++ lib.optionals (pythonOlder "3.8") [
-    importlib-metadata
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} run_tests.py
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "pep8ext_naming"
   ];
 
   meta = with lib; {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Was broken when bumping flake8 to a version newer than 3.9.0, because
their tests "mock out things that are internal to Flake8".

https://github.com/PyCQA/pep8-naming/issues/171

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
