### PR TITLE
stdenv: use named ref

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -22,7 +22,8 @@ fi
 
 
 # Optionally filter out paths not refering to the store.
-expandResponseParams "$@"
+declare -a params=( "$@" )
+expandResponseParams params
 
 # NIX_LINK_TYPE is set if ld has been called through our cc wrapper. We take
 # advantage of this to avoid both recalculating it, and also repeating other

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -30,7 +30,8 @@ cxxInclude=1
 cxxLibrary=1
 cInclude=1
 
-expandResponseParams "$@"
+declare -a params=( "$@" )
+expandResponseParams params
 linkType=$(checkLinkType "$@")
 
 declare -i n=0

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -37,7 +37,8 @@ dontLink=0
 nonFlagArgs=0
 # shellcheck disable=SC2193
 
-expandResponseParams "$@"
+declare -a params=( "$@" )
+expandResponseParams params
 declare -i n=0
 nParams=${#params[@]}
 while (( "$n" < "$nParams" )); do

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -114,16 +114,13 @@ badPath() {
 }
 
 expandResponseParams() {
-    declare -ga params=("$@")
+    declare -n paramsRef=$1
     local arg
-    for arg in "$@"; do
+    for arg in "${paramsRef[@]}"; do
         if [[ "$arg" == @* ]]; then
             # phase separation makes this look useless
-            # shellcheck disable=SC2157
-            if [ -x "@expandResponseParams@" ]; then
-                # params is used by caller
-                #shellcheck disable=SC2034
-                readarray -d '' params < <("@expandResponseParams@" "$@")
+            if [[ -x "@expandResponseParams@" ]]; then
+                paramsRef+=( "@expandResponseParams@" )
                 return 0
             fi
         fi


### PR DESCRIPTION
###### Motivation for this change

This is part of a series of PR that aims at bringing shell improvements.

I'm trying to target staging directly for this one to see if the build gets done in a timely manner (rather than target master to get higher priority)

This PR needs testing, because I'm not exactly sure what is happening with the "@expandResponseParams@" thing. It seems to me that the code would work, however, it needs confirmation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
