### PR TITLE
dkh: init at 1.2

### DIFF
--- a/pkgs/applications/science/chemistry/dkh/default.nix
+++ b/pkgs/applications/science/chemistry/dkh/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, gfortran, fetchFromGitHub, cmake } :
+
+stdenv.mkDerivation rec {
+  pname = "dkh";
+  version = "1.2";
+
+  src = fetchFromGitHub  {
+    owner = "psi4";
+    repo = pname;
+    rev = "v${version}";
+    sha256= "1wb4qmb9f8rnrwnnw1gdhzx1fmhy628bxfrg56khxy3j5ljxkhck";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    cmake
+  ];
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  hardeningDisable = [
+    "format"
+  ];
+
+  meta = with lib; {
+    description = "Arbitrary-order scalar-relativistic Douglas-Kroll-Hess module";
+    license = licenses.lgpl3Only;
+    homepage = "https://github.com/psi4/dkh";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29639,6 +29639,8 @@ in
     gstreamerSupport = true;
   });
 
+  dkh = callPackage ../applications/science/chemistry/dkh { };
+
   openmolcas = callPackage ../applications/science/chemistry/openmolcas { };
 
   pymol = callPackage ../applications/science/chemistry/pymol { };


### PR DESCRIPTION
###### Motivation for this change
Adds the small DKH software, which provides arbitrary order Douglas-Kroll-Hess transformations for relativistic quantum chemistry. Part of the packages @markuskowa and me want to merge from markuskowa/NixOS-QChem#56 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
