### PR TITLE
override ap-normalize version with  0.1.0.1

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -47,5 +47,7 @@ self: super: {
   # Generated with:
   # nix-shell -I nixpkgs=$PWD -p cabal-install -p cabal2nix --run 'cabal update; cabal2nix cabal://arion-compose > pkgs/applications/virtualization/arion/arion-compose.nix'
   arion-compose = self.callPackage ../../applications/virtualization/arion/arion-compose.nix {};
+  # cabal2nix cabal://ap-normalize-0.1.0.1
+  ap-normalize = self.callPackage ../misc/haskell/ap-normalize {};
 
 }

--- a/pkgs/development/misc/haskell/ap-normalize/default.nix
+++ b/pkgs/development/misc/haskell/ap-normalize/default.nix
@@ -1,15 +1,8 @@
-{ mkDerivation, base, fetchgit, inspection-testing, lib
-, transformers
-}:
+{ mkDerivation, base, inspection-testing, lib, transformers }:
 mkDerivation {
   pname = "ap-normalize";
   version = "0.1.0.1";
-  src = fetchgit {
-    url = "https://gitlab.com/lysxia/ap-normalize.git";
-    sha256 = "0xfr00dy5qiisiwkhbmmisbv3zmfak5i8fx3b9ymxswxwvvbhjnc";
-    rev = "ed521b63f02f1fe7d4e4ec5f8c5de2d4f76ab017";
-    fetchSubmodules = true;
-  };
+  sha256 = "820613b12ce759c8c8a254c78a0e4c474b2cd4cfd08fc0c1d4d5584c58ff2288";
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [ base inspection-testing transformers ];
   description = "Self-normalizing applicative expressions";

--- a/pkgs/development/misc/haskell/ap-normalize/default.nix
+++ b/pkgs/development/misc/haskell/ap-normalize/default.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, fetchgit, inspection-testing, lib
+, transformers
+}:
+mkDerivation {
+  pname = "ap-normalize";
+  version = "0.1.0.1";
+  src = fetchgit {
+    url = "https://gitlab.com/lysxia/ap-normalize.git";
+    sha256 = "0xfr00dy5qiisiwkhbmmisbv3zmfak5i8fx3b9ymxswxwvvbhjnc";
+    rev = "ed521b63f02f1fe7d4e4ec5f8c5de2d4f76ab017";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [ base ];
+  testHaskellDepends = [ base inspection-testing transformers ];
+  description = "Self-normalizing applicative expressions";
+  license = lib.licenses.mit;
+}


### PR DESCRIPTION
 sets ap-normalize with fixed bug causing failure on Mac OS Big Sur.