### PR TITLE
fancy-motd: unstable-2021-07-04 -> unstable-2021-07-15

### DIFF
--- a/pkgs/tools/system/fancy-motd/default.nix
+++ b/pkgs/tools/system/fancy-motd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fancy-motd";
-  version = "unstable-2021-07-04";
+  version = "unstable-2021-07-15";
 
   src = fetchFromGitHub {
     owner = "bcyran";
     repo = pname;
-    rev = "2cc3c3c164ef695c9dd465beca61716a364db32c";
-    sha256 = "003p5rsyl216xwldrk8slpnzw6wdrcm8hpfdgy9a0mja5g1xdqzr";
+    rev = "e8d2d2602d9b9fbc132ddc4f9fbf22428d715721";
+    sha256 = "10fxr1grsiwvdc5m2wd4n51lvz0zd4sldg9rzviaim18nw68gdq3";
   };
 
   buildInputs = [ bc curl figlet fortune gawk iproute2 ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
