### PR TITLE
micromamba: init at 0.14.1

### DIFF
--- a/pkgs/tools/package-management/micromamba/default.nix
+++ b/pkgs/tools/package-management/micromamba/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetchFromGitHub, cmake
+, cli11, nlohmann_json, curl, libarchive, libyamlcpp, libsolv, reproc
+}:
+
+let
+  libsolv' = libsolv.overrideAttrs (oldAttrs: {
+    cmakeFlags = oldAttrs.cmakeFlags ++ [
+      "-DENABLE_CONDA=true"  # Maybe enable this in the original libsolv package? No idea about the implications.
+    ];
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "micromamba";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "mamba-org";
+    repo = "mamba";
+    rev = version;
+    sha256 = "0a5kmwk44ll4d8b2akjc0vm6ap9jfxclcw4fclvjxr2in3am9256";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    cli11
+    nlohmann_json
+    curl
+    libarchive
+    libyamlcpp
+    libsolv'
+    reproc
+    # python3Packages.pybind11 # Would be necessary if someone wants to build with bindings I guess.
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_BINDINGS=OFF" # Fails to build, I don't think it's necessary for now.
+    "-DBUILD_EXE=ON"
+  ];
+
+  CXXFLAGS = "-DMAMBA_USE_STD_FS";
+
+  meta = with lib; {
+    description = "Reimplementation of the conda package manager";
+    homepage = "https://github.com/mamba-org/mamba";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mausch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30938,6 +30938,8 @@ in
 
   mas = callPackage ../os-specific/darwin/mas { };
 
+  micromamba = callPackage ../tools/package-management/micromamba { };
+
   moltengamepad = callPackage ../misc/drivers/moltengamepad { };
 
   openzwave = callPackage ../development/libraries/openzwave { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Conda is a hot mess. 
Not only is it slow (which prompted the creation of [mamba / micromamba](https://github.com/mamba-org/mamba)) but also it is difficult to build and package, which has led to its [nix package being perennially out of date](https://github.com/NixOS/nixpkgs/issues/119832), as the package is build from the distribution and not from sources.

This has also caused complexity and oddities in how it's used. 
For example it requires a separate manual installation step by calling `conda-install`, which installs conda to ~/.conda by default. It requires a special FHS shell `conda-shell` that sets up some necessary environment variables.

Compared to Conda, Micromamba is:
- Simple to build (as evidenced by this PR)
- Much faster to resolve packages (like an order of magnitude faster)
- Installs like any other nix package, no separate manual installation step needed
- Does not require any special FHS to operate (though environments created by conda/mamba still require FHS to be _consumed_)
- Smaller (15MB only. miniconda-installer is 68MB)

After this gets merged I'll add a section about it in https://nixos.wiki/wiki/Python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
