### PR TITLE
josm: 17919 → 18004

### DIFF
--- a/pkgs/applications/misc/josm/default.nix
+++ b/pkgs/applications/misc/josm/default.nix
@@ -3,20 +3,20 @@
 }:
 let
   pname = "josm";
-  version = "17919";
+  version = "18004";
   srcs = {
     jar = fetchurl {
       url = "https://josm.openstreetmap.de/download/josm-snapshot-${version}.jar";
-      sha256 = "sha256-Bj1s3vFSHPiZNTjp7hQhu1X2v8nlynC37Cm6sMNOi3g=";
+      sha256 = "sha256-Cd+/sE6A0MddHeAxy3gx7ev+9UR3ZNcR0tCTmdX2FtY=";
     };
     macosx = fetchurl {
       url = "https://josm.openstreetmap.de/download/macosx/josm-macos-${version}-java16.zip";
-      sha256 = "sha256-W+s6ARA5lyRwTuRD89wm4HChb2Up5AXQwh5uk0U7pQk=";
+      sha256 = "sha256-QSVh8043K/f7gPEjosGo/DNj1d75LUFwf6EMeHk68fM=";
     };
     pkg = fetchsvn {
       url = "https://josm.openstreetmap.de/svn/trunk/native/linux/tested";
       rev = version;
-      sha256 = "sha256-IjCFngixh2+7SifrV3Ohi1BjIOP+QSWg/QjeqbbP7aw=";
+      sha256 = "sha256-Ic6RtQPqpQIci1IbKgTcFmLfMdPxSVybrEAk+ttM0j8=";
     };
   };
 in


### PR DESCRIPTION
###### Motivation for this change
[2021-07-11: Stable release 18004](https://josm.openstreetmap.de/wiki/Changelog#stable-release-21.06)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
