### PR TITLE
ventoy-bin: init at 1.0.51

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5332,6 +5332,12 @@
     githubId = 66669;
     name = "Jeff Zellner";
   };
+  k4leg = {
+    name = "k4leg";
+    email = "python.bogdan@gmail.com";
+    github = "k4leg";
+    githubId = 39882583;
+  };
   kaction = {
     name = "Dmitry Bogatov";
     email = "KAction@disroot.org";

--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -1,0 +1,95 @@
+{ lib, stdenv, fetchurl, fetchpatch
+, autoPatchelfHook, makeWrapper
+, hexdump, exfat, dosfstools, e2fsprogs, xz, util-linux, bash, parted
+}:
+
+let arch = {
+  x86_64-linux = "x86_64";
+  i686-linux = "i386";
+  aarch64-linux = "aarch64";
+  mipsel-linux = "mips64el";
+}.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
+in stdenv.mkDerivation rec {
+  pname = "ventoy-bin";
+  version = "1.0.51";
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  buildInputs = [ hexdump exfat dosfstools e2fsprogs xz util-linux bash parted ];
+
+  src = fetchurl {
+    url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";
+    sha256 = "81ae02a06b132b5965dd09c9b64e000a6dafa1d57e03d8564feefda14ef1ee02";
+  };
+  patches = [
+    (fetchpatch {
+      name = "sanitize.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/sanitize.patch?h=ventoy-bin&id=ce4c26c67a1de4b761f9448bf92e94ffae1c8148";
+      sha256 = "c00f9f9cd5b4f81c566267b7b2480fa94d28dda43a71b1e47d6fa86f764e7038";
+    })
+    ./fix-for-read-only-file-system.patch
+  ];
+  patchFlags = [ "-p0" ];
+  postPatch = ''
+    # Fix permissions.
+    find -type f -name \*.sh -exec chmod a+x '{}' \;
+
+    # Fix path to log.
+    sed -i 's:[lL]og\.txt:/var/log/ventoy\.log:g' WebUI/static/js/languages.js
+  '';
+  installPhase = ''
+    # Setup variables.
+    local VENTOY_PATH="$out"/share/ventoy
+    local ARCH='${arch}'
+
+    # Prepare.
+    cd tool/"$ARCH"
+    rm ash* hexdump* mkexfatfs* mount.exfat-fuse* xzcat*
+    for archive in *.xz; do
+        xzcat "$archive" > "''${archive%.xz}"
+        rm "$archive"
+    done
+    chmod a+x *
+    cd -
+
+    # Cleanup.
+    case "$ARCH" in
+        x86_64) rm -r tool/{i386,aarch64,mips64el};;
+        i386) rm -r tool/{x86_64,aarch64,mips64el};;
+        aarch64) rm -r tool/{x86_64,i386,mips64el};;
+        mips64el) rm -r tool/{x86_64,i386,aarch64};;
+    esac
+    rm README
+
+    # Copy from "$src" to "$out".
+    mkdir -p "$out"/bin "$VENTOY_PATH"
+    cp -r . "$VENTOY_PATH"
+
+    # Fill bin dir.
+    for f in Ventoy2Disk.sh_ventoy VentoyWeb.sh_ventoy-web \
+             CreatePersistentImg.sh_ventoy-persistent \
+             ExtendPersistentImg.sh_ventoy-extend-persistent; do
+        makeWrapper "$VENTOY_PATH/''${f%_*}" "$out/bin/''${f#*_}" \
+                    --prefix PATH : "${lib.makeBinPath buildInputs}" \
+                    --run "cd '$VENTOY_PATH' || exit 1"
+    done
+  '';
+
+  meta = with lib; {
+    description = "An open source tool to create bootable USB drive for ISO/WIM/IMG/VHD(x)/EFI files";
+    longDescription = ''
+      An open source tool to create bootable USB drive for
+      ISO/WIM/IMG/VHD(x)/EFI files.  With ventoy, you don't need to format the
+      disk over and over, you just need to copy the ISO/WIM/IMG/VHD(x)/EFI
+      files to the USB drive and boot them directly.  You can copy many files
+      at a time and ventoy will give you a boot menu to select them
+      (screenshot).  x86 Legacy BIOS, IA32 UEFI, x86_64 UEFI, ARM64 UEFI and
+      MIPS64EL UEFI are supported in the same way.  Most type of OS supported
+      (Windows/WinPE/Linux/Unix/VMware/Xen...).
+    '';
+    homepage = "https://www.ventoy.net";
+    changelog = "https://www.ventoy.net/doc_news.html";
+    license = licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" "mipsel-linux" ];
+    maintainers = with maintainers; [ k4leg ];
+  };
+}

