### PR TITLE
xlibsWrapper: preserve meta

### DIFF
--- a/pkgs/development/libraries/xlibs-wrapper/default.nix
+++ b/pkgs/development/libraries/xlibs-wrapper/default.nix
@@ -11,9 +11,9 @@ stdenv.mkDerivation {
   propagatedBuildInputs = packages;
 
   preferLocalBuild = true;
-} // {
+
   # For compatability with XFree86.
-  buildClientLibs = true;
+  passthru.buildClientLibs = true;
 
   meta = {
     platforms = lib.platforms.unix;


### PR DESCRIPTION
`//` erases `meta` generated by `stdenv.mkDerivation`, in particular `meta.available`, which makes `meta.platform` declaration futile
