### PR TITLE
system-config-printer: 1.5.12 -> 1.5.15

### DIFF
--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "system-config-printer";
-  version = "1.5.12";
+  version = "1.5.15";
 
   src = fetchFromGitHub {
     owner = "openPrinting";
     repo = pname;
-    rev = version;
-    sha256 = "1a812jsd9pb02jbz9bq16qj5j6k2kw44g7s1xdqqkg7061rd7mwf";
+    rev = "v${version}";
+    sha256 = "0a3v8fp1dfb5cwwpadc3f6mv608b5yrrqd8ddkmnrngizqwlswsc";
   };
 
   prePatch = ''
@@ -26,17 +26,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./detect_serverbindir.patch
-
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=958104
-    # (Fixes will be included in next upstream release.)
-    (fetchpatch {
-      url = "https://github.com/OpenPrinting/system-config-printer/commit/cf9903466c1a2d18a701f3b5e8c7e03483e1244d.patch";
-      sha256 = "03gpav618w50q90m2kdkgwclc7fv17m493fgjd633zfavb5kqr3n";
-    })
-    (fetchpatch {
-      url = "https://github.com/OpenPrinting/system-config-printer/commit/b9289dfe105bdb502f183f0afe7a115ecae5f2af.patch";
-      sha256 = "12w47hy3ly4phh8jcqxvdnd5sgbnbp8dnscjd7d5y2i43kxj7b23";
-    })
   ];
 
   buildInputs = [
@@ -54,6 +43,10 @@ stdenv.mkDerivation rec {
   ];
 
   pythonPath = with python3Packages; requiredPythonModules [ pycups pycurl dbus-python pygobject3 requests pycairo pysmbc ];
+
+  preConfigure = ''
+    intltoolize --copy --force --automake
+  '';
 
   configureFlags = [
     "--with-udev-rules"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes  #130969

https://github.com/OpenPrinting/system-config-printer/blob/v1.5.15/NEWS
```
1.5.15 changes
--------------
- set the minimum gettext version because autoconf 2.70 requires it (#201)
- create README file because autoconf requires it (#201)
- full fix for #179

1.5.14 changes
--------------
- set preferred driver for DYMO LabelWriter 400
- udev: ignore devices capable of IPP over USB, we have ipp-usb for it
- asyncpk1.py: dont require the exact Gdk version, work arounds #179

1.5.13 changes
--------------
- add checks for NULL in udev-configure-printer (Fedora #1761097)
- github #174 - put back notification about missing pysmbc
- update .pot file because of fix #174
- python3.9 - xml module removed elem.getchildren() method, use list(elem)
- Make the matching rule of printer device path more flexible (#183)
- 
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
