### PR TITLE
wshowkeys: Mark as broken

### DIFF
--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -35,5 +35,7 @@ in stdenv.mkDerivation rec {
     # TODO: gpl3Only or gpl3Plus (ask upstream)?
     platforms = platforms.unix;
     maintainers = with maintainers; [ primeos berbiche ];
+    broken = true; # Unmaintained and fails to run (Wayland protocol error)
+    # TODO (@primeos): Remove this package after the NixOS 21.11 branch-off
   };
 }


### PR DESCRIPTION
It doesn't run anymore:
$ wshowkeys
zwlr_layer_surface_v1@11: error 1: width 0 requested without setting left and right anchors
wl_display_dispatch: Protocol error

We'll remove this package after a while. Fix #129362.

Reported-by: Nicolas Berbiche <nicolas@normie.dev>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note: It could/should still work with compositors that use an older/compatible version of `zwlr_layer_surface_v1`(?) but I don't think someone (/enough people) use such compositors. It should also be possible to patch `wshowkeys` to fix this protocol error but given that it's unmaintained that doesn't seem like a good solution either (without someone committing to an "official" fork).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
