### PR TITLE
google-chrome: add pciutils dep to avoid GPU process crashing

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -18,7 +18,7 @@
 , systemd
 
 # Loaded at runtime.
-, libexif
+, libexif, pciutils
 
 # Additional dependencies according to other distros.
 ## Ubuntu
@@ -62,7 +62,7 @@ let
     alsa-lib libXdamage libXtst libXrandr libxshmfence expat cups
     dbus gdk-pixbuf gcc-unwrapped.lib
     systemd
-    libexif
+    libexif pciutils
     liberation_ttf curl util-linux xdg-utils wget
     flac harfbuzz icu libpng opusWithCustomModes snappy speechd
     bzip2 libcap at-spi2-atk at-spi2-core


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

If our Chrome derivation is Vulkan enabled, the Chrome GPU process
reliably crashes for me under M92 using the proprietary Nvidia drivers.
This is because the PCI-based GPU detection path fails, and we attempt
to use the Vulkan fallback instead, which then crashes(!!)

Including libpci allows us to use Angle's
src/gpu_info_util/SystemInfo_libpci.cpp path instead, which doesn't
crash, unlike src/gpu_info_util/SystemInfo_vulkan.cpp.

This was fixed in M93 by disabling this path again (https://chromium.googlesource.com/angle/angle/+/e981675a10ce4e10ae82aa0c9788cdc2e8c3539c) - https://bugs.chromium.org/p/chromium/issues/detail?id=1192586 has more info, but is Googlers only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
