### PR TITLE
osu-lazer: 2021.707.0 -> 2021.720.0 and fix build failure

### DIFF
--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -16,13 +16,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "osu-lazer";
-  version = "2021.707.0";
+  version = "2021.720.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     rev = version;
-    sha256 = "UdsN/kvpqZrOiigxGttwrExlOkEFa2xWqDQS/d7y/0k=";
+    sha256 = "I7UkbyH2i218d5RCq4al9Gr1C0MX339jFOeyKrKQ3b0=";
   };
 
   patches = [ ./bypass-tamper-detection.patch ];

--- a/pkgs/games/osu-lazer/deps.nix
+++ b/pkgs/games/osu-lazer/deps.nix
@@ -26,8 +26,8 @@
   })
   (fetchNuGet {
     name = "Fody";
-    version = "6.5.1";
-    sha256 = "08zpyrniajjba5isjb09spggfh0af2z6x4h2zy5ilk3y5bb9vdch";
+    version = "6.5.2";
+    sha256 = "0vq97mkfk5ijinwnhpkm212y69ik6cd5x0n61ssyxmz50q1vp84f";
   })
   (fetchNuGet {
     name = "HidSharpCore";
@@ -781,13 +781,13 @@
   })
   (fetchNuGet {
     name = "ppy.LocalisationAnalyser";
-    version = "2021.706.0";
-    sha256 = "087x61vi1rv1slzr8hhcslngdd41p2d5r8yhpqm1kmls24csv556";
+    version = "2021.716.0";
+    sha256 = "0w45af0mlh4bkjxxhk5p4kb6z0na8fmm6xz10dfzs3b4i61h5x3z";
   })
   (fetchNuGet {
     name = "ppy.osu.Framework";
-    version = "2021.707.0";
-    sha256 = "1ai8yam6v67y9z8yipqjn578bk2qzqm05ncyqfgig3in6baxwpna";
+    version = "2021.714.0";
+    sha256 = "175i0hcbl01xy633zvij8185nj4g7ja1rsv2lmfz8qdykqj6g9kl";
   })
   (fetchNuGet {
     name = "ppy.osu.Framework.NativeLibs";
@@ -816,13 +816,13 @@
   })
   (fetchNuGet {
     name = "Realm";
-    version = "10.2.1";
-    sha256 = "14pi7vz7nl8ag0bmlbyds52z5nx9wbg154qkm6jai10rm02ws86l";
+    version = "10.3.0";
+    sha256 = "12zmp43cf2kilzq1yi9x2hy1jdh51c0kbnddw5s960k1kvyx2s2v";
   })
   (fetchNuGet {
     name = "Realm.Fody";
-    version = "10.2.1";
-    sha256 = "1zv57wb7zcgyigsxqikf2yq2h7an4c3dbydl9la5xdpa76dgmxdi";
+    version = "10.3.0";
+    sha256 = "0mhjkahi2ldxcizv08i70mrpwgrvljxdjlr81x3dmwgpxxfji18d";
   })
   (fetchNuGet {
     name = "Remotion.Linq";


### PR DESCRIPTION
The tag `2021.707.0` is deleted from upstream, result in a build failure

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump the version and fix build failure (URL 404 because of deleted tag).

**Depends on #130837 since `nuget` is also broken**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
