### PR TITLE
1password: 1.9.1 -> 1.11.2

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "1.9.1";
+  version = "1.11.2";
   src =
     if stdenv.isLinux then fetchzip {
       url = {
@@ -11,14 +11,14 @@ stdenv.mkDerivation rec {
         "aarch64-linux" = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_arm_v${version}.zip";
       }.${stdenv.hostPlatform.system};
       sha256 = {
-        "i686-linux" = "1x5khnp6yqrjf513x3y6l38rb121nib7d4aiz4cz7fh029kxjhd1";
-        "x86_64-linux" = "1ar8lzkndl7xzcinv93rzg8q25vb23fggbjkhgchgc5x9wkwk8hw";
-        "aarch64-linux" = "1q81pk6qmp96p1dbhx1ijln8f54rac8r81d4ghqx9v756s9szrr1";
+        "i686-linux" = "0rh5bakj9qd43cf6wj5v46a3h98kcwqyc0f1yw72wvcacvjycyjz";
+        "x86_64-linux" = "00nf0cb8cxk1pvzr1wq778wvikzrlzy38r3rzkq44whdpdj50jzx";
+        "aarch64-linux" = "1gv282z49bj3ln5na4wb1z5455a64cyd54fp5i96k8shaxd0apxf";
       }.${stdenv.hostPlatform.system};
       stripRoot = false;
     } else fetchurl {
-      url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.pkg";
-      sha256 = "0904wwy3wdhfvbkvpdap8141a9gqmn0dw45ikrzsqpg7pv1r2zch";
+      url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_apple_universal_v${version}.pkg";
+      sha256 = "14j9071ckd7dy7b8687231rbgyxb96iwwdlpxwyngcq57vhl7n7j";
     };
 
   buildInputs = lib.optionals stdenv.isDarwin [ xar cpio ];

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       stripRoot = false;
     } else fetchurl {
       url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_apple_universal_v${version}.pkg";
-      sha256 = "14j9071ckd7dy7b8687231rbgyxb96iwwdlpxwyngcq57vhl7n7j";
+      sha256 = "1pqdjr6d23j9fpwgahb0s1ni1bpjv9jajs1hapgq5kdrww2w7nhm";
     };
 
   buildInputs = lib.optionals stdenv.isDarwin [ xar cpio ];


### PR DESCRIPTION
(This is my first `nixpkgs` PR, so feel free to correct any errors I make in drafting this PR.)

This PR updates `1password` from version 1.9.1 to version 1.11.2. As you can see in the [release notes](https://app-updates.agilebits.com/product_history/CLI), since version 1.11.1 1password has been distributing a binary for `apple_universal` instead of `darwin_amd64` to support M1 Macs. If that is a problem, we can revert this to version 1.11.0, which is the last version that has `darwin_amd64`. I don't have a Mac machine handy to test this on MacOS, unfortunately.

I fetched the SHAs with

```
nix-prefetch-url --unpack https://cache.agilebits.com/dist/1P/op/pkg/v1.11.2/op_linux_386_v1.11.2.zip
nix-prefetch-url --unpack https://cache.agilebits.com/dist/1P/op/pkg/v1.11.2/op_linux_amd64_v1.11.2.zip
nix-prefetch-url --unpack https://cache.agilebits.com/dist/1P/op/pkg/v1.11.2/op_linux_arm_v1.11.2.zip
nix-prefetch-url --unpack https://cache.agilebits.com/dist/1P/op/pkg/v1.11.2/op_apple_universal_v1.11.2.pkg
```

and got

```
path is '/nix/store/wifdcgnjn9p5ljh3vlgdfbfm2vsg3r9j-op_linux_386_v1.11.2.zip'
0rh5bakj9qd43cf6wj5v46a3h98kcwqyc0f1yw72wvcacvjycyjz
path is '/nix/store/28z2c9zw03pfq7cadwcfm3fhj3rq3956-op_linux_amd64_v1.11.2.zip'
00nf0cb8cxk1pvzr1wq778wvikzrlzy38r3rzkq44whdpdj50jzx
path is '/nix/store/fpklzjc39wiw24jc1h2q2jyvsyk1zr03-op_linux_arm_v1.11.2.zip'
1gv282z49bj3ln5na4wb1z5455a64cyd54fp5i96k8shaxd0apxf
path is '/nix/store/qydgwga60z8w3p37ml2csh92505ic76y-op_apple_universal_v1.11.2.pkg'
14j9071ckd7dy7b8687231rbgyxb96iwwdlpxwyngcq57vhl7n7j
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade the 1password CLI to the latest version (I needed some new features for my dotfiles).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  ```
  david@nixos:~/git/nixpkgs/ > ./result/bin/op --version
  1.11.2
  ```
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
