### PR TITLE
sentry-native: init at 0.4.11

### DIFF
--- a/pkgs/development/libraries/sentry-native/default.nix
+++ b/pkgs/development/libraries/sentry-native/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, cmake, curl, breakpad, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "sentry-native";
+  version = "0.4.11";
+
+  src = fetchFromGitHub {
+    owner = "getsentry";
+    repo = "sentry-native";
+    rev = version;
+    sha256 = "sha256-kasZ5OAtl32Oxed4BkxvHXEFqEvBaBwyslHO7Ga5TRY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ curl breakpad pkg-config ];
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    "-DSENTRY_BREAKPAD_SYSTEM=On"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/getsentry/sentry-native";
+    description = "Sentry SDK for C, C++ and native applications.";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wheelsandmetal ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9769,6 +9769,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  sentry-native = callPackage ../development/libraries/sentry-native { };
+
   vtun = callPackage ../tools/networking/vtun {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add sentry-native lib

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
