### PR TITLE
calibre: Pin zeroconf dependency to 0.31

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchurl
+, fetchFromGitHub
 , poppler_utils
 , pkg-config
 , libpng
@@ -94,7 +95,15 @@ mkDerivation rec {
       python
       regex
       sip
-      zeroconf
+      (zeroconf.overrideAttrs (oldAttrs: rec {
+        version = "0.31.0";
+        src = fetchFromGitHub {
+          owner = "jstasiak";
+          repo = "python-zeroconf";
+          rev = version;
+          sha256 = "158dqay74zvnz6kmpvip4ml0kw59nf2aaajwgaamx0zc8ci1p5pj";
+        };
+      }))
       # the following are distributed with calibre, but we use upstream instead
       odfpy
     ] ++ lib.optional (unrarSupport) unrardll


### PR DESCRIPTION
###### Motivation for this change

Presently, Calibre fails to build ([stacktrace](https://gist.github.com/yaymukund/8f075e02d689bef08cc0dd4d8cb245d1)) on nixos-unstable since [zeroconf was updated to 0.32](https://github.com/NixOS/nixpkgs/commit/10bc114e32c42eea5222d7c8434a7a8d02e51d0b) because of a regression in calibre (https://bugs.launchpad.net/calibre/+bug/1936889) which has been patched, but not yet released (https://github.com/kovidgoyal/calibre/commit/4f9e83e6426483b6cc0929c61f9207c33c573fec).  

This pins Calibre's zeroconf dependency to 0.31 until that gets merged and we can update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
