### PR TITLE
nixos/adguardhome: make config path configurable

### DIFF
--- a/nixos/modules/services/networking/adguardhome.nix
+++ b/nixos/modules/services/networking/adguardhome.nix
@@ -9,7 +9,7 @@ let
     "--no-check-update"
     "--pidfile /run/AdGuardHome/AdGuardHome.pid"
     "--work-dir /var/lib/AdGuardHome/"
-    "--config /var/lib/AdGuardHome/AdGuardHome.yaml"
+    "--config ${cfg.configPath}"
     "--host ${cfg.host}"
     "--port ${toString cfg.port}"
   ] ++ cfg.extraArgs);
@@ -32,6 +32,14 @@ in
       type = port;
       description = ''
         Port to serve HTTP pages on.
+      '';
+    };
+
+    configPath = mkOption {
+      type = path;
+      default = "/var/lib/AdGuardHome/AdGuardHome.yaml";
+      description = ''
+        Location of config file for AdGuardHome.
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

This makes it possible to do something like this:

```nix
services.adguardhome.configPath = (pkgs.formats.yaml { }).generate "AdGuardHome.yaml" {
    someValue = "value";
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
