### PR TITLE
libconfig: fix static build

### DIFF
--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  configureFlags = lib.optional stdenv.targetPlatform.isWindows "--disable-examples";
+  configureFlags = lib.optional
+    (stdenv.targetPlatform.isWindows || stdenv.hostPlatform.isStatic)
+    "--disable-examples";
 
   meta = with lib; {
     homepage = "http://www.hyperrealm.com/libconfig";

--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -11,9 +11,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  configureFlags = lib.optional
-    (stdenv.targetPlatform.isWindows || stdenv.hostPlatform.isStatic)
-    "--disable-examples";
+  configureFlags = lib.optional (stdenv.targetPlatform.isWindows || stdenv.hostPlatform.isStatic) "--disable-examples";
 
   meta = with lib; {
     homepage = "http://www.hyperrealm.com/libconfig";


### PR DESCRIPTION
###### Motivation for this change

libconfig is a small library for processing configuration files. This change makes it possible to build (and thus link) it statically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (there are no binaries, but I have successfully built and statically linked a small C program against libconfig; the resulting binary worked successfully)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
