### PR TITLE
snixembed: init at 0.3.1

### DIFF
--- a/pkgs/applications/misc/snixembed/default.nix
+++ b/pkgs/applications/misc/snixembed/default.nix
@@ -1,0 +1,28 @@
+{ fetchFromSourcehut, gtk3, lib, libdbusmenu-gtk3, pkg-config, stdenv, vala }:
+
+stdenv.mkDerivation rec {
+  pname = "snixembed";
+  version = "0.3.1";
+
+  src = fetchFromSourcehut {
+    owner = "~steef";
+    repo = pname;
+    rev = version;
+    sha256 = "0yy1i4463q43aq98qk4nvvzpw4i6bid2bywwgf6iq545pr3glfj5";
+  };
+
+  nativeBuildInputs = [ pkg-config vala ];
+
+  buildInputs = [ gtk3 libdbusmenu-gtk3 ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Proxy StatusNotifierItems as XEmbedded systemtray-spec icons";
+    homepage = "https://git.sr.ht/~steef/snixembed";
+    changelog = "https://git.sr.ht/~steef/snixembed/refs/${version}";
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26974,6 +26974,8 @@ in
 
   sniproxy = callPackage ../applications/networking/sniproxy { };
 
+  snixembed = callPackage ../applications/misc/snixembed { };
+
   sooperlooper = callPackage ../applications/audio/sooperlooper { };
 
   sops = callPackage ../tools/security/sops { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

snixembed - proxy StatusNotifierItems as XEmbedded systemtray-spec icons

https://git.sr.ht/~steef/snixembed


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
