### PR TITLE
minio-certgen: init 0.0.2

### DIFF
--- a/pkgs/tools/security/minio-certgen/default.nix
+++ b/pkgs/tools/security/minio-certgen/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "minio-certgen";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "minio";
+    repo = "certgen";
+    rev = "v${version}";
+    sha256 = "sha256-HtzcoEUMt3LpQNyT0wGcmc4Q70QqHx7QpjrDh4YSO/Q=";
+  };
+
+  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+
+  meta = with lib; {
+    description = "A simple Minio tool to generate self-signed certificates, and provides SAN certificates with DNS and IP entries";
+    downloadPage = "https://github.com/minio/certgen";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7055,6 +7055,8 @@ in
 
   minio-client = callPackage ../tools/networking/minio-client { };
 
+  minio-certgen = callPackage ../tools/security/minio-certgen { };
+
   minissdpd = callPackage ../tools/networking/minissdpd { };
 
   inherit (callPackage ../tools/networking/miniupnpc


### PR DESCRIPTION
minio-certgen: init 0.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
