### PR TITLE
linux: groundwork to enable LLVM/LTO builds

### DIFF
--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -19,6 +19,7 @@ my $autoModules = $ENV{'AUTO_MODULES'};
 my $preferBuiltin = $ENV{'PREFER_BUILTIN'};
 my $ignoreConfigErrors = $ENV{'ignoreConfigErrors'};
 my $buildRoot = $ENV{'BUILD_ROOT'};
+my $makeFlags = $ENV{'MAKE_FLAGS'};
 $SIG{PIPE} = 'IGNORE';
 
 # Read the answers.
@@ -40,7 +41,7 @@ close ANSWERS;
 sub runConfig {
 
     # Run `make config'.
-    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$buildRoot config SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX}");
+    my $pid = open2(\*IN, \*OUT, "make -C $ENV{SRC} O=$buildRoot config SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX} $makeFlags");
 
     # Parse the output, look for questions and then send an
     # appropriate answer.

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -160,7 +160,6 @@ let
     enableParallelBuilding = true;
 
     passthru = rec {
-
       module = import ../../../../nixos/modules/system/boot/kernel_config.nix;
       # used also in apache
       # { modules = [ { options = res.options; config = svc.config or svc; } ];
@@ -188,7 +187,7 @@ let
 
   passthru = {
     features = kernelFeatures;
-    inherit commonStructuredConfig isZen isHardened isLibre modDirVersion;
+    inherit commonStructuredConfig structuredExtraConfig extraMakeFlags isZen isHardened isLibre modDirVersion;
     isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
     kernelOlder = lib.versionOlder version;
     kernelAtLeast = lib.versionAtLeast version;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,5 @@
 { lib, buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
-, libelf, cpio, elfutils, zstd, gawk
+, libelf, cpio, elfutils, zstd, gawk, python3Minimal
 , writeTextFile
 }:
 
@@ -121,7 +121,7 @@ let
         # See also https://kernelnewbies.org/BuildId
         sed -i Makefile -e 's|--build-id=[^ ]*|--build-id=none|'
 
-        patchShebangs scripts/ld-version.sh
+        patchShebangs scripts
       '';
 
       postPatch = ''
@@ -307,7 +307,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPat
   enableParallelBuilding = true;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk zstd ]
+  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk zstd python3Minimal ]
       ++ optional  (stdenv.hostPlatform.linux-kernel.target == "uImage") buildPackages.ubootTools
       ++ optional  (lib.versionAtLeast version "4.14" && lib.versionOlder version "5.8") libelf
       # Removed util-linuxMinimal since it should not be a dependency.

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -19,6 +19,8 @@ in {
   stdenv,
   # The kernel version
   version,
+  # Additional kernel make flags
+  extraMakeFlags ? [],
   # The version of the kernel module directory
   modDirVersion ? version,
   # The kernel source (tarball, git checkout, etc.)
@@ -173,7 +175,9 @@ let
         "KBUILD_BUILD_VERSION=1-NixOS"
         kernelConf.target
         "vmlinux"  # for "perf" and things like that
-      ] ++ optional isModular "modules";
+      ]
+      ++ optional isModular "modules"
+      ++ extraMakeFlags;
 
       installFlags = [
         "INSTALLKERNEL=${installkernel}"
@@ -325,7 +329,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPat
     "ARCH=${stdenv.hostPlatform.linuxArch}"
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-  ];
+  ] ++ extraMakeFlags;
 
   karch = stdenv.hostPlatform.linuxArch;
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
These patches lay the groundwork to enable us to build the kernel with LLVM
tooling and LTO. It's essentially a collection of fixes for all the roadblocks
I hit while attempting to get things working.

With these changes, you can build a kernel that is fully LTO'd and built with
clang using the following code:
```Nix
{ pkgs ? import ./. { } }:
let
  inherit (pkgs) lib;

  stdenvLLVM =
    let
      llvmPin = pkgs.buildPackages.llvmPackages_12.override {
        bootBintools = null;
        bootBintoolsNoLibc = null;
      };

      stdenv' = pkgs.overrideCC llvmPin.stdenv llvmPin.clangUseLLVM;
    in
    stdenv' // {
      mkDerivation = args: stdenv'.mkDerivation (args // {
        # INFO: This line may seem useless, since we already have lld coming
        # from clangUseLLVM, but it isn't.
        # The lld provided is wrapped "llvm-binutils-wrapper" and will _NOT_
        # work. Adding lld here manually override that one, and works around the
        # issue. The real solution here is to either:
        # 1. Figure out a way to force the usage of the unwrapped bintools
        # 2. Fix our lld wrapper
        nativeBuildInputs = (args.nativeBuildInputs or [ ])
        ++ (with llvmPin; [ lld ]);
      });
    };

  makeLTO = k:
    k.override {
      stdenv = stdenvLLVM;
      extraMakeFlags = k.extraMakeFlags ++ [ "LLVM=1" "LLVM_IAS=1" ];
      argsOverride.structuredExtraConfig =
        with lib.kernel; k.structuredExtraConfig // {
          LTO_NONE = no;
          LTO_CLANG_FULL = yes;
        };
    };
in
  {
    inherit stdenvLLVM;
    linux_latest_lto = makeLTO pkgs.linux_latest;
    linux_lqx_lto = makeLTO pkgs.linux_lqx;
    linux_xanmod_lto = makeLTO pkgs.linux_xanmod;
    linux_zen_lto = makeLTO pkgs.linux_zen;
  }
```

While this is still harder than it should be, it represents a _massive_
improvement from the status quo as currently you must basically sell your soul
to get an LTO'd kernel [see here](https://github.com/lovesegfault/nix-config/blob/bac607e6df306fc38cf76409db76aba53b62ff85/nix/overlays/linux-lto.nix). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
