### PR TITLE
ocamlPackages.ocaml-monadic: 0.4.1 → 0.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-monadic/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-monadic/default.nix
@@ -1,10 +1,10 @@
 { lib, fetchFromGitHub, buildDunePackage
-, ocaml-migrate-parsetree, ppx_tools_versioned
+, ppxlib
 }:
 
 buildDunePackage rec {
   pname = "ocaml-monadic";
-  version = "0.4.1";
+  version = "0.5.0";
 
   useDune2 = true;
 
@@ -12,11 +12,10 @@ buildDunePackage rec {
     owner = "zepalmer";
     repo = pname;
     rev = version;
-    sha256 = "1zcwydypk5vwfn1g7srnl5076scwwq5a5y8xwcjl70pc4cpzszll";
+    sha256 = "1ynv3yhdqmkhkgnz6c5kv6ryjcc934sdvw9rhh8rjg2dlzlffgbw";
   };
 
-  buildInputs = [ ppx_tools_versioned ];
-  propagatedBuildInputs = [ ocaml-migrate-parsetree ];
+  buildInputs = [ ppxlib ];
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -863,9 +863,7 @@ let
 
     ocamlmod = callPackage ../development/tools/ocaml/ocamlmod { };
 
-    ocaml-monadic = callPackage ../development/ocaml-modules/ocaml-monadic {
-      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2;
-    };
+    ocaml-monadic = callPackage ../development/ocaml-modules/ocaml-monadic { };
 
     ocaml_mysql = callPackage ../development/ocaml-modules/mysql { };
 


### PR DESCRIPTION
###### Motivation for this change

Use `ppxlib`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
