### PR TITLE
gnome: an alternate way to manage excluded/included applications

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome.xml
+++ b/nixos/modules/services/x11/desktop-managers/gnome.xml
@@ -47,10 +47,7 @@
     and none of them will be installed.
    </para>
 
-   <para>
-    If you’d only like to omit a subset of the core utilities, you can use <xref linkend="opt-environment.gnome.excludePackages"/>.
-    Note that this mechanism can only exclude core utilities, games and core developer tools.
-   </para>
+   <!--TODO: update documentation-->
   </section>
 
   <section xml:id="sec-gnome-disabling-services">


### PR DESCRIPTION
###### Motivation for this change
I've been working on an alternate way to manage default gnome applications.

`environment.gnome.excludePackages` allows you to exclude them one-by-one, but it's pretty inconvenient to list every unwanted package when you have a specific set of wanted packages. Or you can disable `services.gnome.core-utilities.enable` and re-add packages in `environment.systemPackages`, but then you lose the application-specific integrations.

In this patch, the global exclude option is replaced by `include` (list of packages), `exclude` (list of packages), and `includeDefaults` (boolean) options in the `services.gnome.{core-utilities, core-developer-tools, games}` sections.

It's a breaking change, and it's more complex than the existing setup. It's probably not suitable to be merged, but I've found it useful for my needs and I'd appreciate any comments.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant \[**should do this**\]
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
