### PR TITLE
houdini: 18.0 -> 18.5

### DIFF
--- a/pkgs/applications/misc/houdini/default.nix
+++ b/pkgs/applications/misc/houdini/default.nix
@@ -5,10 +5,6 @@ let
 in buildFHSUserEnv {
   name = "houdini-${houdini-runtime.version}";
 
-  extraBuildCommands = ''
-    mkdir -p $out/usr/lib/sesi
-  '';
-
   passthru = {
     unwrapped = houdini-runtime;
   };

--- a/pkgs/applications/misc/houdini/default.nix
+++ b/pkgs/applications/misc/houdini/default.nix
@@ -1,14 +1,18 @@
 { callPackage, buildFHSUserEnv, undaemonize, unwrapped ? callPackage ./runtime.nix {} }:
 
-let
-  houdini-runtime = callPackage ./runtime.nix { };
-in buildFHSUserEnv {
-  name = "houdini-${houdini-runtime.version}";
+buildFHSUserEnv {
+  name = "houdini-${unwrapped.version}";
+
+  targetPkgs = pkgs: with pkgs; [
+    libGLU libGL alsa-lib fontconfig zlib libpng dbus nss nspr expat pciutils libxkbcommon
+  ] ++ (with xorg; [
+    libICE libSM libXmu libXi libXext libX11 libXrender libXcursor libXfixes
+    libXrender libXcomposite libXdamage libXtst libxcb libXScrnSaver
+  ]);
 
   passthru = {
-    unwrapped = houdini-runtime;
+    inherit unwrapped;
   };
 
-  runScript = "${undaemonize}/bin/undaemonize ${houdini-runtime}/bin/houdini";
+  runScript = "${undaemonize}/bin/undaemonize ${unwrapped}/bin/houdini";
 }
-

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -4,14 +4,11 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "18.0.460";
+  version = "18.5.596";
   pname = "houdini-runtime";
   src = requireFile rec {
-    #name = "houdini-py3-${version}-linux_x86_64_gcc6.3.tar.gz";
-    #sha256 = "10qp8nml1ivl0syh0iwzx3zdwdpilnwakax50wydcrzdzyxza7xw"; # 18.5.621
-    #sha256 = "1b1k7rkn7svmciijqdwvi9p00srsf81vkb55grjg6xa7fgyidjx1"; # 18.5.596
-    name = "houdini-${version}-linux_x86_64_gcc6.3.tar.gz";
-    sha256 = "18rbwszcks2zfn9zbax62rxmq50z9mc3h39b13jpd39qjqdd3jsd"; # 18.0.460
+    name = "houdini-py3-${version}-linux_x86_64_gcc6.3.tar.gz";
+    sha256 = "1b1k7rkn7svmciijqdwvi9p00srsf81vkb55grjg6xa7fgyidjx1";
     url = meta.homepage;
   };
 
@@ -19,18 +16,19 @@ stdenv.mkDerivation rec {
   installPhase = ''
     patchShebangs houdini.install
     mkdir -p $out
-    sed -i "s|/usr/lib/sesi|${license_dir}|g" houdini.install
     ./houdini.install --install-houdini \
+                      --install-license \
                       --no-install-menus \
                       --no-install-bin-symlink \
                       --auto-install \
                       --no-root-check \
-                      --accept-EULA \
+                      --accept-EULA 2020-05-05 \
                       $out
-    echo -e "localValidatorDir = ${license_dir}\nlicensingMode = localValidator" > $out/houdini/Licensing.opt
-    sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/sbin/sesinetd_safe
-    sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/sbin/sesinetd.startup
+    echo "licensingMode = localValidator" >> $out/houdini/Licensing.opt
   '';
+
+  dontFixup = true;
+
   meta = with lib; {
     description = "3D animation application software";
     homepage = "https://www.sidefx.com";

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -1,50 +1,17 @@
-{ lib, stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, libGL, alsa-lib
-, dbus, xkeyboardconfig, nss, nspr, expat, pciutils, libxkbcommon, bc, addOpenGLRunpath
-}:
+{ lib, stdenv, requireFile, bc }:
 
 let
-  # NOTE: Some dependencies only show in errors when run with QT_DEBUG_PLUGINS=1
-  ld_library_path = builtins.concatStringsSep ":" [
-    "${stdenv.cc.cc.lib}/lib64"
-    (lib.makeLibraryPath [
-      libGLU
-      libGL
-      xorg.libXmu
-      xorg.libXi
-      xorg.libXext
-      xorg.libX11
-      xorg.libXrender
-      xorg.libXcursor
-      xorg.libXfixes
-      xorg.libXrender
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXtst
-      xorg.libxcb
-      xorg.libXScrnSaver
-      alsa-lib
-      fontconfig
-      libSM
-      libICE
-      zlib
-      libpng
-      dbus
-      addOpenGLRunpath.driverLink
-      nss
-      nspr
-      expat
-      pciutils
-      libxkbcommon
-    ])
-  ];
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
   version = "18.0.460";
   pname = "houdini-runtime";
   src = requireFile rec {
+    #name = "houdini-py3-${version}-linux_x86_64_gcc6.3.tar.gz";
+    #sha256 = "10qp8nml1ivl0syh0iwzx3zdwdpilnwakax50wydcrzdzyxza7xw"; # 18.5.621
+    #sha256 = "1b1k7rkn7svmciijqdwvi9p00srsf81vkb55grjg6xa7fgyidjx1"; # 18.5.596
     name = "houdini-${version}-linux_x86_64_gcc6.3.tar.gz";
-    sha256 = "18rbwszcks2zfn9zbax62rxmq50z9mc3h39b13jpd39qjqdd3jsd";
+    sha256 = "18rbwszcks2zfn9zbax62rxmq50z9mc3h39b13jpd39qjqdd3jsd"; # 18.0.460
     url = meta.homepage;
   };
 
@@ -63,17 +30,13 @@ stdenv.mkDerivation rec {
     echo -e "localValidatorDir = ${license_dir}\nlicensingMode = localValidator" > $out/houdini/Licensing.opt
     sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/sbin/sesinetd_safe
     sed -i "s|/usr/lib/sesi|${license_dir}|g" $out/houdini/sbin/sesinetd.startup
-    echo "export LD_LIBRARY_PATH=${ld_library_path}" >> $out/bin/app_init.sh
-    echo "export QT_XKB_CONFIG_ROOT="${xkeyboardconfig}/share/X11/xkb"" >> $out/bin/app_init.sh
-    echo "export LD_LIBRARY_PATH=${ld_library_path}" >> $out/houdini/sbin/app_init.sh
-    echo "export QT_XKB_CONFIG_ROOT="${xkeyboardconfig}/share/X11/xkb"" >> $out/houdini/sbin/app_init.sh
   '';
-  meta = {
+  meta = with lib; {
     description = "3D animation application software";
     homepage = "https://www.sidefx.com";
-    license = lib.licenses.unfree;
-    platforms = lib.platforms.linux;
+    license = licenses.unfree;
+    platforms = platforms.linux;
     hydraPlatforms = [ ]; # requireFile src's should be excluded
-    maintainers = with lib.maintainers; [ canndrew kwohlfahrt ];
+    maintainers = with maintainers; [ canndrew kwohlfahrt ];
   };
 }

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -68,15 +68,6 @@ stdenv.mkDerivation rec {
     echo "export LD_LIBRARY_PATH=${ld_library_path}" >> $out/houdini/sbin/app_init.sh
     echo "export QT_XKB_CONFIG_ROOT="${xkeyboardconfig}/share/X11/xkb"" >> $out/houdini/sbin/app_init.sh
   '';
-  postFixup = ''
-    INTERPRETER="$(cat "$NIX_CC"/nix-support/dynamic-linker)"
-    for BIN in $(find $out/bin -type f -executable); do
-      if patchelf $BIN 2>/dev/null ; then
-        echo "Patching ELF $BIN"
-        patchelf --set-interpreter "$INTERPRETER" "$BIN"
-      fi
-    done
-  '';
   meta = {
     description = "3D animation application software";
     homepage = "https://www.sidefx.com";


### PR DESCRIPTION
###### Motivation for this change

Version bump.

There is a regression compared to the previous version - now, the license server (`sesinetd`) must be started manually before Houdini itself (even for non-commercial licenses). I'm not sure if this is an upstream change since the license server has been re-written in this release, or a Nix-related issue. Has anybody tested this on non-NixOS?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
