### PR TITLE
frilouz: init at 0.0.2

### DIFF
--- a/pkgs/development/python-modules/frilouz/default.nix
+++ b/pkgs/development/python-modules/frilouz/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, astunparse
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "frilouz";
+  version = "0.0.2";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "QuantStack";
+    repo = "frilouz";
+    rev = version;
+    sha256 = "0w2qzi4zb10r9iw64151ay01vf0yzyhh0bsjkx1apxp8fs15cdiw";
+  };
+
+  checkInputs = [ astunparse ];
+
+  preCheck = "cd test";
+
+  checkPhase = ''
+    runHook preCheck
+    python -m unittest
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "frilouz" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/QuantStack/frilouz";
+    description = "Python AST parser adapter with partial error recovery";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2734,6 +2734,8 @@ in {
 
   freezegun = callPackage ../development/python-modules/freezegun { };
 
+  frilouz = callPackage ../development/python-modules/frilouz { };
+
   fritzconnection = callPackage ../development/python-modules/fritzconnection { };
 
   fritzprofiles = callPackage ../development/python-modules/fritzprofiles { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the `frilouz` package to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
