### PR TITLE
rm-improved: init at 0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7582,6 +7582,12 @@
     githubId = 26231126;
     name = "Nils ANDRÉ-CHANG";
   };
+  nils-degroot = {
+    email = "nils@peeko.nl";
+    github = "nils-degroot";
+    githubId = 53556985;
+    name = "Nils de Groot";
+  };
   ninjatrappeur = {
     email = "felix@alternativebit.fr";
     github = "ninjatrappeur";

--- a/pkgs/applications/misc/rm-improved/default.nix
+++ b/pkgs/applications/misc/rm-improved/default.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub, rustPlatform, lib }:
+
+with lib;
+
+rustPlatform.buildRustPackage rec {
+  pname = "rm-improved";
+  version = "0.13.0";
+
+  cargoSha256 = "0wgpr6gx9dpvf02xgvrdbyiqfz1k9vipnvriz3jg0cz7n1afqisj";
+
+  src = fetchFromGitHub {
+    owner = "nivekuil";
+    repo = "rip";
+    rev = "0.13.0";
+    sha256 = "0d065xia4mwdhxkiqfg7pic6scfzipzmsvvx7l6l97w62lzpiqx3";
+  };
+
+  meta = {
+    description = "Replacement for rm with focus on safety, ergonomics and performance";
+    homepage = "https://github.com/nivekuil/rip";
+    maintainers = with maintainers; [ nils-degroot ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3218,6 +3218,8 @@ in
 
   rmview = libsForQt5.callPackage ../applications/misc/remarkable/rmview { };
 
+  rm-improved = callPackage ../applications/misc/rm-improved { };
+
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
   restream = callPackage ../applications/misc/remarkable/restream { };


### PR DESCRIPTION
###### Motivation for this change

Hi all. Previously I used this package on a non Nixos machine. The resulting binary (rip) is similar to rm but has a undo.
Here is the source: https://github.com/nivekuil/rip

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).