### PR TITLE
simutrans: 120.4.1 -> 121.0.0

### DIFF
--- a/pkgs/games/simutrans/default.nix
+++ b/pkgs/games/simutrans/default.nix
@@ -11,28 +11,28 @@ let
       else map (name: pakSpec.${name}) (splitString " " paksets)
   );
 
-  ver1 = "120";
-  ver2 = "4";
-  ver3 = "1";
-  version =   "${ver1}.${ver2}.${ver3}";
-  ver_dash =  "${ver1}-${ver2}-${ver3}";
+  ver1 = "121";
+  ver2 = "0";
+  ver3 = "";
+  version  = "${ver1}.${ver2}${lib.optionalString (ver3 != "") ".${ver3}"}";
+  ver_dash = "${ver1}-${ver2}${lib.optionalString (ver3 != "") "-${ver3}"}";
 
   binary_src = fetchurl {
     url = "mirror://sourceforge/simutrans/simutrans/${ver_dash}/simutrans-src-${ver_dash}.zip";
-    sha256 = "0yw7vjvmczp022mgk35swwhpbiszpz91mwsgicxglwivgc30vvic";
+    sha256 = "1f463r6kr5ig0zd3mncc74k93xbjywsq3d06j5r17831jyc9bzb9";
   };
 
 
-  # As of 2015/03, many packsets still didn't have a release for version 120.
+  # As of 2021/07, many of these paksets have not been updated for years, so are on old versions.
   pakSpec = lib.mapAttrs
     (pakName: attrs: mkPak (attrs // {inherit pakName;}))
   {
     pak64 = {
-      srcPath = "121-0/simupak64-121-0";
+      srcPath = "${ver_dash}/simupak64-${ver_dash}";
       sha256 = "1k335kh8dhm1hdn5iwn3sdgnrlpk0rqxmmgqgqcwsi09cmw45m5c";
     };
     "pak64.japan" = {
-      # No release for 120.2 yet!
+      # No release for 121.0 yet!
       srcPath = "120-0/simupak64.japan-120-0-1";
       sha256 = "14swy3h4ij74bgaw7scyvmivfb5fmp21nixmhlpk3mav3wr3167i";
     };


### PR DESCRIPTION
###### Motivation for this change

The former version was having compilation issues; the latter does not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
