### PR TITLE
support installation of  luarocks packages as vim plugins

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -1,4 +1,4 @@
-# nix name, luarocks name, server, version,luaversion,maintainers
+# nix name,luarocks name,server,version,luaversion,maintainers
 alt-getopt,,,,,arobyn
 ansicolors,,,,,
 argparse,,,,,
@@ -16,6 +16,7 @@ cyrussasl,,,,,
 digestif,,,,lua5_3,
 dkjson,,,,,
 fifo,,,,,
+gitsigns.nvim,,,,lua5_1,
 http,,,,,vcunat
 inspect,,,,,
 ldbus,,http://luarocks.org/dev,,,

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1,5 +1,5 @@
 # TODO check that no license information gets lost
-{ callPackage, config, lib, vimUtils, vim, darwin, llvmPackages }:
+{ callPackage, config, lib, vimUtils, vim, darwin, llvmPackages, luaPackages }:
 
 let
 
@@ -7,7 +7,15 @@ let
 
   inherit (lib) extends;
 
-  initialPackages = self: {};
+  initialPackages = self: {
+    # Convert derivation to a vim plugin.
+    toVimPlugin = drv:
+      drv.overrideAttrs(oldAttrs: {
+        passthru = (oldAttrs.passthru or {}) // {
+          vimPlugin = true;
+        };
+      });
+  };
 
   plugins = callPackage ./generated.nix {
     inherit buildVimPluginFrom2Nix;
@@ -22,7 +30,7 @@ let
   overrides = callPackage ./overrides.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreFoundation CoreServices;
     inherit buildVimPluginFrom2Nix;
-    inherit llvmPackages;
+    inherit llvmPackages luaPackages;
   };
 
   aliases = if (config.allowAliases or true) then (import ./aliases.nix lib) else final: prev: {};

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -86,6 +86,8 @@
 , iferr
 , impl
 , reftools
+# must be lua51Packages
+, luaPackages
 }:
 
 self: super: {
@@ -281,6 +283,8 @@ self: super: {
   gitsigns-nvim = super.gitsigns-nvim.overrideAttrs (old: {
     dependencies = with self; [ plenary-nvim ];
   });
+
+  plenary-nvim = super.toVimPlugin(luaPackages.plenary-nvim);
 
   gruvbox-nvim = super.gruvbox-nvim.overrideAttrs (old: {
     dependencies = with self; [ lush-nvim ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32192,10 +32192,14 @@ in
 
   viewnior = callPackage ../applications/graphics/viewnior { };
 
-  vimUtils = callPackage ../misc/vim-plugins/vim-utils.nix { };
+
+  vimUtils = callPackage ../misc/vim-plugins/vim-utils.nix {
+    inherit (lua51Packages) hasLuaModule;
+  };
 
   vimPlugins = recurseIntoAttrs (callPackage ../misc/vim-plugins {
     llvmPackages = llvmPackages_6;
+    luaPackages = lua51Packages;
   });
 
   vimb-unwrapped = callPackage ../applications/networking/browsers/vimb { };

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -83,7 +83,7 @@ with self; {
   };
 
 
-  inherit toLuaModule lua-setup-hook;
+  inherit toLuaModule hasLuaModule lua-setup-hook;
   inherit buildLuarocksPackage buildLuaApplication;
   inherit requiredLuaModules luaOlder luaAtLeast
     isLua51 isLua52 isLua53 isLuaJIT lua callPackage;


### PR DESCRIPTION
###### Motivation for this change
neovim has a vibrant lua ecosystem and I would like to encourage vim plugin authors to rely on luaroicks rather than having every user specify the dependencies themselves. May lead nowhere.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
