### PR TITLE
nixos/geoclue2: allow Phosh to use geoclue

### DIFF
--- a/nixos/modules/programs/phosh.nix
+++ b/nixos/modules/programs/phosh.nix
@@ -159,5 +159,10 @@ in {
       if builtins.isPath cfg.phocConfig then cfg.phocConfig
       else if builtins.isString cfg.phocConfig then pkgs.writeText "phoc.ini" cfg.phocConfig
       else pkgs.writeText "phoc.ini" (renderPhocConfig cfg.phocConfig);
+
+    services.geoclue2.appConfig."sm.puri.Phosh" = {
+      isAllowed = true;
+      isSystem = true;
+    };
   };
 }

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -10,7 +10,7 @@ let
 
   cfg = config.services.geoclue2;
 
-  defaultWhitelist = [ "gnome-shell" "io.elementary.desktop.agent-geoclue2" ];
+  defaultWhitelist = [ "gnome-shell" "io.elementary.desktop.agent-geoclue2" "sm.puri.Phosh" ];
 
   appConfigModule = types.submodule ({ name, ... }: {
     options = {


### PR DESCRIPTION
###### Motivation for this change
Allow Phosh to use geoclue, per:
* https://gitlab.freedesktop.org/geoclue/geoclue/-/commit/a9aea6a4948e2ff9ec5ff066cf20dac069c0d3a0 .
* https://source.puri.sm/Librem5/phosh/-/tags/v0.11.0

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
