### PR TITLE
zola: 0.13.0 -> unstable-2021-07-10

### DIFF
--- a/pkgs/applications/misc/zola/default.nix
+++ b/pkgs/applications/misc/zola/default.nix
@@ -1,31 +1,30 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, cmake, pkg-config, openssl, oniguruma, CoreServices }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, cmake, pkg-config, openssl, oniguruma, CoreServices, installShellFiles }:
 
 rustPlatform.buildRustPackage rec {
   pname = "zola";
-  version = "0.13.0";
+  version = "unstable-2021-07-10";
 
   src = fetchFromGitHub {
     owner = "getzola";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-yTvFQWmNxoB+CNZLHGmzJq7mKuOUxUqV4g8PWlOlRbM=";
+    # unstable because the latest release fails to build
+    rev = "8c3ce7d7fbc0d585d4cbf27598ac7dfe5acd96f1";
+    sha256 = "sha256-Tw3u96ZPb0yUXvtJ+rna6nnb0a+KfTEiR/PPEadFxDA=";
   };
 
-  cargoSha256 = "sha256:19vijhcs1i02jhz68acil7psv3pcn0jzi1i4y2l05i4m3ayxivjf";
+  cargoSha256 = "sha256-mOO39LK7lQ5IxwMgfJpNwX/H5MZ3qKqfeDmnY8zXOx4=";
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config installShellFiles];
   buildInputs = [ openssl oniguruma ]
     ++ lib.optional stdenv.isDarwin CoreServices;
 
   RUSTONIG_SYSTEM_LIBONIG = true;
 
   postInstall = ''
-    install -D -m 444 completions/zola.bash \
-      -t $out/share/bash-completion/completions
-    install -D -m 444 completions/_zola \
-      -t $out/share/zsh/site-functions
-    install -D -m 444 completions/zola.fish \
-      -t $out/share/fish/vendor_completions.d
+    installShellCompletion --cmd zola \
+      --fish completions/zola.fish \
+      --zsh completions/_zola \
+      --bash completions/zola.bash
   '';
 
   meta = with lib; {
@@ -33,5 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://www.getzola.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir _0x4A6F ];
+    # set because of unstable-* version
+    mainProgram = "zola";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://hydra.nixos.org/build/147410337
Fixes the build, by switching to unstable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
