### PR TITLE
Agda: mark packages as broken until 2.6.2 compatible release is made

### DIFF
--- a/pkgs/development/libraries/agda/agda-categories/default.nix
+++ b/pkgs/development/libraries/agda/agda-categories/default.nix
@@ -14,6 +14,8 @@ mkDerivation rec {
   buildInputs = [ standard-library ];
 
   meta = with lib; {
+    # Remove if a version compatible with agda 2.6.2 is made
+    broken = true;
     inherit (src.meta) homepage;
     description = "A new Categories library";
     license = licenses.bsd3;

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -19,6 +19,8 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
+    # Remove if a version compatible with agda 2.6.2 is made
+    broken = true;
     homepage = "https://github.com/UlfNorell/agda-prelude";
     description = "Programming library for Agda";
     license = lib.licenses.mit;

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -23,6 +23,8 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
+    # Remove if a version compatible with agda 2.6.2 is made
+    broken = true;
     description =
       "A cubical type theory library for use with the Agda compiler";
     homepage = src.meta.homepage;

--- a/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
+++ b/pkgs/development/libraries/agda/functional-linear-algebra/default.nix
@@ -18,6 +18,8 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
+    # Remove if a version compatible with agda 2.6.2 is made
+    broken = true;
     homepage = "https://github.com/ryanorendorff/functional-linear-algebra";
     description = ''
       Formalizing linear algebra in Agda by representing matrices as functions

--- a/pkgs/development/libraries/agda/generic/default.nix
+++ b/pkgs/development/libraries/agda/generic/default.nix
@@ -21,6 +21,8 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
+    # Remove if a version compatible with agda 2.6.2 is made
+    broken = true;
     description =
       "A library for doing generic programming in Agda";
     homepage = src.meta.homepage;


### PR DESCRIPTION
###### Motivation for this change
Agda 2.6.2 released which broke most agda packages. Until these release a compatible release they should be marked as broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@cdepillabout @turion 
