### PR TITLE
mdbook: 0.4.9 -> 0.4.10

### DIFF
--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook";
-  version = "0.4.9";
+  version = "0.4.10";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "mdBook";
     rev = "v${version}";
-    sha256 = "sha256-wc3poiLnIHbbl0j2sWQkEbxccpohPnvjLPdNuKfsDSY=";
+    sha256 = "sha256-1Ddy/kb2Q7P+tzyEr3EC3qWm6MGSsDL3/vnPJLAm/J0=";
   };
 
-  cargoSha256 = "sha256-2DNfacPp9IMke2j8WYxpGmMxityaFGyXrc0jOyqPl3c=";
+  cargoSha256 = "sha256-x2BwnvEwTqz378aDE7OHWuEwNEsUnRudLq7sUJjHRpA=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 


### PR DESCRIPTION
###### Motivation for this change
Simple version update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
