### PR TITLE
pythonPackages.debugpy: 1.3.0 → 1.4.1 

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , substituteAll
 , gdb
 , flask
@@ -18,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-YGzc9mMIzPTmUgIXuZROLdYKjUm69x9SR+JtYRVpn24=";
+    hash = "sha256-W4hUVHY2TbFgQhM1qIbosvDPORFxsuoJC+xuCzrYIMI=";
   };
 
   patches = [
@@ -49,12 +48,6 @@ buildPythonPackage rec {
     # To avoid this issue, debugpy should be installed using python.withPackages:
     # python.withPackages (ps: with ps; [ debugpy ])
     ./fix-test-pythonpath.patch
-
-    # Fix tests with flask>=2.0
-    (fetchpatch {
-      url = "https://github.com/microsoft/debugpy/commit/0a7f2cd67dda27ea4d38389b49a4e2a1899b834e.patch";
-      sha256 = "1g070fn07n7jj01jaf5s570zn70akf6klkamigs3ix11gh736rpn";
-    })
   ];
 
   # Remove pre-compiled "attach" libraries and recompile for host platform

--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-W4hUVHY2TbFgQhM1qIbosvDPORFxsuoJC+xuCzrYIMI=";
+    hash = "sha256-W51Y9tZB1Uyp175+hWCpXChwL+MBpDWjudF87F1MRso=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
@@ -1,8 +1,8 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index 6d031b4..ecf21f2 100644
+index 51017f2..46654ab 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-@@ -293,7 +293,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
+@@ -398,7 +398,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
      is_debug = 0
      # Note that the space in the beginning of each line in the multi-line is important!
      cmd = [


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/microsoft/debugpy/releases/tag/v1.4.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, only a Python library.
  Tested through dap-mode in Emacs.
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).