### PR TITLE
[Backport release-21.05] bore: init at 0.3.3 (#129295)

### DIFF
--- a/pkgs/tools/networking/bore/default.nix
+++ b/pkgs/tools/networking/bore/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, rustPlatform, fetchFromBitbucket, llvmPackages, Libsystem, SystemConfiguration, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bore";
+  version = "0.3.3";
+
+  src = fetchFromBitbucket {
+    owner = "delan";
+    repo = "nonymous";
+    rev = version;
+    sha256 = "0gws1f625izrb3armh6bay1k8l9p9csl37jx03yss1r720k4vn2x";
+  };
+
+  cargoSha256 = "1n09gcp1y885lz6g2f73zw3fd0fmv7nwlvaqba2yl0kylzk7naa6";
+  cargoBuildFlags = "-p ${pname}";
+
+  # FIXME can’t test --all-targets and --doc in a single invocation
+  cargoTestFlags = "--features std --all-targets --workspace";
+
+  nativeBuildInputs = [ installShellFiles ]
+    ++ lib.optional stdenv.isDarwin llvmPackages.libclang;
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    Libsystem
+    SystemConfiguration
+  ];
+
+  LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+
+  postInstall = ''
+    installManPage $src/bore/doc/bore.1
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    printf '\0\0\0\0\0\0\0\0\0\0\0\0' \
+    | $out/bin/bore --decode \
+    | grep -q ';; NoError #0 Query 0 0 0 0 flags'
+  '';
+
+  meta = with lib; {
+    description = "DNS query tool";
+    homepage = "https://crates.io/crates/bore";
+    license = licenses.isc;
+    maintainers = [ maintainers.delan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3705,6 +3705,11 @@ in
 
   age = callPackage ../tools/security/age { };
 
+  bore = callPackage ../tools/networking/bore {
+    inherit (darwin) Libsystem;
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
+  };
+
   brotli = callPackage ../tools/compression/brotli { };
 
   biosdevname = callPackage ../tools/networking/biosdevname { };


### PR DESCRIPTION
(cherry picked from commit 8eb54b8e0907ce37ba0eeeacfb67676d42d857bc)


* [x] Before merging, ensure that this backport complies with the Criteria for Backporting.
    * Even as a non-commiter, if you find that it does not comply, leave a comment.