### PR TITLE
hylafaxplus: fix build

### DIFF
--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -2,7 +2,6 @@
 , lib
 , fakeroot
 , fetchurl
-, fetchpatch
 , libfaketime
 , substituteAll
 ## runtime dependencies
@@ -70,11 +69,7 @@ stdenv.mkDerivation {
   };
   patches = [
     # adjust configure check to work with libtiff > 4.1
-    (fetchpatch {
-      name = "libtiff-4.2.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/net-misc/hylafaxplus/files/hylafaxplus-7.0.2-tiff-4.2.patch?id=82e3eefd5447f36e5bb00068a54b91d8c891ccf6";
-      sha256 = "0hhf4wpgj842gz4nxq8s55vnzmciqkyjjaaxdpqawns2746vx0sw";
-    })
+    ./libtiff-4.patch
   ];
   # Note that `configure` (and maybe `faxsetup`) are looking
   # for a couple of standard binaries in the `PATH` and

--- a/pkgs/servers/hylafaxplus/libtiff-4.patch
+++ b/pkgs/servers/hylafaxplus/libtiff-4.patch
@@ -1,0 +1,12 @@
+https://bugs.gentoo.org/706154
+--- a/configure
++++ b/configure
+@@ -2583,7 +2583,7 @@ EOF
+ 				echo '#define TIFFSTRIPBYTECOUNTS uint32'
+ 				echo '#define TIFFVERSION TIFF_VERSION'
+ 				echo '#define TIFFHEADER TIFFHeader';;
+-		4.[01])		tiff_runlen_t="uint32"
++		4.[0-9])	tiff_runlen_t="uint32"
+ 				tiff_offset_t="uint64"
+ 				echo '#define TIFFSTRIPBYTECOUNTS uint64'
+ 				echo '#define TIFFVERSION TIFF_VERSION_CLASSIC'


### PR DESCRIPTION
###### Motivation for this change
Recent libtiff bump broke the build

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
