### PR TITLE
gpick: init at 0.2.6

### DIFF
--- a/pkgs/tools/misc/gpick/default.nix
+++ b/pkgs/tools/misc/gpick/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, glib, boost, pkg-config, gtk3, ragel, lua, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "gpick";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "thezbyg";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "sha256-Z67EJRtKJZLoTUtdMttVTLkzTV2F5rKZ96vaothLiFo=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+  buildInputs = [ boost gtk3 ragel lua ];
+
+  meta = with lib; {
+    description = "Advanced color picker written in C++ using GTK+ toolkit";
+    homepage = "http://www.gpick.org/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.vanilla ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -295,6 +295,8 @@ in
 
   glade = callPackage ../development/tools/glade { };
 
+  gpick = callPackage ../tools/misc/gpick { };
+
   hobbes = callPackage ../development/tools/hobbes { };
 
   html5validator = python3Packages.callPackage ../applications/misc/html5validator { };


### PR DESCRIPTION
###### Motivation for this change
Gpick is an advanced color picker and palette editing tool.
-- quote from [gpick.org](http://www.gpick.org/)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
