### PR TITLE
rebar3: skip failing tests on M1 chip

### DIFF
--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -39,6 +39,14 @@ let
       HOME=. escript bootstrap
     '';
 
+
+    patches = []
+      # Skips test that can write outside the designated tmp directory, potentially resulting in build failures
+      # due to file ownership issues if ran without sandbox (eg. Mac M1 default). This patch can be Removed when
+      # rebar3 releases with the following commit:
+      # https://github.com/erlang/rebar3/commit/11055384dbd5bf7d181bca83a33b0e100275ff21
+      ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ ./tmp-tests-skip.patch ];
+
     checkPhase = ''
       HOME=. escript ./rebar3 ct
     '';

--- a/pkgs/development/tools/build-managers/rebar3/tmp-tests-skip.patch
+++ b/pkgs/development/tools/build-managers/rebar3/tmp-tests-skip.patch
@@ -1,0 +1,17 @@
+diff --git a/test/rebar_file_utils_SUITE.erl b/test/rebar_file_utils_SUITE.erl
+index d771a82..05cfbf7 100644
+--- a/test/rebar_file_utils_SUITE.erl
++++ b/test/rebar_file_utils_SUITE.erl
+@@ -34,13 +34,11 @@
+
+ all() ->
+     [{group, tmpdir},
+-     {group, reset_dir},
+      {group, mv},
+      path_from_ancestor,
+      canonical_path,
+      absolute_path,
+      normalized_path,
+-     resolve_link,
+      split_dirname,
+      mv_warning_is_ignored].


### PR DESCRIPTION
###### Motivation for this change

There are a few rebar3 tests that fail on an M1 Mac. This PR disables them, so that rebar3 can at least be installed

See https://github.com/NixOS/nixpkgs/issues/130012 for details.

###### Things done

I have run `nixpkgs-review` on a NixOS machine, but on an M1 Mac it failed, not sure how much this matters.
I have also run build on the M1 and it worked (duh), but Nix apparently doesn't have sandbox enabled on that machine for whatever reason (didn't change any defaults), so I didn't mark the checkbox.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).