### PR TITLE
python3Packages.embrace: init at 4.0.0

### DIFF
--- a/pkgs/development/python-modules/embrace/default.nix
+++ b/pkgs/development/python-modules/embrace/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromSourcehut, sqlparse, wrapt, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "embrace";
+  version = "4.0.0";
+
+  src = fetchFromSourcehut {
+    vc = "hg";
+    owner = "~olly";
+    repo = "embrace-sql";
+    rev = "v${version}-release";
+    sha256 = "sha256-G/7FeKlMbOWobQOpD7/0JiTFpf8oWZ1TxPpDS9wrKMo=";
+  };
+
+  propagatedBuildInputs = [ sqlparse wrapt ];
+  checkInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "embrace" ];
+
+  meta = with lib; {
+    description = "Embrace SQL keeps your SQL queries in SQL files";
+    homepage = "https://pypi.org/project/embrace/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2288,6 +2288,8 @@ in {
 
   email_validator = callPackage ../development/python-modules/email-validator { };
 
+  embrace = callPackage ../development/python-modules/embrace { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   emv = callPackage ../development/python-modules/emv { };


### PR DESCRIPTION
###### Motivation for this change

This introduces a package for the `embrace` python library.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
