### PR TITLE
exim: add redis lookup support

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -5,6 +5,7 @@
 , enablePAM ? false, pam
 , enableSPF ? true, libspf2
 , enableDMARC ? true, opendmarc
+, enableRedis ? false, hiredis
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +24,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableAuthDovecot dovecot
     ++ lib.optional enablePAM pam
     ++ lib.optional enableSPF libspf2
-    ++ lib.optional enableDMARC opendmarc;
+    ++ lib.optional enableDMARC opendmarc
+    ++ lib.optional enableRedis hiredis;
 
   preBuild = ''
     sed '
@@ -77,6 +79,13 @@ stdenv.mkDerivation rec {
       ${lib.optionalString enableDMARC ''
         s:^# \(SUPPORT_DMARC\)=.*:\1=yes:
         s:^# \(LDFLAGS += -lopendmarc\):\1:
+      ''}
+      ${lib.optionalString enableRedis ''
+        s:^# \(LOOKUP_REDIS=yes\)$:\1:
+        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lhiredis -L${hiredis}/lib/hiredis:
+        s:^# \(LOOKUP_LIBS\)=.*:\1=-lhiredis -L${hiredis}/lib/hiredis:
+        s:^\(LOOKUP_INCLUDE\)=\(.*\):\1=\2 -I${hiredis}/include/hiredis/:
+        s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${hiredis}/include/hiredis/:
       ''}
       #/^\s*#.*/d
       #/^\s*$/d


### PR DESCRIPTION
###### Motivation for this change

Exim can lookup in redis and I use it in production. But I'm not sure whether we should enable redis support by default.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
