### PR TITLE
systemd: remove patchelf, coreutils from nativeBuildInputs as it is p…

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -12,7 +12,6 @@
 , coreutils
 , gperf
 , getent
-, patchelf
 , glibcLocales
 , glib
 , substituteAll
@@ -271,9 +270,7 @@ stdenv.mkDerivation rec {
     gperf
     ninja
     meson
-    coreutils # meson calls date, stat etc.
     glibcLocales
-    patchelf
     getent
     m4
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -90,7 +90,6 @@
   # name argument
 , pname ? "systemd"
 
-
 , libxslt
 , docbook_xsl
 , docbook_xml_dtd_42
@@ -267,55 +266,53 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "man" "dev" ];
 
-  nativeBuildInputs =
-    [
-      pkg-config
-      gperf
-      ninja
-      meson
-      coreutils # meson calls date, stat etc.
-      glibcLocales
-      patchelf
-      getent
-      m4
+  nativeBuildInputs = [
+    pkg-config
+    gperf
+    ninja
+    meson
+    coreutils # meson calls date, stat etc.
+    glibcLocales
+    patchelf
+    getent
+    m4
 
-      intltool
-      gettext
+    intltool
+    gettext
 
-      libxslt
-      docbook_xsl
-      docbook_xml_dtd_42
-      docbook_xml_dtd_45
-      (buildPackages.python3Packages.python.withPackages (ps: with ps; [ python3Packages.lxml ]))
-    ];
+    libxslt
+    docbook_xsl
+    docbook_xml_dtd_42
+    docbook_xml_dtd_45
+    (buildPackages.python3Packages.python.withPackages (ps: with ps; [ python3Packages.lxml ]))
+  ];
 
-  buildInputs =
-    [
-      acl
-      audit
-      glib
-      kmod
-      libcap
-      libgcrypt
-      libidn2
-      libuuid
-      linuxHeaders
-      pam
-    ]
+  buildInputs = [
+    acl
+    audit
+    glib
+    kmod
+    libcap
+    libgcrypt
+    libidn2
+    libuuid
+    linuxHeaders
+    pam
+  ]
 
-    ++ lib.optional withApparmor libapparmor
-    ++ lib.optional wantCurl (lib.getDev curl)
-    ++ lib.optionals withCompression [ bzip2 lz4 xz ]
-    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
-    ++ lib.optional withEfi gnu-efi
-    ++ lib.optional withKexectools kexectools
-    ++ lib.optional withLibseccomp libseccomp
-    ++ lib.optional withNetworkd iptables
-    ++ lib.optional withPCRE2 pcre2
-    ++ lib.optional withResolved libgpgerror
-    ++ lib.optional withSelinux libselinux
-    ++ lib.optional withRemote libmicrohttpd
-    ++ lib.optionals withHomed [ p11-kit libfido2 ]
+  ++ lib.optional withApparmor libapparmor
+  ++ lib.optional wantCurl (lib.getDev curl)
+  ++ lib.optionals withCompression [ bzip2 lz4 xz ]
+  ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
+  ++ lib.optional withEfi gnu-efi
+  ++ lib.optional withKexectools kexectools
+  ++ lib.optional withLibseccomp libseccomp
+  ++ lib.optional withNetworkd iptables
+  ++ lib.optional withPCRE2 pcre2
+  ++ lib.optional withResolved libgpgerror
+  ++ lib.optional withSelinux libselinux
+  ++ lib.optional withRemote libmicrohttpd
+  ++ lib.optionals withHomed [ p11-kit libfido2 ]
   ;
 
   #dontAddPrefix = true;
@@ -368,14 +365,14 @@ stdenv.mkDerivation {
     "-Db_pie=true"
     "-Dinstall-sysconfdir=false"
     /*
-    As of now, systemd doesn't allow runtime configuration of these values. So
-    the settings in /etc/login.defs have no effect on it. Many people think this
-    should be supported however, see
-    - https://github.com/systemd/systemd/issues/3855
-    - https://github.com/systemd/systemd/issues/4850
-    - https://github.com/systemd/systemd/issues/9769
-    - https://github.com/systemd/systemd/issues/9843
-    - https://github.com/systemd/systemd/issues/10184
+      As of now, systemd doesn't allow runtime configuration of these values. So
+      the settings in /etc/login.defs have no effect on it. Many people think this
+      should be supported however, see
+      - https://github.com/systemd/systemd/issues/3855
+      - https://github.com/systemd/systemd/issues/4850
+      - https://github.com/systemd/systemd/issues/9769
+      - https://github.com/systemd/systemd/issues/9843
+      - https://github.com/systemd/systemd/issues/10184
     */
     "-Dsystem-uid-max=999"
     "-Dsystem-gid-max=999"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -112,10 +112,10 @@ assert withCryptsetup ->
 let
   wantCurl = withRemote || withImportd;
 
-  version = "247.6";
 in
-stdenv.mkDerivation {
-  inherit version pname;
+stdenv.mkDerivation rec {
+  inherit pname;
+  version = "247.6";
 
   # We use systemd/systemd-stable for src, and ship NixOS-specific patches inside nixpkgs directly
   # This has proven to be less error-prone than the previous systemd fork.


### PR DESCRIPTION
…art of the stdenv, format

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
