### PR TITLE
stdenv: separate command and conditional

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -851,7 +851,10 @@ _defaultUnpack() {
 unpackFile() {
     curSrc="$1"
     header "unpacking source archive $curSrc" 3
-    if ! runOneHook unpackCmd "$curSrc"; then
+    local status
+    runOneHook unpackCmd "$curSrc"
+    status=$?
+    if (( status != 0)); then
         echo "do not know how to unpack source archive $curSrc"
         exit 1
     fi


### PR DESCRIPTION
###### Motivation for this change

This is part of a series of PR to improve the stdenv shell scripts

This extracts out a command from a conditional. an exit code is swallowed when a command is run in a conditional.
Admittedly, the semantics don't change here and it's a little more verbose.
I would understand if some people might be opposed to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
