### PR TITLE
pidgin: 2.13.0 -> 2.14.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7882,6 +7882,12 @@
     githubId = 757752;
     name = "Jonas Heinrich";
   };
+  ony = {
+    name = "Mykola Orliuk";
+    email = "virkony@gmail.com";
+    github = "ony";
+    githubId = 11265;
+  };
   OPNA2608 = {
     email = "christoph.neidahl@gmail.com";
     github = "OPNA2608";

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -2,8 +2,9 @@
 , gtkspell2, aspell
 , gst_all_1, startupnotification, gettext
 , perlPackages, libxml2, nss, nspr, farstream
-, libXScrnSaver, ncurses, avahi, dbus, dbus-glib, intltool, libidn
+, libXScrnSaver, avahi, dbus, dbus-glib, intltool, libidn
 , lib, python3, libICE, libXext, libSM
+, libgnt, ncurses
 , cyrus_sasl ? null
 , openssl ? null
 , gnutls ? null
@@ -23,8 +24,6 @@ let unwrapped = stdenv.mkDerivation rec {
     sha256 = "bb45f7c032f9efd6922a5dbf2840995775e5584771b23992d04f6eff7dff5336";
   };
 
-  inherit nss ncurses;
-
   nativeBuildInputs = [ makeWrapper ];
 
   NIX_CFLAGS_COMPILE = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
@@ -35,9 +34,10 @@ let unwrapped = stdenv.mkDerivation rec {
     aspell startupnotification
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     libxml2 nss nspr
-    libXScrnSaver ncurses python-with-dbus
+    libXScrnSaver python-with-dbus
     avahi dbus dbus-glib intltool libidn
     libICE libXext libSM cyrus_sasl
+    libgnt ncurses # optional: build finch - the console UI
   ]
   ++ (lib.optional (openssl != null) openssl)
   ++ (lib.optional (gnutls != null) gnutls)

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -3,7 +3,7 @@
 , gst_all_1, startupnotification, gettext
 , perlPackages, libxml2, nss, nspr, farstream
 , libXScrnSaver, ncurses, avahi, dbus, dbus-glib, intltool, libidn
-, lib, python, libICE, libXext, libSM
+, lib, python3, libICE, libXext, libSM
 , cyrus_sasl ? null
 , openssl ? null
 , gnutls ? null
@@ -16,11 +16,11 @@
 let unwrapped = stdenv.mkDerivation rec {
   pname = "pidgin";
   majorVersion = "2";
-  version = "${majorVersion}.13.0";
+  version = "${majorVersion}.14.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/pidgin/${pname}-${version}.tar.bz2";
-    sha256 = "13vdqj70315p9rzgnbxjp9c51mdzf1l4jg1kvnylc4bidw61air7";
+    sha256 = "bb45f7c032f9efd6922a5dbf2840995775e5584771b23992d04f6eff7dff5336";
   };
 
   inherit nss ncurses;
@@ -30,7 +30,7 @@ let unwrapped = stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
 
   buildInputs = let
-    python-with-dbus = python.withPackages (pp: with pp; [ dbus-python ]);
+    python-with-dbus = python3.withPackages (pp: with pp; [ dbus-python ]);
   in [
     aspell startupnotification
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
@@ -62,6 +62,7 @@ let unwrapped = stdenv.mkDerivation rec {
     "--disable-meanwhile"
     "--disable-nm"
     "--disable-tcl"
+    "--disable-gevolution"
   ]
   ++ (lib.optionals (cyrus_sasl != null) [ "--enable-cyrus-sasl=yes" ])
   ++ (lib.optionals (gnutls != null) ["--enable-gnutls=yes" "--enable-nss=no"])

--- a/pkgs/development/libraries/libgnt/default.nix
+++ b/pkgs/development/libraries/libgnt/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchurl, meson, ninja, pkg-config
+, gtk-doc, docbook-xsl-nons
+, glib, ncurses, libxml2
+, buildDocs ? true
+}:
+stdenv.mkDerivation rec {
+  pname = "libgnt";
+  version = "2.14.1";
+
+  outputs = [ "out" "dev" ] ++ lib.optional buildDocs "devdoc";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pidgin/${pname}-${version}.tar.xz";
+    sha256 = "1n2bxg0ignn53c08cp69pj4sdg53kwlqn23rincyjmpr327fdhsy";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ]
+    ++ lib.optionals buildDocs [ gtk-doc docbook-xsl-nons ];
+
+  buildInputs = [ glib ncurses libxml2 ];
+
+  postPatch = ''
+    substituteInPlace meson.build --replace \
+      "ncurses_sys_prefix = '/usr'" \
+      "ncurses_sys_prefix = '${lib.getDev ncurses}'"
+  '' + lib.optionalString (!buildDocs) ''
+    sed "/^subdir('doc')$/d" -i meson.build
+  '';
+
+  meta = with lib; {
+    description = "An ncurses toolkit for creating text-mode graphical user interfaces";
+    homepage = "https://keep.imfreedom.org/libgnt/libgnt/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ ony ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16474,6 +16474,8 @@ in
 
   libgksu = callPackage ../development/libraries/libgksu { };
 
+  libgnt = callPackage ../development/libraries/libgnt { };
+
   libgpgerror = callPackage ../development/libraries/libgpg-error { };
 
   # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=README;h=fd6e1a83f55696c1f7a08f6dfca08b2d6b7617ec;hb=70058cd9f944d620764e57c838209afae8a58c78#l118


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/95296 by picking up https://github.com/NixOS/nixpkgs/pull/102318

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  *(~for `wip` it doesn't seem to do actual builds, but~ for `pr 129962` it seems 27 packages were built and then I got dropped into bash)*
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
*~(missing `meta.maintainers` for `libgnt`)~*


```sh
nix run github:jtojnar/nixpkgs-hammering pidgin libgnt
```
*(didn't touched old warnings for `pidgin` to avoid noisy diff)*

Changes from https://github.com/NixOS/nixpkgs/pull/102318 :
- Point to latest versions of `libgnt` and `pidgin`.
- Address comments from @SuperSandro2000 .
- Fix most of warnings for `libgnt`  reported by `nixpkgs-hammering`.

P.S. @vcunat , do you mind if I'll put you as a maintainer of ~`libgnat`~ `libgnt`?
You are author of original 1eb1fbe926253a8ffb19ffb188dc15fe23bf1ebb for adding it. And you already maintainer of `pidgin` that requires this package. :slightly_smiling_face: 