### PR TITLE
pyls-isort: 0.1.1 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/pyls-isort/default.nix
+++ b/pkgs/development/python-modules/pyls-isort/default.nix
@@ -1,29 +1,29 @@
 { lib, buildPythonPackage, fetchFromGitHub
-, python-language-server, isort
+, python-lsp-server, isort
 }:
 
 buildPythonPackage rec {
   pname = "pyls-isort";
-  version = "0.1.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "paradoxxxzero";
     repo = "pyls-isort";
-    rev = version;
-    sha256 = "0mf8c6dw5lsj9np20p0vrhr1yfycq2awjk2pil28l579xj9nr0dc";
+    rev = "v${version}";
+    sha256 = "0xba0aiyjfdi9swjzxk26l94dwlwvn17kkfjfscxl8gvspzsn057";
   };
 
   # no tests
   doCheck = false;
 
   propagatedBuildInputs = [
-    isort python-language-server
+    isort python-lsp-server
   ];
 
   meta = with lib; {
     homepage = "https://github.com/paradoxxxzero/pyls-isort";
-    description = "Isort plugin for python-language-server";
+    description = "Isort plugin for python-lsp-server";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with maintainers; [ cpcloud ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump pyls-isort to the latest release.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
