### PR TITLE
visidata: 2.4 -> 2.5

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -24,13 +24,13 @@
 }:
 buildPythonApplication rec {
   pname = "visidata";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner = "saulpw";
     repo = "visidata";
     rev = "v${version}";
-    sha256 = "0mvf2603d9b0s6rh7sl7mg4ipbh0nk05xgh1078mwvx31qjsmq1i";
+    sha256 = "1iijggdgj36v7d2zm45c00nrbzxaaah2azflpca0f6fjaaxh3lr2";
   };
 
   propagatedBuildInputs = [
@@ -75,12 +75,6 @@ buildPythonApplication rec {
     rm tests/load-http.vd            # http
     rm tests/graph-cursor-nosave.vd  # http
     rm tests/messenger-nosave.vd     # dns
-
-    # disable some tests which expect Python == 3.6 (not our current version)
-    # see https://github.com/saulpw/visidata/issues/1014
-    rm tests/describe.vd
-    rm tests/describe-error.vd
-    rm tests/edit-type.vd
 
     # tests use git to compare outputs to references
     git init -b "test-reference"


### PR DESCRIPTION
###### Motivation for this change

This updates the visidata package to the latest release.
A bunch of disabled tests have been fixed and re-enabled.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
