### PR TITLE
totem-pl-parser: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/totem-pl-parser/default.nix
+++ b/pkgs/development/libraries/totem-pl-parser/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, gettext, libxml2, gobject-introspection, gnome }:
+{ lib, stdenv, fetchurl, meson, ninja, pkg-config, gettext, libxml2, gobject-introspection, gnome, glib }:
 
 stdenv.mkDerivation rec {
   pname = "totem-pl-parser";
@@ -16,8 +16,14 @@ stdenv.mkDerivation rec {
     };
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext gobject-introspection ];
-  buildInputs = [ libxml2 ];
+  strictDeps = true;
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config gettext glib gobject-introspection ];
+  buildInputs = [ libxml2 glib ];
+
+  mesonFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "-Dintrospection=false"
+  ];
 
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Apps/Videos";


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation. Disables introspection.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
