### PR TITLE
flake.nix: Only add `_file`-key if position of `args.modules` is actually know to the evaluator

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,12 +49,18 @@
                   })).config;
 
                 moduleDeclarationFile =
-                  (builtins.unsafeGetAttrPos "modules" args).file;
+                  let
+                    # Even though `modules` is a mandatory argument for `nixosSystem`, it doesn't
+                    # mean that the evaluator always keeps track of its position. If there
+                    # are too many levels of indirection, the position gets lost at some point.
+                    intermediatePos = builtins.unsafeGetAttrPos "modules" args;
+                  in
+                    if intermediatePos == null then null else intermediatePos.file;
 
                 # Add the invoking file as error message location for modules
                 # that don't have their own locations; presumably inline modules.
                 addModuleDeclarationFile =
-                  m: {
+                  m: if moduleDeclarationFile == null then m else {
                     _file = moduleDeclarationFile;
                     imports = [ m ];
                   };


### PR DESCRIPTION


###### Motivation for this change
This happens if the evaluator "loses" the position of an
attr-declaration[1] because of e.g. too many nested function-calls to
build the final attr-set.

While the actual issue should be fixed in Nix itself, this is IMHO a
fair workaround to unblock affected users[2].

[1] https://github.com/NixOS/nixpkgs/commit/e14c24593420bb9057e7f38b40d17137eaeff9dd#commitcomment-53645936
[2] It seems as everyone using `divnix/digga` or `flake-utils-plus`
    seems affected.

cc @Narice I already checked whether your config evaluates with this change, but you may want to review to confirm :) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
