### PR TITLE
ocamlPackages.uecc: init at 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/uecc/default.nix
+++ b/pkgs/development/ocaml-modules/uecc/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitLab, buildDunePackage, bigstring, alcotest, cstruct, hex }:
+
+buildDunePackage rec {
+  pname = "uecc";
+  version = "0.3";
+
+  src = fetchFromGitLab {
+    owner = "nomadic-labs";
+    repo = "ocaml-uecc";
+    rev = "v${version}";
+    sha256 = "0m3cw34254baajscrwlrj0jp5n0yad3dhgi4jh3pz89iqykj15fr";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    bigstring
+  ];
+
+  checkInputs = [
+    alcotest
+    cstruct
+    hex
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Bindings for ECDH and ECDSA for 8-bit, 32-bit, and 64-bit processors";
+    homepage = https://gitlab.com/nomadic-labs/ocaml-uecc;
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1213,6 +1213,8 @@ let
 
     uchar = callPackage ../development/ocaml-modules/uchar { };
 
+    uecc = callPackage ../development/ocaml-modules/uecc { };
+
     utop = callPackage ../development/tools/ocaml/utop { };
 
     uuidm = callPackage ../development/ocaml-modules/uuidm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a continuation of PR #129444, #129509, #129511, and #129513 which are prerequisites to make LIGO build under nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
