### PR TITLE
pip: 21.0.1 -> 21.1.3; setuptools: 54.2.0 -> 56.2.0; wheel: update hompage

### DIFF
--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "21.0.1";
+  version = "21.1.3";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Yt5xqdo735f5sQKP8GnKM201SoIi7ZP9l2gw+feUVW0=";
+    sha256 = "02cj98lhxqsqbd2pn3m3srdfcq8rwvwvlwcgyfqaks08kvv37wyd";
     name = "${pname}-${version}-source";
   };
 

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -14,7 +14,7 @@
 
 let
   pname = "setuptools";
-  version = "54.2.0";
+  version = "56.2.0";
 
   bootstrap = fetchurl {
     url = "https://raw.githubusercontent.com/pypa/setuptools/v52.0.0/bootstrap.py";
@@ -29,7 +29,7 @@ let
       owner = "pypa";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-ZHJZiwlWLHP4vf2TLwj/DYB9wjbRp0apVmmjsKCLPq0=";
+      sha256 = "02mynrprzzwhifik7v27n6ymz2lbd2nvrsg5fcrgc80pfi3jr62b";
       name = "${pname}-${version}-source";
     };
 

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   pipInstallFlags = [ "--ignore-installed" ];
 
   meta = with lib; {
-    homepage = "https://bitbucket.org/pypa/wheel/";
+    homepage = "https://github.com/pypa/wheel/";
     description = "A built-package format for Python";
     longDescription = ''
       This library is the reference implementation of the Python wheel packaging standard,


### PR DESCRIPTION
###### Motivation for this change


https://github.com/pypa/pip/blob/HEAD/NEWS.rst#2113-2021-06-26
https://github.com/pypa/setuptools/blob/HEAD/CHANGES.rst#v5620

setuptools >= 57.0.0 fails to build in bootstrap.py, and I'm not sure how to rework that step. The bootstrap.py now says to use a PEP-517 compatible installer method. But how do we bootstrap that one without setuptools?

```pytb
❯ nom-build -A python3Packages.pip
these derivations will be built:
  /nix/store/jljikdxvyz3f9c6xbh3khyd67ci2b3a9-setuptools-57.0.0-sdist.tar.gz.drv
  /nix/store/zrdrkw3j25nbji5zf89p2937q6s2am4x-python3.9-bootstrapped-pip-21.1.3.drv
  /nix/store/0wlis1lri41ifg3xqqzx2mmdajnx0w04-python3.9-setuptools-57.0.0.drv
  /nix/store/gffmfx5aq98p1gafa8q6ry9kr1wh3zwh-python-catch-conflicts-hook.drv
  /nix/store/hi079vkq9gw4lk9jzhai0a7vqcgisc14-python3.9-pip-21.1.3.drv
building '/nix/store/jljikdxvyz3f9c6xbh3khyd67ci2b3a9-setuptools-57.0.0-sdist.tar.gz.drv' on 'ssh://hexa@phoibe.cysec.de'...
unpacking sources
unpacking source archive /nix/store/xpggxixcp7dwsrg6046v4s952v9q8qk7-setuptools-57.0.0-source
source root is setuptools-57.0.0-source
patching sources
applying patch /nix/store/0qzs4kq2lvl09k80nf54bl00hd2ylfam-tag-date.patch
patching file setup.cfg
Hunk #1 succeeded at 144 with fuzz 2 (offset 143 lines).
configuring
no configure script, doing nothing
building
adding minimal entry_points
Regenerating egg_info
Traceback (most recent call last):
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 2679, in version
    return self._version
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 2813, in __getattr__
    raise AttributeError(attr)
AttributeError: _version

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/build/setuptools-57.0.0-source/setup.py", line 100, in <module>
    dist = setuptools.setup(**setup_params)
  File "/build/setuptools-57.0.0-source/setuptools/__init__.py", line 152, in setup
    _install_setup_requires(attrs)
  File "/build/setuptools-57.0.0-source/setuptools/__init__.py", line 145, in _install_setup_requires
    dist.parse_config_files(ignore_option_errors=True)
  File "/build/setuptools-57.0.0-source/setuptools/dist.py", line 770, in parse_config_files
    self._parse_config_files(filenames=filenames)
  File "/build/setuptools-57.0.0-source/setuptools/dist.py", line 652, in _parse_config_files
    opt = self.warn_dash_deprecation(opt, section)
  File "/build/setuptools-57.0.0-source/setuptools/dist.py", line 685, in warn_dash_deprecation
    commands = distutils.command.__all__ + self._setuptools_commands()
  File "/build/setuptools-57.0.0-source/setuptools/dist.py", line 699, in _setuptools_commands
    dist = pkg_resources.get_distribution('setuptools')
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 466, in get_distribution
    dist = get_provider(dist)
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 342, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 626, in find
    if dist is not None and dist not in req:
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 3124, in __contains__
    item = item.version
  File "/build/setuptools-57.0.0-source/pkg_resources/__init__.py", line 2687, in version
    raise ValueError(msg, self) from e
ValueError: ("Missing 'Version:' header and/or PKG-INFO file at path: /build/setuptools-57.0.0-source/setuptools.egg-info/PKG-INFO", setuptools [unknown version] (/build/setuptools-57.0.0-source))
Traceback (most recent call last):
  File "/build/setuptools-57.0.0-source/bootstrap.py", line 57, in <module>
    __name__ == '__main__' and ensure_egg_info()
  File "/build/setuptools-57.0.0-source/bootstrap.py", line 38, in ensure_egg_info
    run_egg_info()
  File "/build/setuptools-57.0.0-source/bootstrap.py", line 54, in run_egg_info
    subprocess.check_call(cmd)
  File "/nix/store/j70c02srryah1fjvf36yj54bqx04rqgp-python3-3.9.5/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/nix/store/j70c02srryah1fjvf36yj54bqx04rqgp-python3-3.9.5/bin/python3.9', 'setup.py', 'egg_info']' returned non-zero exit status 1.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
