### PR TITLE
wlroots: 0.14.0 -> 0.14.1

### DIFF
--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "103sf9bsyqw18kmaih11mlxwqi9ddymm95w1lfxz06pf69xwhd39";
+    sha256 = "1sshp3lvlkl1i670kxhwsb4xzxl8raz6769kqvgmxzcb63ns9ay1";
   };
 
   # $out for the library and $examples for the example programs (in examples):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/swaywm/wlroots/releases/tag/0.14.1

nixpkgs-review:
```
23 packages updated:
cage cagebreak dwl fuzzel grimshot hikari labwc nwg-panel qt-video-wlr river-unstable sway sway-unwrapped tinywl (0.14.0 → 0.14.1) waybar waybox-unstable wayfire wayfire wbg-unstable wcm wcm wf-shell wio wlroots (0.14.0 → 0.14.1)

23 packages built:
cage cagebreak dwl fuzzel hikari labwc nwg-panel qt-video-wlr river sway sway-contrib.grimshot sway-unwrapped tinywl waybar waybox wayfire wayfireApplications-unwrapped.wayfire wayfireApplications-unwrapped.wayfirePlugins.wf-shell wayfireApplications-unwrapped.wcm wbg wcm wio wlroots
```

VM tests:
```console
$ nix-build -A nixosTests.sway -A nixosTests.cage -A nixosTests.cagebreak
/nix/store/jzk1iimp9kpzxfjggms6yniiqar8nbwp-vm-test-run-sway
/nix/store/gv1zcwvbv8zrxb8jihksas5v5lwkvjba-vm-test-run-cage
/nix/store/asa56l4yyjqmq93k1cdbbw6a8lhfjv1x-vm-test-run-cagebreak
```

Briefly tested: tinywl, sway, cage, and cagebreak

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
