### PR TITLE
temporal: init 1.10.5

### DIFF
--- a/pkgs/applications/networking/cluster/temporal/default.nix
+++ b/pkgs/applications/networking/cluster/temporal/default.nix
@@ -1,0 +1,42 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "temporal";
+  version = "1.10.5";
+
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "temporal";
+    rev = "v${version}";
+    sha256 = "sha256-+rU/Tn3k/VmAgZl169tVZsRf5SL4bI9r3p1svVfKN2E=";
+  };
+
+  vendorSha256 = "sha256-jbQPhGfZPPxjYTSJ9wMLzQIOhAwxJZypRzqwL421RfM=";
+
+  doCheck = false; # Errors:
+                   #  > === RUN   TestNamespaceHandlerGlobalNamespaceDisabledSuite
+                   # gocql: unable to dial control conn 127.0.0.1:9042: dial tcp 127.0.0.1:9042: connect: connection refused
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 "$GOPATH/bin/cli" -T $out/bin/tctl
+    install -Dm755 "$GOPATH/bin/cassandra" -T $out/bin/temporal-cassandra
+    install -Dm755 "$GOPATH/bin/server" -T $out/bin/temporal-server
+    install -Dm755 "$GOPATH/bin/sql" -T $out/bin/temporal-sql
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/tctl --version | grep ${version} > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A microservice orchestration platform which enables developers to build scalable applications without sacrificing productivity or reliability";
+    downloadPage = "https://github.com/temporalio/temporal";
+    homepage = "https://temporal.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/applications/networking/cluster/temporal/default.nix
+++ b/pkgs/applications/networking/cluster/temporal/default.nix
@@ -13,9 +13,10 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-jbQPhGfZPPxjYTSJ9wMLzQIOhAwxJZypRzqwL421RfM=";
 
-  doCheck = false; # Errors:
-                   #  > === RUN   TestNamespaceHandlerGlobalNamespaceDisabledSuite
-                   # gocql: unable to dial control conn 127.0.0.1:9042: dial tcp 127.0.0.1:9042: connect: connection refused
+  # Errors:
+  #  > === RUN   TestNamespaceHandlerGlobalNamespaceDisabledSuite
+  # gocql: unable to dial control conn 127.0.0.1:9042: dial tcp 127.0.0.1:9042: connect: connection refused
+  doCheck = false;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27214,6 +27214,8 @@ in
 
   tempo = callPackage ../servers/tracing/tempo {};
 
+  temporal = callPackage ../applications/networking/cluster/temporal { };
+
   tendermint = callPackage ../tools/networking/tendermint { };
 
   termdown = python3Packages.callPackage ../applications/misc/termdown { };


### PR DESCRIPTION
###### Motivation for this change

temporal: init 1.10.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
