### PR TITLE
chromium: Fix the Ozone/Wayland support

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,8 +1,7 @@
 { newScope, config, stdenv, fetchurl, makeWrapper
 , llvmPackages_11, llvmPackages_12, ed, gnugrep, coreutils, xdg-utils
 , glib, gtk3, gnome, gsettings-desktop-schemas, gn, fetchgit
-, libva ? null
-, pipewire
+, libva, pipewire, wayland
 , gcc, nspr, nss, runCommand
 , lib
 
@@ -165,7 +164,7 @@ in stdenv.mkDerivation {
 
   buildCommand = let
     browserBinary = "${chromiumWV}/libexec/chromium/chromium";
-    libPath = lib.makeLibraryPath [ libva pipewire gtk3 ];
+    libPath = lib.makeLibraryPath [ libva pipewire wayland gtk3 ];
 
   in with lib; ''
     mkdir -p "$out/bin"


### PR DESCRIPTION
The stable channel update to M92 (97570d30c7f) broke the Wayland support:
$ chromium --enable-features=UseOzonePlatform --ozone-platform=wayland
[31712:31712:0721/114725.940557:ERROR:wayland_connection.cc(137)] Failed to load wayland client libraries.
[31712:31712:0721/114725.940641:FATAL:ozone_platform_wayland.cc(177)] Failed to initialize Wayland platform
[0721/114725.947566:ERROR:process_memory_range.cc(75)] read out of range
Trace/breakpoint trap (core dumped)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
