### PR TITLE
gpu-burn: init at 2021-04-29

### DIFF
--- a/pkgs/applications/misc/gpu-burn/default.nix
+++ b/pkgs/applications/misc/gpu-burn/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, addOpenGLRunpath, cudatoolkit }:
+
+stdenv.mkDerivation rec {
+  pname = "gpu-burn";
+  version = "2021-04-29";
+
+  src = fetchFromGitHub {
+    owner = "wilicc";
+    repo = "gpu-burn";
+    rev = "1e9a84f4bec3b0835c00daace45d79ed6c488edb";
+    sha256 = "sha256-x+kta81Z08PsBgbf+fzRTXhNXUPBd5w8bST/T5nNiQA=";
+  };
+
+  patchPhase = ''
+    substituteInPlace gpu_burn-drv.cpp \
+      --replace "const char *kernelFile = \"compare.ptx\";" \
+                "const char *kernelFile = \"$out/share/compare.ptx\";"
+  '';
+
+  buildInputs = [ cudatoolkit ];
+
+  nativeBuildInputs = [ addOpenGLRunpath ];
+
+  makeFlags = [ "CUDAPATH=${cudatoolkit}" ];
+
+  LDFLAGS = "-L${cudatoolkit}/lib/stubs";
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp gpu_burn $out/bin/
+    cp compare.ptx $out/share/
+  '';
+
+  postFixup = ''
+    addOpenGLRunpath $out/bin/gpu_burn
+  '';
+
+  meta = with lib; {
+    homepage = "http://wili.cc/blog/gpu-burn.html";
+    description = "Multi-GPU CUDA stress test";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ elohmeier ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/applications/misc/gpu-burn/default.nix
+++ b/pkgs/applications/misc/gpu-burn/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-x+kta81Z08PsBgbf+fzRTXhNXUPBd5w8bST/T5nNiQA=";
   };
 
-  postPhase = ''
+  postPatch = ''
     substituteInPlace gpu_burn-drv.cpp \
       --replace "const char *kernelFile = \"compare.ptx\";" \
                 "const char *kernelFile = \"$out/share/compare.ptx\";"

--- a/pkgs/applications/misc/gpu-burn/default.nix
+++ b/pkgs/applications/misc/gpu-burn/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gpu-burn";
-  version = "2021-04-29";
+  version = "unstable-2021-04-29";
 
   src = fetchFromGitHub {
     owner = "wilicc";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-x+kta81Z08PsBgbf+fzRTXhNXUPBd5w8bST/T5nNiQA=";
   };
 
-  patchPhase = ''
+  postPhase = ''
     substituteInPlace gpu_burn-drv.cpp \
       --replace "const char *kernelFile = \"compare.ptx\";" \
                 "const char *kernelFile = \"$out/share/compare.ptx\";"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2819,6 +2819,8 @@ in
 
   gping = callPackage ../tools/networking/gping { };
 
+  gpu-burn = callPackage ../applications/misc/gpu-burn { };
+
   greg = callPackage ../applications/audio/greg {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Added new package gpu-burn, useful for CUDA stress testing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
