### PR TITLE
claws-mail: 3.17.8 -> 4.0.0

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -517,6 +517,14 @@
           <literal>rxvt-unicode</literal> explicitly.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>claws-mail</literal> package now references the
+          new GTK+ 3 release branch, major version 4. To use the GTK+ 2
+          releases, one can install the
+          <literal>claws-mail-gtk2</literal> package.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -126,3 +126,5 @@ In addition to numerous new and upgraded packages, this release has the followin
   However, if [`services.fail2ban.enable`](options.html#opt-services.fail2ban.enable) is `true`, the `fail2ban` will override the verbosity to `"VERBOSE"`, so that `fail2ban` can observe the failed login attempts from the SSH logs.
 
 - Sway: The terminal emulator `rxvt-unicode` is no longer installed by default via `programs.sway.extraPackages`. The current default configuration uses `alacritty` (and soon `foot`) so this is only an issue when using a customized configuration and not installing `rxvt-unicode` explicitly.
+
+- The `claws-mail` package now references the new GTK+ 3 release branch, major version 4. To use the GTK+ 2 releases, one can install the `claws-mail-gtk2` package.

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchgit, wrapGAppsHook, autoreconfHook, bison, flex
+{ stdenv, lib, fetchgit, fetchpatch, wrapGAppsHook, autoreconfHook, bison, flex
 , curl, gtk2, gtk3, pkg-config, python2, python3, shared-mime-info
 , glib-networking, gsettings-desktop-schemas
 
-# Use the experimental gtk3 branch.
-, useGtk3 ? false
+# Selector between the GTK+ 3 and GTK+ 2 releases.
+, useGtk3
 
 # Package compatibility: old parameters whose name were not directly derived
 , enablePgp ? true
@@ -57,16 +57,15 @@
 with lib;
 
 let
-  version = if useGtk3 then "3.99.0" else "3.17.8";
+  # Last release and hash for both the GTK+ 3 and GTK+ 2 version.
+  version = if useGtk3 then "4.0.0" else "3.18.0";
 
-  # The official release uses gtk2 and contains the version tag.
   gtk2src = {
-    sha256 = "0l4f8q11iyj8pi120lrapgq51k5j64xf0jlczkzbm99rym752ch5";
+    sha256 = "1vsiy3xsppw4d8ylsz70wsyrvmgy88lp2hj7vrc353ckny80r9lh";
   };
 
-  # The corresponding commit in the gtk3 branch.
   gtk3src = {
-    sha256 = "176h1swh1zx6dqyzfz470x4a1xicnv0zhy8ir47k7p23g6y17i2k";
+    sha256 = "0mwnjiqg2sj61va0y9yi3v52iyr5kzmbnvsqxav3a48m2f8p27qn";
   };
 
   python = if useGtk3 then python3 else python2;
@@ -125,7 +124,19 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  patches = [ ./mime.patch ];
+  patches = [
+    ./mime.patch
+
+    # Fixes a bug with the automatic authentication method, resulting in errors
+    # with certain mail providers.
+    # <https://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4497>
+    # This MUST be removed for the next release.
+    (fetchpatch {
+      name = "fix-automatic-auth.patch";
+      url = "https://git.claws-mail.org/?p=claws.git;a=patch;h=9c2585c58b49815a0eab8d683f0a94f75cbbe64e";
+      sha256 = "0v8v5q2p4h93lp7yq3gnlvarsrcssv96aks1wqy3187vsr4kdw7a";
+    })
+  ];
 
   preConfigure = ''
     # autotools check tries to dlopen libpython as a requirement for the python plugin

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -129,6 +129,7 @@ mapAliases ({
   clang12Stdenv = lowPrio llvmPackages_12.stdenv;
 
   clangAnalyzer = clang-analyzer;  # added 2015-02-20
+  claws-mail-gtk3 = claws-mail; # added 2021-07-10
   clawsMail = claws-mail; # added 2016-04-29
   clutter_gtk = clutter-gtk; # added 2018-02-25
   cmakeWithQt4Gui = throw "cmakeWithQt4Gui has been removed in favor of cmakeWithGui (Qt 5)"; # added 2021-05

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23280,10 +23280,11 @@ in
 
   cipher = callPackage ../applications/misc/cipher { };
 
-  claws-mail = callPackage ../applications/networking/mailreaders/claws-mail {
+  claws-mail-gtk2 = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;
+    useGtk3 = false;
   };
-  claws-mail-gtk3 = callPackage ../applications/networking/mailreaders/claws-mail {
+  claws-mail = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;
     useGtk3 = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
With Claws Mail's latest double release of 3.18.0 and 4.0.0, the package
will refer to the more "modern" GTK+ 3 release, major version four. The
GTK+ 2 release, major version 3, is now available in the
`claws-mail-gtk2` package.

In other words, this commit bumps the GTK+ 2 version from 3.17.8 to
3.18.0, the previously unstable GTK+ 3 version 3.99.0 to 4.0.0 and
changes the default to GTK+ 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
