### PR TITLE
fennel: init at 0.9.2

### DIFF
--- a/pkgs/development/compilers/fennel/default.nix
+++ b/pkgs/development/compilers/fennel/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromSourcehut, installShellFiles, lua }:
+
+stdenv.mkDerivation rec {
+  pname = "fennel";
+  version = "0.9.2";
+
+  src = fetchFromSourcehut {
+    owner = "~technomancy";
+    repo = pname;
+    rev = version;
+    sha256 = "1kpm3lzxzwkhxm4ghpbx8iw0ni7gb73y68lsc3ll2rcx0fwv9303";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ lua ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postInstall = ''
+    installManPage fennel.1
+  '';
+
+  meta = with lib; {
+    description = "A Lua Lisp language";
+    homepage = "https://fennel-lang.org/";
+    license = licenses.mit;
+    platforms = lua.meta.platforms;
+    maintainers = [ maintainers.maaslalani ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10760,6 +10760,8 @@ in
 
   fasmg = callPackage ../development/compilers/fasmg { };
 
+  fennel = callPackage ../development/compilers/fennel { };
+
   flasm = callPackage ../development/compilers/flasm { };
 
   flyctl = callPackage ../development/web/flyctl { };


### PR DESCRIPTION
###### Motivation for this change
Adds https://fennel-lang.org/ to `nixpkgs` to compile fennel to lua.

Closes https://github.com/NixOS/nixpkgs/pull/106987

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
