### PR TITLE
grafana-agent: 0.15.0 -> 0.16.1

### DIFF
--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,21 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.15.0";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-mRDd9G/VMbDwp/GYPoUE0v9j+BmUd08wOMJjgcg2qdo=";
+    sha256 = "0kqbn6fqlrxjqdkkhbr7qmm2m05a7dlskfdb7y4gr5ggi65m6ik5";
   };
 
-  vendorSha256 = "sha256-sQFWdBOjfYb1e7ZzHGgtgnuEQCU4xnkJTyzC/9DRcYs=";
+  vendorSha256 = "0xi69a1zkcmi5q8m7lfwp3xb4cbkwc2dzqm24lfqsq13xj5jq6ph";
+
+  patches = [
+    # https://github.com/grafana/agent/issues/731
+    ./skip_test_requiring_network.patch
+  ];
 
   # uses go-systemd, which uses libsystemd headers
   # https://github.com/coreos/go-systemd/issues/351

--- a/pkgs/servers/monitoring/grafana-agent/skip_test_requiring_network.patch
+++ b/pkgs/servers/monitoring/grafana-agent/skip_test_requiring_network.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/operator/selector_eventhandler_test.go b/pkg/operator/selector_eventhandler_test.go
+index 7b6ec602..e79bae0e 100644
+--- a/pkg/operator/selector_eventhandler_test.go
++++ b/pkg/operator/selector_eventhandler_test.go
+@@ -39,6 +39,10 @@ var (
+ // TestEnqueueRequestForSelector creates an example Kubenretes cluster and runs
+ // EnqueueRequestForSelector to validate it works.
+ func TestEnqueueRequestForSelector(t *testing.T) {
++	// Requires network access, which is not available during
++	// the nixpkgs sandboxed build
++	t.Skip()
++
+ 	l := log.NewNopLogger()
+ 
+ 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)


### PR DESCRIPTION
###### Motivation for this change
New release!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
