### PR TITLE
libtiff: 4.2.0 -> 4.3.0; adopt

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv
 , fetchurl
 
+, autoreconfHook
 , pkg-config
-, cmake
 
 , libdeflate
 , libjpeg
@@ -19,10 +19,6 @@ stdenv.mkDerivation rec {
     sha256 = "1j3snghqjbhwmnm5vz3dr1zm68dj15mgbx1wqld7vkl7n2nfaihf";
   };
 
-  cmakeFlags = if stdenv.isDarwin then [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
-  ] else null;
-
   # FreeImage needs this patch
   patches = [ ./headers.patch ];
 
@@ -34,7 +30,9 @@ stdenv.mkDerivation rec {
     moveToOutput include/tiffiop.h $dev_private
   '';
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  # If you want to change to a different build system, please make
+  # sure cross-compilation works first!
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   propagatedBuildInputs = [ libjpeg xz zlib ]; #TODO: opengl support (bogus configure detection)
 
@@ -42,8 +40,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doInstallCheck = true;
-  installCheckTarget = "test";
+  doCheck = true;
 
   meta = with lib; {
     description = "Library and utilities for working with the TIFF image file format";

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libtiff";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchurl {
     url = "https://download.osgeo.org/libtiff/tiff-${version}.tar.gz";
-    sha256 = "1jrkjv0xya9radddn8idxvs2gqzp3l2b1s8knlizmn7ad3jq817b";
+    sha256 = "1j3snghqjbhwmnm5vz3dr1zm68dj15mgbx1wqld7vkl7n2nfaihf";
   };
 
   cmakeFlags = if stdenv.isDarwin then [
@@ -47,7 +47,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library and utilities for working with the TIFF image file format";
-    homepage = "http://download.osgeo.org/libtiff";
+    homepage = "https://libtiff.gitlab.io/libtiff";
+    changelog = "https://libtiff.gitlab.io/libtiff/v${version}.html";
+    maintainers = with maintainers; [ qyliss ];
     license = licenses.libtiff;
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libtiff/headers.patch
+++ b/pkgs/development/libraries/libtiff/headers.patch
@@ -1,14 +1,16 @@
-diff --git i/libtiff/CMakeLists.txt w/libtiff/CMakeLists.txt
-index 90105b28..340c75cf 100755
---- i/libtiff/CMakeLists.txt
-+++ w/libtiff/CMakeLists.txt
-@@ -31,6 +31,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tiffconf.h.cmake.in
-                @ONLY)
+diff --git i/libtiff/Makefile.am w/libtiff/Makefile.am
+index 44522b62..d66e5948 100644
+--- i/libtiff/Makefile.am
++++ w/libtiff/Makefile.am
+@@ -36,8 +36,11 @@ EXTRA_DIST = \
+ 	tiffconf.h.cmake.in
  
- set(tiff_public_HEADERS
-+        tiffiop.h
-+        ${CMAKE_CURRENT_BINARY_DIR}/tif_config.h
-+        tif_dir.h
-         tiff.h
-         tiffio.h
-         tiffvers.h
+ libtiffinclude_HEADERS = \
++	tif_config.h \
++	tif_dir.h \
+ 	tiff.h \
+ 	tiffio.h \
++	tiffiop.h \
+ 	tiffvers.h
+ 
+ if HAVE_CXX

--- a/pkgs/development/libraries/libtiff/headers.patch
+++ b/pkgs/development/libraries/libtiff/headers.patch
@@ -1,13 +1,14 @@
-diff -ruN a/libtiff/CMakeLists.txt b/libtiff/CMakeLists.txt
---- a/libtiff/CMakeLists.txt	2019-05-31 13:05:22.849705817 +0000
-+++ b/libtiff/CMakeLists.txt	2020-11-27 21:50:03.527831837 +0000
-@@ -42,6 +42,9 @@
-   libtiffxx.map)
+diff --git i/libtiff/CMakeLists.txt w/libtiff/CMakeLists.txt
+index 90105b28..340c75cf 100755
+--- i/libtiff/CMakeLists.txt
++++ w/libtiff/CMakeLists.txt
+@@ -31,6 +31,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tiffconf.h.cmake.in
+                @ONLY)
  
- set(tiff_HEADERS
-+  tiffiop.h
-+  ${CMAKE_CURRENT_BINARY_DIR}/tif_config.h
-+  tif_dir.h
-   tiff.h
-   tiffio.h
-   tiffvers.h)
+ set(tiff_public_HEADERS
++        tiffiop.h
++        ${CMAKE_CURRENT_BINARY_DIR}/tif_config.h
++        tif_dir.h
+         tiff.h
+         tiffio.h
+         tiffvers.h


### PR DESCRIPTION
Tested by viewing a TIFF file in imv.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
