### PR TITLE
bitwig-studio4: add version 4

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -1,0 +1,81 @@
+{ stdenv, fetchurl, alsa-lib, cairo, dpkg, freetype
+, gdk-pixbuf, glib, gtk3, lib, xorg
+, libglvnd, libjack2, ffmpeg
+, libxkbcommon, xdg-utils, zlib, pulseaudio
+, wrapGAppsHook, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "bitwig-studio";
+  version = "4.0";
+
+  src = fetchurl {
+    url = "https://downloads.bitwig.com/stable/${version}/${pname}-${version}.deb";
+    sha256 = "38381c1a382abd9543931f34d5ae1789c31ec1217a1c852b5c5c442ccaf97063";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
+
+  unpackCmd = ''
+    mkdir -p root
+    dpkg-deb -x $curSrc root
+  '';
+
+  dontBuild = true;
+  dontWrapGApps = true; # we only want $gappsWrapperArgs here
+
+  buildInputs = with xorg; [
+    alsa-lib cairo freetype gdk-pixbuf glib gtk3 libxcb xcbutil xcbutilwm zlib libXtst libxkbcommon pulseaudio libjack2 libX11 libglvnd libXcursor stdenv.cc.cc.lib
+  ];
+
+  binPath = lib.makeBinPath [
+    xdg-utils ffmpeg
+  ];
+
+  ldLibraryPath = lib.strings.makeLibraryPath buildInputs;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r opt/bitwig-studio $out/libexec
+    ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
+    cp -r usr/share $out/share
+    substitute usr/share/applications/com.bitwig.BitwigStudio.desktop \
+      $out/share/applications/com.bitwig.BitwigStudio.desktop \
+      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
+
+      runHook postInstall
+  '';
+
+  postFixup = ''
+    # patchelf fails to set rpath on BitwigStudioEngine, so we use
+    # the LD_LIBRARY_PATH way
+
+    find $out -type f -executable \
+      -not -name '*.so.*' \
+      -not -name '*.so' \
+      -not -name '*.jar' \
+      -not -path '*/resources/*' | \
+    while IFS= read -r f ; do
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
+      wrapProgram $f \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix PATH : "${binPath}" \
+        --suffix LD_LIBRARY_PATH : "${ldLibraryPath}"
+    done
+
+  '';
+
+  meta = with lib; {
+    description = "A digital audio workstation";
+    longDescription = ''
+      Bitwig Studio is a multi-platform music-creation system for
+      production, performance and DJing, with a focus on flexible
+      editing tools and a super-fast workflow.
+    '';
+    homepage = "https://www.bitwig.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ bfortz michalrus mrVanDalo ];
+  };
+}

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -27,12 +27,6 @@ stdenv.mkDerivation rec {
     alsa-lib cairo freetype gdk-pixbuf glib gtk3 libxcb xcbutil xcbutilwm zlib libXtst libxkbcommon pulseaudio libjack2 libX11 libglvnd libXcursor stdenv.cc.cc.lib
   ];
 
-  binPath = lib.makeBinPath [
-    xdg-utils ffmpeg
-  ];
-
-  ldLibraryPath = lib.strings.makeLibraryPath buildInputs;
-
   installPhase = ''
     runHook preInstall
 
@@ -60,8 +54,8 @@ stdenv.mkDerivation rec {
       patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
       wrapProgram $f \
         "''${gappsWrapperArgs[@]}" \
-        --prefix PATH : "${binPath}" \
-        --suffix LD_LIBRARY_PATH : "${ldLibraryPath}"
+        --prefix PATH : "${lib.makeBinPath [ xdg-utils ffmpeg ]}" \
+        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath buildInputs}"
     done
 
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23160,8 +23160,9 @@ in
     inherit (pkgs) bitwig-studio1;
   };
   bitwig-studio3 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio3.nix { };
+  bitwig-studio4 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio4.nix { };
 
-  bitwig-studio = bitwig-studio3;
+  bitwig-studio = bitwig-studio4;
 
   bgpdump = callPackage ../tools/networking/bgpdump { };
 


### PR DESCRIPTION
###### Motivation for this change

A new major version of Bitwig Studio was released.

###### Things done

I've updated the version number and the SHA hash as well as the name of the `.desktop` file which has changed and was preventing the build from completing.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
