### PR TITLE
meson: Add `ninja` as a `propagatedBuildInputs`

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,6 +1,8 @@
 { lib
 , python3
 
+, ninja
+
 , writeTextDir
 , substituteAll
 , fetchpatch
@@ -79,6 +81,8 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
+
+  propagatedBuildInputs = [ ninja ];
 
   postInstall = ''
     installShellCompletion --zsh data/shell-completions/zsh/_meson


### PR DESCRIPTION
Signed-off-by: Pamplemousse <xav.maso@gmail.com>

###### Motivation for this change

I was confused when `meson` failed because it did not find `ninja`, and before learning that the latter needed to be imported manually.
This is a proposal to avoid similar confusion in the future :)

cc @jtojnar @jonringer (from Matrix conversation)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
