### PR TITLE
iwgtk: init at 0.4

### DIFF
--- a/pkgs/tools/networking/iwgtk/default.nix
+++ b/pkgs/tools/networking/iwgtk/default.nix
@@ -1,0 +1,28 @@
+{ fetchFromGitHub, gtk3, lib, pkg-config, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "iwgtk";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "j-lentz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "129h7vq9b1r9a5c79hk8d06bj8lgzrnhq55x54hqri9c471jjh0s";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "Lightweight, graphical wifi management utility for Linux";
+    homepage = "https://github.com/j-lentz/iwgtk";
+    changelog = "https://github.com/j-lentz/iwgtk/blob/v${version}/CHANGELOG";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6075,6 +6075,8 @@ in
 
   itm-tools = callPackage ../development/tools/misc/itm-tools { };
 
+  iwgtk = callPackage ../tools/networking/iwgtk { };
+
   ix = callPackage ../tools/misc/ix { };
 
   jaaa = callPackage ../applications/audio/jaaa { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

iwgtk is a lightweight, graphical wifi management utility for Linux. It is used to control iwd, with supported functionality similar to that of iwctl. It is particularly useful in a system where iwd is being used as a standalone network management daemon (i.e., without NetworkManager).

https://github.com/J-Lentz/iwgtk


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
