### PR TITLE
uptimed nixos/uptimed: switch to /var/lib/ and fix perms

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -596,6 +596,14 @@
           </listitem>
         </itemizedlist>
       </listitem>
+      <listitem>
+        <para>
+          <literal>services.uptimed</literal> now uses
+          <literal>/var/lib/uptimed</literal> as its stateDirectory
+          instead of <literal>/var/spool/uptimed</literal>. Make sure to
+          move all files to the new directory.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -151,6 +151,8 @@ pt-services.clipcat.enable).
   - `CoenraadS.bracket-pair-colorizer` -> `coenraads.bracket-pair-colorizer`
   - `golang.Go` -> `golang.go`
 
+- `services.uptimed` now uses `/var/lib/uptimed` as its stateDirectory instead of `/var/spool/uptimed`. Make sure to move all files to the new directory.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

--- a/nixos/modules/services/system/uptimed.nix
+++ b/nixos/modules/services/system/uptimed.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.services.uptimed;
-  stateDir = "/var/spool/uptimed";
+  stateDir = "/var/lib/uptimed";
 in
 {
   options = {
@@ -21,12 +21,16 @@ in
   };
 
   config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.uptimed ];
+
     users.users.uptimed = {
       description = "Uptimed daemon user";
       home        = stateDir;
-      createHome  = true;
       uid         = config.ids.uids.uptimed;
+      group       = "uptimed";
     };
+    users.groups.uptimed = {};
 
     systemd.services.uptimed = {
       unitConfig.Documentation = "man:uptimed(8) man:uprecords(1)";
@@ -41,7 +45,7 @@ in
         PrivateTmp              = "yes";
         PrivateNetwork          = "yes";
         NoNewPrivileges         = "yes";
-        ReadWriteDirectories    = stateDir;
+        StateDirectory          = [ "uptimed" ];
         InaccessibleDirectories = "/home";
         ExecStart               = "${pkgs.uptimed}/sbin/uptimed -f -p ${stateDir}/pid";
       };

--- a/pkgs/tools/system/uptimed/default.nix
+++ b/pkgs/tools/system/uptimed/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   patches = [ ./no-var-spool-install.patch ];
 
+  postPatch = ''
+    substituteInPlace libuptimed/urec.h \
+      --replace /var/spool /var/lib
+  '';
+
   meta = with lib; {
     description = "Uptime record daemon";
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
@matthiasbeyer
###### Motivation for this change
Closes #22437

###### Things done
switched to /var/lib/uptimed from /var/spool/uptimed
i assume i should create a release note?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
