### PR TITLE
leo3-bin: deprecate phases

### DIFF
--- a/pkgs/applications/science/logic/leo3/binary.nix
+++ b/pkgs/applications/science/logic/leo3/binary.nix
@@ -3,27 +3,26 @@ stdenv.mkDerivation rec {
   pname = "leo3";
   version = "1.2";
 
-  jar = fetchurl {
+  src = fetchurl {
     url = "https://github.com/leoprover/Leo-III/releases/download/v${version}/leo3.jar";
     sha256 = "1lgwxbr1rnk72rnvc8raq5i1q71ckhn998pwd9xk6zf27wlzijk7";
   };
 
-  phases=["installPhase" "fixupPhase"];
+  dontUnpack = true;
 
   installPhase = ''
     mkdir -p "$out"/{bin,lib/java/leo3}
-    cp "${jar}" "$out/lib/java/leo3/leo3.jar"
+    cp "${src}" "$out/lib/java/leo3/leo3.jar"
     echo "#!${runtimeShell}" > "$out/bin/leo3"
     echo "'${openjdk}/bin/java' -jar '$out/lib/java/leo3/leo3.jar' \"\$@\""  >> "$out/bin/leo3"
     chmod a+x "$out/bin/leo3"
   '';
 
-  meta = {
-    inherit version;
+  meta = with lib; {
     description = "An automated theorem prover for classical higher-order logic with choice";
-    license = lib.licenses.bsd3;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [maintainers.raskin];
+    platforms = platforms.linux;
     homepage = "https://page.mi.fu-berlin.de/lex/leo3/";
   };
 }


### PR DESCRIPTION


###### Motivation for this change
#28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
