### PR TITLE
nttcp: init at 1.47

### DIFF
--- a/pkgs/tools/networking/nttcp/default.nix
+++ b/pkgs/tools/networking/nttcp/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchurl, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "nttcp";
+  version = "1.47";
+
+  src = fetchurl {
+    url = "http://deb.debian.org/debian/pool/non-free/n/nttcp/nttcp_${version}.orig.tar.gz";
+    sha256 = "1bl17dsd53lbpjdqfmpgpd7dms6d2w3scpg7ki7qgfjhs8sarq50";
+  };
+
+  patches = [
+    # Fix format string compiler error
+    ./format-security.patch
+  ];
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "New test TCP program";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ angustrau ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/networking/nttcp/format-security.patch
+++ b/pkgs/tools/networking/nttcp/format-security.patch
@@ -1,0 +1,12 @@
+diff -Nur -x '*.orig' -x '*~' nttcp-1.47/nttcp.c nttcp-1.47.new/nttcp.c
+--- nttcp-1.47/nttcp.c	2000-12-18 05:16:54.000000000 -0500
++++ nttcp-1.47.new/nttcp.c	2012-01-30 23:44:02.260501225 -0500
+@@ -372,7 +372,7 @@
+ #define Message(x)	fMessage(stdout, x)
+ 
+ void Exit(char *s, int ret) {
+-    syslog(LOG_DEBUG, s);
++    syslog(LOG_DEBUG, "%s", s);
+     fMessage(stderr,s);
+     exit(ret);
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7519,6 +7519,8 @@ in
 
   numlockx = callPackage ../tools/X11/numlockx { };
 
+  nttcp = callPackage ../tools/networking/nttcp { };
+
   nuttcp = callPackage ../tools/networking/nuttcp { };
 
   nssmdns = callPackage ../tools/networking/nss-mdns { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
