### PR TITLE
test-driver.py: handle qemu process exit

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -611,7 +611,7 @@ class Machine:
 
             tic = time.time()
             if self.shell.recv(1024) == 0:
-                 raise Exception("connect failed (qemu died)")
+                raise Exception("connect failed (qemu died)")
             # TODO: Timeout
             toc = time.time()
 

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -449,6 +449,8 @@ class Machine:
 
         while True:
             chunk = self.shell.recv(4096).decode(errors="ignore")
+            if len(chunk) == 0:
+                 raise Exception(f"command `{command}` failed (qemu died)")
             match = status_code_pattern.match(chunk)
             if match:
                 output += match[1]
@@ -608,7 +610,8 @@ class Machine:
             self.start()
 
             tic = time.time()
-            self.shell.recv(1024)
+            if self.shell.recv(1024) == 0:
+                 raise Exception("connect failed (qemu died)")
             # TODO: Timeout
             toc = time.time()
 


### PR DESCRIPTION
`qemu` process may exit during execution of the test.

It could happen 
 * due to a bug (we are testing software for bugs, so they are expected)
 * or after the guest executes `poweroff`
 * or user click [x] if the test is run intercatively

Now, testdriver just hangs forever in such cases