### PR TITLE
pythonPackages.tomli: init at 1.0.4

### DIFF
--- a/pkgs/development/python-modules/tomli/default.nix
+++ b/pkgs/development/python-modules/tomli/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pytestCheckHook
+, python-dateutil
+}:
+
+buildPythonPackage rec {
+  pname = "tomli";
+  version = "1.0.4";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "hukkin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-ld0PsYnxVH3RbLG/NpvLDj9UhAe+QgwCQVXgGgqh8kE=";
+  };
+
+  nativeBuildInputs = [ flit-core ];
+
+  checkInputs = [
+    pytestCheckHook
+    python-dateutil
+  ];
+
+  pythonImportsCheck = [ "tomli" ];
+
+  meta = with lib; {
+    description = "A Python library for parsing TOML, fully compatible with TOML v1.0.0";
+    homepage = "https://github.com/hukkin/tomli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8689,6 +8689,8 @@ in {
 
   toml = callPackage ../development/python-modules/toml { };
 
+  tomli = callPackage ../development/python-modules/tomli { };
+
   tomlkit = callPackage ../development/python-modules/tomlkit { };
 
   toolz = callPackage ../development/python-modules/toolz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Also, soon to be required by the next `mypy` release: https://github.com/python/mypy/pull/10824

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
