### PR TITLE
fltk14: fix build on apple silicon

### DIFF
--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -35,7 +35,10 @@ stdenv.mkDerivation {
     "--enable-xft"
   ];
 
-  preConfigure = "make clean";
+  preConfigure = ''
+    make clean
+    rm VERSION
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
For some reason having a file called `VERSION` in the package root directory appears to be
interfering with the build process:

```
Compiling Fl_cocoa.mm...
In file included from Fl_cocoa.mm:39:
In file included from ../FL/x.H:32:
In file included from ../FL/mac.H:50:

[...]

In file included from /nix/store/xhvrrnz8n6dxizgig46ijh59m7mfy261-libcxx-11.1.0-dev/include/c++/v1/cstddef:37:
../version:1:1: error: expected unqualified-id
1.4.0
^
```

By removing the file, the build succeeds.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (apple silicon)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
