### PR TITLE
python3Packages.pyvicare: 0.2.5 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/pyvicare/default.nix
+++ b/pkgs/development/python-modules/pyvicare/default.nix
@@ -1,29 +1,43 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
 , requests_oauthlib
 , simplejson
+, pkce
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pyvicare";
-  version = "0.2.5";
+  version = "1.0.0";
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    pname = "PyViCare";
-    inherit version;
-    sha256 = "16wqqjs238ad6znlz2gjadqj8891226bd02a1106xyz6vbbk2gdk";
+  src = fetchFromGitHub {
+    owner = "somm15";
+    repo = "PyViCare";
+    rev = version;
+    sha256 = "05dlasx18fkmh4z1w8550yrb26fmsb5bc73wr9whmkasm32gpfl1";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [
     requests_oauthlib
     simplejson
+    pkce
   ];
 
-  # The published tarball on PyPI is incomplete and there are GitHub releases
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "version_config=True," 'version="${version}",' \
+      --replace "'setuptools-git-versioning'" " "
+  '';
+
   pythonImportsCheck = [ "PyViCare" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.0

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
