### PR TITLE
nat: init at 2.1.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12036,4 +12036,10 @@
     github = "zupo";
     githubId = 311580;
   };
+  tejasag = {
+    name = "Tejas Agarwal";
+    email = "tejas.agarwal.bly@gmail.com";
+    github = "tejasag";
+    githubId = "67542663";
+  };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12040,6 +12040,6 @@
     name = "Tejas Agarwal";
     email = "tejas.agarwal.bly@gmail.com";
     github = "tejasag";
-    githubId = "67542663";
+    githubId = 67542663;
   };
 }

--- a/pkgs/tools/misc/nat/default.nix
+++ b/pkgs/tools/misc/nat/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nat";
+  version = "2.1.14";
+
+  src = fetchFromGitHub {
+    owner = "willdoescode";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256:0629nfcf43pzkx1rp6k1nr5sdpsjsgrs21f8yc7g20kxlnppc7z3";
+  };
+
+  cargoSha256 = "sha256:1kzsh8c1q51bfvpq13a1i74ss9yms4zjw8gxx2fggj69xhpy3pkg";
+
+  meta = with lib; {
+    description = "`ls` alternative with useful info and a splash of color art";
+    homepage = "https://github.com/willdoescode/nat";
+    license = licenses.mit;
+    maintainers = [ maintainers.tejasag ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32208,4 +32208,6 @@ in
   zthrottle = callPackage ../tools/misc/zthrottle { };
 
   zktree = callPackage ../applications/misc/zktree {};
+
+  nat = callPackage ../tools/misc/nat { };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Nat is a fast, useful and aesthetic tool made to replace the native `ls` command
Source: https://github.com/willdoescode/nat

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
