### PR TITLE
apksigner: for apksigcopier, diffoscope, fdroidserver

### DIFF
--- a/pkgs/development/tools/apksigcopier/default.nix
+++ b/pkgs/development/tools/apksigcopier/default.nix
@@ -4,9 +4,8 @@
 , installShellFiles
 , bash
 , pandoc
+, apksigner
 }:
-
-# FIXME: how to "recommend" apksigner like the Debian package?
 
 python3.pkgs.buildPythonApplication rec {
   pname = "apksigcopier";
@@ -22,6 +21,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [ installShellFiles pandoc ];
   propagatedBuildInputs = with python3.pkgs; [ click ];
   checkInputs = with python3.pkgs; [ flake8 mypy pylint ];
+  makeWrapperArgs = [ "--prefix" "PATH" ":" "${lib.makeBinPath [ apksigner ]}" ];
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/development/tools/apksigner/default.nix
+++ b/pkgs/development/tools/apksigner/default.nix
@@ -1,0 +1,15 @@
+{ runCommand
+, makeWrapper
+, jre
+, build-tools
+}:
+let
+  tools = builtins.head build-tools;
+in
+runCommand "apksigner" {
+  nativeBuildInputs = [ makeWrapper ];
+} ''
+  mkdir -p $out/bin
+  makeWrapper "${jre}/bin/java" "$out/bin/apksigner" \
+    --add-flags "-jar ${tools}/libexec/android-sdk/build-tools/${tools.version}/lib/apksigner.jar"
+''

--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -1,7 +1,8 @@
-{ docker
-, fetchFromGitLab
+{ fetchFromGitLab
 , python
-, lib }:
+, lib
+, apksigner
+}:
 
 python.pkgs.buildPythonApplication rec {
   version = "2.0.3";
@@ -46,6 +47,8 @@ python.pkgs.buildPythonApplication rec {
     ruamel_yaml
     yamllint
   ];
+
+  makeWrapperArgs = [ "--prefix" "PATH" ":" "${lib.makeBinPath [ apksigner ]}" ];
 
   # no tests
   doCheck = false;

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, runCommand, makeWrapper, python3Packages, docutils, help2man, installShellFiles
-, abootimg, acl, apktool, binutils-unwrapped, build-tools, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, db, diffutils, dtc
+{ lib, stdenv, fetchurl, python3Packages, docutils, help2man, installShellFiles
+, abootimg, acl, apksigner, apktool, binutils-unwrapped, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, db, diffutils, dtc
 , e2fsprogs, file, findutils, fontforge-fonttools, ffmpeg, fpc, gettext, ghc, ghostscriptX, giflib, gnumeric, gnupg, gnutar
 , gzip, hdf5, imagemagick, jdk, libarchive, libcaca, llvm, lz4, mono, openssh, openssl, pdftk, pgpdump, poppler_utils, qemu, R
 , radare2, sng, sqlite, squashfsTools, tcpdump, odt2txt, unzip, wabt, xxd, xz, zip, zstd
@@ -7,13 +7,6 @@
 }:
 
 # Note: when upgrading this package, please run the list-missing-tools.sh script as described below!
-let
-  apksigner = runCommand "apksigner" { nativeBuildInputs = [ makeWrapper ]; } ''
-    mkdir -p $out/bin
-    makeWrapper "${jdk}/bin/java" "$out/bin/apksigner" \
-      --add-flags "-jar ${builtins.head build-tools}/libexec/android-sdk/build-tools/28.0.3/lib/apksigner.jar"
-  '';
-in
 python3Packages.buildPythonApplication rec {
   pname = "diffoscope";
   version = "178";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4206,7 +4206,6 @@ in
   diff-so-fancy = callPackage ../applications/version-management/git-and-tools/diff-so-fancy { };
 
   diffoscopeMinimal = callPackage ../tools/misc/diffoscope {
-    inherit (androidenv.androidPkgs_9_0) build-tools;
     jdk = jdk8;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1105,6 +1105,10 @@ in
 
   apksigcopier = callPackage ../development/tools/apksigcopier { };
 
+  apksigner = callPackage ../development/tools/apksigner {
+    inherit (androidenv.androidPkgs_9_0) build-tools;
+  };
+
   apktool = callPackage ../development/tools/apktool {
     inherit (androidenv.androidPkgs_9_0) build-tools;
   };


### PR DESCRIPTION
###### Motivation for this change

`apksigcopier`, `diffoscope`, and `fdroidserver` depend on `apksigner` (from the android build tools) for some functionality.

cc @SuperSandro2000 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
