### PR TITLE
psi-plus: add more build options

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,7 +1,21 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake
-, qtbase, qtmultimedia, qtx11extras, qttools
-, libidn, qca-qt5, libXScrnSaver, hunspell
-, libsecret, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, qtbase
+, qtmultimedia
+, qtx11extras
+, qttools
+, libidn
+, qca-qt5
+, libXScrnSaver
+, hunspell
+, libsecret
+, libgcrypt
+, libotr
+, html-tidy
+, libgpgerror
+, libsignal-protocol-c
 , usrsctp
 
 , chatType ? "basic" # See the assertion below for available options
@@ -10,19 +24,19 @@
 
 , enablePlugins ? true
 
-# Voice messages
+  # Voice messages
 , voiceMessagesSupport ? true
 , gst_all_1
 
 , enablePsiMedia ? false
 , pkg-config
 
-, extraCmakeFlags ? [] # In addition to existing ones
+, extraCmakeFlags ? [ ] # In addition to existing ones
 }:
 
 assert builtins.elem (lib.toLower chatType) [
-  "basic"     # Basic implementation, no web stuff involved
-  "webkit"    # Legacy one, based on WebKit (see https://wiki.qt.io/Qt_WebKit)
+  "basic" # Basic implementation, no web stuff involved
+  "webkit" # Legacy one, based on WebKit (see https://wiki.qt.io/Qt_WebKit)
   "webengine" # QtWebEngine (see https://wiki.qt.io/QtWebEngine)
 ];
 
@@ -50,23 +64,36 @@ mkDerivation rec {
     assert builtins.all builtins.isString extraCmakeFlags; extraCmakeFlags
   );
 
-  nativeBuildInputs =
-    [ cmake qttools ]
-    ++ lib.optional enablePsiMedia pkg-config;
+  nativeBuildInputs = [
+    cmake
+    qttools
+  ] ++ lib.optionals enablePsiMedia [
+    pkg-config
+  ];
 
-  buildInputs =
-    [
-      qtbase qtmultimedia qtx11extras
-      libidn qca-qt5 libXScrnSaver hunspell
-      libsecret libgcrypt libotr html-tidy libgpgerror libsignal-protocol-c
-      usrsctp
-    ]
-    ++ lib.optionals voiceMessagesSupport [
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-    ]
-    ++ lib.optional (chatType == "webkit") qtwebkit
-    ++ lib.optional (chatType == "webengine") qtwebengine;
+  buildInputs = [
+    qtbase
+    qtmultimedia
+    qtx11extras
+    libidn
+    qca-qt5
+    libXScrnSaver
+    hunspell
+    libsecret
+    libgcrypt
+    libotr
+    html-tidy
+    libgpgerror
+    libsignal-protocol-c
+    usrsctp
+  ] ++ lib.optionals voiceMessagesSupport [
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+  ] ++ lib.optionals (chatType == "webkit") [
+    qtwebkit
+  ] ++ lib.optionals (chatType == "webengine") [
+    qtwebengine
+  ];
 
   preFixup = lib.optionalString voiceMessagesSupport ''
     qtWrapperArgs+=(

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -4,24 +4,27 @@
 , libsecret, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
 , usrsctp
 
-# Voice messages
-, voiceMessagesSupport ? true
-, gst_all_1
-
 , chatType ? "basic" # See the assertion below for available options
 , qtwebkit
 , qtwebengine
 
+, enablePlugins ? true
+
+# Voice messages
+, voiceMessagesSupport ? true
+, gst_all_1
+
 , extraCmakeFlags ? [] # In addition to existing ones
 }:
-
-assert builtins.isBool voiceMessagesSupport;
 
 assert builtins.elem (lib.toLower chatType) [
   "basic"     # Basic implementation, no web stuff involved
   "webkit"    # Legacy one, based on WebKit (see https://wiki.qt.io/Qt_WebKit)
   "webengine" # QtWebEngine (see https://wiki.qt.io/QtWebEngine)
 ];
