### PR TITLE
go-ethereum: 1.10.4 -> 1.10.5

### DIFF
--- a/pkgs/applications/blockchains/go-ethereum.nix
+++ b/pkgs/applications/blockchains/go-ethereum.nix
@@ -9,17 +9,17 @@ let
 
 in buildGoModule rec {
   pname = "go-ethereum";
-  version = "1.10.4";
+  version = "1.10.5";
 
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-DRlIiO3iXUsQnmOf5T9uk3560tVbS+Hrs8QtVkmllAI=";
+    sha256 = "sha256:1226picbgnph71fk2y0n1hyfrh6m8sh54kgn3pmikydnw176k9j1";
   };
 
   runVend = true;
-  vendorSha256 = "sha256-a/vY9iyqSM9QPs7lGFF6E7e2cMjIerVkNf5KwiWdyr0=";
+  vendorSha256 = "sha256:1nf2gamamlgr2sl5ibib5wai1pipj66xhbhnb4s4480j5pbv9a76";
 
   doCheck = false;
 


### PR DESCRIPTION
(Ran nixpkgs-update locally after not seeing an update for go-ethereum; there are 17 days remaining until the EIP-1559 hard fork. This should also be backported to 21.05, but I don't know how to do that. Please double check this for accuracy since this is the first time I've tried to do anything re: nixpkgs.)

---

meta.description for go-ethereum is: "Official golang implementation of the Ethereum protocol"

meta.homepage for go-ethereum is: "https://geth.ethereum.org/"

meta.changelog for go-ethereum is: ""


###### Updates performed
- Golang update

###### To inspect upstream changes

- [Release on GitHub](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.5)

- [Compare changes on GitHub](https://github.com/ethereum/go-ethereum/compare/v1.10.4...v1.10.5)

###### Impact

<details>
<summary>
<b>Checks done</b> (click to expand)
</summary>

---

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/abidump passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/rlpdump passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/evm passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/abigen passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/puppeth passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/faucet passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/p2psim passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/geth passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/ethkey passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/checkpoint-admin passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/bootnode passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/devp2p passed the binary check.
- /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin/clef passed the binary check.
- 13 of 13 passed binary check by having a zero exit code.
- 9 of 13 passed binary check by having the new version present in output.
- found 1.10.5 with grep in /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5
- found 1.10.5 in filename of file in /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5

---

</details>
<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
1 total rebuild path(s)

1 package rebuild(s)

0 x86_64-linux rebuild(s)
0 i686-linux rebuild(s)
0 x86_64-darwin rebuild(s)
0 aarch64-linux rebuild(s)


First fifty rebuilds by attrpath
go-ethereum
```

</details>

<details>
<summary>
<b>Instructions to test this update</b> (click to expand)
</summary>

---

Build yourself:
```
nix-build -A go-ethereum https://github.com/iceman-p/nixpkgs/archive/c034146099d96c454a176f7fbcdd8d2b91769e80.tar.gz
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
ls -la /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5
ls -la /nix/store/j2k9cd72pi6b6j6mxfmllfpwkcqclxnk-go-ethereum-1.10.5/bin
```

---

</details>
<br/>



### Pre-merge build results

NixPkgs review skipped

---

###### Maintainer pings

cc @adisbladis @lionello @xrelkd @RaghavSood @kalbasit for testing.
Done.
