### PR TITLE
quill: init at 0.2.1

### DIFF
--- a/pkgs/tools/security/quill/default.nix
+++ b/pkgs/tools/security/quill/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, openssl, Security, libiconv, pkg-config, protobuf, which, buildPackages }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "quill";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "dfinity";
+    repo = "quill";
+    rev = "v${version}";
+    sha256 = "02ga2xkdxs36mfr4lv43cy6wkf27c28bdkzfkp3az5jvyk17mkfr";
+  };
+
+  ic = fetchFromGitHub {
+    owner = "dfinity";
+    repo = "ic";
+    rev = "779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f";
+    sha256 = "1r31d5hab7k1n60a7y8fw79fjgfq04cgj9krwa6r9z4isi3919v6";
+  };
+
+  registry = "file://local-registry";
+
+  preBuild = ''
+    export REGISTRY_TRANSPORT_PROTO_INCLUDES=${ic}/rs/registry/transport/proto
+    export IC_BASE_TYPES_PROTO_INCLUDES=${ic}/rs/types/base_types/proto
+    export IC_PROTOBUF_PROTO_INCLUDES=${ic}/rs/protobuf/def
+    export IC_NNS_COMMON_PROTO_INCLUDES=${ic}/rs/nns/common/proto
+    export PROTOC=${buildPackages.protobuf}/bin/protoc
+    export OPENSSL_DIR=${openssl.dev}
+    export OPENSSL_LIB_DIR=${openssl.out}/lib
+  '';
+
+  cargoSha256 = "142pzhyi73ljlqas5vbhjhn4vmp9w9ps1mv8q7s3kzg0h7jcvm1k";
+
+  nativeBuildInputs = [ pkg-config protobuf ];
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Security libiconv ];
+
+  meta = with lib; {
+    homepage = "https://github.com/dfinity/quill";
+    changelog = "https://github.com/dfinity/quill/releases/tag/v${version}";
+    description = "Minimalistic ledger and governance toolkit for cold wallets on the Internet Computer.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ imalison ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18021,6 +18021,10 @@ in
 
   quicksynergy = callPackage ../applications/misc/quicksynergy { };
 
+  quill = callPackage ../tools/security/quill {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   qv2ray = libsForQt5.callPackage ../applications/networking/qv2ray {};
 
   qwt = callPackage ../development/libraries/qwt {};


### PR DESCRIPTION
###### Motivation for this change

Add quill package


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
