### PR TITLE
klavaro: 3.11 -> 3.13, espeak support

### DIFF
--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/tutor.c --replace '"espeak ' '"${espeak}/bin/espeak '
   '';
 
+  patches = [ ./trans_lang_get_similar.patch ];
+
   postInstall = ''
     wrapProgram $out/bin/klavaro \
       --prefix LD_LIBRARY_PATH : $out/lib

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -2,23 +2,29 @@
 , fetchurl
 , makeWrapper
 , curl
+, espeak
 , file
 , gtk3
+, gtkdatabox
 , intltool
 , pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "klavaro";
-  version = "3.11";
+  version = "3.13";
 
   src = fetchurl {
     url = "mirror://sourceforge/klavaro/${pname}-${version}.tar.bz2";
-    sha256 = "1rkxaqb62w4mv86fcnmr32lq6y0h4hh92wmsy5ddb9a8jnzx6r7w";
+    sha256 = "0z6c3lqikk50mkz3ipm93l48qj7b98lxyip8y6ndg9y9k0z0n878";
   };
 
   nativeBuildInputs = [ intltool makeWrapper pkg-config ];
-  buildInputs = [ curl gtk3 ];
+  buildInputs = [ curl gtk3 gtkdatabox ];
+
+  postPatch = ''
+    substituteInPlace src/tutor.c --replace '"espeak ' '"${espeak}/bin/espeak '
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/klavaro \

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/tutor.c --replace '"espeak ' '"${espeak}/bin/espeak '
   '';
 
-  patches = [ ./trans_lang_get_similar.patch ];
+  patches = [ ./icons.patch ./trans_lang_get_similar.patch ];
 
   postInstall = ''
     wrapProgram $out/bin/klavaro \

--- a/pkgs/games/klavaro/icons.patch
+++ b/pkgs/games/klavaro/icons.patch
@@ -9,6 +9,15 @@
                        </object>
                        <packing>
                          <property name="expand">False</property>
+@@ -708,7 +708,7 @@
+                     <property name="can-default">True</property>
+                     <property name="has-default">True</property>
+                     <property name="tooltip-text" translatable="yes">Drag and drop text here to practice with it.</property>
+-                    <property name="secondary-icon-name">gtk-clear</property>
++                    <property name="secondary-icon-name">edit-clear</property>
+                     <property name="secondary-icon-tooltip-text" translatable="yes">Press here to restart the exercise. Hotkey: [Ctrl-R]</property>
+                     <property name="secondary-icon-tooltip-markup" translatable="yes">Press here to restart the exercise. Hotkey: [Ctrl-R]</property>
+                     <signal name="activate" handler="on_entry_mesg_activate" after="yes" swapped="no"/>
 @@ -1232,7 +1232,7 @@
                        <object class="GtkImage" id="image27">
                          <property name="visible">True</property>

--- a/pkgs/games/klavaro/icons.patch
+++ b/pkgs/games/klavaro/icons.patch
@@ -1,0 +1,137 @@
+--- a/data/klavaro.glade	(revision 137)
++++ b/data/klavaro.glade	(working copy)
+@@ -311,7 +311,7 @@
+                       <object class="GtkImage" id="image24">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-delete</property>
++                        <property name="icon-name">edit-delete</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -1232,7 +1232,7 @@
+                       <object class="GtkImage" id="image27">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-delete</property>
++                        <property name="icon-name">edit-delete</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -1352,7 +1352,7 @@
+                       <object class="GtkImage" id="image23">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-open</property>
++                        <property name="icon-name">document-open</property>
+                       </object>
+                       <packing>
+                         <property name="expand">True</property>
+@@ -1510,7 +1510,7 @@
+                       <object class="GtkImage" id="image11">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-open</property>
++                        <property name="icon-name">document-open</property>
+                         <property name="icon_size">2</property>
+                       </object>
+                       <packing>
+@@ -1557,7 +1557,7 @@
+                       <object class="GtkImage" id="image6">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-paste</property>
++                        <property name="icon-name">edit-paste</property>
+                         <property name="icon_size">2</property>
+                       </object>
+                       <packing>
+@@ -1604,7 +1604,7 @@
+                       <object class="GtkImage" id="image19">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-delete</property>
++                        <property name="icon-name">edit-delete</property>
+                         <property name="icon_size">2</property>
+                       </object>
+                       <packing>
+@@ -2051,7 +2051,7 @@
+                       <object class="GtkImage" id="image14">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-delete</property>
++                        <property name="icon-name">edit-delete</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -2343,7 +2343,7 @@
+                   <object class="GtkImage" id="image3">
+                     <property name="visible">True</property>
+                     <property name="can-focus">False</property>
+-                    <property name="icon-name">gtk-media-rewind</property>
++                    <property name="icon-name">media-seek-backward</property>
+                     <property name="icon_size">1</property>
+                   </object>
+                 </child>
+@@ -2418,7 +2418,7 @@
+                       <object class="GtkImage" id="image20">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-go-back</property>
++                        <property name="icon-name">go-previous</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -2469,7 +2469,7 @@
+                       <object class="GtkImage" id="image18">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-go-forward</property>
++                        <property name="icon-name">go-next</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -2577,7 +2577,7 @@
+                       <object class="GtkImage" id="image13">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-save</property>
++                        <property name="icon-name">document-save</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -2825,7 +2825,7 @@
+                       <object class="GtkImage" id="image_basic">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-strikethrough</property>
++                        <property name="icon-name">format-text-strikethrough</property>
+                         <property name="icon_size">6</property>
+                       </object>
+                       <packing>
+@@ -2901,7 +2901,7 @@
+                       <object class="GtkImage" id="image_adapt">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-bold</property>
++                        <property name="icon-name">format-text-bold</property>
+                         <property name="icon_size">6</property>
+                       </object>
+                       <packing>
+@@ -3630,7 +3630,7 @@
+                       <object class="GtkImage" id="image_top10_publish">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-goto-top</property>
++                        <property name="icon-name">go-top</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>
+@@ -3678,7 +3678,7 @@
+                       <object class="GtkImage" id="image_top10_update">
+                         <property name="visible">True</property>
+                         <property name="can-focus">False</property>
+-                        <property name="icon-name">gtk-goto-bottom</property>
++                        <property name="icon-name">go-bottom</property>
+                       </object>
+                       <packing>
+                         <property name="expand">False</property>

