### PR TITLE
blocksat-cli: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/blocksat-cli/default.nix
+++ b/pkgs/development/python-modules/blocksat-cli/default.nix
@@ -1,0 +1,49 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, distro
+, pysnmp
+, python-gnupg
+, qrcode
+, requests
+, sseclient-py
+, zfec
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "blocksat-cli";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06ky5kahh8dm1d7ckid3fdwizvkh3g4aycm39r00kwxdlfca7bgf";
+  };
+
+  propagatedBuildInputs = [
+    distro
+    pysnmp
+    python-gnupg
+    qrcode
+    requests
+    sseclient-py
+    zfec
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [
+    # disable tests which require being connected to the satellite
+    "--ignore=blocksatcli/test_satip.py"
+    "--ignore=blocksatcli/api/test_net.py"
+    # disable tests which require being online
+    "--ignore=blocksatcli/api/test_order.py"
+  ];
+
+  meta = with lib; {
+    description = "Blockstream Satellite CLI";
+    homepage = "https://github.com/Blockstream/satellite";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/pyutil/default.nix
+++ b/pkgs/development/python-modules/pyutil/default.nix
@@ -1,9 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, setuptoolsDarcs
-, setuptoolsTrial
 , simplejson
+, mock
 , twisted
 , isPyPy
 }:
@@ -17,12 +16,9 @@ buildPythonPackage rec {
     sha256 = "8c4d4bf668c559186389bb9bce99e4b1b871c09ba252a756ccaacd2b8f401848";
   };
 
-  buildInputs = [ setuptoolsDarcs setuptoolsTrial ] ++ (if doCheck then [ simplejson ] else []);
-  propagatedBuildInputs = [ twisted ];
+  propagatedBuildInputs = [ simplejson ];
 
-  # Tests fail because they try to write new code into the twisted
-  # package, apparently some kind of plugin.
-  doCheck = false;
+  checkInputs = [ mock twisted ];
 
   prePatch = lib.optionalString isPyPy ''
     grep -rl 'utf-8-with-signature-unix' ./ | xargs sed -i -e "s|utf-8-with-signature-unix|utf-8|g"
@@ -41,8 +37,9 @@ buildPythonPackage rec {
       we're not alone in wanting tools like these.
     '';
 
-    homepage = "http://allmydata.org/trac/pyutil";
+    homepage = "https://github.com/tpltnt/pyutil";
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ prusnak ];
   };
 
 }

--- a/pkgs/development/python-modules/zfec/default.nix
+++ b/pkgs/development/python-modules/zfec/default.nix
@@ -1,8 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, setuptoolsDarcs
 , pyutil
+, setuptoolsTrial
+, twisted
 }:
 
 buildPythonPackage rec {
@@ -14,8 +15,9 @@ buildPythonPackage rec {
     sha256 = "6033b2f3cc3edacf3f7eeed5f258c1ebf8a1d7e5e35b623db352512ce564e5ca";
   };
 
-  buildInputs = [ setuptoolsDarcs ];
   propagatedBuildInputs = [ pyutil ];
+
+  checkInputs = [ setuptoolsTrial twisted ];
 
   # argparse is in the stdlib but zfec doesn't know that.
   postPatch = ''
@@ -23,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = "http://allmydata.org/trac/zfec";
+    homepage = "https://github.com/tahoe-lafs/zfec";
     description = "Zfec, a fast erasure codec which can be used with the command-line, C, Python, or Haskell";
     longDescription = ''
       Fast, portable, programmable erasure coding a.k.a. "forward
@@ -34,6 +36,7 @@ buildPythonPackage rec {
       and Haskell API.
     '';
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ prusnak ];
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1333,6 +1333,8 @@ in
 
   blockbench-electron = callPackage ../applications/graphics/blockbench-electron { };
 
+  blocksat-cli = with python3Packages; toPythonApplication blocksat-cli;
+
   bmap-tools = callPackage ../tools/misc/bmap-tools { };
 
   bonnmotion = callPackage ../development/tools/misc/bonnmotion { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9470,6 +9470,8 @@ in {
 
   zetup = callPackage ../development/python-modules/zetup { };
 
+  zfec = callPackage ../development/python-modules/zfec { };
+
   zha-quirks = callPackage ../development/python-modules/zha-quirks { };
 
   zict = callPackage ../development/python-modules/zict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1141,6 +1141,8 @@ in {
 
   block-io = callPackage ../development/python-modules/block-io { };
 
+  blocksat-cli = callPackage ../development/python-modules/blocksat-cli { };
+
   blspy = callPackage ../development/python-modules/blspy { };
 
   bluepy = callPackage ../development/python-modules/bluepy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5409,6 +5409,8 @@ in {
 
   python-tado = callPackage ../development/python-modules/python-tado { };
 
+  pyutil = callPackage ../development/python-modules/pyutil { };
+
   pkutils = callPackage ../development/python-modules/pkutils { };
 
   plac = callPackage ../development/python-modules/plac { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- new package for communication with the [Blockstream Satellite](https://blockstream.com/satellite/)
- enable pyutil and zfec packages for Python 3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
