### PR TITLE
ceres-solver: 2.0.0 propagate dependencies

### DIFF
--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -20,9 +20,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ eigen ]
-    ++ lib.optional runTests gflags;
-  propagatedBuildInputs = [ glog ];
+  buildInputs = lib.optional runTests gflags;
+  propagatedBuildInputs = [ eigen glog ];
 
   # The Basel BUILD file conflicts with the cmake build directory on
   # case-insensitive filesystems, eg. darwin.

--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -20,8 +20,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ eigen glog ]
+  buildInputs = [ eigen ]
     ++ lib.optional runTests gflags;
+  propagatedBuildInputs = [ glog ];
 
   # The Basel BUILD file conflicts with the cmake build directory on
   # case-insensitive filesystems, eg. darwin.


### PR DESCRIPTION
Move glog and eigen to being propagated inputs. I found this to be needed for down-tree dependencies of ceres within the ROS ecosystem such as the [fuse family of packages from Locus Robotics](https://github.com/locusrobotics/fuse/), otherwise I got CMake errors at configure time. Note that Ubuntu/Debian's packaging of ceres also includes `libceres-dev` -> `libgoogle-glog-dev`/`libeigen3-dev` dependencies:

https://packages.ubuntu.com/focal-updates/libceres-dev

###### Motivation for this change

Not having to patch this in in my overrides. :)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This change is strictly additive, so there is limited scope for what could break from it.

FYI @lopsided98 