### PR TITLE
FIX: agdaPackages.cubical

### DIFF
--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -4,16 +4,18 @@ mkDerivation rec {
 
   # Version 0.2 is meant to be used with the Agda 2.6.1 compiler.
   pname = "cubical";
-  version = "0.2";
+  version = "unstable";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "agda";
-    rev = "v${version}";
-    sha256 = "07qlp2f189jvzbn3aqvpqk2zxpkmkxhhkjsn62iq436kxqj3z6c2";
+    rev = "d5030a9c89070255fc575add4e9f37b97e6a0c0c";
+    sha256 = "8WIrgAyA0bwFgtEjmwlvKQ7rZB91/Ppi8zOSq/qCTKE=";
   };
 
   LC_ALL = "en_US.UTF-8";
+
+  preConfigure = ''export AGDA_EXEC=agda'';
 
   # The cubical library has several `Everything.agda` files, which are
   # compiled through the make file they provide.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19095,6 +19095,7 @@ in
     inherit (haskellPackages) Agda;
   };
   agda = agdaPackages.agda;
+  agda-all = agda.withPackages(p: with p; [ standard-library cubical ]);
 
   ### DEVELOPMENT / LIBRARIES / JAVA
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19095,7 +19095,6 @@ in
     inherit (haskellPackages) Agda;
   };
   agda = agdaPackages.agda;
-  agda-all = agda.withPackages(p: with p; [ standard-library cubical ]);
 
   ### DEVELOPMENT / LIBRARIES / JAVA
 


### PR DESCRIPTION
###### Motivation for this change

Cubical Agda library was not working in Agda version 2.6.2. So I fixed it changing it to a newer version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
