### PR TITLE
orocos-kdl: 1.5.0 propagation fix

### DIFF
--- a/pkgs/development/libraries/orocos-kdl/default.nix
+++ b/pkgs/development/libraries/orocos-kdl/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "source/orocos_kdl";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ eigen ];
+  propagatedBuildInputs = [ eigen ];
 
   meta = with lib; {
     description = "Kinematics and Dynamics Library";


### PR DESCRIPTION
###### Motivation for this change

Without this change, downstream dependencies outside of nixpkgs (eg, ROS packages) are unable to use the orocos-kdl find module, see discussion and example build output here:

https://github.com/NixOS/nixpkgs/pull/126794#issuecomment-879501848

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Limited testing should be needed, since this is strictly additive. FYI @lopsided98 