### PR TITLE
bitcoin: move util-linux from buildInputs to nativeBuildInputs

### DIFF
--- a/pkgs/applications/blockchains/bitcoin.nix
+++ b/pkgs/applications/blockchains/bitcoin.nix
@@ -1,21 +1,22 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
-, pkg-config
 , autoreconfHook
+, pkg-config
+, util-linux
+, hexdump
+, wrapQtAppsHook ? null
+, boost
+, libevent
+, miniupnpc
+, zeromq
+, zlib
 , db48
 , sqlite
-, boost
-, zeromq
-, hexdump
-, zlib
-, miniupnpc
+, qrencode
 , qtbase ? null
 , qttools ? null
-, wrapQtAppsHook ? null
-, util-linux
 , python3
-, qrencode
-, libevent
 , nixosTests
 , withGui
 , withWallet ? true
@@ -43,13 +44,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs =
-    [ pkg-config autoreconfHook ]
-    ++ optional stdenv.isDarwin hexdump
-    ++ optional withGui wrapQtAppsHook;
-  buildInputs = [ boost zlib zeromq miniupnpc libevent ]
+    [ autoreconfHook pkg-config ]
     ++ optionals stdenv.isLinux [ util-linux ]
+    ++ optionals stdenv.isDarwin [ hexdump ]
+    ++ optionals withGui [ wrapQtAppsHook ];
+
+  buildInputs = [ boost libevent miniupnpc zeromq zlib ]
     ++ optionals withWallet [ db48 sqlite ]
-    ++ optionals withGui [ qtbase qttools qrencode ];
+    ++ optionals withGui [ qrencode qtbase qttools ];
 
   postInstall = optional withGui ''
     install -Dm644 ${desktop} $out/share/applications/bitcoin-qt.desktop


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- small cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
