### PR TITLE
ocamlPackages.letsencrypt: 0.2.5 -> 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/letsencrypt/app.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/app.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildDunePackage
+, letsencrypt
+, letsencrypt-dns
+, cmdliner
+, cohttp-lwt-unix
+, logs
+, fmt
+, lwt
+, mirage-crypto-rng
+, ptime
+, bos
+, fpath
+, randomconv
+}:
+
+buildDunePackage {
+  pname = "letsencrypt-app";
+
+  inherit (letsencrypt)
+    src
+    version
+    useDune2
+    minimumOCamlVersion
+    ;
+
+  buildInputs = [
+    letsencrypt
+    letsencrypt-dns
+    cmdliner
+    cohttp-lwt-unix
+    logs
+    fmt
+    lwt
+    mirage-crypto-rng
+    ptime
+    bos
+    fpath
+    randomconv
+  ];
+
+  meta = letsencrypt.meta // {
+    description = "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -6,11 +6,6 @@
 , uri
 , rresult
 , base64
-, cmdliner
-, cohttp
-, cohttp-lwt
-, cohttp-lwt-unix
-, zarith
 , logs
 , fmt
 , lwt
@@ -20,38 +15,25 @@
 , x509
 , yojson
 , ounit
-, dns
-, dns-tsig
 , ptime
-, bos
-, fpath
-, randomconv
 , domain-name
 }:
 
 buildDunePackage rec {
   pname = "letsencrypt";
-  version = "0.2.5";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-v${version}.tbz";
-    sha256 = "6e3bbb5f593823d49e83e698c06cf9ed48818695ec8318507b311ae74731e607";
+    sha256 = "8772b7e6dbda0559a03a7b23b75c1431d42ae09a154eefd64b4c7e23b8d92deb";
   };
 
   minimumOCamlVersion = "4.08";
   useDune2 = true;
 
   buildInputs = [
-    cmdliner
-    cohttp
-    cohttp-lwt-unix
-    zarith
     fmt
-    mirage-crypto-rng
     ptime
-    bos
-    fpath
-    randomconv
     domain-name
   ];
 
@@ -65,11 +47,8 @@ buildDunePackage rec {
     asn1-combinators
     x509
     uri
-    dns
-    dns-tsig
     rresult
     astring
-    cohttp-lwt
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/letsencrypt/dns.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/dns.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildDunePackage
+, letsencrypt
+, logs
+, fmt
+, lwt
+, dns
+, dns-tsig
+, domain-name
+}:
+
+buildDunePackage {
+  pname = "letsencrypt-dns";
+
+  inherit (letsencrypt)
+    version
+    src
+    useDune2
+    minimumOCamlVersion
+    ;
+
+  propagatedBuildInputs = [
+    letsencrypt
+    dns
+    dns-tsig
+    domain-name
+    logs
+    lwt
+    fmt
+  ];
+
+  meta = letsencrypt.meta // {
+    description = "A DNS solver for the ACME implementation in OCaml";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -605,6 +605,10 @@ let
 
     letsencrypt = callPackage ../development/ocaml-modules/letsencrypt { };
 
+    letsencrypt-app = callPackage ../development/ocaml-modules/letsencrypt/app.nix { };
+
+    letsencrypt-dns = callPackage ../development/ocaml-modules/letsencrypt/dns.nix { };
+
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
     llvm = callPackage ../development/ocaml-modules/llvm {


### PR DESCRIPTION
ocamlPackages.letsencrypt-dns: init at 0.3.0
ocamlPackages.letsencrypt-app: init at 0.2.5

https://github.com/mmaker/ocaml-letsencrypt/releases/tag/v0.3.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
