### PR TITLE
tidyp: revert to fetchurl

### DIFF
--- a/pkgs/development/libraries/tidyp/default.nix
+++ b/pkgs/development/libraries/tidyp/default.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "tidyp";
   version = "1.04";
 
-  src = fetchFromGitHub {
-    owner = "petdance";
-    repo = "tidyp";
-    rev = version;
-    sha256 = "0jslskziwzk4hb6i640fvpnbv2zxrvim6pdx2gwx5wyc64aviskc";
+  src = fetchurl {
+    url = "https://github.com/downloads/petdance/tidyp/${pname}-${version}.tar.gz";
+    sha256 = "0f5ky0ih4vap9c6j312jn73vn8m2bj69pl2yd3a5nmv35k9zmc10";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/development/libraries/tidyp/default.nix
+++ b/pkgs/development/libraries/tidyp/default.nix
@@ -5,6 +5,8 @@ stdenv.mkDerivation rec {
   version = "1.04";
 
   src = fetchurl {
+    # downloads from a legacy GitHub download page from ~11 years ago
+    # project does not work with autoconf anymore and the configure script cannot be generated from the source download
     url = "https://github.com/downloads/petdance/tidyp/${pname}-${version}.tar.gz";
     sha256 = "0f5ky0ih4vap9c6j312jn73vn8m2bj69pl2yd3a5nmv35k9zmc10";
   };


### PR DESCRIPTION
It doesn't build with fetchFromGitHub.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
