### PR TITLE
pythonPackages.mysql-connector: Fix on darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7457,6 +7457,12 @@
     githubId = 2590830;
     name = "Sage Raflik";
   };
+  neosimsim = {
+    email = "me@abn.sh";
+    github = "neosimsim";
+    githubId = 1771772;
+    name = "Alexander Ben Nasrallah";
+  };
   nequissimus = {
     email = "tim@nequissimus.com";
     github = "nequissimus";

--- a/pkgs/development/python-modules/mysql-connector/0001-Revert-Fix-MacOS-wheels-platform-tag.patch
+++ b/pkgs/development/python-modules/mysql-connector/0001-Revert-Fix-MacOS-wheels-platform-tag.patch
@@ -1,0 +1,36 @@
+From c5d32ef5d656b0aa4b2c1fc61c901d40bf2fb96a Mon Sep 17 00:00:00 2001
+From: Alexander Ben Nasrallah <me@abn.sh>
+Date: Mon, 19 Jul 2021 17:24:41 +0200
+Subject: [PATCH] Revert "Fix MacOS wheels platform tag"
+
+This reverts commit d1e89fd3d7391084cdf35b0806cb5d2a4b413654.
+---
+ cpydist/__init__.py | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/cpydist/__init__.py b/cpydist/__init__.py
+index 0e7f341..2619d7a 100644
+--- a/cpydist/__init__.py
++++ b/cpydist/__init__.py
+@@ -41,7 +41,7 @@ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
+ from distutils.core import Command
+ from distutils.dir_util import mkpath, remove_tree
+-from distutils.sysconfig import get_config_vars, get_python_version
++from distutils.sysconfig import get_python_version
+ from distutils.version import LooseVersion
+ from subprocess import check_call, Popen, PIPE
+ 
+@@ -57,9 +57,6 @@ version_py = os.path.join("lib", "mysql", "connector", "version.py")
+ with open(version_py, "rb") as fp:
+     exec(compile(fp.read(), version_py, "exec"))
+ 
+-if "MACOSX_DEPLOYMENT_TARGET" in get_config_vars():
+-    get_config_vars()["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
+-
+ COMMON_USER_OPTIONS = [
+     ("byte-code-only", None,
+      "remove Python .py files; leave byte code .pyc only"),
+-- 
+2.31.1
+

--- a/pkgs/development/python-modules/mysql-connector/default.nix
+++ b/pkgs/development/python-modules/mysql-connector/default.nix
@@ -13,6 +13,15 @@ in buildPythonPackage rec {
     sha256 = "1zb5wf65rnpbk0lw31i4piy0bq09hqa62gx7bh241zc5310zccc7";
   };
 
+  patches = [
+    # mysql-connector overrides MACOSX_DEPLOYMENT_TARGET to 11.
+    # This makes the installation with nixpkgs fail. I suspect, that's
+    # because stdenv.targetPlatform.darwinSdkVersion is (currently) set to
+    # 10.12. The patch reverts
+    # https://github.com/mysql/mysql-connector-python/commit/d1e89fd3d7391084cdf35b0806cb5d2a4b413654
+    ./0001-Revert-Fix-MacOS-wheels-platform-tag.patch
+  ];
+
   propagatedBuildInputs = with py.pkgs; [ protobuf dnspython ];
 
   # Tests are failing (TODO: unknown reason)

--- a/pkgs/development/python-modules/mysql-connector/default.nix
+++ b/pkgs/development/python-modules/mysql-connector/default.nix
@@ -31,6 +31,6 @@ in buildPythonPackage rec {
     homepage = "https://github.com/mysql/mysql-connector-python";
     changelog = "https://raw.githubusercontent.com/mysql/mysql-connector-python/${version}/CHANGES.txt";
     license = [ lib.licenses.gpl2Only ];
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ neosimsim turion ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
python module mysql-conncetor fails to build on darwin (macOS) https://github.com/NixOS/nixpkgs/issues/130376.

###### Things done
Compared with last successful version and found out there was a version bump of mysql-connector which add a strange commit https://github.com/mysql/mysql-connector-python/commit/d1e89fd3d7391084cdf35b0806cb5d2a4b413654 for macOS distributions. Reverting this commit makes the derivatoin work again.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
