### PR TITLE
firefox: 89.0.2 -> 90.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -12,6 +12,7 @@
 , autoconf213, which, gnused, rustPackages, rustPackages_1_45
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , gnum4
+, gtk2, gtk3, wrapGAppsHook
 , debugBuild ? false
 
 ### optionals
@@ -21,7 +22,6 @@
 , alsaSupport ? stdenv.isLinux, alsa-lib
 , pulseaudioSupport ? stdenv.isLinux, libpulseaudio
 , ffmpegSupport ? true
-, gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
 , waylandSupport ? true, libxkbcommon, libdrm
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit), overrideCC, buildPackages
 , gssSupport ? true, libkrb5
@@ -79,7 +79,7 @@ let
   flag = tf: x: [(if tf then "--enable-${x}" else "--disable-${x}")];
 
   default-toolkit = if stdenv.isDarwin then "cairo-cocoa"
-                    else "cairo-gtk${if gtk3Support then "3${lib.optionalString waylandSupport "-wayland"}" else "2"}";
+                    else "cairo-gtk3${lib.optionalString waylandSupport "-wayland"}";
 
   binaryName = "firefox";
   binaryNameCapitalized = lib.toUpper (lib.substring 0 1 binaryName) + lib.substring 1 (-1) binaryName;
@@ -139,7 +139,7 @@ buildStdenv.mkDerivation ({
   lib.optional (lib.versionOlder ffversion "86") ./env_var_for_system_dir-ff85.patch ++
   lib.optional (lib.versionAtLeast ffversion "86") ./env_var_for_system_dir-ff86.patch ++
   lib.optional (lib.versionOlder ffversion "83") ./no-buildconfig-ffx76.patch ++
-  lib.optional (lib.versionAtLeast ffversion "84") ./no-buildconfig-ffx84.patch ++
+  lib.optional (lib.versionAtLeast ffversion "90") ./no-buildconfig-ffx90.patch ++
   lib.optional (ltoSupport && lib.versionOlder ffversion "84") ./lto-dependentlibs-generation-ffx83.patch ++
   lib.optional (ltoSupport && lib.versionAtLeast ffversion "84" && lib.versionOlder ffversion "86")
     (fetchpatch {
@@ -164,7 +164,7 @@ buildStdenv.mkDerivation ({
   patchFlags = [ "-p1" "-l" ];
 
   buildInputs = [
-    gtk2 perl zip libjpeg zlib bzip2
+    gtk3 perl zip libjpeg zlib bzip2
     dbus dbus-glib pango freetype fontconfig xorg.libXi xorg.libXcursor
     xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
     xorg.pixman yasm libGLU libGL
@@ -182,14 +182,14 @@ buildStdenv.mkDerivation ({
   ]
   ++ lib.optional  alsaSupport alsa-lib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
-  ++ lib.optional  gtk3Support gtk3
   ++ lib.optional  gssSupport libkrb5
   ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
   ++ lib.optional  pipewireSupport pipewire
   ++ lib.optional  (lib.versionAtLeast ffversion "82") gnum4
   ++ lib.optionals buildStdenv.isDarwin [ CoreMedia ExceptionHandling Kerberos
                                           AVFoundation MediaToolbox CoreLocation
-                                          Foundation libobjc AddressBook cups ];
+                                          Foundation libobjc AddressBook cups ]
+  ++ lib.optional  (lib.versionOlder ffversion "90") gtk2;
 
   NIX_LDFLAGS = lib.optionalString ltoSupport ''
     -rpath ${llvmPackages.libunwind.out}/lib
@@ -232,8 +232,8 @@ buildStdenv.mkDerivation ({
       rustc
       which
       unzip
+      wrapGAppsHook
     ]
-    ++ lib.optional gtk3Support wrapGAppsHook
     ++ lib.optionals buildStdenv.isDarwin [ xcbuild rsync ]
     ++ extraNativeBuildInputs;
 
@@ -362,8 +362,6 @@ buildStdenv.mkDerivation ({
   passthru = {
     inherit updateScript;
     version = ffversion;
-    isFirefox3Like = true;
-    gtk = gtk2;
     inherit alsaSupport;
     inherit pipewireSupport;
     inherit nspr;
@@ -372,7 +370,8 @@ buildStdenv.mkDerivation ({
     inherit execdir;
     inherit browserName;
     inherit tests;
-  } // lib.optionalAttrs gtk3Support { inherit gtk3; };
+    inherit gtk3;
+  };
 
   hardeningDisable = [ "format" ]; # -Werror=format-security
 

--- a/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx90.patch
+++ b/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx90.patch
@@ -1,25 +1,22 @@
-diff --git a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
-index 10ac77b..0125d9b 100644
 --- a/docshell/base/nsAboutRedirector.cpp
 +++ b/docshell/base/nsAboutRedirector.cpp
-@@ -63,8 +63,6 @@ static const RedirEntry kRedirMap[] = {
+@@ -66,8 +66,6 @@ static const RedirEntry kRedirMap[] = {
      {"about", "chrome://global/content/aboutAbout.html", 0},
-     {"addons", "chrome://mozapps/content/extensions/extensions.xhtml",
+     {"addons", "chrome://mozapps/content/extensions/aboutaddons.html",
       nsIAboutModule::ALLOW_SCRIPT},
 -    {"buildconfig", "chrome://global/content/buildconfig.html",
 -     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT},
      {"checkerboard", "chrome://global/content/aboutCheckerboard.html",
       nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
           nsIAboutModule::ALLOW_SCRIPT},
-diff --git a/toolkit/content/jar.mn b/toolkit/content/jar.mn
-index c83b3e2..d543140 100644
 --- a/toolkit/content/jar.mn
 +++ b/toolkit/content/jar.mn
-@@ -40,7 +40,6 @@ toolkit.jar:
+@@ -39,8 +39,6 @@ toolkit.jar:
+    content/global/plugins.html
     content/global/plugins.css
     content/global/plugins.js
-    content/global/browser-child.js
 -*   content/global/buildconfig.html
-    content/global/buildconfig.css
+-   content/global/buildconfig.css
     content/global/contentAreaUtils.js
     content/global/datepicker.xhtml
+ #ifndef MOZ_FENNEC

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "89.0.2";
+    ffversion = "90.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "ffd98ab0887611c5b4aba68346c49a7a31a58150fd8bbae610a4d941c4cff0acef0daaebfbb577787a759b4c1ef3c1199f02681148612f4f5b709983e07e0ccb";
+      sha512 = "233ad59e4ab2f08d2253b49235b51b26fa32fb7c285928110573ccbe67c79965d9401a6c58a3af2ad22b8a58ca5d9b3154e3e8c9d29b153acd16152d9b75442c";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -2,7 +2,7 @@
 , replace, fetchurl, zip, unzip, jq, xdg-utils, writeText
 
 ## various stuff that can be plugged in
-, ffmpeg, xorg, alsa-lib, libpulseaudio, libcanberra-gtk2, libglvnd, libnotify
+, ffmpeg, xorg, alsa-lib, libpulseaudio, libcanberra-gtk3, libglvnd, libnotify
 , gnome/*.gnome-shell*/
 , browserpass, chrome-gnome-shell, uget-integrator, plasma5Packages, bukubrow, pipewire
 , tridactyl-native
@@ -44,8 +44,6 @@ let
     , nixExtensions ? null
     }:
 
-    assert forceWayland -> (browser ? gtk3); # Can only use the wayland backend if gtk3 is being used
-
     let
       ffmpegSupport = browser.ffmpegSupport or false;
       gssSupport = browser.gssSupport or false;
@@ -73,7 +71,7 @@ let
             ++ lib.optional (config.pulseaudio or true) libpulseaudio
             ++ lib.optional alsaSupport alsa-lib
             ++ pkcs11Modules;
-      gtk_modules = [ libcanberra-gtk2 ];
+      gtk_modules = [ libcanberra-gtk3 ];
 
       #########################
       #                       #
@@ -183,7 +181,7 @@ let
       };
 
       nativeBuildInputs = [ makeWrapper lndir ];
-      buildInputs = lib.optional (browser ? gtk3) browser.gtk3;
+      buildInputs = [ browser.gtk3 ];
 
 
       buildCommand = lib.optionalString stdenv.isDarwin ''
@@ -266,13 +264,11 @@ let
             --set MOZ_SYSTEM_DIR "$out/lib/mozilla" \
             --set MOZ_LEGACY_PROFILES 1 \
             --set MOZ_ALLOW_DOWNGRADE 1 \
+            --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+            --suffix XDG_DATA_DIRS : '${gnome.adwaita-icon-theme}/share' \
             ${lib.optionalString forceWayland ''
               --set MOZ_ENABLE_WAYLAND "1" \
-            ''}${lib.optionalString (browser ? gtk3)
-                ''--prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-                  --suffix XDG_DATA_DIRS : '${gnome.adwaita-icon-theme}/share'
-                ''
-            }
+            ''}
         #############################
         #                           #
         #   END EXTRA PREF CHANGES  #


### PR DESCRIPTION
###### Motivation for this change
make gtk3Support non-optional, because it hasn't been for a long time
also make gtk2 conditional on firefox older than 90, because we can get
rid of it with firefox 90, but it's still needed by the current ESR
release

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
