### PR TITLE
alsa-lib: 1.2.5 -> 1.2.5.1

### DIFF
--- a/pkgs/development/python-modules/aqualogic/default.nix
+++ b/pkgs/development/python-modules/aqualogic/default.nix
@@ -1,33 +1,36 @@
 { lib
+, aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pyserial
 , pytestCheckHook
+, websockets
 }:
 
 buildPythonPackage rec {
   pname = "aqualogic";
-  version = "2.6";
+  version = "3.3";
 
   src = fetchFromGitHub {
     owner = "swilson";
     repo = pname;
     rev = version;
-    sha256 = "sha256-dAC/0OjvrC8J/5pu5vcOKV/WqgkAlz0LuFl0up6FQRM=";
+    sha256 = "sha256-6YvkSUtBc3Nl/Ap3LjU0IKY2bE4k86XdSoLo+/c8dDs=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "allow-iobase-objects.patch";
-      url = "https://github.com/swilson/aqualogic/commit/185fe25a86c82c497a55c78914b55ed39f5ca339.patch";
-      sha256 = "072jrrsqv86bn3skibjc57111jlpm8pq2503997fl3h4v6ziwdxg";
-    })
+  propagatedBuildInputs = [
+    pyserial
+    websockets
   ];
 
-  propagatedBuildInputs = [ pyserial ];
+  checkInputs = [
+    aiohttp
+    pytestCheckHook
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  # With 3.3 the event loop is not terminated after the first test
+  # https://github.com/swilson/aqualogic/issues/9
+  doCheck = false;
 
   pythonImportsCheck = [ "aqualogic" ];
 

--- a/pkgs/development/python-modules/foolscap/default.nix
+++ b/pkgs/development/python-modules/foolscap/default.nix
@@ -2,39 +2,48 @@
 , buildPythonPackage
 , fetchPypi
 , mock
-, twisted
 , pyopenssl
+, pytestCheckHook
 , service-identity
+, twisted
 }:
 
 buildPythonPackage rec {
   pname = "foolscap";
-  version = "20.4.0";
+  version = "21.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0rbw9makjmawkcxnkkngybj3n14s0dnzn9gkqqq2krcm514kmlb9";
+    sha256 = "sha256-6dGFU4YNk1joXXZi2c2L84JtUbTs1ICgXfv0/EU2P4Q=";
   };
 
-  propagatedBuildInputs = [ mock twisted pyopenssl service-identity ];
+  propagatedBuildInputs = [
+    mock
+    twisted
+    pyopenssl
+    service-identity
+  ];
 
-  checkPhase = ''
-    # Either uncomment this, or remove this custom check phase entirely, if
-    # you wish to do battle with the foolscap tests. ~ C.
-    # trial foolscap
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Not all dependencies are present
+    "src/foolscap/test/test_connection.py"
+  ];
+
+  pythonImportsCheck = [ "foolscap" ];
 
   meta = with lib; {
-    homepage = "http://foolscap.lothar.com/";
-    description = "Foolscap, an RPC protocol for Python that follows the distributed object-capability model";
+    description = "RPC protocol for Python that follows the distributed object-capability model";
     longDescription = ''
-      "Foolscap" is the name for the next-generation RPC protocol,
-      intended to replace Perspective Broker (part of Twisted).
-      Foolscap is a protocol to implement a distributed
-      object-capabilities model in Python.
+      "Foolscap" is the name for the next-generation RPC protocol, intended to
+      replace Perspective Broker (part of Twisted). Foolscap is a protocol to
+      implement a distributed object-capabilities model in Python.
     '';
-    # See http://foolscap.lothar.com/trac/browser/LICENSE.
+    homepage = "https://github.com/warner/foolscap";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/os-specific/linux/alsa-project/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-lib/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "alsa-lib";
-  version = "1.2.5";
+  version = "1.2.5.1";
 
   src = fetchurl {
     url = "mirror://alsa/lib/${pname}-${version}.tar.bz2";
-    sha256 = "067ga0l6zr782kw8jdsqvbb20pcgnl0vkpnnz2n36fq8ii58k4lh";
+    sha256 = "13j367ris25czx8xfjln7hqj6s8a1i99v29zvqsg5jnfa3cj3132";
   };
 
   patches = [

--- a/pkgs/tools/misc/uutils-coreutils/default.nix
+++ b/pkgs/tools/misc/uutils-coreutils/default.nix
@@ -5,6 +5,7 @@
 , cargo
 , sphinx
 , Security
+, libiconv
 , prefix ? "uutils-"
 , buildMulticallBinary ? true
 }:
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ rustPlatform.cargoSetupHook sphinx ];
 
-  buildInputs = lib.optional stdenv.isDarwin Security;
+  buildInputs = lib.optionals stdenv.isDarwin [ Security libiconv ];
 
   makeFlags = [
     "CARGO=${cargo}/bin/cargo"


### PR DESCRIPTION
###### Motivation for this change

Fixes musl build:

https://git.alsa-project.org/?p=alsa-lib.git;a=commit;h=abe805ed6c7f38e48002e575535afd1f673b9bcd

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
