### PR TITLE
buku: fix build, 4.5 -> 4.6

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,6 +1,26 @@
 { lib, python3, fetchFromGitHub }:
 
-with python3.pkgs; buildPythonApplication rec {
+let
+  python3' = python3.override {
+    packageOverrides = self: super: {
+      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
+        version = "1.3.24";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519";
+        };
+      });
+      sqlalchemy-utils = super.sqlalchemy-utils.overridePythonAttrs (oldAttrs: rec {
+        version = "0.36.6";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0srs5w486wp5zydjs70igi5ypgxhm6h73grb85jz03fqpqaanzvs";
+        };
+      });
+    };
+  };
+in
+with python3'.pkgs; buildPythonApplication rec {
   version = "4.5";
   pname = "buku";
 

--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -21,20 +21,21 @@ let
   };
 in
 with python3'.pkgs; buildPythonApplication rec {
-  version = "4.5";
+  version = "4.6";
   pname = "buku";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "buku";
     rev = "v${version}";
-    sha256 = "1lcq5fk8d5j2kfhn9m5l2hk46v7nj4vfa22m1psz35c9zpw4px8q";
+    sha256 = "sha256-hr9qiP7SbloigDcs+6KVWu0SOlggMaBr7CCfY8zoJG0=";
   };
 
   checkInputs = [
     pytestcov
     hypothesis
     pytest
+    pytest-vcr
     pylint
     flake8
     pyyaml
@@ -75,8 +76,8 @@ with python3'.pkgs; buildPythonApplication rec {
     # Disables a test which requires internet
     substituteInPlace tests/test_bukuDb.py \
       --replace "@pytest.mark.slowtest" "@unittest.skip('skipping')" \
-      --replace "self.assertEqual(shorturl, 'http://tny.im/yt')" "" \
-      --replace "self.assertEqual(url, 'https://www.google.com')" ""
+      --replace "self.assertEqual(shorturl, \"http://tny.im/yt\")" "" \
+      --replace "self.assertEqual(url, \"https://www.google.com\")" ""
     substituteInPlace setup.py \
       --replace mypy-extensions==0.4.1 mypy-extensions>=0.4.1
   '';
@@ -95,7 +96,7 @@ with python3'.pkgs; buildPythonApplication rec {
     homepage = "https://github.com/jarun/Buku";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    maintainers = with maintainers; [ matthiasbeyer infinisil ma27 ];
   };
 }
 


### PR DESCRIPTION


###### Motivation for this change


* Fixing the build-failure from https://hydra.nixos.org/build/148285785
* Update to https://github.com/jarun/buku/releases/tag/v4.6

Further details are in the commit-messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
