### PR TITLE
plex: add MayNiklas to maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6658,6 +6658,12 @@
     githubId = 1191859;
     name = "Maxim Krivchikov";
   };
+  MayNiklas = {
+    email = "info@niklas-steffen.de";
+    github = "MayNiklas";
+    githubId = 44636701;
+    name = "Niklas Steffen";
+  };
   mazurel = {
     email = "mateusz.mazur@yahoo.com";
     github = "Mazurel";

--- a/pkgs/servers/plex/raw.nix
+++ b/pkgs/servers/plex/raw.nix
@@ -88,6 +88,7 @@ stdenv.mkDerivation rec {
       pjones
       thoughtpolice
       maxeaubrey
+      MayNiklas
     ];
     description = "Media library streaming server";
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding myself to maintainers for plex, because:
- I actively maintain plex (for example: https://github.com/NixOS/nixpkgs/pull/111794, https://github.com/NixOS/nixpkgs/pull/113012, https://github.com/NixOS/nixpkgs/pull/113480, https://github.com/NixOS/nixpkgs/pull/113891, https://github.com/NixOS/nixpkgs/pull/114453, https://github.com/NixOS/nixpkgs/pull/115741, https://github.com/NixOS/nixpkgs/pull/117569, https://github.com/NixOS/nixpkgs/pull/125557, https://github.com/NixOS/nixpkgs/pull/127682, https://github.com/NixOS/nixpkgs/pull/130077, https://github.com/NixOS/nixpkgs/pull/130869)
- I have an interest in seeing PR's related to plex

I don't want to create duplicate PR's by mistake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
