### PR TITLE
stdenv: conservative undefined dynamic variables

### DIFF
--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -66,14 +66,19 @@
 ccWrapper_addCVars () {
     # See ../setup-hooks/role.bash
     local role_post
+    local varName
     getHostRoleEnvHook
 
     if [ -d "$1/include" ]; then
-        export NIX_CFLAGS_COMPILE${role_post}+=" -isystem $1/include"
+        varName=NIX_CFLAGS_COMPILE${role_post}
+        eval "$varName=\"${!varName:-} -isystem $1/include\""
+        export "${varName?}"
     fi
 
     if [ -d "$1/Library/Frameworks" ]; then
-        export NIX_CFLAGS_COMPILE${role_post}+=" -iframework $1/Library/Frameworks"
+        varName=NIX_CFLAGS_COMPILE${role_post}
+        eval "$varName=\"${!varName:-} -iframework $1/Library/Frameworks\""
+        export "${varName?}"
     fi
 }
 


### PR DESCRIPTION
###### Motivation for this change

This is part of a series of PR to bring improvements to the stdenv shell scripts.

This separates assignement and export of a dynamic variable. This appends to a dynamic variable more conservatively in case the variable is undefined.

It is more verbose and much uglier. I'm pretty sure there is a way to improve this with a named reference. This is my first pass at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
