### PR TITLE
nix-template: 0.1.1 -> 0.1.4

### DIFF
--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, rustPlatform, fetchFromGitHub
+, installShellFiles
 , makeWrapper
 , nix
 , openssl
@@ -8,18 +9,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-template";
-  version = "0.1.1";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
+    name = "${pname}-${version}-src";
     owner = "jonringer";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-A1b/fgSr27sfMDnTi4R3PUZfhAdLA5wUOd4yh9/4Bnk=";
+    sha256 = "sha256-kNFhSfHUYBUOCXoD6m7thMho4tOIpRHfHGcsW8FTgkc=";
   };
 
-  cargoSha256 = "sha256-resyY/moqLo4KWOKUvFJiOWealCmcEsLFgkN12slKN0=";
+  cargoSha256 = "sha256-7PthFLCEt+E/Gx5//aulHYYBKZqapNEWKtKfRlDr3Pw=";
 
-  nativeBuildInputs = [ makeWrapper pkg-config ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    pkg-config
+  ];
+
   buildInputs = [ openssl ]
     ++ lib.optional stdenv.isDarwin Security;
 
@@ -27,6 +34,10 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     wrapProgram $out/bin/nix-template \
       --prefix PATH : ${lib.makeBinPath [ nix ]}
+
+    installShellCompletion --bash --cmd nix-template <($out/bin/nix-template completions bash)
+    installShellCompletion --zsh --cmd nix-template <($out/bin/nix-template completions zsh)
+    installShellCompletion --fish --cmd nix-template <($out/bin/nix-template completions fish)
   '';
 
   meta = with lib; {

--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -35,9 +35,10 @@ rustPlatform.buildRustPackage rec {
     wrapProgram $out/bin/nix-template \
       --prefix PATH : ${lib.makeBinPath [ nix ]}
 
-    installShellCompletion --bash --cmd nix-template <($out/bin/nix-template completions bash)
-    installShellCompletion --zsh --cmd nix-template <($out/bin/nix-template completions zsh)
-    installShellCompletion --fish --cmd nix-template <($out/bin/nix-template completions fish)
+    installShellCompletion --cmd nix-template \
+      --bash <($out/bin/nix-template completions bash) \
+      --fish <($out/bin/nix-template completions fish) \
+      --zsh <($out/bin/nix-template completions zsh)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
add support for pypi and shell completions

https://github.com/jonringer/nix-template/releases/

closes: https://github.com/jonringer/nix-template/issues/16

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
