### PR TITLE
dnd-tools: init at unstable-2021-02-18

### DIFF
--- a/pkgs/applications/misc/dnd-tools/default.nix
+++ b/pkgs/applications/misc/dnd-tools/default.nix
@@ -1,0 +1,28 @@
+{ python3, fetchFromGitHub, fetchpatch, lib }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "dnd-tools";
+  version = "unstable-2021-02-18";
+
+  src = fetchFromGitHub {
+    owner = "savagezen";
+    repo = pname;
+    rev = "baefb9e4b4b8279be89ec63d256dde9704dee078";
+    sha256 = "1rils3gzbfmwvgy51ah77qihwwbvx50q82lkc1kwcb55b3yinnmj";
+  };
+
+  # gives warning every time unless patched, see https://github.com/savagezen/dnd-tools/pull/20
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/savagezen/dnd-tools/commit/0443f3a232056ad67cfb09eb3eadcb6344659198.patch";
+      sha256 = "00k8rsz2aj4sfag6l313kxbphcb5bjxb6z3aw66h26cpgm4kysp0";
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savagezen/dnd-tools";
+    description = "A set of interactive command line tools for Dungeons and Dragons 5th Edition";
+    license = licenses.agpl3Only;
+    maintainers = [ maintainers.urlordjames ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23471,6 +23471,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  dnd-tools = callPackage ../applications/misc/dnd-tools { };
+
   inherit (callPackage ../applications/virtualization/docker {})
     docker_20_10;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
resolve #128076 because it's a pretty trivial package

#### things I may have done wrong:
- Upstream's `setup.py` says the version is `0.1.5`, but this has not been updated since 2018, so I use short commit sha instead.  I'm not sure if this is the proper way to do this.
- I'm not entirely sure what the difference between `licenses.agpl3Only` and `licenses.agpl3Plus` is, so the license is potentially inaccurate.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).