### PR TITLE
builder.sh: strict non null check

### DIFF
--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -16,6 +16,6 @@ cat "$setup" >> $out/setup
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
 mkdir $out/nix-support
-if [ "$propagatedUserEnvPkgs" ]; then
+if [[ -n "${propagatedUserEnvPkgs:-}" ]]; then
     printf '%s ' $propagatedUserEnvPkgs > $out/nix-support/propagated-user-env-packages
 fi


### PR DESCRIPTION
###### Motivation for this change

This is a PR in series of stdenv shell "fixes"

This PR does two things.
- One "style" change, using `[[` instead of `[` , admittedly there are less pitfalls, and many people recommend it should be the default.
- Another is a more strict null check. The check is to see if the variable is not empty, and it does not fail in case the variable is undefined (useful for enabling strict errcheck).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
