### PR TITLE
openexr_3: init at 3.0.5

### DIFF
--- a/pkgs/development/libraries/imath/default.nix
+++ b/pkgs/development/libraries/imath/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "imath";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = "AcademySoftwareFoundation";
+    repo = "imath";
+    rev = "v${version}";
+    sha256 = "0nwf8622j01p699nkkbal6xxs1snzzhz4cn6d76yppgvdhgyahsc";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Imath is a C++ and python library of 2D and 3D vector, matrix, and math operations for computer graphics";
+    homepage = "https://github.com/AcademySoftwareFoundation/Imath";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ paperdigits ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, zlib
+, cmake
+, imath
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openexr";
+  version = "3.0.5";
+
+  outputs = [ "bin" "dev" "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "AcademySoftwareFoundation";
+    repo = "openexr";
+    rev = "v${version}";
+    sha256 = "0inmpby1syyxxzr0sazqvpb8j63vpj09vpkp4xi7m2qd4rxynkph";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ imath zlib ];
+
+  meta = with lib; {
+    description = "A high dynamic-range (HDR) image file format";
+    homepage = "https://www.openexr.com/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ paperdigits ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18006,7 +18006,9 @@ with pkgs;
 
   imath = callPackage ../development/libraries/imath { };
 
-  openexr = callPackage ../development/libraries/openexr { };
+  openexr = openexr_2;
+  openexr_2 = callPackage ../development/libraries/openexr { };
+  openexr_3 = callPackage ../development/libraries/openexr/3.nix { };
 
   openexrid-unstable = callPackage ../development/libraries/openexrid-unstable { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18004,6 +18004,8 @@ with pkgs;
 
   opencv = opencv4;
 
+  imath = callPackage ../development/libraries/imath { };
+
   openexr = callPackage ../development/libraries/openexr { };
 
   openexrid-unstable = callPackage ../development/libraries/openexrid-unstable { };


### PR DESCRIPTION
###### Motivation for this change
Update openexr to the latest version & package its new dependency, imath.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
