### PR TITLE
asciidoc: support cross-compilation

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -290,6 +290,12 @@ stdenv.mkDerivation rec {
     # --replace "python3 -m asciidoc.a2x" "python3 -m asciidoc.a2x -a revdate=01/01/1980"
     substituteInPlace Makefile.in \
       --replace "python3 a2x.py" "python3 a2x.py -a revdate=01/01/1980"
+
+    # Fix tests
+    for f in $(grep -R --files-with-matches "2002-11-25") ; do
+      substituteInPlace $f --replace "2002-11-25" "1970-01-01"
+      substituteInPlace $f --replace "00:37:42" "00:00:01"
+    done
   '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     # We want to use asciidoc from the build platform to build the documentation.
     substituteInPlace Makefile.in \
@@ -298,6 +304,9 @@ stdenv.mkDerivation rec {
 
   preInstall = "mkdir -p $out/etc/vim";
   makeFlags = lib.optional stdenv.isCygwin "DESTDIR=/.";
+
+  checkInputs = [ sourceHighlight ];
+  doCheck = true;
 
   meta = with lib; {
     description = "Text-based document generation system";

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -40,6 +40,8 @@
 
 # java is problematic on some platforms, where it is unfree
 , enableJava ? true
+
+, buildPackages
 }:
 
 assert enableStandardFeatures ->
@@ -157,7 +159,9 @@ stdenv.mkDerivation rec {
     sha256 = "1clf1axkns23wfmh48xfspzsnw04pjh4mq1pshpzvj0cwxhz0yaq";
   };
 
+  strictDeps = true;
   nativeBuildInputs = [ python3 unzip autoreconfHook ];
+  buildInputs = [ python3 ];
 
   # install filters early, so their shebangs are patched too
   postPatch = with lib; ''
@@ -262,7 +266,20 @@ stdenv.mkDerivation rec {
         -e "s|^XMLLINT =.*|XMLLINT = '${libxml2.bin}/bin/xmllint'|" \
         -i a2x.py
   '') + ''
-    patchShebangs .
+    patchShebangs --host \
+      asciidoc.py \
+      a2x.py \
+      tests/testasciidoc.py \
+      filters/code/code-filter.py \
+      filters/latex/latex2img.py \
+      filters/music/music2png.py \
+      filters/unwraplatex.py \
+      filters/graphviz/graphviz2png.py
+
+    # Hardcode the path to its own asciidoc.
+    # This helps with cross-compilation.
+    substituteInPlace a2x.py \
+      --replace "find_executable(ASCIIDOC)" "'${placeholder "out"}/bin/asciidoc'"
 
     # Note: this substitution will not work in the planned 10.0.0 release:
     #
@@ -273,6 +290,10 @@ stdenv.mkDerivation rec {
     # --replace "python3 -m asciidoc.a2x" "python3 -m asciidoc.a2x -a revdate=01/01/1980"
     substituteInPlace Makefile.in \
       --replace "python3 a2x.py" "python3 a2x.py -a revdate=01/01/1980"
+  '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    # We want to use asciidoc from the build platform to build the documentation.
+    substituteInPlace Makefile.in \
+      --replace "python3 a2x.py" "python3 ${buildPackages.asciidoc}/bin/a2x.py"
   '';
 
   preInstall = "mkdir -p $out/etc/vim";


### PR DESCRIPTION
###### Motivation for this change

After working on this for way too long, I figured out how to get asciidoc cross-compiling.

We need to build asciidoc for the build platform first, unfortunately. But this seems like the easiest / best way to get this working, unless someone else has a better idea. I'm always open for ideas to make this nicer.

I checked the output and there are no build system paths left, so that's good.

I just thought about the fact that it's probably defined as buildInput where it shouldn't be, causing the cross-compilation. Anyhow, anyone willing to 'cross-compile' it can do it with this patch :).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
