### PR TITLE
makeWrapper: add `--add-post-flags arg`

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -11,15 +11,16 @@ assertExecutable() {
 # makeWrapper EXECUTABLE OUT_PATH ARGS
 
 # ARGS:
-# --argv0       NAME    : set name of executed process to NAME
-#                         (otherwise it’s called …-wrapped)
-# --set         VAR VAL : add VAR with value VAL to the executable’s
-#                         environment
-# --set-default VAR VAL : like --set, but only adds VAR if not already set in
-#                         the environment
-# --unset       VAR     : remove VAR from the environment
-# --run         COMMAND : run command before the executable
-# --add-flags   FLAGS   : add FLAGS to invocation of executable
+# --argv0           NAME    : set name of executed process to NAME
+#                             (otherwise it’s called …-wrapped)
+# --set             VAR VAL : add VAR with value VAL to the executable’s
+#                             environment
+# --set-default     VAR VAL : like --set, but only adds VAR if not already set in
+#                             the environment
+# --unset           VAR     : remove VAR from the environment
+# --run             COMMAND : run command before the executable
+# --add-flags       FLAGS   : add FLAGS to invocation of executable before the executable; e.g. `FLAGS $@`
+# --add-post-flags  FLAGS   : add FLAGS behind the argument array passed to the executable; e.g. `$@ FLAGS`
 
 # --prefix          ENV SEP VAL   : suffix/prefix ENV with VAL, separated by SEP
 # --suffix
@@ -31,7 +32,7 @@ makeWrapper() {
     local original="$1"
     local wrapper="$2"
     local params varName value command separator n fileNames
-    local argv0 flagsBefore flags
+    local argv0 flagsBefore flagsAfter flags
 
     assertExecutable "$original"
 
@@ -98,6 +99,10 @@ makeWrapper() {
             flags="${params[$((n + 1))]}"
             n=$((n + 1))
             flagsBefore="$flagsBefore $flags"
+        elif [[ "$p" == "--add-post-flags" ]]; then
+            flags="${params[$((n + 1))]}"
+            n=$((n + 1))
+            flagsAfter="$flagsAfter $flags"
         elif [[ "$p" == "--argv0" ]]; then
             argv0="${params[$((n + 1))]}"
             n=$((n + 1))
@@ -107,7 +112,7 @@ makeWrapper() {
     done
 
     echo exec ${argv0:+-a \"$argv0\"} \""$original"\" \
-         "$flagsBefore" '"$@"' >> "$wrapper"
+         "$flagsBefore" '"$@"' "$flagsAfter" >> "$wrapper"
 
     chmod +x "$wrapper"
 }


### PR DESCRIPTION
`dprint`, a code formatting tool allows specifying plugins via command line argument (`--plugins /path/to/1 /path/to/2 ...`).

I am currently doing:
```
  postBuild = ''
    wrapProgram $out/bin/dprint \
      --add-flags '--plugins ${toString selectedPluginSources}'
  '';
```

however that results in the `--plugins ...` flag to be added BEFORE `$@`.
Unfortunately `dprint` expects the options to be only given AFTER any subcommand:
```
USAGE:
    dprint <SUBCOMMAND> [OPTIONS] [--] [file patterns]...
```
which means that if I prefix, `dprint` only ever shows the help page.

E.g. the wrapper that is currently produced as:
```sh
#! /bin/bash
exec -a "$0" "/path/to/original/.dprint-wrapped"  --plugins /dynamic/path/to/any/plugin.wasm "$@"
```

would need to change to:
```sh
#! /bin/bash
exec -a "$0" "/path/to/original/.dprint-wrapped" "$@"  --plugins /dynamic/path/to/any/plugin.wasm
```

I opened https://github.com/dprint/dprint/issues/372#issuecomment-885392335 to see what the maintainer says.

###### Motivation for this change

A binary that supports plugins has subcommands but expects some flags to only ever be passed after a given subcommand.


I haven't done below things as I am not sure this contribution would be accepted at all.

There are also some workarounds I can think of:
* exposing each `dprint` subcommand as a separate nix binary which I then can append the flags to
* writing a custom wrapper not using `wrapProgram`, however I am unsure how I would get the right nix shebang, etc.
* `shift`ing the first parameter of `$@` and embed it in between as a flag

E.g. this nasty workaround:

```
  postBuild = ''
    wrapProgram $out/bin/dprint \
      --run 'subcommand="$1"; shift' \
      --add-flags '"$subcommand" --plugins ${toString selectedPluginSources}'
  '';
```

or this one:

```
  postBuild = ''
    wrapProgram $out/bin/dprint \
      --run 'if [[ "$#" -gt 0 && "$1" != -* ]]; then set -- "$@" --plugins ${toString selectedPluginSources}; fi'
  '';
```

work but are not very robust.

----

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).