### PR TITLE
ghc: mark broken for musl + integer-simple builds

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.4.nix
+++ b/pkgs/development/compilers/ghc/8.10.4.nix
@@ -309,6 +309,10 @@ stdenv.mkDerivation (rec {
     maintainers = with lib.maintainers; [ marcweber andres peti ];
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
+
+    # integer-simple builds are broken when GHC links against musl.
+    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
+    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -319,6 +319,10 @@ stdenv.mkDerivation (rec {
     maintainers = with lib.maintainers; [ marcweber andres peti ];
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
+
+    # integer-simple builds are broken when GHC links against musl.
+    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
+    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
   dontStrip = (targetPlatform.useAndroidPrebuilt || targetPlatform.isWasm);

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -296,6 +296,10 @@ stdenv.mkDerivation (rec {
     maintainers = with lib.maintainers; [ marcweber andres peti ];
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
+
+    # integer-simple builds are broken when GHC links against musl.
+    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
+    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -81,8 +81,37 @@ let
 
   recursiveUpdateMany = builtins.foldl' lib.recursiveUpdate {};
 
+  # Remove multiple elements from a list at once.
+  #
+  # removeMany
+  #   :: [a]  -- list of elements to remove
+  #   -> [a]  -- list of elements from which to remove
+  #   -> [a]
+  #
+  # > removeMany ["aarch64-linux" "x86_64-darwin"] ["aarch64-linux" "x86_64-darwin" "x86_64-linux"]
+  # ["x86_64-linux"]
   removeMany = itemsToRemove: list: lib.foldr lib.remove list itemsToRemove;
 
+  # Recursively remove platforms from the values in an attribute set.
+  #
+  # removePlatforms
+  #   :: [String]
+  #   -> AttrSet
+  #   -> AttrSet
+  #
+  # > attrSet = {
+  #     foo = ["aarch64-linux" "x86_64-darwin" "x86_64-linux"];
+  #     bar.baz = ["aarch64-linux" "x86_64-linux"];
+  #     bar.quux = ["aarch64-linux" "x86_64-darwin"];
+  #   }
+  # > removePlatforms ["aarch64-linux" "x86_64-darwin"] attrSet
+  # {
+  #   foo = ["x86_64-linux"];
+  #   bar = {
+  #     baz = ["x86_64-linux"];
+  #     quux = [];
+  #   };
+  # }
   removePlatforms = platformsToRemove: packageSet:
     lib.mapAttrsRecursive
       (_: val:

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -321,13 +321,24 @@ let
           ];
         };
         constituents = [
+          # aarch64-linux
+          #
+          # TODO: Times out on Hydra
+          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.aarch64-linux
+          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.aarch64-linux
+          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.aarch64-linux
+
+          # x86_64-darwin
+          #
           # TODO: reenable darwin builds if static libiconv works
+          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.x86_64-darwin
+          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.x86_64-darwin
+          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.x86_64-darwin
+
+          # x86_64-linux
           jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.x86_64-linux
-          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.aarch64-linux
           jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.x86_64-linux
-          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.aarch64-linux
           jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.x86_64-linux
-          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.aarch64-linux
         ];
       };
     }

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -258,8 +258,14 @@ let
       pkgsMusl.haskellPackages =
         removePlatforms
           [
-            "aarch64-linux" # aarch64 does not appear to be supported
-            "x86_64-darwin" # musl only supports linux
+            # pkgsMusl is compiled natively with musl.  It is not
+            # cross-compiled (unlike pkgsStatic).  We can only
+            # natively bootstrap GHC with musl on x86_64-linux because
+            # upstream doesn't provide a musl bindist for aarch64.
+            "aarch64-linux"
+
+            # musl only supports linux, not darwin.
+            "x86_64-darwin"
           ]
           {
             inherit (packagePlatforms pkgs.pkgsMusl.haskellPackages)

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -294,6 +294,23 @@ let
             (name: jobs.haskellPackages."${name}")
             (maintainedPkgNames pkgs.haskellPackages));
       };
+
+      muslGHCs = pkgs.releaseTools.aggregate {
+        name = "haskell-pkgsMusl-ghcs";
+        meta = {
+          description = "GHCs built with musl";
+          maintainers = with lib.maintainers; [
+            nh2
+          ];
+        };
+        constituents = accumulateDerivations [
+          jobs.pkgsMusl.haskell.compiler.ghc8102Binary
+          jobs.pkgsMusl.haskell.compiler.ghc884
+          jobs.pkgsMusl.haskell.compiler.ghc8104
+          jobs.pkgsMusl.haskell.compiler.ghc901
+        ];
+      };
+
       staticHaskellPackages = pkgs.releaseTools.aggregate {
         name = "static-haskell-packages";
         meta = {
@@ -311,21 +328,6 @@ let
           jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.aarch64-linux
           jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.x86_64-linux
           jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.aarch64-linux
-        ];
-      };
-      muslGHCs = pkgs.releaseTools.aggregate {
-        name = "haskell-pkgsMusl-ghcs";
-        meta = {
-          description = "GHCs built with musl";
-          maintainers = with lib.maintainers; [
-            nh2
-          ];
-        };
-        constituents = accumulateDerivations [
-          jobs.pkgsMusl.haskell.compiler.ghc8102Binary
-          jobs.pkgsMusl.haskell.compiler.ghc884
-          jobs.pkgsMusl.haskell.compiler.ghc8104
-          jobs.pkgsMusl.haskell.compiler.ghc901
         ];
       };
     }

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -101,17 +101,6 @@ let
         ghc865Binary = {};
       };
 
