### PR TITLE
jetbrains: add libdbusmenu support

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -40,8 +40,8 @@ with stdenv; lib.makeOverridable mkDerivation rec {
     makeWrapper
     patchelf
     unzip
-  ] ++ optional (!stdenv.isDarwin) [ autoPatchelfHook ];
-  buildInputs = lib.optional (!stdenv.isDarwin) [
+  ] ++ optionals (!stdenv.isDarwin) [ autoPatchelfHook ];
+  buildInputs = lib.optionals (!stdenv.isDarwin) [
     libdbusmenu
     python3
     stdenv.cc.cc

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,9 +1,8 @@
 { lib, stdenv, callPackage, fetchurl
-, jdk, cmake, zlib, python3
+, jdk, cmake, zlib
 , dotnet-sdk_5
-, autoPatchelfHook
-, libdbusmenu
 , vmopts ? null
+, python3
 }:
 
 with lib;
@@ -27,26 +26,12 @@ let
         platforms = platforms.linux;
       };
     }).overrideAttrs (attrs: {
-      nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ optionals (stdenv.isLinux) [
-        autoPatchelfHook
-      ];
-      buildInputs = (attrs.buildInputs or []) ++ optionals (stdenv.isLinux) [
-        python3
-        stdenv.cc.cc
-        libdbusmenu
-      ];
-      dontAutoPatchelf = true;
       postFixup = (attrs.postFixup or "") + optionalString (stdenv.isLinux) ''
         (
-          cd $out/clion-${version}
+          cd $out/${name}
           # bundled cmake does not find libc
           rm -rf bin/cmake/linux
           ln -s ${cmake} bin/cmake/linux
-
-          autoPatchelf $PWD/bin
-
-          wrapProgram $out/bin/clion \
-            --set CL_JDK "${jdk}"
         )
       '';
     });

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,8 +1,7 @@
 { lib, stdenv, callPackage, fetchurl
-, jdk, cmake, zlib
+, jdk, cmake, zlib, python3
 , dotnet-sdk_5
 , vmopts ? null
-, python3
 }:
 
 with lib;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added global menu support for all jetbrains ide by using patchelf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
