### PR TITLE
flann: refactor

### DIFF
--- a/pkgs/development/libraries/flann/default.nix
+++ b/pkgs/development/libraries/flann/default.nix
@@ -1,24 +1,58 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, unzip, cmake, python }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, unzip
+, cmake
+, python ? null
+, lz4
+, pkg-config
+, enablePython ? false
+}:
+
+assert enablePython -> python != null;
 
 stdenv.mkDerivation {
   name = "flann-1.9.1";
 
   src = fetchFromGitHub {
-    owner = "mariusmuja";
+    owner = "flann-lib";
     repo = "flann";
     rev = "1.9.1";
     sha256 = "13lg9nazj5s9a41j61vbijy04v6839i67lqd925xmxsbybf36gjc";
   };
 
   patches = [
-    # Upstream issue: https://github.com/mariusmuja/flann/issues/369
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/buildroot/buildroot/45a39b3e2ba42b72d19bfcef30db1b8da9ead51a/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch";
-      sha256 = "1gmj06cmnqvwxx649mxaivd35727wj6w7710zbcmmgmsnyfh2js4";
+      url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0001-Updated-fix-cmake-hdf5.patch";
+      sha256 = "yM1ONU4mu6lctttM5YcSTg8F344TNUJXwjxXLqzr5Pk=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0001-src-cpp-fix-cmake-3.11-build.patch";
+      sha256 = "REsBnbe6vlrZ+iCcw43kR5wy2o6q10RM73xjW5kBsr4=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/science-team/flann/-/raw/debian/1.9.1+dfsg-9/debian/patches/0003-Use-system-version-of-liblz4.patch";
+      sha256 = "xi+GyFn9PEjLgbJeAIEmsbp7ut9G9KIBkVulyT3nfsg=";
     })
   ];
 
-  nativeBuildInputs = [ unzip cmake python ];
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES:BOOL=OFF"
+    "-DBUILD_TESTS:BOOL=OFF"
+    "-DBUILD_MATLAB_BINDINGS:BOOL=OFF"
+    "-DBUILD_PYTHON_BINDINGS:BOOL=${if enablePython then "ON" else "OFF"}"
+  ];
+
+  nativeBuildInputs = [
+    unzip
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [] ++ lib.optionals enablePython [ python ];
+
+  propagatedBuildInputs = [ lz4 ];
 
   meta = {
     homepage = "http://people.cs.ubc.ca/~mariusm/flann/";

--- a/pkgs/development/libraries/flann/default.nix
+++ b/pkgs/development/libraries/flann/default.nix
@@ -10,12 +10,9 @@
 , enablePython ? false
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "flann";
   version = "1.9.1";
-
-in stdenv.mkDerivation {
-  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "flann-lib";

--- a/pkgs/development/libraries/flann/default.nix
+++ b/pkgs/development/libraries/flann/default.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , lz4
 , pkg-config
+, python3
 , stdenv
 , unzip
 , enablePython ? false
@@ -60,6 +61,8 @@ in stdenv.mkDerivation {
   ];
 
   propagatedBuildInputs = [ lz4 ];
+
+  buildInputs = lib.optionals enablePython [ python3 ];
 
   meta = {
     homepage = "http://people.cs.ubc.ca/~mariusm/flann/";


### PR DESCRIPTION
###### Motivation for this change

Flann is an important package in the robotics community, as it is a dependency of PCL, the pointcloud library. Unfortunately, it hasn't received a release since 2016 and the repo has accumulated a large number of open issues and PRs:

https://github.com/flann-lib/flann/tags

Most notably, the 1.9.1 release has an issue where it bundles a copy of the lz4 headers. This change piggy-backs on the already-reviewed patches used in the Debian version of the package, prepared by @jspricke.

###### Things done

I'm a first-time contributor, so I don't know exactly what is best here, but in my local clone of nixpkgs (on NixOS) I ran:

    nix build .#flann

And confirmed a successful build, with `enablePython` in both possible states.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Am running `nixpkgs-review pr 129491`, and so far I have the following failure:

```
nix log /nix/store/0gx2hycrlqdw8lmbh36yqiykmh5m9kj3-hugin-2019.0.0.drv
...
[ 70%] Linking CXX executable cpfind
/nix/store/scs241fp7dlrvm45d2fjbpjvygirn0ml-binutils-2.35.1/bin/ld: CMakeFiles/cpfind.dir/PanoDetectorLogic.cpp.o: undefined reference to symbol 'LZ4_compress_HC_continue'
/nix/store/scs241fp7dlrvm45d2fjbpjvygirn0ml-binutils-2.35.1/bin/ld: /nix/store/3nf85zf44vyvwr32hx53v7swljxysyjm-lz4-1.9.3/lib/liblz4.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

FYI @lopsided98 