### PR TITLE
libsForQt5.kimageformats: fix CVE-2021-36083

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -28,6 +28,6 @@ mkDerivation {
   CXXFLAGS = "-I${getDev ilmbase}/include/OpenEXR";
 
   meta = with lib; {
-    broken = lib.versionOlder qtbase.version "5.14";
+    broken = versionOlder qtbase.version "5.14";
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -15,10 +15,19 @@ mkDerivation {
       url = "https://invent.kde.org/frameworks/kimageformats/-/commit/bf3f94da766d66a0470ab744dbe1ced4697b572d.diff";
       sha256 = "18d67l5kj9sv88jdpi061k9rl3adzkx9l51ng7saylrkfddwc3ig";
     })
+    (fetchpatch { # included in kimageformats >= 5.82
+      name = "CVE-2021-36083.patch";
+      url = "https://invent.kde.org/frameworks/kimageformats/-/commit/297ed9a2fe339bfe36916b9fce628c3242e5be0f.diff";
+      sha256 = "16axaljgaar0j5796x1mjps93y92393x8zywh3nzw7rm9w2qxzml";
+    })
   ];
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive openexr libavif qtbase ];
   outputs = [ "out" ]; # plugins only
   CXXFLAGS = "-I${getDev ilmbase}/include/OpenEXR";
+
+  meta = with lib; {
+    broken = lib.versionOlder qtbase.version "5.14";
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix CVE-2021-36083.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>libsForQt512.kimageformats</li>
  </ul>
</details>
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>libsForQt5.kimageformats</li>
    <li>libsForQt514.kimageformats</li>
    <li>photoqt</li>
  </ul>
</details>