### PR TITLE
github-runner: 2.278.0 -> 2.279.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.278.0";
+  version = "2.279.0";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -41,6 +41,10 @@ let
     # Online tests
     (x: "FullyQualifiedName!=GitHub.Runner.Common.Tests.Worker.ActionManagerL0.PrepareActions_${x}")
     [
+      "CompositeActionWithActionfile_CompositeContainerNested"
+      "CompositeActionWithActionfile_CompositePrestepNested"
+      "CompositeActionWithActionfile_MaxLimit"
+      "CompositeActionWithActionfile_Node"
       "DownloadActionFromGraph"
       "DownloadActionFromGraph_Legacy"
       "NotPullOrBuildImagesMultipleTimes"
@@ -80,8 +84,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "actions";
     repo = "runner";
-    rev = "62d926efce35d3ea16d7624a25aaa5b300737def"; # v${version}
-    sha256 = "sha256-KAb14739DYnuNIf7ZNZk5CShye6XFGn8aLu8BAcuT/c=";
+    rev = "6b75179ec79e2041b3b5b4e9206b73db2d206aac"; # v${version}
+    sha256 = "sha256-d7LAHL8Ff7R++d1HuLxWjtiBZRogySe7xHY/xJAcFms=";
   };
 
   nativeBuildInputs = [
@@ -122,6 +126,11 @@ stdenv.mkDerivation rec {
     substituteInPlace src/dir.proj \
       --replace 'dotnet test Test/Test.csproj' \
                 "dotnet test Test/Test.csproj --filter '${testFilterXml}'"
+
+    # We don't use a Git checkout
+    substituteInPlace src/dir.proj \
+      --replace 'git update-index --assume-unchanged ./Runner.Sdk/BuildConstants.cs' \
+                'echo Patched out.'
 
     # Fix FHS path
     substituteInPlace src/Test/L0/Util/IOUtilL0.cs \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/actions/runner/releases/tag/v2.279.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
