### PR TITLE
lemmy: init 0.11.2

### DIFF
--- a/pkgs/servers/web-apps/lemmy/default.nix
+++ b/pkgs/servers/web-apps/lemmy/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, openssl
+, postgresql
+, libiconv
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lemmy-server";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = "LemmyNet";
+    repo = "lemmy";
+    rev = "3022c00a0bcd421f9732bd307fce804387268b59";
+    sha256 = "sha256-wDRBeAYjPpAd3DL99fH4Yng994hGmAmxlBqzOeXTP88=";
+  };
+
+  cargoSha256 = "sha256-7wF5mUjSeJvCNLZcR6XB31RX2RLOOEyTGpOQxg+NcWk=";
+
+  buildInputs = [ postgresql ] ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  # Using OPENSSL_NO_VENDOR is not an option on darwin
+  # As of version 0.10.35 rust-openssl looks for openssl on darwin
+  # with a hardcoded path to /usr/lib/libssl.x.x.x.dylib
+  # https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/find_normal.rs#L115
+  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+
+  meta = with lib; {
+    description = "Ultra relevant and instant full-text search API";
+    homepage = "https://join-lemmy.org/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/servers/web-apps/lemmy/default.nix
+++ b/pkgs/servers/web-apps/lemmy/default.nix
@@ -15,13 +15,14 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "LemmyNet";
     repo = "lemmy";
-    rev = "3022c00a0bcd421f9732bd307fce804387268b59";
+    rev = version;
     sha256 = "sha256-wDRBeAYjPpAd3DL99fH4Yng994hGmAmxlBqzOeXTP88=";
   };
 
   cargoSha256 = "sha256-7wF5mUjSeJvCNLZcR6XB31RX2RLOOEyTGpOQxg+NcWk=";
 
-  buildInputs = [ postgresql ] ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+  buildInputs = [ postgresql ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
 
   # Using OPENSSL_NO_VENDOR is not an option on darwin
   # As of version 0.10.35 rust-openssl looks for openssl on darwin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19513,6 +19513,10 @@ in
 
   leafnode = callPackage ../servers/news/leafnode { };
 
+  lemmy = callPackage ../servers/web-apps/lemmy {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   lighttpd = callPackage ../servers/http/lighttpd { };
 
   livepeer = callPackage ../servers/livepeer { };


### PR DESCRIPTION
###### Motivation for this change

Add lemmy to nixpkgs

Here are a couple of comments
- This is only the server part of lemmy. The next step should be to add the lemmy-ui repo
- I've only tested on darwin, not sure how it fares on nixos
- I wanted to use `rev = "v${version}";` but I couldn't figure out why in this case it does not work. Maybe something related to upstream. I don't know in this case.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
