### PR TITLE
glib: 2.68.3 -> 2.69.0

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "glib";
-  version = "2.68.3";
+  version = "2.69.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0f1iprj7v0b5wn9njj39dkl25g6filfs7i4ybk20jq821k1a7qg7";
+    sha256 = "1bmz7nvbh7xm3sbypv5hh0fmc41j1a7dcp1fcav5fg0gc7c3znqw";
   };
 
   patches = optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/storaged-project/libblockdev/commit/5528baef6ccc835a06c45f9db34a2c9c3f2dd940.patch";
       sha256 = "jxq4BLeyTMeNvBvY8k8QXIvYSJ2Gah0J75pq6FpG7PM=";
     })
+
+    # fix build with glib 2.69 (g_spawn_check_exit_status -> g_spawn_check_wait_status)
+    # https://github.com/storaged-project/libblockdev/pull/641
+    # Modified to apply on 2.25
+    ./exec-Fix-deprecated-glib-function-call.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/libblockdev/exec-Fix-deprecated-glib-function-call.patch
+++ b/pkgs/development/libraries/libblockdev/exec-Fix-deprecated-glib-function-call.patch
@@ -1,0 +1,16 @@
+--- a/src/utils/exec.c
++++ b/src/utils/exec.c
+@@ -229,7 +229,12 @@ gboolean bd_utils_exec_and_report_status_error (const gchar **argv, const BDExtr
+     /* g_spawn_sync set the status in the same way waitpid() does, we need
+        to get the process exit code manually (this is similar to calling
+        WEXITSTATUS but also sets the error for terminated processes */
+-    if (!g_spawn_check_exit_status (exit_status, error)) {
++
++    #if !GLIB_CHECK_VERSION(2, 69, 0)
++    #define g_spawn_check_wait_status(x,y) (g_spawn_check_exit_status (x,y))
++    #endif
++
++    if (!g_spawn_check_wait_status (exit_status, error)) {
+         if (g_error_matches (*error, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED)) {
+             /* process was terminated abnormally (e.g. using a signal) */
+             g_free (stdout_data);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The [changelog](https://gitlab.gnome.org/GNOME/glib/-/releases/2.69.0) is huge so more eyes may be needed.

libblockdev builds with `-Werror` so patches are required to update the deprecated API call. I'll leave it to Hydra to test the other packages.

cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
