### PR TITLE
doc/coding-conventions: Increase passthru test timeout 3s -> 60s

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -568,7 +568,7 @@ let
   inherit (phoronix-test-suite) pname version;
 in
 
-runCommand "${pname}-tests" { meta.timeout = 3; }
+runCommand "${pname}-tests" { meta.timeout = 60; }
   ''
     # automatic initial setup to prevent interactive questions
     ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null

--- a/pkgs/tools/misc/phoronix-test-suite/tests.nix
+++ b/pkgs/tools/misc/phoronix-test-suite/tests.nix
@@ -4,7 +4,7 @@ let
   inherit (phoronix-test-suite) pname version;
 in
 
-runCommand "${pname}-tests" { meta.timeout = 3; }
+runCommand "${pname}-tests" { meta.timeout = 60; }
   ''
     # automatic initial setup to prevent interactive questions
     ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null


### PR DESCRIPTION
3s is too small a margin for a loaded slow system to start a bloated
program.
This leads to problems when tests are written on decent dev hardware
but later run on build farms of potentially slower hardware,
particularly in the case of non x86.

The chance of needing the timeout is actually very small, so those
rare 57s are a reasonable price to pay for fewer timeouts on build
farms, each of which should be investigated and usually fixed by
increasing the timeout.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
