### PR TITLE
python3Packages.pygame: enable test suite

### DIFF
--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python library for games";
-    homepage = "http://www.pygame.org/";
+    homepage = "https://www.pygame.org/";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchPypi, buildPythonPackage, python, pkg-config, libX11
 , SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, libpng, libjpeg, portmidi, freetype
+, fontconfig
 }:
 
 buildPythonPackage rec {
@@ -20,9 +21,6 @@ buildPythonPackage rec {
     portmidi libX11 freetype
   ];
 
-  # Tests fail because of no audio device and display.
-  doCheck = false;
-
   preConfigure = ''
     sed \
       -e "s/origincdirs = .*/origincdirs = []/" \
@@ -37,6 +35,15 @@ buildPythonPackage rec {
       '') buildInputs
     }
     LOCALBASE=/ ${python.interpreter} buildconfig/config.py
+  '';
+
+  checkInputs = [ fontconfig ];
+
+  preCheck = ''
+    # No audio or video device in test environment
+    export SDL_VIDEODRIVER=dummy
+    export SDL_AUDIODRIVER=disk
+    export SDL_DISKAUDIOFILE=/dev/null
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The pygame library has had checks disabled since [this commit](https://github.com/NixOS/nixpkgs/commit/f5ec09842dcb16eca6294da30d2f9536bda1d4c0). This patch gets the test suite passing and enables 1584 tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
