### PR TITLE
cudatext: 1.133.5 → 1.137.2

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.133.5";
+  version = "1.137.2";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-0QWYitlOS3x7BQpFTYDAjIgkw83IkRFfA/slyEvQUnw=";
+    sha256 = "sha256-OiLYXx1sBkEJpMPTa/45QPHLtmeI6ZLles7GfjEBGtQ=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -6,33 +6,33 @@
   },
   "ATBinHex-Lazarus": {
     "owner": "Alexey-T",
-    "rev": "2021.02.13",
-    "sha256": "1p2r2q1al6rcsdbbg8ilm4xn6w48bj348khxdmpak7vfwx9741h8"
+    "rev": "2021.07.02",
+    "sha256": "sha256-XSt2XfHMiF/ZIf07M65u+k5FjacyToL0rWbpcflKcuY="
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2021.05.16",
-    "sha256": "sha256-oQW0M8Sx1bC+keOWivXwlD5SDKJuO5Sk/3HiO9HvJtY="
+    "rev": "2021.07.09",
+    "sha256": "sha256-hVoHH29JLPy3qq73e5EV4bxERcizocO4RBgvqD+VhWo="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.05.31",
-    "sha256": "sha256-4B6/I0CH9gfslwUbCTTI4kycgTHUjLGtVrCctfO6gRo="
+    "rev": "0cf6e09f673beb3a25d6957c97eeeee37024617b",
+    "sha256": "sha256-oqxzORNva7tZXNlI/mSe722p6Tbkf7Ie6GPL3TxjV98="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.05.03",
-    "sha256": "sha256-zns83XA2SslHRGqa3iro0phIBlz5/neJ34TTYAKhX5Q="
+    "rev": "2021.07.09",
+    "sha256": "sha256-w5f1s8yjkYfDqAcKISRgJd3fe+f2NyO3ZtFLLfiBm2Q="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.05.27",
-    "sha256": "sha256-D0UBK69V28Izs9FgevtvX6vyDU7KpfIGJqcqpWaxU9E="
+    "rev": "2021.07.02",
+    "sha256": "sha256-PndvBiqdqw681AC6q33UWdzUvcYHxj1WuYsVFi2HK7c="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2021.05.27",
-    "sha256": "sha256-1zhSB6bgeW5G6RAZvhznNTpRk0uEDZnLXsk+cgElKLw="
+    "rev": "2021.07.09",
+    "sha256": "sha256-QCG9i26m3v9J4uO1I1BiDwBerH4iX1rAJuNqx+gHLnA="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://cudatext.github.io/history.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
