### PR TITLE
telepresence2: 2.2.1 -> 2.3.6

### DIFF
--- a/pkgs/tools/networking/telepresence2/default.nix
+++ b/pkgs/tools/networking/telepresence2/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "telepresence2";
-  version = "2.2.1";
+  version = "2.3.6";
 
   src = fetchFromGitHub {
     owner = "telepresenceio";
     repo = "telepresence";
     rev = "v${version}";
-    sha256 = "0pr6vm68jr5ld7hy2b4dwmjziir59vg137c74rdn1wlhq3n8vr41";
+    sha256 = "1bs4h450109vhy18kpyy6y4p5l9kvz4w09m56fxh5z547m5ax6k3";
   };
 
-  vendorSha256 = "0d0p879zchhrzrf6f5zc3vdcd5zi1ind7ibvb46y6wx6lp0f1nrp";
+  vendorSha256 = "0xmw9mc0iy64kb12lsii4nn63ynh6gab9ls8z6mrizjjqz845sa5";
 
   buildFlagsArray = ''
     -ldflags=-s -w -X=github.com/telepresenceio/telepresence/v2/pkg/version.Version=${src.rev}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
