### PR TITLE
Convert phases that contain ":" to dont* = true

### DIFF
--- a/pkgs/development/python-modules/bootstrapped-pip/2.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/2.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper unzip ];
   buildInputs = [ python ];
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = lib.strings.optionalString (!stdenv.hostPlatform.isWindows) ''
     export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper unzip ];
   buildInputs = [ python ];
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = lib.strings.optionalString (!stdenv.hostPlatform.isWindows) ''
     export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0

--- a/pkgs/misc/vim-plugins/build-vim-plugin.nix
+++ b/pkgs/misc/vim-plugins/build-vim-plugin.nix
@@ -54,7 +54,7 @@ rec {
     }));
 
   buildVimPluginFrom2Nix = attrs: buildVimPlugin ({
-    buildPhase = ":";
-    configurePhase =":";
+    dontBuild = true;
+    dontConfigure = true;
   } // attrs);
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
@@ -1,7 +1,7 @@
 { lib, appleDerivation }:
 
 appleDerivation {
-  buildPhase = ":";
+  dontBuild = true;
 
   # install headers only
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
