### PR TITLE
nixos/thelounge: private -> public

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -237,6 +237,13 @@
           set <literal>autoSubUidGidRange = true</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>services.thelounge.private</literal> was removed in
+          favor of <literal>services.thelounge.public</literal>, to
+          follow with upstream changes.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -79,6 +79,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Normal users (with `isNormalUser = true`) which have non-empty `subUidRanges` or `subGidRanges` set no longer have additional implicit ranges allocated. To enable automatic allocation back set `autoSubUidGidRange = true`.
 
+- `services.thelounge.private` was removed in favor of `services.thelounge.public`, to follow with upstream changes.
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.thelounge;
   dataDir = "/var/lib/thelounge";
   configJsData = "module.exports = " + builtins.toJSON (
-    { private = cfg.private; port = cfg.port; } // cfg.extraConfig
+    { inherit (cfg) public port; } // cfg.extraConfig
   );
   pluginManifest = {
     dependencies = builtins.listToAttrs (builtins.map (pkg: { name = getName pkg; value = getVersion pkg; }) cfg.plugins);
@@ -20,14 +20,17 @@ let
   '';
 in
 {
+  imports = [ (mkRemovedOptionModule [ "services" "thelounge" "private" ] "The option was renamed to `services.thelounge.public` to follow upstream changes.") ];
+
   options.services.thelounge = {
     enable = mkEnableOption "The Lounge web IRC client";
 
-    private = mkOption {
+    public = mkOption {
       type = types.bool;
       default = false;
       description = ''
-        Make your The Lounge instance private. You will need to configure user
+        Make your The Lounge instance public.
+        Setting this to <literal>false</literal> will require you to configure user
         accounts by using the (<command>thelounge</command>) command or by adding
         entries in <filename>${dataDir}/users</filename>. You might need to restart
         The Lounge after making changes to the state directory.
@@ -79,7 +82,9 @@ in
       group = "thelounge";
       isSystemUser = true;
     };
+
     users.groups.thelounge = { };
+
     systemd.services.thelounge = {
       description = "The Lounge web IRC client";
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`services.thelounge.private` not taking into effect with, systemd logs saying it's an unknown option.

```
Jul 07 23:53:42 superfluous systemd[1]: Started The Lounge web IRC client.
Jul 07 23:53:42 superfluous thelounge[305760]: 2021-07-07 15:53:42 [WARN] Unknown key "private", please verify your config.
Jul 07 23:53:42 superfluous thelounge[305760]: 2021-07-07 15:53:42 [WARN] Config file owner does not match the user you are currently running The Lounge as.
Jul 07 23:53:42 superfluous thelounge[305760]: 2021-07-07 15:53:42 [WARN] To prevent any issues, please run thelounge commands as the correct user that owns the config folder.
Jul 07 23:53:42 superfluous thelounge[305760]: 2021-07-07 15:53:42 [WARN] See https://thelounge.chat/docs/usage#using-the-correct-system-user for more information.
Jul 07 23:53:43 superfluous thelounge[305760]: 2021-07-07 15:53:43 [INFO] The Lounge v4.2.0 (Node.js 14.17.3 on linux x64)
Jul 07 23:53:43 superfluous thelounge[305760]: 2021-07-07 15:53:43 [INFO] Configuration file: /var/lib/thelounge/config.js
Jul 07 23:53:43 superfluous thelounge[305760]: 2021-07-07 15:53:43 [INFO] Available at http://[::]:9000/ in private mode
Jul 07 23:53:43 superfluous thelounge[305760]: 2021-07-07 15:53:43 [INFO] New VAPID key pair has been generated for use with push subscription.
Jul 07 23:53:43 superfluous thelounge[305760]: 2021-07-07 15:53:43 [INFO] There are currently no users. Create one with thelounge add <name>.
```

It seems that the config option has been renamed to `public` in later versions of The Lounge, but the module wasn't updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
