### PR TITLE
emacs: fix overrideScope' examples

### DIFF
--- a/doc/builders/packages/emacs.section.md
+++ b/doc/builders/packages/emacs.section.md
@@ -110,7 +110,7 @@ overrides = self: super: rec {
   haskell-mode = self.melpaPackages.haskell-mode;
   ...
 };
-((emacsPackagesFor emacs).overrideScope' overrides).emacs.pkgs.withPackages
+((emacsPackagesFor emacs).overrideScope' overrides).withPackages
   (p: with p; [
     # here both these package will use haskell-mode of our own choice
     ghc-mod

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -27,7 +27,7 @@ let customEmacsPackages =
         # use the unstable MELPA version of magit
         magit = self.melpaPackages.magit;
       });
-in customEmacsPackages.emacs.pkgs.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
+in customEmacsPackages.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
 ```
 
 */


### PR DESCRIPTION
###### Motivation for this change
Examples did not work. Close #130020.

###### Things done
Change examples in doc and code.
