### PR TITLE
Tonelib-{gfx,jam,zoom}: fixed runtimeDependencies

### DIFF
--- a/pkgs/applications/audio/tonelib-gfx/default.nix
+++ b/pkgs/applications/audio/tonelib-gfx/default.nix
@@ -12,6 +12,7 @@
 , fribidi
 , pango
 , freetype
+, curl
 }:
 
 stdenv.mkDerivation rec {
@@ -49,6 +50,10 @@ stdenv.mkDerivation rec {
     cp -R $TMP/usr/* $out/
     mv $out/bin/ToneLib-GFX $out/bin/tonelib-gfx
   '';
+
+  runtimeDependencies = [
+    (lib.getLib curl)
+  ];
 
   meta = with lib; {
     description = "Tonelib GFX is an amp and effects modeling software for electric guitar and bass.";

--- a/pkgs/applications/audio/tonelib-jam/default.nix
+++ b/pkgs/applications/audio/tonelib-jam/default.nix
@@ -12,6 +12,7 @@
 , fribidi
 , pango
 , freetype
+, curl
 }:
 
 stdenv.mkDerivation rec {
@@ -49,6 +50,10 @@ stdenv.mkDerivation rec {
     cp -R $TMP/usr/* $out/
     mv $out/bin/ToneLib-Jam $out/bin/tonelib-jam
   '';
+
+  runtimeDependencies = [
+    (lib.getLib curl)
+  ];
 
   meta = with lib; {
     description = "ToneLib Jam – the learning and practice software for guitar players";

--- a/pkgs/applications/audio/tonelib-zoom/default.nix
+++ b/pkgs/applications/audio/tonelib-zoom/default.nix
@@ -6,6 +6,7 @@
 , webkitgtk
 , libjack2
 , alsa-lib
+, curl
 }:
 
 stdenv.mkDerivation rec {
@@ -37,6 +38,10 @@ stdenv.mkDerivation rec {
     cp -R $TMP/usr/* $out/
     mv $out/bin/ToneLib-Zoom $out/bin/tonelib-zoom
   '';
+
+  runtimeDependencies = [
+    (lib.getLib curl)
+  ];
 
   meta = with lib; {
     description = "ToneLib Zoom – change and save all the settings in your Zoom(r) guitar pedal";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The program found a problem with downloading presets. Required curl. The problem is fixed. The program is fully funuing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
