### PR TITLE
rq: drop v8 input

### DIFF
--- a/pkgs/development/tools/rq/default.nix
+++ b/pkgs/development/tools/rq/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, libiconv, llvmPackages, v8 }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rq";
@@ -13,19 +13,11 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0071q08f75qrxdkbx1b9phqpbj15r79jbh391y32acifi7hr35hj";
 
-  buildInputs = [ llvmPackages.libclang v8 ]
-  ++ lib.optionals stdenv.isDarwin [ libiconv ];
-
   postPatch = ''
     # Remove #[deny(warnings)] which is equivalent to -Werror in C.
     # Prevents build failures when upgrading rustc, which may give more warnings.
     substituteInPlace src/lib.rs \
       --replace "#![deny(warnings)]" ""
-  '';
-
-  configurePhase = ''
-    export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib"
-    export V8_SOURCE="${v8}"
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8489,9 +8489,7 @@ in
 
   routino = callPackage ../tools/misc/routino { };
 
-  rq = callPackage ../development/tools/rq {
-    inherit (darwin) libiconv;
-  };
+  rq = callPackage ../development/tools/rq { };
 
   rs-git-fsmonitor = callPackage ../applications/version-management/git-and-tools/rs-git-fsmonitor { };
 


### PR DESCRIPTION
###### Motivation for this change
As pointed out in [its README](https://github.com/dflemstr/rq/blob/1427ea8d93fa4d97e88458288f05e2b7d0b24149/README.md), current versions of rq no longer ship with or require v8 (the jq-like query functionality is no longer present)

It also seems to build without `LIBCLANG_PATH` set; I assume that was related to v8 as well. 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
