### PR TITLE
pythonPackages.mypy: 0.812 -> 0.910

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,18 +1,31 @@
-{ lib, stdenv, fetchPypi, buildPythonPackage, typed-ast, psutil, isPy3k
+{ lib
+, stdenv
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, typed-ast
 , mypy-extensions
 , typing-extensions
+, toml
+, types-toml
+, types-typed-ast
 }:
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.812";
-  disabled = !isPy3k;
+  version = "0.910";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "069i9qnfanp7dn8df1vspnqb0flvsszzn22v00vj08nzlnd061yd";
+    sha256 = "sha256-cECYMCRzyzGiGPF3Woc7N2swtMGCKUIenp3IkW/RYVA=";
   };
 
-  propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
+  nativeBuildInputs = [
+    types-toml
+    types-typed-ast
+  ];
+
+  propagatedBuildInputs = [ typed-ast mypy-extensions typing-extensions toml ];
 
   # Tests not included in pip package.
   doCheck = false;
@@ -37,8 +50,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Optional static typing for Python";
-    homepage    = "http://www.mypy-lang.org";
-    license     = licenses.mit;
+    homepage = "http://www.mypy-lang.org";
+    license = licenses.mit;
     maintainers = with maintainers; [ martingms lnl7 ];
   };
 }

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -29,8 +29,11 @@ buildPythonPackage rec {
 
   # Compile mypy with mypyc, which makes mypy about 4 times faster. The compiled
   # version is also the default in the wheels on Pypi that include binaries.
-  # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
-  MYPY_USE_MYPYC = stdenv.buildPlatform.is64bit;
+  MYPY_USE_MYPYC =
+    # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
+    stdenv.buildPlatform.is64bit
+    # Derivation fails to build since v0.900 if mypyc is enabled.
+    && lib.strings.versionOlder version "0.900";
 
   meta = with lib; {
     description = "Optional static typing for Python";

--- a/pkgs/development/python-modules/types-toml/default.nix
+++ b/pkgs/development/python-modules/types-toml/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-toml";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-M+vme+uuxVoSPsuqK9mP5YgzXY2N2ix6xTUC71qBp5o=";
+  };
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "toml-stubs" ];
+
+  meta = with lib; {
+    description = "Typing stubs for toml";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/types-typed-ast/default.nix
+++ b/pkgs/development/python-modules/types-typed-ast/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-typed-ast";
+  version = "1.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-akcWV2AyGDXRYNogpqxbkGXyPW3CRhYlCMrR7xI4r8M=";
+  };
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "typed_ast-stubs" ];
+
+  meta = with lib; {
+    description = "Typing stubs for typed-ast";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9024,6 +9024,8 @@ in {
 
   types-toml = callPackage ../development/python-modules/types-toml { };
 
+  types-typed-ast = callPackage ../development/python-modules/types-typed-ast { };
+
   typesentry = callPackage ../development/python-modules/typesentry { };
 
   typesystem = callPackage ../development/python-modules/typesystem { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9022,6 +9022,8 @@ in {
 
   types-requests = callPackage ../development/python-modules/types-requests { };
 
+  types-toml = callPackage ../development/python-modules/types-toml { };
+
   typesentry = callPackage ../development/python-modules/typesentry { };
 
   typesystem = callPackage ../development/python-modules/typesystem { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update `mypy` from version `0.812` to `0.910`.

Introduces new build-time dependencies on `types-toml` and `types-typed-ast` which are both added as Python modules. Unfortunately, building fails:

```
[...]
python3.8-mypy> mypy/modulefinder.py:436: error: Library stubs not installed for "toml" (or incompatible with Python 3.8)
python3.8-mypy> mypy/config_parser.py:10: error: Library stubs not installed for "toml" (or incompatible with Python 3.8)
python3.8-mypy> mypy/config_parser.py:10: note: Hint: "python3 -m pip install types-toml"
python3.8-mypy> mypy/config_parser.py:10: note: (or run "mypy --install-types" to install all missing stub packages)
python3.8-mypy> mypy/config_parser.py:10: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
python3.8-mypy> mypy/fastparse.py:109: error: Library stubs not installed for "typed_ast" (or incompatible with Python 3.8)
python3.8-mypy> mypy/fastparse.py:109: note: Hint: "python3 -m pip install types-typed-ast"
python3.8-mypy> mypy/fastparse2.py:57: error: Library stubs not installed for "typed_ast.ast27" (or incompatible with Python 3.8)
python3.8-mypy> mypy/fastparse2.py:68: error: Library stubs not installed for "typed_ast" (or incompatible with Python 3.8)
[...]
```

Building complains about missing stubs for `toml` and `typed-ast` although I added them to the `nativeBuildInputs`.

Maybe someone else has an idea why this is happening.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
