### PR TITLE
nixos/iio: mention iio-sensor-proxy in option description

### DIFF
--- a/nixos/modules/hardware/sensor/iio.nix
+++ b/nixos/modules/hardware/sensor/iio.nix
@@ -9,7 +9,7 @@ with lib;
     hardware.sensor.iio = {
       enable = mkOption {
         description = ''
-          Enable this option to support IIO sensors.
+          Enable this option to support IIO sensors with iio-sensor-proxy.
 
           IIO sensors are used for orientation and ambient light
           sensors on some mobile devices.


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/131094 I mistakenly created a new NixOS module for iio-sensor-proxy because I did not know about `hardware.sensor.iio`.

To help people find `hardware.sensor.iio`, include the string "iio-sensor-proxy" in the description.

To search for an iio-sensor-proxy module, I tried in vain:
* `find -iname '*iio-sensor-proxy*'`
* https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&query=iio-sensor-proxy
    * This PR will ensure this search query finds `hardware.sensor.iio` (to demonstrate, search for "orientation")