### PR TITLE
Adds Rubik font v2.200

### DIFF
--- a/pkgs/data/fonts/rubik/default.nix
+++ b/pkgs/data/fonts/rubik/default.nix
@@ -1,0 +1,103 @@
+{ stdenv, lib, fetchurl }:
+let
+  # Latest commit touching the rubik tree
+  commit = "054aa9d546cd6308f8ff7139b332490e0967aebe";
+in
+stdenv.mkDerivation {
+  pname = "rubik";
+  version = "2.200";
+
+  srcs = [
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Black.ttf";
+      sha256 = "0h4mxqz0b5as7g964bv98aanaghp4wgs2g5wnf7apxnd2fng14dn";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-BlackItalic.ttf";
+      sha256 = "0x8j3fwavkf1jf7s97ncvs0jk463v1fyajcxqxvv7lpk55sjnbpy";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Bold.ttf";
+      sha256 = "0prjqdbdpnhwr66gjw9mc1590gmjl7fir8wnanzch6arvngmxaj9";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-BoldItalic.ttf";
+      sha256 = "1zyl55fkjr61k6yfvgi0cr2iz4s0kkv3mkjpdmpla9jnk10rd8lm";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-ExtraBold.ttf";
+      sha256 = "0vi01lc2dadgmw5z26nkfzn7vl3lsd0flhqqfp40nn8jvpdkb2mq";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-ExtraBoldItalic.ttf";
+      sha256 = "0ldcszzzrc44gldflman7kcfk38x77grjb3zjvxjvgn875ggwabk";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Italic.ttf";
+      sha256 = "09x7fh6ad4w6027410vhkvisgy8vqm2mzdsc19z3szlrxi0gl0rx";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Light.ttf";
+      sha256 = "19a6k0pprcra6nxk3l0k6wkg9g0qn5h1v71rw2m8im64kyjx4qpf";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-LightItalic.ttf";
+      sha256 = "0r9hbh9xnbp0584vjiiq72583j1ai3dw93gfy823c736y6bk0j2m";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Medium.ttf";
+      sha256 = "01nky9la4qjd80dy200j8l7zl0r2h9zw90k7aghzlb5abk4i3zvf";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-MediumItalic.ttf";
+      sha256 = "1i81x9h2cr65bj85z5b2mki59532nvlbh92wb84zfhfdz97s30cq";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Regular.ttf";
+      sha256 = "1vk4n6yc4x1vlwfrp26jhagyl5l86jwa4lalccc320crrwqfc521";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-SemiBold.ttf";
+      sha256 = "0blmy1ywsf9hr1a66cl12bjn32i072w6ncvsir0s5smm2c0gksvb";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-SemiBoldItalic.ttf";
+      sha256 = "1sj22d3jrlxl6ka0naf5nby3k0i7pzadk5b8xgdhcslwijwiib3y";
+    })
+  ];
+
+  sourceRoot = "./";
+
+  unpackCmd = ''
+    ttfName=$(basename $(stripHash $curSrc))
+    cp $curSrc ./$ttfName
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -a *.ttf $out/share/fonts/truetype/
+  '';
+
+  meta = with lib; {
+    homepage = "https://fonts.google.com/specimen/Rubik";
+    description = "Rubik Font - is a 5 weight Roman + Italic family.";
+    longDescription = ''
+      The Rubik Fonts project was initiated as part of the Chrome CubeLab
+      project.
+
+      Rubik is a 5 weight Roman + Italic family.
+
+      Rubik supports the Latin, Cyrillic and Hebrew scripts. The Latin and Cyrillic
+      were designed by Philipp Hubert and Sebastian Fischer at Hubert Fischer.
+
+      The Hebrew was initially designed by Philipp and Sebastian, and then revised by
+      type designer and Hebrew native reader Meir Sadan to adjust proportions,
+      spacing and other design details.
+
+      Cyrillic was initially designed by Philipp and Sebastian, and then revised and
+      expanded by Cyreal Fonts Team (Alexei Vanyashin and Nikita Kanarev). Exising
+      glyphs were improved, and glyph set was expanded to GF Cyrillic Plus.
+    '';
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22678,6 +22678,8 @@ in
 
   recursive = callPackage ../data/fonts/recursive { };
 
+  rubik = callPackage ../data/fonts/rubik { };
+
   rhodium-libre = callPackage ../data/fonts/rhodium-libre { };
 
   rictydiminished-with-firacode = callPackage ../data/fonts/rictydiminished-with-firacode { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I am a huge fan of Rubik font and would like to add it to nixpkgs for everybody to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Tested on a fresh NixOS installation both through Home Manager and from NixOS main configuration file
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
