### PR TITLE
ocamlPackages.secp256k1-internal: init at 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitLab
+, buildDunePackage
+, gmp
+, dune-configurator
+, cstruct
+, bigstring
+, alcotest
+, hex
+}:
+
+buildDunePackage rec {
+  pname = "secp256k1-internal";
+  version = "0.2";
+  src = fetchFromGitLab {
+    owner = "nomadic-labs";
+    repo = "ocaml-secp256k1-internal";
+    rev = "v${version}";
+    sha256 = "1g9fyi78nmmm19l2cggwj14m4n80rz7gmnh1gq376zids71s6qxv";
+  };
+
+  useDune2 = true;
+
+  minimalOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [
+    gmp
+    cstruct
+    bigstring
+  ];
+
+  buildInputs = [
+    dune-configurator
+  ];
+
+  checkInputs = [
+    alcotest
+    hex
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Bindings to secp256k1 internal functions (generic operations on the curve)";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1029,6 +1029,8 @@ let
       inherit (pkgs) secp256k1;
     };
 
+    secp256k1-internal = callPackage ../development/ocaml-modules/secp256k1-internal { };
+
     seq = callPackage ../development/ocaml-modules/seq { };
 
     sosa = callPackage ../development/ocaml-modules/sosa { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

More packages for ligo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
