### PR TITLE
llvmPackages_1[12].llvm: Disable LBR checks for x64_64

### DIFF
--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -19,6 +19,7 @@
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
   || stdenv.isAarch32 # broken for the armv7l builder
+  || stdenv.isx86_64 # broken for AMD Zen2: https://bugs.llvm.org/show_bug.cgi?id=48918
 )
 , enablePolly ? false # TODO should be on by default
 }:

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -19,6 +19,7 @@
 , enablePFM ? !(stdenv.isDarwin
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
   || stdenv.isAarch32 # broken for the armv7l builder
+  || stdenv.isx86_64 # broken for AMD Zen2: https://bugs.llvm.org/show_bug.cgi?id=48918
 )
 , enablePolly ? false
 }:


### PR DESCRIPTION
###### Motivation for this change

LLVM version >=11.0.0 and <=12.0.0 can not be build on an AMD Zen2 architecture. 
The bug is documented upstream in https://bugs.llvm.org/show_bug.cgi?id=48918 and will be fixed with version 12.0.1 . 

Since I did not find a way to override the LLVM Nix expression for the Rust build environment, I propose to deactivate the performance related regression tests, by disabling enablePFM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
