### PR TITLE
ocamlPackages.yojson: remove legacy version 1.2.3

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -1,4 +1,5 @@
 { buildDunePackage
+, cppo
 , stdlib-shims
 , ppx_yojson_conv_lib
 , ocaml-syntax-shims
@@ -26,16 +27,20 @@ buildDunePackage {
   '';
 
   buildInputs = [
-    stdlib-shims
+    cppo
     ppx_yojson_conv_lib
     ocaml-syntax-shims
     octavius
-    uutf
-    csexp
     dune-build-info
     omd
     cmdliner
+  ];
+
+  propagatedBuildInputs = [
+    csexp
     jsonrpc
+    stdlib-shims
+    uutf
   ];
 
   meta = jsonrpc.meta // {

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -1,48 +1,22 @@
-{ lib, stdenv, fetchzip, ocaml, findlib, dune_2, cppo, easy-format, biniou }:
-let
+{ lib, fetchurl, buildDunePackage, cppo, easy-format, biniou }:
+
+buildDunePackage rec {
   pname = "yojson";
-  param =
-  if lib.versionAtLeast ocaml.version "4.02" then rec {
-    version = "1.7.0";
+  version = "1.7.0";
+  useDune2 = true;
+
+  src = fetchurl {
     url = "https://github.com/ocaml-community/yojson/releases/download/${version}/yojson-${version}.tbz";
-    sha256 = "08llz96if8bcgnaishf18si76cv11zbkni0aldb54k3cn7ipiqvd";
-    nativeBuildInputs = [ dune_2 ];
-    extra = {
-      installPhase = ''
-        dune install --prefix $out --libdir $OCAMLFIND_DESTDIR ${pname}
-      '';
-    };
-  } else rec {
-    version = "1.2.3";
-    url = "https://github.com/ocaml-community/yojson/archive/v${version}.tar.gz";
-    sha256 = "10dvkndgwanvw4agbjln7kgb1n9s6lii7jw82kwxczl5rd1sgmvl";
-    extra = {
-      createFindlibDestdir = true;
-
-      makeFlags = [ "PREFIX=$(out)" ];
-
-      preBuild = "mkdir $out/bin";
-    };
-  };
-in
-stdenv.mkDerivation ({
-
-  name = "ocaml${ocaml.version}-${pname}-${param.version}";
-
-  src = fetchzip {
-    inherit (param) url sha256;
+    sha256 = "1iich6323npvvs8r50lkr4pxxqm9mf6w67cnid7jg1j1g5gwcvv5";
   };
 
-  nativeBuildInputs = [ ocaml findlib ] ++ (param.nativeBuildInputs or []);
-  propagatedNativeBuildInputs = [ cppo ];
+  nativeBuildInputs = [ cppo ];
   propagatedBuildInputs = [ easy-format biniou ];
-  configurePlatforms = [];
 
   meta = with lib; {
     description = "An optimized parsing and printing library for the JSON format";
     homepage = "https://github.com/ocaml-community/${pname}";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
   };
-} // param.extra)
+}


### PR DESCRIPTION
###### Motivation for this change

Cleaning.

cc maintainers of `lsp` @symphorien @marsam

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
