### PR TITLE
nodePackages.postcss-cli: add passthru.tests

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -276,6 +276,11 @@ let
           --prefix NODE_PATH : ${self.postcss}/lib/node_modules \
           --prefix NODE_PATH : ${self.autoprefixer}/lib/node_modules
       '';
+      passthru.tests = {
+        simple-execution = pkgs.callPackage ./package-tests/postcss-cli.nix {
+          inherit (self) postcss-cli;
+        };
+      };
       meta.mainProgram = "postcss";
     };
 

--- a/pkgs/development/node-packages/package-tests/postcss-cli.nix
+++ b/pkgs/development/node-packages/package-tests/postcss-cli.nix
@@ -1,0 +1,45 @@
+{ runCommand, postcss-cli }:
+
+let
+  inherit (postcss-cli) packageName version;
+in
+
+runCommand "${packageName}-tests" { meta.timeout = 60; }
+  ''
+    # get version of installed program and compare with package version
+    claimed_version="$(${postcss-cli}/bin/postcss --version)"
+    if [[ "$claimed_version" != "${version}" ]]; then
+      echo "Error: program version does not match package version ($claimed_version != ${version})"
+      exit 1
+    fi
+
+    # run basic help command
+    ${postcss-cli}/bin/postcss --help > /dev/null
+
+    # basic autoprefixer test
+    config_dir="$(mktemp -d)"
+    clean_up() {
+      rm -rf "$config_dir"
+    }
+    trap clean_up EXIT
+    echo "
+      module.exports = {
+        plugins: {
+          'autoprefixer': { overrideBrowserslist: 'chrome 40' },
+        },
+      }
+    " > "$config_dir/postcss.config.js"
+    input='a{ user-select: none; }'
+    expected_output='a{ -webkit-user-select: none; user-select: none; }'
+    actual_output="$(echo $input | ${postcss-cli}/bin/postcss --no-map --config $config_dir)"
+    if [[ "$actual_output" != "$expected_output" ]]; then
+      echo "Error: autoprefixer did not output the correct CSS:"
+      echo "$actual_output"
+      echo "!="
+      echo "$expected_output"
+      exit 1
+    fi
+
+    # needed for Nix to register the command as successful
+    touch $out
+  ''


### PR DESCRIPTION
###### Motivation for this change
See #130027.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).