### PR TITLE
userhosts: init at 1.0.0

### DIFF
--- a/pkgs/tools/networking/userhosts/default.nix
+++ b/pkgs/tools/networking/userhosts/default.nix
@@ -1,0 +1,23 @@
+{lib, stdenv, fetchFromGitHub, pkg-config, ncurses, libnl }:
+
+stdenv.mkDerivation rec {
+  pname = "userhosts";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "figiel";
+    repo = "hosts";
+    rev = "v${version}";
+    hash = "sha256-9uF0fYl4Zz/Ia2UKx7CBi8ZU8jfWoBfy2QSgTSwXo5A";
+  };
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "A libc wrapper providing per-user hosts file";
+    homepage = "https://github.com/figiel/hosts";
+    maintainers = [ maintainers.bobvanderlinden ];
+    license = licenses.cc0;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21292,6 +21292,8 @@ in
 
   usbutils = callPackage ../os-specific/linux/usbutils { };
 
+  userhosts = callPackage ../tools/networking/userhosts { };
+
   usermount = callPackage ../os-specific/linux/usermount { };
 
   util-linux = if stdenv.isLinux then callPackage ../os-specific/linux/util-linux { }


### PR DESCRIPTION
###### Motivation for this change

Userhosts is a library I found while searching for a convenient way to have per-project hosts file using mkShell and direnv.

It is used with LD_PRELOAD, where it overrides address resolving of libc. It lets you specify your own hosts file.

I have made a few PRs on the project to get the features needed. The developer is quite responsive and helpful, so I think it is fine to package this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
