### PR TITLE
zstd: don't build contrib when cross-compiling

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -3,6 +3,9 @@
 , file
 , legacySupport ? false
 , static ? stdenv.hostPlatform.isStatic
+# these need to be ran on the host, thus disable when cross-compiling
+, buildContrib ? stdenv.hostPlatform == stdenv.buildPlatform
+, doCheck ? stdenv.hostPlatform == stdenv.buildPlatform
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +43,7 @@ stdenv.mkDerivation rec {
     (name: value: "-DZSTD_${name}:BOOL=${if value then "ON" else "OFF"}") {
       BUILD_SHARED = !static;
       BUILD_STATIC = static;
-      BUILD_CONTRIB = true;
+      BUILD_CONTRIB = buildContrib;
       PROGRAMS_LINK_SHARED = !static;
       LEGACY_SUPPORT = legacySupport;
       BUILD_TESTS = doCheck;
@@ -53,7 +56,7 @@ stdenv.mkDerivation rec {
   '';
 
   checkInputs = [ file ];
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  inherit doCheck;
   checkPhase = ''
     runHook preCheck
     # Patch shebangs for playTests
@@ -64,7 +67,6 @@ stdenv.mkDerivation rec {
 
   preInstall = ''
     mkdir -p $bin/bin
-    cp contrib/pzstd/pzstd $bin/bin/pzstd
     substituteInPlace ../programs/zstdgrep \
       --replace ":-grep" ":-${gnugrep}/bin/grep" \
       --replace ":-zstdcat" ":-$bin/bin/zstdcat"
@@ -73,6 +75,8 @@ stdenv.mkDerivation rec {
       --replace "zstdcat" "$bin/bin/zstdcat"
   '' + lib.optionalString stdenv.isDarwin ''
     install_name_tool -change @rpath/libzstd.1.dylib $out/lib/libzstd.1.dylib $bin/bin/pzstd
+  '' + lib.optionalString buildContrib ''
+    cp contrib/pzstd/pzstd $bin/bin/pzstd
   '';
 
   outputs = [ "bin" "dev" ]


### PR DESCRIPTION
###### Motivation for this change

Address build failures mentioned here: https://github.com/NixOS/nixpkgs/pull/128824#issuecomment-877651252

    Tests and `./gen_html` from contrib need to run
    on host architecture. Disable them when doing
    cross-compiliation.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
