### PR TITLE
spidermonkey_68: fix cross eval

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/68.nix
+++ b/pkgs/development/interpreters/spidermonkey/68.nix
@@ -14,6 +14,15 @@ in stdenv.mkDerivation rec {
     sha256 = "0azdinwqjfv2q37gqpxmfvzsk86pvsi6cjaq1310zs26gric5j1f";
   };
 
+  patches = [
+    # Backport a change from Firefox 75 that fixes finding the
+    # location of clang and libclang.
+    (fetchpatch {
+      url = "https://hg.mozilla.org/mozilla-central/raw-rev/ccd1356fc8f1d0bfa9d896e88d3cc924425623da";
+      sha256 = "005g3mfmal9nw32khrgyiv3221z7pazfhhm2qvgc8d48i2yzj3j0";
+    })
+  ];
+
   outputs = [ "out" "dev" ];
   setOutputFlags = false; # Configure script only understands --includedir
 
@@ -54,9 +63,6 @@ in stdenv.mkDerivation rec {
     "--enable-posix-nspr-emulation"
     "--with-system-zlib"
     "--with-system-icu"
-
-    "--with-libclang-path=${llvmPackages.libclang.lib}/lib"
-    "--with-clang-path=${llvmPackages.clang}/bin/clang"
 
     "--enable-shared-js"
     "--enable-readline"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The use of unspliced llvmPackages in configureFlags was causing an
eval failure when cross-compiling, but since later versions of
Firefox/Spidermonkey can correctly detect clang and libclang without
those arguments being specified, we can just backport that
patch (which applies cleanly), and not have to worry about it any
more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
