### PR TITLE
Move makeWrapper to nativeBuildInputs for some packages

### DIFF
--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -86,8 +86,7 @@ let
 in stdenv.mkDerivation rec {
   inherit pname version src;
 
-  buildInputs = [ makeWrapper ];
-  nativeBuildInputs = [ jdk11 gradle_5 ];
+  nativeBuildInputs = [ makeWrapper jdk11 gradle_5 ];
 
   buildPhase = ''
     mkdir -p -- ./freeplane/build/emoji/{txt,resources/images}

--- a/pkgs/applications/misc/variety/default.nix
+++ b/pkgs/applications/misc/variety/default.nix
@@ -26,9 +26,9 @@ buildPythonApplication rec {
     sha256 = "sha256-6dLz4KXavXwnk5GizBH46d2EHMHPjRo0WnnUuVMtI1M=";
   };
 
-  nativeBuildInputs = [ intltool wrapGAppsHook ];
+  nativeBuildInputs = [ makeWrapper intltool wrapGAppsHook ];
 
-  buildInputs = [ makeWrapper distutils_extra ];
+  buildInputs = [ distutils_extra ];
 
   doCheck = false;
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -170,7 +170,7 @@ buildStdenv.mkDerivation ({
     xorg.pixman yasm libGLU libGL
     xorg.xorgproto
     xorg.libXdamage
-    xorg.libXext makeWrapper
+    xorg.libXext
     libevent libstartup_notification /* cairo */
     libpng jemalloc glib
     nasm icu67 libvpx_1_8
@@ -224,6 +224,7 @@ buildStdenv.mkDerivation ({
       cargo
       gnused
       llvmPackages.llvm # llvm-objdump
+      makeWrapper
       nodejs
       perl
       pkg-config

--- a/pkgs/games/0ad/wrapper.nix
+++ b/pkgs/games/0ad/wrapper.nix
@@ -6,7 +6,7 @@ buildEnv {
   name = "zeroad-${zeroad-unwrapped.version}";
   inherit (zeroad-unwrapped) meta;
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   paths = [ zeroad-unwrapped zeroad-data ];
 

--- a/pkgs/games/flare/default.nix
+++ b/pkgs/games/flare/default.nix
@@ -8,7 +8,7 @@ buildEnv {
     (callPackage ./game.nix {})
   ];
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   postBuild = ''
     mkdir -p $out/bin
     makeWrapper $out/games/flare $out/bin/flare --run "cd $out/share/games/flare"

--- a/pkgs/games/iortcw/default.nix
+++ b/pkgs/games/iortcw/default.nix
@@ -12,7 +12,7 @@ in buildEnv {
 
   pathsToLink = [ "/opt" ];
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   # so we can launch sp from mp game and vice versa
   postBuild = ''

--- a/pkgs/games/uchess/default.nix
+++ b/pkgs/games/uchess/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   # package does not contain any tests as of v0.2.1
   doCheck = false;
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   postInstall = ''
     wrapProgram $out/bin/uchess --suffix PATH : ${stockfish}/bin
   '';

--- a/pkgs/tools/cd-dvd/brasero/wrapper.nix
+++ b/pkgs/tools/cd-dvd/brasero/wrapper.nix
@@ -6,7 +6,7 @@ in symlinkJoin {
   name = "brasero-${brasero-original.version}";
 
   paths = [ brasero-original ];
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   postBuild = ''
     wrapProgram $out/bin/brasero \

--- a/pkgs/tools/inputmethods/fcitx/wrapper.nix
+++ b/pkgs/tools/inputmethods/fcitx/wrapper.nix
@@ -5,7 +5,7 @@ symlinkJoin {
 
   paths = [ fcitx fcitx-configtool libsForQt5.fcitx-qt5 ] ++ plugins;
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   postBuild = ''
     wrapProgram $out/bin/fcitx \

--- a/pkgs/tools/text/gawk/gawk-with-extensions.nix
+++ b/pkgs/tools/text/gawk/gawk-with-extensions.nix
@@ -1,7 +1,8 @@
 { runCommand, gawk, extensions, makeWrapper }:
 
 runCommand "gawk-with-extensions" {
-  buildInputs = [ makeWrapper gawk ] ++ extensions;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ gawk ] ++ extensions;
 } ''
   mkdir -p $out/bin
   for i in ${gawk}/bin/*; do

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -50,7 +50,8 @@ in (buildEnv {
     "/tex/generic/config" # make it a real directory for scheme-infraonly
   ];
 
-  buildInputs = [ makeWrapper ] ++ pkgList.extraInputs;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ ] ++ pkgList.extraInputs;
 
   # This is set primarily to help find-tarballs.nix to do its job
   passthru.packages = pkgList.all;


### PR DESCRIPTION
###### Motivation for this change

Move makeWrapper from buildInputs to nativeBuildInputs where possible. I've checked eval, but have not built all these packages again. This should fix eval for cross-compilation for these packages.

Please let me know if this should be squashed into one commit.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
