### PR TITLE
{ryujinx,yuzu-ea,yuzu-mainline}: bump

### DIFF
--- a/pkgs/misc/emulators/ryujinx/deps.nix
+++ b/pkgs/misc/emulators/ryujinx/deps.nix
@@ -10,6 +10,11 @@
     sha256 = "1rjdxd4fq5z3n51qx8vrcaf4i277ccc62jxk88xzbsxapdmjjdf9";
   })
   (fetchNuGet {
+    name = "CommandLineParser";
+    version = "2.8.0";
+    sha256 = "1m32xyilv2b7k55jy8ddg08c20glbcj2yi545kxs9hj2ahanhrbb";
+  })
+  (fetchNuGet {
     name = "Concentus";
     version = "1.1.7";
     sha256 = "0y5z444wrbhlmsqpy2sxmajl1fbf74843lvgj3y6vz260dn2q0l0";
@@ -260,11 +265,6 @@
     sha256 = "0dkl9j0yd65s5ds9xj5z6yb7yca7wlycqz25m8dng20d13sqr1zp";
   })
   (fetchNuGet {
-    name = "ppy.SDL2-CS";
-    version = "1.0.225-alpha";
-    sha256 = "1x8hvk9kikwi7wrvwxdxk3pkbs491iss2mvqgiw844zld5izihqc";
-  })
-  (fetchNuGet {
     name = "runtime.any.System.Collections";
     version = "4.3.0";
     sha256 = "0bv5qgm6vr47ynxqbnkc7i797fdi8gbjjxii173syrx14nmrkwg0";
@@ -513,6 +513,11 @@
     name = "Ryujinx.Graphics.Nvdec.Dependencies";
     version = "4.4.0-build7";
     sha256 = "0g1l3lgs0ffxp64ka81v6q1cgsdirl1qlf73255v29r3v337074m";
+  })
+  (fetchNuGet {
+    name = "Ryujinx.SDL2-CS";
+    version = "2.0.15-build11";
+    sha256 = "0s4h69l2b508l5wxp4v4ip8k83k78p3963xxv8bfamin9517przi";
   })
   (fetchNuGet {
     name = "SharpZipLib";

--- a/pkgs/misc/emulators/yuzu/default.nix
+++ b/pkgs/misc/emulators/yuzu/default.nix
@@ -4,25 +4,25 @@ let
 in {
   mainline = libsForQt5.callPackage ./base.nix rec {
     pname = "yuzu-mainline";
-    version = "633";
+    version = "679";
     branchName = branch;
     src = fetchFromGitHub {
       owner = "yuzu-emu";
       repo = "yuzu-mainline";
       rev = "mainline-0-${version}";
-      sha256 = "1zq20dd6x3kk179ls7y3mc5rj9vr73qs12bdj52bl3kscphxybf1";
+      sha256 = "1wkxkgfff5nn30mn2pqcrlsr7fja6bgaallsx1ainlcbamfyspcz";
       fetchSubmodules = true;
     };
   };
   early-access = libsForQt5.callPackage ./base.nix rec {
     pname = "yuzu-ea";
-    version = "1704";
+    version = "1855";
     branchName = branch;
     src = fetchFromGitHub {
       owner = "pineappleEA";
       repo = "pineapple-src";
       rev = "EA-${version}";
-      sha256 = "07pcldcmn8ammzbnxki6by7hgacr6z0548dvhv2p5lp9qcf3xz22";
+      sha256 = "0civ63zi23cym3kii4v3aiqrsg2zzj0w6sp6sa14ixysagqxsd4a";
     };
   };
 }.${branch}


### PR DESCRIPTION
###### Motivation for this change
This updates all Nintendo Switch emulators currently in nixpkgs.

For yuzu, I've removed a patch that aren't required anymore, together with the CMake flags from said patch. I've changed the formatting of the title bar, as they made some changes upstream. I've also added the `dontFixCmake` flag, as it made the build fail. Some bug on their end broke fetching the source archive, as described in #128239. It seems this got fixed with later versions.

Fixes: #128239

For Ryujinx, I've hacked around https://github.com/Ryujinx/Ryujinx/issues/2349. Not sure if there is a better solution for this? Closure size doesn't seem to have changed that much, but it would be nice to have this be removed from the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
