### PR TITLE
ocamlPackages.mdx: 1.8.1 → 1.10.1

### DIFF
--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,16 +1,16 @@
-{ lib, fetchurl, buildDunePackage, opaline, ocaml
+{ lib, fetchurl, buildDunePackage, ocaml
 , alcotest
 , astring, cmdliner, cppo, fmt, logs, ocaml-version, odoc, ocaml_lwt, re, result, csexp
 , pandoc}:
 
 buildDunePackage rec {
   pname = "mdx";
-  version = "1.8.1";
+  version = "1.10.1";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/realworldocaml/mdx/releases/download/${version}/mdx-${version}.tbz";
-    sha256 = "1szik1lyg2vs8jrisnvjdc29n0ifls8mghimff4jcz6f48haa3cv";
+    sha256 = "10d4sfv4qk9569kj46pcaw6cih40v6bkgd44lmsp7cyfhvl8pa9x";
   };
 
   nativeBuildInputs = [ cppo ];
@@ -23,7 +23,9 @@ buildDunePackage rec {
   outputs = [ "bin" "lib" "out" ];
 
   installPhase = ''
-    ${opaline}/bin/opaline -prefix $bin -libdir $lib/lib/ocaml/${ocaml.version}/site-lib
+    runHook preInstall
+    dune install --prefix=$bin --libdir=$lib/lib/ocaml/${ocaml.version}/site-lib ${pname}
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Prepare for OCaml 4.13

cc maintainer @romildo 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
