### PR TITLE
Upgrade pudb

### DIFF
--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -1,17 +1,19 @@
-{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi, pytest, glibcLocales, tox, pytestcov, parso }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, glibcLocales
+, tox
+, pytestcov
+, parso }:
 
 buildPythonPackage rec {
   pname = "jedi";
-  # switch back to stable version on the next release.
-  # current stable is incompatible with parso
-  version = "2020-08-06";
+  version = "0.18.0";
 
-  src = fetchFromGitHub {
-    owner = "davidhalter";
-    repo = "jedi";
-    rev = "216f976fd5cab7a460e5d287e853d11759251e52";
-    sha256 = "1kb2ajzigadl95pnwglg8fxz9cvpg9hx30hqqj91jkgrc7djdldj";
-    fetchSubmodules = true;
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-klUKQEutiv7YgaE37JpGH+1J7KZhQUvkUFkylhTtBwc=";
   };
 
   checkInputs = [ pytest glibcLocales tox pytestcov ];
@@ -22,8 +24,11 @@ buildPythonPackage rec {
     LC_ALL="en_US.UTF-8" py.test test
   '';
 
-  # tox required for tests: https://github.com/davidhalter/jedi/issues/808
+  # A few tests failed because of having to access home directory.
+  # Therefore disable the tests for now.
   doCheck = false;
+
+  pythonImportsCheck = [ "jedi" ];
 
   meta = with lib; {
     homepage = "https://github.com/davidhalter/jedi";

--- a/pkgs/development/python-modules/pudb/default.nix
+++ b/pkgs/development/python-modules/pudb/default.nix
@@ -3,27 +3,30 @@
 , fetchPypi
 , pygments
 , urwid
+, urwid-readline
+, jedi
 , isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "pudb";
-  version = "2020.1";
+  version = "2021.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2ef23d3371439f13fffbe7f8b9fc180a19d4183dc9cab204d878d7c7766464bf";
+    sha256 = "sha256-MJ7oK0Wg/8oLxMf1If0+NXWJx2TzOb353Ku3rUBpLW4=";
   };
 
-  propagatedBuildInputs = [ pygments urwid ];
+  propagatedBuildInputs = [ pygments urwid urwid-readline jedi ];
 
   # Tests fail on python 3 due to writes to the read-only home directory
   doCheck = !isPy3k;
+
+  pythonImportsCheck = [ "pudb" ];
 
   meta = with lib; {
     description = "A full-screen, console-based Python debugger";
     license = licenses.mit;
     platforms = platforms.all;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The package [pudb](https://github.com/inducer/pudb/) is about 1 year older than the current stable version.
Because the new version depends on [jedi](https://pypi.org/project/jedi/#files)'s latest version, I have also upgraded jedi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
