### PR TITLE
trillian: 1.3.11 -> 1.3.13

### DIFF
--- a/pkgs/tools/misc/trillian/default.nix
+++ b/pkgs/tools/misc/trillian/default.nix
@@ -5,28 +5,21 @@
 
 buildGoModule rec {
   pname = "trillian";
-  version = "1.3.11";
-  vendorSha256 = "0zxp1gjzcc3z6vkpc2bchbs1shwm1b28ks0jh4gf6zxpp4361j4l";
+  version = "1.3.13";
+  vendorSha256 = "1ad0vaw0k57njzk9x233iqjbplyvw66qjk8r9j7sx87pdc6a4lpb";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1lh19wba90y91l5jj8ilzjqxgmqqqdvyn7pzrwvmzv7iiy18wcmh";
+    sha256 = "1ns394yd4js9g1psd1dkrffidyzixqvjp5lhw2x2iycrxbnm3y44";
   };
-
-  # Remove tests that require networking
-  postPatch = ''
-    rm cmd/get_tree_public_key/main_test.go
-  '';
 
   subPackages = [
     "cmd/trillian_log_server"
     "cmd/trillian_log_signer"
-    "cmd/trillian_map_server"
     "cmd/createtree"
     "cmd/deletetree"
-    "cmd/get_tree_public_key"
     "cmd/updatetree"
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelogs:
https://github.com/google/trillian/releases/tag/v1.3.12
https://github.com/google/trillian/releases/tag/v1.3.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
