### PR TITLE
saxonb_8_8, saxon: Fix jre incompatibility

### DIFF
--- a/pkgs/development/libraries/java/saxon/default.nix
+++ b/pkgs/development/libraries/java/saxon/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, unzip, jre }:
+{ lib, stdenv, fetchurl, unzip, jre, jre8 }:
 
 let
-  common = { pname, version, src, description
+  common = { pname, version, src, description, java ? jre
            , prog ? null, jar ? null, license ? lib.licenses.mpl20 }:
     stdenv.mkDerivation {
       name = "${pname}-${version}";
@@ -45,6 +45,7 @@ in {
     description = "XSLT 1.0 processor";
     # http://saxon.sourceforge.net/saxon6.5.3/conditions.html
     license = lib.licenses.mpl10;
+    java = jre8;
   };
 
   saxonb_8_8 = common {
@@ -56,6 +57,7 @@ in {
       sha256 = "15bzrfyd2f1045rsp9dp4znyhmizh1pm97q8ji2bc0b43q23xsb8";
     };
     description = "Complete and conformant processor of XSLT 2.0, XQuery 1.0, and XPath 2.0";
+    java = jre8;
   };
 
   saxonb_9_1 = common {


### PR DESCRIPTION
###### Motivation for this change
While migrating to 21.05 I had issues regarding regex in xslt with saxonb_8_8. It seems the jre version in 21.05 and master is to new for the old package saxonb_8_8.
I have no issues using jre8 instead of jre in 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
