### PR TITLE
ocamlPackages.getopt: init at 20120615

### DIFF
--- a/pkgs/development/ocaml-modules/getopt/default.nix
+++ b/pkgs/development/ocaml-modules/getopt/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, ocaml, findlib, ocamlbuild }:
+
+stdenv.mkDerivation {
+  pname = "getopt";
+  version = "20120615";
+
+  src = builtins.fetchurl {
+    url = https://download.ocamlcore.org/ocaml-getopt/ocaml-getopt/20120615/ocaml-getopt-20120615.tar.gz;
+    sha256 = "1rz2mi3gddwpd249bvz6h897swiajk4d6cczrsscibwpkmdvrfwa";
+  };
+
+  buildInputs = [
+    ocaml
+    findlib
+    ocamlbuild
+  ];
+
+  doCheck = true;
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = "https://github.com/gildor478/ocaml-getopt";
+    description = "Parsing of command line arguments (similar to GNU GetOpt) for OCaml";
+    licence = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -397,6 +397,8 @@ let
 
     genspio = callPackage ../development/ocaml-modules/genspio { };
 
+    getopt = callPackage ../development/ocaml-modules/getopt { };
+
     gmap = callPackage ../development/ocaml-modules/gmap { };
 
     gnuplot = callPackage ../development/ocaml-modules/gnuplot {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a continuation of PR #129444 and #129509 which are prerequisites to make LIGO build under nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
