### PR TITLE
Added krunner-symbols

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4337,6 +4337,12 @@
     github = "HolgerPeters";
     githubId = 4097049;
   };
+  hqurve = {
+    email = "hqurve@outlook.com";
+    github = "hqurve";
+    githubId = 53281855;
+    name = "hqurve";
+  };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";

--- a/pkgs/desktops/plasma-5/3rdparty/addons/krunner-symbols.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/krunner-symbols.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv
+, cmake, fetchFromGitHub, extra-cmake-modules
+, qtbase, wrapQtAppsHook, ki18n, kdelibs4support, krunner
+}:
+
+stdenv.mkDerivation rec {
+  pname = "krunner-symbols";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "domschrei";
+    repo = "krunner-symbols";
+    rev = version;
+    sha256 = "sha256-YsoZdPTWpk3/YERwerrVEcaf2IfGVJwpq32onhP8Exo=";
+  };
+
+  buildInputs = [ qtbase ki18n kdelibs4support krunner ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook extra-cmake-modules ];
+
+  postPatch = ''
+    # symbols.cpp hardcodes the location of configuration files
+    substituteInPlace symbols.cpp \
+      --replace "/usr/share/config/krunner-symbol" "$out/share/config/krunner-symbol"
+
+    # change cmake flag names to output using the correct qt-plugin prefix and kservice location
+    substituteInPlace CMakeLists.txt \
+      --replace "LOCATION_PLUGIN" "KDE_INSTALL_PLUGINDIR" \
+      --replace "LOCATION_DESKTOP" "KDE_INSTALL_KSERVICES5DIR"
+  '';
+
+  cmakeFlags = [ "-DLOCATION_CONFIG=share/config" ];
+
+  meta = with lib; {
+    description = "A little krunner plugin (Plasma 5) to retrieve unicode symbols, or any other string, based on a corresponding keyword";
+    homepage = "https://github.com/domschrei/krunner-symbols";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ hqurve ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -158,6 +158,7 @@ let
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };
+        krunner-symbols = callPackage ./3rdparty/addons/krunner-symbols.nix { };
         parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };
       };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1134,6 +1134,7 @@ mapAliases ({
     kwin-dynamic-workspaces
     kwin-tiling
     krohnkite
+    krunner-symbols
   ;
   inherit (libsForQt5)
     sddm


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I would like to use the addon as it is very convenient. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
