### PR TITLE
linuxPackages.xmm7360-pci: init at unstable-2021-05-18

### DIFF
--- a/pkgs/os-specific/linux/xmm7360-pci/default.nix
+++ b/pkgs/os-specific/linux/xmm7360-pci/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, perl, bc, breakpointHook }:
+
+stdenv.mkDerivation rec {
+  pname = "xmm7360-pci";
+  version = "unstable-2021-07-19";
+
+  src = fetchFromGitHub {
+    owner = "xmm7360";
+    repo = "xmm7360-pci";
+    rev = "7086b80bb609180b1b89fb478751e5e8414ab64f";
+    sha256 = "1wdb0phqg9rj9g9ycqdya0m7lx24kzjlh25yw0ifp898ddxrrr0c";
+  };
+
+  makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  INSTALL_MOD_PATH = placeholder "out";
+  installFlags = [ "DEPMOD=true" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/xmm7360/xmm7360-pci";
+    description = "PCI driver for Fibocom L850-GL modem based on Intel XMM7360 modem";
+    downloadPage = "https://github.com/xmm7360/xmm7360-pci";
+    license = licenses.isc;
+    maintainers = with maintainers; [ flokli hexa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21202,6 +21202,8 @@ in
 
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
+    xmm7360-pci = callPackage ../os-specific/linux/xmm7360-pci { };
+
     xpadneo = callPackage ../os-specific/linux/xpadneo { };
 
     zenpower = callPackage ../os-specific/linux/zenpower { };


### PR DESCRIPTION
###### Motivation for this change
Use my Fibocom L850-GL modem from NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
