### PR TITLE
pkgs.haskell.package-list: init

### DIFF
--- a/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
+++ b/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix curl gnused -I nixpkgs=.
+
+# On Hackage every package description shows a category "Distributions" which
+# lists a "NixOS" version.
+# This script uploads a csv to hackage which will update the displayed versions
+# based on the current versions in nixpkgs.  This happens with on simple http
+# request.
+
+# For authorization you just need to have any valid hackage account. This
+# script uses the `username` and `password-command` field from your
+# ~/.cabal/config file.
+
+# e.g. username: maralorn
+#      password-command: pass hackage.haskell.org (this can be any command, but not an arbitrary shell expression.)
+# Those fields are specified under `upload` on the `cabal` man page.
+
+package_list="$(nix-build -A haskell.package-list)/nixos-hackage-packages.csv"
+username=$(grep "^username:" ~/.cabal/config | sed "s/^username: //")
+password_command=$(grep "^password-command:" ~/.cabal/config | sed "s/^password-command: //")
+curl -u "$username:$($password_command)" --digest -H "Content-type: text/csv" -T "$package_list" http://hackage.haskell.org/distro/NixOS/packages.csv

--- a/pkgs/development/haskell-modules/HACKING.md
+++ b/pkgs/development/haskell-modules/HACKING.md
@@ -241,6 +241,14 @@ When you've double-checked these points, go ahead and merge the `haskell-updates
 After merging, **make sure not to delete the `haskell-updates` branch**, since it
 causes all currently open Haskell-related pull-requests to be automatically closed on GitHub.
 
+## Update Hackage Version Information
+
+After merging into master you can update what hackage displays as the current
+version in NixOS for every individual package.
+To do this you run `maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh`.
+See the script for how to provide credentials. Once you have configured that
+running this takes only a few seconds.
+
 ## Additional Info
 
 Here are some additional tips that didn't fit in above.

--- a/pkgs/development/haskell-modules/package-list.nix
+++ b/pkgs/development/haskell-modules/package-list.nix
@@ -1,0 +1,19 @@
+{ runCommand, haskellPackages, lib, all-cabal-hashes, writeShellScript }:
+let
+  pkgLine = name: pkg:
+    let
+      version = pkg.version or "";
+    in
+    if version != "" then
+      ''"${name}","${version}","http://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.${name}.x86_64-linux"''
+    else "";
+  all-haskellPackages = builtins.toFile "all-haskellPackages" (lib.concatStringsSep "\n" (lib.filter (x: x != "") (lib.mapAttrsToList pkgLine haskellPackages)));
+in
+runCommand "hackage-package-list" { }
+  # This command will make a join between all packages on hackage and haskellPackages.*.
+  # It creates a valid csv file which can be uploaded to hackage.haskell.org.
+  # The call is wrapped in echo $(...) to trim trailing newline, which hackage requires.
+  ''
+    mkdir -p $out/bin
+    echo -n "$(tar -t -f ${all-cabal-hashes} | sed 's![^/]*/\([^/]*\)/.*!"\1"!' | sort -u | join -t , - ${all-haskellPackages})" > $out/nixos-hackage-packages.csv
+  ''

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -42,6 +42,8 @@ let
 in {
   lib = haskellLib;
 
+  package-list = callPackage ../development/haskell-modules/package-list.nix {};
+
   compiler = {
 
     ghc865Binary = callPackage ../development/compilers/ghc/8.6.5-binary.nix { };


### PR DESCRIPTION
This commit introduces a maintainer script to upload our current list of
haskellPackages to hackage.

###### Motivation for this change

Previously peti did this with a shell script from his computer and https://github.com/NixOS/package-list.
With the new script this is easily accessible to all maintainers.
Also this script has fewer dependencies (because it is shell and not Haskell) and is more honest on hackage as it shows the version of our main package e.g. `haskellPackages.streamly` not `haskellPackages.streamly_0_8_0`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
