### PR TITLE
treewide: remove unnecessary enableParallelBuilding when using cmake, meson, qmake

### DIFF
--- a/pkgs/applications/audio/dfasma/default.nix
+++ b/pkgs/applications/audio/dfasma/default.nix
@@ -47,8 +47,6 @@ in mkDerivation rec {
     substituteInPlace dfasma.pro --replace "CONFIG += file_sdif" "";
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Analyse and compare audio files in time and frequency";
     longDescription = ''

--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -38,8 +38,6 @@ mkDerivation rec {
       PREFIXSHORTCUT=$out"
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Free Musical Instrument Tuner";
     longDescription = ''

--- a/pkgs/applications/audio/iannix/default.nix
+++ b/pkgs/applications/audio/iannix/default.nix
@@ -19,8 +19,6 @@ mkDerivation rec {
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Graphical open-source sequencer";
     homepage = "https://www.iannix.org/";

--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -110,8 +110,6 @@ mkDerivation rec {
     wavpack
   ];
 
-  enableParallelBuilding = true;
-
   qtWrapperArgs = [
     "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
   ];

--- a/pkgs/applications/audio/tageditor/default.nix
+++ b/pkgs/applications/audio/tageditor/default.nix
@@ -45,8 +45,6 @@ stdenv.mkDerivation rec {
     tagparser
   ];
 
-  enableParallelBuilding = true;
-
   meta = with pkgs.lib; {
     homepage = "https://github.com/Martchus/tageditor";
     description = "A tag editor with Qt GUI and command-line interface supporting MP4/M4A/AAC (iTunes), ID3, Vorbis, Opus, FLAC and Matroska";

--- a/pkgs/applications/editors/focuswriter/default.nix
+++ b/pkgs/applications/editors/focuswriter/default.nix
@@ -12,8 +12,6 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config qmake qttools ];
   buildInputs = [ hunspell qtbase qtmultimedia ];
 
-  enableParallelBuilding = true;
-
   qmakeFlags = [ "PREFIX=/" ];
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 

--- a/pkgs/applications/editors/texmaker/default.nix
+++ b/pkgs/applications/editors/texmaker/default.nix
@@ -19,8 +19,6 @@ mkDerivation rec {
     "METAINFODIR=${placeholder "out"}/share/metainfo"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "TeX and LaTeX editor";
     longDescription=''

--- a/pkgs/applications/editors/tiled/default.nix
+++ b/pkgs/applications/editors/tiled/default.nix
@@ -15,8 +15,6 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config qmake ];
   buildInputs = [ python qtbase qttools ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Free, easy to use and flexible tile map editor";
     homepage = "https://www.mapeditor.org/";

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
   QT_PLUGIN_PATH = "${qtbase}/${qtbase.qtPluginPrefix}";
 
   buildInputs = [ qtbase poppler ];
-  enableParallelBuilding = true;
 
   qmakeFlags = [
     "DESKTOP_INSTALL_DIR=${placeholder "out"}/share/applications"

--- a/pkgs/applications/graphics/yacreader/default.nix
+++ b/pkgs/applications/graphics/yacreader/default.nix
@@ -18,8 +18,6 @@ mkDerivation rec {
   buildInputs = [ poppler libunarr libGLU qtmultimedia qtscript ];
   propagatedBuildInputs = [ qtquickcontrols qtgraphicaleffects qtdeclarative ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "A comic reader for cross-platform reading and managing your digital comic collection";
     homepage = "http://www.yacreader.com";

--- a/pkgs/applications/misc/nixnote2/default.nix
+++ b/pkgs/applications/misc/nixnote2/default.nix
@@ -14,8 +14,6 @@ mkDerivation rec {
 
   buildInputs = [ boost qtbase qtwebkit poppler hunspell ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ qmake ];
 
   postPatch = ''

--- a/pkgs/applications/misc/openbrf/default.nix
+++ b/pkgs/applications/misc/openbrf/default.nix
@@ -13,7 +13,6 @@ mkDerivation {
 
   buildInputs = [ qtbase vcg glew ];
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ qmake ];
 
   qmakeFlags = [ "openBrf.pro" ];

--- a/pkgs/applications/misc/qlcplus/default.nix
+++ b/pkgs/applications/misc/qlcplus/default.nix
@@ -39,8 +39,6 @@ mkDerivation rec {
       variables.pri
   '';
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     ln -sf $out/lib/*/libqlcplus* $out/lib
   '';

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -24,8 +24,6 @@ mkDerivation rec {
 
   nativeBuildInputs = [ qmake qttools ];
 
-  enableParallelBuilding = true;
-
   patches = [
     # Fix path to pass-otp plugin `/usr/lib/password-store/extensions/otp.bash` being hardcoded.
     # TODO: Remove when https://github.com/IJHack/QtPass/pull/499 is merged and available.

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -64,8 +64,6 @@ let
       mv lib $out/
     '';
 
-    enableParallelBuilding = true;
-
     meta = with lib; {
       inherit (src.meta) homepage;
       description = "QtLocation plugin for Google maps tile API";

--- a/pkgs/applications/networking/browsers/qtchan/default.nix
+++ b/pkgs/applications/networking/browsers/qtchan/default.nix
@@ -11,7 +11,6 @@ mkDerivation rec {
     sha256 = "1x11m1kwqindzc0dkpfifcglsb362impaxs85kgzx50p898sz9ll";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase ];
   qmakeFlags = [ "CONFIG-=app_bundle" ];

--- a/pkgs/applications/networking/instant-messengers/tensor/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tensor/default.nix
@@ -15,8 +15,6 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  enableParallelBuilding = true;
-
   buildInputs = [ qtbase qtquickcontrols ];
   nativeBuildInputs = [ qmake ];
 

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libcommuni qtbase ];
 
-  enableParallelBuilding = true;
-
   dontWrapQtApps = true;
 
   preConfigure = ''

--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -24,8 +24,6 @@ mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" "ETCDIR=$(out)/etc" "build_client" "build_man" ];
 
-  enableParallelBuilding = true;
-
   installTargets = [ "install_client" "install_man" ];
 
   qtWrapperArgs = [ "--suffix PATH : ${nx-libs}/bin:${openssh}/libexec" ];

--- a/pkgs/applications/radio/qradiolink/default.nix
+++ b/pkgs/applications/radio/qradiolink/default.nix
@@ -68,8 +68,6 @@ gnuradio3_8.pkgs.mkDerivation rec {
     gnuradio3_8.qt.wrapQtAppsHook
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "SDR transceiver application for analog and digital modes";
     homepage = "http://qradiolink.org/";

--- a/pkgs/applications/radio/qsstv/default.nix
+++ b/pkgs/applications/radio/qsstv/default.nix
@@ -10,8 +10,6 @@ mkDerivation rec {
     sha256 = "0f9hx6sy418cb23fadll298pqbc5l2lxsdivi4vgqbkvx7sw58zi";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     qmake
     pkg-config

--- a/pkgs/applications/science/physics/xflr5/default.nix
+++ b/pkgs/applications/science/physics/xflr5/default.nix
@@ -9,8 +9,6 @@ mkDerivation rec {
     sha256 = "02x3r9iv3ndwxa65mxn9m5dlhcrnjiq7cffi6rmb456gs3v3dnav";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ qmake ];
 
   meta = with lib; {

--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -30,8 +30,6 @@ mkDerivation rec {
       --replace /usr $out
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Ground station software for autonomous vehicles";
     longDescription = ''

--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -17,7 +17,6 @@ mkDerivation rec {
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad wayland
   ];
 
-  enableParallelBuilding = true;
   buildInputs = [ SDL2 ] ++ gstInputs ++ qtInputs;
   nativeBuildInputs = [ pkg-config qmake qttools ];
 

--- a/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
+++ b/pkgs/applications/terminal-emulators/cool-retro-term/default.nix
@@ -29,8 +29,6 @@ mkDerivation rec {
     ln -s $out/bin/cool-retro-term.app/Contents/MacOS/cool-retro-term $out/bin/cool-retro-term
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Terminal emulator which mimics the old cathode display";
     longDescription = ''

--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -34,7 +34,6 @@ mkDerivation rec {
     sha256 = "UdeHbNkJ0U9FeTmpbcU4JxiyIHkrlC8ErhtY6zdCZEk=";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ pkg-config qmake ];
   buildInputs = [
     SDL2

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -50,7 +50,6 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optional enableCUDA "-DTERRA_ENABLE_CUDA=ON";
 
   doCheck = true;
-  enableParallelBuilding = true;
   hardeningDisable = [ "fortify" ];
   outputs = [ "bin" "dev" "out" "static" ];
 

--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -9,7 +9,6 @@ stdenv.mkDerivation {
     rev = "b7212d5640701f93f0cd88fbd3a32c619030ae62";
   };
 
-  enableParallelBuilding = true;
   dontWrapQtApps = true;
   nativeBuildInputs = [ qmake ];
 

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation {
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
-  enableParallelBuilding = true;
-
   dontWrapQtApps = true;
 
   meta = {

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -34,7 +34,6 @@ in stdenv.mkDerivation rec {
     ln -s $out/lib/libqscintilla2_qt?.so $out/lib/libqscintilla2.so
   '';
 
-  enableParallelBuilding = true;
   dontWrapQtApps = true;
 
   postPatch = ''

--- a/pkgs/development/libraries/qtinstaller/default.nix
+++ b/pkgs/development/libraries/qtinstaller/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "doc" ];
 
   setOutputFlags = false;
-  enableParallelBuilding = true;
   NIX_QT_SUBMODULE = true;
   dontWrapQtApps = true;
 

--- a/pkgs/development/tools/build-managers/qbs/default.nix
+++ b/pkgs/development/tools/build-managers/qbs/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase qtscript ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "A tool that helps simplify the build process for developing projects across multiple platforms";
     homepage = "https://wiki.qt.io/Qbs";

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -16,7 +16,6 @@ mkDerivation rec {
 
   sourceRoot = "source/MiniZincIDE";
 
-  enableParallelBuilding = true;
   dontWrapQtApps = true;
 
   postInstall = ''

--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -75,8 +75,6 @@ in stdenv.mkDerivation rec {
 
   __impureHostDeps = lib.optional stdenv.isDarwin "/usr/lib/libicucore.dylib";
 
-  enableParallelBuilding = true;
-
   dontWrapQtApps = true;
 
   installPhase = ''

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -45,8 +45,6 @@ mkDerivation rec {
 
   doCheck = true;
 
-  enableParallelBuilding = true;
-
   buildFlags = optional withDocumentation "docs";
 
   installFlags = [ "INSTALL_ROOT=$(out)" ] ++ optional withDocumentation "install_docs";

--- a/pkgs/games/pokerth/default.nix
+++ b/pkgs/games/pokerth/default.nix
@@ -61,8 +61,6 @@ mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${SDL.dev}/include/SDL";
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     homepage = "https://www.pokerth.net";
     description = "Poker game ${target}";

--- a/pkgs/games/qgo/default.nix
+++ b/pkgs/games/qgo/default.nix
@@ -43,6 +43,4 @@ mkDerivation {
   '';
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtmultimedia qttranslations ];
-  enableParallelBuilding = true;
-
 }

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "A free 2D physics sandbox game";
     homepage = "http://powdertoy.co.uk/";

--- a/pkgs/misc/emulators/firebird-emu/default.nix
+++ b/pkgs/misc/emulators/firebird-emu/default.nix
@@ -12,8 +12,6 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ qmake ];
 
   buildInputs = [ qtbase qtdeclarative ];

--- a/pkgs/test/cuda/cuda-library-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-library-samples/generic.nix
@@ -16,7 +16,6 @@ let
     version = lib.strings.substring 0 7 rev + "-" + lib.versions.majorMinor cudatoolkit.version;
     nativeBuildInputs = [ cmake addOpenGLRunpath ];
     buildInputs = [ cudatoolkit ];
-    enableParallelBuilding = true;
     postFixup = ''
       for exe in $out/bin/*; do
         addOpenGLRunpath $exe

--- a/pkgs/tools/graphics/nifskope/default.nix
+++ b/pkgs/tools/graphics/nifskope/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation {
     done
   '';
 
-  enableParallelBuilding = true;
-
   # Inspired by install/linux-install/nifskope.spec.in.
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -20,8 +20,6 @@ mkDerivation rec {
     "PLUGINDIR=${placeholder "out"}/${qtbase.qtPluginPrefix}"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Qt5 Configuration Tool";
     homepage = "https://www.opendesktop.org/content/show.php?content=168066";

--- a/pkgs/tools/networking/cmst/default.nix
+++ b/pkgs/tools/networking/cmst/default.nix
@@ -15,8 +15,6 @@ mkDerivation rec {
 
   buildInputs = [ qtbase ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     for f in $(find . -name \*.cpp -o -name \*.pri -o -name \*.pro); do
       substituteInPlace $f --replace /etc $out/etc --replace /usr $out

--- a/pkgs/tools/text/glogg/default.nix
+++ b/pkgs/tools/text/glogg/default.nix
@@ -20,7 +20,6 @@ mkDerivation rec {
   buildInputs = [ boost ];
 
   qmakeFlags = [ "VERSION=${version}" ];
-  enableParallelBuilding = true;
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I'm following the heuristic used by [nixpkgs-hammering](https://github.com/jtojnar/nixpkgs-hammering/blob/e42eede0e3dc0316a003106024146f9db681688d/overlays/unnecessary-parallel-building.nix)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
