### PR TITLE
regenkfs, remkrom: init at unstable-2020-10-17

### DIFF
--- a/pkgs/development/tools/knightos/regenkfs/default.nix
+++ b/pkgs/development/tools/knightos/regenkfs/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage {
+  pname = "regenkfs";
+  version = "unstable-2020-10-17";
+
+  src = fetchFromGitHub {
+    owner = "siraben";
+    repo = "regenkfs";
+    rev = "652155445fc39bbe6628f6b9415b5cd6863f592f";
+    sha256 = "sha256-zkwOpMNPGstn/y1l1s8blUKpBebY4Ta9hiPYxVLvG6Y=";
+  };
+
+  cargoSha256 = "sha256-05VmQdop4vdzw2XEvVdp9+RNmyZvay1Q7gKN2n8rDEQ=";
+  cargoBuildFlags = [ "--features=c-undef" ];
+
+  meta = with lib; {
+    description = "Reimplementation of genkfs in Rust";
+    homepage = "https://github.com/siraben/regenkfs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/development/tools/knightos/remkrom/default.nix
+++ b/pkgs/development/tools/knightos/remkrom/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage {
+  pname = "remkrom";
+  version = "unstable-2020-10-17";
+
+  src = fetchFromGitHub {
+    owner = "siraben";
+    repo = "remkrom";
+    rev = "86a0b19c1d382a029ecaa96eeca7e9f76c8561d6";
+    sha256 = "sha256-DhfNfV9bd0p5dLXKgrVLyugQHK+RHsepeg0tGq5J6cI=";
+  };
+
+  cargoSha256 = "sha256-JUyIbg1SxQ7pdqypGv7Kz2MM0ZwL3M9YJekO9oSftLM=";
+
+  meta = with lib; {
+    description = "Reimplementation of mkrom in Rust";
+    homepage = "https://github.com/siraben/remkrom";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11625,6 +11625,8 @@ in
 
   knightos-mkrom = callPackage ../development/tools/knightos/mkrom { };
 
+  remkrom = callPackage ../development/tools/knightos/remkrom { };
+
   knightos-patchrom = callPackage ../development/tools/knightos/patchrom { };
 
   knightos-mktiupgrade = callPackage ../development/tools/knightos/mktiupgrade { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11615,6 +11615,8 @@ in
 
   knightos-genkfs = callPackage ../development/tools/knightos/genkfs { };
 
+  regenkfs = callPackage ../development/tools/knightos/regenkfs { };
+
   knightos-kcc = callPackage ../development/tools/knightos/kcc { };
 
   knightos-kimg = callPackage ../development/tools/knightos/kimg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Disclaimer: I'm the author of the packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
