### PR TITLE
ookla-speedtest: init at 1.0.0

### DIFF
--- a/pkgs/tools/networking/ookla-speedtest/default.nix
+++ b/pkgs/tools/networking/ookla-speedtest/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.speedtest.net/apps/cli";
     license = licenses.unfree;
     maintainers = with maintainers; [ kranzes ];
-    platforms = builtins.attrNames srcs;
+    platforms = lib.attrNames srcs;
   };
 }

--- a/pkgs/tools/networking/ookla-speedtest/default.nix
+++ b/pkgs/tools/networking/ookla-speedtest/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchurl }:
+
+let
+  pname = "ookla-speedtest";
+  version = "1.0.0";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://install.speedtest.net/app/cli/${pname}-${version}-x86_64-linux.tgz";
+      sha256 = "sha256-X+ICjw1EJ+T0Ix2fnPcOZpG7iQpwY211Iy/k2XBjMWg=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://install.speedtest.net/app/cli/${pname}-${version}-aarch64-linux.tgz";
+      sha256 = "sha256-BzaE3DSQUIygGwTFhV4Ez9eX/tM/bqam7cJt+8b2qp4=";
+    };
+  };
+in
+
+stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = srcs.${stdenv.hostPlatform.system};
+
+  setSourceRoot = ''
+    sourceRoot=$PWD
+  '';
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    install -D speedtest $out/bin/speedtest
+    install -D speedtest.5 $out/share/man/man5/speedtest.5
+  '';
+
+  meta = with lib; {
+    description = "Command line internet speedtest tool by Ookla";
+    homepage = "https://www.speedtest.net/apps/cli";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ kranzes ];
+    platforms = builtins.attrNames srcs;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17597,6 +17597,8 @@ in
 
   oobicpl = callPackage ../development/libraries/science/biology/oobicpl { };
 
+  ookla-speedtest = callPackage ../tools/networking/ookla-speedtest { };
+
   openalSoft = callPackage ../development/libraries/openal-soft {
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit AudioToolbox;
   };


### PR DESCRIPTION
###### Motivation for this change
Added Ookla's internet speedtest tool.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
