### PR TITLE
deadbeef-statusnotifier-plugin: init at 1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4557,6 +4557,12 @@
     githubId = 278013;
     name = "Tomasz Kontusz";
   };
+  kurnevsky = {
+    email = "kurnevsky@gmail.com";
+    github = "kurnevsky";
+    githubId = 2943605;
+    name = "Evgeny Kurnevsky";
+  };
   kuznero = {
     email = "roman@kuznero.com";
     github = "kuznero";

--- a/pkgs/applications/audio/deadbeef/plugins/statusnotifier.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/statusnotifier.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, deadbeef, gtk3, perl
+, libdbusmenu-glib }:
+
+stdenv.mkDerivation rec {
+  pname = "deadbeef-statusnotifier-plugin";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "vovochka404";
+    repo = "deadbeef-statusnotifier-plugin";
+    rev = "v${version}";
+    sha256 = "sha256-6WEbY59vPNrL3W5GUwFQJimmSS+td8Ob+G46fPAxfV4=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ deadbeef gtk3 libdbusmenu-glib ];
+
+  buildFlags = [ "gtk3" ];
+
+  postPatch = ''
+    substituteInPlace tools/glib-mkenums \
+      --replace /usr/bin/perl "${perl}/bin/perl"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/deadbeef
+    cp build/sni_gtk3.so $out/lib/deadbeef
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "DeaDBeeF StatusNotifier Plugin";
+    homepage = "https://github.com/vovochka404/deadbeef-statusnotifier-plugin";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.kurnevsky ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19893,6 +19893,7 @@ in
     infobar = callPackage ../applications/audio/deadbeef/plugins/infobar.nix { };
     lyricbar = callPackage ../applications/audio/deadbeef/plugins/lyricbar.nix { };
     mpris2 = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
+    statusnotifier = callPackage ../applications/audio/deadbeef/plugins/statusnotifier.nix { };
   };
 
   deadbeef-with-plugins = callPackage ../applications/audio/deadbeef/wrapper.nix {


### PR DESCRIPTION
###### Motivation for this change
StatusNotifier icon plugin for deadbeef. By default it supports only xembed icons.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
