### PR TITLE
move-docs.sh: shellcheck 2166

### DIFF
--- a/pkgs/build-support/setup-hooks/move-docs.sh
+++ b/pkgs/build-support/setup-hooks/move-docs.sh
@@ -6,7 +6,7 @@ preFixupHooks+=(_moveToShare)
 
 _moveToShare() {
     forceShare=${forceShare:=man doc info}
-    if [ -z "$forceShare" -o -z "$out" ]; then return; fi
+    if [[ -z "$out" ]]; then return; fi
 
     for d in $forceShare; do
         if [ -d "$out/$d" ]; then

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,7 +1,7 @@
 set -eu
 set -o pipefail
 
-if [ -n "${BASH_VERSINFO-}" ] && [ "${BASH_VERSINFO-}" -lt 4 ]; then
+if [[ -n "${BASH_VERSINFO-}" && "${BASH_VERSINFO-}" -lt 4 ]]; then
     echo "Detected Bash version that isn't supported by Nixpkgs (${BASH_VERSION})"
     echo "Please install Bash 4 or greater to continue."
     exit 1
@@ -648,11 +648,11 @@ export NIX_BUILD_CORES
 
 # Prevent SSL libraries from using certificates in /etc/ssl, unless set explicitly.
 # Leave it in impure shells for convenience.
-if [ -z "${NIX_SSL_CERT_FILE:-}" ] && [ "${IN_NIX_SHELL:-}" != "impure" ]; then
+if [[ -z "${NIX_SSL_CERT_FILE:-}" && "${IN_NIX_SHELL:-}" != "impure" ]]; then
   export NIX_SSL_CERT_FILE=/no-cert-file.crt
 fi
 # Another variant left for compatibility.
-if [ -z "${SSL_CERT_FILE:-}" ] && [ "${IN_NIX_SHELL:-}" != "impure" ]; then
+if [[ -z "${SSL_CERT_FILE:-}" && "${IN_NIX_SHELL:-}" != "impure" ]]; then
   export SSL_CERT_FILE=/no-cert-file.crt
 fi
 


### PR DESCRIPTION
###### Motivation for this change

This PR is in the series of stdenv shell improvements
commit from a reject PR commit https://github.com/NixOS/nixpkgs/pull/127736/commits/a37fa9ec98739a6b910dd6a4bf9ee0a852f81ad0

This is coming straight from the book shellcheck 2166
https://github.com/koalaman/shellcheck/wiki/SC2166

IMO it should be straightforward

I'm grouping this with another commit https://github.com/NixOS/nixpkgs/pull/127736/commits/ebf3f629a7aa8c052ca0381f395578f5c47e493a
Since those are very similar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
