### PR TITLE
xcolor: fix build

### DIFF
--- a/pkgs/tools/graphics/xcolor/default.nix
+++ b/pkgs/tools/graphics/xcolor/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, pkg-config, libX11, libXcursor, libxcb, python3 }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, pkg-config, libX11, libXcursor, libxcb, python3 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "xcolor";
@@ -11,7 +11,15 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-rHqK05dN5lrvDNbRCWGghI7KJwWzNCuRDEThEeMzmio=";
   };
 
-  cargoSha256 = "sha256-lHOT/P1Sh1b53EkPIQM3l9Tozdqh60qlUDdjthj32jM=";
+  cargoPatches = [
+    # Update Cargo.lock, lexical_core doesn't build on Rust 1.52.1
+    (fetchpatch {
+      url = "https://github.com/Soft/xcolor/commit/324d80a18a39a11f2f7141b226f492e2a862d2ce.patch";
+      sha256 = "sha256-5VzXitpl/gMef40UQBh1EoHezXPyB08aflqp0mSMAVI=";
+    })
+  ];
+
+  cargoSha256 = "sha256-yD4pX+dCJvbDecsdB8tNt1VsEcyAJxNrB5WsZUhPGII=";
 
   nativeBuildInputs = [ pkg-config python3 ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://hydra.nixos.org/eval/1684571?filter=xcolor&compare=1684461&full=#tabs-still-fail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
