### PR TITLE
bind: Set and use user group with sane perms

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -406,7 +406,7 @@ in
       mpd = 50;
       clamav = 51;
       fprot = 52;
-      #bind = 53; # unused
+      bind = 53; # unused
       wwwrun = 54;
       adm = 55;
       spamd = 56;

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -406,7 +406,7 @@ in
       mpd = 50;
       clamav = 51;
       fprot = 52;
-      bind = 53; # unused
+      bind = 53;
       wwwrun = 54;
       adm = 55;
       spamd = 56;

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -231,7 +231,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        mkdir -m 7600 -p /etc/bind
+        mkdir -m 760 -p /etc/bind
         chown root:${bindGroup} /etc/bind
         if ! [ -f "/etc/bind/rndc.key" ]; then
           ${pkgs.bind.out}/sbin/rndc-confgen -c /etc/bind/rndc.key -u ${bindUser} -a -A hmac-sha256 2>/dev/null

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -236,15 +236,13 @@ in
         if ! [ -f "/etc/bind/rndc.key" ]; then
           ${pkgs.bind.out}/sbin/rndc-confgen -c /etc/bind/rndc.key -u ${bindUser} -a -A hmac-sha256 2>/dev/null
         fi
-
-        ${pkgs.coreutils}/bin/mkdir -p /run/named
-        chown root:${bindGroup} /run/named
       '';
 
       serviceConfig = {
         ExecStart = "${pkgs.bind.out}/sbin/named -u ${bindUser} ${optionalString cfg.ipv4Only "-4"} -c ${cfg.configFile} -f";
         ExecReload = "${pkgs.bind.out}/sbin/rndc -k '/etc/bind/rndc.key' reload";
         ExecStop = "${pkgs.bind.out}/sbin/rndc -k '/etc/bind/rndc.key' stop";
+        RuntimeDirectory = "${bindGroup}";
       };
 
       unitConfig.Documentation = "man:named(8)";

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -232,13 +232,13 @@ in
 
       preStart = ''
         mkdir -m 7600 -p /etc/bind
-        chown ${bindGroup} /etc/bind
+        chown root:${bindGroup} /etc/bind
         if ! [ -f "/etc/bind/rndc.key" ]; then
           ${pkgs.bind.out}/sbin/rndc-confgen -c /etc/bind/rndc.key -u ${bindUser} -a -A hmac-sha256 2>/dev/null
         fi
 
         ${pkgs.coreutils}/bin/mkdir -p /run/named
-        chown ${bindGroup} /run/named
+        chown root:${bindGroup} /run/named
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -214,8 +214,9 @@ in
 
     users = {
       groups = {
-        named = { };
-        gid = config.ids.gids.bind;
+        "${bindGroup}" = {
+          gid = config.ids.gids.bind;
+        };
       }
       users.${bindUser} = {
         uid = config.ids.uids.bind;


### PR DESCRIPTION
This allows system management on systems with multiple sysadmins without the need to set post-deployment scripts by allowing relevant users to have access to /etc/bind and /run/named

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
