### PR TITLE
firefox: add PGO support

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -2,15 +2,29 @@
 
 let
   common = opts: callPackage (import ./common.nix opts) {};
+
+  fetchPGO = { rev, channel, sha512 }: fetchurl {
+    curlOpts = [ "--location" "--fail" ];
+    url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.${channel}.revision.${rev}.firefox.linux64-profile/artifacts/public/build/profdata.tar.xz";
+    inherit sha512;
+    passthru = { inherit rev; };
+  };
 in
 
 rec {
   firefox = common rec {
     pname = "firefox";
     ffversion = "89.0.2";
+    rev = "9fcea995d1dabc5a4f4ef3811dc0e6e00d88cbe3";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
       sha512 = "ffd98ab0887611c5b4aba68346c49a7a31a58150fd8bbae610a4d941c4cff0acef0daaebfbb577787a759b4c1ef3c1199f02681148612f4f5b709983e07e0ccb";
+      passthru = { inherit rev; };
+    };
+    pgodata = fetchPGO {
+      inherit rev;
+      channel = "mozilla-release";
+      sha512 = "f5da4555cf37ad92e03c72c90b42e3a3d59039ec0785019af335c1573c42a6e7f547e163a1a37244d6214d7e57530a51e557718638d0ed1075a73ea0b6a3f972";
     };
 
     meta = {
@@ -33,9 +47,16 @@ rec {
   firefox-esr-78 = common rec {
     pname = "firefox-esr";
     ffversion = "78.11.0esr";
+    rev = "01d6500ecb254baea73ebad2fb3d29f182046952";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
       sha512 = "d02fc2eda587155b1c54ca12a6c5cde220a29f41f154f1c9b71ae8f966d8cc9439201a5b241e03fc0795b74e2479f7aa5d6b69f70b7639432e5382f321f7a6f4";
+      passthru = { inherit rev; };
+    };
+    pgodata = fetchPGO {
+      inherit rev;
+      channel = "mozilla-esr78";
+      sha512 = "fa88abb045de1f9fc8d40376f259eefcf8bb827d5a90fc6777421dedff9037962671a867a4b8779993e2f801343544e2fb0706b21ef0c9ba8ebd910a94057e7b";
     };
 
     meta = {

--- a/pkgs/development/compilers/rust/1_51.nix
+++ b/pkgs/development/compilers/rust/1_51.nix
@@ -1,0 +1,58 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, makeRustPlatform
+, llvmPackages_11, llvm_11
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.51.0";
+  rustcSha256 = "0ixqkqglv3isxbvl4ldr4byrkx692wghsz3fasy1pn5kr2prnsvs";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_11.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages_11.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_11.libllvm.override { enableSharedLibraries = true; };
+
+  llvmBootstrapForDarwin = llvmPackages_11;
+
+  # For use at runtime
+  llvmShared = llvm_11.override { enableSharedLibraries = true; };
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.50.0";
+
+  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "dee56dc425ed5d8e8112f26fba3060fd324c49f1261e0b7e8e29f7d9b852b09a";
+    x86_64-unknown-linux-gnu = "fa889b53918980aea2dea42bfae4e858dcb2104c6fdca6e4fe359f3a49767701";
+    x86_64-unknown-linux-musl = "867cbfb35f5dc9b43e230132ea9e7bfa98d471a9248e41b08ced2266e5ccd00f";
+    arm-unknown-linux-gnueabihf = "1b72979244450e4047ab536448d6720699e1fae0ab1c4ade114099a3037e274b";
+    armv7-unknown-linux-gnueabihf = "f1dde566c4e6ca2e1133c84170e46e566765a21894e1038e1cdc32745d7274ef";
+    aarch64-unknown-linux-gnu = "1db7a4fbddc68cd29eb9bca9fa7d0d2d9e3d59ede7ddaad66222fb4336a6bacf";
+    aarch64-unknown-linux-musl = "adcc6c76a8967bacb6687b565d3cf739e35fde066b03edb745b05b52fa8b5b36";
+    x86_64-apple-darwin = "1bf5a7ecf6468ce1bf9fe49c8083b3f648b40c16fbfb7539d106fe28eb0e792e";
+    aarch64-apple-darwin = "1ed91a867e7b86cc4bc84c0838240f1c25acd007100ec9f7a14c4873e4b56561";
+    powerpc64le-unknown-linux-gnu = "e0472589d3f9ba7ebf27f033af320e0d5cfb70222955bd8ed73ce2c9a70ae535";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_51;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_11" "llvm_11"])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11888,6 +11888,12 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
     llvm_10 = llvmPackages_10.libllvm;
   };
+  # Needed so Firefox PGO profiles can be reused when building
+  # firefox.
+  rust_1_51 = callPackage ../development/compilers/rust/1_51.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    llvm_11 = llvmPackages_11.libllvm;
+  };
   rust_1_53 = callPackage ../development/compilers/rust/1_53.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
     llvm_12 = llvmPackages_12.libllvm;
@@ -11899,6 +11905,7 @@ in
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
   rustPackages_1_45 = rust_1_45.packages.stable;
+  rustPackages_1_51 = rust_1_51.packages.stable;
   rustPackages_1_53 = rust_1_53.packages.stable;
   rustPackages = rustPackages_1_53;
 


### PR DESCRIPTION
This is a draft PR which hopefully will eventually be able to be merged to close issue #76484.

As it stands, I have not built these changes but assume they work as I tested something similar in the past. The biggest issue blocking this is having the hashes for the pgodata get automatically updated. Any insight is appreciated. I am still unsure if how I am going about doing this is even the best way. I have considered making separate packages entirely for the pgodata but exposing them at the top-level seems wrong but that seems to be the only way to update them using the `update-source-version`.