### PR TITLE
fontconfig: 2.13.93 -> 2.13.94

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv
-, fetchpatch
 , substituteAll
 , fetchurl
 , pkg-config
@@ -15,20 +14,12 @@
 
 stdenv.mkDerivation rec {
   pname = "fontconfig";
-  version = "2.13.93";
+  version = "2.13.94";
 
   src = fetchurl {
-    url = "http://fontconfig.org/release/${pname}-${version}.tar.xz";
-    sha256 = "1850q4k80yxma5g3yxkvyv8i5a3xqzswwml8gjy3jmywx8qqd5pa";
+    url = "https://www.freedesktop.org/software/fontconfig/release/${pname}-${version}.tar.xz";
+    sha256 = "0g004r0bkkqz00mpm3svnnxn7d83158q0yb9ggxryizxfg5m5w55";
   };
-
-  patches = [
-    # Fix build with no docbook2html.
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/60ce9b695ee9d1ac514a61f562e210d3278ba605.patch";
-      sha256 = "0hfd2jdvsgackdp29dyzf5b1277pnbacihxqh9vdn63rr932ipra";
-    })
-  ];
 
   outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
