### PR TITLE
kanit-font: init at 2020-06-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10678,6 +10678,16 @@
     githubId = 9853194;
     name = "Philipp Bartsch";
   };
+  toastal = {
+    email = "toastal+nix@posteo.net";
+    github = "toastal";
+    githubId = 561087;
+    name = "toastal";
+    keys = [{
+      longkeyid = "ed25519/5CCE6F1466D47C9E";
+      fingerprint = "7944 74B7 D236 DAB9 C9EF  E7F9 5CCE 6F14 66D4 7C9E";
+    }];
+  };
   tobim = {
     email = "nix@tobim.fastmail.fm";
     github = "tobim";

--- a/pkgs/data/fonts/kanit/default.nix
+++ b/pkgs/data/fonts/kanit/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "kanit";
+  version = "unstable-2020-06-16";
+
+  src = fetchFromGitHub {
+    owner = "cadsondemak";
+    repo = pname;
+    rev = "467dfe842185681d8042cd608b8291199dd37cda";
+    sha256 = "0p0klb0376r8ki4ap2j99j7jcsq6wgb7m1hf3j1dkncwm7ikmg3h";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/doc/${pname}/css/ $out/share/fonts/{opentype,truetype}
+
+    cp $src/OFL.txt $src/documentation/{BRIEF.md,features.html} $out/share/doc/${pname}
+    cp $src/documentation/css/fonts.css $out/share/doc/${pname}/css
+    cp $src/fonts/otf/*.otf $out/share/fonts/opentype
+    cp $src/fonts/ttf/*.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with lib; {
+    homepage = "https://cadsondemak.github.io/kanit/";
+    description = "A loopless Thai and sans serif Latin typeface for contemporary and futuristic uses";
+    longDescription = ''
+      Kanit means mathematics in Thai, and the Kanit typeface family is a formal
+      Loopless Thai and Sans Latin design. It is a combination of concepts,
+      mixing a Humanist Sans Serif motif with the curves of Capsulated Geometric
+      styles that makes it suitable for various uses, contemporary and
+      futuristic. A notable detail is that the stroke terminals have flat angles,
+      which allows the design to enjoy decreased spacing between letters while
+      preserving readability and legibility at smaller point sizes.
+    '';
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.toastal ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22310,6 +22310,8 @@ in
 
   juno-theme = callPackage ../data/themes/juno { };
 
+  kanit-font = callPackage ../data/fonts/kanit { };
+
   kanji-stroke-order-font = callPackage ../data/fonts/kanji-stroke-order-font {};
 
   kawkab-mono-font = callPackage ../data/fonts/kawkab-mono {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There's not enough Thai font options in Nix and [Kanit](https://cadsondemak.github.io/kanit/) is open source and doesn't appear to be in `tlwg`. The build checks out the Kanit git repo from GitHub and copies the prebuilt files into appropriate folders (they don't have "releases"). I'm mostly drawing how this is done by looking at similar fonts. The part that is confusing to me is `name` vs `pname` and if/how `-font` should be added; it doesn't seem too consistent.

```console
$ tree
/nix/store/clqii78x1y81z4fwghksp62ckw4vny3p-kanit-2020-06-16/
└── share
    ├── doc
    │   └── kanit
    │       ├── BRIEF.md
    │       ├── css
    │       │   └── fonts.css
    │       ├── features.html
    │       └── OFL.txt
    └── fonts
        ├── opentype
        │   ├── Kanit-BlackItalic.otf
        │   ├── Kanit-Black.otf
        │   ├── Kanit-BoldItalic.otf
        │   ├── Kanit-Bold.otf
        │   ├── Kanit-ExtraBoldItalic.otf
        │   ├── Kanit-ExtraBold.otf
        │   ├── Kanit-ExtraLightItalic.otf
        │   ├── Kanit-ExtraLight.otf
        │   ├── Kanit-Italic.otf
        │   ├── Kanit-LightItalic.otf
        │   ├── Kanit-Light.otf
        │   ├── Kanit-MediumItalic.otf
        │   ├── Kanit-Medium.otf
        │   ├── Kanit-Regular.otf
        │   ├── Kanit-SemiBoldItalic.otf
        │   ├── Kanit-SemiBold.otf
        │   ├── Kanit-ThinItalic.otf
        │   └── Kanit-Thin.otf
        └── truetype
            ├── Kanit-BlackItalic.ttf
            ├── Kanit-Black.ttf
            ├── Kanit-BoldItalic.ttf
            ├── Kanit-Bold.ttf
            ├── Kanit-ExtraBoldItalic.ttf
            ├── Kanit-ExtraBold.ttf
            ├── Kanit-ExtraLightItalic.ttf
            ├── Kanit-ExtraLight.ttf
            ├── Kanit-Italic.ttf
            ├── Kanit-LightItalic.ttf
            ├── Kanit-Light.ttf
            ├── Kanit-MediumItalic.ttf
            ├── Kanit-Medium.ttf
            ├── Kanit-Regular.ttf
            ├── Kanit-SemiBoldItalic.ttf
            ├── Kanit-SemiBold.ttf
            ├── Kanit-ThinItalic.ttf
            └── Kanit-Thin.ttf
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
