### PR TITLE
stdenv: clarify array semantics

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -120,15 +120,15 @@ exitHandler() {
     exitCode="$?"
     set +e
 
-    if [ -n "${showBuildStats:-}" ]; then
-        times > "$NIX_BUILD_TOP/.times"
-        local -a times=($(cat "$NIX_BUILD_TOP/.times"))
+    if [[ -n "${showBuildStats:-}" ]]; then
+        local -a buildTimesArray
+        IFS=" " read -r -a buildTimesArray < "$NIX_BUILD_TOP/.times"
         # Print the following statistics:
         # - user time for the shell
         # - system time for the shell
         # - user time for all child processes
         # - system time for all child processes
-        echo "build time elapsed: " "${times[@]}"
+        echo "build time elapsed: " "${buildTimesArray[@]}"
     fi
 
     if (( "$exitCode" != 0 )); then


### PR DESCRIPTION
This is a PR in a series of shell improvements to stdenv

###### Motivation for this change

This PR does 2 things
- replace `[` with `[[`
- clarify the array semantics of the variable `buildTimes`
- does not rely on implicit space split and makes that split explicit.
- it removes an extraneous cat

https://github.com/NixOS/nixpkgs/pull/127736/commits/97a83f806f2cee997ac9b58763e2630a15c3d8c2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
