### PR TITLE
apktool: don't hardcode (wrong) build-tools version

### DIFF
--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -18,13 +18,16 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  installPhase = ''
-    install -D ${src} "$out/libexec/apktool/apktool.jar"
-    mkdir -p "$out/bin"
-    makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
-        --add-flags "-jar $out/libexec/apktool/apktool.jar" \
-        --prefix PATH : "${builtins.head build-tools}/libexec/android-sdk/build-tools/28.0.3"
-  '';
+  installPhase =
+    let
+      tools = builtins.head build-tools;
+    in ''
+      install -D ${src} "$out/libexec/apktool/apktool.jar"
+      mkdir -p "$out/bin"
+      makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
+          --add-flags "-jar $out/libexec/apktool/apktool.jar" \
+          --prefix PATH : "${tools}/libexec/android-sdk/build-tools/${tools.version}"
+    '';
 
   meta = with lib; {
     description = "A tool for reverse engineering Android apk files";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
