### PR TITLE
nixos/systemd: fix NSS database ordering

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -562,6 +562,77 @@
           be removed in 22.05.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The order of NSS (host) modules has been brought in line with
+          upstream recommendations:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              The <literal>myhostname</literal> module is placed before
+              the <literal>resolve</literal> (optional) and
+              <literal>dns</literal> entries, but after
+              <literal>file</literal> (to allow overriding via
+              <literal>/etc/hosts</literal> /
+              <literal>networking.extraHosts</literal>, and prevent ISPs
+              with catchall-DNS resolvers from hijacking
+              <literal>.localhost</literal> domains)
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              The <literal>mymachines</literal> module, which provides
+              hostname resolution for local containers (registered with
+              <literal>systemd-machined</literal>) is placed to the
+              front, to make sure its mappings are preferred over other
+              resolvers.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If systemd-networkd is enabled, the
+              <literal>resolve</literal> module is placed before
+              <literal>files</literal> and
+              <literal>myhostname</literal>, as it provides the same
+              logic internally, with caching.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              The <literal>mdns(_minimal)</literal> module has been
+              updated to the new priorities.
+            </para>
+          </listitem>
+        </itemizedlist>
+        <para>
+          If you use your own NSS host modules, make sure to update your
+          priorities according to these rules:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              NSS modules which should be queried before
+              <literal>resolved</literal> DNS resolution should use
+              mkBefore.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              NSS modules which should be queried after
+              <literal>resolved</literal>, <literal>files</literal> and
+              <literal>myhostname</literal>, but before
+              <literal>dns</literal> should use the default priority
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              NSS modules which should come after <literal>dns</literal>
+              should use mkAfter.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -139,3 +139,27 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The wordpress module provides a new interface which allows to use different webservers with the new option [`services.wordpress.webserver`](options.html#opt-services.wordpress.webserver).  Currently `httpd` and `nginx` are supported. The definitions of wordpress sites should now be set in [`services.wordpress.sites`](options.html#opt-services.wordpress.sites).
 
   Sites definitions that use the old interface are automatically migrated in the new option. This backward compatibility will be removed in 22.05.
+
+- The order of NSS (host) modules has been brought in line with upstream
+  recommendations:
+
+  - The `myhostname` module is placed before the `resolve` (optional) and `dns`
+    entries, but after `file` (to allow overriding via `/etc/hosts` /
+    `networking.extraHosts`, and prevent ISPs with catchall-DNS resolvers from
+    hijacking `.localhost` domains)
+  - The `mymachines` module, which provides hostname resolution for local
+    containers (registered with `systemd-machined`) is placed to the front, to
+    make sure its mappings are preferred over other resolvers.
+  - If systemd-networkd is enabled, the `resolve` module is placed before
+    `files` and `myhostname`, as it provides the same logic internally, with
+    caching.
+  - The `mdns(_minimal)` module has been updated to the new priorities.
+
+  If you use your own NSS host modules, make sure to update your priorities
+  according to these rules:
+
+  - NSS modules which should be queried before `resolved` DNS resolution should
+    use mkBefore.
+  - NSS modules which should be queried after `resolved`, `files` and
+    `myhostname`, but before `dns` should use the default priority
+  - NSS modules which should come after `dns` should use mkAfter.

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -124,8 +124,8 @@ with lib;
       group = mkBefore [ "files" ];
       shadow = mkBefore [ "files" ];
       hosts = mkMerge [
-        (mkBefore [ "files" ])
-        (mkAfter [ "dns" ])
+        (mkOrder 998 [ "files" ])
+        (mkOrder 1499 [ "dns" ])
       ];
       services = mkBefore [ "files" ];
     };

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -240,8 +240,8 @@ in
 
     system.nssModules = optional cfg.nssmdns pkgs.nssmdns;
     system.nssDatabases.hosts = optionals cfg.nssmdns (mkMerge [
-      (mkOrder 900 [ "mdns_minimal [NOTFOUND=return]" ]) # must be before resolve
-      (mkOrder 1501 [ "mdns" ]) # 1501 to ensure it's after dns
+      (mkBefore [ "mdns_minimal [NOTFOUND=return]" ]) # before resolve
+      (mkAfter [ "mdns" ]) # after dns
     ]);
 
     environment.systemPackages = [ pkgs.avahi ];

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -140,7 +140,8 @@ in
 
     # add resolve to nss hosts database if enabled and nscd enabled
     # system.nssModules is configured in nixos/modules/system/boot/systemd.nix
-    system.nssDatabases.hosts = optional config.services.nscd.enable "resolve [!UNAVAIL=return]";
+    # added with order 501 to allow modules to go before with mkBefore
+    system.nssDatabases.hosts = (mkOrder 501 ["resolve [!UNAVAIL=return]"]);
 
     systemd.additionalUpstreamSystemUnits = [
       "systemd-resolved.service"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -925,9 +925,8 @@ in
     system.nssModules = [ systemd.out ];
     system.nssDatabases = {
       hosts = (mkMerge [
-        [ "mymachines" ]
-        (mkOrder 1600 [ "myhostname" ] # 1600 to ensure it's always the last
-      )
+        (mkOrder 400 ["mymachines"]) # 400 to ensure it comes before resolve (which is mkBefore'd)
+        (mkOrder 999 ["myhostname"]) # after files (which is 998), but before regular nss modules
       ]);
       passwd = (mkMerge [
         (mkAfter [ "systemd" ])


### PR DESCRIPTION
- The order of NSS (host) modules has been brought in line with [upstream
  recommendations](https://github.com/systemd/systemd/pull/20103)

  - The `myhostname` module is placed before the `resolve` (optional) and `dns`
    entries, but after `file` (to allow overriding via `/etc/hosts` /
    `networking.extraHosts`, and prevent ISPs with catchall-DNS resolvers from
    hijacking `.localhost` domains)
  - The `mymachines` module, which provides hostname resolution for local
    containers (registered with `systemd-machined`) is placed to the front, to
    make sure its mappings are preferred over other resolvers.
  - If systemd-networkd is enabled, the `resolve` module is placed before
    `files` and `myhostname`, as it provides the same logic internally, with
    caching.
  - The `mdns(_minimal)` module has been updated to the new priorities.


As a summary, the priorities are as follows:
```
 - mymachines   "mkBefore-100" (400)
 - mdns_minimal 500
 - resolve      mkBefore+1 (501)
 - files        "default-2" (998)
 - myhostname   "default-1" (999)
 - …
 - dns          mkAfter-1=1499
 - mdns         1500
```

###### Things done

I manually verified the order in `nsswitch.conf`, and ran the avahi tests (both with and without networkd)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
