### PR TITLE
watson: fix build problem with click 8

### DIFF
--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -2,8 +2,23 @@
 
 with pythonPackages;
 
-buildPythonApplication rec {
+let
+  # Watson is currently not compatible with Click 8. See the following
+  # upstream issues / MRs:
+  #
+  # https://github.com/TailorDev/Watson/issues/430
+  # https://github.com/TailorDev/Watson/pull/432
+  #
+  # Workaround the issue by providing click 7 explicitly.
+  click7 = pythonPackages.callPackage ../../../development/python-modules/click/7.nix {};
+  click7-didyoumean = click-didyoumean.override {
+    click = click7;
+  };
+in buildPythonApplication rec {
   pname = "watson";
+
+  # When you update Watson, please check whether the Click 7
+  # workaround above can go away.
   version = "2.0.1";
 
   src = fetchFromGitHub {
@@ -19,7 +34,7 @@ buildPythonApplication rec {
   '';
 
   checkInputs = [ pytestCheckHook pytest-mock mock pytest-datafiles ];
-  propagatedBuildInputs = [ arrow click click-didyoumean requests ];
+  propagatedBuildInputs = [ arrow click7 click7-didyoumean requests ];
   nativeBuildInputs = [ installShellFiles ];
 
   meta = with lib; {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Watson currently fails to build. The reason is that pythonPackages brings click 8. Unfortunately, watson is not ready to consume this library version yet. Fix by explicitly pulling in click 7 as dependency. See these upstream discussions:

https://github.com/TailorDev/Watson/issues/430
https://github.com/TailorDev/Watson/pull/432

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
