### PR TITLE
python3Packages.pylev: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pylev/default.nix
+++ b/pkgs/development/python-modules/pylev/default.nix
@@ -1,23 +1,29 @@
-{ lib, buildPythonPackage, fetchFromGitHub }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+}:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "pylev";
-  version = "1.3.0";
+  version = "1.4.0";
 
-  # No tests in PyPi tarball
   src = fetchFromGitHub {
     owner = "toastdriven";
     repo = "pylev";
-    # Can't use a tag because it's missing
-    # https://github.com/toastdriven/pylev/issues/10
-    # rev = "v${version};
-    rev = "72e3d490515c3188e2acac9c15ea1b466f9ff938";
-    sha256 = "18dg1rfnqgfl6x4vafiq4la9d7f65xak19gcvngslq0bm1z6hyd8";
+    rev = "v${version}";
+    sha256 = "0fgxjdnvnvavnxmxxd0fl5jyr2f31g3a26bwyxcpy56mgpd095c1";
   };
 
+  checkPhase = ''
+    ${python.interpreter} -m unittest tests
+  '';
+
+  pythonImportsCheck = [ "pylev" ];
+
   meta = with lib; {
+    description = "Python Levenshtein implementation";
     homepage = "https://github.com/toastdriven/pylev";
-    description = "A pure Python Levenshtein implementation that's not freaking GPL'd";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jakewaksbaum ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4.0

Change log: https://github.com/toastdriven/pylev#version-history

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
