### PR TITLE
calibre: Pin autoconf dependency to 0.31

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -94,7 +94,7 @@ mkDerivation rec {
       python
       regex
       sip
-      zeroconf
+      (callPackage ./zeroconf.nix { })
       # the following are distributed with calibre, but we use upstream instead
       odfpy
     ] ++ lib.optional (unrarSupport) unrardll

--- a/pkgs/applications/misc/calibre/zeroconf.nix
+++ b/pkgs/applications/misc/calibre/zeroconf.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, ifaddr
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "zeroconf";
+  version = "0.31.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-U6GAJIRxxvgb0f/8vOA+2T19jq8QkFyRIaweqZbRmEQ=";
+  };
+
+  propagatedBuildInputs = [ ifaddr ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "zeroconf/test.py" ];
+
+  disabledTests = [
+    # disable tests that expect some sort of networking in the build container
+    "test_close_multiple_times"
+    "test_launch_and_close"
+    "test_launch_and_close_v4_v6"
+    "test_launch_and_close_v6_only"
+    "test_integration_with_listener_ipv6"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_lots_of_names"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "zeroconf" ];
+
+  meta = with lib; {
+    description = "Python implementation of multicast DNS service discovery";
+    homepage = "https://github.com/jstasiak/python-zeroconf";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Presently, Calibre fails to build ([stacktrace](https://gist.github.com/yaymukund/8f075e02d689bef08cc0dd4d8cb245d1)) on nixos-unstable since autoconf was updated to 0.32 because of a regression in calibre (https://bugs.launchpad.net/calibre/+bug/1936889) which has been patched, but not yet released (https://github.com/kovidgoyal/calibre/commit/4f9e83e6426483b6cc0929c61f9207c33c573fec).  

This pins Calibre's autoconf to 0.31 until that gets merged and we can update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
