### PR TITLE
soapysdr: fix CMAKE_INSTALL_LIBDIR for runtime module loading

### DIFF
--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -32,6 +32,7 @@ in stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_INSTALL_LIBDIR=lib" # needs relative path due to module path construction at runtime
   ] ++ lib.optional usePython "-DUSE_PYTHON_CONFIG=ON";
 
   postFixup = lib.optionalString (lib.length extraPackages != 0) ''


### PR DESCRIPTION
this sets the `CMAKE_INSTALL_LIBDIR` to `lib` (relative-path)
instead of the default absolute path. this is due to soapysdr
concatenating it with the value of `CMAKE_INSTALL_PREFIX` for
module discovery and which also is an absolute-path, leading
to an invalid "double-absolute" path.

###### Motivation for this change

I recently encountered problems in using gqrx with my SDRplay RSP1A, wherein SoapySDR didn't find the libsdrPlaySupport module and failed with `SoapySDR::Device::make() no match`.
After inspection with `strace` i found, that SoapySDR looks for modules in `/nix/store/p66f9qf80jlp9bcwvsri93vnbcwiim0i-soapysdr-0.8.0//nix/store/p66f9qf80jlp9bcwvsri93vnbcwiim0i-soapysdr-0.8.0/lib/SoapySDR/modules0.8`
The path seems definitively wrong as the prefix to the package directory is duplicated.
Looking into the [SoapySDR source](https://github.com/pothosware/SoapySDR/blob/master/lib/Modules.in.cpp#L126) shows, that - in the end - the library at runtime concatenates the values of `CMAKE_INSTALL_PREFIX` and `CMAKE_INSTALL_LIBDIR`, which both are absoulte paths in NixOS by default, if I understand that correctly, thus leading to the above invalid path.

Looking around in nixpkgs, I found multiple examples of setting `CMAKE_INSTALL_PREFIX` to `lib`, to avoid this problem. So I guess, this might be the correct solution to this problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
