### PR TITLE
md-tangle: init at 1.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6847,6 +6847,12 @@
       fingerprint = "3DEE 1C55 6E1C 3DC5 54F5  875A 003F 2096 411B 5F92";
     }];
   };
+  michaelhthomas = {
+    email = "linuxoveruser@protonmail.com";
+    github = "michaelhthomas";
+    githubId = 18223295;
+    name = "Michael Thomas";
+  };
   michaelpj = {
     email = "michaelpj@gmail.com";
     github = "michaelpj";

--- a/pkgs/development/tools/md-tangle/default.nix
+++ b/pkgs/development/tools/md-tangle/default.nix
@@ -1,0 +1,27 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "md-tangle";
+  version = "1.3.0";
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "joakimmj";
+    repo = "md-tangle";
+    rev = "v${version}";
+    sha256 = "1xsqbq7kbgq5r050b07ixfn5v0w61a8nwd9d0vbbyjqgc8i6m6c6";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  meta = with lib; {
+    description = "Generates (\"tangles\") source code from Markdown documents";
+    homepage = "https://github.com/joakimmj/md-tangle";
+    license = licenses.mit;
+    maintainers = with maintainers; [ michaelhthomas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13828,6 +13828,8 @@ in
 
   mbed-cli = callPackage ../development/tools/mbed-cli { };
 
+  md-tangle = callPackage ../development/tools/md-tangle { };
+
   mdl = callPackage ../development/tools/misc/mdl { };
 
   python-language-server = callPackage ../development/dotnet-modules/python-language-server {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This adds [md-tangle](https://github.com/joakimmj/md-tangle) to nixpkgs, a python tool which "tangles" source code from Markdown documents, similar to Emacs Org-mode and org-babel-tangle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
