### PR TITLE
cmake: 3.19.7 -> 3.21.0

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/application-services.patch
@@ -1,8 +1,8 @@
 diff --git a/Source/CMakeLists.txt b/Source/CMakeLists.txt
-index 1b6bb00d4c..487114daa8 100644
+index 9a18184fd3..278d146dd1 100644
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -893,7 +893,6 @@ endif()
+@@ -933,7 +933,6 @@ endif()
  # On Apple we need CoreFoundation and CoreServices
  if(APPLE)
    target_link_libraries(CMakeLib "-framework CoreFoundation")
@@ -11,27 +11,25 @@ index 1b6bb00d4c..487114daa8 100644
  
  if(WIN32 AND NOT UNIX)
 diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.cxx
-index a5ce5d18f4..3d6838ce82 100644
+index 77403b076a..d5aac95e1e 100644
 --- a/Source/cmGlobalXCodeGenerator.cxx
 +++ b/Source/cmGlobalXCodeGenerator.cxx
-@@ -43,11 +43,10 @@
- 
- struct cmLinkImplementation;
+@@ -49,10 +49,6 @@ struct cmLinkImplementation;
  
  #if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
--#  define HAVE_APPLICATION_SERVICES
--#  include <ApplicationServices/ApplicationServices.h>
-+#  include <CoreFoundation/CoreFoundation.h>
+ #  include <CoreFoundation/CoreFoundation.h>
+-#  if !TARGET_OS_IPHONE
+-#    define HAVE_APPLICATION_SERVICES
+-#    include <ApplicationServices/ApplicationServices.h>
+-#  endif
  #endif
-
- #if !defined(CMAKE_BOOTSTRAP)
- #  include "cmXMLParser.h"
  
+ #if !defined(CMAKE_BOOTSTRAP)
 diff --git a/Utilities/cmlibarchive/CMakeLists.txt b/Utilities/cmlibarchive/CMakeLists.txt
-index bfcaf30bb7..1da540aee5 100644
+index 79452ffff6..a848731b7e 100644
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -2007,11 +2007,6 @@ IF(ENABLE_TEST)
+@@ -2013,11 +2013,6 @@ IF(ENABLE_TEST)
  ENDIF(ENABLE_TEST)
  ENDIF()
  

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -16,12 +16,11 @@ stdenv.mkDerivation rec {
           + lib.optionalString isBootstrap "-boot"
           + lib.optionalString useNcurses "-cursesUI"
           + lib.optionalString withQt5 "-qt5UI";
-  version = "3.19.7";
+  version = "3.21.0";
 
   src = fetchurl {
     url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
-    # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
-    sha256 = "sha256-WKFfDVagr8zDzFNxI0/Oc/zGyPnb13XYmOUQuDF1WI4=";
+    sha256 = "sha256-SkLVZEmlH004CatNO2H9SpakaeViZuiWzhAJtXaL0qs=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New Release: https://cmake.org/cmake/help/v3.21/release/3.21.html
We skipped 3.20, which is documented here: https://cmake.org/cmake/help/v3.21/release/3.20.html

###### Things done

Recreated `application-services.patch` due to a conflict.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
