### PR TITLE
python3Packages.forecast-solar: 1.3.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/forecast-solar/default.nix
+++ b/pkgs/development/python-modules/forecast-solar/default.nix
@@ -1,24 +1,28 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , aiodns
 , aiohttp
+, backports-zoneinfo
 }:
 
 buildPythonPackage rec {
   pname = "forecast-solar";
-  version = "1.3.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "forecast_solar";
     rev = version;
-    sha256 = "1kqzr1ypvdjw0zvac4spb6xdd2qpms9h8nr6vf0w9qx756ir0f95";
+    sha256 = "12d9bb3q7gp0yy152x0rcbi727wrg3w9458asp2nhnqlb8nm6j4d";
   };
 
   propagatedBuildInputs = [
     aiodns
     aiohttp
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    backports-zoneinfo
   ];
 
   # no unit tests implemented


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.0

Change log: https://github.com/home-assistant-libs/forecast_solar/releases/tag/2.0.0

- Related Home Assistant change: https://github.com/home-assistant/core/pull/53259
- Target Home Assistant release: 2021.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
