### PR TITLE
s9fes: init at 20181205

### DIFF
--- a/pkgs/development/interpreters/s9fes/default.nix
+++ b/pkgs/development/interpreters/s9fes/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, ncurses, buildPackages }:
+
+let
+  isCrossCompiling = stdenv.hostPlatform != stdenv.buildPlatform;
+in
+
+stdenv.mkDerivation rec {
+  pname = "s9fes";
+  version = "20181205";
+
+  src = fetchurl {
+    url = "http://www.t3x.org/s9fes/s9fes-${version}.tgz";
+    sha256 = "sha256-Lp/akaDy3q4FmIE6x0fj9ae/SOD7tdsmzy2xdcCh13o=";
+  };
+
+  # Fix cross-compilation
+  postPatch = ''
+    substituteInPlace Makefile --replace 'ar q' '${stdenv.cc.targetPrefix}ar q'
+    substituteInPlace Makefile --replace 'strip' '${stdenv.cc.targetPrefix}strip'
+    ${lib.optionalString isCrossCompiling "substituteInPlace Makefile --replace ./s9 '${buildPackages.s9fes}/bin/s9'"}
+  '';
+
+  buildInputs = [ ncurses ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "PREFIX=$(out)" ];
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Scheme 9 From Empty Space, an interpreter for R4RS Scheme";
+    homepage = "http://www.t3x.org/s9fes/index.html";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4429,6 +4429,8 @@ in
 
   rar2fs = callPackage ../tools/filesystems/rar2fs { };
 
+  s9fes = callPackage ../development/interpreters/s9fes { };
+
   s-tar = callPackage ../tools/archivers/s-tar {};
 
   sonota = callPackage ../tools/misc/sonota { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [Scheme 9 from Empty Space](www.t3x.org/s9fes/index.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
