### PR TITLE
chromium: get-commit-message.py: Improve the parsing

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/get-commit-message.py
+++ b/pkgs/applications/networking/browsers/chromium/get-commit-message.py
@@ -19,14 +19,14 @@ for entry in feed.entries:
         continue
     url = requests.get(entry.link).url.split('?')[0]
     content = entry.content[0].value
+    content = html_tags.sub('', content)  # Remove any HTML tags
     if re.search(r'Linux', content) is None:
         continue
     #print(url)  # For debugging purposes
     version = re.search(r'\d+(\.\d+){3}', content).group(0)
     print('chromium: TODO -> ' + version)
     print('\n' + url)
-    if fixes := re.search(r'This update includes .+ security fixes\.', content):
-        fixes = html_tags.sub('', fixes.group(0))
+    if fixes := re.search(r'This update includes .+ security fixes\.', content).group(0):
         zero_days = re.search(r'Google is aware( of reports)? that .+ in the wild\.', content)
         if zero_days:
             fixes += " " + zero_days.group(0)


### PR DESCRIPTION
The current stable release announcement [0] uses more HTML tags which
broke the detection of "fixes" and "zero_days". Proper HTML parsing
could be done using html.parser [1] but for our purposes the naive regex
trick works well enough.

[0]: https://chromereleases.googleblog.com/2021/07/stable-channel-update-for-desktop.html
[1]: https://docs.python.org/3/library/html.parser.html

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
