### PR TITLE
pythonPackages.fastparquet: 0.6.3 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "fastparquet";
-  version = "0.6.3";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = pname;
     rev = version;
-    hash = "sha256-wSJ6PqW7c8DJCsGuPhXaVGM2s/1dZhLjG4C0JWPcjhY=";
+    hash = "sha256-08hanzRnt6WuMriNNtOd+ZHycr2XBeIRav+5sgvT7Do=";
   };
 
   nativeBuildInputs = [ pytest-runner ];

--- a/pkgs/development/python-modules/smbprotocol/default.nix
+++ b/pkgs/development/python-modules/smbprotocol/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , cryptography
 , fetchFromGitHub
@@ -30,6 +31,16 @@ buildPythonPackage rec {
   checkInputs = [
     pytest-mock
     pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # https://github.com/jborean93/smbprotocol/issues/119
+    "test_copymode_local_to_local_symlink_dont_follow"
+    "test_copystat_local_to_local_symlink_dont_follow_fail"
+
+    # fail in sandbox due to networking
+    "test_small_recv"
+    "test_recv_"
   ];
 
   pythonImportsCheck = [ "smbprotocol" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

https://github.com/dask/fastparquet/compare/0.6.3...0.7.0

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
