### PR TITLE
netbsd: Split out path merging from bsd setup hook

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -16,6 +16,10 @@ let
     tag = "netbsd-${lib.replaceStrings ["."] ["-"] version}-RELEASE";
   };
 
+  netbsdSetupHook = makeSetupHook {
+    name = "netbsd-setup-hook";
+  } ./setup-hook.sh;
+
   otherSplices = {
     selfBuildBuild = pkgsBuildBuild.netbsd;
     selfBuildHost = pkgsBuildHost.netbsd;
@@ -60,7 +64,7 @@ in lib.makeScopeWithSplicing
     extraPaths = [ ];
 
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install tsort lorder mandoc groff statHook rsync
     ];
@@ -118,7 +122,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
 
     buildInputs = with self; [];
-    nativeBuildInputs = with buildPackages.netbsd; [ bsdSetupHook rsync ];
+    nativeBuildInputs = with buildPackages.netbsd; [ bsdSetupHook netbsdSetupHook rsync ];
 
     skipIncludesPhase = true;
 
@@ -126,6 +130,7 @@ in lib.makeScopeWithSplicing
       patchShebangs configure
       ${self.make.postPatch}
     '';
+
     buildPhase = ''
       runHook preBuild
 
@@ -133,6 +138,7 @@ in lib.makeScopeWithSplicing
 
       runHook postBuild
     '';
+
     installPhase = ''
       runHook preInstall
 
@@ -143,6 +149,7 @@ in lib.makeScopeWithSplicing
 
       runHook postInstall
     '';
+
     extraPaths = with self; [ make.src ] ++ make.extraPaths;
   };
 
@@ -165,7 +172,7 @@ in lib.makeScopeWithSplicing
     HOST_CC = "${buildPackages.stdenv.cc.targetPrefix}cc";
 
     nativeBuildInputs = with buildPackages.netbsd; commonDeps ++ [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       rsync
     ];
@@ -238,7 +245,7 @@ in lib.makeScopeWithSplicing
     sha256 = "1f6pbz3qv1qcrchdxif8p5lbmnwl8b9nq615hsd3cyl4avd5bfqj";
     extraPaths = with self; [ mtree.src make.src ];
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       mandoc groff rsync
     ];
@@ -262,7 +269,7 @@ in lib.makeScopeWithSplicing
     sha256 = "01d4fpxvz1pgzfk5xznz5dcm0x0gdzwcsfm1h3d0xc9kc6hj2q77";
     version = "9.2";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook rsync
+      bsdSetupHook netbsdSetupHook rsync
     ];
     propagatedBuildInputs = with self; compatIfNeeded;
     extraPaths = with self; [
@@ -298,7 +305,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
     sha256 = "18nqwlndfc34qbbgqx5nffil37jfq9aw663ippasfxd2hlyc106x";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff rsync
     ];
@@ -320,7 +327,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
     sha256 = "1dqvf9gin29nnq3c4byxc7lfd062pg7m84843zdy6n0z63hnnwiq";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff rsync
     ];
@@ -331,7 +338,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
     sha256 = "0rjf9blihhm0n699vr2bg88m4yjhkbxh6fxliaay3wxkgnydjwn2";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff rsync
     ];
@@ -433,7 +440,7 @@ in lib.makeScopeWithSplicing
     HOSTPROG = "tic";
     buildInputs = with self; compatIfNeeded;
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff nbperf
     ];
@@ -465,7 +472,7 @@ in lib.makeScopeWithSplicing
     sha256 = "1yz3n4hncdkk6kp595fh2q5lg150vpqg8iw2dccydkyw4y3hgsjj";
     NIX_CFLAGS_COMPILE = [ "-DMAKE_BOOTSTRAP" ];
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal install mandoc byacc flex rsync
     ];
     buildInputs = with self; compatIfNeeded;
@@ -483,7 +490,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
     sha256 = "0nxnmj4c8s3hb9n3fpcmd0zl3l1nmhivqgi9a35sis943qvpgl9h";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff rsync nbperf rpcgen
     ];
@@ -510,7 +517,7 @@ in lib.makeScopeWithSplicing
 
     propagatedBuildInputs = with self; [ include ];
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal install tsort lorder statHook rsync uudecode config genassym
     ];
 
@@ -573,7 +580,7 @@ in lib.makeScopeWithSplicing
     sha256 = "02gm5a5zhh8qp5r5q5r7x8x6x50ir1i0ncgsnfwh1vnrz6mxbq7z";
     extraPaths = with self; [ common libc.src sys.src ];
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       byacc install tsort lorder mandoc statHook
     ];
@@ -607,7 +614,7 @@ in lib.makeScopeWithSplicing
     version = "9.2";
     sha256 = "0pq05k3dj0dfsczv07frnnji92mazmy2qqngqbx2zgqc1x251414";
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal install tsort lorder mandoc statHook nbperf tic
     ];
     buildInputs = with self; compatIfNeeded;
@@ -670,7 +677,7 @@ in lib.makeScopeWithSplicing
     makeFlags = [ "INCSDIR=$(out)/include/rpcsvc" ];
     meta.platforms = lib.platforms.netbsd;
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install tsort lorder rpcgen statHook
     ];
@@ -748,7 +755,7 @@ in lib.makeScopeWithSplicing
     sha256 = "0al5jfazvhlzn9hvmnrbchx4d0gm282hq5gp4xs2zmj9ycmf6d03";
     meta.platforms = lib.platforms.netbsd;
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff flex
       byacc genassym gencat lorder tsort statHook rsync
@@ -786,7 +793,7 @@ in lib.makeScopeWithSplicing
       (fetchNetBSD "external/bsd/jemalloc" "9.2" "0cq704swa0h2yxv4gc79z2lwxibk9k7pxh3q5qfs7axx3jx3n8kb")
     ];
     nativeBuildInputs = with buildPackages.netbsd; [
-      bsdSetupHook
+      bsdSetupHook netbsdSetupHook
       makeMinimal
       install mandoc groff flex
       byacc genassym gencat lorder tsort statHook rsync rpcgen

--- a/pkgs/os-specific/bsd/netbsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/setup-hook.sh
@@ -1,0 +1,10 @@
+mergeNetBSDSourceDir() {
+  # merge together all extra paths
+  # there should be a better way to do this
+  chmod -R u+w $BSDSRCDIR
+  for path in $extraPaths; do
+    rsync -Er --chmod u+w $path/ $BSDSRCDIR/
+  done
+}
+
+postUnpackHooks+=(mergeNetBSDSourceDir)

--- a/pkgs/os-specific/bsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/setup-hook.sh
@@ -63,15 +63,9 @@ addMakeFlags() {
 }
 
 setBSDSourceDir() {
-  # merge together all extra paths
-  # there should be a better way to do this
   sourceRoot=$PWD/$sourceRoot
   export BSDSRCDIR=$sourceRoot
   export _SRC_TOP_=$BSDSRCDIR
-  chmod -R u+w $sourceRoot
-  for path in $extraPaths; do
-    rsync -Er --chmod u+w $path/ $sourceRoot/
-  done
 
   cd $sourceRoot
   if [ -d "$BSD_PATH" ]


### PR DESCRIPTION
###### Motivation for this change

I plan on doing the sources for FreeBSD differently. Indeed we might
want to change this for NetBSD too eventually.

In any event, the way we manage sources is not intrinsically the same
across BSDs so it makes sense to pull this out.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
