### PR TITLE
stdenv: use named ref

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -409,15 +409,14 @@ findInputs() {
     # The current package's host and target offset together
     # provide a <=-preserving homomorphism from the relative
     # offsets to current offset
-    local -i mapOffsetResult
     function mapOffset() {
         local -r inputOffset="$1"
+        local -n outputOffset="$2"
         if (( inputOffset <= 0 )); then
-            local -r outputOffset=$((inputOffset + hostOffset))
+            outputOffset=$((inputOffset + hostOffset))
         else
-            local -r outputOffset=$((inputOffset - 1 + targetOffset))
+            outputOffset=$((inputOffset - 1 + targetOffset))
         fi
-        mapOffsetResult="$outputOffset"
     }
 
     # Host offset relative to that of the package whose immediate
@@ -429,16 +428,16 @@ findInputs() {
 
         # Host offset relative to the package currently being
         # built---as absolute an offset as will be used.
-        mapOffset relHostOffset
-        local -i hostOffsetNext="$mapOffsetResult"
+        local hostOffsetNext
+        mapOffset "$relHostOffset" hostOffsetNext
 
         # Ensure we're in bounds relative to the package currently
         # being built.
-        [[ "${allPlatOffsets[*]}" = *"$hostOffsetNext"*  ]] || continue
+        (( -1 <= hostOffsetNext && hostOffsetNext <= 1 )) || continue
 
         # Target offset relative to the *host* offset of the package
         # whose immediate dependencies we are currently exploring.
-        local -i relTargetOffset
+        local relTargetOffset
         for relTargetOffset in "${allPlatOffsets[@]}"; do
             (( "$relHostOffset" <= "$relTargetOffset" )) || continue
 
@@ -448,12 +447,12 @@ findInputs() {
 
             # Target offset relative to the package currently being
             # built.
-            mapOffset relTargetOffset
-            local -i targetOffsetNext="$mapOffsetResult"
+            local targetOffsetNext
+            mapOffset "$relTargetOffset" targetOffsetNext
 
             # Once again, ensure we're in bounds relative to the
             # package currently being built.
-            [[ "${allPlatOffsets[*]}" = *"$targetOffsetNext"* ]] || continue
+            (( -1 <= hostOffsetNext && hostOffsetNext <= 1 )) || continue
 
             [[ -f "$pkg/nix-support/$file" ]] || continue
 


### PR DESCRIPTION
###### Motivation for this change

Instead of using an intermediary variable, use a named reference.
the named reference feature was introduced in bash 4.3 and is exactly the use case.
IMO it is an improvement, however I want to check if others feel that way toward using a named reference (there are other places where this can be used).

I had a PR previously to enable some stdenv "improvements" that actually broke the build (https://github.com/NixOS/nixpkgs/pull/127736)
The idea is to try to break that PR logically into commits so things can be easily accepted or rejected.
Some of the changes will be related to enabling another shell, some of the changes will be things that I think should be improvements.

I will try to mark each PR as "Can be controversial" vs "I think this is OK". The current PR IMO is "I think this is OK"

I will cc people that I think would be interested in this PR and just add in the comments the other PRs that are related.

@aszlig @matthewbauer 
If you know of somebody else that could be interested, I would be happy to know.

Please note I'm only using master as a faster way to get some evaluations. My plan is to first break down the previous big PR into separate smaller ones. Then separately build on my machine the ones that don't fail the CI. Then ask someone from the hydra team to test them. (as the previous one broke quite some stuff and caused pain).

I also have some questions if anybody knows the answer.
- Why are we not using bash 5 ? Is it because it's just a matter of making the PR to upgrade, or is there another reason?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
