### PR TITLE
portaudio: 190600-20161030 -> 190700_20210406

### DIFF
--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -1,31 +1,31 @@
-{ lib, stdenv, fetchurl, alsa-lib, pkg-config, libjack2
-, AudioUnit, AudioToolbox, CoreAudio, CoreServices, Carbon }:
+{ lib
+, stdenv
+, fetchurl
+, alsa-lib
+, pkg-config
+, AudioUnit
+, AudioToolbox
+, CoreAudio
+, CoreServices
+, Carbon }:
 
-stdenv.mkDerivation {
-  name = "portaudio-190600-20161030";
+stdenv.mkDerivation rec {
+  pname = "portaudio";
+  version =  "190700_20210406";
 
   src = fetchurl {
-    url = "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz";
-    sha256 = "04qmin6nj144b8qb9kkd9a52xfvm0qdgm8bg8jbl7s3frmyiv8pm";
+    url = "http://files.portaudio.com/archives/pa_stable_v${version}.tgz";
+    sha256 = "1vrdrd42jsnffh6rq8ap2c6fr4g9fcld89z649fs06bwqx1bzvs7";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libjack2 ]
-    ++ lib.optional (!stdenv.isDarwin) alsa-lib;
+  buildInputs = lib.optional (!stdenv.isDarwin) alsa-lib;
 
   configureFlags = [ "--disable-mac-universal" "--enable-cxx" ];
 
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=nullability-inferred-on-nested-type -Wno-error=nullability-completeness-on-arrays";
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-const-int-float-conversion -Wno-error=nullability-completeness-on-arrays";
 
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ AudioUnit AudioToolbox CoreAudio CoreServices Carbon ];
-
-  patchPhase = lib.optionalString stdenv.isDarwin ''
-    sed -i '50 i\
-      #include <CoreAudio/AudioHardware.h>\
-      #include <CoreAudio/AudioHardwareBase.h>\
-      #include <CoreAudio/AudioHardwareDeprecated.h>' \
-      include/pa_mac_core.h
-  '';
 
   # not sure why, but all the headers seem to be installed by the make install
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Build the latest port audio.  Also fix the build on apple silicon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (apple silicon)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
