### PR TITLE
stdenv: regex fixes

### DIFF
--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -54,15 +54,16 @@ _multioutConfig() {
     #   and reordering would cause more trouble than worth.
     if [ -z "$shareDocName" ]; then
         local confScript="$configureScript"
-        if [ -z "$confScript" ] && [ -x ./configure ]; then
+        if [[ -z "$confScript" && -x ./configure ]]; then
             confScript=./configure
         fi
-        if [ -f "$confScript" ]; then
-            local shareDocName="$(sed -n "s/^PACKAGE_TARNAME='\(.*\)'$/\1/p" < "$confScript")"
+        if [[ -f "$confScript" ]]; then
+            local shareDocName
+            shareDocName="$(sed -n "s/^PACKAGE_TARNAME='\(.*\)'$/\1/p" < "$confScript")"
         fi
-                                    # PACKAGE_TARNAME sometimes contains garbage.
-        if [ -z "$shareDocName" ] || echo "$shareDocName" | grep -q '[^a-zA-Z0-9_-]'; then
-            shareDocName="$(echo "$name" | sed 's/-[^a-zA-Z].*//')"
+        # PACKAGE_TARNAME sometimes contains garbage.
+        if [[ -z "$shareDocName" || ! $shareDocName =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            shareDocName="${name//-[^a-zA-Z].*/}"
         fi
     fi
 


### PR DESCRIPTION
###### Motivation for this change

This Commit does the following
- separate declaration and assignement of variable https://github.com/koalaman/shellcheck/wiki/SC2155
- Replace a sed command with a bash builtin regex. The idea here is to not try to put commands inside conditionals
- replaces another sed command with bash builtin search and replace functionality
- replaces some `[` with `[[`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
