### PR TITLE
ocamlPackages.lwt: remove unnecessary dependency on OMP

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchzip, pkg-config, ncurses, libev, buildDunePackage, ocaml
-, cppo, dune-configurator, ocaml-migrate-parsetree, ocplib-endian, result
+, cppo, dune-configurator, ocplib-endian, result
 , mmap, seq
 , ocaml-syntax-shims
 }:
@@ -18,7 +18,7 @@ buildDunePackage rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ cppo dune-configurator ocaml-migrate-parsetree ]
+  buildInputs = [ cppo dune-configurator ]
    ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -618,9 +618,7 @@ let
       inherit (pkgs) file;
     };
 
-    lwt = callPackage ../development/ocaml-modules/lwt {
-      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2;
-    };
+    lwt = callPackage ../development/ocaml-modules/lwt { };
 
     lwt-canceler = callPackage ../development/ocaml-modules/lwt-canceler { };
 


### PR DESCRIPTION
###### Motivation for this change

Cleaning.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
