### PR TITLE
pythonPackages.docker: 4.4.4 -> 5.0.0, docker-compose: 1.28.6 -> 1.29.2

### DIFF
--- a/pkgs/applications/virtualization/docker-compose/default.nix
+++ b/pkgs/applications/virtualization/docker-compose/default.nix
@@ -8,12 +8,12 @@
 }:
 
 buildPythonApplication rec {
-  version = "1.28.6";
+  version = "1.29.2";
   pname = "docker-compose";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1d44906f7ab738ba2d1785130ed31b16111eee6dc5a1dbd7252091dae48c5281";
+    sha256 = "sha256-TIzZ0h0jdBJ5PRi9MxEASe6a+Nqz/iwhO70HM5WbCbc=";
   };
 
   # lots of networking and other fails

--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "docker";
-  version = "4.4.4";
+  version = "5.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db";
+    sha256 = "sha256-PovEdTTgypMx1ywy8ogbsTuT3tC83qs8gz+3z2HAqaU=";
   };
 
   nativeBuildInputs = lib.optional isPy27 mock;


### PR DESCRIPTION
###### Motivation for this change

docker-compose 1.29.x depends on v5 or newer of the python Docker package. Here we update both together, as older docker-compose is untested with newer python docker packages.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
