### PR TITLE
python3Packages.sphinx-copybutton: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/sphinx-copybutton/default.nix
+++ b/pkgs/development/python-modules/sphinx-copybutton/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-copybutton";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "executablebooks";
+    repo = "sphinx-copybutton";
+    rev = "v${version}";
+    sha256 = "sha256-vrEIvQeP7AMXSme1PBp0ox5k8Q1rz+1cbHIO+o17Jqc=";
+    fetchSubmodules = true;
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "sphinx_copybutton" ];
+
+  meta = with lib; {
+    description = "A small sphinx extension to add a \"copy\" button to code blocks";
+    homepage = "https://github.com/executablebooks/sphinx-copybutton";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8234,6 +8234,8 @@ in {
 
   sphinx-autobuild = callPackage ../development/python-modules/sphinx-autobuild { };
 
+  sphinx-copybutton = callPackage ../development/python-modules/sphinx-copybutton { };
+
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
   sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };


### PR DESCRIPTION
###### Motivation for this change
Add sphinx-copybutton, which will be useful to build the documentation of the next kitty version using Nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).