### PR TITLE
inkcut: use 'lpr' from closure

### DIFF
--- a/pkgs/applications/misc/inkcut/default.nix
+++ b/pkgs/applications/misc/inkcut/default.nix
@@ -2,6 +2,7 @@
 , python3Packages
 , fetchFromGitHub
 , wrapQtAppsHook
+, cups
 }:
 
 with python3Packages;
@@ -16,6 +17,11 @@ buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "0px0xdv6kyzkkpmvryrdfavv1qy2xrqdxkpmhvx1gj649xcabv32";
   };
+
+  postPatch = ''
+    substituteInPlace inkcut/device/transports/printer/plugin.py \
+      --replace ", 'lpr', " ", '${cups}/bin/lpr', "
+  '';
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 


### PR DESCRIPTION
###### Motivation for this change

To fix plotting via CUPS, closes #130351

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).