### PR TITLE
Make QMK actually work as per the official documentation

### DIFF
--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -43,6 +43,7 @@ python3.pkgs.buildPythonApplication rec {
     teensy-loader-cli
     gcc-arm-embedded
     pkgsCross.avr.buildPackages.binutils
+    pkgsCross.avr.buildPackages.binutils.bintools
     pkgsCross.avr.buildPackages.gcc8
     pkgsCross.avr.libcCross
   ];

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -1,5 +1,10 @@
 { lib
 , python3
+, pkgsCross
+, avrdude
+, dfu-programmer
+, dfu-util
+, gcc-arm-embedded
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -30,6 +35,14 @@ python3.pkgs.buildPythonApplication rec {
     milc
     pygments
     pyusb
+  ] ++ [ # Binaries need to be in the path so this is in propagatedBuildInputs
+    avrdude
+    dfu-programmer
+    dfu-util
+    gcc-arm-embedded
+    pkgsCross.avr.buildPackages.binutils
+    pkgsCross.avr.buildPackages.gcc8
+    pkgsCross.avr.libcCross
   ];
 
   # buildPythonApplication requires setup.py; the setup.py file crafted below
@@ -61,6 +74,6 @@ python3.pkgs.buildPythonApplication rec {
       - ... and many more!
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple babariviere ];
+    maintainers = with maintainers; [ bhipple babariviere ekleog ];
   };
 }

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -5,6 +5,7 @@
 , dfu-programmer
 , dfu-util
 , gcc-arm-embedded
+, teensy-loader-cli
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -39,6 +40,7 @@ python3.pkgs.buildPythonApplication rec {
     avrdude
     dfu-programmer
     dfu-util
+    teensy-loader-cli
     gcc-arm-embedded
     pkgsCross.avr.buildPackages.binutils
     pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 21.05, sandbox = "true"
**packages declared changed:** {"python3Packages.pyrsistent", "qmk", "qmk-udev-rules", "python3Packages.pyusb"}
**manual tests declared performed:**
 * ✔ built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions
 * manually compile and flash a moonlander keyboard as per the official documentation

**complies with contributing.md:** ✔ yes
**package python3Packages.pyrsistent:** ✔ continued building
**package qmk:** ✔ continued building
**package qmk-udev-rules:** 💚 started building again
**package python3Packages.pyusb:** ✔ continued building
**closure size for python3Packages.pyrsistent:** ✔ increased by 2.6 KB, from 98.8 MB to 98.8 MB
**tests of python3Packages.pyrsistent:** 😢 there are no tests

**closure size for qmk:** 😢 increased by 2.4 GB, from 181.5 MB to 2.6 GB
**tests of qmk:** 😢 there are no tests
**binaries of qmk:**
  * *updated binaries:*
    * ✔ qmk continued running successfully


**tests of qmk-udev-rules:** 😢 there are no tests

**closure size for python3Packages.pyusb:** ✔ increased by 2.6 KB, from 150.5 MB to 150.5 MB
**tests of python3Packages.pyusb:** 😢 there are no tests