### PR TITLE
qtspim: init at 9.1.22

### DIFF
--- a/pkgs/development/tools/misc/qtspim/default.nix
+++ b/pkgs/development/tools/misc/qtspim/default.nix
@@ -1,0 +1,61 @@
+{ lib, stdenv, fetchsvn, wrapQtAppsHook, qtbase, qttools, qmake, bison, flex, ... }:
+stdenv.mkDerivation rec {
+  pname = "qtspim";
+  version = "9.1.22";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/spimsimulator/code/";
+    rev = "r739";
+    sha256 = "1kazfgrbmi4xq7nrkmnqw1280rhdyc1hmr82flrsa3g1b1rlmj1s";
+  };
+
+  postPatch = ''
+    cd QtSpim
+
+    # Patches from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=qtspim
+    sed -i 's/zero_imm/is_zero_imm/g' parser_yacc.cpp
+    sed -i 's/^int data_dir/bool data_dir/g' parser_yacc.cpp
+    sed -i 's/^int text_dir/bool text_dir/g' parser_yacc.cpp
+    sed -i 's/^int parse_error_occurred/bool parse_error_occurred/g' parser_yacc.cpp
+
+    substituteInPlace QtSpim.pro --replace /usr/lib/qtspim/lib $out/lib
+    substituteInPlace menu.cpp \
+      --replace /usr/lib/qtspim/bin/assistant ${qttools.dev}/bin/assistant \
+      --replace /usr/lib/qtspim/help/qtspim.qhc $out/share/help/qtspim.qhc
+    substituteInPlace ../Setup/qtspim_debian_deployment/qtspim.desktop \
+      --replace /usr/bin/qtspim qtspim \
+      --replace /usr/lib/qtspim/qtspim.png qtspim
+  '';
+
+  nativeBuildInputs = [ wrapQtAppsHook qttools qmake bison flex ];
+  buildInputs = [ qtbase ];
+  QT_PLUGIN_PATH = "${qtbase}/${qtbase.qtPluginPrefix}";
+
+  qmakeFlags = [
+    "QtSpim.pro"
+    "-spec"
+    "linux-g++"
+    "CONFIG+=release"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D QtSpim $out/bin/qtspim
+    install -D ../Setup/qtspim_debian_deployment/copyright $out/share/licenses/qtspim/copyright
+    install -D ../Setup/qtspim_debian_deployment/qtspim.desktop $out/share/applications/qtspim.desktop
+    install -D ../Setup/NewIcon48x48.png $out/share/icons/hicolor/48x48/apps/qtspim.png
+    install -D ../Setup/NewIcon256x256.png $out/share/icons/hicolor/256x256/apps/qtspim.png
+    cp -r help $out/share/help
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "New user interface for spim, a MIPS simulator";
+    homepage = "http://spimsimulator.sourceforge.net/";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ angustrau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8321,6 +8321,8 @@ in
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  qtspim = libsForQt5.callPackage ../development/tools/misc/qtspim { };
+
   quadrafuzz = callPackage ../applications/audio/quadrafuzz { };
 
   quickfix = callPackage ../development/libraries/quickfix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the QtSpim MIPS simulator 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
