### PR TITLE
cdpr: init at 2.4

### DIFF
--- a/pkgs/tools/networking/cdpr/default.nix
+++ b/pkgs/tools/networking/cdpr/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchurl, libpcap }:
+
+stdenv.mkDerivation rec {
+  pname = "cdpr";
+  version = "2.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}/${version}/${pname}-${version}.tgz";
+    sha256 = "1idyvyafkk0ifcbi7mc65b60qia6hpsdb6s66j4ggqp7if6vblrj";
+  };
+
+  buildInputs = [ libpcap ];
+
+  installPhase = ''
+    install -Dm755 cdpr $out/bin/cdpr
+  '';
+
+  meta = with lib; {
+    description = "Cisco Discovery Protocol Reporter";
+    homepage = "http://cdpr.sourceforge.net/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.sgo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3597,6 +3597,8 @@ in
 
   cdimgtools = callPackage ../tools/cd-dvd/cdimgtools { };
 
+  cdpr = callPackage ../tools/networking/cdpr { };
+
   cdrdao = callPackage ../tools/cd-dvd/cdrdao { };
 
   cdrkit = callPackage ../tools/cd-dvd/cdrkit { };


### PR DESCRIPTION
This PR adds `cdpr` which is used to decode Cisco Disovery Protocol (CDP) packets

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
