### PR TITLE
tfk8s: 0.1.4 -> 0.1.5

### DIFF
--- a/pkgs/tools/misc/tfk8s/default.nix
+++ b/pkgs/tools/misc/tfk8s/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "tfk8s";
-  version = "0.1.4";
+  version = "0.1.5";
   tag = "v${version}";
 
   src = fetchFromGitHub {
     owner = "jrhouston";
     repo = "tfk8s";
     rev = tag;
-    sha256 = "sha256-Ha/F8rCGZqFYqJzfemmKRyEBI5khaSIerJxvf2Pf2ao=";
+    sha256 = "sha256-T0zM2JOmzk8YyS3+De6yGwiwLgyb6Rwy6hT9b44wNxQ=";
   };
 
-  vendorSha256 = "sha256-wS5diDQFkt8IAp13d8Yeh8ihLvKWdR0Mbw0fMZpqqKE=";
+  vendorSha256 = "sha256-eLPmghs05pMMtys97Ja7YGdVMZmMmiaFeMwzaWNxW0I=";
   runVend = true;
 
   buildFlagsArray = [

--- a/pkgs/tools/misc/tfk8s/default.nix
+++ b/pkgs/tools/misc/tfk8s/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, callPackage }:
 
 buildGoModule rec {
   pname = "tfk8s";
@@ -29,6 +29,10 @@ buildGoModule rec {
   installCheckPhase = ''
     $out/bin/tfk8s --version | grep ${tag} > /dev/null
   '';
+
+  passthru.tests = {
+    sample1 = callPackage ./tests/sample1 { };
+  };
 
   meta = with lib; {
     description = "An utility to convert Kubernetes YAML manifests to Terraform's HCL format";

--- a/pkgs/tools/misc/tfk8s/tests/sample1/default.nix
+++ b/pkgs/tools/misc/tfk8s/tests/sample1/default.nix
@@ -1,0 +1,11 @@
+{ runCommandCC, tfk8s }:
+
+runCommandCC "tfk8s-test-sample1" {
+    buildInputs = [
+      tfk8s
+    ];
+    meta.timeout = 60;
+  }
+  ''
+    cmp <(${tfk8s}/bin/tfk8s -f ${./input.yaml}) ${./output.tf} > $out
+  ''

--- a/pkgs/tools/misc/tfk8s/tests/sample1/input.yaml
+++ b/pkgs/tools/misc/tfk8s/tests/sample1/input.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  TEST: test

--- a/pkgs/tools/misc/tfk8s/tests/sample1/output.tf
+++ b/pkgs/tools/misc/tfk8s/tests/sample1/output.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_manifest" "configmap_test" {
+  manifest = {
+    "apiVersion" = "v1"
+    "data" = {
+      "TEST" = "test"
+    }
+    "kind" = "ConfigMap"
+    "metadata" = {
+      "name" = "test"
+    }
+  }
+}


### PR DESCRIPTION
* tfk8s: 0.1.4 -> 0.1.5
* tfk8s: add passthru.tests.sample1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
