### PR TITLE
java-language-server: init at 0.2.38

### DIFF
--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     buildPhase = ''
       runHook preBuild
 
-      mvn package -Dmaven.repo.local=$out/.m2 -DskipTests
+      mvn package -Dmaven.repo.local=$out -DskipTests
 
       runHook postBuild
     '';
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     dontConfigure = true;
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-2MVlF3QIWiDvUlnMH4RLi2Od57aoh8zK/OmHqztOnZ4=";
+    outputHash = "sha256-YkcQKmm8oeEH7uyUzV/qGoe4LiI6o5wZ7o69qrO3oCA=";
   };
 
 
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
       --no-man-pages \
       --compress 2
 
-    mvn package --offline -Dmaven.repo.local=${fetchedMavenDeps}/.m2 -DskipTests
+    mvn package --offline -Dmaven.repo.local=${fetchedMavenDeps} -DskipTests
 
     runHook postBuild
   '';

--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub
-, jdk, maven, runtimeShell
+, jdk, maven
+, runtimeShell, makeWrapper
 }:
 
 let
@@ -54,7 +55,7 @@ stdenv.mkDerivation rec {
   };
 
 
-  nativeBuildInputs = [ maven jdk ];
+  nativeBuildInputs = [ maven jdk makeWrapper ];
 
   dontConfigure = true;
   buildPhase = ''
@@ -79,13 +80,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/java/java-language-server
     cp -r dist/classpath dist/*${platform}* $out/share/java/java-language-server
 
-    mkdir -p $out/bin
     # a link is not used as lang_server_${platform}.sh makes use of "dirname $0" to access other files
-    cat << _EOF > $out/bin/java-language-server
-    #!${runtimeShell}
-    $out/share/java/java-language-server/lang_server_${platform}.sh "\$@"
-    _EOF
-    chmod +x $out/bin/java-language-server
+    makeWrapper $out/share/java/java-language-server/lang_server_${platform}.sh $out/bin/java-language-server
 
     runHook postInstall
   '';

--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     jlink \
-      ${lib.strings.optionalString (!stdenv.isDarwin) "--module-path './jdks/${platform}/jdk-13/jmods'"} \
+      ${lib.optionalString (!stdenv.isDarwin) "--module-path './jdks/${platform}/jdk-13/jmods'"} \
       --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
       --output dist/${platform} \
       --no-header-files \

--- a/pkgs/development/tools/java/java-language-server/default.nix
+++ b/pkgs/development/tools/java/java-language-server/default.nix
@@ -1,0 +1,107 @@
+{ lib, stdenv, fetchFromGitHub
+, jdk, maven
+# The name of the link which would be placed in the bin directory.
+# Set to null if no link is to be made.
+, linkBinName ? "java-language-server"
+}:
+
+let
+  platform =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "mac"
+    else "windows";
+in
+stdenv.mkDerivation rec {
+  pname = "java-language-server";
+  version = "0.2.38";
+
+  src = fetchFromGitHub {
+    owner = "georgewfraser";
+    repo = pname;
+    # commit hash is used as owner sometimes forgets to set tags. See https://github.com/georgewfraser/java-language-server/issues/104
+    rev = "1dfdc54d1f1e57646a0ec9c0b3f4a4f094bd9f17";
+    sha256 = "sha256-zkbl/SLg09XK2ZhJNzWEtvFCQBRQ62273M/2+4HV1Lk=";
+  };
+
+  fetchedMavenDeps = stdenv.mkDerivation {
+    name = "java-language-server-${version}-maven-deps";
+    inherit src;
+    buildInputs = [ maven ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      mvn package -Dmaven.repo.local=$out/.m2 -DskipTests
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+    dontConfigure = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-2MVlF3QIWiDvUlnMH4RLi2Od57aoh8zK/OmHqztOnZ4=";
+  };
+
+
+  nativeBuildInputs = [ maven jdk ];
+
+  dontConfigure = true;
+  buildPhase = ''
+    runHook preBuild
+
+    jlink \
+      ${lib.strings.optionalString (!stdenv.isDarwin) "--module-path './jdks/${platform}/jdk-13/jmods'"} \
+      --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
+      --output dist/${platform} \
+      --no-header-files \
+      --no-man-pages \
+      --compress 2
+
+    mvn package --offline -Dmaven.repo.local=${fetchedMavenDeps}/.m2 -DskipTests
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/java/java-language-server
+    cp -r dist/classpath $out/share/java/java-language-server
+    cp -r dist/*${platform}* $out/share/java/java-language-server
+
+    ${lib.strings.optionalString (linkBinName != null && platform != "windows")
+    ''
+      mkdir -p $out/bin
+      # a link is not used as lang_server_${platform}.sh makes use of "dirname $0" to access other files
+      cat << _EOF > $out/bin/${linkBinName}
+      #!/usr/bin/env bash
+      $out/share/java/java-language-server/lang_server_${platform}.sh "\$@"
+      _EOF
+      chmod +x $out/bin/${linkBinName}
+    ''
+    }
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Java language server based on v3.0 of the protocol and implemented using the Java compiler API";
+    homepage = "https://github.com/georgewfraser/java-language-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hqurve ];
+    platforms = concatLists (with platforms; [ linux darwin windows ]);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14504,6 +14504,8 @@ in
     readline = readline81;
   };
 
+  java-language-server = callPackage ../development/tools/java/java-language-server { };
+
   jhiccup = callPackage ../development/tools/java/jhiccup { };
 
   valgrind = callPackage ../development/tools/analysis/valgrind {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Something I would like, also its a packaging request closes https://github.com/NixOS/nixpkgs/issues/128999

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
