### PR TITLE
xorg.xorgserver: 1.20.11 -> 1.20.12

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3102,11 +3102,11 @@ lib.makeScope newScope (self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xorgserver = callPackage ({ stdenv, pkg-config, fetchurl, xorgproto, openssl, libX11, libXau, libXaw, libxcb, xcbutil, xcbutilwm, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, libXdmcp, libXfixes, libxkbfile, libXmu, libXpm, libXrender, libXres, libXt }: stdenv.mkDerivation {
     pname = "xorg-server";
-    version = "1.20.11";
+    version = "1.20.12";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/xserver/xorg-server-1.20.11.tar.bz2";
-      sha256 = "0jacqgin8kcyy8fyv0lhgb4if8g9hp60rm3ih3s1mgps7xp7jk4i";
+      url = "mirror://xorg/individual/xserver/xorg-server-1.20.12.tar.xz";
+      sha256 = "1b4ckvxaiiiwdxwyfzbbfkr384qqy5qzfsm37z0fr08x8f9w0v9k";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -218,4 +218,4 @@ mirror://xorg/individual/util/lndir-1.0.3.tar.bz2
 mirror://xorg/individual/util/makedepend-1.0.6.tar.bz2
 mirror://xorg/individual/util/util-macros-1.19.3.tar.bz2
 mirror://xorg/individual/util/xorg-cf-files-1.0.6.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-1.20.11.tar.bz2
+mirror://xorg/individual/xserver/xorg-server-1.20.12.tar.xz


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-July/003098.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
nixosTests.i3wm
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).