### PR TITLE
fetchgitlab: add deepClone, fetchSubmodules, leaveDotGit arguments

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,22 +1,26 @@
-{ fetchzip, lib }:
+{ fetchgit, fetchzip, lib }:
 
 # gitlab example
 { owner, repo, rev, domain ? "gitlab.com", name ? "source", group ? null
+, fetchSubmodules ? false, leaveDotGit ? false, deepClone ? false
 , ... # For hash agility
 } @ args:
 
-with lib;
-
 let
-  slug = concatStringsSep "/"
-    ((optional (group != null) group) ++ [ owner repo ]);
+  slug = lib.concatStringsSep "/" ((lib.optional (group != null) group) ++ [ owner repo ]);
+  escapedSlug = lib.replaceStrings [ "." "/" ] [ "%2E" "%2F" ] slug;
+  escapedRev = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] rev;
+  passthruAttrs = removeAttrs args [ "domain" "owner" "group" "repo" "rev" ];
 
-  escapedSlug = replaceStrings ["." "/"] ["%2E" "%2F"] slug;
-  escapedRev = replaceStrings ["+" "%" "/"] ["%2B" "%25" "%2F"] rev;
+  useFetchGit = deepClone || fetchSubmodules || leaveDotGit;
+  fetcher = if useFetchGit then fetchgit else fetchzip;
+
+  fetcherArgs = (if useFetchGit then {
+    inherit rev deepClone fetchSubmodules leaveDotGit;
+    url = "https://${domain}/${slug}.git";
+  } else {
+    url = "https://${domain}/api/v4/projects/${escapedSlug}/repository/archive.tar.gz?sha=${escapedRev}";
+  }) // passthruAttrs // { inherit name; };
 in
 
-fetchzip ({
-  inherit name;
-  url = "https://${domain}/api/v4/projects/${escapedSlug}/repository/archive.tar.gz?sha=${escapedRev}";
-  meta.homepage = "https://${domain}/${slug}/";
-} // removeAttrs args [ "domain" "owner" "group" "repo" "rev" ]) // { inherit rev; }
+fetcher fetcherArgs // { meta.homepage = "https://${domain}/${slug}/"; inherit rev; }


### PR DESCRIPTION
I also made fetchFromGitLab more similar to fetchFromGitHub.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
