### PR TITLE
treewide: convert phases that contain ":" to dont* = true

### DIFF
--- a/nixos/modules/services/continuous-integration/hercules-ci-agent/common.nix
+++ b/nixos/modules/services/continuous-integration/hercules-ci-agent/common.nix
@@ -105,7 +105,7 @@ let
       pkgs.stdenv.mkDerivation {
         name = "hercules-ci-check-system-nix-src";
         inherit (config.nix.package) src patches;
-        configurePhase = ":";
+        dontConfigure = true;
         buildPhase = ''
           echo "Checking in-memory pathInfoCache expiry"
           if ! grep 'PathInfoCacheValue' src/libstore/store-api.hh >/dev/null; then

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan4_etc_files.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan4_etc_files.nix
@@ -54,8 +54,7 @@ stdenv.mkDerivation {
     ${addAllNetDev netDevices}
   '';
 
-  installPhase = ":";
-
+  dontInstall = true;
   dontStrip = true;
   dontPatchELF = true;
 

--- a/pkgs/applications/editors/emacs/elisp-packages/cedille/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/cedille/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ emacs ];
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     install -d $out/share/emacs/site-lisp

--- a/pkgs/applications/editors/kakoune/plugins/build-kakoune-plugin.nix
+++ b/pkgs/applications/editors/kakoune/plugins/build-kakoune-plugin.nix
@@ -27,7 +27,7 @@ rec {
     });
 
   buildKakounePluginFrom2Nix = attrs: buildKakounePlugin ({
-    buildPhase = ":";
-    configurePhase = ":";
+    dontBuild = true;
+    dontConfigure = true;
   } // attrs);
 }

--- a/pkgs/applications/misc/thinking-rock/default.nix
+++ b/pkgs/applications/misc/thinking-rock/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     chmod +x $out/bin/thinkingrock
   '';
 
