### PR TITLE
[21.05] libslirp: 4.5.0 -> 4.6.1

### DIFF
--- a/pkgs/development/libraries/libslirp/default.nix
+++ b/pkgs/development/libraries/libslirp/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libslirp";
-  version = "4.6.0";
+  version = "4.6.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "slirp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-1Zp1+PW0WtNzRYIA87X42CJeSzVFhi5sGi9/rlUP4Vo=";
+    sha256 = "sha256-AM6NxO4hjFiUAzRYbXV3fe18xwCBmzdM63n93UOxjKw=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];

--- a/pkgs/development/libraries/libslirp/default.nix
+++ b/pkgs/development/libraries/libslirp/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libslirp";
-  version = "4.5.0";
+  version = "4.6.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "slirp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-UdKBED7xR0gDf3aj3+6I62CnAwGP7XxskaFzWeUUkkk=";
+    sha256 = "sha256-1Zp1+PW0WtNzRYIA87X42CJeSzVFhi5sGi9/rlUP4Vo=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-3592
https://nvd.nist.gov/vuln/detail/CVE-2021-3593
https://nvd.nist.gov/vuln/detail/CVE-2021-3594
https://nvd.nist.gov/vuln/detail/CVE-2021-3595

Fortunately the bump contains little more than the fixes.

See #128396

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
