### PR TITLE
mkvtoolnix: 56.0.0 -> 59.0.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,69 +1,138 @@
-{ lib, stdenv, fetchFromGitLab, pkg-config, autoconf, automake, libiconv, drake
-, ruby, docbook_xsl, file, xdg-utils, gettext, expat, boost, libebml, zlib
-, fmt, libmatroska, libogg, libvorbis, flac, libxslt, cmark, pcre2
+{ lib
+, stdenv
+, mkDerivation
+, fetchFromGitLab
+, pkg-config
+, autoreconfHook
+, qmake
+, rake
+, boost
+, cmark
+, docbook_xsl
+, expat
+, file
+, flac
+, fmt
+, gettext
+, gmp
+, gtest
+, libdvdread
+, libebml
+, libiconv
+, libmatroska
+, libogg
+, libvorbis
+, libxslt
+, nlohmann_json
+, pugixml
+, qtbase
+, qtmultimedia
+, xdg-utils
+, zlib
 , withGUI ? true
-  , qtbase ? null
-  , qtmultimedia ? null
-  , wrapQtAppsHook ? null
+, wrapQtAppsHook
 }:
 
-assert withGUI -> qtbase != null && qtmultimedia != null && wrapQtAppsHook != null;
+let
+  inherit (lib) enableFeature optional optionals optionalString;
 
-with lib;
+  phase = name: args:
+    ''
+      runHook pre${name}
 
-stdenv.mkDerivation rec {
+      rake ${args}
+
+      runHook post${name}
+    '';
+
+in
+mkDerivation rec {
   pname = "mkvtoolnix";
-  version = "56.0.0";
+  version = "59.0.0";
 
   src = fetchFromGitLab {
-    owner  = "mbunkus";
-    repo   = "mkvtoolnix";
-    rev    = "release-${version}";
-    sha256 = "0nhpp1zkggxqjj7lhj6as5mcjcz5yk3l1d1xcgs7i9153blam1yj";
+    owner = "mbunkus";
+    repo = "mkvtoolnix";
+    rev = "release-${version}";
+    sha256 = "sha256-bPypOsveXrkz1V961b9GTJKFdgru/kcW15z/yik/4yQ=";
   };
 
   nativeBuildInputs = [
-    pkg-config autoconf automake gettext
-    drake ruby docbook_xsl libxslt
-  ];
+    autoreconfHook
+    docbook_xsl
+    gettext
+    gtest
+    libxslt
+    pkg-config
+    rake
+  ]
+  ++ optional withGUI wrapQtAppsHook;
 
+  # 1. qtbase and qtmultimedia are needed without the GUI
+  # 2. we have utf8cpp in nixpkgs but it doesn't find it
   buildInputs = [
-    expat file xdg-utils boost libebml zlib fmt
-    libmatroska libogg libvorbis flac cmark pcre2
-  ] ++ optional  stdenv.isDarwin libiconv
-    ++ optionals withGUI [ qtbase qtmultimedia wrapQtAppsHook ];
+    boost
+    expat
+    file
+    flac
+    fmt
+    gmp
+    libdvdread
+    libebml
+    libmatroska
+    libogg
+    libvorbis
+    nlohmann_json
+    pugixml
+    qtbase
+    qtmultimedia
+    xdg-utils
+    zlib
+  ]
+  ++ optional withGUI cmark
+  ++ optional stdenv.isDarwin libiconv;
 
-  preConfigure = "./autogen.sh; patchShebangs .";
-  buildPhase   = "drake -j $NIX_BUILD_CORES";
-  installPhase = "drake install -j $NIX_BUILD_CORES";
+  # autoupdate is not needed but it silences a ton of pointless warnings
+  postPatch = ''
+    patchShebangs . > /dev/null
+    autoupdate configure.ac ac/*.m4
+  '';
 
   configureFlags = [
-    "--enable-magic"
+    "--disable-debug"
+    "--disable-precompiled-headers"
+    "--disable-profiling"
+    "--disable-static-qt"
     "--enable-optimization"
     "--with-boost-libdir=${boost.out}/lib"
-    "--disable-debug"
-    "--disable-profiling"
-    "--disable-precompiled-headers"
-    "--disable-static-qt"
-    "--with-gettext"
     "--with-docbook-xsl-root=${docbook_xsl}/share/xml/docbook-xsl"
-    (enableFeature withGUI "qt")
+    "--with-gettext"
+    (enableFeature withGUI "gui")
   ];
+
+  buildPhase = phase "Build" "";
+
+  installPhase = phase "Install" "install";
+
+  doCheck = true;
+
+  checkPhase = phase "Check" "tests:run_unit";
 
   CXXFLAGS = optional stdenv.cc.isClang "-std=c++17";
   LDFLAGS = optional stdenv.cc.isClang "-lc++fs";
 
   dontWrapQtApps = true;
+
   postFixup = optionalString withGUI ''
     wrapQtApp $out/bin/mkvtoolnix-gui
   '';
 
   meta = with lib; {
     description = "Cross-platform tools for Matroska";
-    homepage    = "http://www.bunkus.org/videotools/mkvtoolnix/";
-    license     = licenses.gpl2Only;
+    homepage = "https://mkvtoolnix.download/";
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ codyopel rnhmjoj ];
-    platforms   = platforms.linux
+    platforms = platforms.linux
       ++ optionals (!withGUI) platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17409,7 +17409,7 @@ in
 
   mkvtoolnix = libsForQt5.callPackage ../applications/video/mkvtoolnix { };
 
-  mkvtoolnix-cli = callPackage ../applications/video/mkvtoolnix {
+  mkvtoolnix-cli = mkvtoolnix.override {
     withGUI = false;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Additional changes:

1. Qt is now needed for both the cli and gui variants.
2. Run the test suite
3. Drop a number of dependencies that are no longer needed
4. We have nlohmann_json and pugixml, so use those instead of the
   vendored versions
5. Add support for reading chapters from DVDs
6. Build with rake as recommended by upstream


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
