### PR TITLE
python3Packages.pync: enable for python3 and update checkInputs

### DIFF
--- a/pkgs/development/python-modules/pync/default.nix
+++ b/pkgs/development/python-modules/pync/default.nix
@@ -1,22 +1,23 @@
 { lib, stdenv
 , buildPythonPackage
 , fetchPypi
-, isPy27
 , python-dateutil
 , pkgs
+, coreutils
+, which
 }:
 
 buildPythonPackage rec {
   version  = "2.0.3";
   pname = "pync";
-  disabled = ! isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "38b9e61735a3161f9211a5773c5f5ea698f36af4ff7f77fa03e8d1ff0caa117f";
   };
 
-  buildInputs = [ pkgs.coreutils ];
+  nativeBuildInputs = [ coreutils ];
+  checkInputs = [ which ];
   propagatedBuildInputs = [ python-dateutil ];
 
   preInstall = lib.optionalString stdenv.isDarwin ''
@@ -25,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python Wrapper for Mac OS 10.8 Notification Center";
-    homepage    = "https://pypi.python.org/pypi/pync/1.4";
+    homepage    = "https://pypi.python.org/pypi/pync";
     license     = licenses.mit;
     platforms   = platforms.darwin;
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6276,7 +6276,9 @@ in {
 
   pynanoleaf = callPackage ../development/python-modules/pynanoleaf { };
 
-  pync = callPackage ../development/python-modules/pync { };
+  pync = callPackage ../development/python-modules/pync {
+    inherit (pkgs) coreutils which;
+  };
 
   pynest2d = callPackage ../development/python-modules/pynest2d { };
 


### PR DESCRIPTION
Enable pync for Python 3 and add the which package to test dependencies
so that pync's tests pass.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

pync cannot currently be installed since it is disabled for all Python versions
except 2.7. It also fails its unit tests because it cannot find "which".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
