### PR TITLE
[nixos/stunnel]: Add globalConfig and switch to freeform for servers/clients

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2691,6 +2691,12 @@
     githubId = 997543;
     name = "Dmitry Malikov";
   };
+  dminuoso = {
+    email = "Victor.Nawothnig+nix@icloud.com";
+    github = "dminuoso";
+    githubId = 20192137;
+    name = "Victor Nawothnig";
+  };
   DmitryTsygankov = {
     email = "dmitry.tsygankov@gmail.com";
     github = "DmitryTsygankov";

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -155,3 +155,5 @@ pt-services.clipcat.enable).
 - The wordpress module provides a new interface which allows to use different webservers with the new option [`services.wordpress.webserver`](options.html#opt-services.wordpress.webserver).  Currently `httpd` and `nginx` are supported. The definitions of wordpress sites should now be set in [`services.wordpress.sites`](options.html#opt-services.wordpress.sites).
 
   Sites definitions that use the old interface are automatically migrated in the new option. This backward compatibility will be removed in 22.05.
+
+- The `stunnel` module now allows configuring every available option in stunnel. The existing submodules are now freeform, and a new option [`services.stunnel.globalConfig`](options.html#opt-services.stunnel.globalConfig) has been added. This is backwards compatible, existing installations can remain unchanged.

--- a/nixos/tests/stunnel.nix
+++ b/nixos/tests/stunnel.nix
@@ -1,0 +1,29 @@
+import ./make-test-python.nix ({ pkgs, lib, ...}:
+let pskFile = pkgs.writeText "psk-secrets" "nc-proxy:oaP4EishaeSaishei6rio6xeeph3az";
+in {
+  nodes = {
+    server = {
+      services.stunnel.enable = true;
+      services.stunnel.servers."nc-server" =
+        { accept = "/tmp/nc.sock";
+          connect = "localhost:4002";
+          ciphers = "PSK";
+          PSKsecrets = pskFile;
+        };
+      services.stunnel.clients."nc-server" =
+        { accept = "localhost:4001";
+          connect = "/tmp/nc.sock";
+          ciphers = "PSK";
+          PSKsecrets = pskFile;
+        };
+    };
+  };
+
+  testScript = ''
+    server.wait_for_unit("stunnel.service")
+    server.execute("nc -l 4002 &")
+    with subtest("stunnel set up with PSK works correctly"):
+      server.succeed("nc localhost 4001 -z")
+  '';
+  maintainers = with lib.maintainers; [ dminuoso ];
+})


### PR DESCRIPTION
###### Motivation for this change

The current stunnel module offers very limited configurability. For example, it does not let the user choose PSK ciphers.

###### Things done

The pull request adds a new option `services.stunnel.globalConfig`, which is the driver for configurations set in https://www.stunnel.org/static/stunnel.html#GLOBAL-OPTIONS
Existing options will generate default values inside `globalConfig`.

At the same time, the submodules for `services.stunnel.servers` and `services.stunnel.clients` (https://www.stunnel.org/static/stunnel.html#SERVICE-LEVEL-OPTIONS) were turned into freeform modules with liberal attribute types. This let's a user model an arbitrary config with just nix.

All of this is done in a backwards compatible way, where the options whose names don't directly match with stunnel options (verifyHostName, certMode, enableInsecureSSLv3) are still available.

Some server/client (cert/verifyPeer/verifyChain) options were removed together with an assertion, because their presence only made sense in a non-PSK setting. Because the submodules are now freeformStyle, they will still work however.

Also added a test alongside.

Updated 2021-07-21:

- Also changed the default log level from `info` to `notice` to reduce logging noise in frequent environments by default. If a user wants to debug connections, they know where the knob is.
- Removed previous maintainers as per request, taking over the module.

Updated 2021-07-22:

- Correctly generate list of strings

Updated 2021-07-24

- Fixed a bug with lists in globalConfig and restructured config generation
- Removed some dead code

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Current maintainers: @lschuermann @dasJ 