### PR TITLE
pythonPackages.youtube-transcript-api: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/youtube-transcript-api/default.nix
+++ b/pkgs/development/python-modules/youtube-transcript-api/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests, mock, httpretty, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "youtube-transcript-api";
+  version = "0.4.1";
+
+  # PyPI tarball is missing some test files
+  src = fetchFromGitHub {
+    owner = "jdepoix";
+    repo = "youtube-transcript-api";
+    rev = "v${version}";
+    sha256 = "1gpk13j1n2bifwsg951gmrfnq8kfxjr15rq46dxn1bhyk9hr1zql";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ mock httpretty pytestCheckHook ];
+
+  pythonImportsCheck = [ "youtube_transcript_api" ];
+
+  meta = with lib; {
+    description = "Python API which allows you to get the transcripts/subtitles for a given YouTube video";
+    homepage = "https://github.com/jdepoix/youtube-transcript-api";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9462,6 +9462,8 @@ in {
 
   youtube-search = callPackage ../development/python-modules/youtube-search { };
 
+  youtube-transcript-api = callPackage ../development/python-modules/youtube-transcript-api { };
+
   yowsup = callPackage ../development/python-modules/yowsup { };
 
   yq = callPackage ../development/python-modules/yq {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
