### PR TITLE
yandex-disk: 0.1.5.1039 -> 0.1.6.1074

### DIFF
--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -4,12 +4,12 @@ let
   p = if stdenv.is64bit then {
       arch = "x86_64";
       gcclib = "${stdenv.cc.cc.lib}/lib64";
-      sha256 = "d61bf5c9bd285246f0e47fa529049e21cc187eb3";
+      sha256 = "e4f579963199f05476657f0066beaa32d1261aef2203382f3919e1ed4bc4594e";
     }
     else {
       arch = "i386";
       gcclib = "${stdenv.cc.cc.lib}/lib";
-      sha256 = "929f530a7b31f95a7ae3e6a2a40c60f2f4f16fee";
+      sha256 = "69113bf33ba0c57a363305b76361f2866c3b8394b173eed0f49db1f50bfe0373";
     };
 in
 stdenv.mkDerivation rec {

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -4,18 +4,18 @@ let
   p = if stdenv.is64bit then {
       arch = "x86_64";
       gcclib = "${stdenv.cc.cc.lib}/lib64";
-      sha256 = "14bpc5ddhxvgfxkxhj5q9z443s7z4nn1zf4k1hxj7rbf13rcpg00";
+      sha256 = "d61bf5c9bd285246f0e47fa529049e21cc187eb3";
     }
     else {
       arch = "i386";
       gcclib = "${stdenv.cc.cc.lib}/lib";
-      sha256 = "1s829q8gy9xgz0jm7w70aljqs2h49x402blqfr9zvn806aprmrm5";
+      sha256 = "929f530a7b31f95a7ae3e6a2a40c60f2f4f16fee";
     };
 in
 stdenv.mkDerivation rec {
 
   pname = "yandex-disk";
-  version = "0.1.5.1039";
+  version = "0.1.6.1074-1";
 
   src = fetchurl {
     url = "https://repo.yandex.ru/yandex-disk/rpm/stable/${p.arch}/${pname}-${version}-1.fedora.${p.arch}.rpm";

--- a/pkgs/tools/filesystems/yandex-disk/default.nix
+++ b/pkgs/tools/filesystems/yandex-disk/default.nix
@@ -15,7 +15,7 @@ in
 stdenv.mkDerivation rec {
 
   pname = "yandex-disk";
-  version = "0.1.6.1074-1";
+  version = "0.1.6.1074";
 
   src = fetchurl {
     url = "https://repo.yandex.ru/yandex-disk/rpm/stable/${p.arch}/${pname}-${version}-1.fedora.${p.arch}.rpm";


### PR DESCRIPTION
###### Motivation for this change

Yandex have removed the old `.rpm` from their servers, so in order to install it, I needed to do a version bump. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
