### PR TITLE
haskell-updates: add explanation for adding new NixOS/haskell member

### DIFF
--- a/pkgs/development/haskell-modules/HACKING.md
+++ b/pkgs/development/haskell-modules/HACKING.md
@@ -287,3 +287,26 @@ Here are some additional tips that didn't fit in above.
 
 -   The Haskell team members generally hang out in the Matrix room
     [#haskell:nixos.org](https://matrix.to/#/#haskell:nixos.org).
+
+-   This is a checklist for things that need to happen when a new
+    member is added to the Nixpkgs Haskell team.
+
+    1.  Add the person to the
+        [@NixOS/haskell](https://github.com/orgs/NixOS/teams/haskell)
+        team.  You may need to ask someone in the NixOS organization
+        to do this, like [@domenkozar](https://github.com/domenkozar).
+        This gives the new member access to repos like
+        [cabal2nix](https://github.com/NixOS/cabal2nix).
+
+    1.  Add the person to the `haskell` team in
+        [`maintainers/team-list.nix`](../../../maintainers/team-list.nix).
+        This team is responsible for some important packages in
+        [release-haskell.nix](../../top-level/release-haskell.nix).
+
+    1.  Update the
+        [Nextcloud Calendar](https://cloud.maralorn.de/apps/calendar/p/Mw5WLnzsP7fC4Zky)
+        and work the new member into the `haskell-updates` rotation.
+
+    1.  Optionally, have the new member add themselves to the Haskell
+        section in [`CODEOWNERS`](../../../.github/CODEOWNERS).  This
+        will cause them to get pinged on most Haskell-related PRs.


### PR DESCRIPTION
###### Motivation for this change

This PR adds a checklist for what we need to do when we add a new member to @NixOS/haskell.

It looks like we forgot to add @expipiplus1 to `maintainers/team-list.nix`, so I just wanted to make sure we had an easy checklist to reference so we won't forget in the future.

(I went ahead and added @expipiplus1 to the team-list in b939816cb7a on https://github.com/NixOS/nixpkgs/pull/130424.)