### PR TITLE
coreterminal: init at 4.2.0

### DIFF
--- a/pkgs/applications/terminal-emulators/coreterminal/default.nix
+++ b/pkgs/applications/terminal-emulators/coreterminal/default.nix
@@ -1,0 +1,42 @@
+{ mkDerivation
+, lib
+, fetchFromGitLab
+, cmake
+, ninja
+, qtbase
+, qtserialport
+, qtermwidget
+, libcprime
+}:
+
+mkDerivation rec {
+  pname = "coreterminal";
+  version = "4.2.0";
+
+  src = fetchFromGitLab {
+    owner = "cubocore/coreapps";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-YXs6VTem3AaK4n1DYwKP/jqNuf09Srn2THHyJJnArlc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    qtbase
+    qtserialport
+    qtermwidget
+    libcprime
+  ];
+
+  meta = with lib; {
+    description = "A terminal emulator from the C Suite";
+    homepage = "https://gitlab.com/cubocore/coreapps/coreterminal";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dan4ik605743 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libcprime/default.nix
+++ b/pkgs/development/libraries/libcprime/default.nix
@@ -1,0 +1,40 @@
+{ mkDerivation
+, lib
+, fetchFromGitLab
+, libnotify
+, cmake
+, ninja
+, qtbase
+, qtconnectivity
+}:
+
+mkDerivation rec {
+  pname = "libcprime";
+  version = "4.2.2";
+
+  src = fetchFromGitLab {
+    owner = "cubocore";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-RywvFATA/+fDP/TR5QRWaJlDgy3EID//iVmrJcj3GXI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    qtbase
+    qtconnectivity
+    libnotify
+  ];
+
+  meta = with lib; {
+    description = "A library for bookmarking, saving recent activites, managing settings of C-Suite";
+    homepage = "https://gitlab.com/cubocore/coreapps/libcprime";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dan4ik605743 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -931,6 +931,10 @@ in
 
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };
 
+  coreterminal = libsForQt5.callPackage ../applications/terminal-emulators/coreterminal {
+    inherit (lxqt) qtermwidget;
+  };
+
   eterm = callPackage ../applications/terminal-emulators/eterm { };
 
   evilvte = callPackage ../applications/terminal-emulators/evilvte (config.evilvte or {});

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6363,6 +6363,8 @@ in
 
   libscrypt = callPackage ../development/libraries/libscrypt { };
 
+  libcprime = libsForQt5.callPackage ../development/libraries/libcprime { };
+
   libcloudproviders = callPackage ../development/libraries/libcloudproviders { };
 
   libcoap = callPackage ../applications/networking/libcoap {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
