### PR TITLE
easyeffects: re-add plugins

### DIFF
--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , desktop-file-utils
 , fetchFromGitHub
+, calf
 , fftwFloat
 , glib
 , glibmm
@@ -12,6 +14,7 @@
 , libsamplerate
 , libsndfile
 , lilv
+, lsp-plugins
 , lv2
 , meson
 , ninja
@@ -23,6 +26,7 @@
 , rubberband
 , speexdsp
 , wrapGAppsHook
+, zam-plugins
 , zita-convolver
 }:
 
@@ -71,6 +75,24 @@ stdenv.mkDerivation rec {
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
   '';
+
+  preFixup =
+    let
+      lv2Plugins = [
+        calf # limiter, compressor exciter, bass enhancer and others
+        lsp-plugins # delay
+      ];
+      ladspaPlugins = [
+        rubberband # pitch shifting
+        zam-plugins # maximizer
+      ];
+    in
+    ''
+      gappsWrapperArgs+=(
+        --set LV2_PATH "${lib.makeSearchPath "lib/lv2" lv2Plugins}"
+        --set LADSPA_PATH "${lib.makeSearchPath "lib/ladspa" ladspaPlugins}"
+      )
+    '';
 
   separateDebugInfo = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix the problem discussed in  #129564: Easyeffects not being able to detect plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
