### PR TITLE
trash-cli: 0.21.6.30 -> 0.21.7.23

### DIFF
--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "trash-cli";
-  version = "0.21.6.30";
+  version = "0.21.7.23";
 
   src = fetchFromGitHub {
     owner = "andreafrancia";
     repo = "trash-cli";
     rev = version;
-    sha256 = "09vwg4jpx7pl7rd5ybq5ldgwky8zzf59msmzvmim9vipnmjgkxv7";
+    sha256 = "1kdkzs9mbyac8ndc6r0wa39z8d3fj8zglqp149id4j37aydxb10l";
   };
 
   propagatedBuildInputs = [ python3Packages.psutil ];
@@ -18,8 +18,27 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  # Skip `test_user_specified` since its result depends on the mount path.
-  disabledTests = [ "test_user_specified" ];
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Create a home directory with a test file.
+    HOME="$(mktemp -d)"
+    touch "$HOME/deleteme"
+
+    # Verify that trash list is initially empty.
+    [[ $($out/bin/trash-list) == "" ]]
+
+    # Trash a test file and verify that it shows up in the list.
+    $out/bin/trash "$HOME/deleteme"
+    [[ $($out/bin/trash-list) == *" $HOME/deleteme" ]]
+
+    # Empty the trash and verify that it is empty.
+    $out/bin/trash-empty
+    [[ $($out/bin/trash-list) == "" ]]
+
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/andreafrancia/trash-cli";


### PR DESCRIPTION
###### Motivation for this change

Bump trash-cli and add installation check.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
