### PR TITLE
apostrophe: fix HTML export by referencing fira fonts from store

### DIFF
--- a/pkgs/applications/editors/apostrophe/default.nix
+++ b/pkgs/applications/editors/apostrophe/default.nix
@@ -2,7 +2,7 @@
 , wrapGAppsHook, pkg-config, desktop-file-utils
 , appstream-glib, pythonPackages, glib, gobject-introspection
 , gtk3, webkitgtk, glib-networking, gnome, gspell, texlive
-, shared-mime-info, libhandy
+, shared-mime-info, libhandy, fira
 }:
 
 let
@@ -31,6 +31,12 @@ in stdenv.mkDerivation rec {
     glib-networking libhandy ];
 
   postPatch = ''
+    substituteInPlace data/media/css/web/base.css                                        \
+      --replace 'url("/app/share/fonts/FiraSans-Regular.ttf") format("ttf")'             \
+                'url("${fira}/share/fonts/opentype/FiraSans-Regular.otf") format("otf")' \
+      --replace 'url("/app/share/fonts/FiraMono-Regular.ttf") format("ttf")'             \
+                'url("${fira}/share/fonts/opentype/FiraMono-Regular.otf") format("otf")'
+
     patchShebangs --build build-aux/meson_post_install.py
   '';
 


### PR DESCRIPTION
pandoc can embed fonts and stylesheets on export which apostrophe uses —
however it has hardcoded paths for the fonts which only work in the
flatpak version, so we need to substitute them.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
