### PR TITLE
Update Android Studio

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -9,9 +9,9 @@ let
     inherit buildFHSUserEnv;
   };
   stableVersion = {
-    version = "4.2.1.0"; # "Android Studio 4.2.1"
-    build = "202.7351085";
-    sha256Hash = "074y6i0h8zamjgvvs882im44clds3g6aq8rssl7sq1wx6hrn5q36";
+    version = "4.2.2.0"; # "Android Studio 4.2.2"
+    build = "202.7486908";
+    sha256Hash = "18zc9xr2xmphj6m6a1ilwripmvqzplp2583afq1pzzz3cv5h8fvk";
   };
   betaVersion = {
     version = "2020.3.1.20"; # "Android Studio Arctic Fox (2020.3.1) Beta 5"

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -14,8 +14,8 @@ let
     sha256Hash = "074y6i0h8zamjgvvs882im44clds3g6aq8rssl7sq1wx6hrn5q36";
   };
   betaVersion = {
-    version = "2020.3.1.16"; # "Android Studio Arctic Fox (2020.3.1) Beta 1"
-    sha256Hash = "0mp1cmxkqc022nv8cggywbwcf8lp6r802nh8hcw5j00hcdnhkcq0";
+    version = "2020.3.1.20"; # "Android Studio Arctic Fox (2020.3.1) Beta 5"
+    sha256Hash = "0swcsjx29ar4b0c8yhbynshqdn2sv94ga58h2nrc99927vp17g85";
   };
   latestVersion = { # canary & dev
     version = "2021.1.1.1"; # "Android Studio Bumblebee (2021.1.1) Canary 1"

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -18,8 +18,8 @@ let
     sha256Hash = "0swcsjx29ar4b0c8yhbynshqdn2sv94ga58h2nrc99927vp17g85";
   };
   latestVersion = { # canary & dev
-    version = "2021.1.1.1"; # "Android Studio Bumblebee (2021.1.1) Canary 1"
-    sha256Hash = "0aavmk8byw817356jm28rl998gcp3zm7x3fq14hm2awzhk5jaklm";
+    version = "2021.1.1.3"; # "Android Studio Bumblebee (2021.1.1) Canary 3"
+    sha256Hash = "1n8iahaqhmzvpps9vhv93n3yabb26vl78yndd6gid028r8r90y4x";
   };
 in {
   # Attributes are named by their corresponding release channels


### PR DESCRIPTION
###### Motivation for this change
This updates the versions of Android Studio for the stable, canary and beta channels to the latest versions as listed [here](https://developer.android.com/studio/archive).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