--- a/pkgs/games/klavaro/trans_lang_get_similar.patch
+++ b/pkgs/games/klavaro/trans_lang_get_similar.patch
@@ -1,0 +1,71 @@
+--- a/src/translation.c	(revision 137)
++++ b/src/translation.c	(working copy)
+@@ -257,23 +257,23 @@
+  * Private auxiliar function
+  */
+ static gboolean
+-trans_lang_get_similar (gchar * test)
++trans_lang_get_similar (gchar ** test)
+ {
+ 	gint i;
+ 	gchar aux_code_2[3];
+ 
+ 	/* Prefer C over en_GB for English variants other than en_GB. (Debian patch 02) */
+-	if (g_str_has_prefix (test, "en"))
++	if (g_str_has_prefix (*test, "en"))
+ 	{
+-		g_free (test);
+-		test = g_strdup ("C");
++		g_free (*test);
++		*test = g_strdup ("C");
+ 		return (TRUE);
+ 	}
+ 
+-	if (g_str_equal (test, "C"))
++	if (g_str_equal (*test, "C"))
+ 		return TRUE;
+ 
+-	strncpy (aux_code_2, test, 2);
++	strncpy (aux_code_2, *test, 2);
+ 	aux_code_2[2] = '\0';
+ 
+ 	for (i = 0; i < lang_num; i++)
+@@ -280,15 +280,15 @@
+ 	{
+ 		if (strstr (lang[i].code, aux_code_2))
+ 		{
+-			g_free (test);
+-			test = g_strdup (lang[i].code);
++			g_free (*test);
++			*test = g_strdup (lang[i].code);
+ 			break;
+ 		}
+ 	}
+-	if (i == lang_num && g_str_has_prefix (test, "en"))
++	if (i == lang_num && g_str_has_prefix (*test, "en"))
+ 	{
+-		g_free (test);
+-		test = g_strdup ("C");
++		g_free (*test);
++		*test = g_strdup ("C");
+ 		return (TRUE);
+ 	}
+ 	return (i == lang_num ? FALSE : TRUE);
+@@ -356,7 +356,7 @@
+ 					lang_ok = (i == 0 ? TRUE : FALSE);
+ 					break;
+ 				}
+-				lang_ok = trans_lang_get_similar (tmp_code);
++				lang_ok = trans_lang_get_similar (&tmp_code);
+ 				if (lang_ok == TRUE)
+ 					break;
+ 				g_free (tmp_code);
+@@ -368,7 +368,7 @@
+ 		tmp_code = g_win32_getlocale ();
+ 		lang_ok = trans_lang_is_available (tmp_code);
+ 		if (lang_ok == FALSE)
+-			lang_ok = trans_lang_get_similar (tmp_code);
++			lang_ok = trans_lang_get_similar (&tmp_code);
+ #endif
+ 	}
+ 	if (tmp_code == NULL)


### PR DESCRIPTION
###### Motivation for this change

* Update klavaro
* ensure espeak is available
* bump gtkdatabox to latest (and gtk3) as klavaro requires this
  * (gtkdatabox appears otherwise unused in our tree)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).