### PR TITLE
libgxps: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/libgxps/default.nix
+++ b/pkgs/development/libraries/libgxps/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Denable-test=false"
+  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "-Ddisable-introspection=true"
   ];
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation. Disables introspection.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
