### PR TITLE
gcc-arm-embedded: add numVersion attribute for convenience

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
@@ -7,6 +7,7 @@
 stdenv.mkDerivation rec {
   pname = "gcc-arm-embedded";
   version = "10-2020-q4-major";
+  numVersion = "10.2.1";
   subdir = "10-2020q4";
 
   suffix = {

--- a/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
@@ -7,6 +7,7 @@
 stdenv.mkDerivation rec {
   pname = "gcc-arm-embedded";
   version = "6-2017-q2-update";
+  numVersion = "6.3.1";
   subdir = "6-2017q2";
 
   suffix = {

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -7,6 +7,7 @@
 stdenv.mkDerivation rec {
   pname = "gcc-arm-embedded";
   version = "7-2018-q2-update";
+  numVersion = "7.3.1";
   subdir = "7-2018q2";
 
   suffix = {

--- a/pkgs/development/compilers/gcc-arm-embedded/8/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/8/default.nix
@@ -7,6 +7,7 @@
 stdenv.mkDerivation rec {
   pname = "gcc-arm-embedded";
   version = "8-2019-q3-update";
+  numVersion = "8.3.1";
   subdir = "8-2019q3/RC1.1";
 
   suffix = {

--- a/pkgs/development/compilers/gcc-arm-embedded/9/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/9/default.nix
@@ -7,6 +7,7 @@
 stdenv.mkDerivation rec {
   pname = "gcc-arm-embedded";
   version = "9-2020-q2-update";
+  numVersion = "9.3.1";
   subdir = "9-2020q2";
 
   suffix = {


### PR DESCRIPTION
There are builds which rely on having the numeric version of gcc (eg "10.2.1")
declared in an environment variable.

Running 'arm-none-eabi-gcc --version' returns:
"arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.2.1 20201103 (release)"

However, the attribute arm-none-eabi-gcc.version is "10-2020-q4-major",
from which there is no way to derive "10.2.1".

Contrast this with the attribute gcc.version which (at this time) gives "10.3.0".

By adding a numVersion attribute, consumers of this package can
correctly determine what GCC version is being executed.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>