### PR TITLE
binutils: Patch `strip` performance regression

### DIFF
--- a/pkgs/development/tools/misc/binutils/bfd-elf-Dont-read-non-existing-secondary-relocs.patch
+++ b/pkgs/development/tools/misc/binutils/bfd-elf-Dont-read-non-existing-secondary-relocs.patch
@@ -1,0 +1,26 @@
+X-Git-Url: https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Felf.c;h=af62aadc3d446cd5b1f0201b207c90c22e7809b1;hp=36733e080dd9d9be28b576b246aaf5bd8c8569c7;hb=84fd26d8209e99fc3a432dd0b09b6c053de1ce65;hpb=abe2a28aaa7a2bfd0f3061c72a98eb898976b721
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index 36733e080dd..af62aadc3d4 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -2454,6 +2454,8 @@ bfd_section_from_shdr (bfd *abfd, unsigned int shindex)
+ 		     "for section %pA found - ignoring"),
+ 		   abfd, name, target_sect);
+ 	      }
++	    else
++	      esdt->has_secondary_relocs = TRUE;
+ 	    goto success;
+ 	  }
+ 
+@@ -12587,6 +12589,9 @@ _bfd_elf_slurp_secondary_reloc_section (bfd *       abfd,
+ #endif
+     r_sym = elf32_r_sym;
+   
++  if (!elf_section_data (sec)->has_secondary_relocs)
++    return TRUE;
++
+   /* Discover if there are any secondary reloc sections
+      associated with SEC.  */
+   for (relsec = abfd->sections; relsec != NULL; relsec = relsec->next)
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -61,6 +61,15 @@ stdenv.mkDerivation {
     # cross-compiling.
     ./always-search-rpath.patch
 
+    # Fix quadratic slowdown in `strip` performance.
+    # See #129467 and https://sourceware.org/bugzilla/show_bug.cgi?id=28058
+    # Remove when we're on binutils > 2.36.1.
+    # The patch is downloaded from
+    #     https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff_plain;f=bfd/elf.c;h=af62aadc3d446cd5b1f0201b207c90c22e7809b1;hp=36733e080dd9d9be28b576b246aaf5bd8c8569c7;hb=84fd26d8209e99fc3a432dd0b09b6c053de1ce65;hpb=abe2a28aaa7a2bfd0f3061c72a98eb898976b721
+    # which is the 2.36 backport (using `TRUE` instead of `true` of binutils master commit:
+    #     https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=956ea65cd707707c0f725930214cbc781367a831
+    ./bfd-elf-Dont-read-non-existing-secondary-relocs.patch
+
     ./CVE-2020-35448.patch
   ] ++ lib.optional stdenv.targetPlatform.isiOS ./support-ios.patch
     ++ # This patch was suggested by Nick Clifton to fix


### PR DESCRIPTION
###### Motivation for this change

Fixes #129467.

`binutils 2.37` will have this patch, but I don't know how long it will take NixOS to switch to that (given that `staging` has 2.35.1 and 2.36.1 was already released 5 months ago), thus posting the inclusion of the patch here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've also built everything in [`static-haskell-nix`](https://github.com/nh2/static-haskell-nix) against it and the programs work fine, so it looks like a safe patch to apply.