### PR TITLE
engauge-digitizer: init at 12.1

### DIFF
--- a/pkgs/applications/science/math/engauge-digitizer/default.nix
+++ b/pkgs/applications/science/math/engauge-digitizer/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchFromGitHub, fftw, libjpeg, log4cpp, openjpeg
+, libpng12, poppler, qtbase, qt5, qmake, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "engauge-digitizer";
+  version = "12.1";
+
+  src = fetchFromGitHub {
+    owner = "markummitchell";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12gflxqaa4w6vifwpaqwl0l3f9qq5pbrh45s1rpc584nmr0897a7";
+  };
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  buildInputs = [
+    qtbase
+    qt5.qttools
+    poppler
+    libpng12
+    openjpeg
+    openjpeg.dev
+    log4cpp
+    libjpeg
+    fftw
+  ];
+
+  qmakeFlags = [
+    "CONFIG+=jpeg2000"
+    "CONFIG+=pdf"
+    "CONFIG+=log4cpp_null"
+  ];
+
+  POPPLER_INCLUDE = "${poppler.dev}/include/poppler/qt5";
+
+  POPPLER_LIB = "${poppler}/lib";
+
+  OPENJPEG_INCLUDE = "${openjpeg.dev}/include/${openjpeg.pname}-${lib.versions.majorMinor openjpeg.version}";
+
+  OPENJPEG_LIB = "${openjpeg}/lib";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp bin/engauge $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Engauge Digitizer is a tool for recovering graph data from an image file";
+    homepage = "https://markummitchell.github.io/engauge-digitizer";
+    license = with licenses; [ gpl2Only ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4350,6 +4350,8 @@ in
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  engauge-digitizer = libsForQt5.callPackage ../applications/science/math/engauge-digitizer { };
+
   epubcheck = callPackage ../tools/text/epubcheck { };
 
   luckybackup = libsForQt5.callPackage ../tools/backup/luckybackup {


### PR DESCRIPTION
###### Motivation for this change
Adds engauge-digitizer, a handy tool for extracting the original data from graphs, that are only available as images otherwise.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
