### PR TITLE
python3Packages.slack-sdk: 3.7.0 -> 3.8.0

### DIFF
--- a/pkgs/development/python-modules/slack-sdk/default.nix
+++ b/pkgs/development/python-modules/slack-sdk/default.nix
@@ -11,9 +11,7 @@
 , isPy3k
 , psutil
 , pytest-asyncio
-, pytest-cov
 , pytestCheckHook
-, pytestrunner
 , sqlalchemy
 , websocket-client
 , websockets
@@ -21,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "slack-sdk";
-  version = "3.7.0";
+  version = "3.8.0";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "slackapi";
     repo = "python-slack-sdk";
     rev = "v${version}";
-    sha256 = "0bc52v5n8r3b2fy1c90w253r1abl752kaqdk6bgzkwsvbhgcxf2s";
+    sha256 = "sha256-r3GgcU4K2jj+4aIytpY2HiVqHzChynn2BCn1VNTL2t0=";
   };
 
   propagatedBuildInputs = [
@@ -47,20 +45,23 @@ buildPythonPackage rec {
     flask-sockets
     psutil
     pytest-asyncio
-    pytest-cov
     pytestCheckHook
-    pytestrunner
   ];
 
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
 
-  # Exclude tests that requires network features
-  pytestFlagsArray = [ "--ignore=integration_tests" ];
+  disabledTestPaths = [
+    # Exclude tests that requires network features
+    "integration_tests"
+  ];
+
   disabledTests = [
+    # Requires network features
     "test_start_raises_an_error_if_rtm_ws_url_is_not_returned"
     "test_org_installation"
+    "test_interactions"
   ];
 
   pythonImportsCheck = [ "slack_sdk" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.8.0

Change log: https://github.com/slackapi/python-slack-sdk/releases/tag/v3.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
