### PR TITLE
kicad-unstable: update; now requires python

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,23 +27,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2021-05-16";
+      version =			"2021-07-12";
       src = {
-        rev =			"c33b2cfa8d16072b9d1bce558e443c4afa889d06";
-        sha256 =		"1fvbxjpf880ikjqjhzj8wlxj0845gzrj1yv35rk7akbg4vl9ph72";
+        rev =			"76a6177eb7fc2efe8b5fd522355e70c44a33b150";
+        sha256 =		"1a94z29if73cnxjx75vkgasm339dasbrjwbg2zk1c35pfygnwrj5";
       };
     };
     libVersion = {
-      version =			"2021-05-16";
+      version =			"2021-07-12";
       libSources = {
         i18n.rev =		"e89d9a89bec59199c1ade56ee2556591412ab7b0";
         i18n.sha256 =		"04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
-        symbols.rev =		"32de73ea01347a005790119eb4102c550815685c";
-        symbols.sha256 =	"0gj10v06rkxlxngc40d1sfmlcagy5p7jfxid0lch4w0wxfjmks7z";
+        symbols.rev =		"a6f64c12c9cdea4cda25cdd2c92708e7eb461d46";
+        symbols.sha256 =	"0j6ng3ysqlxcggjyq3bsgqzg6j50if74q2dpyrdh5pckfqvvmv20";
         templates.rev =		"073d1941c428242a563dcb5301ff5c7479fe9c71";
         templates.sha256 =	"14p06m2zvlzzz2w74y83f2zml7mgv5dhy2nyfkpblanxawrzxv1x";
-        footprints.rev =	"8fa36dfa3423d8777472e3475c1c2b0b2069624f";
-        footprints.sha256 =	"138xfkr0prxw2djkwc1m4mlp9km99v12sivbqhm1jkq5yxngdbin";
+        footprints.rev =	"1bacc7562198e2a2985df7f2fbcd7620b4fd0d46";
+        footprints.sha256 =	"1h17q0xpl4k4klg3mafzsbl88wzrg73xjsh8llyni2jzs531545a";
         packages3d.rev =	"d8b7e8c56d535f4d7e46373bf24c754a8403da1f";
         packages3d.sha256 =	"0dh8ixg0w43wzj5h3164dz6l1vl4llwxhi3qcdgj1lgvrs28aywd";
       };


### PR DESCRIPTION
###### Motivation for this change
upstream changed to always require python on 2021-06-01
https://gitlab.com/kicad/code/kicad/-/merge_requests/796

###### Things done
bump to latest commit
rearranged some conditional statements to always have python in kicad-unstable
but still be able to disable scripting to avoid requiring wxpython
this should get simplified when unstable becomes v6, along with a lot of other stuff

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
