### PR TITLE
powershell: Add keyutils

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -1,21 +1,37 @@
-{ stdenv, lib, autoPatchelfHook, fetchzip, libunwind, libuuid, icu, curl
-, darwin, makeWrapper, less, openssl_1_1, pam, lttng-ust }:
+{ stdenv
+, lib
+, autoPatchelfHook
+, fetchzip
+, libunwind
+, libuuid
+, icu
+, curl
+, darwin
+, makeWrapper
+, less
+, openssl_1_1
+, pam
+, lttng-ust
+, keyutils
+}:
 
-let archString = if stdenv.isAarch64 then "arm64"
-                 else if stdenv.isx86_64 then "x64"
-                 else throw "unsupported platform";
-    platformString = if stdenv.isDarwin then "osx"
-                     else if stdenv.isLinux then "linux"
-                     else throw "unsupported platform";
-    platformSha = if stdenv.isDarwin then "0w44ws8b6zfixf7xz93hmplqsx18279n9x8j77y4rbzs13fldvsn"
-                     else if (stdenv.isLinux && stdenv.isx86_64) then "0xm7l49zhkz2fly3d751kjd5cy3ws9zji9i0061lkd06dvkch7jy"
-                     else if (stdenv.isLinux && stdenv.isAarch64) then "1axbi4kmb1ydys7c45jhp729w1srid3c8jgivb4bdmdp56rf6h32"
-                     else throw "unsupported platform";
-    platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
-                     else if stdenv.isLinux then "LD_LIBRARY_PATH"
-                     else throw "unsupported platform";
-                     libraries = [ libunwind libuuid icu curl openssl_1_1 ] ++
-                       (if stdenv.isLinux then [ pam lttng-ust ] else [ darwin.Libsystem ]);
+let
+  archString = if stdenv.isAarch64 then "arm64"
+    else if stdenv.isx86_64 then "x64"
+    else throw "unsupported platform";
+  platformString = if stdenv.isDarwin then "osx"
+    else if stdenv.isLinux then "linux"
+    else throw "unsupported platform";
+  platformSha = if stdenv.isDarwin then "0w44ws8b6zfixf7xz93hmplqsx18279n9x8j77y4rbzs13fldvsn"
+    else if (stdenv.isLinux && stdenv.isx86_64) then "0xm7l49zhkz2fly3d751kjd5cy3ws9zji9i0061lkd06dvkch7jy"
+    else if (stdenv.isLinux && stdenv.isAarch64) then "1axbi4kmb1ydys7c45jhp729w1srid3c8jgivb4bdmdp56rf6h32"
+    else throw "unsupported platform";
+  platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
+    else if stdenv.isLinux then "LD_LIBRARY_PATH"
+    else throw "unsupported platform";
+  libraries = [ libunwind libuuid icu curl openssl_1_1 ]
+    ++ lib.optionals stdenv.isLinux [ pam lttng-ust keyutils ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.Libsystem ];
 in
 stdenv.mkDerivation rec {
   pname = "powershell";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Keyutils is needed to authenticate to Microsoft Graph (used with `Install-Module Microsoft.Graph -Scope CurrentUser`)

###### Things done
Added keyutils.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
