### PR TITLE
dnschef: init at 0.4

### DIFF
--- a/pkgs/tools/networking/dnschef/default.nix
+++ b/pkgs/tools/networking/dnschef/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonApplication, fetchFromGitHub, dnslib, lib }:
+
+buildPythonApplication rec {
+  pname = "dnschef";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "iphelix";
+    repo = "dnschef";
+    rev = "a395411ae1f5c262d0b80d06a45a445f696f3243";
+    sha256 = "0ll3hw6w5zhzyqc2p3c9443gcp12sx6ddybg5rjpl01dh3svrk1q";
+  };
+
+  format = "other";
+  installPhase = ''
+    install -D ./dnschef.py $out/bin/dnschef
+  '';
+
+  propagatedBuildInputs = [ dnslib ];
+
+  meta = with lib; {
+    homepage = "https://github.com/iphelix/dnschef";
+    description = "Highly configurable DNS proxy for penetration testers and malware analysts";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.gfrascadorio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2559,6 +2559,8 @@ in
 
   dgen-sdl = callPackage ../misc/emulators/dgen-sdl { };
 
+  dnschef = python3Packages.callPackage ../tools/networking/dnschef { };
+
   doitlive = callPackage ../tools/misc/doitlive { };
 
   dokuwiki = callPackage ../servers/web-apps/dokuwiki { };


### PR DESCRIPTION

###### Motivation for this change

Adds the dnschef python application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS (don't have)
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (no existing tests)
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
