### PR TITLE
gappa: 1.3.5 → 1.4.0

### DIFF
--- a/pkgs/applications/science/logic/gappa/default.nix
+++ b/pkgs/applications/science/logic/gappa/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation {
   name = "gappa-1.4.0";
 
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/38044/gappa-1.4.0.tar.gz";
-    sha256 = "sha256-/IDIf5XnFBqVllgH5GtQ6C8g7vxheaVcXNoZiXlsPGA=";
+    url = "https://gforge.inria.fr/frs/download.php/file/38436/gappa-1.4.0.tar.gz";
+    sha256 = "12x42z901pr05ldmparqdi8sq9s7fxbavhzk2dbq3l6hy247dwbb";
   };
 
   buildInputs = [ gmp mpfr boost.dev ];


### PR DESCRIPTION
###### Motivation for this change

Fixes #127010.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
