### PR TITLE
cgoban: init at 3.5.23

### DIFF
--- a/pkgs/games/cgoban/default.nix
+++ b/pkgs/games/cgoban/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, writers
+, adoptopenjdk-jre-bin
+, fetchurl
+, makeWrapper
+}:
+stdenv.mkDerivation rec {
+  pname = "cgoban";
+  version = "3.5.23";
+
+  nativeBuildInputs = [ adoptopenjdk-jre-bin makeWrapper ];
+
+  src = fetchurl {
+    url = "http://files.gokgs.com/javaBin/cgoban.jar";
+    sha256 = "0srw1hqr9prgr9dagfbh2j6p9ivaj40kdpyhs6zjkg7lhnnrrrcv";
+  };
+
+  dontConfigure = true;
+  dontUnpack = true;
+  dontBuild = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D $src $out/lib/cgoban.jar
+    makeWrapper ${adoptopenjdk-jre-bin}/bin/java $out/bin/cgoban --add-flags "-jar $out/lib/cgoban.jar"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Client for the KGS Go Server";
+    homepage = "https://www.gokgs.com/";
+    license = licenses.free;
+    maintainers = with maintainers; [ savannidgerinel ];
+    platforms = adoptopenjdk-jre-bin.meta.platforms;
+  };
+}
+

--- a/pkgs/games/cgoban/default.nix
+++ b/pkgs/games/cgoban/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ adoptopenjdk-jre-bin makeWrapper ];
 
   src = fetchurl {
-    url = "http://web.archive.org/web/20210717230228/https://files.gokgs.com/javaBin/cgoban.jar";
+    url = "https://web.archive.org/web/20210116034119/https://files.gokgs.com/javaBin/cgoban.jar"";
     sha256 = "0srw1hqr9prgr9dagfbh2j6p9ivaj40kdpyhs6zjkg7lhnnrrrcv";
   };
 

--- a/pkgs/games/cgoban/default.nix
+++ b/pkgs/games/cgoban/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ adoptopenjdk-jre-bin makeWrapper ];
 
   src = fetchurl {
-    url = "http://files.gokgs.com/javaBin/cgoban.jar";
+    url = "http://web.archive.org/web/20210717230228/https://files.gokgs.com/javaBin/cgoban.jar";
     sha256 = "0srw1hqr9prgr9dagfbh2j6p9ivaj40kdpyhs6zjkg7lhnnrrrcv";
   };
 
@@ -36,4 +36,3 @@ stdenv.mkDerivation rec {
     platforms = adoptopenjdk-jre-bin.meta.platforms;
   };
 }
-

--- a/pkgs/games/cgoban/default.nix
+++ b/pkgs/games/cgoban/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ adoptopenjdk-jre-bin makeWrapper ];
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20210116034119/https://files.gokgs.com/javaBin/cgoban.jar"";
+    url = "https://web.archive.org/web/20210116034119/https://files.gokgs.com/javaBin/cgoban.jar";
     sha256 = "0srw1hqr9prgr9dagfbh2j6p9ivaj40kdpyhs6zjkg7lhnnrrrcv";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28632,6 +28632,8 @@ in
 
   cdogs-sdl = callPackage ../games/cdogs-sdl { };
 
+  cgoban = callPackage ../games/cgoban { };
+
   chessdb = callPackage ../games/chessdb { };
 
   chessx = libsForQt5.callPackage ../games/chessx { };


### PR DESCRIPTION
###### Motivation for this change

KGS is one of a few popular Go servers, and cgoban is their official application for communicating with it. While it is a simple Java file and easy to download, it would be convenient to just have it as a derivation without any need to know that it's a Java file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
