### PR TITLE
slides: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/applications/misc/slides/default.nix
+++ b/pkgs/applications/misc/slides/default.nix
@@ -1,14 +1,14 @@
-{ lib, buildGoModule, fetchFromGitHub, bash, go, python3, ruby, sd }:
+{ lib, buildGoModule, fetchFromGitHub, bash, go, python3, ruby }:
 
 buildGoModule rec {
   pname = "slides";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "maaslalani";
     repo = "slides";
     rev = "v${version}";
-    sha256 = "15f4sn1zsqqhzxnmwb1igh8xhka6li31ygdqgbjvxzm93lkarxvs";
+    sha256 = "1cywqrqj199hmx532h4vn0j17ypswq2zkmv8qpxpayvjwimx4pwk";
   };
 
   checkInputs = [
@@ -16,7 +16,6 @@ buildGoModule rec {
     go
     python3
     ruby
-    sd
   ];
 
   vendorSha256 = "0y6fz9rw702mji571k0gp4kpfx7xbv7rvlnmpfjygy6lmp7wga6f";


### PR DESCRIPTION
###### Motivation for this change
Bump `slides` package to latest (`v0.4.1`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
