### PR TITLE
pynac: 0.7.27 -> 0.7.29

### DIFF
--- a/pkgs/applications/science/math/pynac/default.nix
+++ b/pkgs/applications/science/math/pynac/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , autoreconfHook
 , pkg-config
 , flint
@@ -11,56 +10,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.27";
+  version = "0.7.29";
   pname = "pynac";
 
   src = fetchFromGitHub {
     owner = "pynac";
     repo = "pynac";
     rev = "pynac-${version}";
-    sha256 = "sha256-1HHCIeaNE2UsJNX92UlDGLJS8I4nC/8FnwX7Y4F9HpU=";
+    sha256 = "sha256-ocR7emXtKs+Xe2f6dh4xEDAacgiolY8mtlLnWnNBS8A=";
   };
-
-  patches = [
-    # the five patches below are included with sage 9.3. since pynac
-    # is a self-described "Sage Math support library", we include them
-    # here.
-
-    # https://trac.sagemath.org/ticket/30688
-    (fetchpatch {
-      name = "power_inf_loop.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/pynac/patches/power_inf_loop.patch?h=9.3";
-      sha256 = "sha256-VYeaJl8u2wl7FQ/6xnpZv1KpdNYEmJoPhuMrBADyTRs=";
-    })
-
-    # https://trac.sagemath.org/ticket/31479
-    (fetchpatch {
-      name = "disable_poly_mul_expand.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/pynac/patches/disable_poly_mul_expand.patch?h=9.3";
-      sha256 = "sha256-gRjoltU9Tzj7fjNyE25fY+iyDxERzSTOMigzxFpUqPo=";
-    })
-
-    # https://trac.sagemath.org/ticket/31530
-    (fetchpatch {
-      name = "too_much_sub.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/pynac/patches/too_much_sub.patch?h=9.3";
-      sha256 = "sha256-lw7xSQ/l+rzPu+ghWF4omYF0mKksGGPuuHJTktvbdis=";
-    })
-
-    # https://trac.sagemath.org/ticket/31554
-    (fetchpatch {
-      name = "handle_factor.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/pynac/patches/handle_factor.patch?h=9.3";
-      sha256 = "sha256-U1lb5qwBqZZgklfDMhBX4K5u8bz5x42O4w7hyNy2YVw=";
-    })
-
-    # https://trac.sagemath.org/ticket/31645
-    (fetchpatch {
-      name = "seriesbug.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/pynac/patches/seriesbug.patch?h=9.3";
-      sha256 = "sha256-b3//oirN7JHDYqrvE+tDYcnKpSYQJ08yBzcNlII2Dts=";
-    })
-  ];
 
   buildInputs = [
     flint
@@ -84,7 +42,7 @@ stdenv.mkDerivation rec {
       of the full GiNaC, and it is *only* meant to be used as a Python library.
     '';
     homepage    = "http://pynac.org";
-    license = licenses.gpl3;
+    license = licenses.gpl2Plus;
     maintainers = teams.sage.members;
     platforms   = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Upstream update. Allows us to remove a few patches. Also fixed the license to GPL2+ (to match the comments in [every source file](https://github.com/pynac/pynac/blob/master/ginac/ginac.h#L10)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
