### PR TITLE
the-powder-toy: 95.0 -> 96.0.348

### DIFF
--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -1,27 +1,26 @@
-{ lib, stdenv, fetchFromGitHub, scons, pkg-config, SDL2, lua, fftwFloat,
-  zlib, bzip2, curl, darwin }:
+{ lib, stdenv, fetchFromGitHub, meson, luajit, ninja, pkg-config
+, python3, SDL2, lua, fftwFloat, zlib, bzip2, curl, darwin }:
 
 stdenv.mkDerivation rec {
   pname = "the-powder-toy";
-  version = "95.0";
+  version = "96.0.348";
 
   src = fetchFromGitHub {
     owner = "The-Powder-Toy";
     repo = "The-Powder-Toy";
     rev = "v${version}";
-    sha256 = "18rp2g1mj0gklra06wm9dm57h73hmm301npndh0y8ap192i5s8sa";
+    sha256 = "sha256-PAnjNeqGJPW7TeoIsaOnuOb1loyKs8pjBseKoD0CvQU=";
   };
 
-  nativeBuildInputs = [ scons pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config python3 ];
 
-  propagatedBuildInputs = lib.optionals stdenv.isDarwin
-    [ darwin.apple_sdk.frameworks.Cocoa ];
-
-  buildInputs = [ SDL2 lua fftwFloat zlib bzip2 curl ];
+  buildInputs = [ luajit SDL2 lua fftwFloat zlib bzip2 curl ];
 
   installPhase = ''
-    install -Dm 755 build/powder* "$out/bin/powder"
+    install -Dm 755 powder $out/bin/powder
   '';
+
+  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
