### PR TITLE
python3Packages.pyavm: 0.9.4 -> 0.9.5

### DIFF
--- a/pkgs/development/python-modules/pyavm/default.nix
+++ b/pkgs/development/python-modules/pyavm/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Simple pure-python AVM meta-data handling";
-    homepage = "http://astrofrog.github.io/pyavm/";
+    homepage = "https://astrofrog.github.io/pyavm/";
     license = licenses.mit;
     maintainers = with maintainers; [ smaret ];
   };

--- a/pkgs/development/python-modules/pyavm/default.nix
+++ b/pkgs/development/python-modules/pyavm/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, pytestCheckHook
 , astropy
 , astropy-helpers
 , pillow
@@ -9,29 +9,35 @@
 
 buildPythonPackage rec {
   pname = "pyavm";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchPypi {
     pname = "PyAVM";
     inherit version;
-    sha256 = "f298b864e5bc101ecbb0e46252e95e18a180ac28ba6ec362e63c12a7e914e386";
+    sha256 = "sha256-gV78ypvYwohHmdjP3lN5F97PfmxuV91tvw5gsYeZ7i8=";
   };
 
-  propagatedBuildInputs = [ astropy-helpers ];
+  propagatedBuildInputs = [
+    astropy-helpers
+  ];
 
-  checkInputs = [ pytest astropy pillow ];
-
-  checkPhase = "pytest";
+  checkInputs = [
+    astropy
+    pillow
+    pytestCheckHook
+  ];
 
   # Disable automatic update of the astropy-helper module
   postPatch = ''
     substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
   '';
 
+  pythonImportsCheck = [ "pyavm" ];
+
   meta = with lib; {
     description = "Simple pure-python AVM meta-data handling";
     homepage = "http://astrofrog.github.io/pyavm/";
     license = licenses.mit;
-    maintainers = [ maintainers.smaret ];
+    maintainers = with maintainers; [ smaret ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.5

Change log: https://github.com/astrofrog/pyavm/blob/master/CHANGES


- Switch to `pytestCheckHook`
-
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
