### PR TITLE
ocamlPackages.lwt-canceler: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/lwt-canceler/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-canceler/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitLab, buildDunePackage, lwt }:
+
+buildDunePackage rec {
+  pname = "lwt-canceler";
+  version = "0.2";
+
+  src = fetchFromGitLab {
+    owner = "nomadic-labs";
+    repo = "lwt-canceler";
+    rev = "v${version}";
+    sha256 = "07931486vg83sl1c268i0vyw61l8n8xs2krjsj43070zljqi8rf1";
+  };
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    lwt
+  ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://gitlab.com/nomadic-labs/lwt-canceler";
+    description = "Cancellation synchronization object";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -612,6 +612,8 @@ let
       ocaml-migrate-parsetree = ocaml-migrate-parsetree-2;
     };
 
+    lwt-canceler = callPackage ../development/ocaml-modules/lwt-canceler { };
+
     ocaml_lwt = lwt;
 
     lwt_camlp4 = callPackage ../development/ocaml-modules/lwt/camlp4.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a continuation of PR #129444, #129509, and #129511 which are prerequisites to make LIGO build under nix.
The version is the specific version that LIGO needs that's why it's not the latest on opam.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
