### PR TITLE
vscode-extensions.vadimcn.vscode-lldb: Fix build on Darwin

### DIFF
--- a/pkgs/misc/vscode-extensions/vscode-lldb/default.nix
+++ b/pkgs/misc/vscode-extensions/vscode-lldb/default.nix
@@ -31,7 +31,7 @@ let
 
     buildAndTestSubdir = "adapter";
 
-    cargoFlags = [
+    cargoBuildFlags = [
       "--lib"
       "--bin=codelldb"
       "--features=weak-linkage"
@@ -99,6 +99,5 @@ in stdenv.mkDerivation {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ oxalica ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin; # Build failed on x86_64-darwin currently.
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the build on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Additional information

I built and tested that the binaries ran on Darwin and Linux. I tested debugging in Xcode with a Rust project successfully on Darwin. There are a few caveats:

- The vendored version of lldb contains a broken link to `lldb-argdumper` in `lldb/lib/python3.9/site-packages/lldb`. Possibly related to #125183?
- The vendored version of lldb doesn’t build `debugserver`, but Darwin requires requires a code-signed `debugserver` for debugging to work, so it wouldn’t work even if it did provide it. See #18420.

Not sure what to do about `debugserver`. I worked around the issue by setting `LLDB_DEBUGSERVER_PATH` in `lldb.adapterEnv` to a working `debugserver` from Xcode. I suppose that means the extension is still technically broken out of the box.