### PR TITLE
python3Packages.synergy: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/synergy/default.nix
+++ b/pkgs/development/python-modules/synergy/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, numpy
+, scipy
+, matplotlib
+, plotly
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "synergy";
+  version = "0.5.1";
+  disabled = pythonOlder "3.5";
+
+  # Pypi does not contain unit tests
+  src = fetchFromGitHub {
+    owner = "djwooten";
+    repo = "synergy";
+    rev = "v${version}";
+    sha256 = "1c60dpvr72g4wjqg6bc601kssl5z55v9bg09xbyh9ahch58bi212";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    matplotlib
+    plotly
+    pandas
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "synergy" ];
+
+  meta = with lib; {
+    description = "A Python library for calculating, analyzing, and visualizing drug combination synergy";
+    homepage = "https://github.com/djwooten/synergy";
+    maintainers = [ maintainers.ivar ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8436,6 +8436,8 @@ in {
 
   syncer = callPackage ../development/python-modules/syncer { };
 
+  synergy = callPackage ../development/python-modules/synergy { };
+
   synologydsm-api = callPackage ../development/python-modules/synologydsm-api { };
 
   systembridge = callPackage ../development/python-modules/systembridge { };


### PR DESCRIPTION

###### Motivation for this change
Really interesting python module i wanted to check out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
