### PR TITLE
super-slicer: 2.3.56.5 -> 2.3.56.8

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub, makeDesktopItem, prusa-slicer }:
 let
   appname = "SuperSlicer";
-  version = "2.3.56.5";
+  version = "2.3.56.8";
   pname = "super-slicer";
   description = "PrusaSlicer fork with more features and faster development cycle";
   override = super: {
@@ -10,13 +10,15 @@ let
     src = fetchFromGitHub {
       owner = "supermerill";
       repo = "SuperSlicer";
-      sha256 = "sha256-Gg+LT1YKyUGNJE9XvWE1LSlIQ6Vq5GfVBTUw/A7Qx7E=";
+      sha256 = "sha256-em0OgrcPaV2VYM8DpvtVJjgdojStMF/ROUEtZ8iLZfo=";
       rev = version;
       fetchSubmodules = true;
     };
 
     # We don't need PS overrides anymore, and gcode-viewer is embedded in the binary.
     postInstall = null;
+    dontStrip = true;
+    separateDebugInfo = true;
 
     # See https://github.com/supermerill/SuperSlicer/issues/432
     cmakeFlags = super.cmakeFlags ++ [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump ~also added Debug=True and symbols for easier debugging~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
