### PR TITLE
vector: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -28,16 +28,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "timberio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-wtihrR19jMJ7Kgvy6XBzOUrC/WKNVl2MVx4lWgXYlvg=";
+    sha256 = "sha256-8ZsZyV6zlMiNTVYPwqQi7F1OJ4hV33IqrrGkvUb8JaY=";
   };
 
-  cargoSha256 = "sha256-VYIzAqh5Xxmn1koxhh+UDb2G3WS2UVXffuBY7h5Kr7A=";
+  cargoSha256 = "sha256-t6KeyBwIfCQTfaennFiFX3K+8unFOsduBP7nRbAo9wI=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optional stdenv.isDarwin [ Security libiconv coreutils CoreServices ];


### PR DESCRIPTION
###### Motivation for this change

just a package update

Here is the changelog for it
https://vector.dev/releases/0.15.0/

Mostly things added, and this time, nothing was needed to be done to make this update work (on the nix side)

Since it's fairly basic, I'm leaving this one day open in case anyone wants to have a look at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
