### PR TITLE
nixos/tests/chromium: Check the version and that it's an official build

### DIFF
--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -243,6 +243,16 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
         machine.wait_for_text("Graphics Feature Status")
 
 
+    with test_new_win("version_info", "chrome://version", "About Version") as clipboard:
+        filters = [
+            r"${chromiumPkg.version} \(Official Build",
+        ]
+        if not all(
+            re.search(filter, clipboard) for filter in filters
+        ):
+            assert False, "Version info not correct."
+
+
     machine.shutdown()
   '';
 }) channelMap


### PR DESCRIPTION
This also prints and screenshots the output of chrome://version which
contains useful information.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
$ nix-build nixos/tests/chromium.nix -A stable -A beta -A chrome-stable -A chrome-beta -A chrome-dev
/nix/store/0np2rah7h6spcvk94y59dsvhj17d2d2k-vm-test-run-chromium-stable
/nix/store/ai1wm5jn6hb5qjrr7f8f7dj03nv6hg3f-vm-test-run-chromium-beta
/nix/store/xh52ij7wmh8k6blr5s1b3j2m0bhvn1fz-vm-test-run-chromium-chrome-stable
/nix/store/0ywqbj9fkh9ydhnxnifmz29s5wlz54s5-vm-test-run-chromium-chrome-beta
/nix/store/iwd2y2yp7fb4kysxd9zvbp3acq8z23w0-vm-test-run-chromium-chrome-dev

Chromium	92.0.4515.107 (Official Build) (64-bit)
Chromium        92.0.4515.107 (Official Build) (64-bit)
Google Chrome   92.0.4515.107 (Official Build) (64-bit)
Google Chrome   92.0.4515.107 (Official Build) beta (64-bit)
Google Chrome   93.0.4577.8 (Official Build) dev (64-bit)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
