### PR TITLE
git-machete: add test and update script

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -1,6 +1,8 @@
 { lib, buildPythonApplication, fetchPypi
 , installShellFiles, pbr
-, flake8, mock, pycodestyle, pylint, tox }:
+, flake8, mock, pycodestyle, pylint, tox
+, nix-update-script
+}:
 
 buildPythonApplication rec {
   pname = "git-machete";
@@ -22,6 +24,12 @@ buildPythonApplication rec {
       installShellCompletion --bash --name git-machete completion/git-machete.completion.bash
       installShellCompletion --zsh --name _git-machete completion/git-machete.completion.zsh
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/VirtusLab/git-machete";

--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -2,6 +2,7 @@
 , installShellFiles, pbr
 , flake8, mock, pycodestyle, pylint, tox
 , nix-update-script
+, testVersion, git-machete
 }:
 
 buildPythonApplication rec {
@@ -28,6 +29,12 @@ buildPythonApplication rec {
   passthru = {
     updateScript = nix-update-script {
       attrPath = pname;
+    };
+
+    tests = {
+      version = testVersion {
+        package = git-machete;
+      };
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add an update script and a simple version test for `git-machete` to allow fearless automatic updates by @r-ryantm.

I've tried out the update script via `nix-shell ./maintainers/scripts/update.nix --argstr package git-machete` and it works for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@pawellipski