### PR TITLE
ponyc: 0.41.1 -> 0.42.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.41.1";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "02wx070cy1193xzv58vh79yzwgpqiayqlwd3i285698fppbcg69a";
+    sha256 = "1s8glmzz0g5lj1fjwwy4m3n660smiq5wl9r1lg686wqh42hcgnsy";
 
 # Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
 # LLVM.  (The submodule is a specific tag in the LLVM source tree).

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,21 +1,21 @@
---- a/lib/CMakeLists.txt	2021-05-27 15:58:36.819331229 -0400
-+++ b/lib/CMakeLists.txt	2021-05-27 16:00:19.768268649 -0400
-@@ -10,12 +10,12 @@
+--- a/lib/CMakeLists.txt.orig	2021-07-07 13:40:20.209410160 -0400
++++ a/lib/CMakeLists.txt	2021-07-07 13:43:11.886969662 -0400
+@@ -15,12 +15,12 @@
  endif()
  
  ExternalProject_Add(gbenchmark
--    URL https://github.com/google/benchmark/archive/v1.5.2.tar.gz
-+    SOURCE_DIR gbenchmark-prefix/src/benchmark
+-    URL ${PONYC_GBENCHMARK_URL}
++	SOURCE_DIR gbenchmark-prefix/src/benchmark
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
  )
  
  ExternalProject_Add(googletest
 -    URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
-+    URL @googletest@
++	URL @googletest@
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=-fpic -Dgtest_force_shared_crt=ON --no-warn-unused-cli
  )
  
-@@ -28,75 +28,6 @@
+@@ -33,75 +33,6 @@
      COMPONENT library
  )
  


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Don't allow PONYPATH to override standard library [PR #3780](https://github.com/ponylang/ponyc/pull/3780) [Security Related]
* Fix bug where Flags.remove could set flags in addition to unsetting them [PR #3777](https://github.com/ponylang/ponyc/pull/3777)
* Allow Flags instances to be created with a set bit encoding [PR #3778](https://github.com/ponylang/ponyc/pull/3778)
* Fix "iftype" expressions not being usable in lambdas or object literals [PR #3763](https://github.com/ponylang/ponyc/pull/3763)
* Fix code generation for variadic FFI functions on arm64 [PR #3768](https://github.com/ponylang/ponyc/pull/3768)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
