### PR TITLE
ocamlPackages.lwt-watcher: init at 0.1

### DIFF
--- a/pkgs/development/ocaml-modules/lwt-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-watcher/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchFromGitLab
+, buildDunePackage
+, lwt
+}:
+
+buildDunePackage rec {
+  pname = "lwt-watcher";
+  version = "0.1";
+  src = fetchFromGitLab {
+    owner = "nomadic-labs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0kaf7py02i0dn9rvrbzxh4ljfg059wc8xvm093m9wy7lsa68rax9";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    lwt
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "One-to-many broadcast in Lwt";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -630,6 +630,8 @@ let
 
     lwt-dllist = callPackage ../development/ocaml-modules/lwt-dllist { };
 
+    lwt-watcher = callPackage ../development/ocaml-modules/lwt-watcher { };
+
     lwt_log = callPackage ../development/ocaml-modules/lwt_log { };
 
     lwt_ppx = callPackage ../development/ocaml-modules/lwt/ppx.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

More packages for ligo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
