### PR TITLE
lib: fix functionArgs for functors

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -132,6 +132,16 @@ runTests {
     expected = [ 1 1 0 ];
   };
 
+  testFunctionArgsFunctor = {
+    expr = functionArgs { __functor = self: { a, b }: null; };
+    expected = { a = false; b = false; };
+  };
+
+  testFunctionArgsSetFunctionArgs = {
+    expr = functionArgs (setFunctionArgs (args: args.x) { x = false; });
+    expected = { x = false; };
+  };
+
 # STRINGS
 
   testConcatMapStrings = {

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -334,7 +334,10 @@ rec {
      has the same return type and semantics as builtins.functionArgs.
      setFunctionArgs : (a → b) → Map String Bool.
   */
-  functionArgs = f: f.__functionArgs or (builtins.functionArgs f);
+  functionArgs = f:
+    if f ? __functor
+    then f.__functionArgs or (lib.functionArgs (f.__functor f))
+    else builtins.functionArgs f;
 
   /* Check whether something is a function or something
      annotated with function args.


### PR DESCRIPTION
`functionArgs` should give valid results on
functions that have been identified with `lib.isFunction`
instead of erroring out.

this probably requires considerable backporting?

/cc @Infinisil 
