### PR TITLE
update ap-normalize version 0.1.0.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
@@ -147,7 +147,7 @@ default-package-overrides:
   - apecs-physics ==0.4.5
   - api-field-json-th ==0.1.0.2
   - api-maker ==0.1.0.0
-  - ap-normalize ==0.1.0.0
+  - ap-normalize ==0.1.0.1
   - appar ==0.1.8
   - appendmap ==0.1.5
   - apply-refact ==0.9.2.0


### PR DESCRIPTION
https://stackage.org/nightly/cabal.config mentions 0.1.0.1 but in repo is still old version, this cause problem Big Sur
Very strange - why this auto generated file is under git anyway?!