### PR TITLE
nodePackages: fix generate.sh failing on path with space

### DIFF
--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 node2nix=$(nix-build ../../.. -A nodePackages.node2nix)
-cd ${DIR}
+cd "$DIR"
 rm -f ./node-env.nix
 ${node2nix}/bin/node2nix -i node-packages.json -o node-packages.nix -c composition.nix
 # using --no-out-link in nix-build argument would cause the


### PR DESCRIPTION
###### Motivation for this change
When the path to the Nixpkgs repo contains a space, generate.sh would fail. This can be esily fixed by adding quotes around the variable containing the path.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).