### PR TITLE
pkgs:octaveFull: darwin fixes

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -187,6 +187,11 @@ let
     # Fix linker error on Darwin (see https://trac.macports.org/ticket/61865)
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lobjc";
 
+    # Avoid Qt 5.12 problem on Big Sur: https://bugreports.qt.io/browse/QTBUG-87014
+    qtWrapperArgs = lib.optionals stdenv.isDarwin [
+      "--set QT_MAC_WANTS_LAYER 1"
+    ];
+
     # See https://savannah.gnu.org/bugs/?50339
     F77_INTEGER_8_FLAG = if use64BitIdx then "-fdefault-integer-8" else "";
 

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -184,6 +184,9 @@ let
 
     enableParallelBuilding = true;
 
+    # Fix linker error on Darwin (see https://trac.macports.org/ticket/61865)
+    NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lobjc";
+
     # See https://savannah.gnu.org/bugs/?50339
     F77_INTEGER_8_FLAG = if use64BitIdx then "-fdefault-integer-8" else "";
 

--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-mac-universal" "--enable-cxx" ];
 
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=deprecated-declarations -Wno-error=implicit-const-int-float-conversion -Wno-error=nullability-completeness-on-arrays";
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=deprecated-declarations -Wno-error=nullability-completeness-on-arrays";
 
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ AudioUnit AudioToolbox CoreAudio CoreServices Carbon ];
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These are fixes I needed (along with #131378) to get pkgs.octaveFull to work on Darwin, I can separate into different PRs if required.

The most questionable is the addition of the QT_MAC_WANTS_LAYER environment variable.  The underlying issue appears to be fixed in Qt 5.12.11, but I'm unable to get that to compile right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
