### PR TITLE
nvidia-x11: compile nvidia-uvm.ko with HMM support

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -20,7 +20,7 @@ buildPhase() {
         sysSrc=$(echo $kernel/lib/modules/$kernelVersion/source)
         sysOut=$(echo $kernel/lib/modules/$kernelVersion/build)
         unset src # used by the nv makefile
-        make IGNORE_PREEMPT_RT_PRESENCE=1 SYSSRC=$sysSrc SYSOUT=$sysOut module -j$NIX_BUILD_CORES
+        make IGNORE_PREEMPT_RT_PRESENCE=1 NV_BUILD_SUPPORTS_HMM=1 SYSSRC=$sysSrc SYSOUT=$sysOut module -j$NIX_BUILD_CORES
 
         cd ..
     fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The first [Heterogeneous Memory Management](https://www.kernel.org/doc/html/latest/vm/hmm.html) patches landed in the kernel in 2017 and many more since. For reasons unknown as comments mention an internal bug report, the flag still needs to be enabled to build with support for it.

```sh
# Avoid even building HMM until the HMM patch is in the upstream kernel.
# Bug 1772628 has details.
NV_BUILD_SUPPORTS_HMM ?= 0

ifeq ($(NV_BUILD_SUPPORTS_HMM),1)
  NVIDIA_UVM_CFLAGS += -DNV_BUILD_SUPPORTS_HMM
endif
```

This doesn't change the current opt-in status, since you still have to set:
```
extraModprobeConfig = ''
  options nvidia_uvm uvm_ats_mode=0
  options nvidia_uvm uvm_hmm=1
'';
``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
