### PR TITLE
drogon: cleanup

### DIFF
--- a/pkgs/development/libraries/drogon/default.nix
+++ b/pkgs/development/libraries/drogon/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, jsoncpp, libossp_uuid, zlib, openssl, lib
-# miscellaneous
-, brotli, c-ares
-# databases
+{ stdenv, fetchFromGitHub, cmake, jsoncpp, libossp_uuid, zlib, lib
+# optional but of negligible size
+, openssl, brotli, c-ares
+# optional databases
 , sqliteSupport ? true, sqlite
 , postgresSupport ? false, postgresql
 , redisSupport ? false, hiredis
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "1.7.1";
 
   src = fetchFromGitHub {
-    owner = "an-tao";
+    owner = "drogonframework";
     repo = "drogon";
     rev = "v${version}";
     sha256 = "0rhwbz3m5x3vy5zllfs8r347wqprg29pff5q7i53f25bh8y0n49i";
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional sqliteSupport sqlite
     ++ lib.optional postgresSupport postgresql
     ++ lib.optional redisSupport hiredis
-    # drogon uses mariadb for mysql (see https://github.com/an-tao/drogon/wiki/ENG-02-Installation#Library-Dependencies)
+    # drogon uses mariadb for mysql (see https://github.com/drogonframework/drogon/wiki/ENG-02-Installation#Library-Dependencies)
     ++ lib.optional mysqlSupport [ libmysqlclient mariadb ];
 
   patches = [
@@ -48,17 +48,16 @@ stdenv.mkDerivation rec {
   # modifying PATH here makes drogon_ctl visible to the test
   installCheckPhase = ''
     cd ..
-    patchShebangs test.sh
-    PATH=$PATH:$out/bin ./test.sh
+    PATH=$PATH:$out/bin bash test.sh
   '';
 
   doInstallCheck = true;
 
   meta = with lib; {
-    homepage = "https://github.com/an-tao/drogon";
+    homepage = "https://github.com/drogonframework/drogon";
     description = "C++14/17 based HTTP web application framework";
     license = licenses.mit;
-    maintainers = [ maintainers.urlordjames ];
+    maintainers = with maintainers; [ urlordjames ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Drogon has moved their repository to an organization now, so I changed the URL here to reflect that.  I also cleaned it up a little bit since I have the opportunity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
