### PR TITLE
vmalert: init

### DIFF
--- a/nixos/modules/services/monitoring/vmalert.nix
+++ b/nixos/modules/services/monitoring/vmalert.nix
@@ -1,0 +1,124 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.vmalert;
+  mkConfigFile =
+    pkgs.writeText "rules.yaml" (lib.generators.toYAML { } cfg.configuration);
+
+  checkedConfig = file:
+    pkgs.runCommand "checked-config" { buildInputs = [ cfg.package ]; } ''
+      ln -s ${file} $out
+    '';
+
+  vmalertRulesYAML = let
+    yml = if cfg.configText != null then
+      pkgs.writeText "rules.yaml" cfg.configText
+    else
+      mkConfigFile;
+  in checkedConfig yml;
+
+in {
+
+  options.services.vmalert = with lib; {
+
+    enable = mkEnableOption "vmalert";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.victoriametrics;
+      defaultText = "pkgs.victoriametrics";
+      description = ''
+        The VictoriaMetrics distribution to use.
+      '';
+    };
+
+    notifierUrls = mkOption {
+      type = types.listOf types.str;
+      default = [ "http://localhost:9093" ];
+      description = ''
+        AlertManager URL
+      '';
+    };
+
+    remoteWriteUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:8428";
+      description = ''
+        remote write compatible storage to persist rules
+      '';
+    };
+
+    remoteReadUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:8428";
+      description = ''
+        PromQL compatible datasource to restore alerts state from
+      '';
+    };
+
+    dataSourceUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:8428";
+      description = ''
+        PromQL compatible datasource
+      '';
+    };
+
+    configuration = mkOption {
+      type = types.nullOr types.attrs;
+      default = null;
+      description = ''
+        vmalert configuration as nix attribute set.
+      '';
+    };
+
+    configText = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      description = ''
+        Test
+      '';
+    };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Extra options to pass to Victoriametrics Alert. See the README: <link
+        xlink:href="https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmalert/README.md" />
+        or <command>vmalert -help</command> for more
+        information.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.vmalert = {
+      description = "vmalert";
+      after = [ "network.target" ];
+      preStart = ''
+        cp "${vmalertRulesYAML}" "/tmp/rules.yaml"
+      '';
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 1;
+        StartLimitBurst = 5;
+        StateDirectory = "vmalert";
+        DynamicUser = true;
+        ExecStart = ''
+          ${cfg.package}/bin/vmalert -rule /tmp/rules.yaml ${
+            lib.concatMapStrings
+            (notifierUrl: "-notifier.url=${toString notifierUrl}")
+            cfg.notifierUrls
+          } -datasource.url=${toString cfg.dataSourceUrl} -remoteWrite.url=${
+            toString cfg.remoteWriteUrl
+          } -remoteRead.url=${toString cfg.remoteReadUrl} ${
+            lib.escapeShellArgs cfg.extraOptions
+          }
+        '';
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Adding the vmalert service from the victriametrics package. This allows running vmalert as a standalone service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
