### PR TITLE
build(deps): bump zeebe-io/backport-action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,13 +15,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
         # should be kept in sync with `version`
-        uses: zeebe-io/backport-action@2b994724142df0774855690db56bc6308fb99ffa
+        uses: zeebe-io/backport-action@0.0.5
         with:
           # Config README: https://github.com/zeebe-io/backport-action#backport-action
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}
           # should be kept in sync with `uses`
-          version: 2b994724142df0774855690db56bc6308fb99ffa
+          version: 0.0.5
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}
           # should be kept in sync with `uses`
-          version: 0.0.5
+          version: v0.0.5
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
         # should be kept in sync with `version`
-        uses: zeebe-io/backport-action@0.0.5
+        uses: zeebe-io/backport-action@v0.0.5
         with:
           # Config README: https://github.com/zeebe-io/backport-action#backport-action
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
see https://github.com/Mic92/nixpkgs/pull/5

Bumps [zeebe-io/backport-action](https://github.com/zeebe-io/backport-action) from 2b994724142df0774855690db56bc6308fb99ffa to 0.0.5. This release includes the previously tagged commit.
- [Release notes](https://github.com/zeebe-io/backport-action/releases)
- [Commits](https://github.com/zeebe-io/backport-action/compare/2b994724142df0774855690db56bc6308fb99ffa...e5d4d7c39c94b65670847d11d259b2f574fa3d30)

---
updated-dependencies:
- dependency-name: zeebe-io/backport-action
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>