### PR TITLE
vscode-extensions.hashicorp.terraform: 2.13.0 -> 2.13.2

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,13 +3,13 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.13.1";
+    version = "2.13.2";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/${mktplcRef.name}-${mktplcRef.version}.vsix";
-    sha256 = "1l7gsb28yj2z1zfzgb8xiyf166v4blxfdkyiixlm1pqnn2lj6yb6";
+    sha256 = "0h7c6p2dcwsg7wlp49p2fsq0f164pzkx65929imd1m2df77aykqa";
   };
 
   patches = [ ./fix-terraform-ls.patch ];

--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,19 +3,19 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.13.0";
+    version = "2.13.1";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/${mktplcRef.name}-${mktplcRef.version}.vsix";
-    sha256 = "1wc4jl4h3ja4ivynf20yxzwqssi6yd7alvqvcjrkksic98480qcz";
+    sha256 = "1l7gsb28yj2z1zfzgb8xiyf166v4blxfdkyiixlm1pqnn2lj6yb6";
   };
 
   patches = [ ./fix-terraform-ls.patch ];
 
   postPatch = ''
-    substituteInPlace out/extension.js --replace TERRAFORM-LS-PATH ${terraform-ls}/bin/terraform-ls
+    substituteInPlace out/clientHandler.js --replace TERRAFORM-LS-PATH ${terraform-ls}/bin/terraform-ls
   '';
 
   meta = with lib; {

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,5 +1,5 @@
 diff --git a/out/clientHandler.js b/out/clientHandler.js
-index 6d314ea..dadab90 100644
+index 7f9716d..a543d60 100644
 --- a/out/clientHandler.js
 +++ b/out/clientHandler.js
 @@ -33,8 +33,7 @@ class ClientHandler {
@@ -13,14 +13,13 @@ index 6d314ea..dadab90 100644
      }
      startClients(folders) {
 diff --git a/out/extension.js b/out/extension.js
-index f1eb66d..9b0f832 100644
+index 7a271fc..726bbf8 100644
 --- a/out/extension.js
 +++ b/out/extension.js
-@@ -145,25 +145,6 @@ function updateLanguageServer(clientHandler, installPath) {
-     return __awaiter(this, void 0, void 0, function* () {
-         const delay = 1000 * 60 * 60 * 24;
-         languageServerUpdater.timeout(updateLanguageServer, delay); // check for new updates every 24hrs
--        // skip install if a language server binary path is set
+@@ -149,24 +149,6 @@ function updateLanguageServer(clientHandler, installPath) {
+             updateLanguageServer(clientHandler, installPath);
+         }, 24 * hour);
+         // skip install if a language server binary path is set
 -        if (!vscodeUtils_1.config('terraform').get('languageServer.pathToBinary')) {
 -            const installer = new languageServerInstaller_1.LanguageServerInstaller(installPath, reporter);
 -            const install = yield installer.needsInstall();

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,8 +1,22 @@
+diff --git a/out/clientHandler.js b/out/clientHandler.js
+index 6d314ea..dadab90 100644
+--- a/out/clientHandler.js
++++ b/out/clientHandler.js
+@@ -33,8 +33,7 @@ class ClientHandler {
+             this.reporter.sendTelemetryEvent('usePathToBinary');
+         }
+         else {
+-            const installPath = path.join(context.extensionPath, 'lsp');
+-            this.pathToBinary = path.join(installPath, 'terraform-ls');
++            this.pathToBinary = 'TERRAFORM-LS-PATH';
+         }
+     }
+     startClients(folders) {
 diff --git a/out/extension.js b/out/extension.js
-index e932d27..099126b 100644
+index f1eb66d..9b0f832 100644
 --- a/out/extension.js
 +++ b/out/extension.js
-@@ -143,25 +143,6 @@ function updateLanguageServer() {
+@@ -145,25 +145,6 @@ function updateLanguageServer(clientHandler, installPath) {
      return __awaiter(this, void 0, void 0, function* () {
          const delay = 1000 * 60 * 60 * 24;
          languageServerUpdater.timeout(updateLanguageServer, delay); // check for new updates every 24hrs
@@ -11,7 +25,7 @@ index e932d27..099126b 100644
 -            const installer = new languageServerInstaller_1.LanguageServerInstaller(installPath, reporter);
 -            const install = yield installer.needsInstall();
 -            if (install) {
--                yield stopClients();
+-                yield clientHandler.stopClients();
 -                try {
 -                    yield installer.install();
 -                }
@@ -25,15 +39,6 @@ index e932d27..099126b 100644
 -                }
 -            }
 -        }
-         return startClients(); // on repeat runs with no install, this will be a no-op
+         return clientHandler.startClients(vscodeUtils_1.prunedFolderNames()); // on repeat runs with no install, this will be a no-op
      });
  }
-@@ -259,7 +240,7 @@ function pathToBinary() {
-                 reporter.sendTelemetryEvent('usePathToBinary');
-             }
-             else {
--                command = path.join(installPath, 'terraform-ls');
-+                command = 'TERRAFORM-LS-PATH';
-             }
-             _pathToBinaryPromise = Promise.resolve(command);
-         }


### PR DESCRIPTION
###### Motivation for this change

I've kept intentionally both commit so you have access to the patch in both versions.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
