### PR TITLE
fs-uae-launcher: init at 3.0.5

### DIFF
--- a/pkgs/misc/emulators/fs-uae-launcher/default.nix
+++ b/pkgs/misc/emulators/fs-uae-launcher/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchurl, makeWrapper, python3, gettext
+, pyqt5, setuptools, requests
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fs-uae-launcher";
+  version = "3.0.5";
+
+  src = fetchurl {
+    url = "https://fs-uae.net/stable/${version}/${pname}-${version}.tar.gz";
+    sha256 = "1dknra4ngz7bpppwqghmza1q68pn1yaw54p9ba0f42zwp427ly97";
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+  nativeBuildInputs = [ makeWrapper python3 gettext ];
+  buildInputs = [ pyqt5 setuptools requests ];
+  postInstall = ''
+    wrapProgram $out/bin/fs-uae-launcher --set PYTHONPATH "$PYTHONPATH"
+  '';
+
+  meta = {
+    description = "Graphical front-end for the FS-UAE emulator";
+    license = lib.licenses.gpl2Plus;
+    homepage = "https://fs-uae.net";
+    maintainers = with lib; [ maintainers.sander ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31500,6 +31500,10 @@ in
 
   fsuae = callPackage ../misc/emulators/fs-uae { };
 
+  fsuae-launcher = callPackage ../misc/emulators/fs-uae-launcher {
+    inherit (python3Packages) pyqt5 setuptools requests;
+  };
+
   putty = callPackage ../applications/networking/remote/putty {
     gtk2 = gtk2-x11;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds a graphical front-end to FS-UAE: an Amiga emulator. FS-UAE is command-line driven only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
