### PR TITLE
modemmanager: 1.16.6 -> 1.16.8

### DIFF
--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -1,25 +1,16 @@
-{ lib, stdenv, fetchurl, fetchpatch
+{ lib, stdenv, fetchurl
 , glib, udev, libgudev, polkit, ppp, gettext, pkg-config, python3
 , libmbim, libqmi, systemd, vala, gobject-introspection, dbus
 }:
 
 stdenv.mkDerivation rec {
   pname = "modem-manager";
-  version = "1.16.6";
+  version = "1.16.8";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/ModemManager/ModemManager-${version}.tar.xz";
-    sha256 = "05wn94x71qr36avxjzvyf56nj5illynnf9nn15b17lv61wkbd41a";
+    sha256 = "sha256-If36+UFxJhrZ2ZdxiU9a3kvDnvPR/x1CEFTRRxPpeIA=";
   };
-
-  patches = [
-    # Fix a broken test.
-    # https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/556
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/a324667386f35df0c3b3bbf615fa0560d215485d.patch";
-      sha256 = "1xj9gfl6spbp4xdp6gn76k8zvzam5m6lgmbiwdn6ixffzhlfwi5l";
-    })
-  ];
 
   nativeBuildInputs = [ vala gobject-introspection gettext pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.

https://lists.freedesktop.org/archives/modemmanager-devel/2021-July/008737.html
```
ModemManager 1.16.8
-------------------------------------------

  * MBIM:
    ** Fixed wrong session id management when multiple bearers are created.

  * Modem interface:
    ** Fixed the enabling operation on multiple plugins that don't have explicit power up/down operations.

  * libmm-glib:
    ** Modem interface: added missing input argument checks.
    ** Messaging interface: fixed get_supported_storages() handling when it's called several consecutive times.
    ** 3GPP interface: fixed initial EPS bearer settings property updates.

  * plugins:
    ** cinterion: fixed double free when loading initial EPS context.

  * udev:
    ** Explicitly ignore "FIREHOSE" WWAN ports.
    ** Add support to match WWAN type via sysfs attributes.

  * Several other minor improvements and fixes.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
