### PR TITLE
Package gprbuild, xmlada, gnatcoll-* and properly build ada-mode

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -234,6 +234,11 @@ stdenv.mkDerivation {
       wrap ${targetPrefix}gnatmake ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatmake
       wrap ${targetPrefix}gnatbind ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatbind
       wrap ${targetPrefix}gnatlink ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatlink
+
+      # this symlink points to the unwrapped gnat's output "out". It is used by
+      # our custom gprconfig compiler description to find GNAT's ada runtime. See
+      # ../../development/tools/build-managers/gprbuild/{boot.nix, nixpkgs-gnat.xml}
+      ln -sf ${cc} $out/nix-support/gprconfig-gnat-unwrapped
     ''
 
     + optionalString cc.langD or false ''

--- a/pkgs/development/libraries/ada/gnatcoll/bindings.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/bindings.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gnat
+, gprbuild
+, gnatcoll-core
+, component
+# component dependencies
+, gmp
+, libiconv
+, xz
+, gcc-unwrapped
+, readline
+, zlib
+, python3
+, ncurses
+}:
+
+let
+  # omit python (2.7), no need to introduce a
+  # dependency on an EOL package for no reason
+  libsFor = {
+    iconv = [ libiconv ];
+    gmp = [ gmp ];
+    lzma = [ xz ];
+    readline = [ readline ];
+    python3 = [ python3 ncurses ];
+    syslog = [ ];
+    zlib = [ zlib ];
+  };
+in
+
+
+stdenv.mkDerivation rec {
+  pname = "gnatcoll-${component}";
+  version = "21.0.0";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "gnatcoll-bindings";
+    rev = "v${version}";
+    sha256 = "1214hf0m8iz289rjpxdiddnixj65l2xjwbcr7mq5ysbddmig5992";
+  };
+
+  patches = [
+    ./omp-setup-text-mode.patch
+  ];
+
+  nativeBuildInputs = [
+    gprbuild
+    gnat
+    python3
+  ];
+
+  # propagate since gprbuild needs to find referenced .gpr files
+  # and all dependency C libraries when statically linking a
+  # downstream executable.
+  propagatedBuildInputs = [
+    gnatcoll-core
+  ] ++ libsFor."${component}" or [];
+
+  # explicit flag for GPL acceptance because upstreams
+  # allows a gcc runtime exception for all bindings
+  # except for readline (since it is GPL w/o exceptions)
+  buildFlags = lib.optionals (component == "readline") [
+    "--accept-gpl"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    python3 ${component}/setup.py build $buildFlags
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    python3 ${component}/setup.py install --prefix $out
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "GNAT Components Collection - Bindings to C libraries";
+    homepage = "https://github.com/AdaCore/gnatcoll-bindings";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/libraries/ada/gnatcoll/core.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/core.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, gnat
+, gprbuild
+, fetchFromGitHub
+, xmlada
+, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnatcoll-core";
+  version = "21.0.0";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "gnatcoll-core";
+    rev = "v${version}";
+    sha256 = "0jgs2299zfbr6jg5bxlhqizi60si2m8vw7zq6ns4yhr38qqdskqg";
+  };
+
+  nativeBuildInputs = [
+    gprbuild
+    which
+    gnat
+  ];
+
+  # propagate since gprbuild needs to find
+  # referenced GPR project definitions
+  propagatedBuildInputs = [
+    gprbuild # libgpr
+  ];
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "PROCESSORS=$(NIX_BUILD_CORES)"
+    # confusingly, for gprbuild --target is autoconf --host
+    "TARGET=${stdenv.hostPlatform.config}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/AdaCore/gnatcoll-core";
+    description = "GNAT Components Collection - Core packages";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ada/gnatcoll/db.nix
+++ b/pkgs/development/libraries/ada/gnatcoll/db.nix
@@ -1,0 +1,110 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gnat
+, gprbuild
+, which
+, gnatcoll-core
+, xmlada
+, component
+# components built by this derivation other components depend on
+, gnatcoll-sql
+, gnatcoll-sqlite
+, gnatcoll-xref
+# component specific extra dependencies
+, gnatcoll-iconv
+, gnatcoll-readline
+, sqlite
+, postgresql
+}:
+
+let
+  libsFor = {
+    gnatcoll_db2ada = [
+      gnatcoll-sql
+    ];
+    gnatinspect = [
+      gnatcoll-sqlite
+      gnatcoll-readline
+      gnatcoll-xref
+    ];
+    postgres = [
+      gnatcoll-sql
+      postgresql
+    ];
+    sqlite = [
+      gnatcoll-sql
+      sqlite
+    ];
+    xref = [
+      gnatcoll-iconv
+      gnatcoll-sqlite
+    ];
+  };
+
+  # These components are just tools and don't install a library
+  onlyExecutable = builtins.elem component [
+    "gnatcoll_db2ada"
+    "gnatinspect"
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "gnatcoll-${component}";
+  version = "21.0.0";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "gnatcoll-db";
+    rev = "v${version}";
+    sha256 = "0fdfng3yfy645nlw8l3c2za0zkn6pdhkvyrw20wnjx4k26glgb6r";
+  };
+
+  patches = lib.optionals (component == "sqlite") [
+    # fixes build of the static sqlite component
+    # when building against the system libsqlite3
+    # See https://github.com/AdaCore/gprbuild/issues/27#issuecomment-298444608
+    ./gnatcoll-db-sqlite-static-external.patch
+  ];
+
+  # Link executables dynamically unless specified by the platform,
+  # as we usually do in nixpkgs where possible
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+    for f in gnatcoll_db2ada/Makefile gnatinspect/Makefile; do
+      substituteInPlace "$f" --replace "=static" "=relocatable"
+    done
+  '';
+
+  nativeBuildInputs = [
+    gnat
+    gprbuild
+    which
+  ];
+
+  # Propagate since GPRbuild needs to find referenced .gpr files
+  # and other libraries to link against when static linking is used.
+  # For executables this is of course not relevant and we can reduce
+  # the closure size dramatically
+  ${if onlyExecutable then "buildInputs" else "propagatedBuildInputs"} = [
+    gnatcoll-core
+  ] ++ libsFor."${component}" or [];
+
+  makeFlags = [
+    "-C" component
+    "PROCESSORS=$(NIX_BUILD_CORES)"
+    # confusingly, for gprbuild --target is autoconf --host
+    "TARGET=${stdenv.hostPlatform.config}"
+    "prefix=${placeholder "out"}"
+  ] ++ lib.optional (component == "sqlite") [
+    # link against packaged, not vendored libsqlite3
+    "GNATCOLL_SQLITE=external"
+  ];
+
+  meta = with lib; {
+    description = "GNAT Components Collection - Database packages";
+    homepage = "https://github.com/AdaCore/gnatcoll-db";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ada/gnatcoll/gnatcoll-db-sqlite-static-external.patch
+++ b/pkgs/development/libraries/ada/gnatcoll/gnatcoll-db-sqlite-static-external.patch
@@ -1,0 +1,18 @@
+diff --git a/sqlite/gnatcoll_sqlite.gpr b/sqlite/gnatcoll_sqlite.gpr
+index 5bd53d35..580739f8 100644
+--- a/sqlite/gnatcoll_sqlite.gpr
++++ b/sqlite/gnatcoll_sqlite.gpr
+@@ -69,7 +69,12 @@ project GnatColl_Sqlite is
+          for Source_Dirs use (".", "amalgamation");
+       when "external" =>
+          for Source_Dirs use (".");
+-         for Library_Options use ("-lsqlite3") & Thread_Lib;
++         case Library_Type is
++            when "relocatable" =>
++               for Library_Options use ("-lsqlite3") & Thread_Lib;
++            when others =>
++               null;
++         end case;
+    end case;
+ 
+    package Compiler is

--- a/pkgs/development/libraries/ada/gnatcoll/omp-setup-text-mode.patch
+++ b/pkgs/development/libraries/ada/gnatcoll/omp-setup-text-mode.patch
@@ -1,0 +1,23 @@
+commit 37c815ee660d1bf37256638d23b0346ad7cc19e7
+Author: sternenseemann <0rpkxez4ksa01gb3typccl0i@systemli.org>
+Date:   Wed Jul 21 00:18:30 2021 +0200
+
+    omp/setup.py: open version_information in text mode
+    
+    Otherwise saving the config in setup_support.py will fail as a bytes
+    object is not encodeable as JSON. Luckily, version_information is text
+    anyways.
+
+diff --git a/omp/setup.py b/omp/setup.py
+index 942ab1f5..5281398e 100755
+--- a/omp/setup.py
++++ b/omp/setup.py
+@@ -25,7 +25,7 @@ class GNATCollOMP(SetupApp):
+ 
+         # Set library version
+         with open(os.path.join(config.source_dir, '..',
+-                               'version_information'), 'rb') as fd:
++                               'version_information'), 'r') as fd:
+             version = fd.read().strip()
+         config.set_data('GNATCOLL_VERSION', version, sub='gprbuild')
+ 

