### PR TITLE
python3Packages.python-lsp-server: add missing setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -19,6 +19,7 @@
 , python-lsp-jsonrpc
 , pythonOlder
 , rope
+, setuptools
 , ujson
 , yapf
 }:
@@ -47,6 +48,7 @@ buildPythonPackage rec {
     pylint
     python-lsp-jsonrpc
     rope
+    setuptools
     ujson
     yapf
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without `setuptools`, I get this error:

```
Traceback (most recent call last):
  File "/nix/store/vzz30j2i399glx7qbq96vnqfsmb92sa8-python3.8-python-lsp-server-1.1.0/bin/.pylsp-wrapped", line 6, in <module>
    from pylsp.__main__ import main
  File "/nix/store/vzz30j2i399glx7qbq96vnqfsmb92sa8-python3.8-python-lsp-server-1.1.0/lib/python3.8/site-packages/pylsp/__main__.py", line 15, in <module>
    from .python_lsp import (PythonLSPServer, start_io_lang_server,
  File "/nix/store/vzz30j2i399glx7qbq96vnqfsmb92sa8-python3.8-python-lsp-server-1.1.0/lib/python3.8/site-packages/pylsp/python_lsp.py", line 15, in <module>
    from .config import config
  File "/nix/store/vzz30j2i399glx7qbq96vnqfsmb92sa8-python3.8-python-lsp-server-1.1.0/lib/python3.8/site-packages/pylsp/config/config.py", line 7, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

I am using Neovim and the nvim-lspconfig plugin without any additional configuration for this server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
