### PR TITLE
rPackages.R_cache: fix build

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -644,6 +644,7 @@ let
     "Rmpi"     # tries to run MPI processes
     "pbdMPI"   # tries to run MPI processes
     "data_table" # fails to rename shared library before check
+    "R_cache"  # tries to write to home folder on check
   ];
 
   # Packages which cannot be installed due to lack of dependencies or other reasons.

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -203,7 +203,7 @@ let
   defaultOverrides = old: new:
     let old0 = old; in
     let
-      old1 = old0 // (overrideRequireX packagesRequireingX old0);
+      old1 = old0 // (overrideRequireX packagesRequiringX old0);
       old2 = old1 // (overrideSkipCheck packagesToSkipCheck old1);
       old3 = old2 // (overrideRDepends packagesWithRDepends old2);
       old4 = old3 // (overrideNativeBuildInputs packagesWithNativeBuildInputs old3);
@@ -452,7 +452,7 @@ let
     statmod = [ pkgs.libiconv ];
   };
 
-  packagesRequireingX = [
+  packagesRequiringX = [
     "accrual"
     "ade4TkGUI"
     "analogue"

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -674,7 +674,6 @@ let
   ];
 
   packagesRequiringHome = [
-    "R_cache"  # tries to write to home folder on check
   ];
 
   packagesToSkipCheck = [


### PR DESCRIPTION
Disable R.cache checks as it tries to write to home folder storage in its tests.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Prior to this change the build fails with:

```
$ nix-build -A rPackages.R_cache
this derivation will be built:
  /nix/store/35wf9bdk9pnfi53b7vsh85ky25ny749p-r-R.cache-0.15.0.drv
...
* installing *source* package 'R.cache' ...
...
Warning in normalizePath("~") :
  path[1]="/homeless-shelter": No such file or directory
Error: package or namespace load failed for 'R.cache':
 .onLoad failed in loadNamespace() for 'R.cache', details:
  call: mkdirs.default(parent, mustWork = mustWork, maxTries = maxTries,
  error: Failed to create directory (tried 5 times), most likely because of lack of file permissions (directory '' exists but nothing beyond): /homeless-shelter
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
