### PR TITLE
lib/modules: improve errors for `options`/`config`-mixups

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -197,7 +197,7 @@ rec {
 
   withRecursion =
     args@{
-      /* If this option is not null, `toPretty` will stop evaluating at a certain depth */
+      /* If this option is not null, the given value will stop evaluating at a certain depth */
       depthLimit
       /* If this option is true, an error will be thrown, if a certain given depth is exceeded */
     , throwOnDepthLimit ? true
@@ -207,7 +207,7 @@ rec {
         transform = depth:
           if depthLimit != null && depth > depthLimit then
             if throwOnDepthLimit
-              then throw "Exceeded maximum eval-depth limit of ${toString depthLimit} while trying to pretty-print with `generators.withRecursion'!"
+              then throw "Exceeded maximum eval-depth limit of ${toString depthLimit} while trying to evaluate with `generators.withRecursion'!"
               else const "<unevaluated>"
           else id;
         mapAny = with builtins; depth: v:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -162,13 +162,24 @@ rec {
             baseMsg = "The option `${showOption (prefix ++ firstDef.prefix)}' does not exist. Definition values:${showDefs [ firstDef ]}";
           in
             if attrNames options == [ "_module" ]
-              then throw ''
-                ${baseMsg}
+              then
+                let
+                  optionName = showOption prefix;
+                in
+                  if optionName == ""
+                    then throw ''
+                      ${baseMsg}
 
-                However there are no options defined in `${showOption prefix}'. Are you sure you've
-                declared your options properly? This can happen if you e.g. declared your options in `types.submodule'
-                under `config' rather than `options'.
-              ''
+                      It seems as you're trying to declare an option by placing it into `config' rather than `options'!
+                    ''
+                  else
+                    throw ''
+                      ${baseMsg}
+
+                      However there are no options defined in `${showOption prefix}'. Are you sure you've
+                      declared your options properly? This can happen if you e.g. declared your options in `types.submodule'
+                      under `config' rather than `options'.
+                    ''
             else throw baseMsg
         else null;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -170,7 +170,7 @@ rec {
                     then throw ''
                       ${baseMsg}
 
-                      It seems as you're trying to declare an option by placing it into `config' rather than `options'!
+                      It seems as if you're trying to declare an option by placing it into `config' rather than `options'!
                     ''
                   else
                     throw ''

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -247,7 +247,9 @@ rec {
   showDefs = defs: concatMapStrings (def:
     let
       # Pretty print the value for display, if successful
-      prettyEval = builtins.tryEval (lib.generators.toPretty { depthLimit = 10; } def.value);
+      prettyEval = builtins.tryEval
+        (lib.generators.toPretty { }
+          (lib.generators.withRecursion { depthLimit = 10; throwOnDepthLimit = false; } def.value));
       # Split it into its lines
       lines = filter (v: ! isList v) (builtins.split "\n" prettyEval.value);
       # Only display the first 5 lines, and indent them for better visibility

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -247,7 +247,7 @@ rec {
   showDefs = defs: concatMapStrings (def:
     let
       # Pretty print the value for display, if successful
-      prettyEval = builtins.tryEval (lib.generators.toPretty {} def.value);
+      prettyEval = builtins.tryEval (lib.generators.toPretty { depthLimit = 10; } def.value);
       # Split it into its lines
       lines = filter (v: ! isList v) (builtins.split "\n" prettyEval.value);
       # Only display the first 5 lines, and indent them for better visibility

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -529,6 +529,24 @@ runTests {
     };
   };
 
+  testToPrettyLimit =
+    let
+      a.b = 1;
+      a.c = a;
+    in {
+      expr = generators.toPretty { depthLimit = 2; } a;
+      expected = "{\n  b = 1;\n  c = {\n    b = 1;\n    c = {\n      b = <unevaluated>;\n      c = <unevaluated>;\n    };\n  };\n}";
+    };
+
+  testToPrettyLimitThrow =
+    let
+      a.b = 1;
+      a.c = a;
+    in {
+      expr = (builtins.tryEval (generators.toPretty { depthLimit = 2; throwOnDepthLimit = true; } a)).success;
+      expected = false;
+    };
+
   testToPrettyMultiline = {
     expr = mapAttrs (const (generators.toPretty { })) rec {
       list = [ 3 4 [ false ] ];

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -534,8 +534,8 @@ runTests {
       a.b = 1;
       a.c = a;
     in {
-      expr = generators.toPretty { depthLimit = 2; } a;
-      expected = "{\n  b = 1;\n  c = {\n    b = 1;\n    c = {\n      b = <unevaluated>;\n      c = <unevaluated>;\n    };\n  };\n}";
+      expr = generators.toPretty { } (generators.withRecursion { throwOnDepthLimit = false; depthLimit = 2; } a);
+      expected = "{\n  b = 1;\n  c = {\n    b = \"<unevaluated>\";\n    c = {\n      b = \"<unevaluated>\";\n      c = \"<unevaluated>\";\n    };\n  };\n}";
     };
 
   testToPrettyLimitThrow =
@@ -543,7 +543,8 @@ runTests {
       a.b = 1;
       a.c = a;
     in {
-      expr = (builtins.tryEval (generators.toPretty { depthLimit = 2; throwOnDepthLimit = true; } a)).success;
+      expr = (builtins.tryEval
+        (generators.toPretty { } (generators.withRecursion { depthLimit = 2; } a))).success;
       expected = false;
     };
 


### PR DESCRIPTION


###### Motivation for this change

I realized that the error-message I implemented in fa30c9a isn't very helpful if `config` and `options` isn't mixed up in a submodule, but in a "top-level" declaration. While working on that, I also added a `depthLimit`-parameter to `generators.toPretty` to avoid weird `stack overflow`-errors.

The details can be found in the commit-messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
