### PR TITLE
hydrus: Update and improve package

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 pythonPackages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "441";
+  version = "447";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "v${version}";
-    sha256 = "13h4qcz0iqba4mwyvgmdqh99jy22x7kw20f3g43b5aq3qyk9ca2h";
+    sha256 = "0a9nrsbw3w1229bm90xayixvkpvr6g338w64x4v75sqxvpbx84lz";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -108,6 +108,6 @@ pythonPackages.buildPythonPackage rec {
     description = "Danbooru-like image tagging and searching system for the desktop";
     license = licenses.wtfpl;
     homepage = "https://hydrusnetwork.github.io/hydrus/";
-    maintainers = [ maintainers.evanjs ];
+    maintainers = with maintainers; [ dandellion evanjs ];
   };
 }

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -34,6 +34,7 @@ pythonPackages.buildPythonPackage rec {
     psutil
     pyopenssl
     pyyaml
+    pylzma
     requests
     send2trash
     service-identity

--- a/pkgs/development/python-modules/pylzma/default.nix
+++ b/pkgs/development/python-modules/pylzma/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pylzma";
+  version = "0.5.0";
+
+  # This vendors an old LZMA SDK
+  # After some discussion, it seemed most reasonable to keep it that way
+  # xz, and uefi-firmware-parser also does this
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "074anvhyjgsv2iby2ql1ixfvjgmhnvcwjbdz8gk70xzkzcm1fx5q";
+  };
+
+  pythonImportsCheck = [ "pylzma" ];
+
+  meta = with lib; {
+    homepage = "https://www.joachim-bauch.de/projects/pylzma/";
+    description = "Platform independent python bindings for the LZMA compression library";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/tools/video/swftools/default.nix
+++ b/pkgs/tools/video/swftools/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = [ maintainers.koral ];
     platforms = lib.platforms.unix;
-    broken = true;
     knownVulnerabilities = [
       "CVE-2017-10976"
       "CVE-2017-11096"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6211,6 +6211,8 @@ in {
 
   pylxd = callPackage ../development/python-modules/pylxd { };
 
+  pylzma = callPackage ../development/python-modules/pylzma { };
+
   pymacaroons = callPackage ../development/python-modules/pymacaroons { };
 
   pymaging = callPackage ../development/python-modules/pymaging { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While updating the package I came across many small bugs in the package
I think everything should now be included properly.

I've packaged pyzlma as well since that's a dependency, note that it has some C stuff included in it that I'm not sure what to do with: In https://matrix.to/#/!KqkRjyTEzAGRiZFBYT:nixos.org/$H3u4N1qdSCPZafVmkwQNElZE6BvCOFmw-dwHi_C-ALU?via=nixos.org&via=matrix.org&via=tchncs.de we came to the conclusion to just let it be for now. If you have any comments on it feel free to express them

swftools was marked as broken in #118934, but I'm not sure why. It compiles, but it might be broken for some other reason.
I've tested a couple of the binaries and they seem to work, so marking as unbroken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
