### PR TITLE
OMPython: OpenModelica interface for Python

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1124,6 +1124,12 @@
     email = "sivaraman.balaji@gmail.com";
     name = "Balaji Sivaraman";
   };
+  balodja = {
+    email = "balodja@gmail.com";
+    github = "balodja";
+    githubId = 294444;
+    name = "Vladimir Korolev";
+  };
   baloo = {
     email = "nixpkgs@superbaloo.net";
     github = "baloo";

--- a/pkgs/development/python-modules/ompython/default.nix
+++ b/pkgs/development/python-modules/ompython/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, numpy
+, future
+, pyparsing
+, psutil
+, pyzmq
+}:
+
+buildPythonPackage rec {
+  pname = "OMPython";
+  version = "3.3.0";
+  disabled = pythonOlder "2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6ff325723db358f96d64d1c0621ca2fd8b3cd41c1a6dfe122b761facafa05c8c";
+  };
+
+  propagatedBuildInputs = [ numpy future pyparsing psutil pyzmq ];
+
+  meta = with lib; {
+    description = "OpenModelica Python interface that uses ZeroMQ";
+    homepage = "https://github.com/OpenModelica/OMPython";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ balodja ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4966,6 +4966,8 @@ in {
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };
 
+  ompython = callPackage ../development/python-modules/ompython { };
+
   ondilo = callPackage ../development/python-modules/ondilo { };
 
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };


### PR DESCRIPTION
###### Motivation for this change
This is ongoing effort for incorporating Modelica environment. After resurrecting OpenModelica in #122828, it's time to add Python interface.

###### Things done
Tested with current OpenModelica 1.17.0. Works for me.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
