### PR TITLE
telegram-cli: init 20200106

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-cli/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, jansson, lib, libconfig, libevent, libgcrypt, lua, lua53Packages
+, makeWrapper, openssl, pkg-config, python3, readline, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "telegram-cli";
+  version = "20200106";
+
+  src = fetchFromGitHub {
+    owner = "kenorb-contrib";
+    repo = "tg";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-wYBPr2b8IOycO9y/CNyGjnRsyGyYl3oiXYtTzwTurVA=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    jansson
+    libconfig
+    libevent
+    libgcrypt
+    lua
+    lua53Packages.lgi
+    openssl
+    python3
+    readline
+    zlib
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ./bin/telegram-cli $out/bin/telegram-cli-keyless
+    install -Dm644 ./tg-server.pub -t $out/share/telegram-cli
+    makeWrapper $out/bin/telegram-cli-keyless $out/bin/telegram-cli \
+      --add-flags "-k $out/share/telegram-cli/tg-server.pub"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Command-line interface for Telegram, that uses readline interface, it's a client implementation of TGL library";
+    downloadPage = "https://github.com/kenorb-contrib/tg";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27335,6 +27335,8 @@ in
 
   tektoncd-cli = callPackage ../applications/networking/cluster/tektoncd-cli { };
 
+  telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli { };
+
   telepathy-gabble = callPackage ../applications/networking/instant-messengers/telepathy/gabble { };
 
   telepathy-haze = callPackage ../applications/networking/instant-messengers/telepathy/haze {};


### PR DESCRIPTION
telegram-cli: init 20200106

Package requested by @Cyberx9901

Known issue:
* Config file path is odd: `/home/intj//.telegram-cli`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
