### PR TITLE
plausible, nixos/plausible: Default to listen on localhost.

### DIFF
--- a/nixos/modules/services/web-apps/plausible.nix
+++ b/nixos/modules/services/web-apps/plausible.nix
@@ -128,6 +128,13 @@ in {
     };
 
     erlang = {
+      enableDistribution = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable Erlang's distributed multi-machine features.
+        '';
+      };
       vmListenAddress = mkOption {
         default = "127.0.0.1";
         type = types.str;
@@ -140,6 +147,10 @@ in {
 
           The value given here is a normal IP address; it is translated
           to an Erlang IP address tuple by this module.
+
+          This setting has no effect if
+          <xref linkend="opt-services.plausible.erlang.enableDistribution" />
+          is <literal>false</literal>.
         '';
       };
       epmdListenAddress = mkOption {
@@ -151,6 +162,11 @@ in {
           <link xlink:href="https://erlang.org/doc/man/epmd.html#environment-variables">
             <literal>ERL_EPMD_ADDRESS</literal>
           </link>.
+          is <literal>false</literal>.
+
+          This setting has no effect if
+          <xref linkend="opt-services.plausible.erlang.enableDistribution" />
+          is <literal>false</literal>.
         '';
       };
     };
@@ -302,7 +318,9 @@ in {
             SMTP_HOST_SSL_ENABLED = boolToString cfg.mail.smtp.enableSSL;
 
             SELFHOST = "true";
-          } // (optionalAttrs (cfg.mail.smtp.user != null) {
+          } // (optionalAttrs (!cfg.erlang.enableDistribution) {
+            RELEASE_DISTRIBUTION = "none";
+          }) // (optionalAttrs (cfg.mail.smtp.user != null) {
             SMTP_USER_NAME = cfg.mail.smtp.user;
           });
 

--- a/pkgs/servers/web-apps/plausible/default.nix
+++ b/pkgs/servers/web-apps/plausible/default.nix
@@ -69,6 +69,14 @@ beamPackages.mixRelease {
     # Ensure that `tzdata` doesn't write into its store-path
     # https://github.com/plausible/analytics/pull/1096, but rebased onto 1.3.0
     ./tzdata-rebased.patch
+
+    # Allow user to specify listen interface via LISTEN_IP.
+    # https://github.com/plausible/analytics/pull/1190, but rebased onto 1.3.0
+    (fetchpatch {
+      name = "plausible-Allow-user-to-specify-listen-interface-via-LISTEN_IP.patch";
+      url = "https://github.com/nh2/analytics/commit/63aa7f5206ba2459ff7d04a842fe3ed6663975bc.patch";
+      sha256 = "1lhlhipnsisb9cz5m28i120c0ffwcfjjrypvmjxivlh32lx8mhbx";
+    })
   ];
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

This is a safer default configuration, changing:

* the plausible HTTP web server
* the Erlang Beam VM inter-node RPC port
* the Erlang EPMD port

to be listening on localhost only.

This makes Plausible have a safe default configuration, like all other
networked services in NixOS

For background discussion, see: #130244

## TODO

* [x] Based on #130062, merge that first.
* [ ] Potentially wait for added patch to be upstreamed
  * Patch was merged upstream in https://github.com/plausible/analytics/pull/1190 / https://github.com/plausible/analytics/commit/1337b46e5225db3fc47700f67137c5c8a50699c5, but as of writing there is no release yet that contains it.
* [ ] Write release notes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
