### PR TITLE
lib.licenses: cleanup, consistency and redistributable attribute

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -749,6 +749,10 @@ in mkLicense lset) ({
     fullName = "Server Side Public License";
     url = "https://www.mongodb.com/licensing/server-side-public-license";
     free = false;
+    # NOTE Debatable.
+    # The license a slightly modified AGPL but still considered unfree by the
+    # OSI for what seem like political reasons
+    redistributable = true; # Definitely redistributable though, it's an AGPL derivative
   };
 
   stk = {
@@ -775,10 +779,12 @@ in mkLicense lset) ({
   unfreeRedistributable = {
     fullName = "Unfree redistributable";
     free = false;
+    redistributable = true;
   };
 
   unfreeRedistributableFirmware = {
     fullName = "Unfree redistributable firmware";
+    redistributable = true;
     # Note: we currently consider these "free" for inclusion in the
     # channel and NixOS images.
   };

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1,8 +1,10 @@
 { lib }:
 
 lib.mapAttrs (lname: lset: let
-  defaultLicense = {
+  defaultLicense = rec {
     shortName = lname;
+    free = true; # Most of our licenses are Free, explicitly declare unfree additions as such!
+    deprecated = false;
   };
 
   mkLicense = licenseDeclaration: let

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1,44 +1,52 @@
 { lib }:
-let
 
-  spdx = lic: lic // {
-    url = "https://spdx.org/licenses/${lic.spdxId}.html";
+lib.mapAttrs (lname: lset: let
+  defaultLicense = {
+    shortName = lname;
   };
 
-in
-
-lib.mapAttrs (n: v: v // { shortName = n; }) ({
+  mkLicense = licenseDeclaration: let
+    applyDefaults = license: defaultLicense // license;
+    applySpdx = license:
+      if license ? spdxId
+      then license // { url = "https://spdx.org/licenses/${license.spdxId}.html"; }
+      else license;
+  in lib.pipe licenseDeclaration [
+    applyDefaults
+    applySpdx
+  ];
+in mkLicense lset) ({
   /* License identifiers from spdx.org where possible.
    * If you cannot find your license here, then look for a similar license or
    * add it to this list. The URL mentioned above is a good source for inspiration.
    */
 
-  abstyles = spdx {
+  abstyles = {
     spdxId = "Abstyles";
     fullName = "Abstyles License";
   };
 
-  afl20 = spdx {
+  afl20 = {
     spdxId = "AFL-2.0";
     fullName = "Academic Free License v2.0";
   };
 
-  afl21 = spdx {
+  afl21 = {
     spdxId = "AFL-2.1";
     fullName = "Academic Free License v2.1";
   };
 
-  afl3 = spdx {
+  afl3 = {
     spdxId = "AFL-3.0";
     fullName = "Academic Free License v3.0";
   };
 
-  agpl3Only = spdx {
+  agpl3Only = {
     spdxId = "AGPL-3.0-only";
     fullName = "GNU Affero General Public License v3.0 only";
   };
 
-  agpl3Plus = spdx {
+  agpl3Plus = {
     spdxId = "AGPL-3.0-or-later";
     fullName = "GNU Affero General Public License v3.0 or later";
   };
@@ -55,7 +63,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  apsl20 = spdx {
+  apsl20 = {
     spdxId = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";
   };
@@ -65,72 +73,72 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://www.freedesktop.org/wiki/Arphic_Public_License/";
   };
 
-  artistic1 = spdx {
+  artistic1 = {
     spdxId = "Artistic-1.0";
     fullName = "Artistic License 1.0";
   };
 
-  artistic2 = spdx {
+  artistic2 = {
     spdxId = "Artistic-2.0";
     fullName = "Artistic License 2.0";
   };
 
-  asl20 = spdx {
+  asl20 = {
     spdxId = "Apache-2.0";
     fullName = "Apache License 2.0";
   };
 
-  boost = spdx {
+  boost = {
     spdxId = "BSL-1.0";
     fullName = "Boost Software License 1.0";
   };
 
-  beerware = spdx {
+  beerware = {
     spdxId = "Beerware";
     fullName = "Beerware License";
   };
 
-  blueOak100 = spdx {
+  blueOak100 = {
     spdxId = "BlueOak-1.0.0";
     fullName = "Blue Oak Model License 1.0.0";
   };
 
-  bsd0 = spdx {
+  bsd0 = {
     spdxId = "0BSD";
     fullName = "BSD Zero Clause License";
   };
 
-  bsd1 = spdx {
+  bsd1 = {
     spdxId = "BSD-1-Clause";
     fullName = "BSD 1-Clause License";
   };
 
-  bsd2 = spdx {
+  bsd2 = {
     spdxId = "BSD-2-Clause";
     fullName = ''BSD 2-clause "Simplified" License'';
   };
 
-  bsd2Patent = spdx {
+  bsd2Patent = {
     spdxId = "BSD-2-Clause-Patent";
     fullName = "BSD-2-Clause Plus Patent License";
   };
 
-  bsd3 = spdx {
+  bsd3 = {
     spdxId = "BSD-3-Clause";
     fullName = ''BSD 3-clause "New" or "Revised" License'';
   };
 
-  bsdOriginal = spdx {
+  bsdOriginal = {
     spdxId = "BSD-4-Clause";
     fullName = ''BSD 4-clause "Original" or "Old" License'';
   };
 
-  bsdOriginalUC = spdx {
+  bsdOriginalUC = {
     spdxId = "BSD-4-Clause-UC";
     fullName = "BSD 4-Clause University of California-Specific";
   };
 
-  bsdProtection = spdx {
+  bsdProtection = {
     spdxId = "BSD-Protection";
     fullName = "BSD Protection License";
   };
@@ -141,119 +149,119 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  clArtistic = spdx {
+  clArtistic = {
     spdxId = "ClArtistic";
     fullName = "Clarified Artistic License";
   };
 
-  cc0 = spdx {
+  cc0 = {
     spdxId = "CC0-1.0";
     fullName = "Creative Commons Zero v1.0 Universal";
   };
 
-  cc-by-nc-sa-20 = spdx {
+  cc-by-nc-sa-20 = {
     spdxId = "CC-BY-NC-SA-2.0";
     fullName = "Creative Commons Attribution Non Commercial Share Alike 2.0";
     free = false;
   };
 
-  cc-by-nc-sa-25 = spdx {
+  cc-by-nc-sa-25 = {
     spdxId = "CC-BY-NC-SA-2.5";
     fullName = "Creative Commons Attribution Non Commercial Share Alike 2.5";
     free = false;
   };
 
-  cc-by-nc-sa-30 = spdx {
+  cc-by-nc-sa-30 = {
     spdxId = "CC-BY-NC-SA-3.0";
     fullName = "Creative Commons Attribution Non Commercial Share Alike 3.0";
     free = false;
   };
 
-  cc-by-nc-sa-40 = spdx {
+  cc-by-nc-sa-40 = {
     spdxId = "CC-BY-NC-SA-4.0";
     fullName = "Creative Commons Attribution Non Commercial Share Alike 4.0";
     free = false;
   };
 
-  cc-by-nc-30 = spdx {
+  cc-by-nc-30 = {
     spdxId = "CC-BY-NC-3.0";
     fullName = "Creative Commons Attribution Non Commercial 3.0 Unported";
     free = false;
   };
 
-  cc-by-nc-40 = spdx {
+  cc-by-nc-40 = {
     spdxId = "CC-BY-NC-4.0";
     fullName = "Creative Commons Attribution Non Commercial 4.0 International";
     free = false;
   };
 
-  cc-by-nd-30 = spdx {
+  cc-by-nd-30 = {
     spdxId = "CC-BY-ND-3.0";
     fullName = "Creative Commons Attribution-No Derivative Works v3.00";
     free = false;
   };
 
-  cc-by-sa-25 = spdx {
+  cc-by-sa-25 = {
     spdxId = "CC-BY-SA-2.5";
     fullName = "Creative Commons Attribution Share Alike 2.5";
   };
 
-  cc-by-30 = spdx {
+  cc-by-30 = {
     spdxId = "CC-BY-3.0";
     fullName = "Creative Commons Attribution 3.0";
   };
 
-  cc-by-sa-30 = spdx {
+  cc-by-sa-30 = {
     spdxId = "CC-BY-SA-3.0";
     fullName = "Creative Commons Attribution Share Alike 3.0";
   };
 
-  cc-by-40 = spdx {
+  cc-by-40 = {
     spdxId = "CC-BY-4.0";
     fullName = "Creative Commons Attribution 4.0";
   };
 
-  cc-by-sa-40 = spdx {
+  cc-by-sa-40 = {
     spdxId = "CC-BY-SA-4.0";
     fullName = "Creative Commons Attribution Share Alike 4.0";
   };
 
-  cddl = spdx {
+  cddl = {
     spdxId = "CDDL-1.0";
     fullName = "Common Development and Distribution License 1.0";
   };
 
-  cecill20 = spdx {
+  cecill20 = {
     spdxId = "CECILL-2.0";
     fullName = "CeCILL Free Software License Agreement v2.0";
   };
 
-  cecill-b = spdx {
+  cecill-b = {
     spdxId = "CECILL-B";
     fullName  = "CeCILL-B Free Software License Agreement";
   };
 
-  cecill-c = spdx {
+  cecill-c = {
     spdxId = "CECILL-C";
     fullName  = "CeCILL-C Free Software License Agreement";
   };
 
-  cpal10 = spdx {
+  cpal10 = {
     spdxId = "CPAL-1.0";
     fullName = "Common Public Attribution License 1.0";
   };
 
-  cpl10 = spdx {
+  cpl10 = {
     spdxId = "CPL-1.0";
     fullName = "Common Public License 1.0";
   };
 
-  curl = spdx {
+  curl = {
     spdxId = "curl";
     fullName = "curl License";
   };
 
-  doc = spdx {
+  doc = {
     spdxId = "DOC";
     fullName = "DOC License";
   };
@@ -264,12 +272,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  efl10 = spdx {
+  efl10 = {
     spdxId = "EFL-1.0";
     fullName = "Eiffel Forum License v1.0";
   };
 
-  efl20 = spdx {
+  efl20 = {
     spdxId = "EFL-2.0";
     fullName = "Eiffel Forum License v2.0";
   };
@@ -280,12 +288,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  epl10 = spdx {
+  epl10 = {
     spdxId = "EPL-1.0";
     fullName = "Eclipse Public License 1.0";
   };
 
-  epl20 = spdx {
+  epl20 = {
     spdxId = "EPL-2.0";
     fullName = "Eclipse Public License 2.0";
   };
@@ -296,42 +304,42 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  eupl11 = spdx {
+  eupl11 = {
     spdxId = "EUPL-1.1";
     fullName = "European Union Public License 1.1";
   };
 
-  eupl12 = spdx {
+  eupl12 = {
     spdxId = "EUPL-1.2";
     fullName = "European Union Public License 1.2";
   };
 
-  fdl11Only = spdx {
+  fdl11Only = {
     spdxId = "GFDL-1.1-only";
     fullName = "GNU Free Documentation License v1.1 only";
   };
 
-  fdl11Plus = spdx {
+  fdl11Plus = {
     spdxId = "GFDL-1.1-or-later";
     fullName = "GNU Free Documentation License v1.1 or later";
   };
 
-  fdl12Only = spdx {
+  fdl12Only = {
     spdxId = "GFDL-1.2-only";
     fullName = "GNU Free Documentation License v1.2 only";
   };
 
-  fdl12Plus = spdx {
+  fdl12Plus = {
     spdxId = "GFDL-1.2-or-later";
     fullName = "GNU Free Documentation License v1.2 or later";
   };
 
-  fdl13Only = spdx {
+  fdl13Only = {
     spdxId = "GFDL-1.3-only";
     fullName = "GNU Free Documentation License v1.3 only";
   };
 
-  fdl13Plus = spdx {
+  fdl13Plus = {
     spdxId = "GFDL-1.3-or-later";
     fullName = "GNU Free Documentation License v1.3 or later";
   };
@@ -346,7 +354,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     fullName = "Unspecified free software license";
   };
 
-  ftl = spdx {
+  ftl = {
     spdxId = "FTL";
     fullName = "Freetype Project License";
   };
@@ -362,22 +370,22 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  gpl1Only = spdx {
+  gpl1Only = {
     spdxId = "GPL-1.0-only";
     fullName = "GNU General Public License v1.0 only";
   };
 
-  gpl1Plus = spdx {
+  gpl1Plus = {
     spdxId = "GPL-1.0-or-later";
     fullName = "GNU General Public License v1.0 or later";
   };
 
-  gpl2Only = spdx {
+  gpl2Only = {
     spdxId = "GPL-2.0-only";
     fullName = "GNU General Public License v2.0 only";
   };
 
-  gpl2Classpath = spdx {
+  gpl2Classpath = {
     spdxId = "GPL-2.0-with-classpath-exception";
     fullName = "GNU General Public License v2.0 only (with Classpath exception)";
   };
@@ -392,17 +400,17 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://www.mysql.com/about/legal/licensing/foss-exception";
   };
 
-  gpl2Plus = spdx {
+  gpl2Plus = {
     spdxId = "GPL-2.0-or-later";
     fullName = "GNU General Public License v2.0 or later";
   };
 
-  gpl3Only = spdx {
+  gpl3Only = {
     spdxId = "GPL-3.0-only";
     fullName = "GNU General Public License v3.0 only";
   };
 
-  gpl3Plus = spdx {
+  gpl3Plus = {
     spdxId = "GPL-3.0-or-later";
     fullName = "GNU General Public License v3.0 or later";
   };
@@ -412,12 +420,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception";
   };
 
-  hpnd = spdx {
+  hpnd = {
     spdxId = "HPND";
     fullName = "Historic Permission Notice and Disclaimer";
   };
 
-  hpndSellVariant = spdx {
+  hpndSellVariant = {
     fullName = "Historical Permission Notice and Disclaimer - sell variant";
     spdxId = "HPND-sell-variant";
   };
@@ -428,12 +436,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://old.calculate-linux.org/packages/licenses/iASL";
   };
 
-  ijg = spdx {
+  ijg = {
     spdxId = "IJG";
     fullName = "Independent JPEG Group License";
   };
 
-  imagemagick = spdx {
+  imagemagick = {
     fullName = "ImageMagick License";
     spdxId = "imagemagick";
   };
@@ -450,17 +458,17 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free     = false;
   };
 
-  ipa = spdx {
+  ipa = {
     spdxId = "IPA";
     fullName = "IPA Font License";
   };
 
-  ipl10 = spdx {
+  ipl10 = {
     spdxId = "IPL-1.0";
     fullName = "IBM Public License v1.0";
   };
 
-  isc = spdx {
+  isc = {
     spdxId = "ISC";
     fullName = "ISC License";
   };
@@ -478,52 +486,52 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  lgpl2Only = spdx {
+  lgpl2Only = {
     spdxId = "LGPL-2.0-only";
     fullName = "GNU Library General Public License v2 only";
   };
 
-  lgpl2Plus = spdx {
+  lgpl2Plus = {
     spdxId = "LGPL-2.0-or-later";
     fullName = "GNU Library General Public License v2 or later";
   };
 
-  lgpl21Only = spdx {
+  lgpl21Only = {
     spdxId = "LGPL-2.1-only";
     fullName = "GNU Lesser General Public License v2.1 only";
   };
 
-  lgpl21Plus = spdx {
+  lgpl21Plus = {
     spdxId = "LGPL-2.1-or-later";
     fullName = "GNU Lesser General Public License v2.1 or later";
   };
 
-  lgpl3Only = spdx {
+  lgpl3Only = {
     spdxId = "LGPL-3.0-only";
     fullName = "GNU Lesser General Public License v3.0 only";
   };
 
-  lgpl3Plus = spdx {
+  lgpl3Plus = {
     spdxId = "LGPL-3.0-or-later";
     fullName = "GNU Lesser General Public License v3.0 or later";
   };
 
-  lgpllr = spdx {
+  lgpllr = {
     spdxId = "LGPLLR";
     fullName = "Lesser General Public License For Linguistic Resources";
   };
 
-  libpng = spdx {
+  libpng = {
     spdxId = "Libpng";
     fullName = "libpng License";
   };
 
-  libpng2 = spdx {
+  libpng2 = {
     spdxId = "libpng-2.0"; # Used since libpng 1.6.36.
     fullName = "PNG Reference Library version 2";
   };
 
-  libtiff = spdx {
+  libtiff = {
     spdxId = "libtiff";
     fullName = "libtiff License";
   };
@@ -533,22 +541,22 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://opensource.franz.com/preamble.html";
   };
 
-  llvm-exception = spdx {
+  llvm-exception = {
     spdxId = "LLVM-exception";
     fullName = "LLVM Exception"; # LLVM exceptions to the Apache 2.0 License
   };
 
-  lppl12 = spdx {
+  lppl12 = {
     spdxId = "LPPL-1.2";
     fullName = "LaTeX Project Public License v1.2";
   };
 
-  lppl13c = spdx {
+  lppl13c = {
     spdxId = "LPPL-1.3c";
     fullName = "LaTeX Project Public License v1.3c";
   };
 
-  lpl-102 = spdx {
+  lpl-102 = {
     spdxId = "LPL-1.02";
     fullName = "Lucent Public License v1.02";
   };
@@ -560,43 +568,43 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
 
   # spdx.org does not (yet) differentiate between the X11 and Expat versions
   # for details see https://en.wikipedia.org/wiki/MIT_License#Various_versions
-  mit = spdx {
+  mit = {
     spdxId = "MIT";
     fullName = "MIT License";
   };
 
-  mpl10 = spdx {
+  mpl10 = {
     spdxId = "MPL-1.0";
     fullName = "Mozilla Public License 1.0";
   };
 
-  mpl11 = spdx {
+  mpl11 = {
     spdxId = "MPL-1.1";
     fullName = "Mozilla Public License 1.1";
   };
 
-  mpl20 = spdx {
+  mpl20 = {
     spdxId = "MPL-2.0";
     fullName = "Mozilla Public License 2.0";
   };
 
-  mspl = spdx {
+  mspl = {
     spdxId = "MS-PL";
     fullName = "Microsoft Public License";
   };
 
-  nasa13 = spdx {
+  nasa13 = {
     spdxId = "NASA-1.3";
     fullName = "NASA Open Source Agreement 1.3";
     free = false;
   };
 
-  ncsa = spdx {
+  ncsa = {
     spdxId = "NCSA";
     fullName  = "University of Illinois/NCSA Open Source License";
   };
 
-  nposl3 = spdx {
+  nposl3 = {
     spdxId = "NPOSL-3.0";
     fullName = "Non-Profit Open Software License 3.0";
   };
@@ -613,53 +621,53 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  odbl = spdx {
+  odbl = {
     spdxId = "ODbL-1.0";
     fullName = "Open Data Commons Open Database License v1.0";
   };
 
-  ofl = spdx {
+  ofl = {
     spdxId = "OFL-1.1";
     fullName = "SIL Open Font License 1.1";
   };
 
-  openldap = spdx {
+  openldap = {
     spdxId = "OLDAP-2.8";
     fullName = "Open LDAP Public License v2.8";
   };
 
-  openssl = spdx {
+  openssl = {
     spdxId = "OpenSSL";
     fullName = "OpenSSL License";
   };
 
-  osl2 = spdx {
+  osl2 = {
     spdxId = "OSL-2.0";
     fullName = "Open Software License 2.0";
   };
 
-  osl21 = spdx {
+  osl21 = {
     spdxId = "OSL-2.1";
     fullName = "Open Software License 2.1";
   };
 
-  osl3 = spdx {
+  osl3 = {
     spdxId = "OSL-3.0";
     fullName = "Open Software License 3.0";
   };
 
-  parity70 = spdx {
+  parity70 = {
     spdxId = "Parity-7.0.0";
     fullName = "Parity Public License 7.0.0";
     url = "https://paritylicense.com/versions/7.0.0.html";
   };
 
-  php301 = spdx {
+  php301 = {
     spdxId = "PHP-3.01";
     fullName = "PHP License v3.01";
   };
 
-  postgresql = spdx {
+  postgresql = {
     spdxId = "PostgreSQL";
     fullName = "PostgreSQL License";
   };
@@ -670,7 +678,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  psfl = spdx {
+  psfl = {
     spdxId = "Python-2.0";
     fullName = "Python Software Foundation License version 2";
     url = "https://docs.python.org/license.html";
@@ -691,12 +699,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://prosperitylicense.com/versions/3.0.0.html";
   };
 
-  qhull = spdx {
+  qhull = {
     spdxId = "Qhull";
     fullName = "Qhull License";
   };
 
-  qpl = spdx {
+  qpl = {
     spdxId = "QPL-1.0";
     fullName = "Q Public License 1.0";
   };
@@ -706,22 +714,22 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://qwt.sourceforge.io/qwtlicense.html";
   };
 
-  ruby = spdx {
+  ruby = {
     spdxId = "Ruby";
     fullName = "Ruby License";
   };
 
-  sendmail = spdx {
+  sendmail = {
     spdxId = "Sendmail";
     fullName = "Sendmail License";
   };
 
-  sgi-b-20 = spdx {
+  sgi-b-20 = {
     spdxId = "SGI-B-2.0";
     fullName = "SGI Free Software License B v2.0";
   };
 
-  sleepycat = spdx {
+  sleepycat = {
     spdxId = "Sleepycat";
     fullName = "Sleepycat License";
   };
@@ -745,7 +753,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://github.com/thestk/stk/blob/master/LICENSE";
   };
 
-  tcltk = spdx {
+  tcltk = {
     spdxId = "TCL";
     fullName = "TCL/TK License";
   };
@@ -771,17 +779,17 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     # channel and NixOS images.
   };
 
-  unicode-dfs-2015 = spdx {
+  unicode-dfs-2015 = {
     spdxId = "Unicode-DFS-2015";
     fullName = "Unicode License Agreement - Data Files and Software (2015)";
   };
 
-  unicode-dfs-2016 = spdx {
+  unicode-dfs-2016 = {
     spdxId = "Unicode-DFS-2016";
     fullName = "Unicode License Agreement - Data Files and Software (2016)";
   };
 
-  unlicense = spdx {
+  unlicense = {
     spdxId = "Unlicense";
     fullName = "The Unlicense";
   };
@@ -791,7 +799,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://oss.oracle.com/licenses/upl/";
   };
 
-  vim = spdx {
+  vim = {
     spdxId = "Vim";
     fullName = "Vim License";
   };
@@ -802,17 +810,17 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     free = false;
   };
 
-  vsl10 = spdx {
+  vsl10 = {
     spdxId = "VSL-1.0";
     fullName = "Vovida Software License v1.0";
   };
 
-  watcom = spdx {
+  watcom = {
     spdxId = "Watcom-1.0";
     fullName = "Sybase Open Watcom Public License 1.0";
   };
 
-  w3c = spdx {
+  w3c = {
     spdxId = "W3C";
     fullName = "W3C Software Notice and License";
   };
@@ -822,12 +830,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "https://fedoraproject.org/wiki/Licensing:Wadalab?rd=Licensing/Wadalab";
   };
 
-  wtfpl = spdx {
+  wtfpl = {
     spdxId = "WTFPL";
     fullName = "Do What The F*ck You Want To Public License";
   };
 
-  wxWindows = spdx {
+  wxWindows = {
     spdxId = "wxWindows";
     fullName = "wxWindows Library Licence, Version 3.1";
   };
@@ -837,68 +845,68 @@ lib.mapAttrs (n: v: v // { shortName = n; }) ({
     url = "http://mcj.sourceforge.net/authors.html#xfig"; # https is broken
   };
 
-  zlib = spdx {
+  zlib = {
     spdxId = "Zlib";
     fullName = "zlib License";
   };
 
-  zpl20 = spdx {
+  zpl20 = {
     spdxId = "ZPL-2.0";
     fullName = "Zope Public License 2.0";
   };
 
-  zpl21 = spdx {
+  zpl21 = {
     spdxId = "ZPL-2.1";
     fullName = "Zope Public License 2.1";
   };
 } // {
   # TODO: remove legacy aliases
-  agpl3 = spdx {
+  agpl3 = {
     spdxId = "AGPL-3.0";
     fullName = "GNU Affero General Public License v3.0";
     deprecated = true;
   };
-  fdl11 = spdx {
+  fdl11 = {
     spdxId = "GFDL-1.1";
     fullName = "GNU Free Documentation License v1.1";
     deprecated = true;
   };
-  fdl12 = spdx {
+  fdl12 = {
     spdxId = "GFDL-1.2";
     fullName = "GNU Free Documentation License v1.2";
     deprecated = true;
   };
-  fdl13 = spdx {
+  fdl13 = {
     spdxId = "GFDL-1.3";
     fullName = "GNU Free Documentation License v1.3";
     deprecated = true;
   };
-  gpl1 = spdx {
+  gpl1 = {
     spdxId = "GPL-1.0";
     fullName = "GNU General Public License v1.0";
     deprecated = true;
   };
-  gpl2 = spdx {
+  gpl2 = {
     spdxId = "GPL-2.0";
     fullName = "GNU General Public License v2.0";
     deprecated = true;
   };
-  gpl3 = spdx {
+  gpl3 = {
     spdxId = "GPL-3.0";
     fullName = "GNU General Public License v3.0";
     deprecated = true;
   };
-  lgpl2 = spdx {
+  lgpl2 = {
     spdxId = "LGPL-2.0";
     fullName = "GNU Library General Public License v2";
     deprecated = true;
   };
-  lgpl21 = spdx {
+  lgpl21 = {
     spdxId = "LGPL-2.1";
     fullName = "GNU Lesser General Public License v2.1";
     deprecated = true;
   };
-  lgpl3 = spdx {
+  lgpl3 = {
     spdxId = "LGPL-3.0";
     fullName = "GNU Lesser General Public License v3.0";
     deprecated = true;

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -13,9 +13,11 @@ lib.mapAttrs (lname: lset: let
       if license ? spdxId
       then license // { url = "https://spdx.org/licenses/${license.spdxId}.html"; }
       else license;
+    applyRedistributable = license: { redistributable = license.free; } // license;
   in lib.pipe licenseDeclaration [
     applyDefaults
     applySpdx
+    applyRedistributable
   ];
 in mkLicense lset) ({
   /* License identifiers from spdx.org where possible.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Application of common attributes was not expandable
* `free` and `deprecated` were only set on licenses where they're false and true respectively 
* https://github.com/NixOS/nixpkgs/issues/83884 needs the ability to know whether a package is redistributable 

Future work: Make hydra look for `redistributable` instead of `free`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @mkg20001