### PR TITLE
lsiutil: 1.60 -> 1.72

### DIFF
--- a/pkgs/os-specific/linux/lsiutil/default.nix
+++ b/pkgs/os-specific/linux/lsiutil/default.nix
@@ -1,41 +1,44 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ lib
+, stdenv
+, fetchurl
+, kmod
+, coreutils
+}:
 
-let
-
-  version = "1.60";
+stdenv.mkDerivation rec {
+  pname = "lsiutil";
+  version = "1.72";
 
   src = fetchurl {
-    name = "lsiutil-${version}.zip";
-    url = "http://www.lsi.com/DistributionSystem/AssetDocument/support/downloads/hbas/fibre_channel/hardware_drivers/LSIUtil%20Kit_${version}.zip";
-    sha256 = "1d4337faa56e24f7d98db87b9de94d6e2c17ab671f4e301b93833eea08b9e426";
+    url = "https://github.com/exactassembly/meta-xa-stm/raw/f96cf6e13f3c9c980f5651510dd96279b9b2af4f/recipes-support/lsiutil/files/lsiutil-${version}.tar.gz";
+    sha256 = "sha256-aTi+EogY1aDWYq3anjRkjz1mzINVfUPQbOPHthxrvS4=";
   };
 
-in
+  buildPhase = ''
+    runHook preBuild
 
-stdenv.mkDerivation {
-  pname = "lsiutils";
-  inherit version;
+    substituteInPlace lsiutil.c \
+      --replace /sbin/modprobe "${kmod}/bin/modprobe" \
+      --replace /bin/mknod "${coreutils}/bin/mknod"
+    gcc -Wall -O lsiutil.c -o lsiutil
 
-  srcs = [ src "Source/lsiutil.tar.gz" ];
+    runHook postBuild
+  '';
 
-  nativeBuildInputs = [ unzip ];
+  installPhase = ''
+    runHook preInstall
 
-  sourceRoot = "lsiutil";
+    mkdir -p "$out/bin"
+    install -Dm755 lsiutil "$out/bin/lsiutil"
 
-  preBuild =
-    ''
-      mkdir -p $out/bin
-      substituteInPlace Makefile --replace /usr/bin $out/bin
-      substituteInPlace lsiutil.c \
-        --replace /sbin/modprobe modprobe \
-        --replace /bin/mknod $(type -P mknod)
-    '';
+    runHook postInstall
+  '';
 
-  installPhase = "true";
-
-  meta = {
-    homepage = "http://www.lsi.com/";
-    description = "LSI Logic Fusion MPT command line management tool";
-    license = lib.licenses.unfree;
+  meta = with lib; {
+    homepage = "https://github.com/exactassembly/meta-xa-stm/tree/master/recipes-support/lsiutil/files";
+    description = "Configuration utility for MPT adapters (FC, SCSI, and SAS/SATA)";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Luflosi ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update the version.
Also make various improvements and fixes:
- Rename pname from lsiutils to lsiutil since that is the actual name
- Update the URL since the old one was broken
- Inline the call to fetchurl
- Use the installPhase to install instead of installing in the buildPhase
- Replace a call to the modprobe binary with the absolute path to the binary
- Properly determine the absolute path of the mknod binary
- Update the description with text from the source code header
- Declare that this only works on Linux
- Add myself as maintainer

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).