### PR TITLE
nixos/plasma5: add environment.plasma5.excludePackages option

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -174,6 +174,13 @@ in
       };
     };
 
+    environment.plasma5.excludePackages = mkOption {
+      default = [ ];
+      example = literalExample "[ pkgs.plasma5Packages.konsole ]";
+      type = types.listOf types.package;
+      description = "Which packages Plasma 5 (KDE 5) should exclude from the default environment";
+    };
+
   };
 
   imports = [
@@ -212,115 +219,117 @@ in
       '';
 
       environment.systemPackages =
-        with libsForQt5;
-        with plasma5; with kdeGear; with kdeFrameworks;
-        [
-          frameworkintegration
-          kactivities
-          kauth
-          kcmutils
-          kconfig
-          kconfigwidgets
-          kcoreaddons
-          kdoctools
-          kdbusaddons
-          kdeclarative
-          kded
-          kdesu
-          kdnssd
-          kemoticons
-          kfilemetadata
-          kglobalaccel
-          kguiaddons
-          kiconthemes
-          kidletime
-          kimageformats
-          kinit
-          kirigami2  # In system profile for SDDM theme. TODO: wrapper.
-          kio
-          kjobwidgets
-          knewstuff
-          knotifications
-          knotifyconfig
-          kpackage
-          kparts
-          kpeople
-          krunner
-          kservice
-          ktextwidgets
-          kwallet
-          kwallet-pam
-          kwalletmanager
-          kwayland
-          kwidgetsaddons
-          kxmlgui
-          kxmlrpcclient
-          plasma-framework
-          solid
-          sonnet
-          threadweaver
+        pkgs.gnome.removePackagesByName
+          (with libsForQt5;
+          with plasma5; with kdeGear; with kdeFrameworks;
+          [
+            frameworkintegration
+            kactivities
+            kauth
+            kcmutils
+            kconfig
+            kconfigwidgets
+            kcoreaddons
+            kdoctools
+            kdbusaddons
+            kdeclarative
+            kded
+            kdesu
+            kdnssd
+            kemoticons
+            kfilemetadata
+            kglobalaccel
+            kguiaddons
+            kiconthemes
+            kidletime
+            kimageformats
+            kinit
+            kirigami2  # In system profile for SDDM theme. TODO: wrapper.
+            kio
+            kjobwidgets
+            knewstuff
+            knotifications
+            knotifyconfig
+            kpackage
+            kparts
+            kpeople
+            krunner
+            kservice
+            ktextwidgets
+            kwallet
+            kwallet-pam
+            kwalletmanager
+            kwayland
+            kwidgetsaddons
+            kxmlgui
+            kxmlrpcclient
+            plasma-framework
+            solid
+            sonnet
+            threadweaver
 
-          breeze-qt5
-          kactivitymanagerd
-          kde-cli-tools
-          kdecoration
-          kdeplasma-addons
-          kgamma5
-          khotkeys
-          kinfocenter
-          kmenuedit
-          kscreen
-          kscreenlocker
-          ksysguard
-          kwayland
-          kwin
-          kwrited
-          libkscreen
-          libksysguard
-          milou
-          plasma-browser-integration
-          plasma-integration
-          polkit-kde-agent
-          spectacle
-          systemsettings
+            breeze-qt5
+            kactivitymanagerd
+            kde-cli-tools
+            kdecoration
+            kdeplasma-addons
+            kgamma5
+            khotkeys
+            kinfocenter
+            kmenuedit
+            kscreen
+            kscreenlocker
+            ksysguard
+            kwayland
+            kwin
+            kwrited
+            libkscreen
+            libksysguard
+            milou
+            plasma-browser-integration
+            plasma-integration
+            polkit-kde-agent
+            spectacle
+            systemsettings
 
-          plasma-desktop
-          plasma-workspace
-          plasma-workspace-wallpapers
+            plasma-desktop
+            plasma-workspace
+            plasma-workspace-wallpapers
 
-          dolphin
-          dolphin-plugins
-          ffmpegthumbs
-          kdegraphics-thumbnailers
-          khelpcenter
-          kio-extras
-          konsole
-          oxygen
-          print-manager
+            dolphin
+            dolphin-plugins
+            ffmpegthumbs
+            kdegraphics-thumbnailers
+            khelpcenter
+            kio-extras
+            konsole
+            oxygen
+            print-manager
 
-          breeze-icons
-          pkgs.hicolor-icon-theme
+            breeze-icons
+            pkgs.hicolor-icon-theme
 
-          kde-gtk-config breeze-gtk
+            kde-gtk-config breeze-gtk
 
-          qtvirtualkeyboard
+            qtvirtualkeyboard
 
-          pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
-        ]
+            pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
+          ]
 
-        # Phonon audio backend
-        ++ lib.optional (cfg.phononBackend == "gstreamer") libsForQt5.phonon-backend-gstreamer
-        ++ lib.optional (cfg.phononBackend == "vlc") libsForQt5.phonon-backend-vlc
+          # Phonon audio backend
+          ++ lib.optional (cfg.phononBackend == "gstreamer") libsForQt5.phonon-backend-gstreamer
+          ++ lib.optional (cfg.phononBackend == "vlc") libsForQt5.phonon-backend-vlc
 
-        # Optional hardware support features
-        ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt pkgs.openobex pkgs.obexftp ]
-        ++ lib.optional config.networking.networkmanager.enable plasma-nm
-        ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
-        ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
-        ++ lib.optional config.powerManagement.enable powerdevil
-        ++ lib.optional config.services.colord.enable pkgs.colord-kde
-        ++ lib.optionals config.services.samba.enable [ kdenetwork-filesharing pkgs.samba ]
-        ++ lib.optional config.services.xserver.wacom.enable pkgs.wacomtablet;
+          # Optional hardware support features
+          ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt pkgs.openobex pkgs.obexftp ]
+          ++ lib.optional config.networking.networkmanager.enable plasma-nm
+          ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
+          ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
+          ++ lib.optional config.powerManagement.enable powerdevil
+          ++ lib.optional config.services.colord.enable pkgs.colord-kde
+          ++ lib.optionals config.services.samba.enable [ kdenetwork-filesharing pkgs.samba ]
+          ++ lib.optional config.services.xserver.wacom.enable pkgs.wacomtablet)
+          config.environment.plasma5.excludePackages;
 
       environment.pathsToLink = [
         # FIXME: modules should link subdirs of `/share` rather than relying on this


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
