### PR TITLE
rgp: 1.10 -> 1.11

### DIFF
--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -12,22 +12,22 @@
 , libX11
 , libxcb
 , libXi
-, ncurses5
+, ncurses
 , qtbase
 , qtdeclarative
 , zlib
 }:
 
 let
-  buildNum = "2021-03-31-696";
+  buildNum = "2021-06-30-819";
 in
 stdenv.mkDerivation rec {
   pname = "rgp";
-  version = "1.10";
+  version = "1.11";
 
   src = fetchurl {
     url = "https://gpuopen.com/download/radeon-developer-tool-suite/RadeonDeveloperToolSuite-${buildNum}.tgz";
-    sha256 = "1GUV75KpYbeq7KkE86QqTfGnf/t3VEgviaAsbg/LWJI=";
+    sha256 = "ru+e/oY844x4nvSVRBrTGDdnzUOBhwkaIrnftBITyE8=";
   };
 
   nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
@@ -42,15 +42,10 @@ stdenv.mkDerivation rec {
     libX11
     libxcb
     libXi
-    ncurses5
+    ncurses
     qtbase
     qtdeclarative
     zlib
-  ];
-
-  runtimeDependencies = [
-    "${placeholder "out"}/opt/rgp"
-    "${placeholder "out"}/opt/rgp/qt"
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
1.11 was published: https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v1.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
