### PR TITLE
tektoncd-cli: 0.19.1 -> 0.20.0

### DIFF
--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -2,20 +2,18 @@
 
 buildGoModule rec {
   pname = "tektoncd-cli";
-  version = "0.19.1";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "tektoncd";
     repo = "cli";
     rev = "v${version}";
-    sha256 = "sha256-duJSTk5LmJWbaVYybZZHWDe8E/ZqZLCCsdPIiH5d/G4=";
+    sha256 = "sha256-aVR1xNmL6M/m+1znt70vrCtuABCqDz0sDp8mDFI2uIg=";
   };
 
   vendorSha256 = null;
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${version}")
-  '';
+  ldflags = [ "-s" "-w" "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${version}" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -27,7 +25,7 @@ buildGoModule rec {
     # Some tests try to write to the home dir
     export HOME="$TMPDIR"
     # Change the golden files to match our desired version
-    sed -i "s/dev/${version}/" pkg/cmd/version/testdata/TestGetVersions-*.golden
+    sed -i "s/dev/${version}/" pkg/cmd/version/testdata/{TestGetVersions-,TestGetComponentVersions/}*.golden
   '';
 
   postInstall = ''
@@ -43,8 +41,7 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/tkn --help
-    # New tkn version functionality outputs empty https://github.com/tektoncd/cli/issues/1389
-    # $out/bin/tkn version | grep "Client version: ${version}"
+    $out/bin/tkn version | grep "Client version: ${version}"
     runHook postInstallCheck
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump tektoncd-cli to `0.20.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
