### PR TITLE
linode-cli: 5.4.3 -> 5.5.1

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -11,17 +11,17 @@
 }:
 
 let
-  specVersion = "4.96.0"; # Version taken from: https://www.linode.com/docs/api/openapi.yaml at `info.version`.
+  specVersion = "4.98.0"; # Version taken from: https://www.linode.com/docs/api/openapi.yaml at `info.version`.
   spec = fetchurl {
     url = "https://raw.githubusercontent.com/linode/linode-api-docs/v${specVersion}/openapi.yaml";
-    sha256 = "sha256-4+j5BBTOFLLiA+n0YEUH/ICK4Iuxr6nNB7ZRrYACW2I=";
+    sha256 = "sha256-3SweDMfgq2+QQIdeb6EjL7A2Grd/7KQzsbMNZKPtXts=";
   };
 
 in
 
 buildPythonApplication rec {
   pname = "linode-cli";
-  version = "5.4.3";
+  version = "5.5.1";
 
   src = fetchFromGitHub {
     owner = "linode";


### PR DESCRIPTION
linode-cli: 5.4.3 -> 5.5.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
