### PR TITLE
pythonPackages.crate: mark broken

### DIFF
--- a/pkgs/development/python-modules/agate-sql/default.nix
+++ b/pkgs/development/python-modules/agate-sql/default.nix
@@ -22,7 +22,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ agate sqlalchemy ];
 
-  checkInputs = [ crate nose geojson ];
+  # crate is broken with SQLAlchemy > 1.3
+  # These tests rely on crate, and make the whole build fail
+  #checkInputs = [ crate nose geojson ];
+  doCheck = false;
 
   checkPhase = ''
     nosetests

--- a/pkgs/development/python-modules/agate-sql/default.nix
+++ b/pkgs/development/python-modules/agate-sql/default.nix
@@ -22,10 +22,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ agate sqlalchemy ];
 
-  # crate is broken with SQLAlchemy > 1.3
-  # These tests rely on crate, and make the whole build fail
-  #checkInputs = [ crate nose geojson ];
+  # crate is broken in nixpkgs, with SQLAlchemy > 1.3
+  # Skip tests for now as they rely on it.
   doCheck = false;
+
+  checkInputs = [ crate nose geojson ];
 
   checkPhase = ''
     nosetests

--- a/pkgs/development/python-modules/crate/default.nix
+++ b/pkgs/development/python-modules/crate/default.nix
@@ -39,5 +39,11 @@ buildPythonPackage rec {
     description = "A Python client library for CrateDB";
     license = licenses.asl20;
     maintainers = with maintainers; [ doronbehar ];
+    # 2021-07-12 (@layus): Please unbreak when an update fixes compatibility
+    # with the version of SQLAlchemy in nixpkgs
+    # And also re-enable tests in pythonPackages.agate-sql.
+    # The version string below is intentionally split, so nixpkgs-update does
+    # not change it. That would make this warning pretty useless.
+    broken = assert version == "0.2"+"6.0"; true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

csvkit was broken because "crate" python package does not (yet) support SQLAlchemy >= 1.4 that nixpkgs ships since 9974c90a1597a7b2b009e798374615899d57db7d.

Mark "crate" broken for now, and disable tests in agate-sql, as "crate" is only used for tests.

Use a complex, opinionated mechanism to force a re-evaluation of this strategy when "crate" gets updated.

and voilà: csvkit works again.

From a quick analysis, this crate package is only used in agate-sql. Hence the long time to fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I was really light on testing the impact on other packages, but given that the build is broken, marking the package as broken should not have such an incredible impact.

