### PR TITLE
Add Pslab python lib

### DIFF
--- a/pkgs/development/python-modules/pslab/default.nix
+++ b/pkgs/development/python-modules/pslab/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, numpy, pyserial, scipy
+, pytest-mock, pytest, coverage}:
+
+buildPythonPackage rec {
+  pname = "pslab";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "fossasia";
+    repo = "pslab-python";
+    rev = "v" + version;
+    sha256 = "12n2zdbgbhrnkgf1z7hlpvgl8zycvw3qxc6fhh1srkj6j2jwvr2n";
+  };
+
+  propagatedBuildInputs = [ numpy pyserial scipy ];
+  checkInputs = [ pytest pytest-mock coverage ];
+
+  # from tox.ini
+  checkPhase = ''
+    coverage run --source pslab -m pytest
+  '';
+
+  pythonImportsCheck = [ "pslab" ];
+
+  meta = with lib; {
+    description = "The Python library for the Pocket Science Lab from FOSSASIA";
+    homepage = "https://github.com/fossasia/pslab-python";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.viric ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5577,6 +5577,8 @@ in {
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
+  pslab = callPackage ../development/python-modules/pslab { };
+
   psutil = callPackage ../development/python-modules/psutil { };
 
   psycopg2 = callPackage ../development/python-modules/psycopg2 { };


### PR DESCRIPTION
###### Motivation for this change

Add the lib to interact with the pslab electronic board.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
