### PR TITLE
flake/lib.nixosSystem: add `_file`-keys for error-location if needed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,8 +47,20 @@
                       })
                     ];
                   })).config;
+
+                moduleDeclarationFile =
+                  (builtins.unsafeGetAttrPos "modules" args).file;
+
+                # Add the invoking file as error message location for modules
+                # that don't have their own locations; presumably inline modules.
+                addModuleDeclarationFile =
+                  m: {
+                    _file = moduleDeclarationFile;
+                    imports = [ m ];
+                  };
+
               in
-              modules ++ [
+              map addModuleDeclarationFile modules ++ [
                 {
                   system.nixos.versionSuffix =
                     ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";


### PR DESCRIPTION
###### Motivation for this change

:warning: **Caution:** this is a late-night idea and I'm not sure if it's a good one! Before anybody considers to merge this, a review from our module-system experts is needed :) 

-------

When inlining a module with a problematic declaration, you usually get
get a not-so helpful error like this:

    $ cat flake.nix
    {
      description = "A very basic flake";
      inputs.nixpkgs.url = path:../.;
      outputs = { self, nixpkgs }: {
        nixosConfigurations.foo = nixpkgs.lib.nixosSystem {
          system = "x86_64-linux";
          modules = [
            ({ lib, ... }: { services.wrong = 2; })
            { services.nginx.enable = true; }
          ];
        };
      };
    }
    $ nixos-rebuild build --flake .#foo -L
    error: The option `services.wrong' does not exist. Definition values:
           - In `<unknown-file>': 2

While it's certainly possible to guess where this comes from, this is
IMHO fairly confusing for beginners (and kinda reminds me of the
infamous "infinite recursion at undefined position"-error).

The module-system determines the position of a declaration using the
`_file`-key: this is either `toString path` if `path` is e.g. a value
from `imports = [ ./foo.nix ]` or the file used as `NIXOS_CONFIG` in
`<nixpkgs/nixos>`.

However such a mechanism doesn't exist (yet) for inlined flake modules,
so I tried to implement this in a fairly basic way:

* `modules = [ ./path.nix ]` in `lib.nixosSystem` doesn't require any
  additional steps, `./path.nix` is used as position for all
  declarations inside `./path.nix`.

* For non-path declarations, the position of `modules` inside the
  `flake.nix` which declares these modules is determined by doing
  `unsafeGetAttrPos` on the `modules`-argument of `lib.nixosSystem`.

  So the `flake.nix` from above would now raise the following
  error-message:

        $ nixos-rebuild build --flake .#foo -L
        error: The option `services.wrong' does not exist. Definition values:
               - In `/nix/store/4vi3nhqjyma73ygs4f93q38qjkhkaxw8-source/flake.nix': 2



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
