### PR TITLE
mc: add libX11 with patchelf to fix #130353

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -57,9 +57,14 @@ stdenv.mkDerivation rec {
       --replace /bin/rm ${coreutils}/bin/rm
   '';
 
-  preFixup = ''
+  postFixup = ''
     # remove unwanted build-dependency references
     sed -i -e "s!PKG_CONFIG_PATH=''${PKG_CONFIG_PATH}!PKG_CONFIG_PATH=$(echo "$PKG_CONFIG_PATH" | sed -e 's/./0/g')!" $out/bin/mc
+
+    # libX11.so is loaded dynamically so autopatch doesn't detect it
+    patchelf \
+      --add-needed ${libX11}/lib/libX11.so \
+      $out/bin/mc
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #130353

###### Things done
before
```
ldd ./result/bin/mc
	linux-vdso.so.1 (0x00007ffeb3f21000)
	libslang.so.2 => /nix/store/ymppcr6m5yk1ka6m7w49q4qjzzdjhgxm-slang-2.3.2/lib/libslang.so.2 (0x00007faf55db8000)
	libncursesw.so.6 => /nix/store/00smfa1qz4xh6f00msjzm15mwmh933ja-ncurses-6.2/lib/libncursesw.so.6 (0x00007faf55d46000)
	libgpm.so.2 => /nix/store/knxbd4vmmsg3spsivbjifiar5gmc9r7y-gpm-1.20.7/lib/libgpm.so.2 (0x00007faf55d3e000)
	libe2p.so.2 => /nix/store/vvhwcw4gz6a40jk3yqgl1hmbrbcgdxlb-e2fsprogs-1.46.2/lib/libe2p.so.2 (0x00007faf55d32000)
	libssh2.so.1 => /nix/store/i2dnjv3354kzcxy3hxxx26wzl8b6dvwq-libssh2-1.9.0/lib/libssh2.so.1 (0x00007faf55cef000)
	libgmodule-2.0.so.0 => /nix/store/i6z36ml0nm0vl93q9jn40bwjbi5b6r8g-glib-2.68.3/lib/libgmodule-2.0.so.0 (0x00007faf55ce8000)
	libglib-2.0.so.0 => /nix/store/i6z36ml0nm0vl93q9jn40bwjbi5b6r8g-glib-2.68.3/lib/libglib-2.0.so.0 (0x00007faf55bb2000)
	libutil.so.1 => /nix/store/j5p0j1w27aqdzncpw73k95byvhh5prw2-glibc-2.33-47/lib/libutil.so.1 (0x00007faf55bad000)
	libpthread.so.0 => /nix/store/j5p0j1w27aqdzncpw73k95byvhh5prw2-glibc-2.33-47/lib/libpthread.so.0 (0x00007faf55b8d000)
	libc.so.6 => /nix/store/j5p0j1w27aqdzncpw73k95byvhh5prw2-glibc-2.33-47/lib/libc.so.6 (0x00007faf559c8000)
	libdl.so.2 => /nix/store/j5p0j1w27aqdzncpw73k95byvhh5prw2-glibc-2.33-47/lib/libdl.so.2 (0x00007faf559c1000)
	libm.so.6 => /nix/store/j5p0j1w27aqdzncpw73k95byvhh5prw2-glibc-2.33-47/lib/libm.so.6 (0x00007faf55880000)
	libssl.so.1.1 => /nix/store/cp2smk79dih0vz099s470lz4ri0bybxv-openssl-1.1.1k/lib/libssl.so.1.1 (0x00007faf557e9000)
	libcrypto.so.1.1 => /nix/store/cp2smk79dih0vz099s470lz4ri0bybxv-openssl-1.1.1k/lib/libcrypto.so.1.1 (0x00007faf554fd000)
	libz.so.1 => /nix/store/zg4jsb0s6l9wnzlz8a20hwni9g67ynlc-zlib-1.2.11/lib/libz.so.1 (0x00007faf554e0000)
	libpcre.so.1 => /nix/store/i3kchbfby0bjxfv0lpi4ymcp387ssnj3-pcre-8.44/lib/libpcre.so.1 (0x00007faf55465000)
	/nix/store/j5p0j1w27aqdzncpw73k95byvhh5prw2-glibc-2.33-47/lib/ld-linux-x86-64.so.2 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib64/ld-linux-x86-64.so.2 (0x00007faf56093000)
```

after
```
ldd ./result/bin/mc
	linux-vdso.so.1 (0x00007ffe607eb000)
	/nix/store/rgg6b29c29554i1y6r430csnc440yvsn-libX11-1.7.2/lib/libX11.so (0x00007f15dd48b000)
	libslang.so.2 => /nix/store/kbnklszx194lm9ww5sprmyakd029s3ya-slang-2.3.2/lib/libslang.so.2 (0x00007f15dd1b2000)
	libncursesw.so.6 => /nix/store/m4x0hqp8amgh987v1862x9hpxpi5rsgj-ncurses-6.2/lib/libncursesw.so.6 (0x00007f15dd140000)
	libgpm.so.2 => /nix/store/vb1lk44md0lnnvs3xisid985nsi0f0gf-gpm-1.20.7/lib/libgpm.so.2 (0x00007f15dd138000)
	libe2p.so.2 => /nix/store/v9pif9fxmwzj28j47xm8ajfn97zm5f93-e2fsprogs-1.46.2/lib/libe2p.so.2 (0x00007f15dd12a000)
	libssh2.so.1 => /nix/store/3hf78q5fqbv8b3bn7ql898m6dzz51wjv-libssh2-1.9.0/lib/libssh2.so.1 (0x00007f15dd0e9000)
	libgmodule-2.0.so.0 => /nix/store/jlx0886w36728v3d0maswjq7y1qnp9nx-glib-2.68.3/lib/libgmodule-2.0.so.0 (0x00007f15dd0e2000)
	libglib-2.0.so.0 => /nix/store/jlx0886w36728v3d0maswjq7y1qnp9nx-glib-2.68.3/lib/libglib-2.0.so.0 (0x00007f15dcfac000)
	libutil.so.1 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib/libutil.so.1 (0x00007f15dcfa7000)
	libpthread.so.0 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib/libpthread.so.0 (0x00007f15dcf86000)
	libc.so.6 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib/libc.so.6 (0x00007f15dcdc3000)
	libxcb.so.1 => /nix/store/2i2paf9vr4nsfjnzx9i97rjk35vcd9vf-libxcb-1.14/lib/libxcb.so.1 (0x00007f15dcd97000)
	libdl.so.2 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib/libdl.so.2 (0x00007f15dcd92000)
	libm.so.6 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib/libm.so.6 (0x00007f15dcc4f000)
	libssl.so.1.1 => /nix/store/0ng6wv06zd6phmw16qxh0ay7b3gwvw1d-openssl-1.1.1k/lib/libssl.so.1.1 (0x00007f15dcbb8000)
	libcrypto.so.1.1 => /nix/store/0ng6wv06zd6phmw16qxh0ay7b3gwvw1d-openssl-1.1.1k/lib/libcrypto.so.1.1 (0x00007f15dc8ca000)
	libz.so.1 => /nix/store/vh5k4xa2zk5l5yrbppa4xjilqmb79ncp-zlib-1.2.11/lib/libz.so.1 (0x00007f15dc8ad000)
	libpcre.so.1 => /nix/store/90mpp18a1g5pb0a69rjvzq7mc47iwm19-pcre-8.44/lib/libpcre.so.1 (0x00007f15dc834000)
	/nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib/ld-linux-x86-64.so.2 => /nix/store/wvgyhnd3rn6dhxzbr5r71gx2q9mhgshj-glibc-2.32-48/lib64/ld-linux-x86-64.so.2 (0x00007f15dd5d2000)
	libXau.so.6 => /nix/store/x2n5zq07q5nzwhzidqgbrnrks0g3mnw1-libXau-1.0.9/lib/libXau.so.6 (0x00007f15dc82f000)
	libXdmcp.so.6 => /nix/store/qs46gan3w05phfz4jj121m93kgizkf2l-libXdmcp-1.1.3/lib/libXdmcp.so.6
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