--- a/pkgs/development/libraries/ada/xmlada/default.nix
+++ b/pkgs/development/libraries/ada/xmlada/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gnat
+# use gprbuild-boot since gprbuild proper depends
+# on this xmlada derivation.
+, gprbuild-boot
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xmlada";
+  version = "21.0.0";
+
+  src = fetchFromGitHub {
+    name = "xmlada-${version}-src";
+    owner = "AdaCore";
+    repo = "xmlada";
+    rev = "v${version}";
+    sha256 = "00vljkvck951nj853v9sda5qbfm1mp8y2k61ja2595rmp8qcrazw";
+  };
+
+  nativeBuildInputs = [
+    gnat
+    gprbuild-boot
+  ];
+
+  meta = with lib; {
+    description = "XML/Ada: An XML parser for Ada";
+    homepage = "https://github.com/AdaCore/xmlada";
+    maintainers = [ maintainers.sternenseemann ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/tools/build-managers/gprbuild/boot.nix
+++ b/pkgs/development/tools/build-managers/gprbuild/boot.nix
@@ -1,0 +1,90 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gnat
+, which
+, xmlada # for src
+}:
+
+let
+  version = "21.0.0";
+
+  gprConfigKbSrc = fetchFromGitHub {
+    name = "gprconfig-kb-${version}-src";
+    owner = "AdaCore";
+    repo = "gprconfig_kb";
+    rev = "v${version}";
+    sha256 = "11qmzfdd0ipmhxl4k2hjidqc9i40bywrfkbiivd3lhscxca5pxpg";
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "gprbuild-boot";
+  inherit version;
+
+  src = fetchFromGitHub {
+    name = "gprbuild-${version}";
+    owner = "AdaCore";
+    repo = "gprbuild";
+    rev = "v${version}";
+    sha256 = "1knpwasbrz6sxh3dhkc4izchcz4km04j77r4vxxhi23fbd8v1ynj";
+  };
+
+  nativeBuildInputs = [
+    gnat
+    which
+  ];
+
+  postPatch = ''
+    # The Makefile uses gprbuild to build gprbuild which
+    # we can't do at this point, delete it to prevent the
+    # default phases from failing.
+    rm Makefile
+
+    # make sure bootstrap script runs
+    patchShebangs --build bootstrap.sh
+  '';
+
+  # This setupHook populates GPR_PROJECT_PATH which is used by
+  # gprbuild to find dependencies. It works quite similar to
+  # the pkg-config setupHook in the sense that it also splits
+  # dependencies into GPR_PROJECT_PATH and GPR_PROJECT_PATH_FOR_BUILD,
+  # but gprbuild itself doesn't support this, so we'll need to
+  # introducing a wrapper for it in the future remains TODO.
+  # For the moment this doesn't matter since we have no situation
+  # were gprbuild is used to build something used at build time.
+  setupHook = ./gpr-project-path-hook.sh;
+
+  installPhase = ''
+    runHook preInstall
+
+    ./bootstrap.sh \
+      --with-xmlada=${xmlada.src} \
+      --with-kb=${gprConfigKbSrc} \
+      --prefix=$out
+
+    # Install custom compiler description which can detect nixpkgs'
+    # GNAT wrapper as a proper Ada compiler. The default compiler
+    # description expects the runtime library to be installed in
+    # the same prefix which isn't the case for nixpkgs. As a
+    # result, it would detect the unwrapped GNAT as a proper
+    # compiler which is unable to produce working binaries.
+    #
+    # Our compiler description is very similar to the upstream
+    # GNAT description except that we use a symlink in $out/nix-support
+    # created by the cc-wrapper to find the associated runtime
+    # libraries and use gnatmake instead of gnatls to find GNAT's
+    # bin directory.
+    install -m644 ${./nixpkgs-gnat.xml} $out/share/gprconfig/nixpkgs-gnat.xml
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Multi-language extensible build tool";
+    homepage = "https://github.com/AdaCore/gprbuild";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/gprbuild/default.nix
+++ b/pkgs/development/tools/build-managers/gprbuild/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, gprbuild-boot
+, which
+, gnat
+, xmlada
+}:
+
+stdenv.mkDerivation {
+  pname = "gprbuild";
+
+  # See ./boot.nix for an explanation of the gprbuild setupHook,
+  # our custom knowledge base entry and the situation wrt a
+  # (future) gprbuild wrapper.
+  inherit (gprbuild-boot)
+    version
+    src
+    setupHook
+    meta
+    ;
+
+  nativeBuildInputs = [
+    gnat
+    gprbuild-boot
+    which
+  ];
+
+  propagatedBuildInputs = [
+    xmlada
+  ];
+
+  makeFlags = [
+    "ENABLE_SHARED=${if stdenv.hostPlatform.isStatic then "no" else "yes"}"
+    "PROCESSORS=$(NIX_BUILD_CORES)"
+    # confusingly, for gprbuild --target is autoconf --host
+    "TARGET=${stdenv.hostPlatform.config}"
+    "prefix=${placeholder "out"}"
+  ] ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+    "LIBRARY_TYPE=relocatable"
+  ];
+
+  # Fixes gprbuild being linked statically always
+  patches = lib.optional (!stdenv.hostPlatform.isStatic) (fetchpatch {
+    name = "gprbuild-relocatable-build.patch";
+    url = "https://aur.archlinux.org/cgit/aur.git/plain/relocatable-build.patch?h=gprbuild&id=1d4e8a5cb982e79135a0aaa3ef87654bed1fe4f0";
+    sha256 = "1r3xsp1pk9h666mm8mdravkybmd5gv2f751x2ffb1kxnwq1rwiyn";
+  });
+
+  buildFlags = [ "all" "libgpr.build" ];
+
+  installFlags = [ "all" "libgpr.install" ];
+
+  # link gprconfig_kb db from gprbuild-boot into build dir,
+  # the install process copies its contents to $out
+  preInstall = ''
+    ln -sf ${gprbuild-boot}/share/gprconfig share/gprconfig
+  '';
+
+  # no need for the install script
+  postInstall = ''
+    rm $out/doinstall
+  '';
+}

