### PR TITLE
iio-sensor-proxy: new service

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -62,6 +62,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/">iio-sensor-proxy</link>,
+          proxies sensor devices (accelerometers, light sensors,
+          compass) to applications through D-Bus. Available as
+          <link xlink:href="options.html#opt-services.iio-sensor-proxy.enable">services.iio-sensor-proxy</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://www.isc.org/kea/">Kea</link>, ISCs
           2nd generation DHCP and DDNS server suite. Available at
           <link xlink:href="options.html#opt-services.kea">services.kea</link>.

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -20,6 +20,8 @@ pt-services.clipcat.enable).
 
 - [geoipupdate](https://github.com/maxmind/geoipupdate), a GeoIP database updater from MaxMind. Available as [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
 
+- [iio-sensor-proxy](https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/), proxies sensor devices (accelerometers, light sensors, compass) to applications through D-Bus. Available as [services.iio-sensor-proxy](options.html#opt-services.iio-sensor-proxy.enable).
+
 - [Kea](https://www.isc.org/kea/), ISCs 2nd generation DHCP and DDNS server suite. Available at [services.kea](options.html#opt-services.kea).
 
 - [sourcehut](https://sr.ht), a collection of tools useful for software development. Available as [services.sourcehut](options.html#opt-services.sourcehut.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -392,6 +392,7 @@
   ./services/hardware/fancontrol.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix
+  ./services/hardware/iio-sensor-proxy.nix
   ./services/hardware/illum.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix

--- a/nixos/modules/services/hardware/iio-sensor-proxy.nix
+++ b/nixos/modules/services/hardware/iio-sensor-proxy.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.iio-sensor-proxy;
+in {
+  options = {
+    services.iio-sensor-proxy = {
+      enable = lib.mkEnableOption "iio-sensor-proxy";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.dbus.packages = [ pkgs.iio-sensor-proxy ];
+    services.udev.packages = [ pkgs.iio-sensor-proxy ];
+    systemd.packages = [ pkgs.iio-sensor-proxy ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Make it easy to setup iio-sensor-proxy.

https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/
https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/os-specific/linux/iio-sensor-proxy/default.nix

Tested to work on a Pinephone: Phosh uses the ambient light sensor to control auto brightness, and applications can use the compass.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
