### PR TITLE
git-sync: Wrap both binaries

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
@@ -31,8 +31,13 @@ stdenv.mkDerivation rec {
   fixupPhase = ''
     patchShebangs $out/bin
 
+    wrap_path="${wrapperPath}":$out/bin
+
     wrapProgram $out/bin/git-sync \
-      --prefix PATH : "${wrapperPath}"
+      --prefix PATH : $wrap_path
+
+    wrapProgram $out/bin/git-sync-on-inotify \
+      --prefix PATH : $wrap_path
   '';
 
   meta = {

--- a/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
@@ -28,9 +28,7 @@ stdenv.mkDerivation rec {
     gnused
   ];
 
-  fixupPhase = ''
-    patchShebangs $out/bin
-
+  postFixup = ''
     wrap_path="${wrapperPath}":$out/bin
 
     wrapProgram $out/bin/git-sync \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
