### PR TITLE
fulcio: init at 0.1.0

### DIFF
--- a/pkgs/tools/security/fulcio/default.nix
+++ b/pkgs/tools/security/fulcio/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "fulcio";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "sigstore";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-+HWzhg+LTKpr9VJ9mzQghwOuGgp3EBb4/zltaqp0zHw=";
+  };
+  vendorSha256 = "sha256-1tR1vUm5eFBS93kELQoKWEyFlfMF28GBI8VEHxTyeM4=";
+
+  ldflags = [ "-s" "-w" ];
+
+  # Install completions post-install
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd fulcio \
+      --bash <($out/bin/fulcio completion bash) \
+      --fish <($out/bin/fulcio completion fish) \
+      --zsh <($out/bin/fulcio completion zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/fulcio --help
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sigstore/fulcio";
+    changelog = "https://github.com/sigstore/fulcio/releases/tag/${version}";
+    description = "A Root-CA for code signing certs - issuing certificates based on an OIDC email address";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lesuisse jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4946,6 +4946,8 @@ in
 
   fswebcam = callPackage ../os-specific/linux/fswebcam { };
 
+  fulcio = callPackage ../tools/security/fulcio { };
+
   fuseiso = callPackage ../tools/filesystems/fuseiso { };
 
   fusuma = callPackage ../tools/inputmethods/fusuma {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package sigstore fulcio `0.1.0` for nixpkgs

@LeSuisse - added you as a maintainer :smiley: 

I've ran the binary, help, and I've fed it a cert and it served fine `./result/bin/fulcio serve --ca ~/dloads/fuclio_cert.pem` but I haven't done any further interactions yet

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
