### PR TITLE
virtscreen: unbreak

### DIFF
--- a/pkgs/tools/admin/virtscreen/default.nix
+++ b/pkgs/tools/admin/virtscreen/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, python3Packages, x11vnc, xrandr, libGL }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3Packages
+, x11vnc
+, xrandr
+, libGL
+, qt5
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "virtscreen";
@@ -16,6 +24,8 @@ python3Packages.buildPythonApplication rec {
     sha256 = "005qach6phz8w17k8kqmyd647c6jkfybczybxq0yxi5ik0s91a08";
   };
 
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
   propagatedBuildInputs = with python3Packages; [
     netifaces
     pyqt5
@@ -24,10 +34,17 @@ python3Packages.buildPythonApplication rec {
     xrandr
   ];
 
-  postPatch = let
-    ext = stdenv.hostPlatform.extensions.sharedLibrary; in ''
+  dontWrapQtApps = true;
+
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+    # import Qt.labs.platform failed without this
+    "--prefix QML2_IMPORT_PATH : ${qt5.qtquickcontrols2.bin}/${qt5.qtbase.qtQmlPrefix}"
+  ];
+
+  postPatch = ''
     substituteInPlace virtscreen/__main__.py \
-      --replace "'GL'" "'${libGL}/lib/libGL${ext}'" \
+      --replace "'GL'" "'${libGL}/lib/libGL${stdenv.hostPlatform.extensions.sharedLibrary}'" \
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #84511

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
