### PR TITLE
[21.05] networkmanager: 1.30.4 -> 1.30.6

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.30.4";
+  version = "1.30.6";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "sha256-YFC3JCEuo85zhhEzWb6pr6H2eaVPYNmZpZmYkuZywZA=";
+    sha256 = "sha256-/p+RYUKjgACYu6ECPdEUCHv1O850zc78/wwnxknBHvI=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/1.30.6/NEWS
```
===============================================
NetworkManager-1.30.6
Overview of changes since NetworkManager-1.30.4
===============================================

* By default, don't touch existing traffic control (TC) configuration
  on devices.
* Send ARP announcements only when the interface gets carrier.
* Support the 'peer_notif_delay' bond option.
* Always start DHCPv6 on the default interface when an IPv6 prefix
  delegation is needed.
* Prefer the IPv4 address to determine the system hostname via address
  lookup.
* Support DHCP option 249 (Microsoft classless static route) with the
  internal nettools client.
* Force a restart of hostname resolution via DNS on signal SIGUSR1
  when resolv.conf is not managed by NetworkManager.
* Fix adding duplicate iptables rules for shared mode.
* Fix parsing of Wi-Fi Information Element (IE) for Microsoft Network
  Cost.
* Fix parsing of empty DHCP option 40 (NIS domain name) in the
  internal nettools client.
* Other various bugfixes.
```

I'm opening this directly against 21.05 as there's #127461 for unstable already (update to 1.32.x). If a backport is preferred though, I can close this and reopen 1.30.6 against unstable, and rebase that PR to be a version bump from 1.30.6 instead. But that seemed unnecessary with the other PR already open.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
