### PR TITLE
kfctl: init at 1.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/kfctl/default.nix
+++ b/pkgs/applications/networking/cluster/kfctl/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "kfctl";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "kubeflow";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-FY7o4QULobLY1djfcc2l6awE/v2stN7cc2lffMkjoPc=";
+  };
+
+  vendorSha256 = "sha256-+6sxXp0LKegZjEFv1CIQ6xYh+hXLn+o9LggRYamCzpI=";
+
+  subPackages = [ "cmd/kfctl" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+  installShellCompletion --cmd eksctl \
+    --bash <($out/bin/kfctl completion bash) \
+    --zsh <($out/bin/kfctl completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "A CLI for deploying and managing Kubeflow";
+    homepage = "https://github.com/kubeflow/kfctl";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mvnetbiz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6221,6 +6221,8 @@ in
 
   keystore-explorer = callPackage ../applications/misc/keystore-explorer { };
 
+  kfctl = callPackage ../applications/networking/cluster/kfctl { };
+
   kibana6 = callPackage ../development/tools/misc/kibana/6.x.nix { };
   kibana6-oss = callPackage ../development/tools/misc/kibana/6.x.nix {
     enableUnfree = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I needed kfctl command (kubeflow)

###### Things done
Packaged kfctl.

I have tested that it deploys kubeflow on a kubernetes cluster.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
