### PR TITLE
kodi: set proper PYTHONPATH for addons

### DIFF
--- a/pkgs/applications/video/kodi-packages/certifi/default.nix
+++ b/pkgs/applications/video/kodi-packages/certifi/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "1z49b8va7wdyr714c8ixb2sldi0igffcjj3xpbmga58ph0z985vy";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.certifi";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.certifi";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/chardet/default.nix
+++ b/pkgs/applications/video/kodi-packages/chardet/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "1jsd165mb1b8jdan2jbjd3y3xa0xam2cxcccmwazkybpa0r6a7dj";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.chardet";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.chardet";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/dateutil/default.nix
+++ b/pkgs/applications/video/kodi-packages/dateutil/default.nix
@@ -14,8 +14,11 @@ buildKodiAddon rec {
     six
   ];
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.dateutil";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.dateutil";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/idna/default.nix
+++ b/pkgs/applications/video/kodi-packages/idna/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "0pm86m8kh2p0brps3xzxcmmabvb4izkglzkj8dsn33br3vlc7cm7";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.idna";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.idna";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/inputstreamhelper/default.nix
+++ b/pkgs/applications/video/kodi-packages/inputstreamhelper/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "0y4xn3ygwv1kb7gya7iwdga0g9sa89snpnram0wwqzqn8wn2lyb4";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.inputstreamhelper";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.inputstreamhelper";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/kodi-six/default.nix
+++ b/pkgs/applications/video/kodi-packages/kodi-six/default.nix
@@ -10,8 +10,11 @@ buildKodiAddon rec {
     sha256 = "14m232p9hx925pbk8knsg994m1nbpa5278zmcrnfblh4z84gjv4x";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.kodi-six";
+  passthru = {
+    pythonPath = "libs";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.kodi-six";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/myconnpy/default.nix
+++ b/pkgs/applications/video/kodi-packages/myconnpy/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "1cx3qdzw9lkkmbyvyrmc2i193is20fihn2sfl7kmv43f708vam0k";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.myconnpy";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.myconnpy";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/pdfreader/default.nix
+++ b/pkgs/applications/video/kodi-packages/pdfreader/default.nix
@@ -11,6 +11,8 @@ buildKodiAddon rec {
     sha256 = "0nkqhlm1gyagq6xpdgqvd5qxyr2ngpml9smdmzfabc8b972mwjml";
   };
 
+  passthru.pythonPath = "lib/api";
+
   meta = with lib; {
     homepage = "https://forum.kodi.tv/showthread.php?tid=187421";
     description = "A comic book reader";

--- a/pkgs/applications/video/kodi-packages/requests/default.nix
+++ b/pkgs/applications/video/kodi-packages/requests/default.nix
@@ -16,8 +16,11 @@ buildKodiAddon rec {
     urllib3
   ];
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.requests";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.requests";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/signals/default.nix
+++ b/pkgs/applications/video/kodi-packages/signals/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "1qcjbakch8hvx02wc01zv014nmzgn6ahc4n2bj5mzr114ppd3hjs";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.signals";
+  passthru= {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.signals";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/urllib3/default.nix
+++ b/pkgs/applications/video/kodi-packages/urllib3/default.nix
@@ -9,8 +9,11 @@ buildKodiAddon rec {
     sha256 = "1d2k6gbsnhdadcl1xc7igz4m71z2fcnpln5ppfjv455cmkk110vf";
   };
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.urllib3";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.urllib3";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/websocket/default.nix
+++ b/pkgs/applications/video/kodi-packages/websocket/default.nix
@@ -14,8 +14,11 @@ buildKodiAddon rec {
     six
   ];
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.websocket";
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.websocket";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi-packages/youtube/default.nix
+++ b/pkgs/applications/video/kodi-packages/youtube/default.nix
@@ -16,8 +16,11 @@ buildKodiAddon rec {
     inputstreamhelper
   ];
 
-  passthru.updateScript = addonUpdateScript {
-    attrPath = "kodi.packages.youtube";
+  passthru = {
+    pythonPath = "resources/lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.youtube";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -1,8 +1,19 @@
-{ lib, makeWrapper, buildEnv, kodi, addons }:
+{ lib, makeWrapper, buildEnv, kodi, addons, callPackage }:
 
 let
+  kodiPackages = callPackage ../../../top-level/kodi-packages.nix { inherit kodi; };
+
   # linux distros are supposed to provide pillow and pycryptodome
-  requiredPythonPackages = with kodi.pythonPackages; [ pillow pycryptodome] ++ addons;
+  requiredPythonPath = with kodi.pythonPackages; makePythonPath ([ pillow pycryptodome ]);
+
+  # each kodi addon can potentially export a python module which should be included in PYTHONPATH
+  # see any addon which supplies `passthru.pythonPath` and the corresponding entry in the addons `addon.xml`
+  # eg. `<extension point="xbmc.python.module" library="lib" />` -> pythonPath = "lib";
+  additionalPythonPath =
+    let
+      addonsWithPythonPath = lib.filter (addon: addon ? pythonPath) addons;
+    in
+      lib.concatMapStringsSep ":" (addon: "${addon}${kodiPackages.addonDir}/${addon.namespace}/${addon.pythonPath}") addonsWithPythonPath;
 in
 
 buildEnv {
@@ -18,7 +29,7 @@ buildEnv {
     for exe in kodi{,-standalone}
     do
       makeWrapper ${kodi}/bin/$exe $out/bin/$exe \
-        --prefix PYTHONPATH : ${kodi.pythonPackages.makePythonPath requiredPythonPackages} \
+        --prefix PYTHONPATH : ${requiredPythonPath}:${additionalPythonPath} \
         --prefix KODI_HOME : $out/share/kodi \
         --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath
           (lib.concatMap


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently the `PYTHONPATH` set for `kodi` is mostly useless because it points to the wrong path for each addon - the root of the addon derivation. Many `kodi` addons provide a `python` module and specify the directory in `addon.xml` - but we never add those paths to `PYTHONPATH`, which causes issues like [this](https://github.com/NixOS/nixpkgs/pull/127173#issuecomment-865439469). So let's stop appending pointless paths to `PYTHONPATH` and instead append what `addon.xml` files tell us to. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
