### PR TITLE
nixos/etc: Rework make-etc.sh

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1045,7 +1045,7 @@ in
           done
         '' + concatMapStrings (name: optionalString (hasPrefix "tmpfiles.d/" name) ''
           rm -f $out/${removePrefix "tmpfiles.d/" name}
-        '') config.system.build.etc.targets;
+        '') config.system.build.etc.passthru.targets;
       }) + "/*";
 
       "systemd/system-generators" = { source = hooks "generators" cfg.generators; };

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -16,12 +16,14 @@ let
     preferLocalBuild = true;
     allowSubstitutes = false;
 
-    /* !!! Use toXML. */
-    sources = map (x: x.source) etc';
-    targets = map (x: x.target) etc';
-    modes = map (x: x.mode) etc';
-    users  = map (x: x.user) etc';
-    groups  = map (x: x.group) etc';
+    nativeBuildInputs = [ pkgs.jq ];
+
+    # Filter etc' down to the attributes we need
+    entries = builtins.toJSON (map (x: { inherit (x) source target mode user group; }) etc');
+    passAsFile = [ "entries" ];
+
+    # This is needed for the systemd module
+    passthru.targets = map (x: x.target) etc';
   };
 
 in

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -1,45 +1,58 @@
-source $stdenv/setup
+# Ensure the script fails properly
+set -euo pipefail
 
-mkdir -p $out/etc
+# shellcheck disable=SC1091,SC2154
+source "$stdenv/setup"
 
-set -f
-sources_=($sources)
-targets_=($targets)
-modes_=($modes)
-users_=($users)
-groups_=($groups)
-set +f
+# shellcheck disable=SC2154
+mkdir -p "$out/etc"
 
-for ((i = 0; i < ${#targets_[@]}; i++)); do
-    source="${sources_[$i]}"
-    target="${targets_[$i]}"
+# This reads the JSON into a big array named 'entries'.
+# Essentially, the jq converts every entry into a \0-separated
+# string of the specified fields source, mode, ....
+# Then all these strings are \0-separated as well and fed into
+# readarray, resulting in a big list of blocks of the 5 fields.
+# \0-separating the strings ensures **any** character can be part
+# of any of the fields (since \0 is not a valid character in paths).
+# shellcheck disable=SC2154
+readarray -d $'\0' -t entries < <(jq -rj '[.[] | [.source, .target, .mode, .user, .group] | join("\u0000")] | join("\u0000")' < "${entriesPath}")
 
-    if [[ "$source" =~ '*' ]]; then
+ret=0
+for ((i = 0; i < ${#entries[@]}; i+=5)); do
+    src="${entries[$i]}"
+    target="${entries[$i + 1]}"
+    mode="${entries[$i + 2]}"
+    user="${entries[$i + 3]}"
+    group="${entries[$i + 4]}"
+
+    if [[ "$src" = *'*'* ]]; then
 
         # If the source name contains '*', perform globbing.
-        mkdir -p $out/etc/$target
-        for fn in $source; do
-            ln -s "$fn" $out/etc/$target/
+        mkdir -p "$out/etc/$target"
+        for fn in $src; do
+            ln -s "$fn" "$out/etc/$target/"
         done
 
     else
 
-        mkdir -p $out/etc/$(dirname $target)
-        if ! [ -e $out/etc/$target ]; then
-            ln -s $source $out/etc/$target
+        mkdir -p "$out/etc/$(dirname "$target")"
+        if ! [ -e "$out/etc/$target" ]; then
+            ln -s "$src" "$out/etc/$target"
         else
-            echo "duplicate entry $target -> $source"
-            if test "$(readlink $out/etc/$target)" != "$source"; then
-                echo "mismatched duplicate entry $(readlink $out/etc/$target) <-> $source"
-                exit 1
+            echo "duplicate entry $target -> $src"
+            if [ "$(readlink "$out/etc/$target")" != "$src" ]; then
+                echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $src"
+                ret=1
+                continue
             fi
         fi
 
-        if test "${modes_[$i]}" != symlink; then
-            echo "${modes_[$i]}"  > $out/etc/$target.mode
-            echo "${users_[$i]}"  > $out/etc/$target.uid
-            echo "${groups_[$i]}" > $out/etc/$target.gid
+        if [ "${mode}" != symlink ]; then
+            echo "${mode}" > "$out/etc/$target.mode"
+            echo "${user}" > "$out/etc/$target.uid"
+            echo "${group}" > "$out/etc/$target.gid"
         fi
-
     fi
 done
+
+exit "${ret}"


### PR DESCRIPTION
This commit changes the data format from 5 arrays to one big JSON file
which ensures special characters (like \n) don't break anything.

For this to work, make-etc.sh needs jq and will create a big list from
\0-separated values (see the comment in the file).

Also this commit quotes all variables, sets useful shell options,
and fixes all shellcheck issues. Additionally, we show all errors before
exiting instead of exiting on the first error. And finally, rename
source to src since source is a bash keyword.

Closes #130935
Closes #131102
Closes #108779
Closes #41241
Closes #41276

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) → `simple.nix`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
