### PR TITLE
lrzsz: add patch for CVE-2018-10195

### DIFF
--- a/pkgs/tools/misc/lrzsz/default.nix
+++ b/pkgs/tools/misc/lrzsz/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, gettext, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "lrzsz-0.12.20";
@@ -7,6 +7,16 @@ stdenv.mkDerivation rec {
     url = "https://ohse.de/uwe/releases/${name}.tar.gz";
     sha256 = "1wcgfa9fsigf1gri74gq0pa7pyajk12m4z69x7ci9c6x9fqkd2y2";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-10195.patch";
+      url = "https://bugzilla.redhat.com/attachment.cgi?id=79507";
+      sha256 = "0jlh8w0cjaz6k56f0h3a0h4wgc51axmrdn3mdspk7apjfzqcvx3c";
+    })
+  ];
+
+  nativeBuildInputs = [ gettext ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2018-10195

Twenty year old bug here. Most detailed explanation of this bug in https://bugzilla.suse.com/show_bug.cgi?id=1090051

Need to provide `gettext` because modifying source files triggers localization regeneration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
