### PR TITLE
nodePackages.autoprefixer: init at 10.3.1

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -14,6 +14,17 @@ let
       '';
     };
 
+    autoprefixer = super.autoprefixer.override {
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postInstall = ''
+        wrapProgram "$out/bin/autoprefixer" \
+          --prefix NODE_PATH : ${self.postcss}/lib/node_modules
+      '';
+      passthru.tests = {
+        simple-execution = pkgs.callPackage ./package-tests/autoprefixer.nix { inherit (self) autoprefixer; };
+      };
+    };
+
     aws-azure-login = super.aws-azure-login.override {
       meta.platforms = pkgs.lib.platforms.linux;
       nativeBuildInputs = [ pkgs.makeWrapper ];
@@ -262,7 +273,8 @@ let
       nativeBuildInputs = [ pkgs.makeWrapper ];
       postInstall = ''
         wrapProgram "$out/bin/postcss" \
-          --prefix NODE_PATH : ${self.postcss}/lib/node_modules
+          --prefix NODE_PATH : ${self.postcss}/lib/node_modules \
+          --prefix NODE_PATH : ${self.autoprefixer}/lib/node_modules
       '';
       meta.mainProgram = "postcss";
     };

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -13,6 +13,7 @@
 , "@webassemblyjs/wast-refmt"
 , "alloy"
 , "asar"
+, "autoprefixer"
 , "aws-azure-login"
 , "balanceofsatoshis"
 , "bash-language-server"

--- a/pkgs/development/node-packages/package-tests/autoprefixer.nix
+++ b/pkgs/development/node-packages/package-tests/autoprefixer.nix
@@ -1,0 +1,25 @@
+{ runCommand, autoprefixer }:
+
+let
+  inherit (autoprefixer) packageName version;
+in
+
+runCommand "${packageName}-tests" { meta.timeout = 60; }
+  ''
+    # get version of installed program and compare with package version
+    claimed_version="$(${autoprefixer}/bin/autoprefixer --version | awk '{print $2}')"
+    if [[ "$claimed_version" != "${version}" ]]; then
+      echo "Error: program version does not match package version ($claimed_version != ${version})"
+      exit 1
+    fi
+
+    # run dummy commands
+    ${autoprefixer}/bin/autoprefixer --help > /dev/null
+    ${autoprefixer}/bin/autoprefixer --info > /dev/null
+
+    # Testing the actual functionality is done in the test for postcss
+    # because autoprefixer is a postcss plugin
+
+    # needed for Nix to register the command as successful
+    touch $out
+  ''


### PR DESCRIPTION
###### Motivation for this change
This adds autoprefixer, a postcss plugin.
The comment in the test about testing the actual functionality in the postcss test is not yet accurate. #130204 will add the postcss test.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).