### PR TITLE
fdroidserver: 1.1.9 -> 2.0.3

### DIFF
--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -4,19 +4,18 @@
 , lib }:
 
 python.pkgs.buildPythonApplication rec {
-  version = "1.1.9";
+  version = "2.0.3";
   pname = "fdroidserver";
 
   src = fetchFromGitLab {
     owner = "fdroid";
     repo = "fdroidserver";
     rev = version;
-    sha256 = "098dcg8jdi4q1prfjmd2lbhcyzb8fmmfhbxhid4kqx8vcv7r0iql";
+    sha256 = "1z9d56fmc6lnsgmapgl80690wfin5adj8m8zzms6gcf3vzkgimgy";
   };
 
   patchPhase = ''
     substituteInPlace fdroidserver/common.py --replace "FDROID_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))" "FDROID_PATH = '$out/bin'"
-    substituteInPlace setup.py --replace "pyasn1-modules == 0.2.1" "pyasn1-modules"
   '';
 
   preConfigure = ''
@@ -33,8 +32,6 @@ python.pkgs.buildPythonApplication rec {
     androguard
     clint
     defusedxml
-    docker
-    docker-py
     GitPython
     libcloud
     mwclient
@@ -47,6 +44,7 @@ python.pkgs.buildPythonApplication rec {
     qrcode
     requests
     ruamel_yaml
+    yamllint
   ];
 
   # no tests
@@ -56,7 +54,7 @@ python.pkgs.buildPythonApplication rec {
     homepage = "https://f-droid.org";
     description = "Server and tools for F-Droid, the Free Software repository system for Android";
     license = licenses.agpl3;
-    maintainers = [ lib.maintainers.pmiddend ];
+    maintainers = [ lib.maintainers.obfusk ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Newer version available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

NB: since the last contribution to this package from @pmiddend was in 2019, I've changed the maintainer to myself.