### PR TITLE
python-language-server: 2020-10-08 -> 2021-05-20

### DIFF
--- a/pkgs/development/dotnet-modules/python-language-server/default.nix
+++ b/pkgs/development/dotnet-modules/python-language-server/default.nix
@@ -10,8 +10,7 @@
 }:
 
 let deps = import ./deps.nix { inherit fetchurl; };
-
-    version = "2020-10-08";
+    version = "2021-05-20";
 
     # Build the nuget source needed for the later build all by itself
     # since it's a time-consuming step that only depends on ./deps.nix.
@@ -49,8 +48,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "python-language-server";
-    rev = "76a29da373a4bb1e81b052f25802f3ca872d0a67";
-    sha256 = "16jb90lacdrhi4dpp084bqzx351mv23f4mhl4lz5h6rkfzj5jxgg";
+    rev = "86825796eae15d4d46919bc6e32f1197196ba1b3";
+    sha256 = "sha256-izDE7Oil9g47Jf3eHPtW5coNixF71t9i0oYSuelakCo=";
   };
 
   buildInputs = [dotnet-sdk_3 openssl icu];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
