### PR TITLE
xarchiver: replace unfree rar handler

### DIFF
--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, gtk3, pkg-config, intltool, libxslt, makeWrapper,
-  coreutils, zip, unzip, p7zip, unrar, gnutar, bzip2, gzip, lhasa, wrapGAppsHook }:
+  coreutils, zip, unzip, p7zip, unar, gnutar, bzip2, gzip, lhasa, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   version = "0.5.4.17";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/xarchiver \
-    --prefix PATH : ${lib.makeBinPath [ zip unzip p7zip unrar gnutar bzip2 gzip lhasa coreutils ]}
+    --prefix PATH : ${lib.makeBinPath [ zip unzip p7zip unar gnutar bzip2 gzip lhasa coreutils ]}
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Since version 0.5.4.11, Xarchiver supports using either unrar or unar to
unpack .rar files. The former being released under an unfree license,
using the latter by default is preferable.

This avoids indirectly guarding the xarchiver package under
`nixpkgs.config.allowUnfree` due to the dependency on unrar.

Users who would like to use the unfree implementation may do so by
adding the unrar package to the environment from which they are calling
xarchiver.

Related issue: https://github.com/NixOS/nixpkgs/issues/16868


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
