### PR TITLE
palemoon: 29.2.1 -> 29.3.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -52,14 +52,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.2.1";
+  version = "29.3.0";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "0djjl79jrnny16p32db5w7pwwv0a24dc8mg1s1bnavhlvmmk52vq";
+    sha256 = "1q0w1ffmdfk22df4p2ks4n55zmz44ir8fbcdn5a5h4ihy73nf6xp";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
https://repo.palemoon.org/MoonchildProductions/Pale-Moon/releases/tag/29.3.0_Release

> This is a development, bugfix and security release.
> …
> - Fixed several crashes.
> - Linux: blocked particularly old versions of Mesa/Nouveau drivers due to issues.
> - Security issues addressed: CVE-2021-30547 and several other issues that don’t have a CVE number.
> - Unified XUL Platform Mozilla Security Patch Summary: 3 fixed, 3 DiD, 2 deferred (DiD), 12 not applicable.

Needs backporting to stable.

![grafik](https://user-images.githubusercontent.com/23431373/126335110-aa7adcc5-2b11-4bc8-ba02-a96b15aad928.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
