### PR TITLE
unison: add desktop file

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchFromGitHub, ocamlPackages, fontschumachermisc, xset, makeWrapper, ncurses, gnugrep, fetchpatch
+{lib, stdenv, fetchFromGitHub, ocamlPackages, fontschumachermisc, xset, makeWrapper, ncurses, gnugrep, fetchpatch, copyDesktopItems, makeDesktopItem
 , enableX11 ? true}:
 
 let inherit (ocamlPackages) ocaml lablgtk; in
@@ -14,7 +14,7 @@ stdenv.mkDerivation (rec {
     sha256 = "sha256-42hmdMwOYSWGiDCmhuqtpCWtvtyD2l+kA/bhHD/Qh5Y=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ] ++ (lib.lists.optional enableX11 copyDesktopItems);
   buildInputs = [ ocaml ncurses ];
 
   patches = [
@@ -27,9 +27,9 @@ stdenv.mkDerivation (rec {
     })
   ];
 
-  preBuild = (if enableX11 then ''
+  preBuild = (lib.strings.optionalString enableX11 ''
     sed -i "s|\(OCAMLOPT=.*\)$|\1 -I $(echo "${lablgtk}"/lib/ocaml/*/site-lib/lablgtk2)|" src/Makefile.OCaml
-  '' else "") + ''
+  '') + ''
   echo -e '\ninstall:\n\tcp $(FSMONITOR)$(EXEC_EXT) $(INSTALLDIR)' >> src/fsmonitor/linux/Makefile
   '';
 
@@ -40,14 +40,31 @@ stdenv.mkDerivation (rec {
 
   preInstall = "mkdir -p $out/bin";
 
-  postInstall = if enableX11 then ''
+  postInstall = lib.strings.optionalString enableX11 ''
     for i in $(cd $out/bin && ls); do
       wrapProgram $out/bin/$i \
         --run "[ -n \"\$DISPLAY\" ] && (${xset}/bin/xset q | ${gnugrep}/bin/grep -q \"${fontschumachermisc}\" || ${xset}/bin/xset +fp \"${fontschumachermisc}/lib/X11/fonts/misc\")"
     done
-  '' else "";
+
+    install -D $src/icons/U.svg $out/share/icons/hicolor/scalable/apps/unison.svg
+  '';
 
   dontStrip = !ocaml.nativeCompilers;
+
+  desktopItems = lib.lists.optional enableX11 (makeDesktopItem {
+    name = pname;
+    desktopName = "Unison";
+    comment = "Bidirectional file synchronizer";
+    genericName = "File synchronization tool";
+    exec = "unison";
+    icon = "unison";
+    categories = "Utility;FileTools;GTK;";
+    extraDesktopEntries={
+      StartupWMClass="Unison";
+      StartupNotify="true";
+      X-MultipleArgs="false";
+    };
+  });
 
   meta = {
     homepage = "https://www.cis.upenn.edu/~bcpierce/unison/";


### PR DESCRIPTION
###### Motivation for this change
This GUI program can only be launched by command line.

###### Things done
Added a desktop file for program launchers. 
Also replaced instances of `if string else ""` with `lib.strings.optionalString`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
