### PR TITLE
Fix packages on Darwin

### DIFF
--- a/pkgs/applications/misc/gcal/default.nix
+++ b/pkgs/applications/misc/gcal/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses, fetchpatch }:
+{ lib, stdenv, fetchurl, ncurses, gettext, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "gcal";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ ncurses ];
+  buildInputs = [ ncurses ] ++ lib.optional stdenv.isDarwin gettext;
 
   meta = {
     description = "Program for calculating and printing calendars";

--- a/pkgs/tools/misc/bmon/default.nix
+++ b/pkgs/tools/misc/bmon/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
-  buildInputs = [ ncurses libconfuse libnl ];
+  buildInputs = [ ncurses libconfuse ] ++ lib.optional stdenv.isLinux libnl;
 
   preConfigure = ''
     # Must be an absolute path
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     #  - https://github.com/tgraf/bmon/blob/master/LICENSE.BSD
     #  - https://github.com/tgraf/bmon/blob/master/LICENSE.MIT
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ bjornfor pSub ];
   };
 }

--- a/pkgs/tools/networking/ifstat-legacy/default.nix
+++ b/pkgs/tools/networking/ifstat-legacy/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "01zmv6vk5kh5xmd563xws8a1qnxjb6b6kv59yzz9r3rrghxhd6c5";
   };
 
-  buildInputs = [ net-snmp ];
+  buildInputs = lib.optional stdenv.isLinux net-snmp;
 
   nativeBuildInputs = [ autoreconfHook ];
 


### PR DESCRIPTION
#### Motivation for this change

Make  a few packages work on macOS. This is based on seeing those packages run when installed with Homebrew.

#### Things done

This makes `ifstat-legacy`, `bmon` and `gcal` derivations work on Darwin.

- For `ifstat-legacy`, use `net-snmp` as dependency only on Linux (as it is a Linux-only library).
- For `bmon`, use `libnl` as dependency only on Linux (as it is a Linux-only library).
- For `gcal`, add `gettext` as dependency on Darwin (in Linux it is provided by `glibc`). It builds without it, but then the binary crashes when running it.

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).