### PR TITLE
duplicity: 0.8.17 -> 0.8.20

### DIFF
--- a/pkgs/tools/backup/duplicity/gnutar-in-test.patch
+++ b/pkgs/tools/backup/duplicity/gnutar-in-test.patch
@@ -1,9 +1,11 @@
+diff --git a/testing/functional/test_restart.py b/testing/functional/test_restart.py
+index 6d972c82..e8435fd5 100644
 --- a/testing/functional/test_restart.py
 +++ b/testing/functional/test_restart.py
-@@ -323,14 +323,7 @@ class RestartTestWithoutEncryption(RestartTest):
+@@ -350,14 +350,7 @@ class RestartTestWithoutEncryption(RestartTest):
          https://launchpad.net/bugs/929067
          """
-
+ 
 -        if platform.system().startswith(u'Linux'):
 -            tarcmd = u"tar"
 -        elif platform.system().startswith(u'Darwin'):
@@ -13,6 +15,6 @@
 -        else:
 -            raise Exception(u"Platform %s not supported by tar/gtar." % platform.platform())
 +        tarcmd = u"tar"
-
+ 
          # Intial normal backup
-         self.backup("full", "testfiles/blocktartest")
+         self.backup(u"full", u"{0}/testfiles/blocktartest".format(_runtest_dir))

--- a/pkgs/tools/backup/duplicity/linux-disable-timezone-test.patch
+++ b/pkgs/tools/backup/duplicity/linux-disable-timezone-test.patch
@@ -1,10 +1,16 @@
+commit f0142706c377b7c133753db57b5c4c90baa2de30
+Author: Guillaume Girol <symphorien+git@xlumurb.eu>
+Date:   Sun Jul 11 17:48:15 2021 +0200
+
+diff --git a/testing/unit/test_statistics.py b/testing/unit/test_statistics.py
+index 4be5000c..80545853 100644
 --- a/testing/unit/test_statistics.py
 +++ b/testing/unit/test_statistics.py
-@@ -59,6 +59,7 @@ class StatsObjTest(UnitTestCase):
+@@ -63,6 +63,7 @@ class StatsObjTest(UnitTestCase):
          s1 = StatsDeltaProcess()
-         assert s1.get_stat('SourceFiles') == 0
-
+         assert s1.get_stat(u'SourceFiles') == 0
+ 
 +    @unittest.skip("Broken on Linux in Nix' build environment")
      def test_get_stats_string(self):
-         """Test conversion of stat object into string"""
+         u"""Test conversion of stat object into string"""
          s = StatsObj()

--- a/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
+++ b/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
@@ -1,48 +1,62 @@
+commit ccd4dd92cd37acce1da20966ad9e4e0c7bcf1709
+Author: Guillaume Girol <symphorien+git@xlumurb.eu>
+Date:   Sun Jul 11 12:00:00 2021 +0000
+
+    use installed duplicity when running tests
+
+diff --git a/setup.py b/setup.py
+index fa474f20..604a242a 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -92,10 +92,6 @@ class TestCommand(test):
+@@ -205,10 +205,6 @@ class TestCommand(test):
                  except Exception:
                      pass
-
+ 
 -        os.environ[u'PATH'] = u"%s:%s" % (
 -            os.path.abspath(build_scripts_cmd.build_dir),
 -            os.environ.get(u'PATH'))
 -
          test.run(self)
-
-     def run_tests(self):
+ 
+ 
+diff --git a/testing/functional/__init__.py b/testing/functional/__init__.py
+index 4221576d..3cf44945 100644
 --- a/testing/functional/__init__.py
 +++ b/testing/functional/__init__.py
-@@ -107,7 +107,7 @@ class FunctionalTestCase(DuplicityTestCase):
-         if basepython is not None:
-             cmd_list.extend([basepython])
+@@ -111,7 +111,7 @@ class FunctionalTestCase(DuplicityTestCase):
+         run_coverage = os.environ.get(u'RUN_COVERAGE', None)
+         if run_coverage is not None:
              cmd_list.extend([u"-m", u"coverage", u"run", u"--source=duplicity", u"-p"])
--        cmd_list.extend([u"../bin/duplicity"])
+-        cmd_list.extend([u"{0}/bin/duplicity".format(_top_dir)])
 +        cmd_list.extend([u"duplicity"])
          cmd_list.extend(options)
          cmd_list.extend([u"-v0"])
          cmd_list.extend([u"--no-print-statistics"])
+diff --git a/testing/functional/test_log.py b/testing/functional/test_log.py
+index 9dfc86a6..b9cb55db 100644
 --- a/testing/functional/test_log.py
 +++ b/testing/functional/test_log.py
-@@ -47,9 +47,9 @@ class LogTest(FunctionalTestCase):
+@@ -49,9 +49,9 @@ class LogTest(FunctionalTestCase):
          # Run actual duplicity command (will fail, because no arguments passed)
          basepython = os.environ.get(u'TOXPYTHON', None)
          if basepython is not None:
--            os.system(u"{} ../bin/duplicity --log-file={} >/dev/null 2>&1".format(basepython, self.logfile))
-+            os.system(u"{} duplicity --log-file={} >/dev/null 2>&1".format(basepython, self.logfile))
+-            os.system(u"{0} {1}/bin/duplicity --log-file={2} >/dev/null 2>&1".format(basepython, _top_dir, self.logfile))
++            os.system(u"{0} duplicity --log-file={1} >/dev/null 2>&1".format(basepython, self.logfile))
          else:
--            os.system(u"../bin/duplicity --log-file={} >/dev/null 2>&1".format(self.logfile))
-+            os.system(u"duplicity --log-file={} >/dev/null 2>&1".format(self.logfile))
+-            os.system(u"{0}/bin/duplicity --log-file={1} >/dev/null 2>&1".format(_top_dir, self.logfile))
++            os.system(u"duplicity --log-file={0} >/dev/null 2>&1".format(self.logfile))
  
          # The format of the file should be:
          # """ERROR 2
+diff --git a/testing/functional/test_rdiffdir.py b/testing/functional/test_rdiffdir.py
+index 0cbfdb33..47acd029 100644
 --- a/testing/functional/test_rdiffdir.py
 +++ b/testing/functional/test_rdiffdir.py
-@@ -42,7 +42,7 @@ class RdiffdirTest(FunctionalTestCase):
+@@ -44,7 +44,7 @@ class RdiffdirTest(FunctionalTestCase):
          basepython = os.environ.get(u'TOXPYTHON', None)
          if basepython is not None:
              cmd_list.extend([basepython])
--        cmd_list.extend([u"../bin/rdiffdir"])
+-        cmd_list.extend([u"{0}/bin/rdiffdir".format(_top_dir)])
 +        cmd_list.extend([u"rdiffdir"])
          cmd_list.extend(argstring.split())
          cmdline = u" ".join([u'"%s"' % x for x in cmd_list])


### PR DESCRIPTION

###### Motivation for this change


https://github.com/NixOS/nixpkgs/issues/128650

WIP because I still need to test it, I open this to avoid duplicated effort

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
