### PR TITLE
sshuttle: 1.0.3 -> 1.0.5

### DIFF
--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -11,11 +11,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sshuttle";
-  version = "1.0.3";
+  version = "1.0.5";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0fff1c88669a20bb6a4e7331960673a3a02a2e04ff163e4c9299496646edcf61";
+    sha256 = "fd8c691aac2cb80933aae7f94d9d9e271a820efc5c48e73408f1a90da426a1bd";
   };
 
   patches = [ ./sudo.patch ];
@@ -26,6 +26,8 @@ python3Packages.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [ makeWrapper python3Packages.setuptools-scm ];
+
+  propagatedBuildInputs = [ python3Packages.psutil ];
 
   checkInputs = with python3Packages; [ mock pytestCheckHook flake8 ];
 
@@ -42,7 +44,7 @@ python3Packages.buildPythonApplication rec {
       target network (though it does require Python 2.7, Python 3.5 or later at both ends).
       Works with Linux and Mac OS and supports DNS tunneling.
     '';
-    license = licenses.gpl2;
+    license = licenses.lgpl21;
     maintainers = with maintainers; [ domenkozar carlosdagos ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Get the latest version.

From commit message:

New dependency: psutil
Changed license: LGPL-2.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
