### PR TITLE
[21.05] kbd: update search-paths.patch

### DIFF
--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
     "--disable-nls"
   ];
 
+  patches = [
+    ./search-paths.patch
+  ];
+
   postPatch =
     ''
       # Renaming keymaps with name clashes, because loadkeys just picks

--- a/pkgs/os-specific/linux/kbd/search-paths.patch
+++ b/pkgs/os-specific/linux/kbd/search-paths.patch
@@ -1,0 +1,85 @@
+Add /etc/kbd to the list of directories to search for the console
+fonts, screen mappings, Unicode maps, keytable files, etc.
+
+Without this patch, kbd will only look inside
+/nix/store/<hash>-kbd-x.x.x/share.
+
+--- a/src/libkeymap/analyze.l
++++ b/src/libkeymap/analyze.l
+@@ -109,6 +109,9 @@ static const char *const include_dirpath1[] = {
+ 	NULL
+ };
+ static const char *const include_dirpath3[] = {
++	"/etc/kbd/" KEYMAPDIR "/include/",
++	"/etc/kbd/" KEYMAPDIR "/i386/include/",
++	"/etc/kbd/" KEYMAPDIR "/mac/include/",
+ 	DATADIR "/" KEYMAPDIR "/include/",
+ 	DATADIR "/" KEYMAPDIR "/i386/include/",
+ 	DATADIR "/" KEYMAPDIR "/mac/include/",
+--- a/src/libkfont/context.c
++++ b/src/libkfont/context.c
+@@ -13,6 +13,7 @@
+ /* search for the map file in these directories (with trailing /) */
+ static const char *const mapdirpath[]  = {
+ 	"",
++	"/etc/kbd/" TRANSDIR "/",
+ 	DATADIR "/" TRANSDIR "/",
+ 	NULL
+ };
+@@ -28,6 +29,7 @@ static const char *const mapsuffixes[] = {
+ /* search for the font in these directories (with trailing /) */
+ static const char *const fontdirpath[]  = {
+ 	"",
++	"/etc/kbd/" FONTDIR "/",
+ 	DATADIR "/" FONTDIR "/",
+ 	NULL
+ };
+@@ -42,6 +44,7 @@ static char const *const fontsuffixes[] = {
+ 
+ static const char *const unidirpath[]  = {
+ 	"",
++	"/etc/kbd/" UNIMAPDIR "/",
+ 	DATADIR "/" UNIMAPDIR "/",
+ 	NULL
+ };
+@@ -55,6 +58,7 @@ static const char *const unisuffixes[] = {
+ /* hide partial fonts a bit - loading a single one is a bad idea */
+ const char *const partfontdirpath[]  = {
+ 	"",
++	"/etc/kbd/" FONTDIR "/" PARTIALDIR "/",
+ 	DATADIR "/" FONTDIR "/" PARTIALDIR "/",
+ 	NULL
+ };
+--- a/src/loadkeys.c
++++ b/src/loadkeys.c
+@@ -27,6 +27,7 @@
+ 
+ static const char *const dirpath1[] = {
+ 	"",
++	"/etc/kbd/" KEYMAPDIR "/**",
+ 	DATADIR "/" KEYMAPDIR "/**",
+ 	KERNDIR "/",
+ 	NULL
+--- a/src/resizecons.c
++++ b/src/resizecons.c
+@@ -104,6 +104,7 @@ static void vga_set_verticaldisplayend_lowbyte(int);
+ 
+ const char *const dirpath[]  = {
+ 	"",
++	"/etc/kbd/" VIDEOMODEDIR "/",
+ 	DATADIR "/" VIDEOMODEDIR "/",
+ 	NULL
+ };
+--- a/src/setfont.c
++++ b/src/setfont.c
+@@ -48,8 +48,8 @@ usage(void)
+ 	                    "    -v         Be verbose.\n"
+ 	                    "    -C <cons>  Indicate console device to be used.\n"
+ 	                    "    -V         Print version and exit.\n"
+-	                    "Files are loaded from the current directory or %s/*/.\n"),
+-	        DATADIR);
++	                    "Files are loaded from the current directory or %s/*/ or %s/*/.\n"),
++	        DATADIR, "/etc/kbd");
+ 	exit(EX_USAGE);
+ }
+ 


### PR DESCRIPTION
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/125704

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
