### PR TITLE
polymake: 3.2.rc4 -> 4.4

### DIFF
--- a/pkgs/applications/science/math/polymake/default.nix
+++ b/pkgs/applications/science/math/polymake/default.nix
@@ -1,27 +1,32 @@
 { lib, stdenv, fetchurl
-, ninja, libxml2, libxslt, readline, perl, gmp, mpfr, boost
+, perl, gmp, mpfr, flint, boost
 , bliss, ppl, singular, cddlib, lrs, nauty
-, ant, openjdk
+, ninja, ant, openjdk
 , perlPackages
 , makeWrapper
 }:
 
+# polymake compiles its own version of sympol and atint because we
+# don't have those packages. other missing optional dependencies:
+# javaview, libnormaliz, scip, soplex, jreality.
+
 stdenv.mkDerivation rec {
   pname = "polymake";
-  version = "3.2.rc4";
+  version = "4.4";
 
   src = fetchurl {
-    url = "https://polymake.org/lib/exe/fetch.php/download/polymake-3.2r4.tar.bz2";
-    sha256 = "02jpkvy1cc6kc23vkn7nkndzr40fq1gkb3v257bwyi1h5d37fyqy";
+    # "The minimal version is a packager friendly version which omits
+    # the bundled sources of cdd, lrs, libnormaliz, nauty and jReality."
+    url = "https://polymake.org/lib/exe/fetch.php/download/polymake-${version}-minimal.tar.bz2";
+    sha256 = "sha256-2nF5F2xznI77pl2TslrxA8HLpw4fmzVnPOM8N3kOwJE=";
   };
 
   buildInputs = [
-    libxml2 libxslt readline perl gmp mpfr boost
+    perl gmp mpfr flint boost
     bliss ppl singular cddlib lrs nauty
     openjdk
-  ] ++
-  (with perlPackages; [
-    XMLLibXML XMLLibXSLT XMLWriter TermReadLineGnu TermReadKey
+  ] ++ (with perlPackages; [
+    JSON TermReadLineGnu TermReadKey XMLSAX
   ]);
 
   nativeBuildInputs = [
@@ -36,11 +41,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Software for research in polyhedral geometry";
-    license = lib.licenses.gpl2 ;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = teams.sage.members;
+    platforms = platforms.linux;
     homepage = "https://www.polymake.org/doku.php";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26547,9 +26547,7 @@ in
 
   polylith = callPackage ../development/tools/misc/polylith { };
 
-  polymake = callPackage ../applications/science/math/polymake {
-    openjdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-  };
+  polymake = callPackage ../applications/science/math/polymake { };
 
   pond = callPackage ../applications/networking/instant-messengers/pond { };
 


### PR DESCRIPTION
###### Motivation for this change

Polymake 3.2 fails to compile:
```
build/polymake-3.2/lib/core/src/perl/RefHash.xxs: In function 'OP* pm::perl::glue::{anonymous}::intercept_pp_keys(PerlInterpreter*)':
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:384:15: error: 'Perl_pp_keys' was not declared in this scope; did you mean 'Perl_pp_akeys'?
  384 |       OP* ret=Perl_pp_keys(aTHX);
      |               ^~~~~~~~~~~~
      |               Perl_pp_akeys
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:392:11: error: 'Perl_pp_keys' was not declared in this scope; did you mean 'Perl_pp_akeys'?
  392 |    return Perl_pp_keys(aTHX);
      |           ^~~~~~~~~~~~
      |           Perl_pp_akeys
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs: In function 'OP* pm::perl::glue::{anonymous}::pp_rv2hv_ref_retrieve(PerlInterpreter*)':
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:521:12: error: 'Perl_pp_rv2hv' was not declared in this scope; did you mean 'Perl_pp_rv2sv'?
  521 |    OP *ret=Perl_pp_rv2hv(aTHX);
      |            ^~~~~~~~~~~~~
      |            Perl_pp_rv2sv
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs: In function 'OP* pm::perl::glue::{anonymous}::intercept_pp_rv2hv(PerlInterpreter*)':
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:546:16: error: 'Perl_pp_rv2hv' was not declared in this scope; did you mean 'Perl_pp_rv2sv'?
  546 |          PL_op=Perl_pp_rv2hv(aTHX);
      |                ^~~~~~~~~~~~~
      |                Perl_pp_rv2sv
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:566:20: error: 'Perl_pp_rv2hv' was not declared in this scope; did you mean 'Perl_pp_rv2sv'?
  566 |             return Perl_pp_rv2hv(aTHX);
      |                    ^~~~~~~~~~~~~
      |                    Perl_pp_rv2sv
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:570:7: error: 'Perl_pp_rv2hv' was not declared in this scope; did you mean 'Perl_pp_rv2sv'?
  570 |       Perl_pp_rv2hv(aTHX);               // get the hash
      |       ^~~~~~~~~~~~~
      |       Perl_pp_rv2sv
/build/polymake-3.2/lib/core/src/perl/RefHash.xxs:577:11: error: 'Perl_pp_rv2hv' was not declared in this scope; did you mean 'Perl_pp_rv2sv'?
  577 |    return Perl_pp_rv2hv(aTHX);
      |           ^~~~~~~~~~~~~
      |           Perl_pp_rv2sv
```
The new version, 4.4, works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
