### PR TITLE
google-compute-image: Add a setting for GZIP compression level

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -36,6 +36,14 @@ in
         `<nixpkgs/nixos/modules/virtualisation/google-compute-image.nix>`.
       '';
     };
+
+    virtualisation.googleComputeImage.compressionLevel = mkOption {
+      type = types.int;
+      default = 6;
+      description = ''
+        GZIP compression level of the resulting disk image (1-9).
+      '';
+    };
   };
 
   #### implementation
@@ -47,7 +55,8 @@ in
         PATH=$PATH:${with pkgs; lib.makeBinPath [ gnutar gzip ]}
         pushd $out
         mv $diskImage disk.raw
-        tar -Szcf nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.raw.tar.gz disk.raw
+        tar -Sc disk.raw | gzip -${toString cfg.compressionLevel} > \
+          nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.raw.tar.gz
         rm $out/disk.raw
         popd
       '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I've got a situation in which I need to build several different google compute images, from partially shared sources - that is, changing one often (but not always) changes the others as well. As per Google's docs, these images have to be either uncompressed, or gzip'd, meaning compression speed doesn't scale with number of cores, only CPU- and IO speed.

Currently, images are gzip'd with the default compression speed, equivalent to `gzip -6`, which on my machine takes ~1m20s to achieve a ~69% compression ratio. I'd like to be able to dial that down to `gzip -1`, which takes only ~30s to achieve a ~65% compression ratio.

I'm not expecting this to be super useful to everyone, and `gzip -6` is fine for most people, which is why I'm not proposing changing the default - but in my specific situation, uploading an additional ~80MB from my build machine is significantly faster than waiting for that additional 4% compression.

I can also imagine wanting to make the most of a slow uplink or a data cap by turning this all the way up to a `gzip -9`, although for me, that takes a whopping 4min to achieve an additional 0.2% compression ratio. (This will vary depending on your machine and how compressible the contents of your disk image is.)

---

Numbers on simply decompressing and re-compressing a built image with `gzip -6` (the default):

```
$ time gzip -6 < nixos-image-21.11pre-git-x86_64-linux.raw.tar > nixos-image-21.11pre-git-x86_64-linux.raw.tar.6.gz
________________________________________________________
Executed in   76.79 secs    fish           external
   usr time   73.08 secs    1.29 millis   73.08 secs
   sys time    3.68 secs    1.17 millis    3.68 secs

$ gunzip -l nixos-image-21.11pre-git-x86_64-linux.raw.tar.6.gz
         compressed        uncompressed  ratio uncompressed_name
          685016616          2196531200  68.8% nixos-image-21.11pre-git-x86_64-linux.raw.tar.6
```

With `gzip -1` (the lowest possible value):

```
$ time gzip -1 < nixos-image-21.11pre-git-x86_64-linux.raw.tar > nixos-image-21.11pre-git-x86_64-linux.raw.tar.1.gz
________________________________________________________
Executed in   31.39 secs    fish           external
   usr time   27.63 secs    1.30 millis   27.63 secs
   sys time    3.68 secs    0.14 millis    3.68 secs

$ gunzip -l nixos-image-21.11pre-git-x86_64-linux.raw.tar.1.gz 
         compressed        uncompressed  ratio uncompressed_name
          771798382          2196531200  64.9% nixos-image-21.11pre-git-x86_64-linux.raw.tar.1
```

And, for science, `gzip -9` (the highest possible value):

```
$ time gzip -9 < nixos-image-21.11pre-git-x86_64-linux.raw.tar > nixos-image-21.11pre-git-x86_64-linux.raw.tar.9.gz
________________________________________________________
Executed in  248.11 secs    fish           external
   usr time  244.18 secs  652.00 micros  244.18 secs
   sys time    3.89 secs  968.00 micros    3.89 secs

$ gunzip -l nixos-image-21.11pre-git-x86_64-linux.raw.tar.9.gz 
         compressed        uncompressed  ratio uncompressed_name
          679218974          2196531200  69.1% nixos-image-21.11pre-git-x86_64-linux.raw.tar.9
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
