### PR TITLE
zrepl: wrap with ssh in PATH

### DIFF
--- a/pkgs/tools/backup/zrepl/default.nix
+++ b/pkgs/tools/backup/zrepl/default.nix
@@ -1,5 +1,9 @@
-{ lib, buildGoModule, fetchFromGitHub }:
-
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, openssh
+}:
 buildGoModule rec {
   pname = "zrepl";
   version = "0.4.0";
@@ -15,10 +19,17 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
   postInstall = ''
     mkdir -p $out/lib/systemd/system
     substitute dist/systemd/zrepl.service $out/lib/systemd/system/zrepl.service \
       --replace /usr/local/bin/zrepl $out/bin/zrepl
+
+    wrapProgram $out/bin/zrepl \
+      --prefix PATH : ${lib.makeBinPath [ openssh ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
This allows the ssh+stdinserver connection type function properly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/129698.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
