### PR TITLE
minio-client: 2021-03-23T05-46-11Z -> 2021-06-13T17-48-22Z

### DIFF
--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -2,18 +2,16 @@
 
 buildGoModule rec {
   pname = "minio-client";
-  version = "2021-03-23T05-46-11Z";
+  version = "2021-06-13T17-48-22Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "mc";
     rev = "RELEASE.${version}";
-    sha256 = "sha256-AtE9Zy8tRvcE+gYc0pqJDEFnXL4jSbJ4b6l3ZOe69Y4=";
+    sha256 = "sha256-u0WO7KSalDqlRwbN3b74FOb632fIGPZ2F0T8qLrvt+U=";
   };
 
-  vendorSha256 = "sha256-cIr8d5jz4EfBFuOBZG4Kz20wSXy1Cni77V+JR6vLHwQ=";
-
-  doCheck = false;
+  vendorSha256 = "sha256-BadW8AKHcrkCS3sXR7bqdgNhRYkfXIQOteMxIbiLvwg=";
 
   subPackages = [ "." ];
 
@@ -23,10 +21,15 @@ buildGoModule rec {
     sed -i "s/CommitID.*/CommitID = \"${src.rev}\"/g" cmd/build-constants.go
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/mc --version | grep ${version} > /dev/null
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/minio/mc";
     description = "A replacement for ls, cp, mkdir, diff and rsync commands for filesystems and object storage";
-    maintainers = with maintainers; [ eelco bachp ];
+    maintainers = with maintainers; [ bachp eelco superherointj ];
     platforms = platforms.unix;
     license = licenses.asl20;
   };


### PR DESCRIPTION
minio-client: 2021-03-23T05-46-11Z -> 2021-06-13T17-48-22Z

Enabled tests.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
