### PR TITLE
ocamlPackages.otoml: init at 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/otoml/default.nix
+++ b/pkgs/development/ocaml-modules/otoml/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, menhir
+, menhirLib
+, uutf
+}:
+
+buildDunePackage rec {
+  pname = "otoml";
+  version = "0.9.0";
+
+  useDune2 = true;
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "dmbaturin";
+    repo = pname;
+    rev = version;
+    sha256 = "0l0c60rzgk11y8xq05kr8q9hkzb3c8vi995mq84x98ys73wb42j3";
+  };
+
+  buildInputs = [ menhir ];
+
+  propagatedBuildInputs = [ menhirLib uutf ];
+
+  meta = {
+    description = "A TOML parsing and manipulation library for OCaml";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -963,6 +963,8 @@ let
 
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
+    otoml = callPackage ../development/ocaml-modules/otoml { };
+
     otr = callPackage ../development/ocaml-modules/otr { };
 
     owee = callPackage ../development/ocaml-modules/owee { };


### PR DESCRIPTION
###### Motivation for this change

A dependency of recent [soupault](https://soupault.app/).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
