### PR TITLE
esphome, platformio: fix build

### DIFF
--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,30 +1,74 @@
-{ stdenv, lib, buildPythonApplication
-, ajsonrpc
-, bottle
-, click
-, click-completion
-, colorama
+{ stdenv, lib, python3
+, fetchFromGitHub
 , git
-, jsondiff
-, lockfile
-, marshmallow
-, pyelftools
-, pyserial
-, pytest
-, requests
-, semantic-version
 , spdx-license-list-data
-, starlette
-, tabulate
-, tox
-, uvicorn
-, wsproto
-, zeroconf
 , version, src
 }:
 
 let
-  args = lib.concatStringsSep " " ((map (e: "--deselect tests/${e}") [
+  python = python3.override {
+    packageOverrides = self: super: {
+      aiofiles = super.aiofiles.overridePythonAttrs (oldAttrs: rec {
+        version = "0.6.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "e0281b157d3d5d59d803e3f4557dcc9a3dff28a4dd4829a9ff478adae50ca092";
+        };
+      });
+
+      click = super.click.overridePythonAttrs (oldAttrs: rec {
+        version = "7.1.2";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "06kbzd6sjfkqan3miwj9wqyddfxc2b6hi7p5s4dvqjb3gif2bdfj";
+        };
+      });
+
+      uvicorn = super.uvicorn.overridePythonAttrs (oldAttrs: rec {
+        version = "0.13.2";
+        src = fetchFromGitHub {
+          owner = "encode";
+          repo = "uvicorn";
+          rev = version;
+          sha256 = "04zgmp9z46k72ay6cz7plga6d3w3a6x41anabm7ramp7jdqf6na9";
+        };
+      });
+    };
+  };
+in
+with python.pkgs; buildPythonApplication rec {
+  pname = "platformio";
+  inherit version src;
+
+  propagatedBuildInputs = [
+    ajsonrpc
+    bottle
+    click
+    click-completion
+    colorama
+    git
+    lockfile
+    marshmallow
+    pyelftools
+    pyserial
+    requests
+    semantic-version
+    starlette
+    tabulate
+    uvicorn
+    wsproto
+    zeroconf
+  ];
+
+  HOME = "/tmp";
+
+  checkInputs = [
+    jsondiff
+    pytestCheckHook
+    tox
+  ];
+
+  pytestFlagsArray = (map (e: "--deselect tests/${e}") [
     "commands/test_ci.py::test_ci_boards"
     "commands/test_ci.py::test_ci_build_dir"
     "commands/test_ci.py::test_ci_keep_build_dir"
@@ -88,43 +132,9 @@ let
     "commands/test_update.py"
     "test_maintenance.py"
     "test_ino2cpp.py"
-  ]));
-
-in buildPythonApplication rec {
-  pname = "platformio";
-  inherit version src;
-
-  propagatedBuildInputs = [
-    ajsonrpc
-    bottle
-    click
-    click-completion
-    colorama
-    git
-    lockfile
-    marshmallow
-    pyelftools
-    pyserial
-    requests
-    semantic-version
-    starlette
-    tabulate
-    uvicorn
-    wsproto
-    zeroconf
+  ]) ++ [
+    "tests"
   ];
-
-  HOME = "/tmp";
-
-  checkInputs = [ pytest tox jsondiff ];
-
-  checkPhase = ''
-    runHook preCheck
-
-    py.test -v tests ${args}
-
-    runHook postCheck
-  '';
 
   patches = [
     ./fix-searchpath.patch

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -8,9 +8,13 @@
 }:
 
 let
-  esphome-dashboard = pkgs.callPackage ./dashboard.nix {};
+  python = python3.override {
+    packageOverrides = self: super: {
+      esphome-dashboard = pkgs.callPackage ./dashboard.nix {};
+    };
+  };
 in
-python3.pkgs.buildPythonApplication rec {
+with python.pkgs; buildPythonApplication rec {
   pname = "esphome";
   version = "1.19.4";
 
@@ -49,7 +53,7 @@ python3.pkgs.buildPythonApplication rec {
   # They have validation functions like:
   # - validate_cryptography_installed
   # - validate_pillow_installed
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     click
     colorama
     cryptography
@@ -73,13 +77,20 @@ python3.pkgs.buildPythonApplication rec {
     "--set ESPHOME_USE_SUBPROCESS ''"
   ];
 
-  checkInputs = with python3.pkgs; [
+  checkInputs = [
     hypothesis
     mock
     pytest-asyncio
     pytest-mock
     pytest-sugar
     pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # requires hypothesis 5.49, we have 6.x
+    # ImportError: cannot import name 'ip_addresses' from 'hypothesis.provisional'
+    "tests/unit_tests/test_core.py"
+    "tests/unit_tests/test_helpers.py"
   ];
 
   postCheck = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes the esphome build.

Pins some packages in platformio, disables some test paths in esphome,

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
