### PR TITLE
geeqie: 1.5.1 -> 1.6

### DIFF
--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -1,15 +1,31 @@
-{ lib, stdenv, fetchurl, pkg-config, autoconf, automake, gettext, intltool
-, gtk3, lcms2, exiv2, libchamplain, clutter-gtk, ffmpegthumbnailer, fbida
-, wrapGAppsHook, fetchpatch
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, autoconf
+, automake
+, gettext
+, intltool
+, gtk3
+, lcms2
+, exiv2
+, libchamplain
+, clutter-gtk
+, ffmpegthumbnailer
+, fbida
+, wrapGAppsHook
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "geeqie";
-  version = "1.5.1";
+  version = "1.6";
 
-  src = fetchurl {
-    url = "http://geeqie.org/${pname}-${version}.tar.xz";
-    sha256 = "02m1vqaasin249xx792cdj11xyag8lnanwzxd108y7y34g9xam28";
+  src = fetchFromGitHub {
+    owner = "BestImageViewer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1i9yd8lddp6b9s9vjjjzbpqj4bvwidxc6kiba6vdrk7dda5akyky";
   };
 
   patches = [
@@ -23,12 +39,23 @@ stdenv.mkDerivation rec {
 
   preConfigure = "./autogen.sh";
 
-  nativeBuildInputs = [ pkg-config autoconf automake gettext intltool
+  nativeBuildInputs = [
+    pkg-config
+    autoconf
+    automake
+    gettext
+    intltool
     wrapGAppsHook
   ];
 
   buildInputs = [
-    gtk3 lcms2 exiv2 libchamplain clutter-gtk ffmpegthumbnailer fbida
+    gtk3
+    lcms2
+    exiv2
+    libchamplain
+    clutter-gtk
+    ffmpegthumbnailer
+    fbida
   ];
 
   postInstall = ''
@@ -42,7 +69,6 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Lightweight GTK based image viewer";
-
     longDescription =
       ''
         Geeqie is a lightweight GTK based image viewer for Unix like
@@ -53,11 +79,8 @@ stdenv.mkDerivation rec {
         image comparison, sorting and managing photo collection.  Geeqie was
         initially based on GQview.
       '';
-
     license = licenses.gpl2Plus;
-
-    homepage = "http://geeqie.sourceforge.net";
-
+    homepage = "https://github.com/BestImageViewer/geeqie";
     maintainers = with maintainers; [ jfrankenau pSub markus1189 ];
     platforms = platforms.gnu ++ platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Update geeqie to the latest version. The project changed their website and recommended fetching the source from github.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
