### PR TITLE
dwm: support cross-compilation by setting proper CC

### DIFF
--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     in
     lib.optionalString (conf != null) "cp ${configFile} config.def.h";
 
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
   meta = with lib; {
     homepage = "https://dwm.suckless.org/";
     description = "An extremely fast, small, and dynamic window manager for X";


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation of dwm. This only requires setting the proper compiler.

Tested build using `nix-build -A pkgsCross.aarch64-multiplatform.dwm --arg config '{ contentAddressedByDefault = true; }'`. Also tested native compilation as well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> dwm: another window manager is already running
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
