### PR TITLE
eternity-engine: 3.43.02 -> 4.02.00

### DIFF
--- a/pkgs/games/eternity-engine/default.nix
+++ b/pkgs/games/eternity-engine/default.nix
@@ -1,27 +1,28 @@
-{ lib, stdenv, cmake, libGL, SDL, SDL_mixer, SDL_net, fetchFromGitHub, makeWrapper }:
+{ lib, stdenv, cmake, libGL, SDL2, SDL2_mixer, SDL2_net, fetchFromGitHub, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "eternity-engine";
-  version = "3.42.02";
+  version = "4.02.00";
   src = fetchFromGitHub {
     owner = "team-eternity";
     repo = "eternity";
     rev = version;
-    sha256 = "00kpq4k23hjmzjaymw3sdda7mqk8fjq6dzf7fmdal9fm7lfmj41k";
+    sha256 = "0dlz7axbiw003bgwk2hl43w8r2bwnxhi042i1xwdiwaja0cpnf5y";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [ libGL SDL SDL_mixer SDL_net ];
+  buildInputs = [ libGL SDL2 SDL2_mixer SDL2_net ];
 
   installPhase = ''
-    install -Dm755 source/eternity $out/lib/eternity/eternity
+    install -Dm755 eternity/eternity $out/lib/eternity/eternity
     cp -r $src/base $out/lib/eternity/base
     mkdir $out/bin
     makeWrapper $out/lib/eternity/eternity $out/bin/eternity
   '';
 
   meta = {
-    homepage = "http://doomworld.com/eternity";
+    homepage = "https://doomworld.com/eternity";
     description = "New school Doom port by James Haley";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Update eternity engine to the most recent version. Some new WADs require the latest version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
