### PR TITLE
zstd: fix 1.5.0 tests on darwin

### DIFF
--- a/pkgs/tools/compression/zstd/playtests-darwin.patch
+++ b/pkgs/tools/compression/zstd/playtests-darwin.patch
@@ -1,14 +1,14 @@
 --- a/tests/playTests.sh
 +++ b/tests/playTests.sh
-@@ -112,22 +112,12 @@ case "$OS" in
+@@ -112,7 +112,6 @@ case "$OS" in
  esac
  
  case "$UNAME" in
 -  Darwin) MD5SUM="md5 -r" ;;
--  FreeBSD) MD5SUM="gmd5sum" ;;
--  NetBSD) MD5SUM="md5 -n" ;;
--  OpenBSD) MD5SUM="md5" ;;
-   *) MD5SUM="md5sum" ;;
+   FreeBSD) MD5SUM="gmd5sum" ;;
+   NetBSD) MD5SUM="md5 -n" ;;
+   OpenBSD) MD5SUM="md5" ;;
+@@ -120,14 +119,8 @@ case "$UNAME" in
  esac
  
  MTIME="stat -c %Y"
@@ -23,7 +23,7 @@
  
  assertFilePermissions() {
      STAT1=$($GET_PERMS "$1")
-@@ -967,7 +957,6 @@ $MD5SUM dirTestDict/* > tmph1
+@@ -967,7 +960,6 @@ $MD5SUM dirTestDict/* > tmph1
  zstd -f --rm dirTestDict/* -D tmpDictC
  zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
  case "$UNAME" in


### PR DESCRIPTION
Fixes #131288

They introduced some additional attempts at darwin compatibility upstream and cruel twist of fate, broke darwin compilation in nix. This was the [upstream commit](https://github.com/facebook/zstd/commit/018ed6552a3ce4079e19085a0f8dc05f8b6d145a#diff-42536bf464c71391b206ee443025608ed6bbd0d083d554e985cbd51a3f0e0543)

###### Motivation for this change

The current 1.5.0 in master (and 21.05) do not compile cleanly on darwin.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
