### PR TITLE
dict-dbs: deprecate phases

### DIFF
--- a/pkgs/servers/dict/dictd-db-collector.nix
+++ b/pkgs/servers/dict/dictd-db-collector.nix
@@ -1,20 +1,20 @@
 {stdenv, lib, dict}:
 ({dictlist, allowList ? ["127.0.0.1"], denyList ? []}:
 /*
- dictlist is a list of form 
+ dictlist is a list of form
  [ { filename = /path/to/files/basename;
  name = "name"; } ]
- basename.dict.dz and basename.index should be 
+ basename.dict.dz and basename.index should be
  dict files. Or look below for other options.
  allowList is a list of IP/domain *-wildcarded strings
  denyList is the same..
 */
 
 let
-	link_arguments = map 
+	link_arguments = map
 			(x: '' "${x.filename}" '')
-			dictlist; 
-	databases = lib.concatStrings (map (x : 
+			dictlist;
+	databases = lib.concatStrings (map (x :
 		"${x.name}	${x.filename}\n") dictlist);
 	allow = lib.concatStrings (map (x: "allow ${x}\n") allowList);
 	deny = lib.concatStrings (map (x: "deny ${x}\n") denyList);
@@ -24,18 +24,18 @@ let
 			${deny}
 		}
 	";
-	installPhase = ''  
+	installPhase = ''
   	mkdir -p $out/share/dictd
 	cd $out/share/dictd
-	echo "${databases}" >databases.names 
+	echo "${databases}" >databases.names
 	echo "${accessSection}" > dictd.conf
-	for j in ${toString link_arguments}; do 
+	for j in ${toString link_arguments}; do
 		name="$(egrep '	'"$j"\$ databases.names)"
 		name=''${name%	$j}
 		if test -d "$j"; then
 			if test -d "$j"/share/dictd ; then
 				echo "Got store path $j"
-				j="$j"/share/dictd 
+				j="$j"/share/dictd
 			fi
 			echo "Directory reference: $j"
 			i=$(ls "$j""/"*.index)
@@ -47,8 +47,8 @@ let
 		locale=$(cat "$(dirname "$i")"/locale)
 		base="$(basename "$i")"
 		echo "Locale is $locale"
-		export LC_ALL=$locale 
-		export LANG=$locale 
+		export LC_ALL=$locale
+		export LANG=$locale
 		if test -e "$i".dict.dz; then
 			ln -s "$i".dict.dz
 		else
@@ -73,7 +73,6 @@ in
 stdenv.mkDerivation {
   name = "dictd-dbs";
 
-  phases = ["installPhase"];
   buildInputs = [dict];
 
   inherit installPhase;

--- a/pkgs/servers/dict/dictd-db-collector.nix
+++ b/pkgs/servers/dict/dictd-db-collector.nix
@@ -1,79 +1,82 @@
-{stdenv, lib, dict}:
-({dictlist, allowList ? ["127.0.0.1"], denyList ? []}:
+{ stdenv, lib, dict }:
+({ dictlist, allowList ? [ "127.0.0.1" ], denyList ? [ ] }:
+
 /*
- dictlist is a list of form
- [ { filename = /path/to/files/basename;
- name = "name"; } ]
- basename.dict.dz and basename.index should be
- dict files. Or look below for other options.
- allowList is a list of IP/domain *-wildcarded strings
- denyList is the same..
+  dictlist is a list of form
+  [ { filename = /path/to/files/basename;
+  name = "name"; } ]
+  basename.dict.dz and basename.index should be
+  dict files. Or look below for other options.
+  allowList is a list of IP/domain *-wildcarded strings
+  denyList is the same..
 */
 
 let
-	link_arguments = map
-			(x: '' "${x.filename}" '')
-			dictlist;
-	databases = lib.concatStrings (map (x :
-		"${x.name}	${x.filename}\n") dictlist);
-	allow = lib.concatStrings (map (x: "allow ${x}\n") allowList);
-	deny = lib.concatStrings (map (x: "deny ${x}\n") denyList);
-	accessSection = "
-		access {
-			${allow}
-			${deny}
-		}
-	";
-	installPhase = ''
-  	mkdir -p $out/share/dictd
-	cd $out/share/dictd
-	echo "${databases}" >databases.names
-	echo "${accessSection}" > dictd.conf
-	for j in ${toString link_arguments}; do
-		name="$(egrep '	'"$j"\$ databases.names)"
-		name=''${name%	$j}
-		if test -d "$j"; then
-			if test -d "$j"/share/dictd ; then
-				echo "Got store path $j"
-				j="$j"/share/dictd
-			fi
-			echo "Directory reference: $j"
-			i=$(ls "$j""/"*.index)
-			i="''${i%.index}";
-		else
-			i="$j";
-		fi
-		echo "Basename is $i"
-		locale=$(cat "$(dirname "$i")"/locale)
-		base="$(basename "$i")"
-		echo "Locale is $locale"
-		export LC_ALL=$locale
-		export LANG=$locale
-		if test -e "$i".dict.dz; then
-			ln -s "$i".dict.dz
-		else
-			cp "$i".dict .
-			dictzip "$base".dict
-		fi
-		ln -s "$i".index .
-		dictfmt_index2word --locale $locale < "$base".index > "$base".word || true
-		dictfmt_index2suffix --locale $locale < "$base".index > "$base".suffix || true
+  link_arguments = map
+    (x: '' "${x.filename}" '')
+    dictlist;
+  databases = lib.concatStrings (map
+    (x:
+      "${x.name}  ${x.filename}\n")
+    dictlist);
+  allow = lib.concatStrings (map (x: "allow ${x}\n") allowList);
+  deny = lib.concatStrings (map (x: "deny ${x}\n") denyList);
+  accessSection = "
+  access {
+    ${allow}
+    ${deny}
+  }
+";
+  installPhase = ''
+      mkdir -p $out/share/dictd
+    cd $out/share/dictd
+    echo "${databases}" >databases.names
+    echo "${accessSection}" > dictd.conf
+    for j in ${toString link_arguments}; do
+      name="$(egrep '  '"$j"\$ databases.names)"
+      name=''${name%  $j}
+      if test -d "$j"; then
+        if test -d "$j"/share/dictd ; then
+          echo "Got store path $j"
+          j="$j"/share/dictd
+        fi
+        echo "Directory reference: $j"
+        i=$(ls "$j""/"*.index)
+        i="''${i%.index}";
+      else
+        i="$j";
+      fi
+      echo "Basename is $i"
+      locale=$(cat "$(dirname "$i")"/locale)
+      base="$(basename "$i")"
+      echo "Locale is $locale"
+      export LC_ALL=$locale
+      export LANG=$locale
+      if test -e "$i".dict.dz; then
+        ln -s "$i".dict.dz
+      else
+        cp "$i".dict .
+        dictzip "$base".dict
+      fi
+      ln -s "$i".index .
+      dictfmt_index2word --locale $locale < "$base".index > "$base".word || true
+      dictfmt_index2suffix --locale $locale < "$base".index > "$base".suffix || true
 
-		echo "database $name {" >> dictd.conf
-		echo "  data $out/share/dictd/$base.dict.dz" >> dictd.conf
-		echo "  index $out/share/dictd/$base.index" >> dictd.conf
-		echo "  index_word $out/share/dictd/$base.word" >> dictd.conf
-		echo "  index_suffix $out/share/dictd/$base.suffix" >> dictd.conf
-		echo "}" >> dictd.conf
-	done
-  	'';
+      echo "database $name {" >> dictd.conf
+      echo "  data $out/share/dictd/$base.dict.dz" >> dictd.conf
+      echo "  index $out/share/dictd/$base.index" >> dictd.conf
+      echo "  index_word $out/share/dictd/$base.word" >> dictd.conf
+      echo "  index_suffix $out/share/dictd/$base.suffix" >> dictd.conf
+      echo "}" >> dictd.conf
+    done
+  '';
 
 in
 
 stdenv.mkDerivation {
   name = "dictd-dbs";
 
-  buildInputs = [dict];
+  buildInputs = [ dict ];
 
   inherit installPhase;
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
this package has not seen an update for 10 years... could someone tell me if we want to keep it?

###### Motivation for this change
#28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
