### PR TITLE
nixos/qemu-vm: load nix db if boot via bootloader

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2047,6 +2047,12 @@
     github = "brianmcgee";
     githubId = 1173648;
   };
+  brprice = {
+    name = "Ben Price";
+    email = "ben-nixos@brprice.uk";
+    github = "brprice";
+    githubId = 5623458;
+  };
   Br1ght0ne = {
     email = "brightone@protonmail.com";
     github = "Br1ght0ne";

--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -98,10 +98,10 @@ There are a few special NixOS options for test VMs:
 
 `virtualisation.writableStore`
 
-:   By default, the Nix store in the VM is not writable. If you enable
-    this option, a writable union file system is mounted on top of the
-    Nix store to make it appear writable. This is necessary for tests
-    that run Nix operations that modify the store.
+:   By default, the Nix store in the VM is writable - a writable union
+    file system is mounted on top of the shared host Nix store to make
+    it appear writable. This is necessary for tests that run Nix
+    operations that modify the store.
 
 For more options, see the module
 [`qemu-vm.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/qemu-vm.nix).

--- a/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
+++ b/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
@@ -137,11 +137,10 @@ nixos-lib.runTest {
         </term>
         <listitem>
           <para>
-            By default, the Nix store in the VM is not writable. If you
-            enable this option, a writable union file system is mounted
-            on top of the Nix store to make it appear writable. This is
-            necessary for tests that run Nix operations that modify the
-            store.
+            By default, the Nix store in the VM is writable - a writable
+            union file system is mounted on top of the shared host Nix
+            store to make it appear writable. This is necessary for
+            tests that run Nix operations that modify the store.
           </para>
         </listitem>
       </varlistentry>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -319,11 +319,14 @@
       </para>
 
       <para>
-       The VM mounts the Nix store of the host through the 9P file system. The
-       host Nix store is read-only, so Nix commands that modify the Nix store
-       will not work in the VM. This includes commands such as
-       <command>nixos-rebuild</command>; to change the VM’s configuration,
-       you must halt the VM and re-run the commands above.
+       The VM mounts the Nix store of the host through the 9P file system.
+       The host Nix store is read-only. Depending on the value of the
+       configuration's <literal>virtualisation.writableStore</literal>, a
+       writable overlay may be added so that Nix commands that modify the Nix
+       store can work in the VM. (Note that this includes commands such as
+       <command>nixos-rebuild</command>; if this setting is
+       <literal>false</literal> then to change the VM’s configuration, you must
+       halt the VM and re-run the commands above.
       </para>
 
       <para>

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -284,6 +284,10 @@ let
           export NIXOS_INSTALL_BOOTLOADER=1
           ${config.system.build.toplevel}/bin/switch-to-configuration boot
 
+          # Record the nix db to load on boot (underlying nix store is shared with host)
+          # This is a poor man's symlink, as the /boot fs doesn't support true symlinks
+          echo "${regInfo}/registration" > /boot/regInfo
+
           umount /boot
         '' # */
     );
@@ -905,17 +909,31 @@ in
 
     # After booting, register the closure of the paths in
     # `virtualisation.additionalPaths' in the Nix database in the VM.  This
-    # allows Nix operations to work in the VM.  The path to the
-    # registration file is passed through the kernel command line to
-    # allow `system.build.toplevel' to be included.  (If we had a direct
-    # reference to ${regInfo} here, then we would get a cyclic
-    # dependency.)
-    boot.postBootCommands = lib.mkIf config.nix.enable
+    # allows Nix operations to work in the VM.
+    # When running without a bootloader, the path to the registration file is
+    # passed through the kernel command line to allow `system.build.toplevel'
+    # to be included.  (If we had a direct reference to ${regInfo} here, then
+    # we would get a cyclic dependency.)
+    # When running with a bootloader, we instead pass through a file in /boot,
+    # which is loaded by systemd after the fs is mounted. (This is to support
+    # both systemd-boot and grub.)
+    boot.postBootCommands = lib.mkIf (config.nix.enable && !cfg.useBootLoader)
       ''
         if [[ "$(cat /proc/cmdline)" =~ regInfo=([^ ]*) ]]; then
           ${config.nix.package.out}/bin/nix-store --load-db < ''${BASH_REMATCH[1]}
         fi
       '';
+
+    systemd.services.nix-load-db = lib.mkIf (config.nix.enable && cfg.useBootLoader) {
+        description = "Load nix db shared by host";
+        wantedBy = [ "default.target" ];
+        wants = ["boot.mount"];
+        after = ["boot.mount"];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "/bin/sh -c 'cat $(cat /boot/regInfo) | ${config.nix.package.out}/bin/nix-store --load-db'";
+        };
+      };
 
     boot.initrd.availableKernelModules =
       optional cfg.writableStore "overlay"

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1,11 +1,14 @@
 # This module creates a virtual machine from the NixOS configuration.
 # Building the `config.system.build.vm' attribute gives you a command
 # that starts a KVM/QEMU VM running the NixOS configuration defined in
-# `config'.  The Nix store is shared read-only with the host, which
-# makes (re)building VMs very efficient.  However, it also means you
-# can't reconfigure the guest inside the guest - you need to rebuild
-# the VM in the host.  On the other hand, the root filesystem is a
-# read/writable disk image persistent across VM reboots.
+# `config'.  The host's Nix store is shared read-only with the guest,
+# which makes (re)building VMs very efficient.  If
+# `virtualisation.writableStore` is `true` (the default), then an
+# overlay filesystem will be added to make the guest's store writable.
+# Note that if `writableStore = false`, you can't reconfigure the
+# guest inside the guest - you need to rebuild the VM in the host.  On
+# the other hand, the root filesystem is a read/writable disk image
+# persistent across VM reboots.
 
 { config, lib, pkgs, options, ... }:
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -710,6 +710,7 @@ in {
   victoriametrics = handleTest ./victoriametrics.nix {};
   vikunja = handleTest ./vikunja.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
+  vm = handleTest ./vm.nix {};
   vscodium = discoverTests (import ./vscodium.nix);
   vsftpd = handleTest ./vsftpd.nix {};
   warzone2100 = handleTest ./warzone2100.nix {};

--- a/nixos/tests/vm.nix
+++ b/nixos/tests/vm.nix
@@ -1,0 +1,37 @@
+{ system, pkgs }:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+let testStoreSharing = { useBootLoader, initrdSystemd }: makeTest  {
+  name = "vm";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ brprice ];
+  };
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      imports = [ ../modules/virtualisation/qemu-vm.nix ];
+      virtualisation.useBootLoader = useBootLoader;
+      boot.initrd.systemd.enable = initrdSystemd;
+    };
+
+  testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("current-system roots"):
+          machine.succeed("nix-store --query /run/current-system --roots | grep -q -F '/run/current-system'")
+
+      with subtest("all roots"):
+          machine.succeed("test $(nix-store --gc --print-roots | wc -l) -ge 1")
+
+      with subtest("dump db"):
+          machine.succeed("test $(nix-store --dump-db | wc -l) -ge 1")
+  '';
+};
+in
+{
+  noBootLoader = testStoreSharing {useBootLoader = false; initrdSystemd = false;};
+  withBootLoader = testStoreSharing {useBootLoader = true; initrdSystemd = false;};
+  noBootLoaderInitrdSystemd = testStoreSharing {useBootLoader = false; initrdSystemd = true;};
+  withBootLoaderInitrdSystemd = testStoreSharing {useBootLoader = true; initrdSystemd = true;};
+}


### PR DESCRIPTION
###### Motivation for this change
Previously, we only loaded the host's shared DB when booting the kernel
directly, since this information was transmitted via the kernel command
line given to QEMU. We now also load this when booting via a bootloader.

This fixes #128216

###### Things done
This is implemented via recording the path to load in the /boot
partition, and then loading it via a systemd unit. Thus it is
independent of whether we choose (e.g.) systemd-boot or grub, as opposed
to the strategy of manually mangling the kernel parameters in the
bootloader configuration.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
