### PR TITLE
bisq-desktop: Nix package improvements

### DIFF
--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -62,9 +62,9 @@ stdenv.mkDerivation rec {
       name = "Bisq";
       exec = "bisq-desktop";
       icon = "bisq";
-      desktopName = "Bisq";
+      desktopName = "Bisq ${version}";
       genericName = "Decentralized bitcoin exchange";
-      categories = "Network;Utility;";
+      categories = "Network;P2P;";
     })
   ];
 

--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -35,11 +35,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bisq-desktop";
-  version = "1.7.0";
+  version = "1.7.2";
 
   src = fetchurl {
     url = "https://github.com/bisq-network/bisq/releases/download/v${version}/Bisq-64bit-${version}.deb";
-    sha256 = "0crry5k7crmrqn14wxiyrnhk09ac8a9ksqrwwky7jsnyah0bx5k4";
+    sha256 = "0b2rh9sphc9wffkawprrl20frgv0rah7y2k5sfxpjc3shgkqsw80";
   };
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems imagemagick dpkg gnutar zip xz ];

--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "A decentralized bitcoin exchange network";
     homepage = "https://bisq.network";

--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -24,7 +24,7 @@ let
     # whereas Nix only scans for hashes in uncompressed text.
     # ${bisq-tor}
 
-    JAVA_TOOL_OPTIONS="-XX:MaxRAM=4g" bisq-desktop-wrapped "$@"
+    JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:MaxHeapFreeRatio=10 -XX:MinHeapFreeRatio=5 -XX:+UseStringDeduplication" bisq-desktop-wrapped "$@"
   '';
 
   bisq-tor = writeScript "bisq-tor" ''

--- a/pkgs/applications/blockchains/bisq-desktop/update.sh
+++ b/pkgs/applications/blockchains/bisq-desktop/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnused gnupg common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl -s https://api.github.com/repos/bisq-network/bisq/releases| jq '.[] | {name,prerelease} | select(.prerelease==false) | limit(1;.[])' | sed 's/[\"v]//g' | head -n 1)"
+depname="Bisq-64bit-$version.deb"
+src="https://github.com/bisq-network/bisq/releases/download/v$version/$depname"
+signature="$src.asc"
+key="CB36 D7D2 EBB2 E35D 9B75 500B CD5D C1C5 29CD FD3B"
+
+pushd $(mktemp -d --suffix=-bisq-updater)
+export GNUPGHOME=$PWD/gnupg
+mkdir -m 700 -p "$GNUPGHOME"
+curl -L -o "$depname" -- "$src"
+curl -L -o signature.asc -- "$signature"
+gpg --batch --recv-keys "$key"
+gpg --batch --verify signature.asc "$depname"
+sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$depname")
+popd
+
+update-source-version bisq-desktop "$version" "$sha256"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 1. Add the Bisq version number to the desktop menu entry.
 2. Fix the *.desktop categories.
 3. Use the embedded Tor binary instead of executing Tor with a script.
 4. Update Bisq from 1.7.0 to 1.7.2
 5. Add Java VM optimizations that can reduce memory consumption starting with Bisq 1.7.2
 6.  Add updater script with signature verification.

###### Minimum version requirement

 Sometimes the Bisq network raises the minimum required Bisq version. Adding the version number so that it's displayed in the desktop environment's menu makes it easy for users to confirm whether they have the necessary version.

###### Free Desktop categories

 Originally, there were two main categories assigned, which violates the Free Desktop standard. This change removes one of the main categories and adds an auxillary category.

###### Return of The Embedded Tor Binary

Bisq comes with an embedded Tor binary (provided by a third party), but we don't use it in this package because it's build for a FHS-abiding Linux distro; Meaning, Tor won't execute because it tried to load libraries from standard locations. To address this problem, the Nix package launches an ephemeral Tor instance for Bisq. The approach works, but it does mean having to manage the tor process, something which is already handled well by Bisq. 

This change modifies the Bisq Jar archive such that it launches the Tor binary from Nixpkgs, allowing Bisq to manage Tor as it does on other Linux distros and operating systems. In a nutshell, when Bisq is launched it extracts a copy of the tor binary from its Jar file and saves it in the Bisq data directory. It is then executed from there. Since Nix doesn't know that Bisq has a runtime dependency on Tor, this change modifies the launcher script to contain a reference to Tor, thus convincing Nix that Tor is a runtime dependency.

###### Updater script

The newly-added updater script allows existing Nix infrastructure to check for Bisq updates and create a corresponding Nixpkgs pulll request. The updater includes signature verification, so that's one less step which needs to be done manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~
   - [x] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests]~(https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`~
- [X] Tested execution of all binary files (usually in `./result/bin/`). Successfully completed a trade.
- ~[21.11 Release Notes (or backporting 21.05 Relase notes)]~(https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