--- a/pkgs/development/tools/build-managers/gprbuild/gpr-project-path-hook.sh
+++ b/pkgs/development/tools/build-managers/gprbuild/gpr-project-path-hook.sh
@@ -1,0 +1,8 @@
+addAdaObjectsPath() {
+    local role_post
+    getHostRoleEnvHook
+
+    addToSearchPath "GPR_PROJECT_PATH${role_post}" "$1/share/gpr"
+}
+
+addEnvHooks "$targetOffset" addAdaObjectsPath

--- a/pkgs/development/tools/build-managers/gprbuild/nixpkgs-gnat.xml
+++ b/pkgs/development/tools/build-managers/gprbuild/nixpkgs-gnat.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<gprconfig>
+  <!-- This differs from the default GNAT compiler description
+       in the following ways:
+
+       * gnatmake is used over gnatls to detect the GNAT version
+         since the latter is not part of the wrapper.
+       * to find the runtime libraries, we rely on the symlink
+         ../nix-support/gprconfig-gnat-unwrapped which is a
+         gprconfig-specific addition to the cc-wrapper we employ
+         for Ada compilers (which is only GNAT at the moment).
+
+       For documentation on this file format and its use refer to
+       https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/companion_tools.html#the-gprconfig-knowledge-base
+  -->
+  <compiler_description>
+    <!-- We would like to name this something different, so users
+         of gprconfig know this is something custom, nixpkgs-related,
+         but unfortunately the knowledge base depends on the name of
+         the compiler for e. g. linker settings.
+    -->
+    <name>GNAT</name>
+    <executable prefix="1">(.*-.*-.*)?gnatmake</executable>
+    <version>
+      <external>${PREFIX}gnatmake -v</external>
+      <grep regexp="^GNATMAKE.+?(\d+(\.\d+)?)" group="1"></grep>
+    </version>
+    <languages>Ada</languages>
+    <variable name="gcc_version">
+      <external>${PREFIX}gcc -v</external>
+      <grep regexp="^[-\w]*gcc \S+ (\S+)" group="1"></grep>
+    </variable>
+    <!-- The ada runtime libraries and objects are only part of the unwrapped
+         GNAT derivation. We can't symlink them into the wrapper derivation
+         (at least not the canonical location) since that screws with linking
+         against libraries distributed with gcc.
+
+         As a workaround, we create a symlink to the unwrapped GNAT's "out"
+         output in the cc-wrapper which we can read into a variable here and
+         use to find GNAT's Ada runtime.
+    -->
+    <variable name="gnat_unwrapped">
+      <external>readlink -n ${PATH}/../nix-support/gprconfig-gnat-unwrapped</external>
+    </variable>
+    <runtimes default="default,kernel,native">
+       <directory group="default" >$gnat_unwrapped/lib/gcc(-lib)?/$TARGET/$gcc_version/adalib/</directory>
+       <directory group="default" contents="^rts-">$gnat_unwrapped/lib/gcc(-lib)?/$TARGET/$gcc_version/ada_object_path</directory>
+       <directory group="2" >$gnat_unwrapped/lib/gcc(-lib)?/$TARGET/$gcc_version/rts-(.*)/adalib/</directory>
+       <directory group="1" >$gnat_unwrapped/$TARGET/lib/gnat/(.*)/adalib/</directory>
+    </runtimes>
+    <target>
+      <external>${PREFIX}gcc -dumpmachine</external>
+      <grep regexp="[^\r\n]+"></grep>
+    </target>
+  </compiler_description>
+</gprconfig>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13699,6 +13699,14 @@ in
 
   global = callPackage ../development/tools/misc/global { };
 
