### PR TITLE
nixos-option: add backwards compatibility layer

### DIFF
--- a/nixos/modules/installer/tools/nixos-option/default.nix
+++ b/nixos/modules/installer/tools/nixos-option/default.nix
@@ -1,0 +1,1 @@
+{ pkgs, ... }: pkgs.nixos-option


### PR DESCRIPTION
This adds a basic `nixos-option/default.nix` file to provide some measure of backwards compatibility with Nixpkgs prior to ce6f17f9530ea013d267e07d2dd958bb4e3019dd.

See #129779.