### PR TITLE
spectacle: add dependencies required to annotate screenshots

### DIFF
--- a/pkgs/applications/kde/spectacle.nix
+++ b/pkgs/applications/kde/spectacle.nix
@@ -4,17 +4,20 @@
   ki18n, xcb-util-cursor,
   kconfig, kcoreaddons, kdbusaddons, kdeclarative, kio, kipi-plugins,
   knotifications, kscreen, kwidgetsaddons, kwindowsystem, kxmlgui, libkipi,
-  qtx11extras, knewstuff, kwayland, qttools
+  qtbase, qtx11extras, knewstuff, kwayland, qttools, kcolorpicker, kimageannotator
 }:
 
 mkDerivation {
   pname = "spectacle";
-  meta = with lib; { maintainers = with maintainers; [ ttuegel ]; };
+  meta = with lib; {
+    maintainers = with maintainers; [ ttuegel ];
+    broken = versionOlder qtbase.version "5.15";
+  };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kconfig kcoreaddons kdbusaddons kdeclarative ki18n kio knotifications
     kscreen kwidgetsaddons kwindowsystem kxmlgui libkipi qtx11extras xcb-util-cursor
-    knewstuff kwayland
+    knewstuff kwayland kcolorpicker kimageannotator
   ];
   postPatch = ''
     substituteInPlace desktop/org.kde.spectacle.desktop.cmake \

--- a/pkgs/development/libraries/kcolorpicker/default.nix
+++ b/pkgs/development/libraries/kcolorpicker/default.nix
@@ -1,0 +1,24 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase }:
+
+mkDerivation rec {
+  pname = "kcolorpicker";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "ksnip";
+    repo = "kColorPicker";
+    rev = "v${version}";
+    sha256 = "1167xwk75yiz697vddbz3lq42l7ckhyl2cvigy4m05qgg9693ksd";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase ];
+
+  meta = with lib; {
+    description = "Qt based Color Picker with popup menu";
+    homepage = "https://github.com/ksnip/kColorPicker";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ fliegendewurst ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/kimageannotator/default.nix
+++ b/pkgs/development/libraries/kimageannotator/default.nix
@@ -1,0 +1,24 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, kcolorpicker, qttools }:
+
+mkDerivation rec {
+  pname = "kimageannotator";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "ksnip";
+    repo = "kImageAnnotator";
+    rev = "v${version}";
+    sha256 = "0hfvrd78lgwd7bccz0fx2pr7g0v3s401y5plra63rxwk55ffkxf8";
+  };
+
+  nativeBuildInputs = [ cmake qttools ];
+  buildInputs = [ qtbase kcolorpicker ];
+
+  meta = with lib; {
+    description = "Tool for annotating images";
+    homepage = "https://github.com/ksnip/kImageAnnotator";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ fliegendewurst ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -80,6 +80,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
   kde2-decoration = callPackage ../data/themes/kde2 { };
 
+  kcolorpicker = callPackage ../development/libraries/kcolorpicker { };
+
   kdiagram = callPackage ../development/libraries/kdiagram { };
 
   kdsoap = callPackage ../development/libraries/kdsoap { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -88,6 +88,8 @@ in (kdeFrameworks // plasma5 // plasma5.thirdParty // kdeGear // qt5 // {
 
   kf5gpgmepp = callPackage ../development/libraries/kf5gpgmepp { };
 
+  kimageannotator = callPackage ../development/libraries/kimageannotator { };
+
   kproperty = callPackage ../development/libraries/kproperty { };
 
   kpeoplevcard = callPackage ../development/libraries/kpeoplevcard { };


### PR DESCRIPTION
###### Motivation for this change
Closes #129676

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files: annotation editor works
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
