### PR TITLE
nixos/cri-o: Add RFC42 'settings' option

### DIFF
--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -16,7 +16,7 @@ in
   ];
 
   meta = {
-    maintainers = lib.teams.podman.members;
+    maintainers = teams.podman.members;
   };
 
   options.virtualisation.cri-o = {
@@ -58,7 +58,7 @@ in
     extraPackages = mkOption {
       type = with types; listOf package;
       default = [ ];
-      example = lib.literalExample ''
+      example = literalExample ''
         [
           pkgs.gvisor
         ]
@@ -68,7 +68,7 @@ in
       '';
     };
 
-    package = lib.mkOption {
+    package = mkOption {
       type = types.package;
       default = crioPackage;
       internal = true;
@@ -84,7 +84,7 @@ in
       internal = true;
     };
 
-    settings = lib.mkOption {
+    settings = mkOption {
       type = format.type;
       default = { };
       description = ''
@@ -103,13 +103,13 @@ in
       storage_driver = cfg.storageDriver;
 
       image = {
-        pause_image = lib.mkIf (cfg.pauseImage != null) cfg.pauseImage;
-        pause_command = lib.mkIf (cfg.pauseCommand != null) cfg.pauseCommand;
+        pause_image = mkIf (cfg.pauseImage != null) cfg.pauseImage;
+        pause_command = mkIf (cfg.pauseCommand != null) cfg.pauseCommand;
       };
 
       network = {
         plugin_dirs = [ "${pkgs.cni-plugins}/bin" ];
-        network_dir = lib.mkIf (cfg.networkDir != null) cfg.networkDir;
+        network_dir = mkIf (cfg.networkDir != null) cfg.networkDir;
       };
 
       runtime = {
@@ -121,8 +121,8 @@ in
           optional (config.virtualisation.containers.ociSeccompBpfHook.enable)
             config.boot.kernelPackages.oci-seccomp-bpf-hook;
 
-        default_runtime = lib.mkIf (cfg.runtime != null) cfg.runtime;
-        runtimes = lib.mkIf (cfg.runtime != null) {
+        default_runtime = mkIf (cfg.runtime != null) cfg.runtime;
+        runtimes = mkIf (cfg.runtime != null) {
           "${cfg.runtime}" = { };
         };
       };

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -6,6 +6,9 @@ let
 
   crioPackage = (pkgs.cri-o.override { inherit (cfg) extraPackages; });
 
+  format = pkgs.formats.toml { };
+
+  cfgFile = format.generate "00-default.conf" cfg.settings;
 in
 {
   imports = [
@@ -80,6 +83,15 @@ in
       description = "Override the network_dir option.";
       internal = true;
     };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      description = ''
+        Configuration for cri-o, see
+        <link xlink:href="https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md"/>.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -87,36 +99,38 @@ in
 
     environment.etc."crictl.yaml".source = utils.copyFile "${pkgs.cri-o-unwrapped.src}/crictl.yaml";
 
-    environment.etc."crio/crio.conf.d/00-default.conf".text = ''
-      [crio]
-      storage_driver = "${cfg.storageDriver}"
+    virtualisation.cri-o.settings.crio = {
+      storage_driver = cfg.storageDriver;
 
-      [crio.image]
-      ${optionalString (cfg.pauseImage != null) ''pause_image = "${cfg.pauseImage}"''}
-      ${optionalString (cfg.pauseCommand != null) ''pause_command = "${cfg.pauseCommand}"''}
+      image = {
+        pause_image = lib.mkIf (cfg.pauseImage != null) cfg.pauseImage;
+        pause_command = lib.mkIf (cfg.pauseCommand != null) cfg.pauseCommand;
+      };
 
-      [crio.network]
-      plugin_dirs = ["${pkgs.cni-plugins}/bin/"]
-      ${optionalString (cfg.networkDir != null) ''network_dir = "${cfg.networkDir}"''}
+      network = {
+        plugin_dirs = [ "${pkgs.cni-plugins}/bin" ];
+        network_dir = lib.mkIf (cfg.networkDir != null) cfg.networkDir;
+      };
 
-      [crio.runtime]
-      cgroup_manager = "systemd"
-      log_level = "${cfg.logLevel}"
-      pinns_path = "${cfg.package}/bin/pinns"
-      hooks_dir = [
-      ${lib.optionalString config.virtualisation.containers.ociSeccompBpfHook.enable
-        ''"${config.boot.kernelPackages.oci-seccomp-bpf-hook}",''}
-      ]
+      runtime = {
+        cgroup_manager = "systemd";
+        log_level = cfg.logLevel;
+        manage_ns_lifecycle = true;
+        pinns_path = "${cfg.package}/bin/pinns";
+        hooks_dir =
+          optional (config.virtualisation.containers.ociSeccompBpfHook.enable)
+            config.boot.kernelPackages.oci-seccomp-bpf-hook;
 
-      ${optionalString (cfg.runtime != null) ''
-      default_runtime = "${cfg.runtime}"
-      [crio.runtime.runtimes]
-      [crio.runtime.runtimes.${cfg.runtime}]
-      ''}
-    '';
+        default_runtime = lib.mkIf (cfg.runtime != null) cfg.runtime;
+        runtimes = lib.mkIf (cfg.runtime != null) {
+          "${cfg.runtime}" = { };
+        };
+      };
+    };
 
     environment.etc."cni/net.d/10-crio-bridge.conf".source = utils.copyFile "${pkgs.cri-o-unwrapped.src}/contrib/cni/10-crio-bridge.conf";
     environment.etc."cni/net.d/99-loopback.conf".source = utils.copyFile "${pkgs.cri-o-unwrapped.src}/contrib/cni/99-loopback.conf";
+    environment.etc."crio/crio.conf.d/00-default.conf".source = cfgFile;
 
     # Enable common /etc/containers configuration
     virtualisation.containers.enable = true;
@@ -139,6 +153,7 @@ in
         TimeoutStartSec = "0";
         Restart = "on-abnormal";
       };
+      restartTriggers = [ cfgFile ];
     };
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This migrates the `virtualisation.cri-o` module to use an [RFC42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant `settings` option.

Previously, the only way to set CRI-O settings was to add a drop-in using `environment.etc`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
