### PR TITLE
go: enable MIPS GOARCH/cross integration

### DIFF
--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -41,6 +41,7 @@ let
     "armv6l" = "arm";
     "armv7l" = "arm";
     "powerpc64le" = "ppc64le";
+    "mips" = "mips";
   }.${platform.parsed.cpu.name} or (throw "Unsupported system");
 
   # We need a target compiler which is still runnable at build time,

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -41,6 +41,7 @@ let
     "armv6l" = "arm";
     "armv7l" = "arm";
     "powerpc64le" = "ppc64le";
+    "mips" = "mips";
   }.${platform.parsed.cpu.name} or (throw "Unsupported system");
 
   # We need a target compiler which is still runnable at build time,

--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -41,6 +41,7 @@ let
     "armv6l" = "arm";
     "armv7l" = "arm";
     "powerpc64le" = "ppc64le";
+    "mips" = "mips";
   }.${platform.parsed.cpu.name} or (throw "Unsupported system");
 
   # We need a target compiler which is still runnable at build time,


### PR DESCRIPTION
###### Motivation for this change

This allows the Go compiler in nixpkgs (eg. buildGoModule) to work with crossSystem.config == mips-*, eg mips-unknown-linux-musl, and succesfully generate Go MIPS binaries.

###### Things done

    nix-build -A grpcurl --arg crossSystem '{ config = "mips-unknown-linux-musl"; }'

This unfortunately cannot currently be tested on qemu-mips as Go emits ELF files that fail to execute correctly in qemu-user (see:
https://go-review.googlesource.com/c/go/+/239217, on track to land in Go 1.17). However, I have tested this on a physical MIPS device.

I have not been able to build anything using cgo (hit various compilation errors in C dependencies), but considering mips-unknown-linux-musl is not a support nixpkgs target this isn't that surprising.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