+  gnatcoll-db2ada = callPackage ../development/libraries/ada/gnatcoll/db.nix {
+    component = "gnatcoll_db2ada";
+  };
+
+  gnatinspect = callPackage ../development/libraries/ada/gnatcoll/db.nix {
+    component = "gnatinspect";
+  };
+
   gnome-doc-utils = callPackage ../development/tools/documentation/gnome-doc-utils {};
 
   gnome-desktop-testing = callPackage ../development/tools/gnome-desktop-testing {};
@@ -15576,6 +15584,12 @@ in
   gnatcoll-readline = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "readline"; };
   gnatcoll-syslog = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "syslog"; };
   gnatcoll-zlib = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "zlib"; };
+
+  # gnatcoll-db repository
+  gnatcoll-postgres = callPackage ../development/libraries/ada/gnatcoll/db.nix { component = "postgres"; };
+  gnatcoll-sql = callPackage ../development/libraries/ada/gnatcoll/db.nix { component = "sql"; };
+  gnatcoll-sqlite = callPackage ../development/libraries/ada/gnatcoll/db.nix { component = "sqlite"; };
+  gnatcoll-xref = callPackage ../development/libraries/ada/gnatcoll/db.nix { component = "xref"; };
 
   gns3Packages = dontRecurseIntoAttrs (callPackage ../applications/networking/gns3 { });
   gns3-gui = gns3Packages.guiStable;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13739,6 +13739,10 @@ in
 
   gotty = callPackage ../servers/gotty { };
 
