### PR TITLE
eureka-editor: 1.21 -> 1.27b

### DIFF
--- a/pkgs/applications/misc/eureka-editor/default.nix
+++ b/pkgs/applications/misc/eureka-editor/default.nix
@@ -1,25 +1,22 @@
-{ lib, stdenv, fetchzip, fltk, zlib, xdg-utils, xorg, libjpeg, libGL }:
+{ lib, stdenv, fetchzip, fltk, zlib, xdg-utils, xorg, libjpeg, libGLU }:
 
 stdenv.mkDerivation rec {
   pname = "eureka-editor";
-  version = "1.21";
-  shortver = "121";
+  version = "1.27b";
+  majorVersion = "1.27";
 
   src = fetchzip {
-    url = "mirror://sourceforge/eureka-editor/Eureka/${version}/eureka-${shortver}-source.tar.gz";
-    sha256 = "0fpj13aq4wh3f7473cdc5jkf1c71jiiqmjc0ihqa0nm3hic1d4yv";
+    url = "mirror://sourceforge/eureka-editor/Eureka/${majorVersion}/eureka-${version}-source.tar.gz";
+    sha256 = "075w7xxsgbgh6dhndc1pfxb2h1s5fhsw28yl1c025gmx9bb4v3bf";
   };
 
-  buildInputs = [ fltk zlib xdg-utils libjpeg xorg.libXinerama libGL ];
+  buildInputs = [ fltk zlib xdg-utils libjpeg xorg.libXinerama libGLU ];
 
   enableParallelBuilding = true;
 
   preBuild = ''
-    substituteInPlace src/main.cc \
-      --replace /usr/local $out
-    substituteInPlace Makefile \
-      --replace /usr/local $out \
-      --replace "-o root " ""
+    substituteInPlace src/main.cc --replace /usr/local $out
+    substituteInPlace Makefile    --replace /usr/local $out
   '';
 
   preInstall = ''
@@ -32,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://eureka-editor.sourceforge.net";
     description = "A map editor for the classic DOOM games, and a few related games such as Heretic and Hexen";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
     broken = stdenv.isDarwin;
     maintainers = with maintainers; [ neonfuz ];

--- a/pkgs/applications/misc/eureka-editor/default.nix
+++ b/pkgs/applications/misc/eureka-editor/default.nix
@@ -3,10 +3,9 @@
 stdenv.mkDerivation rec {
   pname = "eureka-editor";
   version = "1.27b";
-  majorVersion = "1.27";
 
   src = fetchzip {
-    url = "mirror://sourceforge/eureka-editor/Eureka/${majorVersion}/eureka-${version}-source.tar.gz";
+    url = "mirror://sourceforge/eureka-editor/Eureka/${lib.versions.majorMinor version}/eureka-${version}-source.tar.gz";
     sha256 = "075w7xxsgbgh6dhndc1pfxb2h1s5fhsw28yl1c025gmx9bb4v3bf";
   };
 
@@ -14,7 +13,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  preBuild = ''
+  postPatch = ''
     substituteInPlace src/main.cc --replace /usr/local $out
     substituteInPlace Makefile    --replace /usr/local $out
   '';
@@ -31,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "A map editor for the classic DOOM games, and a few related games such as Heretic and Hexen";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
+    badPlatforms = platforms.darwin;
     maintainers = with maintainers; [ neonfuz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump, several new features and improvements.

There is a new main developer since previous release. There has been improvements to openGL rendering. The project seems to use libGLU now instead of libGL so I swapped in that library.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
