### PR TITLE
fig2dev: apply patch for CVE-2021-3561

### DIFF
--- a/pkgs/applications/graphics/fig2dev/default.nix
+++ b/pkgs/applications/graphics/fig2dev/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , ghostscript
 , libpng
 , makeWrapper
@@ -19,6 +20,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/mcj/fig2dev-${version}.tar.xz";
     sha256 = "1bm75lf9j54qpbjx8hzp6ixaayp1x9w4v3yxl6vxyw8g5m4sqdk3";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-3561.patch";
+      # Using Debian patch since it is not possible to download it directly from Sourceforge
+      url = "https://sources.debian.org/data/main/f/fig2dev/1:3.2.8-3/debian/patches/33_sanitize-color.patch";
+      sha256 = "1bppr3li03nj4qjibnddr2f38mpk55pcn5z6k98pf00gabq33fgs";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpng ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-3561.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>chemtool</li>
    <li>fig2dev</li>
    <li>fped</li>
    <li>xfig</li>
  </ul>
</details>
