### PR TITLE
Use dependabot to bump GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
To prevent actions getting outdated, resulting into errors like https://github.com/NixOS/nixpkgs/pull/130545/checks?check_run_id=3097436672