### PR TITLE
wofi-emoji: init at unstable-2021-05-24

### DIFF
--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, lib, fetchFromGitHub, jq }:
+
+let
+  emojiJSON = fetchFromGitHub {
+    owner = "github";
+    repo = "gemoji";
+    sha256 = "sha256-Tn0vba129LPlX+MRcCBA9qp2MU1ek1jYzVCqoNxCL/w=";
+    rev = "v4.0.0.rc2";
+  };
+  meta = with lib; {
+   license = licenses.mit;
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "wofi-emoji";
+  version = "unstable-2021-05-24";
+
+  src = fetchFromGitHub {
+    owner = "dln";
+    repo = pname;
+    rev = "bfe35c1198667489023109f6843217b968a35183";
+    sha256 = "sha256-wMIjTUCVn4uF0cpBkPfs76NRvwS0WhGGJRy9vvtmVWQ=";
+  };
+
+  nativeBuildInputs = [ jq ];
+
+  postPatch = ''
+    cp "${emojiJSON}/db/emoji.json" .
+    substituteInPlace build.sh \
+      --replace 'curl https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json' 'cat emoji.json'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    bash build.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp wofi-emoji $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Simple emoji selector for Wayland using wofi and wl-clipboard";
+    homepage = "https://github.com/dln/wofi-emoji";
+    license = licenses.mit;
+    maintainers = [ maintainers.ymarkus ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -7,9 +7,6 @@ let
     sha256 = "sha256-Tn0vba129LPlX+MRcCBA9qp2MU1ek1jYzVCqoNxCL/w=";
     rev = "v4.0.0.rc2";
   };
-  meta = with lib; {
-   license = licenses.mit;
-  };
 
 in stdenv.mkDerivation rec {
   pname = "wofi-emoji";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27882,6 +27882,8 @@ in
 
   wofi = callPackage ../applications/misc/wofi { };
 
+  wofi-emoji = callPackage ../applications/misc/wofi-emoji { };
+
   wordnet = callPackage ../applications/misc/wordnet {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
