### PR TITLE
blackshades: 1.1.1 -> 1.3.1

### DIFF
--- a/pkgs/games/blackshades/default.nix
+++ b/pkgs/games/blackshades/default.nix
@@ -1,30 +1,29 @@
 { lib, stdenv, fetchFromSourcehut
-, SDL, SDL_image, libGLU, libGL, openal, libvorbis, freealut }:
+, SDL, stb, libGLU, libGL, openal, libvorbis, freealut }:
 
 stdenv.mkDerivation rec {
   pname = "blackshades";
-  version = "1.1.1";
+  version = "1.3.1";
 
   src = fetchFromSourcehut {
     owner = "~cnx";
     repo = pname;
     rev = version;
-    sha256 = "1gx43hcqahbd21ib8blhzmsrwqfzx4qy7f10ck0mh2zc4bfihz64";
+    sha256 = "0yzp74ynkcp6hh5m4zmvrgx5gwm186hq7p3m7qkww54qdyijb3rv";
   };
 
-  buildInputs = [ SDL SDL_image libGLU libGL openal libvorbis freealut ];
+  buildInputs = [ SDL stb libGLU libGL openal libvorbis freealut ];
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s,Data/,$out/share/$pname/,g \
       -e s,Data:,$out/share/$pname/,g \
       src/*.cpp
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/doc/$pname
+    mkdir -p $out/bin $out/share
     cp build/blackshades $out/bin
     cp -R Data $out/share/$pname
-    cp README.md $out/share/doc/$pname
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Replacing deprecated SDL_image 1 by stb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
