### PR TITLE
soapui: 5.5.0 -> 5.6.0 

### DIFF
--- a/nixos/tests/soapui.nix
+++ b/nixos/tests/soapui.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "soapui";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ asbachb ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+
+    environment.systemPackages = [ pkgs.soapui ];
+  };
+
+  testScript = ''
+    machine.wait_for_x()
+    machine.succeed("soapui &")
+    machine.wait_for_window(r"SoapUI \d+\.\d+\.\d+")
+    machine.sleep(1)
+    machine.screenshot("soapui")
+  '';
+})

--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
+    # Adjust java path to point to derivation paths
     (writeText "soapui-${version}.patch" ''
       --- a/bin/soapui.sh
       +++ b/bin/soapui.sh

--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -13,10 +13,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ jdk ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/java
     cp -R bin lib $out/share/java
 
     makeWrapper $out/share/java/bin/soapui.sh $out/bin/soapui --set SOAPUI_HOME $out/share/java
+
+    runHook postInstall
   '';
 
   patches = [

--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "soapui";
-  version = "5.5.0";
+  version = "5.6.0";
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/downloads.eviware/soapuios/${version}/SoapUI-${version}-linux-bin.tar.gz";
-    sha256 = "0v1wiy61jgvlxjk8qdvcnyn1gh2ysxf266zln7r4wpzwd5gc3dpw";
+    sha256 = "0vmj11fswja0ddnbc4vb7gj1al8km7ilma9bv1waaj8h5c8qpayi";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, writeText, jdk, maven, makeWrapper }:
+{ fetchurl, lib, stdenv, writeText, jdk, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "soapui";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk maven ];
+  buildInputs = [ jdk ];
 
   installPhase = ''
     mkdir -p $out/share/java

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8899,7 +8899,9 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  soapui = callPackage ../applications/networking/soapui { };
+  soapui = callPackage ../applications/networking/soapui {
+    jdk = jdk11;
+  };
 
   spglib = callPackage ../development/libraries/spglib { };
 


### PR DESCRIPTION
Closes #93433
Closes #117477

###### Motivation for this change
In the current state `soapui` is broken. see #117477 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
