### PR TITLE
nixos-rebuild: print run-*-vm location with bootloader

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -519,7 +519,7 @@ if [ "$action" = switch -o "$action" = boot -o "$action" = test -o "$action" = d
 fi
 
 
-if [ "$action" = build-vm ]; then
+if [ "$action" = build-vm -o "$action" = build-vm-with-bootloader ]; then
     cat >&2 <<EOF
 
 Done.  The virtual machine can be started by running $(echo $pathToConfig/bin/run-*-vm)


### PR DESCRIPTION
###### Motivation for this change
Previously when doing a `nixos-rebuild build-vm`we see a message saying how to run the VM, but with `nixos-rebuild build-vm-with-bootloader` we did not.

The status quo has an unfortunate effect with https://github.com/NixOS/nixpkgs/pull/126960 (with flakes, `nixos-rebuild` does not create `result` symlinks) not having landed on 21.05 yet (though it is in master) causing it to be really hard to find the build products!

###### Things done
We now show it in both cases, with a minor edit to `nixos-rebuild.sh`.

I have only tested a rebased onto 21.05 version, as the only way I could figure out how to do so with a flaked configuration.nix was to rebuild my system against the nixpkgs with the patch. Running a `nix shell .#nixos-rebuild -c nixos-rebuild build-vm-with-bootloader` brings up `error: 'flake' is not a recognised command`, presumably because it is running against a `nix` which does not have flakes enabled.