### PR TITLE
lutris: add extraLibraries/extraPkgs args

### DIFF
--- a/pkgs/applications/misc/lutris/fhsenv.nix
+++ b/pkgs/applications/misc/lutris/fhsenv.nix
@@ -1,4 +1,6 @@
 { lib, buildFHSUserEnv, lutris-unwrapped
+, extraPkgs ? pkgs: [ ]
+, extraLibraries ? pkgs: [ ]
 , steamSupport ? true
 }:
 
@@ -87,7 +89,8 @@ in buildFHSUserEnv {
     soundfont-fluid bzip2 game-music-emu
   ] ++ qt5Deps pkgs
     ++ gnomeDeps pkgs
-    ++ lib.optional steamSupport pkgs.steam;
+    ++ lib.optional steamSupport pkgs.steam
+    ++ extraPkgs pkgs;
 
   multiPkgs = pkgs: with pkgs; [
     # Common
@@ -110,7 +113,8 @@ in buildFHSUserEnv {
 
     # Winetricks
     fribidi
-  ] ++ xorgDeps pkgs;
+  ] ++ xorgDeps pkgs
+    ++ extraLibraries pkgs;
 
   extraInstallCommands = ''
     mkdir -p $out/share


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

steam has extraLibraries and extraPkgs arguments which allow the user
to define additional libraries and software which may be required to
run their Steam software.

This commit simply add the same mechanic to lutris.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
