### PR TITLE
nheko Matrix client with with Spaces support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , cmake
 , cmark
+, coeurl
 , lmdb
 , lmdbxx
 , libsecret
@@ -25,17 +26,23 @@
 , voipSupport ? true
 , gst_all_1
 , libnice
+, libevent
+, curl
+, xorg
+, pcre
+, libunwind
+, elfutils
 }:
 
 mkDerivation rec {
   pname = "nheko";
-  version = "0.8.2";
+  version = "0.8.2-git";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "nheko";
-    rev = "v${version}";
-    sha256 = "sha256-w4l91/W6F1FL+Q37qWSjYRHv4vad/10fxdKwfNeEwgw=";
+    rev = "f5d3804476f8450f96eb54868dab8ea91c9b0930";
+    sha256 = "0irb8ccbc868mh7k244d5almhasqs21945brdbcvy2slbqj4k8dp";
   };
 
   nativeBuildInputs = [
@@ -45,10 +52,17 @@ mkDerivation rec {
   ];
 
   buildInputs = [
+    xorg.libXdmcp
+    pcre
+    libunwind
+    elfutils # for libdw
     nlohmann_json
     mtxclient
     olm
     boost17x
+    coeurl
+    curl
+    libevent
     libsecret
     lmdb
     spdlog
@@ -69,8 +83,13 @@ mkDerivation rec {
       libnice
     ]);
 
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace "# Fixup bundled keychain include dirs" "find_package(Boost COMPONENTS iostreams system  thread REQUIRED)"
+  '';
+
   cmakeFlags = [
     "-DCOMPILE_QML=ON" # see https://github.com/Nheko-Reborn/nheko/issues/389
+    "-DBUILD_SHARED_LIBS=OFF"
   ];
 
   preFixup = lib.optionalString voipSupport ''

--- a/pkgs/development/libraries/coeurl/default.nix
+++ b/pkgs/development/libraries/coeurl/default.nix
@@ -1,0 +1,54 @@
+{ cmake
+, curl
+, fetchFromGitLab
+, lib
+, libevent
+, meson
+, ninja
+, pkg-config
+, spdlog
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "coeurl";
+  version = "git";
+
+  src = fetchFromGitLab {
+    domain = "nheko.im";
+    owner = "nheko-reborn";
+    repo = "coeurl";
+    rev = "e9010d1ce14e7163d1cb5407ed27b23303781796";
+    sha256 = "1as81hmfjhnk1ghqwv815hg9wi0x177v4sghkrmczrd34sfxjhq4";
+  };
+
+  nativeBuildInputs = [
+    # cmake
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    libevent
+    spdlog
+  ];
+
+  # postBuild = ''
+  #   find .
+  #   exit 1
+  # '';
+
+  # cmakeFlags = [
+  # ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A simple async wrapper around CURL for C++";
+    homepage = "https://nheko.im/nheko-reborn/coeurl";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -2,24 +2,29 @@
 , fetchFromGitHub
 , fetchpatch
 , cmake
+, libevent
 , pkg-config
 , boost17x
 , openssl
 , olm
 , spdlog
 , nlohmann_json
+, curl
+, coeurl
 }:
 
 stdenv.mkDerivation rec {
   pname = "mtxclient";
-  version = "0.5.1";
+  version = "0.5.1-git";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "mtxclient";
-    rev = "v${version}";
-    sha256 = "sha256-UKroV1p7jYuNzCAFMsuUsYC/C9AZ1D4rhwpwuER39vc=";
+    rev = "0411d176f0d81f8f3eced2fa94e72b4585203a40";
+    sha256 = "154p03k0y4q08ydpqkqs8sxjwk16r2xz9rar84s1y3d6hj497i4z";
   };
+
+  # CXX_FLAGS = "-DSPDLOG_FMT_EXTERNAL";
 
   cmakeFlags = [
     # Network requiring tests can't be disabled individually:
@@ -30,6 +35,7 @@ stdenv.mkDerivation rec {
     # Can be removed once either https://github.com/NixOS/nixpkgs/pull/85254 or
     # https://github.com/NixOS/nixpkgs/pull/73940 are merged
     "-DBoost_NO_BOOST_CMAKE=TRUE"
+    "-DCMAKE_CXX_FLAGS=-DSPDLOG_FMT_EXTERNAL" # HACK: Overwrites all other CXX_FLAGS!
   ];
 
   nativeBuildInputs = [
@@ -37,6 +43,9 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
   buildInputs = [
+    curl
+    coeurl
+    libevent
     spdlog
     boost17x
     openssl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14425,6 +14425,8 @@ in
 
   cmrt = callPackage ../development/libraries/cmrt { };
 
+  coeurl = callPackage ../development/libraries/coeurl { };
+
   cogl = callPackage ../development/libraries/cogl { };
 
   coin3d = callPackage ../development/libraries/coin3d { };


### PR DESCRIPTION
###### Motivation for this change

Hacky WIP for the not-yet-released [`nheko`](https://nheko-reborn.github.io/) Matrix desktop client to support a basic form of Matrix spaces.

In case other Matrix users want to try out Spaces with a desktop client that can do E2E encryption.

Not intended to be merged before the next nheko release is out, but it would make sense to already start addressing the WIP issues, some of which will benefit from fixing upstream issues _before_ that next release.

This just compiles the latest git version and applies small changes to make the compile errors go away. Many of them should be upstreamed / fixed more properly, but I don't have time right now. This will be relevant when the next version of `nheko` is released.

## Usage instructions

* You will need to wipe your local profile (`mv ~/.local/share/nheko ~/.local/share/nheko.moved`) because the version isn't properly backwards compatible with the release version. Wiithout this, Spaces won't appear on the left, and the stdout/stderr will show some lmdb incompatibility errors.

## TODO

* [ ] Fix the ugly hacks / upstream proper fixes, like the `CMakeList.txt` boost dependency declaration.
  * You can see what's wrong by commenting out the ugly hacks.
* [ ] Regarget against `master` instead of `release-21.05`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

FYI maintainers @ekleog @fpletz