### PR TITLE
debugedit-unstable: init at e04296ddf / 2021-07-05

### DIFF
--- a/pkgs/development/tools/misc/debugedit/default.nix
+++ b/pkgs/development/tools/misc/debugedit/default.nix
@@ -1,0 +1,30 @@
+#TODO@deliciouslytyped The tool seems to unnecessarily force mutable access for the debugedit `-l` feature
+{fetchgit, lib, stdenv, autoreconfHook, pkg-config, elfutils, help2man, util-linux}:
+stdenv.mkDerivation {
+  name = "debugedit";
+  version = "unstable-2021-07-05";
+
+  nativeBuildInputs = [ autoreconfHook pkg-config help2man ];
+  buildInputs = [ elfutils ];
+  checkInputs = [ util-linux ]; # Tests use `rev`
+
+  src = fetchgit {
+    url = "git://sourceware.org/git/debugedit.git";
+    rev = "e04296ddf34cbc43303d7af32ab3a73ac20af51a";
+    sha256 = "19cjkpzhdn2z6fl7xw8556m6kyrb7nxwbz2rmiv2rynyp74yg44z";
+  };
+
+  preBuild = ''
+    patchShebangs scripts/find-debuginfo.in
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Provides programs and scripts for creating debuginfo and source file distributions, collect build-ids and rewrite source paths in DWARF data for debugging, tracing and profiling";
+    homepage = "https://sourceware.org/debugedit/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ deliciouslytyped ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4009,6 +4009,8 @@ in
 
   debootstrap = callPackage ../tools/misc/debootstrap { };
 
+  debugedit-unstable = callPackage ../development/tools/misc/debugedit { };
+
   deer = callPackage ../shells/zsh/zsh-deer { };
 
   delta = callPackage ../applications/version-management/git-and-tools/delta {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds a tool for a limited set of manipulation operations for file paths in debug info sections.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
