### PR TITLE
pylsp-mypy: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -11,7 +11,7 @@
 buildPythonPackage rec {
   pname = "pylsp-mypy";
   version = "0.5.1";
-  disabled = !(pythonAtLeast "3.6");
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "Richardk2n";

--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, mypy
+, pytestCheckHook
+, python-lsp-server
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "pylsp-mypy";
+  version = "0.5.1";
+  disabled = !(pythonAtLeast "3.6");
+
+  src = fetchFromGitHub {
+    owner = "Richardk2n";
+    repo = "pylsp-mypy";
+    rev = version;
+    sha256 = "1d119csj1k5m9j0f7wdvpvnd02h548css6ybxqah92nk2v0rjscr";
+  };
+
+  checkInputs = [ pytestCheckHook mock ];
+
+  propagatedBuildInputs = [ mypy python-lsp-server ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Richardk2n/pylsp-mypy";
+    description = "Mypy plugin for the Python LSP Server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -5,7 +5,7 @@
 , mypy
 , pytestCheckHook
 , python-lsp-server
-, pythonAtLeast
+, pythonOlder
 }:
 
 buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6180,6 +6180,8 @@ in {
 
   pyls-spyder = callPackage ../development/python-modules/pyls-spyder { };
 
+  pylsp-mypy = callPackage ../development/python-modules/pylsp-mypy { };
+
   PyLTI = callPackage ../development/python-modules/pylti { };
 
   pylutron = callPackage ../development/python-modules/pylutron { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the `pylsp-mypy` plugin. This plugin is the `pylsp`-compatible
version of `pyls-mypy`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
