### PR TITLE
python3Packages.requests-cache: 0.6.4 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -1,52 +1,57 @@
 { lib
-, buildPythonPackage
-, pythonOlder
-, fetchFromGitHub
 , attrs
+, buildPythonPackage
+, cattrs
+, fetchFromGitHub
 , itsdangerous
-, requests
-, url-normalize
+, poetry-core
 , pytestCheckHook
+, pythonOlder
+, pyyaml
+, requests
 , requests-mock
+, rich
 , timeout-decorator
+, ujson
+, url-normalize
 }:
 
 buildPythonPackage rec {
   pname = "requests-cache";
-  version = "0.6.4";
-
+  version = "0.7.0";
   disabled = pythonOlder "3.6";
-
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "reclosedev";
     repo = "requests-cache";
     rev = "v${version}";
-    sha256 = "10rvs611j16kakqx38kpqpc1v0dfb9rmbz2whpskswb1lsksv3j9";
+    sha256 = "sha256-P7JzImidUXOD4DUMdfy3sgM5RISti23wNnLwDHPoiTA=";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     attrs
+    cattrs
     itsdangerous
+    pyyaml
     requests
+    ujson
     url-normalize
   ];
 
   checkInputs = [
     pytestCheckHook
     requests-mock
+    rich
     timeout-decorator
   ];
 
-  disabledTestPaths = [
-    # connect to database on localhost
-    "tests/integration/test_cache.py"
-    "tests/integration/test_dynamodb.py"
-    "tests/integration/test_gridfs.py"
-    "tests/integration/test_mongodb.py"
-    "tests/integration/test_redis.py"
-  ];
+  # Integration tests require local DBs
+  pytestFlagsArray = [ "tests/unit" ];
 
   pythonImportsCheck = [ "requests_cache" ];
 
@@ -54,5 +59,6 @@ buildPythonPackage rec {
     description = "Persistent cache for requests library";
     homepage = "https://github.com/reclosedev/requests-cache";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/tvdb_api/default.nix
+++ b/pkgs/development/python-modules/tvdb_api/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbr/tvdb_api";
     license = licenses.unlicense;
     maintainers = with maintainers; [ peterhoeg ];
+    # https://github.com/dbr/tvdb_api/issues/94
+    broken = true;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.7.0

Change log: https://github.com/reclosedev/requests-cache/blob/master/HISTORY.md#070-2021-07-07

`tvbd_api` doesn't support `requests-cache > 0.6.0` (https://github.com/dbr/tvdb_api/issues/94) yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
