### PR TITLE
rofi-vpn: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/rofi-vpn/default.nix
+++ b/pkgs/applications/networking/rofi-vpn/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, makeWrapper
+, networkmanager
+, rofi-unwrapped
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-vpn";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "DamienCassou";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04jcfb2jy8yyrk4mg68krwh3zb5qcyj1aq1bwk96fhybrq9k2hhp";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D --target-directory=$out/bin/ ./rofi-vpn
+
+    wrapProgram $out/bin/rofi-vpn \
+      --prefix PATH ":" ${lib.makeBinPath [ rofi-unwrapped networkmanager ]}
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  meta = with lib; {
+    description = "Rofi-based interface to enable VPN connections with NetworkManager";
+    homepage = "https://gitlab.com/DamienCassou/rofi-vpn";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ DamienCassou ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25667,6 +25667,8 @@ in
 
   rofi-power-menu = callPackage ../applications/misc/rofi-power-menu { };
 
+  rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   # a somewhat more maintained fork of ympd


### PR DESCRIPTION

###### Motivation for this change

Add [rofi-vpn](https://gitlab.com/DamienCassou/rofi-vpn/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