--- a/pkgs/tools/cd-dvd/ventoy-bin/fix-for-read-only-file-system.patch
+++ b/pkgs/tools/cd-dvd/ventoy-bin/fix-for-read-only-file-system.patch
@@ -1,0 +1,118 @@
+diff -Naurp0 old/CreatePersistentImg.sh new/CreatePersistentImg.sh
+--- CreatePersistentImg.sh	2021-07-17 13:13:51.000000000 +0300
++++ CreatePersistentImg.sh	2021-07-20 17:37:53.605911754 +0300
+@@ -94,7 +94,3 @@ if [ -n "$config" ]; then
+-    if [ -d ./persist_tmp_mnt ]; then
+-        rm -rf ./persist_tmp_mnt
+-    fi
+-    
+-    mkdir ./persist_tmp_mnt
+-    if mount $freeloop ./persist_tmp_mnt; then
+-        echo '/ union' > ./persist_tmp_mnt/$config
++    path_to_persist_mnt="$(mktemp -d)"
++    if mount $freeloop "$path_to_persist_mnt"; then
++        echo '/ union' > "$path_to_persist_mnt"/$config
+@@ -102 +98 @@ if [ -n "$config" ]; then
+-        umount ./persist_tmp_mnt
++        umount "$path_to_persist_mnt"
+@@ -104 +100 @@ if [ -n "$config" ]; then
+-    rm -rf ./persist_tmp_mnt
++    rm -rf "$path_to_persist_mnt"
+diff -Naurp0 old/tool/VentoyWorker.sh new/tool/VentoyWorker.sh
+--- tool/VentoyWorker.sh	2021-07-17 13:13:51.000000000 +0300
++++ tool/VentoyWorker.sh	2021-07-20 17:27:10.885452119 +0300
+@@ -153,12 +152,0 @@ fi
+-#check tmp_mnt directory
+-if [ -d ./tmp_mnt ]; then
+-    vtdebug "There is a tmp_mnt directory, now delete it."
+-    umount ./tmp_mnt >/dev/null 2>&1
+-    rm -rf ./tmp_mnt
+-    if [ -d ./tmp_mnt ]; then
+-        vterr "tmp_mnt directory exits, please delete it first."
+-        exit 1
+-    fi
+-fi
+-
+-
+@@ -322 +310 @@ if [ "$MODE" = "install" ]; then
+-        mkdir ./tmp_mnt
++        path_to_mnt="$(mktemp -d)"
+@@ -326 +314 @@ if [ "$MODE" = "install" ]; then
+-            if mount ${PART2} ./tmp_mnt > /dev/null 2>&1; then
++            if mount ${PART2} "$path_to_mnt" > /dev/null 2>&1; then
+@@ -335,9 +323,9 @@ if [ "$MODE" = "install" ]; then
+-        rm -f ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
+-        rm -f ./tmp_mnt/EFI/BOOT/grubx64.efi
+-        rm -f ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
+-        rm -f ./tmp_mnt/EFI/BOOT/grubia32.efi
+-        rm -f ./tmp_mnt/EFI/BOOT/MokManager.efi
+-        rm -f ./tmp_mnt/EFI/BOOT/mmia32.efi
+-        rm -f ./tmp_mnt/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
+-        mv ./tmp_mnt/EFI/BOOT/grubx64_real.efi  ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
+-        mv ./tmp_mnt/EFI/BOOT/grubia32_real.efi  ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
++        rm -f "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
++        rm -f "$path_to_mnt"/EFI/BOOT/grubx64.efi
++        rm -f "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
++        rm -f "$path_to_mnt"/EFI/BOOT/grubia32.efi
++        rm -f "$path_to_mnt"/EFI/BOOT/MokManager.efi
++        rm -f "$path_to_mnt"/EFI/BOOT/mmia32.efi
++        rm -f "$path_to_mnt"/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
++        mv "$path_to_mnt"/EFI/BOOT/grubx64_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
++        mv "$path_to_mnt"/EFI/BOOT/grubia32_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
+@@ -348 +336 @@ if [ "$MODE" = "install" ]; then
+-            if umount ./tmp_mnt; then
++            if umount "$path_to_mnt"; then
+@@ -350 +338 @@ if [ "$MODE" = "install" ]; then
+-                rm -rf ./tmp_mnt
++                rm -rf "$path_to_mnt"
+@@ -407,2 +395,2 @@ else
+-    rm -f ./diskuuid.bin
+-    dd status=none conv=fsync if=${DISK} skip=384 bs=1 count=16 of=./diskuuid.bin
++    path_to_diskuuid="$(mktemp)"
++    dd status=none conv=fsync if=${DISK} skip=384 bs=1 count=16 of="$path_to_diskuuid"
+@@ -411,2 +399,2 @@ else
+-    dd status=none conv=fsync if=./diskuuid.bin of=$DISK bs=1 count=16 seek=384
+-    rm -f ./diskuuid.bin
++    dd status=none conv=fsync if="$path_to_diskuuid" of=$DISK bs=1 count=16 seek=384
++    rm -f "$path_to_diskuuid"
+@@ -415,2 +403,2 @@ else
+-    rm -f ./rsvdata.bin
+-    dd status=none conv=fsync if=${DISK} skip=2040 bs=512 count=8 of=./rsvdata.bin
++    path_to_rsvdata="$(mktemp)"
++    dd status=none conv=fsync if=${DISK} skip=2040 bs=512 count=8 of="$path_to_rsvdata"
+@@ -438,2 +426,2 @@ else
+-    dd status=none conv=fsync if=./rsvdata.bin seek=2040 bs=512 count=8 of=${DISK}
+-    rm -f ./rsvdata.bin
++    dd status=none conv=fsync if="$path_to_rsvdata" seek=2040 bs=512 count=8 of=${DISK}
++    rm -f "$path_to_rsvdata"
+@@ -448 +436 @@ else
+-        mkdir ./tmp_mnt
++        path_to_mnt="$(mktemp -d)"
+@@ -454 +442 @@ else
+-            if mount ${PART2} ./tmp_mnt > /dev/null 2>&1; then
++            if mount ${PART2} "$path_to_mnt" > /dev/null 2>&1; then
+@@ -463,9 +451,9 @@ else
+-        rm -f ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
+-        rm -f ./tmp_mnt/EFI/BOOT/grubx64.efi
+-        rm -f ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
+-        rm -f ./tmp_mnt/EFI/BOOT/grubia32.efi
+-        rm -f ./tmp_mnt/EFI/BOOT/MokManager.efi
+-        rm -f ./tmp_mnt/EFI/BOOT/mmia32.efi
+-        rm -f ./tmp_mnt/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
+-        mv ./tmp_mnt/EFI/BOOT/grubx64_real.efi  ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
+-        mv ./tmp_mnt/EFI/BOOT/grubia32_real.efi  ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
++        rm -f "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
++        rm -f "$path_to_mnt"/EFI/BOOT/grubx64.efi
++        rm -f "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
++        rm -f "$path_to_mnt"/EFI/BOOT/grubia32.efi
++        rm -f "$path_to_mnt"/EFI/BOOT/MokManager.efi
++        rm -f "$path_to_mnt"/EFI/BOOT/mmia32.efi
++        rm -f "$path_to_mnt"/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
++        mv "$path_to_mnt"/EFI/BOOT/grubx64_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
++        mv "$path_to_mnt"/EFI/BOOT/grubia32_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
+@@ -476 +464 @@ else
+-            if umount ./tmp_mnt > /dev/null 2>&1; then
++            if umount "$path_to_mnt" > /dev/null 2>&1; then
+@@ -478 +466 @@ else
+-                rm -rf ./tmp_mnt
++                rm -rf "$path_to_mnt"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -896,6 +896,8 @@ in
 
   veikk-linux-driver-gui = libsForQt5.callPackage ../tools/misc/veikk-linux-driver-gui { };
 
+  ventoy-bin = callPackage ../tools/cd-dvd/ventoy-bin { };
+
   xcd = callPackage ../tools/misc/xcd { };
 
   xtrt = callPackage ../tools/archivers/xtrt { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] other Linux distributions
- Tested execution of all binary files (usually in `result/bin/`)
   - `ventoy`
      - [x] `-i`
      - [x] `-I`
      - [x] `-u`
      - [x] `-l`
      - [x] `-r`
      - [x] `-s`
      - [x] `-g`
      - [x] `-L`
   - [x] `ventoy-extend-persistent`
   - `ventoy-persistent`
      - [x] `-s`
      - [x] `-t`
      - [x] `-l`
      - [x] `-c`
      - [x] `-o`
   - `ventoy-web`
      - [x] `-H`
      - [x] `-p`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
