### PR TITLE
 top-level/release-haskell.nix: add agda packages and test to jobset 

### DIFF
--- a/pkgs/development/libraries/agda/iowa-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/iowa-stdlib/default.nix
@@ -26,6 +26,8 @@ mkDerivation (rec {
     platforms = lib.platforms.unix;
     # broken since Agda 2.6.1
     broken = true;
+    # remove once unbroken
+    hydraPlatforms = lib.platforms.none;
     maintainers = with lib.maintainers; [ alexarice turion ];
   };
 })

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -91,6 +91,9 @@ let
 
       tests.haskell = packagePlatforms pkgs.tests.haskell;
 
+      nixosTests.agda = (packagePlatforms pkgs.nixosTests).agda;
+      agdaPackages = packagePlatforms pkgs.agdaPackages;
+
       pkgsMusl.haskell.compiler = packagePlatforms pkgs.pkgsMusl.haskell.compiler // {
         # remove musl ghc865Binary since it is known to be broken and
         # causes an evaluation error on darwin.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
