### PR TITLE
eclair: init at 0.6.1

### DIFF
--- a/pkgs/applications/blockchains/eclair.nix
+++ b/pkgs/applications/blockchains/eclair.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchzip
+, jq
+, openjdk11
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eclair";
+  version = "0.6.1";
+  revision = "d3ae323";
+
+  src = fetchzip {
+    url = "https://github.com/ACINQ/eclair/releases/download/v${version}/eclair-node-${version}-${revision}-bin.zip";
+    sha256 = "0hmdssj6pxhvadrgr1svb2lh7hfbd2axr5wsl7glizv1a21g0l2c";
+  };
+
+  propagatedBuildInputs = [ jq openjdk11 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -a * $out
+    mv $out/bin/eclair-node.sh $out/bin/eclair-node
+    rm $out/bin/eclair-node.bat
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A scala implementation of the Lightning Network";
+    homepage = "https://github.com/ACINQ/eclair";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28537,6 +28537,8 @@ in
   dogecoin  = callPackage ../applications/blockchains/dogecoin.nix { boost = boost165; withGui = true; };
   dogecoind = callPackage ../applications/blockchains/dogecoin.nix { boost = boost165; withGui = false; };
 
+  eclair = callPackage ../applications/blockchains/eclair.nix { };
+
   electrs = callPackage ../applications/blockchains/electrs.nix { };
 
   elements  = libsForQt5.callPackage ../applications/blockchains/elements.nix { miniupnpc = miniupnpc_2; withGui = true; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- new package - Lightning Network node

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
