### PR TITLE
stdenv: conservative dynamic undefined variables

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -12,9 +12,11 @@ bintoolsWrapper_addLDVars () {
     # See ../setup-hooks/role.bash
     local role_post
     getHostRoleEnvHook
+    local var_name=NIX_LDFLAGS${role_post}
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_LDFLAGS${role_post}+=" -L$1/lib64"
+        eval "$var_name=\"${!var_name:-} -L$1/lib64\""
+        export "${var_name?}"
     fi
 
     if [[ -d "$1/lib" ]]; then
@@ -24,7 +26,8 @@ bintoolsWrapper_addLDVars () {
         # directories and bloats the size of the environment variable space.
         local -a glob=( $1/lib/lib* )
         if [ "${#glob[*]}" -gt 0 ]; then
-            export NIX_LDFLAGS${role_post}+=" -L$1/lib"
+            eval "$var_name=\"${!var_name:-} -L$1/lib\""
+            export "${var_name?}"
         fi
     fi
 }


### PR DESCRIPTION
###### Motivation for this change

This PR takes into account if a dynamic variable is not set and replaces the `+=` with a more conservative alternative.

This PR can be controversial this the result is quite uglier than what it was before.

Perhaps an alternative here would be to just define the dynamic variable beforehand ? Not sure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
