### PR TITLE
nwg-drawer: init at 0.1.4

### DIFF
--- a/pkgs/applications/misc/nwg-drawer/default.nix
+++ b/pkgs/applications/misc/nwg-drawer/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, pkg-config
+, cairo
+, gobject-introspection
+, gtk3
+, gtk-layer-shell
+}:
+
+buildGoModule rec {
+  pname = "nwg-drawer";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-YjMuXSBAgRh6vZUxKHLTqT2lEU/f+AuI/dX4PHfftZg=";
+  };
+
+  vendorSha256 = "sha256-HyrjquJ91ddkyS8JijHd9HjtfwSQykXCufa2wzl8RNk=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ cairo gobject-introspection gtk3 gtk-layer-shell ];
+
+  meta = with lib; {
+    description = "Application drawer for sway Wayland compositor";
+    homepage = "https://github.com/nwg-piotr/nwg-drawer";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ plabadens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25886,6 +25886,8 @@ in
   nootka = qt5.callPackage ../applications/audio/nootka { };
   nootka-unstable = qt5.callPackage ../applications/audio/nootka/unstable.nix { };
 
+  nwg-drawer = callPackage ../applications/misc/nwg-drawer { };
+
   nwg-launchers = callPackage ../applications/misc/nwg-launchers { };
 
   nwg-menu = callPackage ../applications/misc/nwg-menu { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`nwg-drawer` is an application drawer for sway and related Wayland compositors, written in Go.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
