### PR TITLE
gsettings-desktop-schemas: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -19,17 +19,19 @@ stdenv.mkDerivation rec {
     sha256 = "11an29br55dp0b26kfqlrfxj19glfrmhcdpds2n1w9n04gq3pf7i";
   };
 
+  strictDeps = true;
+  depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [
     glib
     meson
     ninja
     pkg-config
     python3
+    gobject-introspection
   ];
 
-  buildInputs = [
-    glib
-    gobject-introspection
+  mesonFlags = [
+    "-Dintrospection=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation. Disable introspection.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
