### PR TITLE
python3Packages.python-registry: 1.3.1 -> 1.4

### DIFF
--- a/pkgs/development/python-modules/python-registry/default.nix
+++ b/pkgs/development/python-modules/python-registry/default.nix
@@ -1,16 +1,20 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , enum-compat
+, fetchFromGitHub
+, pytestCheckHook
 , unicodecsv
 }:
+
 buildPythonPackage rec {
   pname = "python-registry";
-  version = "1.3.1";
+  version = "1.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "99185f67d5601be3e7843e55902d5769aea1740869b0882f34ff1bd4b43b1eb2";
+  src = fetchFromGitHub {
+    owner = "williballenthin";
+    repo = pname;
+    rev = version;
+    sha256 = "0gwx5jcribgmmbz0ikhz8iphz7yj2d2nmk24nkdrjd3y5irly11s";
   };
 
   propagatedBuildInputs = [
@@ -18,8 +22,13 @@ buildPythonPackage rec {
     unicodecsv
   ];
 
-  # no tests
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    "samples"
+  ];
 
   pythonImportsCheck = [
     "Registry"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4

Change log: https://github.com/williballenthin/python-registry/releases/tag/1.4

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
