### PR TITLE
idutils: fix by using latest gnulib

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "gnulib";
-  version = "20200223";
+  version = "20210702";
 
   src = fetchgit {
     url = "https://git.savannah.gnu.org/r/gnulib.git";
-    rev = "292fd5d6ff5ecce81ec3c648f353732a9ece83c0";
-    sha256 = "0hkg3nql8nsll0vrqk4ifda0v4kpi67xz42r8daqsql6c4rciqnw";
+    rev = "901694b904cd861adc2529b2e05a3fb33f9b534f";
+    sha256 = "1f5znlv2wjziglw9vlygdgm4jfbsz34h2dz6w4h90bl4hm0ycb1w";
   };
 
   postPatch = ''

--- a/pkgs/tools/X11/xprintidle-ng/default.nix
+++ b/pkgs/tools/X11/xprintidle-ng/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace configure.ac \
-      --replace "AC_PREREQ([2.62])" "AC_PREREQ([2.63])"
+      --replace "AC_PREREQ([2.62])" "AC_PREREQ([2.64])"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/tools/compression/lbzip2/default.nix
+++ b/pkgs/tools/compression/lbzip2/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake ];
 
   preConfigure = ''
+    substituteInPlace configure.ac --replace 'AC_PREREQ([2.63])' 'AC_PREREQ(2.64)'
     ./build-aux/autogen.sh
   '';
 

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation {
   ++ map fetchurl (import ./grub1.patches.nix)
   ;
 
+  preConfigure = ''
+    substituteInPlace ./configure.ac --replace 'AC_PREREQ(2.61)' 'AC_PREREQ(2.64)'
+  '';
+
   # autoreconfHook required for the splashimage patch.
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ texinfo ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5546,7 +5546,17 @@ in
 
   grub2 = grub2_full;
 
-  grub2_full = callPackage ../tools/misc/grub/2.0x.nix { };
+  grub2_full = callPackage ../tools/misc/grub/2.0x.nix {
+    # update breaks grub2
+    gnulib = pkgs.gnulib.overrideAttrs (oldAttrs: rec {
+      version = "20200223";
+      src = fetchgit {
+        url = "https://git.savannah.gnu.org/r/gnulib.git";
+        rev = "292fd5d6ff5ecce81ec3c648f353732a9ece83c0";
+        sha256 = "0hkg3nql8nsll0vrqk4ifda0v4kpi67xz42r8daqsql6c4rciqnw";
+      };
+    });
+  };
 
   grub2_efi = grub2.override {
     efiSupport = true;


### PR DESCRIPTION
###### Motivation for this change
Fix broken idutils by updating gnulib to latest from savannah.gnu.org
See issue #129658 (idutils: is marked broken but just needs gnulib update )

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS  (don't have MacOS)
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
