### PR TITLE
Avogadro2: init at 1.94.0

### DIFF
--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, cmake, eigen, avogadrolibs, molequeue, hdf5
+, openbabel, qttools, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "avogadro2";
+  version = "1.94.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = "avogadroapp";
+    rev = version;
+    sha256 = "6RaiX23YUMfTYAuSighcLGGlJtqeydNgi3PWGF77Jp8=";
+  };
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  buildInputs = [
+    avogadrolibs
+    molequeue
+    eigen
+    hdf5
+    qttools
+  ];
+
+  propagatedBuildInputs = [ openbabel ];
+
+  qtWrapperArgs = [ "--prefix PATH : ${openbabel}/bin" ];
+
+  meta = with lib; {
+    description = "Molecule editor and visualizer";
+    maintainers = with maintainers; [ sheepforce ];
+    homepage = "https://github.com/OpenChemistry/avogadroapp";
+    platforms = platforms.mesaPlatforms;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -1,0 +1,68 @@
+{ lib, stdenv, fetchFromGitHub, cmake, zlib, eigen, libGL, doxygen, spglib
+, mmtf-cpp, glew, python3, libarchive, libmsym, msgpack, qttools, wrapQtAppsHook
+}:
+
+let
+  pythonWP = python3.withPackages (p: with p; [ openbabel-bindings numpy ]);
+
+  # Pure data repositories
+  moleculesRepo = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = "molecules";
+    rev = "1.0.0";
+    sha256 = "guY6osnpv7Oqt+HE1BpIqL10POp+x8GAci2kY0bLmqg=";
+  };
+  crystalsRepo = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = "crystals";
+    rev = "1.0.1";
+    sha256 = "sH/WuvLaYu6akOc3ssAKhnxD8KNoDxuafDSozHqJZC4=";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "avogadrolibs";
+  version = "1.94.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = pname;
+    rev = version;
+    sha256 = "6bChJhqrjOxeEWZBNToq3JExHPu7DUMsEHWBDe75zAo=";
+  };
+
+  postUnpack = ''
+    cp -r ${moleculesRepo} molecules
+    cp -r ${crystalsRepo} crystals
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    eigen
+    zlib
+    libGL
+    spglib
+    mmtf-cpp
+    glew
+    libarchive
+    libmsym
+    msgpack
+    qttools
+  ];
+
+  postFixup = ''
+    substituteInPlace $out/lib/cmake/${pname}/AvogadroLibsConfig.cmake \
+      --replace "''${AvogadroLibs_INSTALL_PREFIX}/$out" "''${AvogadroLibs_INSTALL_PREFIX}"
+  '';
+
+  meta = with lib; {
+    description = "Molecule editor and visualizer";
+    maintainers = with maintainers; [ sheepforce ];
+    homepage = "https://github.com/OpenChemistry/avogadrolibs";
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+  };
+}

--- a/pkgs/development/libraries/science/chemistry/libmsym/default.nix
+++ b/pkgs/development/libraries/science/chemistry/libmsym/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, cmake } :
+
+stdenv.mkDerivation rec {
+  pname = "libmsym";
+  version = "0.2.3";
+
+  src = fetchFromGitHub  {
+    owner = "mcodev31";
+    repo = pname;
+    rev = "v${version}";
+    sha256= "k+OEwrA/saupP/wX6Ii5My0vffiJ0X9xMCTrliMSMik=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = " molecular point group symmetry lib";
+    homepage = "https://github.com/rcsb/mmtf-cpp";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/libraries/science/chemistry/mmtf-cpp/default.nix
+++ b/pkgs/development/libraries/science/chemistry/mmtf-cpp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, cmake, msgpack } :
+
+stdenv.mkDerivation rec {
+  pname = "mmtf-cpp";
+  version = "1.0.0";
+
+  src = fetchFromGitHub  {
+    owner = "rcsb";
+    repo = pname;
+    rev = "v${version}";
+    sha256= "17ylramda69plf5w0v5hxbl4ggkdi5s15z55cv0pljl12yvyva8l";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ msgpack ];
+
+  meta = with lib; {
+    description = "A library of exchange-correlation functionals with arbitrary-order derivatives";
+    homepage = "https://github.com/rcsb/mmtf-cpp";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/development/libraries/science/chemistry/molequeue/default.nix
+++ b/pkgs/development/libraries/science/chemistry/molequeue/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, cmake, qttools, wrapQtAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "molequeue";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = pname;
+    rev = version;
+    sha256 = "+NoY8YVseFyBbxc3ttFWiQuHQyy1GN8zvV1jGFjmvLg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [ qttools ];
+
+  postFixup = ''
+    substituteInPlace $out/lib/cmake/molequeue/MoleQueueConfig.cmake \
+      --replace "''${MoleQueue_INSTALL_PREFIX}/$out" "''${MoleQueue_INSTALL_PREFIX}"
+  '';
+
+  meta = with lib; {
+    description = "Desktop integration of high performance computing resources";
+    maintainers = with maintainers; [ sheepforce ];
+    homepage = "https://github.com/OpenChemistry/molequeue";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29854,6 +29854,8 @@ in
 
   molequeue = libsForQt5.callPackage ../development/libraries/science/chemistry/molequeue { };
 
+  avogadro2 = libsForQt5.callPackage ../applications/science/chemistry/avogadro2 { };
+
   chemtool = callPackage ../applications/science/chemistry/chemtool { };
 
   d-seams = callPackage ../applications/science/chemistry/d-seams {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29850,6 +29850,8 @@ in
     eigen = eigen2;
   };
 
+  molequeue = libsForQt5.callPackage ../development/libraries/science/chemistry/molequeue { };
+
   chemtool = callPackage ../applications/science/chemistry/chemtool { };
 
   d-seams = callPackage ../applications/science/chemistry/d-seams {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6813,6 +6813,8 @@ in
 
   libmesode = callPackage ../development/libraries/libmesode {};
 
+  libmsym = callPackage ../development/libraries/science/chemistry/libmsym { };
+
   libnabo = callPackage ../development/libraries/libnabo { };
 
   libngspice = callPackage ../development/libraries/libngspice { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13957,6 +13957,8 @@ in
 
   mkdocs = callPackage ../development/tools/documentation/mkdocs { };
 
+  mmtf-cpp = callPackage ../development/libraries/science/chemistry/mmtf-cpp { };
+
   mockgen = callPackage ../development/tools/mockgen { };
 
   modd = callPackage ../development/tools/modd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29850,6 +29850,8 @@ in
     eigen = eigen2;
   };
 
+  avogadrolibs = libsForQt5.callPackage ../development/libraries/science/chemistry/avogadrolibs { };
+
   molequeue = libsForQt5.callPackage ../development/libraries/science/chemistry/molequeue { };
 
   chemtool = callPackage ../applications/science/chemistry/chemtool { };


### PR DESCRIPTION
###### Motivation for this change
While Avogadro is in nixpkgs, the development was discontinued in favour of Avogadro2, which this PR adds. Contrary to Avogadro it builds using recent versions of OpenBabel and Eigen and offers some new functionalyties, while missing some that Avogadro1 has. Therefore both packages are still somewhat orthogonal.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
