### PR TITLE
layan-gtk-theme: init at 2021-06-30

### DIFF
--- a/pkgs/data/themes/layan-gtk-theme/default.nix
+++ b/pkgs/data/themes/layan-gtk-theme/default.nix
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
-  postPatch = "patchShebangs install.sh";
+  postPatch = ''
+    patchShebangs install.sh
+  '';
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/themes

--- a/pkgs/data/themes/layan-gtk-theme/default.nix
+++ b/pkgs/data/themes/layan-gtk-theme/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, gtk-engine-murrine
+}:
+
+stdenv.mkDerivation rec {
+  pname = "layan-gtk-theme";
+  version = "2021-06-30";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-FI8+AJlcPHGOzxN6HUKLtPGLe8JTfTQ9Az9NsvVUK7g=";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  postPatch = "patchShebangs install.sh";
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes
+    unset name && ./install.sh -d $out/share/themes
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A flat Material Design theme for GTK 3, GTK 2 and Gnome-Shell.";
+    homepage = "https://github.com/vinceliuice/Layan-gtk-theme";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.vanilla ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22286,6 +22286,8 @@ in
 
   kreative-square-fonts = callPackage ../data/fonts/kreative-square-fonts { };
 
+  layan-gtk-theme = callPackage ../data/themes/layan-gtk-theme { };
+
   lato = callPackage ../data/fonts/lato {};
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};


### PR DESCRIPTION
###### Motivation for this change

Layan is a flat Material Design theme for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Budgie, etc.
-- quote from [vinceliuice/Layan-gtk-theme](https://github.com/vinceliuice/Layan-gtk-theme)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
