### PR TITLE
python3Packages.pure-python-adb-homeassistant: 0.1.6.dev0 -> 0.1.7.dev0

### DIFF
--- a/pkgs/development/python-modules/pure-python-adb-homeassistant/default.nix
+++ b/pkgs/development/python-modules/pure-python-adb-homeassistant/default.nix
@@ -4,19 +4,21 @@
 }:
 buildPythonPackage rec {
   pname = "pure-python-adb-homeassistant";
-  version = "0.1.6.dev0";
+  version = "0.1.7.dev0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "fe6d90220a6880649f6d6df4e707ce5034676710ee6146145ef995f7b769a482";
+    sha256 = "sha256-xXXEp8oYGcJLTfoBDUSZrIHSgDvB2EHbVMHoG4Hk+t8=";
   };
 
   # Disable tests as they require docker, docker-compose and a dedicated
   # android emulator
   doCheck = false;
 
+  pythonImportsCheck = [ "adb_messenger" ];
+
   meta = with lib; {
-    description = "Pure python implementation of the adb client";
+    description = "Python implementation of the ADB client";
     homepage = "https://github.com/JeffLIrion/pure-python-adb";
     license = licenses.mit;
     maintainers = [ maintainers.makefu ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.1.7.dev0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
