### PR TITLE
mysql: 8.0.22 -> 8.0.25

### DIFF
--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, fetchurl, bison, cmake, pkg-config
 , boost, icu, libedit, libevent, lz4, ncurses, openssl, protobuf, re2, readline, zlib, zstd
-, numactl, perl, cctools, CoreServices, developer_cmds, libtirpc, rpcsvc-proto
+, numactl, perl, cctools, CoreServices, developer_cmds, libtirpc, rpcsvc-proto, curl
 }:
 
 let
 self = stdenv.mkDerivation rec {
   pname = "mysql";
-  version = "8.0.22";
+  version = "8.0.25";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${self.mysqlVersion}/${pname}-${version}.tar.gz";
-    sha256 = "9fd85bb243940ef8234d21384ef421a0962fd4d13406fc1420efa902115ce17a";
+    sha256 = "c16aa9cf621bc028efba2bb11f3c36a323b125fa0d108ff92fab60e46309206e";
   };
 
   patches = [
@@ -27,7 +27,7 @@ self = stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    boost icu libedit libevent lz4 ncurses openssl protobuf re2 readline zlib
+    boost curl icu libedit libevent lz4 ncurses openssl protobuf re2 readline zlib
     zstd
   ] ++ lib.optionals stdenv.isLinux [
     numactl libtirpc

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19838,7 +19838,7 @@ in
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     boost = boost173; # Configure checks for specific version.
-    protobuf = protobuf3_7;
+    protobuf = protobuf3_11;
     icu =  icu67;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Package update. Closes #129551 

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