+  gprbuild-boot = callPackage ../development/tools/build-managers/gprbuild/boot.nix { };
+
+  gprbuild = callPackage ../development/tools/build-managers/gprbuild { };
+
   gputils = callPackage ../development/tools/misc/gputils { };
 
   gpuvis = callPackage ../development/tools/misc/gpuvis { };
@@ -19048,6 +19052,8 @@ in
       xorg.libXft xorg.libXext xorg.libSM xorg.libICE
     ];
   };
+
+  xmlada = callPackage ../development/libraries/ada/xmlada { };
 
   xmlrpc_c = callPackage ../development/libraries/xmlrpc-c { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15567,6 +15567,16 @@ in
 
   gnatcoll-core = callPackage ../development/libraries/ada/gnatcoll/core.nix { };
 
+  # gnatcoll-bindings repository
+  gnatcoll-gmp = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "gmp"; };
+  gnatcoll-iconv = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "iconv"; };
+  gnatcoll-lzma = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "lzma"; };
+  gnatcoll-omp = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "omp"; };
+  gnatcoll-python3 = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "python3"; };
+  gnatcoll-readline = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "readline"; };
+  gnatcoll-syslog = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "syslog"; };
+  gnatcoll-zlib = callPackage ../development/libraries/ada/gnatcoll/bindings.nix { component = "zlib"; };
+
   gns3Packages = dontRecurseIntoAttrs (callPackage ../applications/networking/gns3 { });
   gns3-gui = gns3Packages.guiStable;
   gns3-server = gns3Packages.serverStable;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15565,6 +15565,8 @@ in
   # A GMP fork
   mpir = callPackage ../development/libraries/mpir {};
 
