### PR TITLE
nix-template: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -1,17 +1,33 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub
+, makeWrapper
+, nix
+, openssl
+, pkg-config
+, Security
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-template";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "jonringer";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1h6xdvhzg7nb0s82b3r5bsh8bfdb1l5sm7fa24lfwd396xp9yyig";
+    sha256 = "sha256-A1b/fgSr27sfMDnTi4R3PUZfhAdLA5wUOd4yh9/4Bnk=";
   };
 
-  cargoSha256 = "0hp31b5q4s6grkha2jz55945cbjkqdpvx1l8m49zv5prczhd7mz5";
+  cargoSha256 = "sha256-resyY/moqLo4KWOKUvFJiOWealCmcEsLFgkN12slKN0=";
+
+  nativeBuildInputs = [ makeWrapper pkg-config ];
+  buildInputs = [ openssl ]
+    ++ lib.optional stdenv.isDarwin Security;
+
+  # needed for nix-prefetch-url
+  postInstall = ''
+    wrapProgram $out/bin/nix-template \
+      --prefix PATH : ${lib.makeBinPath [ nix ]}
+  '';
 
   meta = with lib; {
     description = "Make creating nix expressions easy";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3079,7 +3079,9 @@ in
 
   nix-output-monitor = haskell.lib.justStaticExecutables (haskellPackages.nix-output-monitor);
 
-  nix-template = callPackage ../tools/package-management/nix-template { };
+  nix-template = callPackage ../tools/package-management/nix-template {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   nodepy-runtime = with python3.pkgs; toPythonApplication nodepy-runtime;
 


### PR DESCRIPTION
###### Motivation for this change
Bump my template application for nix expressions

Changelog: https://github.com/jonringer/nix-template/releases/tag/v0.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
