### PR TITLE
ocamlPackages.graphql_ppx: 1.0.1 → 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/graphql_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/graphql_ppx/default.nix
@@ -1,32 +1,37 @@
-{ lib, buildDunePackage, fetchFromGitHub, alcotest, cppo
-, ocaml-migrate-parsetree, ppx_tools_versioned, reason, yojson }:
+{ lib, buildDunePackage, fetchFromGitHub, alcotest, reason
+, ppxlib
+, yojson }:
 
 buildDunePackage rec {
   pname = "graphql_ppx";
-  version = "1.0.1";
+  version = "1.2.0";
 
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "reasonml-community";
     repo = "graphql-ppx";
     rev = "v${version}";
-    sha256 = "0lvmv1sb0ca9mja6di1dbmsgjqgj3w9var4amv1iz9nhwjjx4cpi";
+    sha256 = "1fymmvk616wv5xkwfdmqibdgfl47ry6idc5wfh20a3mz9mpaa13s";
   };
 
-  propagatedBuildInputs =
-    [ cppo ocaml-migrate-parsetree ppx_tools_versioned reason yojson ];
+  buildInputs = [ ppxlib ];
 
-  checkInputs = lib.optional doCheck alcotest;
+  propagatedBuildInputs = [
+    reason
+    yojson
+  ];
 
-  doCheck = false;
+  checkInputs = [ alcotest ];
+
+  doCheck = true;
 
   useDune2 = true;
 
   meta = {
     homepage = "https://github.com/reasonml-community/graphql_ppx";
     description = "GraphQL PPX rewriter for Bucklescript/ReasonML";
-    license = lib.licenses.bsd3;
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Zimmi48 jtcoolen ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Use ppxlib.

cc maintainers @Zimmi48 @jtcoolen 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
