### PR TITLE
openjdk: 11.0.11+9 -> 11.0.12+7

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -11,8 +11,8 @@
 let
   major = "11";
   minor = "0";
-  update = "11";
-  build = "9";
+  update = "12";
+  build = "7";
 
   openjdk = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
@@ -22,7 +22,7 @@ let
       owner = "openjdk";
       repo = "jdk${major}u";
       rev = "jdk-${version}";
-      sha256 = "0jncsj424340xjfwv6sx5hy9sas80qa3ymkx0ng3by3z01y5rgfx";
+      sha256 = "0s8g6gj5vhm7hbp05cqaxasjrkwr41fm634qim8q6slklm4pkkli";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest bugfix release 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 75, done.
remote: Counting objects: 100% (71/71), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 75 (delta 36), reused 44 (delta 28), pack-reused 4
Unpacking objects: 100% (75/75), 57.85 KiB | 811.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   a9a0ec04146..61ac6539fc4  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-13a8746306dfacc4308a142df59ecde0ba5b7372-dirty/nixpkgs 61ac6539fc420ab21f606e534ef2711bfe4c5e1e
Preparing worktree (detached HEAD 61ac6539fc4)
Updating files: 100% (27085/27085), done.
HEAD is now at 61ac6539fc4 Merge pull request #126807 from Vonfry/update/emacs/add-nongnu
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-13a8746306dfacc4308a142df59ecde0ba5b7372-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
```
result/bin/./java -version
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on
openjdk version "11.0.12" 2021-07-20
OpenJDK Runtime Environment (build 11.0.12+0-adhoc..source)
OpenJDK 64-Bit Server VM (build 11.0.12+0-adhoc..source, mixed mode)
```
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
