### PR TITLE
rhythmbox: add support for more features (depend on more libraries)

### DIFF
--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -6,6 +6,8 @@
 , intltool
 , libpeas
 , libsoup
+, libsecret
+, libnotify
 , libdmapsharing
 , gnome
 , totem-pl-parser
@@ -17,8 +19,6 @@
 , gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
 }:
 let
-  pname = "rhythmbox";
-  version = "3.4.4";
 
   # The API version of libdmapsharing required by rhythmbox 3.4.4 is 3.0.
 
@@ -39,10 +39,11 @@ let
   });
 
 in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "rhythmbox";
+  version = "3.4.4";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "142xcvw4l19jyr5i72nbnrihs953pvrrzcbijjn9dxmxszbv03pf";
   };
 
@@ -66,11 +67,21 @@ in stdenv.mkDerivation rec {
 
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
 
     libdmapsharing_3 # necessary for daap support
+    libsecret
+    libnotify
   ] ++ gst_plugins;
 
-  configureFlags = [ "--enable-daap" ];
+  configureFlags = [
+    "--enable-daap"
+    "--enable-libnotify"
+    "--with-libsecret"
+  ];
 
   enableParallelBuilding = true;
 
@@ -84,7 +95,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Apps/Rhythmbox";
     description = "A music playing application for GNOME";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.rasendubi ];
   };


### PR DESCRIPTION
- libsecret: remember passwords for DAAP servers in the keyring
- libnotify: watch changes in the music library
- more gstreamer plugins


###### Motivation for this change

Enables the listed features.

The last item (gstreamer plugins) includes fixing  #31155 and #123335. A key aspect is to expose the plugins using 
```
    gappsWrapperArgs+=(
      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
    )
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes: #31155
Fixes: #123335