### PR TITLE
thunderbird: improve integration by depending on xdg-utils

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -41,6 +41,7 @@
 , pango
 , runtimeShell
 , writeScript
+, xdg-utils
 , xidel
 }:
 
@@ -164,6 +165,7 @@ stdenv.mkDerivation {
         --set MOZ_LEGACY_PROFILES 1 \
         --set MOZ_ALLOW_DOWNGRADE 1 \
         --prefix PATH : "${lib.getBin gnupg}/bin" \
+        --prefix PATH : "${lib.getBin xdg-utils}/bin" \
         --prefix LD_LIBRARY_PATH : "${lib.getLib gpgme}/lib"
     '';
 

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -50,6 +50,7 @@
 , unzip
 , which
 , writeScript
+, xdg-utils
 , xidel
 , xorg
 , yasm
@@ -311,6 +312,7 @@ stdenv.mkDerivation rec {
       --set MOZ_LEGACY_PROFILES 1
       --set MOZ_ALLOW_DOWNGRADE 1
       --prefix PATH : "${lib.getBin gnupg}/bin"
+      --prefix PATH : "${lib.getBin xdg-utils}/bin"
       --prefix LD_LIBRARY_PATH : "${lib.getLib gpgme}/lib"
     )
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In the absence of xdg-utils (on linux, when firefox defaults to that) thunderbird incorrectly reports that it is not the default mail reader. It could be wiser to skip that "integration" when the command is not found, but it is not how thunderbird proceeds. See https://searchfox.org/comm-central/rev/c530d3a7895a1b0b4034946d6e27f275637bf379/mail/components/shell/nsGNOMEShellService.cpp#225-247

Furthermore, the use of SNAP_NAME introduced in https://github.com/NixOS/nixpkgs/pull/61980 force thunderbird to run in snap mode, making xdg-utils a hard requirement, because in that mode it does not use the gnome service for that (see searchfox link above).

This commit (re?)introduces xdg-utils as a dependency for thunderbird and thunderbird-bin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
