### PR TITLE
dmenu-wayland: support cross-compilation

### DIFF
--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, cairo, pango, pkg-config, wayland-protocols
-, glib, wayland, libxkbcommon, makeWrapper
+, glib, wayland, libxkbcommon, makeWrapper, wayland-scanner
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -15,8 +16,18 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
-  nativeBuildInputs = [ meson ninja pkg-config makeWrapper ];
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config makeWrapper wayland-scanner ];
   buildInputs = [ cairo pango wayland-protocols glib wayland libxkbcommon ];
+
+  # Patch to support cross-compilation, see https://github.com/nyyManni/dmenu-wayland/pull/23/
+  patches = [
+    # can be removed when https://github.com/nyyManni/dmenu-wayland/pull/23 is included
+    (fetchpatch {
+      url = "https://github.com/nyyManni/dmenu-wayland/commit/3434410de5dcb007539495395f7dc5421923dd3a.patch";
+      sha256 = "sha256-im16kU8RWrCY0btYOYjDp8XtfGEivemIPlhwPX0C77o=";
+    })
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/dmenu-wl_run \


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