+
+assert builtins.isBool voiceMessagesSupport;
+assert builtins.isBool enablePlugins;
 
 mkDerivation rec {
   pname = "psi-plus";
@@ -36,7 +39,7 @@ mkDerivation rec {
 
   cmakeFlags = [
     "-DCHAT_TYPE=${chatType}"
-    "-DENABLE_PLUGINS=ON"
+    "-DENABLE_PLUGINS=${if enablePlugins then "ON" else "OFF"}"
   ] ++ (
     assert builtins.all builtins.isString extraCmakeFlags; extraCmakeFlags
   );

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -11,6 +11,8 @@
 , chatType ? "basic" # See the assertion below for available options
 , qtwebkit
 , qtwebengine
+
+, extraCmakeFlags ? [] # In addition to existing ones
 }:
 
 assert builtins.isBool voiceMessagesSupport;
@@ -35,7 +37,9 @@ mkDerivation rec {
   cmakeFlags = [
     "-DCHAT_TYPE=${chatType}"
     "-DENABLE_PLUGINS=ON"
-  ];
+  ] ++ (
+    assert builtins.all builtins.isString extraCmakeFlags; extraCmakeFlags
+  );
 
   nativeBuildInputs = [ cmake qttools ];
 

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchFromGitHub, cmake
-, qtbase, qtmultimedia, qtx11extras, qttools, qtwebengine
+, qtbase, qtmultimedia, qtx11extras, qttools
 , libidn, qca-qt5, libXScrnSaver, hunspell
 , libsecret, libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
 , usrsctp
@@ -7,7 +7,19 @@
 # Voice messages
 , voiceMessagesSupport ? true
 , gst_all_1
+
+, chatType ? "basic" # See the assertion below for available options
+, qtwebkit
+, qtwebengine
 }:
+
+assert builtins.isBool voiceMessagesSupport;
+
+assert builtins.elem (lib.toLower chatType) [
+  "basic"     # Basic implementation, no web stuff involved
+  "webkit"    # Legacy one, based on WebKit (see https://wiki.qt.io/Qt_WebKit)
+  "webengine" # QtWebEngine (see https://wiki.qt.io/QtWebEngine)
+];
 
 mkDerivation rec {
   pname = "psi-plus";
@@ -21,20 +33,24 @@ mkDerivation rec {
   };
 
   cmakeFlags = [
+    "-DCHAT_TYPE=${chatType}"
     "-DENABLE_PLUGINS=ON"
   ];
 
   nativeBuildInputs = [ cmake qttools ];
 
   buildInputs = [
-    qtbase qtmultimedia qtx11extras qtwebengine
+    qtbase qtmultimedia qtx11extras
     libidn qca-qt5 libXScrnSaver hunspell
     libsecret libgcrypt libotr html-tidy libgpgerror libsignal-protocol-c
     usrsctp
-  ] ++ lib.optionals voiceMessagesSupport [
+  ]
+  ++ lib.optionals voiceMessagesSupport [
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
-  ];
+  ]
+  ++ lib.optional (chatType == "webkit") qtwebkit
+  ++ lib.optional (chatType == "webengine") qtwebengine;
 
   preFixup = lib.optionalString voiceMessagesSupport ''
     qtWrapperArgs+=(

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -30,8 +30,6 @@
 
 , enablePsiMedia ? false
 , pkg-config
-
-, extraCmakeFlags ? [ ] # In addition to existing ones
 }:
 
 assert builtins.elem (lib.toLower chatType) [

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -40,9 +40,6 @@ assert builtins.elem (lib.toLower chatType) [
   "webengine" # QtWebEngine (see https://wiki.qt.io/QtWebEngine)
 ];
 
-assert builtins.isBool voiceMessagesSupport;
-assert builtins.isBool enablePlugins;
-assert builtins.isBool enablePsiMedia;
 assert enablePsiMedia -> enablePlugins;
 
 mkDerivation rec {
@@ -60,9 +57,7 @@ mkDerivation rec {
     "-DCHAT_TYPE=${chatType}"
     "-DENABLE_PLUGINS=${if enablePlugins then "ON" else "OFF"}"
     "-DBUILD_PSIMEDIA=${if enablePsiMedia then "ON" else "OFF"}"
-  ] ++ (
-    assert builtins.all builtins.isString extraCmakeFlags; extraCmakeFlags
-  );
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Psi+ itself supports many cmake build options. For instance “chat type” is a very common one that people customize for themselves. But on the Nix side there is no native representation of those options. It would be a lot nicer to have simple Nix-side build options. This MR adds Nix-native customization options for these:

1. `CHAT_TYPE`
2. Customizable `ENABLE_PLUGINS` option
3. `BUILD_PSIMEDIA`
4. `extraCmakeFlags` that only adds additional cmake flags to what we already have. In case a user doesn’t wanna override original value completely.

I tested builds with all 3 possible values of “chat type”. And I also tested other options as well. All works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
