### PR TITLE
corkscrew: name -> pname

### DIFF
--- a/pkgs/tools/networking/corkscrew/default.nix
+++ b/pkgs/tools/networking/corkscrew/default.nix
@@ -1,10 +1,11 @@
 { lib, stdenv, fetchurl, automake }:
 
 stdenv.mkDerivation rec {
-  name = "corkscrew-2.0";
+  pname = "corkscrew";
+  version = "2.0";
 
   src = fetchurl {
-    url = "http://agroman.net/corkscrew/${name}.tar.gz";
+    url = "http://agroman.net/corkscrew/corkscrew-${version}.tar.gz";
     sha256 = "0d0fcbb41cba4a81c4ab494459472086f377f9edb78a2e2238ed19b58956b0be";
   };
 


### PR DESCRIPTION
###### Motivation for this change
According to the manual, this is preferred for packages in Nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).