### PR TITLE
aether: init at 2.0.0-dev.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6604,6 +6604,12 @@
     githubId = 35892750;
     name = "Maxine Aubrey";
   };
+  maxhille = {
+    email = "mh@lambdasoup.com";
+    github = "maxhille";
+    githubId = 693447;
+    name = "Max Hille";
+  };
   maxhbr = {
     email = "nixos@maxhbr.dev";
     github = "maxhbr";

--- a/pkgs/applications/networking/aether/default.nix
+++ b/pkgs/applications/networking/aether/default.nix
@@ -1,0 +1,115 @@
+{ autoPatchelfHook, makeDesktopItem, lib, stdenv, wrapGAppsHook
+, alsa-lib, at-spi2-atk, at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig
+, freetype, gdk-pixbuf, glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid
+, libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
+, libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence
+, mesa, nspr, nss, pango, systemd, libappindicator-gtk3, libdbusmenu
+, fetchurl, fetchFromGitHub, imagemagick, copyDesktopItems
+}:
+
+let
+  binaryName = "AetherP2P";
+in
+stdenv.mkDerivation rec {
+  pname = "aether";
+  version = "2.0.0-dev.15";
+
+  srcs = [
+    (fetchurl {
+      url = "https://static.getaether.net/Releases/Aether-${version}/2011262249.19338c93/linux/Aether-${version}%2B2011262249.19338c93.tar.gz";
+      sha256 = "1hi8w83zal3ciyzg2m62shkbyh6hj7gwsidg3dn88mhfy68himf7";
+      # % in the url / canonical filename causes an error
+      name = "aether-tarball.tar.gz";
+    })
+    (fetchFromGitHub {
+      owner = "aethereans";
+      repo = "aether-app";
+      rev = "53b6c8b2a9253cbf056ea3ebb077e0e08cbc5b1d";
+      sha256 = "1kgkzh7ih2q9dsckdkinh5dbzvr7gdykf8yz6h8pyhvzyjhk1v0r";
+    })
+  ];
+
+  sourceRoot = "Aether-${version}+2011262249.19338c93";
+
+  # there is no logo in the tarball so we grab it from github and convert it in the build phase
+  buildPhase = ''
+    convert ../source/aether-core/aether/client/src/app/ext_dep/images/Linux-Windows-App-Icon.png -resize 512x512 aether.png
+  '';
+
+  dontWrapGApps = true;
+
+  buildInputs = [
+    alsa-lib
+    cups
+    libdrm
+    libuuid
+    libXdamage
+    libX11
+    libXScrnSaver
+    libXtst
+    libxcb
+    libxshmfence
+    mesa
+    nss
+  ];
+
+  nativeBuildInputs = [
+    imagemagick
+    autoPatchelfHook
+    wrapGAppsHook
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = binaryName;
+      icon = pname;
+      desktopName = "Aether";
+      genericName = meta.description;
+      categories = "Network;";
+      mimeType = "x-scheme-handler/aether";
+    })
+  ];
+
+  installPhase =
+  let
+    libPath = lib.makeLibraryPath [
+      libcxx systemd libpulseaudio libdrm mesa
+      stdenv.cc.cc alsa-lib atk at-spi2-atk at-spi2-core cairo cups dbus expat fontconfig freetype
+      gdk-pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
+      libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+      libXtst nspr nss libxcb pango systemd libXScrnSaver
+      libappindicator-gtk3 libdbusmenu
+    ];
+  in
+  ''
+    mkdir -p $out/{bin,opt/${binaryName},share/icons/hicolor/512x512/apps}
+    mv * $out/opt/${binaryName}
+
+    chmod +x $out/opt/${binaryName}/${binaryName}
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+        $out/opt/${binaryName}/${binaryName}
+
+    wrapProgram $out/opt/${binaryName}/${binaryName} \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}" \
+        --prefix LD_LIBRARY_PATH : ${libPath}
+
+    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
+
+    ln -s $out/opt/${binaryName}/aether.png $out/share/icons/hicolor/512x512/apps/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Peer-to-peer ephemeral public communities";
+    homepage = "https://getaether.net/";
+    downloadPage = "https://getaether.net/download/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ maxhille ];
+    # other platforms could be supported by building from source
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -174,6 +174,8 @@ in
 
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 
+  aether = callPackage ../applications/networking/aether { };
+
   alda = callPackage ../development/interpreters/alda { };
 
   althttpd = callPackage ../servers/althttpd { };


### PR DESCRIPTION
The changes in this PR add myself to the maintainer list and the Aether P2P client as a package.

about Aether: https://getaether.net/

###### Motivation for this change

No package yes. People were asking for it (https://github.com/NixOS/nixpkgs/issues/66414)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