-  installPhase = ":";
+  dontInstall = true;
 
   meta = with lib; {
     description = "Task management system";

--- a/pkgs/applications/science/biology/macse/default.nix
+++ b/pkgs/applications/science/biology/macse/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  dontUnpack = true;
   dontBuild = true;
-  unpackPhase = ":";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -226,7 +226,7 @@ in {
       mkdir -p $out/lib/vdr
     '';
 
-    installPhase = ":";
+    dontInstall = true;
 
     meta = with lib; {
       homepage = "https://projects.vdr-developer.org/projects/plg-text2skin";

--- a/pkgs/development/compilers/apache-flex-sdk/default.nix
+++ b/pkgs/development/compilers/apache-flex-sdk/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ jre ];
 
-  buildPhase = ":";
+  dontBuild = true;
 
   postPatch = ''
     shopt -s extglob
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     cp ${playerglobal} $t/frameworks/libs/player/${playerglobal_ver}/playerglobal.swc
   '';
 
-  fixupPhase = ":";
+  dontFixup = true;
 
   meta = with lib; {
     description = "Flex SDK for Adobe Flash / ActionScript";

--- a/pkgs/development/libraries/nanopb/test-message-with-annotations/default.nix
+++ b/pkgs/development/libraries/nanopb/test-message-with-annotations/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/libraries/nanopb/test-message-with-options/default.nix
+++ b/pkgs/development/libraries/nanopb/test-message-with-options/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/libraries/nanopb/test-simple-proto2/default.nix
+++ b/pkgs/development/libraries/nanopb/test-simple-proto2/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/libraries/nanopb/test-simple-proto3/default.nix
+++ b/pkgs/development/libraries/nanopb/test-simple-proto3/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   ];
 
   # pytest-astropy is a meta package and has no tests
-  checkPhase = ":";
+  doCheck = false;
 
   meta = with lib; {
     description = "Meta-package containing dependencies for testing";

--- a/pkgs/development/ruby-modules/with-packages/default.nix
+++ b/pkgs/development/ruby-modules/with-packages/default.nix
@@ -57,7 +57,7 @@ let
       nativeBuildInputs = [ makeWrapper ];
       buildInputs = [ selected ruby ];
 
-      unpackPhase = ":";
+      dontUnpack = true;
 
       installPhase = ''
         for i in ${ruby}/bin/* ${gemEnv}/bin/*; do

--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -17,7 +17,7 @@ mkDerivation rec {
 
   dontUseQmakeConfigure = true;
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     python build.py install --verbose --prefix="$out"

--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation {
   buildInputs = [ tree-sitter ];
 
   dontUnpack = true;
-  configurePhase = ":";
+  dontConfigure = true;
+
   buildPhase = ''
     runHook preBuild
     scanner_cc="$src/src/scanner.cc"

--- a/pkgs/development/web/now-cli/default.nix
+++ b/pkgs/development/web/now-cli/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     gunzip -c $curSrc > now-linux
   '';
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     mkdir $out

--- a/pkgs/misc/apulse/pressureaudio.nix
+++ b/pkgs/misc/apulse/pressureaudio.nix
@@ -8,8 +8,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config intltool autoreconfHook ];
 
   dontConfigure = true;
-
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     echo "Copying libraries from apulse."

--- a/pkgs/os-specific/linux/wooting-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/wooting-udev-rules/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   # Source: https://wooting.helpscoutdocs.com/article/68-wootility-configuring-device-access-for-wootility-under-linux-udev-rules
   src = [ ./wooting.rules ];
 
-  unpackPhase = ":";
+  dontUnpack = true;
 
   installPhase = ''
     install -Dpm644 $src $out/lib/udev/rules.d/70-wooting.rules

--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -12,7 +12,7 @@ let
      inherit src;
      locale = _locale;
      dbName = _name;
-     buildPhase = ":";
+     dontBuild = true;
      unpackPhase = ''
        tar xf  ${src}
      '';

--- a/pkgs/servers/foundationdb/vsmake.nix
+++ b/pkgs/servers/foundationdb/vsmake.nix
@@ -21,7 +21,7 @@ let
     };
 
     dontConfigure = true;
-    buildPhase = ":";
+    dontBuild = true;
     installPhase = "mkdir -p $out/include && cp -R boost $out/include/";
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1riz0xvwb6y02j0fljbr9hcbqb2jqs4njlivmavy9ysbcrrv1vrf";
   };
 
-  buildPhase = ":";
+  dontBuild = true;
   installPhase = ''
     mkdir -p $out/share/postgresql/extension
     cp pg*sql *.control $out/share/postgresql/extension

--- a/pkgs/tools/backup/ori/default.nix
+++ b/pkgs/tools/backup/ori/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     scons PREFIX=$out WITH_ORILOCAL=1 install
   '';
 
-  installPhase = ":";
+  dontInstall = true;
 
   meta = with lib; {
     description = "A secure distributed file system";

--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -21,7 +21,7 @@
       ar p "$src" data.tar.xz | tar xJ
     '';
 
-    buildPhase = ":";
+    dontBuild = true;
 
     installPhase = ''
       mkdir -p $out/bin $out/share/sweep-visualizer

--- a/pkgs/tools/misc/zsh-autoenv/default.nix
+++ b/pkgs/tools/misc/zsh-autoenv/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "004svkfzhc3ab6q2qvwzgj36wvicg5bs8d2gcibx6adq042di7zj";
   };
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/{bin,share}

--- a/pkgs/tools/system/uefitool/common.nix
+++ b/pkgs/tools/system/uefitool/common.nix
@@ -20,8 +20,10 @@ mkDerivation rec {
   buildInputs = [ qtbase ];
   nativeBuildInputs = [ qmake cmake zip ];
 
-  configurePhase = ":";
-  buildPhase = "bash unixbuild.sh";
+  dontConfigure = true;
+  buildPhase = ''
+    bash unixbuild.sh
+  '';
 
   installPhase = ''
     mkdir -p "$out"/bin

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -309,7 +309,7 @@ latexindent = perlPackages.buildPerlPackage rec {
   preConfigure = ''
     touch Makefile.PL
   '';
-  buildPhase = ":";
+  dontBuild = true;
   installPhase = ''
     install -D ./scripts/latexindent/latexindent.pl "$out"/bin/latexindent
     mkdir -p "$out"/${perl.libPrefix}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
