### PR TITLE
Stdenv cosmetic

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -29,6 +29,7 @@ isExecutable() {
     isExeResult="$(LANG=C $READELF -h -l "$1" 2> /dev/null \
         | grep '^ *Type: *EXEC\>\|^ *INTERP\>')"
     # not using grep -q, because it can cause Broken pipe
+    # https://unix.stackexchange.com/questions/305547/broken-pipe-when-grepping-output-but-only-with-i-flag
     [ -n "$isExeResult" ]
 }
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -487,7 +487,7 @@ activatePackage() {
     # build platform are included here. That would be `depsBuild*`,
     # and legacy `nativeBuildInputs`, in general. If we aren't cross
     # compiling, however, everything can be put on the PATH. To ease
-    # the transition, we do include everything in thatcase.
+    # the transition, we do include everything in that case.
     #
     # TODO(@Ericson2314): Don't special-case native compilation
     if [[ -z "${strictDeps-}" || "$hostOffset" -le -1 ]]; then


### PR DESCRIPTION
###### Motivation for this change

The changes are really trivial really. There is a space missing and I'm just adding a link for an explanation of a comment
coming from https://github.com/NixOS/nixpkgs/pull/127736/commits/29a2e18d5191045eb7c1d6bc05633b8b8c739bff
and https://github.com/NixOS/nixpkgs/pull/127736/commits/907e9b9ea57586fb02086c721c44b4ad929647b2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
