### PR TITLE
gst_all_1: get all dependencies via callPackage

### DIFF
--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,29 +1,27 @@
 { callPackage, AudioToolbox, AVFoundation, Cocoa, CoreFoundation, CoreMedia, CoreServices, CoreVideo, DiskArbitration, Foundation, IOKit, MediaToolbox, OpenGL, VideoToolbox }:
 
-rec {
+{
   gstreamer = callPackage ./core { inherit CoreServices; };
 
   gstreamermm = callPackage ./gstreamermm { };
 
-  gst-plugins-base = callPackage ./base { inherit gstreamer Cocoa OpenGL; };
+  gst-plugins-base = callPackage ./base { inherit Cocoa OpenGL; };
 
-  gst-plugins-good = callPackage ./good { inherit gst-plugins-base Cocoa; };
+  gst-plugins-good = callPackage ./good { inherit Cocoa; };
 
-  gst-plugins-bad = callPackage ./bad { inherit gst-plugins-base AudioToolbox AVFoundation CoreMedia CoreVideo Foundation MediaToolbox VideoToolbox; };
+  gst-plugins-bad = callPackage ./bad { inherit AudioToolbox AVFoundation CoreMedia CoreVideo Foundation MediaToolbox VideoToolbox; };
 
-  gst-plugins-ugly = callPackage ./ugly { inherit gst-plugins-base CoreFoundation DiskArbitration IOKit; };
+  gst-plugins-ugly = callPackage ./ugly { inherit CoreFoundation DiskArbitration IOKit; };
 
-  gst-rtsp-server = callPackage ./rtsp-server { inherit gst-plugins-base gst-plugins-bad; };
+  gst-rtsp-server = callPackage ./rtsp-server { };
 
-  gst-libav = callPackage ./libav { inherit gst-plugins-base; };
+  gst-libav = callPackage ./libav { };
 
-  gst-devtools = callPackage ./devtools { inherit gstreamer gst-plugins-base; };
+  gst-devtools = callPackage ./devtools { };
 
-  gst-editing-services = callPackage ./ges { inherit gst-plugins-base gst-plugins-bad gst-devtools; };
+  gst-editing-services = callPackage ./ges { };
 
-  gst-vaapi = callPackage ./vaapi {
-    inherit gst-plugins-base gstreamer gst-plugins-bad;
-  };
+  gst-vaapi = callPackage ./vaapi { };
 
   # note: gst-python is in ./python/default.nix - called under pythonPackages
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15533,7 +15533,7 @@ in
   gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
 
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
-    callPackage = newScope { libav = pkgs.ffmpeg; };
+    callPackage = newScope (gst_all_1 // { libav = pkgs.ffmpeg; });
     inherit (darwin.apple_sdk.frameworks) AudioToolbox AVFoundation Cocoa CoreFoundation CoreMedia CoreServices CoreVideo DiskArbitration Foundation IOKit MediaToolbox OpenGL VideoToolbox;
   });
 


### PR DESCRIPTION
###### Motivation for this change

Just a small cleanup that won't change anything or cause rebuilds. The use of `rec` bypasses callPackage machinery and hinders overrides and overlays, so gstreamer should get its interdependencies from callPackage/newScope instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