+  gnatcoll-core = callPackage ../development/libraries/ada/gnatcoll/core.nix { };
+
   gns3Packages = dontRecurseIntoAttrs (callPackage ../applications/networking/gns3 { });
   gns3-gui = gns3Packages.guiStable;
   gns3-server = gns3Packages.serverStable;

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -26,7 +26,7 @@
 let
 
   mkElpaPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/elpa-packages.nix {
-    inherit (pkgs) stdenv texinfo writeText gcc;
+    inherit (pkgs) stdenv texinfo writeText gcc pkgs buildPackages;
     inherit lib;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For context, this PR is mostly the result of a multi-day yak shave I embarked on to get `emacsPackages.elpaPackages.ada-mode` to work properly by building the Ada executables that are distributed with it.

This required to:

* Package the GPRbuild build tool which required packaging the XML/Ada library as well
* Package gnatcoll-xref which required packaging:
  * gnatcoll-core
  * gnatcoll-iconv
  * gnatcoll-sql
  * gnatcoll-sqlite
* When packaging those gnatcoll packages we basically got all the other `gnatcoll-*` packages for basically free

For a more in depth description, I'd recommend the fairly extensive commit messages and the comments in the derivations.

Also for anyone interested: While working on this I discovered that GNAT is quite inferior to other compilers in nixpkgs in the sense that we can't yet build a cross compiler version of it. I've started working on this and will try to add this in a future PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
