### PR TITLE
python3Packages.pyhocon: 0.3.53 -> 0.3.58

### DIFF
--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/chimpler/pyhocon/";
     description = "HOCON parser for Python";
+    # taken from https://pypi.org/project/pyhocon/
     longDescription = ''
       A HOCON parser for Python. It additionally provides a tool
       (pyhocon) to convert any HOCON content into json, yaml and properties

--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -1,38 +1,38 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-# Runtime inputs:
-, pyparsing
-# Check inputs:
-, pytest
 , mock
+, pyparsing
+, pytestCheckHook
+, python-dateutil
 }:
 
 buildPythonPackage rec {
   pname = "pyhocon";
-  version = "0.3.53";
+  version = "0.3.58";
 
   src = fetchFromGitHub {
     owner = "chimpler";
     repo = "pyhocon";
     rev = version;
-    sha256 = "1lr56piiasnq1aiwli8ldw2wc3xjfck8az991mr5rdbqqsrh9vkv";
+    sha256 = "sha256-ddspVDKy9++cISWH6R95r+gJrzNGqMTybI04OgVtIUU=";
   };
 
-  propagatedBuildInputs = [ pyparsing ];
+  propagatedBuildInputs = [
+    pyparsing
+    python-dateutil
+  ];
 
-  checkInputs = [ pytest mock ];
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
-  # Tests fail because necessary data files aren't packaged for PyPi yet.
-  # See https://github.com/chimpler/pyhocon/pull/203
-  doCheck = false;
+  pythonImportsCheck = [ "pyhocon" ];
 
   meta = with lib; {
     homepage = "https://github.com/chimpler/pyhocon/";
     description = "HOCON parser for Python";
-    # Long description copied from
-    # https://github.com/chimpler/pyhocon/blob/55a9ea3ebeeac5764bdebebfbeacbf099f64db26/setup.py
-    # (the tip of master as of 2019-03-24).
     longDescription = ''
       A HOCON parser for Python. It additionally provides a tool
       (pyhocon) to convert any HOCON content into json, yaml and properties


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.3.58

Change log:
- https://github.com/chimpler/pyhocon/releases/tag/0.3.58

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
