### PR TITLE
stdenv: use command that doesn't exit non-zero

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -68,9 +68,10 @@ _callImplicitHook() {
     local hookName="$2"
     if declare -F "$hookName" > /dev/null; then
         "$hookName"
-    elif type -p "$hookName" > /dev/null; then
+    elif [[ -e "$hookName" ]]; then
+        # shellcheck disable=SC1090
         source "$hookName"
-    elif [ -n "${!hookName:-}" ]; then
+    elif [[ -n "${!hookName:-}" ]]; then
         eval "${!hookName}"
     else
         return "$def"


### PR DESCRIPTION
###### Motivation for this change

This is a PR in the series of stdenv shell improvements.

This current PR replaces a command that exits with a non-zero code on failure with one that does not.
The code is in my opinion a test semantic rather than an "exit on failure" one.
This change serves in enabling strict err exit at some point.
In the previous commit @zimbatm pointed that the semantics are a little different.
If the $hookName is a directory the semantics change. In my experience this cannot be possible, however this is something that will need to be verified with the hydra tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
