### PR TITLE
python3Packages.ev3dev2: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/ev3dev2/default.nix
+++ b/pkgs/development/python-modules/ev3dev2/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "ev3dev2";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ev3dev";
+    repo = "ev3dev-lang-python";
+    rev = version;
+    sha256 = "XxsiQs3k5xKb+3RewARbvBbxaztdvdq3w5ZMgTq+kRc=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    echo "${version}\n" > RELEASE-VERSION
+  '';
+
+  propagatedBuildInputs = [ pillow ];
+
+  checkPhase = ''
+    chmod -R g+rw ./tests/fake-sys/devices/**/*
+    ${python.interpreter} -W ignore::ResourceWarning tests/api_tests.py
+  '';
+
+  meta = with lib; {
+    description = "Python language bindings for ev3dev";
+    homepage = "https://github.com/ev3dev/ev3dev-lang-python";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2355,6 +2355,8 @@ in {
 
   et_xmlfile = callPackage ../development/python-modules/et_xmlfile { };
 
+  ev3dev2 = callPackage ../development/python-modules/ev3dev2 { };
+
   evdev = callPackage ../development/python-modules/evdev { };
 
   eve = callPackage ../development/python-modules/eve { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
