### PR TITLE
python3Packages.shellingham: 1.3.2 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/shellingham/default.nix
+++ b/pkgs/development/python-modules/shellingham/default.nix
@@ -1,18 +1,33 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "shellingham";
   version = "1.4.0";
   format = "pyproject";
+  disabled = pythonOlder "3.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-SFXCRY1pBIKb00wpnxH97tfP77+KLFIuTK6mzXazFx4=";
+  src = fetchFromGitHub {
+    owner = "sarugaku";
+    repo = pname;
+    rev = version;
+    sha256 = "0f686ym3ywjffis5jfqkhsshjgii64060hajysczflhffrjn9jcp";
   };
 
+  checkInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "shellingham" ];
+
   meta = with lib; {
-    description = "Tool to Detect Surrounding Shell";
+    description = "Tool to detect the surrounding shell";
     homepage = "https://github.com/sarugaku/shellingham";
     license = licenses.isc;
     maintainers = with maintainers; [ mbode ];

--- a/pkgs/development/python-modules/shellingham/default.nix
+++ b/pkgs/development/python-modules/shellingham/default.nix
@@ -3,12 +3,12 @@
 
 buildPythonPackage rec {
   pname = "shellingham";
-  version = "1.3.2";
+  version = "1.4.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "576c1982bea0ba82fb46c36feb951319d7f42214a82634233f58b40d858a751e";
+    sha256 = "sha256-SFXCRY1pBIKb00wpnxH97tfP77+KLFIuTK6mzXazFx4=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4.0

Change log: https://github.com/sarugaku/shellingham/blob/master/CHANGELOG.rst

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
