### PR TITLE
python3Packages.devtools: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4793,6 +4793,12 @@
     githubId = 1383440;
     name = "Jason Gilliland";
   };
+  jdahm = {
+    email = "johann.dahm@gmail.com";
+    github = "jdahm";
+    githubId = 68032;
+    name = "Johann Dahm";
+  };
   jdanek = {
     email = "jdanek@redhat.com";
     github = "jdanekrh";

--- a/pkgs/development/python-modules/devtools/default.nix
+++ b/pkgs/development/python-modules/devtools/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, pythonOlder, fetchFromGitHub, lib, pygments
+, pytestCheckHook, pytest-mock }:
+
+buildPythonPackage rec {
+  pname = "devtools";
+  version = "0.6.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "samuelcolvin";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "0s1d2jwijini7y1a3318yhb98mh1mw4pzlfx2zck3a8nqw984ki3";
+  };
+
+  propagatedBuildInputs = [ pygments ];
+
+  checkInputs = [ pytestCheckHook pytest-mock ];
+
+  pythonImportsCheck = [ "devtools" ];
+
+  meta = with lib; {
+    description = "Python's missing debug print command and other development tools";
+    homepage = "https://python-devtools.helpmanual.io/";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/devtools/default.nix
+++ b/pkgs/development/python-modules/devtools/default.nix
@@ -23,5 +23,6 @@ buildPythonPackage rec {
     description = "Python's missing debug print command and other development tools";
     homepage = "https://python-devtools.helpmanual.io/";
     license = licenses.mit;
+    maintainers = with maintainers; [ jdahm ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1909,6 +1909,8 @@ in {
 
   devpi-common = callPackage ../development/python-modules/devpi-common { };
 
+  devtools = callPackage ../development/python-modules/devtools { };
+
   diagrams = callPackage ../development/python-modules/diagrams { };
 
   diceware = callPackage ../development/python-modules/diceware { };


### PR DESCRIPTION
###### Motivation for this change

Add "Python's missing debug print command and other development tools".

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
