### PR TITLE
stdenv: separate dynamic var export

### DIFF
--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -10,8 +10,10 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-if [ -n "@gettextNeedsLdflags@" -a -z "${dontAddExtraLibs-}" ]; then
+if [[ -n "@gettextNeedsLdflags@" && -z "${dontAddExtraLibs-}" ]]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
-    export NIX_LDFLAGS${role_post}+=" -lintl"
+    varName=NIX_LDFLAGS${role_post}
+    eval "$varName=\"${!varName:-} -lintl\""
+    export "${varName?}"
 fi


### PR DESCRIPTION
###### Motivation for this change

This PR is part of a series of PR aiming to bring some shell improvements.

The idea here is to separate dynamic variable assignement with the export. The advantage being that in case of strict errexit the error code would not get swallowed. It makes a more conservative assignement as well in case the variable is undefined.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
