### PR TITLE
vimPlugins.nvim-treesitter: document plugins

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -120,7 +120,7 @@ After that you can install your special grafted `myVim` or `myNeovim` packages.
 
 If one of your favourite plugins isn't packaged, you can package it yourself:
 
-```
+```nix
 { config, pkgs, ... }:
 
 let
@@ -153,6 +153,33 @@ in
   ];
 }
 ```
+
+### Specificities for some plugins
+#### Tree sitter
+
+By default `nvim-treesitter` encourages you to download, compile and install
+the required tree-sitter grammars at run time with `:TSInstall`. This works
+poorly on NixOS.  Instead, to install the `nvim-treesitter` plugins with a set
+of precompiled grammars, you can use `nvim-treesitter.withPlugins` function:
+
+```nix
+(pkgs.neovim.override {
+  configure = {
+    packages.myPlugins = with pkgs.vimPlugins; {
+      start = [
+        (nvim-treesitter.withPlugins (
+          plugins: with plugins; [
+            tree-sitter-nix
+            tree-sitter-python
+          ]
+        ))
+      ];
+    };
+  };
+})
+```
+
+To enable all grammars packaged in nixpkgs, use `(pkgs.vimPlugins.nvim-treesitter.withPlugins (plugins: pkgs.tree-sitter.allGrammars))`.
 
 ## Managing plugins with vim-plug {#managing-plugins-with-vim-plug}
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


cc @rnhmjoj 

Rendered:
![image](https://user-images.githubusercontent.com/12595971/125657632-cbae88d9-9c18-43fd-a053-8814792557aa.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
