### PR TITLE
python3Packages.furl: 2.1.0 -> 2.1.2

### DIFF
--- a/pkgs/development/python-modules/furl/default.nix
+++ b/pkgs/development/python-modules/furl/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , flake8
 , orderedmultidict
 , pytestCheckHook
@@ -10,20 +9,12 @@
 
 buildPythonPackage rec {
   pname = "furl";
-  version = "2.1.0";
+  version = "2.1.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "08dnw3bs1mk0f1ccn466a5a7fi1ivwrp0jspav9arqpf3wd27q60";
+    sha256 = "sha256-99ujPq++59vIOWNTSyXnL4FsztSKxTGR7mC/zGKTORg=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "tests_overcome_bpo42967.patch";
-      url = "https://github.com/gruns/furl/files/6030371/tests_overcome_bpo42967.patch.txt";
-      sha256 = "1l0lxmcp9x73kxy0ky2bh7zxa4n1cf1qxyyax97n90d1s3dc7k2q";
-    })
-  ];
 
   propagatedBuildInputs = [
     orderedmultidict
@@ -33,11 +24,6 @@ buildPythonPackage rec {
   checkInputs = [
     flake8
     pytestCheckHook
-  ];
-
-  disabledTests = [
-     # see https://github.com/gruns/furl/issues/121
-    "join"
   ];
 
   pythonImportsCheck = [ "furl" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.2

Change log: https://github.com/gruns/furl/releases/tag/v2.1.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
