### PR TITLE
apksigcopier: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/tools/apksigcopier/default.nix
+++ b/pkgs/development/tools/apksigcopier/default.nix
@@ -10,13 +10,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "apksigcopier";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "obfusk";
     repo = "apksigcopier";
     rev = "v${version}";
-    sha256 = "1la1ml91jvqc1zakbqfpayjbs67pi3i18bsgz3mf11rxgphd3fpk";
+    sha256 = "07ldq3q1x2lpb15q5s5i1pbg89sn6ah45amskm9pndqlh16z9k2x";
   };
 
   nativeBuildInputs = [ installShellFiles pandoc ];
@@ -42,12 +42,11 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "Copy/extract/patch apk signatures & compare apks";
+    description = "Copy/extract/patch android apk signatures & compare apks";
     longDescription = ''
-      apksigcopier is a tool for copying APK signatures from a signed APK
-      to an unsigned one (in order to verify reproducible builds).  It can
-      also be used to compare two APKs with different signatures.  Its
-      command-line tool offers four operations:
+      apksigcopier is a tool for copying android APK signatures from a signed APK to an unsigned one (in order to verify reproducible builds).
+      It can also be used to compare two APKs with different signatures.
+      Its command-line tool offers four operations:
 
       * copy signatures directly from a signed to an unsigned APK
       * extract signatures from a signed APK to a directory


### PR DESCRIPTION
###### Motivation for this change

* New version :sweat_smile:

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
