### PR TITLE
gphotos-sync: add recommended package

### DIFF
--- a/pkgs/tools/backup/gphotos-sync/default.nix
+++ b/pkgs/tools/backup/gphotos-sync/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib, fetchFromGitHub, python3Packages, ffmpeg }:
 
 python3Packages.buildPythonApplication rec {
   pname = "gphotos-sync";
@@ -19,10 +19,14 @@ python3Packages.buildPythonApplication rec {
     pyyaml
     requests_oauthlib
   ];
+
+  buildInputs = [ ffmpeg ];
+
   checkInputs = with python3Packages; [
     pytestCheckHook
     mock
   ];
+
   checkPhase = ''
     export HOME=$(mktemp -d)
 


### PR DESCRIPTION
###### Motivation for this change

Add missing recommended package <https://github.com/gilesknap/gphotos-sync#introduction>:

> the comparison code uses an external tool 'ffprobe'. It will run without it but will not be able to extract metadata from video files and revert to relying on Google Photos meta data and file modified date (this is a much less reliable way to match video files, but the results should be OK if the backup folder was originally created using gphotos-sync).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
