### PR TITLE
rnix-lsp: 0.1.0 -> unstable-2021-07-18

### DIFF
--- a/pkgs/development/tools/rnix-lsp/default.nix
+++ b/pkgs/development/tools/rnix-lsp/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rnix-lsp";
-  version = "0.1.0";
+  version = "unstable-2021-07-18";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "rnix-lsp";
-    rev = "v${version}";
+    rev = "1fdd7cf9bf56b8ad2dddcfd27354dae8aef2b453";
 
-    sha256 = "0fy620c34kxl27sd62x9mj0555bcdmnmbsxavmyiwb497z1m9wnn";
+    sha256 = "sha256-w0hpyFXxltmOpbBKNQ2tfKRWELQzStc/ho1EcNyYaWc=";
   };
 
-  cargoSha256 = "1akapxrh38g44531r25dgik8y5qyy9y6zb031hg8v61px2ajs39s";
+  cargoSha256 = "sha256-X6eCwi2zxEUZA54SIHiqjLOXGIfxwoAVe7VdCnBe7TE=";
 
   meta = with lib; {
     description = "A work-in-progress language server for Nix, with syntax checking and basic completion";

--- a/pkgs/development/tools/rnix-lsp/default.nix
+++ b/pkgs/development/tools/rnix-lsp/default.nix
@@ -17,6 +17,6 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "A work-in-progress language server for Nix, with syntax checking and basic completion";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ lovesegfault ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The project doesn't see frequent releases, and the 0.1.0 release has its
internal `nixpkgs-fmt` out-of-sync with the `nixpkgs-fmt` in `nixpkgs`, causing
constant formatting flip-flops.

This makes us just use the current master instead of any given release.

cc. @Ma27

###### Things done

- rnix-lsp: add lovesegfault as maintainer
- rnix-lsp: 0.1.0 -> unstable-2021-07-18

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
