### PR TITLE
borgbackup: 1.1.16 -> 1.1.17

### DIFF
--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -1,22 +1,13 @@
-{ lib, stdenv, python3, fetchpatch, acl, libb2, lz4, zstd, openssl, openssh, nixosTests }:
+{ lib, stdenv, python3, acl, libb2, lz4, zstd, openssl, openssh, nixosTests }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "borgbackup";
-  version = "1.1.16";
+  version = "1.1.17";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "0l1dqfwrd9l34rg30cmzmq5bs6yha6kg4vy313jq611jsqj94mmw";
+    sha256 = "0x0ncy0b0bmf586hbdgrif3gjmkdw760vfnfxndr493v07y29fbs";
   };
-
-  patches = [
-    # fix compatibility with sphinx 4
-    (fetchpatch {
-      url = "https://github.com/borgbackup/borg/commit/6a1f31bf2914d167e2f5051f1d531d5d4a19f54b.patch";
-      includes = [ "docs/conf.py" ];
-      sha256 = "0aa4kyb3j4apgwqcy1hzg6lxvpf60m2mijcj60vh101b42410hiz";
-    })
-  ];
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools-scm
@@ -27,6 +18,7 @@ python3.pkgs.buildPythonApplication rec {
     libb2 lz4 zstd openssl
   ] ++ lib.optionals stdenv.isLinux [ acl ];
   propagatedBuildInputs = with python3.pkgs; [
+    packaging
     cython llfuse
   ];
 

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenv, python3, acl, libb2, lz4, zstd, openssl, openssh, nixosTests }:
+{ lib
+, stdenv
+, acl
+, e2fsprogs
+, libb2
+, lz4
+, openssh
+, openssl
+, python3
+, zstd
+, nixosTests
+}:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "borgbackup";
@@ -9,17 +20,33 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "0x0ncy0b0bmf586hbdgrif3gjmkdw760vfnfxndr493v07y29fbs";
   };
 
+  postPatch = ''
+    # sandbox does not support setuid/setgid/sticky bits
+    substituteInPlace src/borg/testsuite/archiver.py \
+      --replace "0o4755" "0o0755"
+  '';
+
   nativeBuildInputs = with python3.pkgs; [
     setuptools-scm
     # For building documentation:
-    sphinx guzzle_sphinx_theme
+    sphinx
+    guzzle_sphinx_theme
   ];
+
   buildInputs = [
-    libb2 lz4 zstd openssl
-  ] ++ lib.optionals stdenv.isLinux [ acl ];
+    libb2
+    lz4
+    zstd
+    openssl
+  ] ++ lib.optionals stdenv.isLinux [
+    acl
+  ];
+
   propagatedBuildInputs = with python3.pkgs; [
+    cython
+    llfuse
     packaging
-    cython llfuse
+    pyfuse3
   ];
 
   preConfigure = ''
@@ -53,15 +80,36 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   checkInputs = with python3.pkgs; [
-    pytest
+    e2fsprogs
+    pytest-benchmark
+    pytest-xdist
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    HOME=$(mktemp -d) py.test --pyargs borg.testsuite
-  '';
+  pytestFlagsArray = [
+    "--numprocesses" "auto"
+    "--benchmark-skip"
+    "--pyargs" "borg.testsuite"
+  ];
 
-  # 64 failures, needs pytest-benchmark
-  doCheck = false;
+  disabledTests = [
+    # fuse: device not found, try 'modprobe fuse' first
+    "test_fuse"
+    "test_fuse_allow_damaged_files"
+    "test_fuse_mount_hardlinks"
+    "test_fuse_mount_options"
+    "test_fuse_versions_view"
+    "test_readonly_mount"
+    # Error: Permission denied while trying to write to /var/{,tmp}
+    "test_get_cache_dir"
+    "test_get_keys_dir"
+    "test_get_security_dir"
+    "test_get_config_dir"
+  ];
+
+  preCheck = ''
+    export HOME=$TEMP
+  '';
 
   passthru.tests = {
     inherit (nixosTests) borgbackup;


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/borgbackup/borg/blob/1.1.17/docs/changes.rst#version-1117-2021-07-12
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
