### PR TITLE
neo4j-desktop: 1.4.5 -> 1.4.7

### DIFF
--- a/pkgs/applications/misc/neo4j-desktop/default.nix
+++ b/pkgs/applications/misc/neo4j-desktop/default.nix
@@ -9,13 +9,14 @@ let
     hash = "sha256-oEcSW7UIeiGY2fCPJQ5EtDBRtd73Q04HaSk+7ObLKJc=";
   };
 
-  appimageContents = appimageTools.extract { inherit src; name = pname; };
+  appimageContents = appimageTools.extract { inherit name src; };
 in appimageTools.wrapType2 {
   inherit name src;
 
   extraPkgs = pkgs: with pkgs; [ libsecret ];
 
   extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/applications/misc/neo4j-desktop/default.nix
+++ b/pkgs/applications/misc/neo4j-desktop/default.nix
@@ -1,12 +1,12 @@
 { appimageTools, lib, fetchurl }:
 let
   pname = "neo4j-desktop";
-  version = "1.4.5";
+  version = "1.4.7";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://s3-eu-west-1.amazonaws.com/dist.neo4j.org/${pname}/linux-offline/${name}-x86_64.AppImage";
-    sha256 = "sha256-TCkjYhvGhgqgrDEMvC4Ww/sDxRhHC70YgfDlCIFitMo";
+    hash = "sha256-oEcSW7UIeiGY2fCPJQ5EtDBRtd73Q04HaSk+7ObLKJc=";
   };
 
   appimageContents = appimageTools.extract { inherit src; name = pname; };


### PR DESCRIPTION
###### Motivation for this change

neo4j-desktop is not up-to-date.

In addition, the binary needed to be renamed so that I can do:

`result/bin/neo4j-desktop`

instead of 

`result/bin/neo4j-desktop-1.4.7`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
