### PR TITLE
netbsd: Use rsync to speed up source merging

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -7,6 +7,8 @@
 }:
 
 let
+  inherit (buildPackages.buildPackages) rsync;
+
   fetchNetBSD = path: version: sha256: fetchcvs {
     cvsRoot = ":pserver:anoncvs@anoncvs.NetBSD.org:/cvsroot";
     module = "src/${path}";
@@ -60,7 +62,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
       makeMinimal
-      install tsort lorder mandoc groff statHook
+      install tsort lorder mandoc groff statHook rsync
     ];
     buildInputs = with self; compatIfNeeded;
 
@@ -116,7 +118,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
 
     buildInputs = with self; [];
-    nativeBuildInputs = with buildPackages.netbsd; [ bsdSetupHook ];
+    nativeBuildInputs = with buildPackages.netbsd; [ bsdSetupHook rsync ];
 
     skipIncludesPhase = true;
 
@@ -165,6 +167,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; commonDeps ++ [
       bsdSetupHook
       makeMinimal
+      rsync
     ];
 
     buildInputs = with self; commonDeps;
@@ -237,7 +240,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
       makeMinimal
-      mandoc groff
+      mandoc groff rsync
     ];
     skipIncludesPhase = true;
     buildInputs = with self; compatIfNeeded ++ [ fts ];
@@ -259,7 +262,7 @@ in lib.makeScopeWithSplicing
     sha256 = "01d4fpxvz1pgzfk5xznz5dcm0x0gdzwcsfm1h3d0xc9kc6hj2q77";
     version = "9.2";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook rsync
     ];
     propagatedBuildInputs = with self; compatIfNeeded;
     extraPaths = with self; [
@@ -297,7 +300,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
       makeMinimal
-      install mandoc groff
+      install mandoc groff rsync
     ];
   };
 
@@ -319,7 +322,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
       makeMinimal
-      install mandoc groff
+      install mandoc groff rsync
     ];
   };
 
@@ -330,7 +333,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
       makeMinimal
-      install mandoc groff
+      install mandoc groff rsync
     ];
   };
   ##
@@ -463,7 +466,7 @@ in lib.makeScopeWithSplicing
     NIX_CFLAGS_COMPILE = [ "-DMAKE_BOOTSTRAP" ];
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
-      makeMinimal install mandoc byacc flex
+      makeMinimal install mandoc byacc flex rsync
     ];
     buildInputs = with self; compatIfNeeded;
     extraPaths = with self; [ cksum.src ];
@@ -482,7 +485,7 @@ in lib.makeScopeWithSplicing
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
       makeMinimal
-      install mandoc groff nbperf rpcgen
+      install mandoc groff rsync nbperf rpcgen
     ];
     extraPaths = with self; [ common ];
     headersOnly = true;
@@ -508,7 +511,7 @@ in lib.makeScopeWithSplicing
     propagatedBuildInputs = with self; [ include ];
     nativeBuildInputs = with buildPackages.netbsd; [
       bsdSetupHook
-      makeMinimal install tsort lorder statHook uudecode config genassym
+      makeMinimal install tsort lorder statHook rsync uudecode config genassym
     ];
 
     postConfigure = ''
@@ -748,7 +751,7 @@ in lib.makeScopeWithSplicing
       bsdSetupHook
       makeMinimal
       install mandoc groff flex
-      byacc genassym gencat lorder tsort statHook
+      byacc genassym gencat lorder tsort statHook rsync
     ];
     buildInputs = with self; [ headers ];
     extraPaths = with self; [ sys.src ld_elf_so.src ];
@@ -786,7 +789,7 @@ in lib.makeScopeWithSplicing
       bsdSetupHook
       makeMinimal
       install mandoc groff flex
-      byacc genassym gencat lorder tsort statHook rpcgen
+      byacc genassym gencat lorder tsort statHook rsync rpcgen
     ];
     buildInputs = with self; [ headers csu ];
     NIX_CFLAGS_COMPILE = "-B${self.csu}/lib";

--- a/pkgs/os-specific/bsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/setup-hook.sh
@@ -70,10 +70,7 @@ setBSDSourceDir() {
   export _SRC_TOP_=$BSDSRCDIR
   chmod -R u+w $sourceRoot
   for path in $extraPaths; do
-    cd $path
-    find . -type d -exec mkdir -p $sourceRoot/\{} \;
-    find . -type f -exec cp -pr \{} $sourceRoot/\{} \;
-    chmod -R u+w $sourceRoot
+    rsync -Er --chmod u+w $path/ $sourceRoot/
   done
 
   cd $sourceRoot
@@ -104,6 +101,9 @@ moveUsrDir() {
   if [ -d $prefix ]; then
     # Remove lingering /usr references
     if [ -d $prefix/usr ]; then
+      # Didn't try using rsync yet because per
+      # https://unix.stackexchange.com/questions/127712/merging-folders-with-mv,
+      # it's not neessarily better.
       pushd $prefix/usr
       find . -type d -exec mkdir -p $out/\{} \;
       find . \( -type f -o -type l \) -exec mv \{} $out/\{} \;


### PR DESCRIPTION
###### Motivation for this change

The find -exec that was there before is quite slow on my machine. This is much faster.

Testing so far:
 - [x] Built `pkgsCross.x86_64-netbsd.hello`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
