### PR TITLE
stdenv: remove bash version compatibility hack

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -555,12 +555,12 @@ _addToEnv() {
                 #
                 # TODO(@Ericson2314): Don't special-case native compilation
                 for pkg in \
-                    ${pkgsBuildBuild+"${pkgsBuildBuild[@]}"} \
-                    ${pkgsBuildHost+"${pkgsBuildHost[@]}"} \
-                    ${pkgsBuildTarget+"${pkgsBuildTarget[@]}"} \
-                    ${pkgsHostHost+"${pkgsHostHost[@]}"} \
-                    ${pkgsHostTarget+"${pkgsHostTarget[@]}"} \
-                    ${pkgsTargetTarget+"${pkgsTargetTarget[@]}"}
+                    "${pkgsBuildBuild[@]}" \
+                    "${pkgsBuildHost[@]}" \
+                    "${pkgsBuildTarget[@]}" \
+                    "${pkgsHostHost[@]}" \
+                    "${pkgsHostTarget[@]}" \
+                    "${pkgsTargetTarget[@]}"
                 do
                     if [[ "$visitedPkgs" = *"$pkg"* ]]; then
                         continue
@@ -1004,7 +1004,7 @@ configurePhase() {
         # Old bash empty array hack
         # shellcheck disable=SC2086
         local flagsArray=(
-            $configureFlags ${configureFlagsArray+"${configureFlagsArray[@]}"}
+            $configureFlags "${configureFlagsArray[@]}"
         )
         echoCmd 'configure flags' "${flagsArray[@]}"
         # shellcheck disable=SC2086
@@ -1034,8 +1034,8 @@ buildPhase() {
         local flagsArray=(
             ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
             SHELL=$SHELL
-            $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-            $buildFlags ${buildFlagsArray+"${buildFlagsArray[@]}"}
+            $makeFlags "${makeFlagsArray[@]}"
+            $buildFlags "${buildFlagsArray[@]}"
         )
 
         echoCmd 'build flags' "${flagsArray[@]}"
@@ -1073,8 +1073,8 @@ checkPhase() {
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
             SHELL=$SHELL
-            $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-            ${checkFlags:-VERBOSE=y} ${checkFlagsArray+"${checkFlagsArray[@]}"}
+            $makeFlags "${makeFlagsArray[@]}"
+            ${checkFlags:-VERBOSE=y} "${checkFlagsArray[@]}"
             ${checkTarget}
         )
 
@@ -1099,8 +1099,8 @@ installPhase() {
     # shellcheck disable=SC2086
     local flagsArray=(
         SHELL=$SHELL
-        $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-        $installFlags ${installFlagsArray+"${installFlagsArray[@]}"}
+        $makeFlags "${makeFlagsArray[@]}"
+        $installFlags "${installFlagsArray[@]}"
         ${installTargets:-install}
     )
 
@@ -1207,8 +1207,8 @@ installCheckPhase() {
         local flagsArray=(
             ${enableParallelChecking:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}
             SHELL=$SHELL
-            $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}
-            $installCheckFlags ${installCheckFlagsArray+"${installCheckFlagsArray[@]}"}
+            $makeFlags "${makeFlagsArray[@]}"
+            $installCheckFlags "${installCheckFlagsArray[@]}"
             ${installCheckTarget:-installcheck}
         )
 
@@ -1227,7 +1227,7 @@ distPhase() {
     # Old bash empty array hack
     # shellcheck disable=SC2086
     local flagsArray=(
-        $distFlags ${distFlagsArray+"${distFlagsArray[@]}"} ${distTarget:-dist}
+        $distFlags "${distFlagsArray[@]}" ${distTarget:-dist}
     )
 
     echo 'dist flags: %q' "${flagsArray[@]}"


### PR DESCRIPTION
###### Motivation for this change

This removes a compatibility hack accross all version of bash prior to 4.4
In my understanding we won't be using older versions of bash anymore, so this is safe to remove.
For more informations check https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u

Note that there are other occurrences of this in the nixpkgs (notably in cargo-hooks) just search for the pattern `Array+"` to find them. I want to remove those at the same time, but I'm not sure those other occurrences can be safely removed.

I think this PR is uncontroversial

This is coming from https://github.com/NixOS/nixpkgs/pull/127736/commits/d685a680e74a65354d0700410877bfb350b2dca6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
