### PR TITLE
kernel: Enable Chrome platform modules

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -881,6 +881,22 @@ let
       # Keeping it a built-in ensures it will be used if possible.
       FB_SIMPLE = yes;
 
+    } // optionalAttrs (versionAtLeast version "5.4" && (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux")) {
+      # Required for various hardware features on Chrome OS devices
+      CHROME_PLATFORMS = yes;
+      CHROMEOS_TBMC = module;
+
+      CROS_EC = module;
+
+      CROS_EC_I2C = module;
+      CROS_EC_SPI = module;
+      CROS_EC_LPC = module;
+      CROS_EC_ISHTP = module;
+
+      CROS_KBD_LED_BACKLIGHT = module;
+    } // optionalAttrs (versionAtLeast version "5.4" && stdenv.hostPlatform.system == "x86_64-linux") {
+      CHROMEOS_LAPTOP = module;
+      CHROMEOS_PSTORE = module;
     };
   };
 in


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR enables modules required for certain hardware functionalities (touchpad, tablet switch, etc.) on Chrome OS devices. They were enabled in 5.4 but then disappeared, so let's enable them again explicitly. To keep the version constraints simple, we are matching kernel >5.4 even though some of them have been available since 4.x.

See also [Arch Linux's kernel config](https://github.com/archlinux/svntogit-packages/blob/1d233db826ea38fadabf2f208355b9e21df7d55e/trunk/config#L8377). Tested to fix touchpad on Samsung Chromebook Pro w/ Linux 5.12.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
