### PR TITLE
python3Packages.aiosmb: 0.2.48 -> 0.2.49

### DIFF
--- a/pkgs/development/python-modules/aiosmb/default.nix
+++ b/pkgs/development/python-modules/aiosmb/default.nix
@@ -5,6 +5,7 @@
 , fetchPypi
 , minikerberos
 , prompt_toolkit
+, pycryptodomex
 , pythonOlder
 , six
 , tqdm
@@ -14,12 +15,12 @@
 
 buildPythonPackage rec {
   pname = "aiosmb";
-  version = "0.2.48";
+  version = "0.2.49";
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f5518987e3d41d213a4ffc4dd38362465b5d2cf99417014cb5402f8ee8c5abac";
+    sha256 = "sha256-XCaAaY7a6Gdddm9B0ET+rVzFra5W0GTI/HUMuvpyhzM=";
   };
 
   propagatedBuildInputs = [
@@ -27,6 +28,7 @@ buildPythonPackage rec {
     colorama
     minikerberos
     prompt_toolkit
+    pycryptodomex
     six
     tqdm
     winacl
@@ -35,6 +37,7 @@ buildPythonPackage rec {
 
   # Project doesn't have tests
   doCheck = false;
+
   pythonImportsCheck = [ "aiosmb" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upddate to latest upstream release 0.2.49


Change log: https://github.com/skelsec/aiosmb/releases/tag/0.2.49

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
