### PR TITLE
neo4j: resolve compgen dependency error

### DIFF
--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/share/neo4j"
     cp -R * "$out/share/neo4j"
 
@@ -32,12 +34,14 @@ stdenv.mkDerivation rec {
             --prefix PATH : "${lib.makeBinPath [ jre which gawk ]}:$out/share/neo4j/bin/" \
             --set JAVA_HOME "${jre}"
     done
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";
     homepage = "http://www.neo4j.org/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
 
     maintainers = [ maintainers.offline ];
     platforms = lib.platforms.unix;

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre, which, gawk }:
+{ lib, stdenv, fetchurl, makeWrapper, jre, which, gawk, bashInteractive }:
 
 with lib;
 
@@ -18,11 +18,18 @@ stdenv.mkDerivation rec {
     cp -R * "$out/share/neo4j"
 
     mkdir -p "$out/bin"
+
+    compgen_wrapper="$out/share/neo4j/bin/compgen"
+    cat > $compgen_wrapper << _EOF_
+    "${bashInteractive}/bin/bash" -c 'compgen "\$@"'
+    _EOF_
+    chmod +x $compgen_wrapper
+
     for NEO4J_SCRIPT in neo4j neo4j-admin neo4j-import cypher-shell
     do
         makeWrapper "$out/share/neo4j/bin/$NEO4J_SCRIPT" \
             "$out/bin/$NEO4J_SCRIPT" \
-            --prefix PATH : "${lib.makeBinPath [ jre which gawk ]}" \
+            --prefix PATH : "${lib.makeBinPath [ jre which gawk ]}:$out/share/neo4j/bin/" \
             --set JAVA_HOME "${jre}"
     done
   '';

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -1,14 +1,12 @@
 { lib, stdenv, fetchurl, makeWrapper, jre, which, gawk, bashInteractive }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "neo4j";
-  version = "3.5.14";
+  version = "4.3.2";
 
   src = fetchurl {
     url = "https://neo4j.com/artifact.php?name=neo4j-community-${version}-unix.tar.gz";
-    sha256 = "1zjb6cgk2lpzx6pq1cs5fh65in6b5ccpl1cgfiglgpjc948mnhzv";
+    sha256 = "3474f3ec9da57fb627af71652ae6ecbd036e6ea689379f09e77e4cd8ba4b5515";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -27,7 +25,7 @@ stdenv.mkDerivation rec {
     _EOF_
     chmod +x $compgen_wrapper
 
-    for NEO4J_SCRIPT in neo4j neo4j-admin neo4j-import cypher-shell
+    for NEO4J_SCRIPT in neo4j neo4j-admin cypher-shell
     do
         makeWrapper "$out/share/neo4j/bin/$NEO4J_SCRIPT" \
             "$out/bin/$NEO4J_SCRIPT" \
@@ -40,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";
-    homepage = "http://www.neo4j.org/";
+    homepage = "https://www.neo4j.org/";
     license = licenses.gpl3Only;
 
     maintainers = [ maintainers.offline ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20003,7 +20003,7 @@ in
   check_systemd = callPackage ../servers/monitoring/nagios/plugins/check_systemd.nix { };
 
   neo4j = callPackage ../servers/nosql/neo4j {
-    jre = jre8_headless;
+    jre = openjdk11_headless;
   };
 
   neo4j-desktop = callPackage ../applications/misc/neo4j-desktop { };


### PR DESCRIPTION
- Fix #130112.
- neo4j was unable to find `compgen` at runtime.
- Need to use `bashInteractive` version of bash since default bash does
not have `compgen`.
- Add a compgen wrapper shell script to pass `compgen` calls to `bash
-c 'compgen "$@"'` in order to run `compgen` outside of a `bash`
shell.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes issue #130112 where neo4j cannot find compgen.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
