### PR TITLE
fast-cli: 1.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -46,17 +46,16 @@ let
       '';
     };
 
-    fast-cli = super.fast-cli.override (
-      {
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        prePatch = ''
-          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-        '';
-        postInstall = ''
-          wrapProgram $out/bin/fast \
-            --set PUPPETEER_EXECUTABLE_PATH ${pkgs.chromium.outPath}/bin/chromium
-        '';
-      });
+    fast-cli = super.fast-cli.override ({
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      prePatch = ''
+        export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+      '';
+      postInstall = ''
+        wrapProgram $out/bin/fast \
+          --set PUPPETEER_EXECUTABLE_PATH ${pkgs.chromium.outPath}/bin/chromium
+      '';
+    });
 
     hyperspace-cli = super."@hyperspace/cli".override {
       nativeBuildInputs = with pkgs; [

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -46,6 +46,18 @@ let
       '';
     };
 
+    fast-cli = super.fast-cli.override (
+      {
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        prePatch = ''
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+        '';
+        postInstall = ''
+          wrapProgram $out/bin/fast \
+            --set PUPPETEER_EXECUTABLE_PATH ${pkgs.chromium.outPath}/bin/chromium
+        '';
+      });
+
     hyperspace-cli = super."@hyperspace/cli".override {
       nativeBuildInputs = with pkgs; [
         makeWrapper
@@ -65,10 +77,6 @@ let
     };
 
     coc-imselect = super.coc-imselect.override {
-      meta.broken = since "10";
-    };
-
-    "fast-cli-1.x" = super."fast-cli-1.x".override {
       meta.broken = since "10";
     };
 
@@ -93,14 +101,6 @@ let
       name = "bitwarden-cli-${drv.version}";
       meta.mainProgram = "bw";
     });
-
-    fast-cli = super."fast-cli-1.x".override {
-      preRebuild = ''
-        # Simply ignore the phantomjs --version check. It seems to need a display but it is safe to ignore
-        sed -i -e "s|console.error('Error verifying phantomjs, continuing', err)|console.error('Error verifying phantomjs, continuing', err); return true;|" node_modules/phantomjs-prebuilt/lib/util.js
-      '';
-      buildInputs = [ pkgs.phantomjs2 ];
-    };
 
     flood = super.flood.override {
       buildInputs = [ self.node-pre-gyp ];

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -90,7 +90,7 @@
 , "eslint_d"
 , "esy"
 , "expo-cli"
-, {"fast-cli": "1.x"}
+, "fast-cli"
 , "fauna-shell"
 , "firebase-tools"
 , "fixjson"


### PR DESCRIPTION
###### Motivation for this change

Unpin fast-cli from version 1.  This adds support for the `--upload` flag so you can test upload speed in addition to download speed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This PR is based on a slightly old version of `master` because I currently can't run the `node-packages/generate.sh` script, which encounters this [error](https://github.com/NixOS/nixpkgs/pull/129697#issuecomment-882963109).  Therefore, I also haven't been able to run `nixpkgs-review`, which aborts when it hits a merge conflict.