### PR TITLE
coq: enable parallel building

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -162,6 +162,7 @@ self = stdenv.mkDerivation {
   prefixKey = "-prefix ";
 
   buildFlags = [ "revision" "coq" "coqide" "bin/votour" ];
+  enableParallelBuilding = true;
 
   createFindlibDestdir = true;
 


### PR DESCRIPTION
###### Motivation for this change
Significantly speed up Coq build by setting `enableParallelBuilding = true`.  Noticed by @aaronjanse.

When set to true (on a 32-core machine):

```ShellSession
$ time nix build .#coq
real    2m32.864s
user    8m35.106s
sys     2m23.534s
```

When not specified:

```ShellSession
$ time nix build .#coq
real    10m4.412s
user    7m53.749s
sys     2m11.999s
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
