### PR TITLE
wmctrl: support cross-compilation

### DIFF
--- a/pkgs/tools/X11/wmctrl/default.nix
+++ b/pkgs/tools/X11/wmctrl/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
     sha256 = "1afclc57b9017a73mfs9w7lbdvdipmf9q0xdk116f61gnvyix2np";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  strictDeps = true;
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ glib.dev ];
   buildInputs = [ libX11 libXmu glib ];
 
   patches = [ ./64-bit-data.patch ];


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
