### PR TITLE
firecracker: 0.24.3 -> 0.24.4

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,17 +1,17 @@
 { fetchurl, lib, stdenv }:
 
 let
-  version = "0.24.3";
+  version = "0.24.4";
 
   suffix = {
-    x86_64-linux  = "x86_64";
+    x86_64-linux = "x86_64";
     aarch64-linux = "aarch64";
   }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
 
   dlbin = sha256: fetchurl {
-    url    = "${baseurl}/v${version}/firecracker-v${version}-${suffix}.tgz";
+    url = "${baseurl}/v${version}/firecracker-v${version}-${suffix}.tgz";
     sha256 = sha256."${stdenv.hostPlatform.system}";
   };
 
@@ -22,15 +22,15 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
   src = dlbin {
-    x86_64-linux  = "sha256-i6NMVFoLm4hQJH7RnhfC0t+0DJCINoP5b/iCv9JyRdk=";
-    aarch64-linux = "0m7xs12g97z1ipzaf7dgknf3azlah0p6bdr9i454azvzg955238b";
+    x86_64-linux = "sha256-EKndfLdkxn+S+2ElAyQ+mKEo5XN6kqZLuLCsQf+fKuk=";
+    aarch64-linux = "0zzr8x776aya6f6pw0dc0a6jxgbqv3f37p1vd8mmlsdv66c4kmfb";
   };
 
   configurePhase = ":";
 
-  buildPhase     = ''
-    mv firecracker-* firecracker
-    mv jailer-*      jailer
+  buildPhase = ''
+    mv release-v${version}/firecracker-v${version}-${suffix} firecracker
+    mv release-v${version}/jailer-v${version}-${suffix} jailer
     chmod +x firecracker jailer
   '';
 
@@ -48,9 +48,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Secure, fast, minimal micro-container virtualization";
-    homepage    = "http://firecracker-microvm.io";
-    license     = licenses.asl20;
-    platforms   = [ "x86_64-linux" "aarch64-linux" ];
-    maintainers = with maintainers; [ thoughtpolice ];
+    homepage = "http://firecracker-microvm.io";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ thoughtpolice endocrimes ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updated firecracker to v0.24.4. This required updating the buildPhase to
point to new compilation result paths.

Formatting changes were performed by `nix-update --format`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
