### PR TITLE
1password-gui: 8.0.34 - 8.1.1

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -96,9 +96,9 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath ${rpath}:$out/share/1password $file
       done
 
-      # I'm adding udev to the LD_LIBRARY_PATH. Electron is trying to open it
-      # via dlopen(), and for some reason that doesn't seem to be impacted from the
-      # rpath.
+      # Electron is trying to open udev via dlopen()
+      # and for some reason that doesn't seem to be impacted from the rpath.
+      # Adding udev to LD_LIBRARY_PATH fixes that.
       makeWrapper $out/share/1password/1password $out/bin/1password \
         --prefix PATH : ${lib.makeBinPath [ xdg-utils ]} \
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -106,13 +106,13 @@ stdenv.mkDerivation rec {
       runHook postInstall
     '';
 
-    passthru.updateScript = ./update.sh;
+  passthru.updateScript = ./update.sh;
 
-    meta = with lib; {
-      description = "Multi-platform password manager";
-      homepage = "https://1password.com/";
-      license = licenses.unfree;
-      maintainers = with maintainers; [ timstott savannidgerinel ];
-      platforms = [ "x86_64-linux" ];
-    };
-  }
+  meta = with lib; {
+    description = "Multi-platform password manager";
+    homepage = "https://1password.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ timstott savannidgerinel ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

8.1.1 has been out for a few weeks. In addition to updating, I am also setting up attributes to make the version, hash, and channel overridable so folks (including myself) can easily switch to beta versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
