### PR TITLE
fcp: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/fcp/default.nix
+++ b/pkgs/tools/misc/fcp/default.nix
@@ -1,0 +1,33 @@
+{ expect, fetchFromGitHub, lib, rustPlatform, stdenv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fcp";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "svetlitski";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ahd79dh48hsi4bhs4zs0a7hr55jzsjix9c61lc42ipdbqgifg2d";
+  };
+
+  cargoSha256 = "1arrw4fz3f3wfjy9nb8vm707vhh4x0vv9wv8z2s07b4qcwwih8k4";
+
+  nativeBuildInputs = [ expect ];
+
+  # character_device fails with "File name too long" on darwin
+  doCheck = !stdenv.isDarwin;
+
+  postPatch = ''
+    patchShebangs tests/*.exp
+  '';
+
+  meta = with lib; {
+    description = "A significantly faster alternative to the classic Unix cp(1) command";
+    homepage = "https://github.com/svetlitski/fcp";
+    changelog = "https://github.com/svetlitski/fcp/releases/tag/v${version}";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24050,6 +24050,8 @@ in
 
   fbida = callPackage ../applications/graphics/fbida { };
 
+  fcp = callPackage ../tools/misc/fcp { };
+
   fdupes = callPackage ../tools/misc/fdupes { };
 
   feh = callPackage ../applications/graphics/feh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`fcp` is a [significantly faster](https://github.com/Svetlitski/fcp#benchmarks) alternative to the classic Unix [`cp(1)`](https://man7.org/linux/man-pages/man1/cp.1.html) command


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
