### PR TITLE
ociTools: various improvements

### DIFF
--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -42,7 +42,7 @@
       "/sys/fs/cgroup" = {
         type = "cgroup";
         source = "cgroup";
-        options = [ "nosuid" "noexec" "nodev" "realatime" "ro" ];
+        options = [ "nosuid" "noexec" "nodev" "relatime" "ro" ];
       };
     };
     config = writeText "config.json" (builtins.toJSON {

--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -7,6 +7,7 @@
     , os ? "linux"
     , arch ? "x86_64"
     , readonly ? false
+    , extraOciConfig ? {}
     }:
   let
     sysMounts = {
@@ -45,7 +46,7 @@
         options = [ "nosuid" "noexec" "nodev" "relatime" "ro" ];
       };
     };
-    config = writeText "config.json" (builtins.toJSON {
+    merged = lib.recursiveUpdate {
       ociVersion = "1.0.0";
       platform = {
         inherit os arch;
@@ -66,7 +67,8 @@
       mounts = lib.mapAttrsToList (destination: { type, source, options ? null }: {
         inherit destination type source options;
       }) sysMounts;
-    });
+    } extraOciConfig;
+    config = writeText "config.json" (builtins.toJSON merged);
   in
     runCommand "oci-image" {} ''
       set -o pipefail

--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -68,7 +68,7 @@
       }) sysMounts;
     });
   in
-    runCommand "join" {} ''
+    runCommand "oci-image" {} ''
       set -o pipefail
       mkdir -p $out/rootfs/{dev,proc,sys}
       cp ${config} $out/config.json

--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -1,11 +1,16 @@
 { lib, writeText, runCommand, writeReferencesToFile }:
 
+let
+  currentSystemSplit = lib.splitString "-" builtins.currentSystem;
+  currentOS = lib.last currentSystemSplit;
+  currentArch = lib.head currentSystemSplit;
+in
 {
   buildContainer =
     { args
     , mounts ? {}
-    , os ? "linux"
-    , arch ? "x86_64"
+    , os ? currentOS
+    , arch ? currentArch
     , readonly ? false
     , extraOciConfig ? {}
     }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Turns out that ociTools has been broken since the day it was introduced - `realatime` is incorrect mount option, making none of the OCI-compatible runtimes accept the bundle generated using it.

This PR also introduces a way to specify extra OCI configuration to be merged into bundle's `config.json`, and makes a minor adjustment to final `runCommand` step to set image derivation output name which makes more sense.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
