### PR TITLE
oxen: init at 9.1.3

### DIFF
--- a/pkgs/applications/blockchains/oxen/default.nix
+++ b/pkgs/applications/blockchains/oxen/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, lib, fetchurl, fetchFromGitHub, fetchpatch
+, cmake, pkg-config
+, boost, openssl, unbound
+, pcsclite, readline, libsodium, hidapi
+, rapidjson
+, curl, sqlite
+, trezorSupport ? true
+, libusb1
+, protobuf
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "oxen";
+  version = "9.1.3";
+
+  src = fetchFromGitHub {
+    owner = "oxen-io";
+    repo = "oxen-core";
+    rev = "v${version}";
+    sha256 = "11g3wqn0syk47yfcsdql5737kpad8skwdxhifn2yaz9zy8n3xqqb";
+    fetchSubmodules = true;
+  };
+
+  # Required for static linking, the only supported install path
+  lbzmqsrc = fetchurl {
+    url = "https://github.com/zeromq/libzmq/releases/download/v4.3.3/zeromq-4.3.3.tar.gz";
+    sha512 = "4c18d784085179c5b1fcb753a93813095a12c8d34970f2e1bfca6499be6c9d67769c71c68b7ca54ff181b20390043170e89733c22f76ff1ea46494814f7095b1";
+  };
+
+  postPatch = ''
+    # remove vendored libraries
+    rm -r external/rapidjson
+    sed -i s,/lib/,/lib64/, external/loki-mq/cmake/local-libzmq//LocalLibzmq.cmake
+  '';
+
+  postInstall = ''
+    rm -R $out/lib $out/include
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    boost openssl unbound
+    pcsclite readline
+    libsodium hidapi rapidjson
+    protobuf curl sqlite
+  ] ++ lib.optionals trezorSupport [ libusb1 protobuf python3 ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    # "-DUSE_DEVICE_TREZOR=ON"
+    # "-DBUILD_GUI_DEPS=ON"
+    "-DReadline_ROOT_DIR=${readline.dev}"
+    # It build with shared libs but doesn't install them. Fail.
+    # "-DBUILD_SHARED_LIBS=ON"
+    "-DLIBZMQ_TARBALL_URL=${lbzmqsrc}"
+  ] ++ lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
+
+  meta = with lib; {
+    description = "Private cryptocurrency based on Monero";
+    homepage    = "https://oxen.io/";
+    license     = licenses.bsd3;
+    platforms   = platforms.all;
+    maintainers = [ maintainers.viric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28347,6 +28347,10 @@ in
     boost = boost17x;
   };
 
+  oxen = callPackage ../applications/blockchains/oxen {
+    boost = boost17x;
+  };
+
   monero-gui = libsForQt5.callPackage ../applications/blockchains/monero-gui {
     boost = boost17x;
   };


### PR DESCRIPTION
Based on Monero expression

###### Motivation for this change

Add the oxen wallet

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
