### PR TITLE
steamPackages.steam-fhsenv: fix Proton

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -220,6 +220,7 @@ self = stdenv.mkDerivation {
   passthru = {
     inherit libdrm;
     inherit (libglvnd) driverLink;
+    inherit llvmPackages;
 
     tests.devDoesNotDependOnLLVM = stdenv.mkDerivation {
       name = "mesa-dev-does-not-depend-on-llvm";

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -150,6 +150,7 @@ in buildFHSUserEnv rec {
 
     # dependencies for mesa drivers, needed inside pressure-vessel
     mesa.drivers
+    mesa.llvmPackages.llvm.lib
     vulkan-loader
     expat
     wayland
@@ -157,7 +158,6 @@ in buildFHSUserEnv rec {
     xorg.libXdamage
     xorg.libxshmfence
     xorg.libXxf86vm
-    llvm_11.lib
     libelf
   ] ++ (if (!nativeOnly) then [
     (steamPackages.steam-runtime-wrapped.override {


### PR DESCRIPTION
###### Motivation for this change
LLVM must match version required by Mesa.

Fixes https://github.com/NixOS/nixpkgs/issues/127068

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).