### PR TITLE
black: Disable failing tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     # fails on darwin
     "test_expression_diff"
+    # Fail on Hydra, see https://github.com/NixOS/nixpkgs/pull/130785
     "test_bpo_2142_workaround"
     "test_skip_magic_trailing_comma"
   ];

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -54,6 +54,8 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     # fails on darwin
     "test_expression_diff"
+    "test_bpo_2142_workaround"
+    "test_skip_magic_trailing_comma"
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
These two tests have been failing for me for a while.

```
BlackTestCase.test_bpo_2142_workaround
E       AssertionError: '--- /tmp/blk_fnxuyc4p.log\t2021-07-20 13:43:3[279 chars
]er\n' != '--- [Deterministic header]\n+++ [Deterministi[253 chars]er\n'        E       - --- /tmp/blk_fnxuyc4p.log     2021-07-20 13:43:33 +0000
E       + --- [Deterministic header]
E         +++ [Deterministic header]
E         @@ -1,3 +1,3 @@
E          # A comment-only file, with no final EOL character                   E          # This triggers https://bugs.python.org/issue2142                    E         -# This is the line without the EOL character
E         \ No newline at end of file
E         +# This is the line without the EOL character
tests/test_black.py:2063: AssertionError
```

This one isn't reproduced in full because it's very long:

```
BlackTestCase.test_skip_magic_trailing_comma

E           AssertionError: '--- [Deterministic header]\n+++ [Deterministi[15605
 chars]ER\n' != '--- /tmp/blk_viwf7zen.log\t2021-07-20 13:43:4[15631 chars]ER\n'
E           - --- [Deterministic header]
E           + --- /tmp/blk_viwf7zen.log 2021-07-20 13:43:45 +0000
E             +++ [Deterministic header]
E             @@ -1,8 +1,8 @@
E              ...
E             -'some_string'
E             -b'\\xa3'
E             +"some_string"
E             +b"\\xa3"
E              Name
E              None
E              True
E              False
E              1
[ SNIPPED ]
E             +)
E              last_call()
E              # standalone comment at ENDMARKER
E            : Expected diff isn't equal to the actual. If you made changes to e
xpression.py and this is an anticipated difference, overwrite tests/data/express
ion_skip_magic_trailing_comma.diff with /tmp/blk_3ub2s4er.log

/private/tmp/nix-build-python3.8-black-21.6b0.drv-0/black-21.6b0/tests/test_blac
k.py:449: AssertionError
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Black has been failing to build for me on Darwin for a while now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
