### PR TITLE
ocamlPackages.lwt-dllist: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/lwt-dllist/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-dllist/default.nix
@@ -1,23 +1,22 @@
-{ lib, buildDunePackage, fetchurl, lwt }:
+{ lib, buildDunePackage, fetchurl, lwt, ocaml }:
 
 buildDunePackage rec {
   pname = "lwt-dllist";
-  version = "1.0.0";
+  version = "1.0.1";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.03";
+  minimumOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0g111f8fq9k1hwccpkhylkp83f73mlz4xnxxr3rf9xpi2f8fh7j9";
+    sha256 = "e86ce75e40f00d51514cf8b2e71e5184c4cb5dae96136be24613406cfc0dba6e";
   };
 
-  propagatedBuildInputs = [
+  checkInputs = [
     lwt
   ];
-
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.03";
 
   meta = with lib; {
     description = "Mutable doubly-linked list with Lwt iterators";


### PR DESCRIPTION
https://github.com/mirage/lwt-dllist/releases/tag/v1.0.1

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
