### PR TITLE
[21.05] Preparations for backporting Chromium M92

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -62,7 +62,7 @@ mkChromiumDerivation (base: rec {
       -e '/\[Desktop Entry\]/a\' \
       -e 'StartupWMClass=chromium-browser' \
       $out/share/applications/chromium-browser.desktop
-  '' + lib.optionalString (channel == "dev") ''
+  '' + lib.optionalString (channel != "stable") ''
     cp -v "$buildPath/crashpad_handler" "$libExecPath/"
   '';
 

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -84,7 +84,7 @@ mkChromiumDerivation (base: rec {
       else "https://www.chromium.org/";
     maintainers = with maintainers; if ungoogled
       then [ squalus primeos ]
-      else [ primeos thefloweringash bendlas ];
+      else [ primeos thefloweringash ];
     license = if enableWideVine then licenses.unfree else licenses.bsd3;
     platforms = platforms.linux;
     mainProgram = "chromium";

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -175,12 +175,6 @@ let
         sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
         revert = true;
       })
-      # To fix building from a release tarball (which we do):
-      (githubPatch {
-        # Revert back to generating chromium_git_revision.h via version.py
-        commit = "bd524d08f8465364d12d32a84fd1aa983aecc502";
-        sha256 = "1jsxidg5jzwkrcpx3lylx4gyg56zjyd7sc957kaaqqc853bn83b4";
-      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -175,18 +175,6 @@ let
         sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
         revert = true;
       })
-      # To fix build errors with the older system FFmpeg:
-      (githubPatch {
-        # unbundle: add libavcodec/packet.h to shim headers
-        commit = "e4d228ec30607b06bf3fed77497abef89c29966a";
-        sha256 = "02jg2bdmgjcpmk6alb72jc93wy3nf2fpa72hb4aarq337i2mwn4v";
-      })
-      (githubPatch {
-        # Roll src/third_party/ffmpeg/ 7e1d53a09..cf7ee6598 (1000 commits)
-        commit = "3ec3b2992238d4b4764f99f04605e154688c7990";
-        sha256 = "1fwb154s5qcis490rvcvm14zrmaj59g5lg9zg8ada36vw9hycbrf";
-        revert = true;
-      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -175,6 +175,18 @@ let
         sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
         revert = true;
       })
+      # To fix build errors with the older system FFmpeg:
+      (githubPatch {
+        # unbundle: add libavcodec/packet.h to shim headers
+        commit = "e4d228ec30607b06bf3fed77497abef89c29966a";
+        sha256 = "02jg2bdmgjcpmk6alb72jc93wy3nf2fpa72hb4aarq337i2mwn4v";
+      })
+      (githubPatch {
+        # Roll src/third_party/ffmpeg/ 7e1d53a09..cf7ee6598 (1000 commits)
+        commit = "3ec3b2992238d4b4764f99f04605e154688c7990";
+        sha256 = "1fwb154s5qcis490rvcvm14zrmaj59g5lg9zg8ada36vw9hycbrf";
+        revert = true;
+      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -175,6 +175,12 @@ let
         sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
         revert = true;
       })
+      # To fix building from a release tarball (which we do):
+      (githubPatch {
+        # Revert back to generating chromium_git_revision.h via version.py
+        commit = "bd524d08f8465364d12d32a84fd1aa983aecc502";
+        sha256 = "1jsxidg5jzwkrcpx3lylx4gyg56zjyd7sc957kaaqqc853bn83b4";
+      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/get-commit-message.py
+++ b/pkgs/applications/networking/browsers/chromium/get-commit-message.py
@@ -19,14 +19,14 @@ for entry in feed.entries:
         continue
     url = requests.get(entry.link).url.split('?')[0]
     content = entry.content[0].value
+    content = html_tags.sub('', content)  # Remove any HTML tags
     if re.search(r'Linux', content) is None:
         continue
     #print(url)  # For debugging purposes
     version = re.search(r'\d+(\.\d+){3}', content).group(0)
     print('chromium: TODO -> ' + version)
     print('\n' + url)
-    if fixes := re.search(r'This update includes .+ security fixes\.', content):
-        fixes = html_tags.sub('', fixes.group(0))
+    if fixes := re.search(r'This update includes .+ security fixes\.', content).group(0):
         zero_days = re.search(r'Google is aware( of reports)? that .+ in the wild\.', content)
         if zero_days:
             fixes += " " + zero_days.group(0)

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.59",
-    "sha256": "0lpmd4sybr9qxqj7ab25xjliaw2dk9njnik51gdffrrwphv9qdxb",
-    "sha256bin64": "0qq9a3pzyn5d6bagx3py86ksl8n488lmlrmadgam2gb7421jq71a",
+    "version": "92.0.4515.70",
+    "sha256": "06yhpxr5bg0gx7hmrhc6zg4gr1d9s34y2rb98rpl4dilmc548i6q",
+    "sha256bin64": "1fkakh1r87pg5nr101m6v86y8iyyfba8vnzrg0229kcar7v8wzf7",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.40",
-    "sha256": "1v0vmnzdqq7d2rqp1sam8nk7z20xg5l9lnlpqjxj30y8k37gzh8p",
-    "sha256bin64": "0i3plysx51n2gsm5vbf9666rz73pqbbns7v09wznbbncvw9zngrf",
+    "version": "92.0.4515.51",
+    "sha256": "0x9c5fy95wnri9z0s8pbwyq1lw684n7d70l1s2rp5yxh0snannxg",
+    "sha256bin64": "036km5dp7asq5n86qx7c9119mdch7sl89lhq1ffss0f4mzcq42yd",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.70",
-    "sha256": "06yhpxr5bg0gx7hmrhc6zg4gr1d9s34y2rb98rpl4dilmc548i6q",
-    "sha256bin64": "1fkakh1r87pg5nr101m6v86y8iyyfba8vnzrg0229kcar7v8wzf7",
+    "version": "92.0.4515.80",
+    "sha256": "142v8y275mysgksvfprc83a7r1dlcnb5rqi8a451fmfnj6wrsq8i",
+    "sha256bin64": "0sz2fvg6l7q7syc5pysa246p03sganmgjdfvind42i8cqxw8gycp",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.80",
-    "sha256": "142v8y275mysgksvfprc83a7r1dlcnb5rqi8a451fmfnj6wrsq8i",
-    "sha256bin64": "0sz2fvg6l7q7syc5pysa246p03sganmgjdfvind42i8cqxw8gycp",
+    "version": "92.0.4515.93",
+    "sha256": "077i1rw84cgcmg2k0p1ycg5pwvnhgsa3qdfsr7icrn7gmagagqd0",
+    "sha256bin64": "1gf4qv8wvaagdgsinf2gprx9wcfgm8jql6870k50bi26mjqv9800",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "93.0.4542.2",
-    "sha256": "0sfyi52kaxg5mllcvn61285fjnj72vglv9fjf36ri93v6gh34rgw",
-    "sha256bin64": "0hk31b9nk834gykv977dv7f1hyl7jp527bx5ldxhwcy27333h1hr",
+    "version": "93.0.4549.3",
+    "sha256": "0bkr67n1d75ayd1d9sa57c99j85r83gadzfs8iw7kwiha9g0mjgp",
+    "sha256bin64": "1hac6m668nrdzvfqx3vyc74pnx8lf973m1jxnm3cfy83g7wynphz",
     "deps": {
       "gn": {
-        "version": "2021-06-11",
+        "version": "2021-06-18",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "e0c476ffc83dc10897cb90b45c03ae2539352c5c",
-        "sha256": "01p5w57kksihzg9nb5096a74cw2rp8zzgdjcjm1pgrqvd1mxpjm4"
+        "rev": "170c2dba1e0c0299fe8c6a441caf2f2352a42ae0",
+        "sha256": "1ylx8a5fxq7aciqs0mx7fld763sqkqn39lb9k951w6gksm15lrn3"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "93.0.4549.3",
-    "sha256": "0bkr67n1d75ayd1d9sa57c99j85r83gadzfs8iw7kwiha9g0mjgp",
-    "sha256bin64": "1hac6m668nrdzvfqx3vyc74pnx8lf973m1jxnm3cfy83g7wynphz",
+    "version": "93.0.4557.4",
+    "sha256": "06397k5mkrrdrmd7icyvd1ifnmhincgw5nskgc3m436qzzifsab9",
+    "sha256bin64": "1q2c2dhx1yya6vhr82asf7h2zrv6kjzjv1a0zlfxkp3i6lnivgrd",
     "deps": {
       "gn": {
-        "version": "2021-06-18",
+        "version": "2021-06-25",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "170c2dba1e0c0299fe8c6a441caf2f2352a42ae0",
-        "sha256": "1ylx8a5fxq7aciqs0mx7fld763sqkqn39lb9k951w6gksm15lrn3"
+        "rev": "4d207c94eab41f09c9a8505eb47f3d2919e47943",
+        "sha256": "1jfgksa7rifh3ynnmd7m8xxggwxckz0jnwjaq9m5xapksb89hbn1"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "93.0.4557.4",
-    "sha256": "06397k5mkrrdrmd7icyvd1ifnmhincgw5nskgc3m436qzzifsab9",
-    "sha256bin64": "1q2c2dhx1yya6vhr82asf7h2zrv6kjzjv1a0zlfxkp3i6lnivgrd",
+    "version": "93.0.4573.0",
+    "sha256": "0knks0padlcqhwnjpg32d875nycznlbd228sx8qwnylg1ilrzqck",
+    "sha256bin64": "1kxbsdcc0gh2pllz3szmnjswxqbw9sr457pq8aafpgk9rdchikg1",
     "deps": {
       "gn": {
-        "version": "2021-06-25",
+        "version": "2021-07-08",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "4d207c94eab41f09c9a8505eb47f3d2919e47943",
-        "sha256": "1jfgksa7rifh3ynnmd7m8xxggwxckz0jnwjaq9m5xapksb89hbn1"
+        "rev": "24e2f7df92641de0351a96096fb2c490b2436bb8",
+        "sha256": "1lwkyhfhw0zd7daqz466n7x5cddf0danr799h4jg3s0yvd4galjl"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.93",
-    "sha256": "077i1rw84cgcmg2k0p1ycg5pwvnhgsa3qdfsr7icrn7gmagagqd0",
-    "sha256bin64": "1gf4qv8wvaagdgsinf2gprx9wcfgm8jql6870k50bi26mjqv9800",
+    "version": "92.0.4515.101",
+    "sha256": "1jcas265hhlqd9f63h4zw4n4xsl26c5zmjlmbf1px5icvcjfb2xd",
+    "sha256bin64": "0sb5l5nzfzisvrnhcfwhdh9rn6z6pkzqz4p92c40q2mlhmjrfhj0",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.51",
-    "sha256": "0x9c5fy95wnri9z0s8pbwyq1lw684n7d70l1s2rp5yxh0snannxg",
-    "sha256bin64": "036km5dp7asq5n86qx7c9119mdch7sl89lhq1ffss0f4mzcq42yd",
+    "version": "92.0.4515.59",
+    "sha256": "0lpmd4sybr9qxqj7ab25xjliaw2dk9njnik51gdffrrwphv9qdxb",
+    "sha256bin64": "0qq9a3pzyn5d6bagx3py86ksl8n488lmlrmadgam2gb7421jq71a",
     "deps": {
       "gn": {
         "version": "2021-05-07",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "93.0.4535.3",
-    "sha256": "19iy4p59n0pg9s39g614y4yxh5f6h86bcp471qdnm6fvzmzcxd18",
-    "sha256bin64": "16q9s8l20bmr2n0y3pi505l5hbhbmpi8kh47aylj5gzk1nr30a8r",
+    "version": "93.0.4542.2",
+    "sha256": "0sfyi52kaxg5mllcvn61285fjnj72vglv9fjf36ri93v6gh34rgw",
+    "sha256bin64": "0hk31b9nk834gykv977dv7f1hyl7jp527bx5ldxhwcy27333h1hr",
     "deps": {
       "gn": {
-        "version": "2021-05-07",
+        "version": "2021-06-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "39a87c0b36310bdf06b692c098f199a0d97fc810",
-        "sha256": "0x63jr5hssm9dl6la4q5ahy669k4gxvbapqxi5w32vv107jrj8v4"
+        "rev": "e0c476ffc83dc10897cb90b45c03ae2539352c5c",
+        "sha256": "01p5w57kksihzg9nb5096a74cw2rp8zzgdjcjm1pgrqvd1mxpjm4"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "93.0.4573.0",
-    "sha256": "0knks0padlcqhwnjpg32d875nycznlbd228sx8qwnylg1ilrzqck",
-    "sha256bin64": "1kxbsdcc0gh2pllz3szmnjswxqbw9sr457pq8aafpgk9rdchikg1",
+    "version": "93.0.4577.8",
+    "sha256": "1x6i5bmcnj8bkpcb9gcyd1m9nzpq206yyprxrnpak117k7abr2b1",
+    "sha256bin64": "0qjfb9jxr2gmwb1dsvl6yzz06vsjny2l3icrsdcm0pl6r6davk2w",
     "deps": {
       "gn": {
         "version": "2021-07-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "92.0.4515.101",
-    "sha256": "1jcas265hhlqd9f63h4zw4n4xsl26c5zmjlmbf1px5icvcjfb2xd",
-    "sha256bin64": "0sb5l5nzfzisvrnhcfwhdh9rn6z6pkzqz4p92c40q2mlhmjrfhj0",
+    "version": "92.0.4515.107",
+    "sha256": "04khamgxwzgbm2rn7is53j5g55vm5qfyz7zwxqc51sd429jsqlbf",
+    "sha256bin64": "179i18lckd85i6cc60mqpvv2jqdshc338m686yackdgz9qjrrlwd",
     "deps": {
       "gn": {
         "version": "2021-05-07",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`chromium` and `google-chrome` remain unchanged by this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
