### PR TITLE
Revert google-fonts update to unstable, fixing Inconsolata

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -1,17 +1,21 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub }:
 
-stdenvNoCC.mkDerivation {
+stdenv.mkDerivation {
   pname = "google-fonts";
-  version = "unstable-2021-06-12";
+  version = "unstable-2021-01-19";
 
   outputs = [ "out" "adobeBlank" ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
-    rev = "370c795d7e5f9b02db9a793c2779e2c8f94c6adc";
-    sha256 = "sha256-XKjxmupY2KuefCtKZMXWaba1TnNwdYM/P0xGXOtBGmM=";
+    rev = "a3a831f0fe44cd58465c6937ea06873728f2ba0d";
+    sha256 = "19abx2bj7mkysv2ihr43m3kpyf6kv6v2qjlm1skxc82rb72xqhix";
   };
+
+  phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
   patchPhase = ''
     # These directories need to be removed because they contain
@@ -28,8 +32,6 @@ stdenvNoCC.mkDerivation {
       exit 1
     fi
   '';
-
-  dontBuild = true;
 
   installPhase = ''
     adobeBlankDest=$adobeBlank/share/fonts/truetype

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -1,18 +1,16 @@
-{ lib
-, stdenv
-, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   pname = "google-fonts";
-  version = "unstable-2021-01-19";
+  version = "2019-07-14";
 
   outputs = [ "out" "adobeBlank" ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
-    rev = "a3a831f0fe44cd58465c6937ea06873728f2ba0d";
-    sha256 = "19abx2bj7mkysv2ihr43m3kpyf6kv6v2qjlm1skxc82rb72xqhix";
+    rev = "f113126dc4b9b1473d9354a86129c9d7b837aa1a";
+    sha256 = "0safw5prpa63mqcyfw3gr3a535w4c9hg5ayw5pkppiwil7n3pyxs";
   };
 
   phases = [ "unpackPhase" "patchPhase" "installPhase" ];
@@ -23,9 +21,18 @@ stdenv.mkDerivation {
     # directories. This causes non-determinism in the install since
     # the installation order of font files with the same name is not
     # fixed.
-    rm -rv ofl/cabincondensed \
-           ofl/signikanegative \
-           ofl/signikanegativesc
+    rm -rv ofl/alefhebrew \
+      ofl/misssaintdelafield \
+      ofl/mrbedford \
+      ofl/siamreap \
+      ofl/terminaldosislight
+
+    # See comment above, the structure of these is a bit odd
+    # We keep the ofl/<font>/static/ variants
+    rm -rv ofl/comfortaa/*.ttf \
+      ofl/mavenpro/*.ttf \
+      ofl/muli/*.ttf \
+      ofl/oswald/*.ttf
 
     if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then
       echo "error: duplicate font names"

--- a/pkgs/data/fonts/inconsolata/default.nix
+++ b/pkgs/data/fonts/inconsolata/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   inherit (google-fonts) src version;
 
   installPhase = ''
-    install -m644 --target $out/share/fonts/truetype/inconsolata -D $src/ofl/inconsolata/static/*.ttf
+    install -m644 --target $out/share/fonts/truetype/inconsolata -D $src/ofl/inconsolata/*.ttf
   '';
 
   meta = with lib; {


### PR DESCRIPTION

###### Motivation for this change

An update to an unstable version of `google-fonts` broke the `Inconsolata` monospace font in programs that use xft such as urxvt. This PR reverts some recent `google-fonts` commits back to the stable version.

See:

https://github.com/googlefonts/Inconsolata/issues/42
https://discourse.nixos.org/t/how-to-fix-broken-inconsolata-font-in-urxvt-on-21-05/13437

cc @jakubgs  @06kellyjac @petabyteboy @tu-maurice 
