### PR TITLE
foot: fix cross compilation

### DIFF
--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -15,6 +15,7 @@
 , scdoc
 , tllist
 , wayland-protocols
+, wayland-scanner
 , pkg-config
 , utf8proc
 , allowPgo ? true
@@ -77,7 +78,7 @@ let
   }."${compilerName}";
 
   # ar with lto support
-  ar = {
+  ar = stdenv.cc.bintools.targetPrefix + {
     "clang" = "llvm-ar";
     "gcc" = "gcc-ar";
     "unknown" = "ar";
@@ -97,19 +98,24 @@ stdenv.mkDerivation rec {
     sha256 = "0yrz7n0wls8g8w7ja934icwxmng3sxh70x87qmzc9c9cb1wyd989";
   };
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
+    wayland-scanner
     meson
     ninja
     ncurses
     scdoc
-    tllist
-    wayland-protocols
     pkg-config
   ] ++ lib.optionals (compilerName == "clang") [
     stdenv.cc.cc.libllvm.out
   ];
 
   buildInputs = [
+    tllist
+    wayland-protocols
     fontconfig
     freetype
     pixman


### PR DESCRIPTION
* needs PKG_CONFIG_FOR_BUILD

* in the non-native case we need wayland-scanner (build) and
  wayland-protocols (host) separately

* ar needs targetPrefix as well

Only tested compilation of `pkgsCross.aarch64-multiplatform.foot`, not execution.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
