### PR TITLE
tree-sitter-latex: init at HEAD

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -16,6 +16,7 @@
   tree-sitter-jsdoc = (builtins.fromJSON (builtins.readFile ./tree-sitter-jsdoc.json));
   tree-sitter-json = (builtins.fromJSON (builtins.readFile ./tree-sitter-json.json));
   tree-sitter-julia = (builtins.fromJSON (builtins.readFile ./tree-sitter-julia.json));
+  tree-sitter-latex = (builtins.fromJSON (builtins.readFile ./tree-sitter-latex.json));
   tree-sitter-lua = (builtins.fromJSON (builtins.readFile ./tree-sitter-lua.json));
   tree-sitter-markdown = (builtins.fromJSON (builtins.readFile ./tree-sitter-markdown.json));
   tree-sitter-nix = (builtins.fromJSON (builtins.readFile ./tree-sitter-nix.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/latex-lsp/tree-sitter-latex",
+  "rev": "7f720661de5316c0f8fee956526d4002fa1086d8",
+  "date": "2021-05-11T16:35:53+02:00",
+  "path": "/nix/store/ssqxahrza89qmb97bxas6dvhbqd7w0dr-tree-sitter-latex",
+  "sha256": "14jfmbv3czs643bggcsi3pyxhf81jirpvg8hxcbcdx1f3fzhs16m",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -74,6 +74,10 @@ let
       orga = "cstrahan";
       repo = "tree-sitter-nix";
     };
+    "tree-sitter-latex" = {
+      orga = "latex-lsp";
+      repo = "tree-sitter-latex";
+    };
     "tree-sitter-lua" = {
       orga = "nvim-treesitter";
       repo = "tree-sitter-lua";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

tested in neovim

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via nix-build -A tree-sitter.tests
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @Profpatsch as maintainer