### PR TITLE
python3Packages.aqualogic: 2.6 -> 3.3

### DIFF
--- a/pkgs/development/python-modules/aqualogic/default.nix
+++ b/pkgs/development/python-modules/aqualogic/default.nix
@@ -1,33 +1,36 @@
 { lib
+, aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pyserial
 , pytestCheckHook
+, websockets
 }:
 
 buildPythonPackage rec {
   pname = "aqualogic";
-  version = "2.6";
+  version = "3.3";
 
   src = fetchFromGitHub {
     owner = "swilson";
     repo = pname;
     rev = version;
-    sha256 = "sha256-dAC/0OjvrC8J/5pu5vcOKV/WqgkAlz0LuFl0up6FQRM=";
+    sha256 = "sha256-6YvkSUtBc3Nl/Ap3LjU0IKY2bE4k86XdSoLo+/c8dDs=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "allow-iobase-objects.patch";
-      url = "https://github.com/swilson/aqualogic/commit/185fe25a86c82c497a55c78914b55ed39f5ca339.patch";
-      sha256 = "072jrrsqv86bn3skibjc57111jlpm8pq2503997fl3h4v6ziwdxg";
-    })
+  propagatedBuildInputs = [
+    pyserial
+    websockets
   ];
 
-  propagatedBuildInputs = [ pyserial ];
+  checkInputs = [
+    aiohttp
+    pytestCheckHook
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  # With 3.3 the event loop is not terminated after the first test
+  # https://github.com/swilson/aqualogic/issues/9
+  doCheck = false;
 
   pythonImportsCheck = [ "aqualogic" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.3

Change log: https://github.com/swilson/aqualogic/compare/2.6...3.3

Tests are no passing (https://github.com/swilson/aqualogic/issues/9).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
