### PR TITLE
lha: init at 2021-01-07

### DIFF
--- a/pkgs/tools/archivers/lha/default.nix
+++ b/pkgs/tools/archivers/lha/default.nix
@@ -1,0 +1,27 @@
+{stdenv, lib, fetchFromGitHub, autoreconfHook}:
+
+stdenv.mkDerivation {
+  pname = "lha";
+  version = "unstable-2021-01-07";
+
+  src = fetchFromGitHub {
+    owner = "jca02266";
+    repo = "lha";
+    rev = "03475355bc6311f7f816ea9a88fb34a0029d975b";
+    sha256 = "18w2x0g5yq89yxkxh1fmb05lz4hw7a3b4jmkk95gvh11mwbbr5lm";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "LHa is an archiver and compressor using the LZSS and Huffman encoding compression algorithms";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sander ];
+    # Some of the original LhA code has been rewritten and the current author
+    # considers adopting a "true" free and open source license for it.
+    # However, old code is still covered by the original LHa license, which is
+    # not a free software license (it has additional requirements on commercial
+    # use).
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6357,6 +6357,8 @@ in
 
   lf = callPackage ../tools/misc/lf {};
 
+  lha = callPackage ../tools/archivers/lha { };
+
   lhasa = callPackage ../tools/compression/lhasa {};
 
   libcpuid = callPackage ../tools/misc/libcpuid { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds lha: an archiver commonly used on AmigaOS, and MS-DOS/Windows. It is still popular in Japan on the latter two OSes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