-      # test some statically linked packages to catch regressions
-      # and get some cache going for static compilation with GHC
-      # Use integer-simple to avoid GMP linking problems (LGPL)
-      pkgsStatic.haskell.packages.integer-simple.ghc8104 = {
-        inherit (staticHaskellPackagesPlatforms)
-          hello
-          random
-          lens
-          ;
-      };
-
       # top-level packages that depend on haskellPackages
       inherit (pkgsPlatforms)
         agda
@@ -218,6 +207,23 @@ let
         ;
 
       elmPackages.elm = pkgsPlatforms.elmPackages.elm;
+
+      # Test some statically linked packages to catch regressions
+      # and get some cache going for static compilation with GHC.
+      # Use integer-simple to avoid GMP linking problems (LGPL)
+      pkgsStatic.haskell.packages.integer-simple.ghc8104 =
+        removePlatforms
+          [
+            "aarch64-linux" # times out on Hydra
+            "x86_64-darwin" # TODO: reenable when static libiconv works on darwin
+          ]
+          {
+            inherit (packagePlatforms pkgs.pkgsStatic.haskell.packages.integer-simple.ghc8104)
+              hello
+              lens
+              random
+              ;
+          };
     })
     (versionedCompilerJobs {
       # Packages which should be checked on more than the

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -94,13 +94,6 @@ let
       nixosTests.agda = (packagePlatforms pkgs.nixosTests).agda;
       agdaPackages = packagePlatforms pkgs.agdaPackages;
 
-      pkgsMusl.haskell.compiler = packagePlatforms pkgs.pkgsMusl.haskell.compiler // {
-        # remove musl ghc865Binary since it is known to be broken and
-        # causes an evaluation error on darwin.
-        # TODO: remove ghc865Binary altogether and use ghc8102Binary
-        ghc865Binary = {};
-      };
-
       # top-level packages that depend on haskellPackages
       inherit (pkgsPlatforms)
         agda
@@ -207,6 +200,18 @@ let
         ;
 
       elmPackages.elm = pkgsPlatforms.elmPackages.elm;
+
+      # GHCs linked to musl.
+      pkgsMusl.haskell.compiler = packagePlatforms pkgs.pkgsMusl.haskell.compiler // {
+        # remove musl ghc865Binary since it is known to be broken and
+        # causes an evaluation error on darwin.
+        # TODO: remove ghc865Binary altogether and use ghc8102Binary
+        ghc865Binary = {};
+
+        # remove integer-simple because it appears to be broken with
+        # musl and non-static-linking.
+        integer-simple = {};
+      };
 
       # Test some statically linked packages to catch regressions
       # and get some cache going for static compilation with GHC.

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -18,18 +18,22 @@ let
   };
 
   inherit (releaseLib)
-    pkgs
-    packagePlatforms
+    lib
     mapTestOn
-    aggregate
+    packagePlatforms
+    pkgs
     ;
 
-  inherit (pkgs) lib;
-
-  # helper function which traverses a (nested) set
+  # Helper function which traverses a (nested) set
   # of derivations produced by mapTestOn and flattens
   # it to a list of derivations suitable to be passed
   # to `releaseTools.aggregate` as constituents.
+  # Removes all non derivations from the input jobList.
+  #
+  # accumulateDerivations :: [ Either Derivation AttrSet ] -> [ Derivation ]
+  #
+  # > accumulateDerivations [ drv1 "string" { foo = drv2; bar = { baz = drv3; }; } ]
+  # [ drv1 drv2 drv3 ]
   accumulateDerivations = jobList:
     lib.concatMap (
       attrs:
@@ -383,25 +387,10 @@ let
             lib.maintainers.rnhmjoj
           ];
         };
-        constituents = [
-          # aarch64-linux
-          #
-          # TODO: Times out on Hydra
-          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.aarch64-linux
-          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.aarch64-linux
-          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.aarch64-linux
-
-          # x86_64-darwin
-          #
-          # TODO: reenable darwin builds if static libiconv works
-          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.x86_64-darwin
-          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.x86_64-darwin
-          # jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.x86_64-darwin
-
-          # x86_64-linux
-          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello.x86_64-linux
-          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens.x86_64-linux
-          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random.x86_64-linux
+        constituents = accumulateDerivations [
+          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.hello
+          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.lens
+          jobs.pkgsStatic.haskell.packages.integer-simple.ghc8104.random
         ];
       };
     }


### PR DESCRIPTION

###### Motivation for this change

This PR correctly marks the GHC musl integer-simple builds as broken.

See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
