### PR TITLE
[21.05] varnish: bump, add patches for CVE-2021-36740

### DIFF
--- a/pkgs/servers/varnish/6.2-6.3-CVE-2021-36740.patch
+++ b/pkgs/servers/varnish/6.2-6.3-CVE-2021-36740.patch
@@ -1,0 +1,132 @@
+An interpolation of https://github.com/varnishcache/varnish-cache/commit/9be22198e258d0e7a5c41f4291792214a29405cf
+and https://github.com/varnishcache/varnish-cache/commit/82b0a629f60136e76112c6f2c6372cce77b683be
+which applies to both 6.2 and 6.3
+
+diff --git a/bin/varnishd/http2/cache_http2.h b/bin/varnishd/http2/cache_http2.h
+index c377d03aac..205b96ccb7 100644
+--- a/bin/varnishd/http2/cache_http2.h
++++ b/bin/varnishd/http2/cache_http2.h
+@@ -131,6 +131,8 @@ struct h2_req {
+ 	/* Where to wake this stream up */
+ 	struct worker			*wrk;
+ 
++	ssize_t				reqbody_bytes;
++
+ 	VTAILQ_ENTRY(h2_req)		tx_list;
+ 	h2_error			error;
+ 
+diff --git a/bin/varnishd/http2/cache_http2_proto.c b/bin/varnishd/http2/cache_http2_proto.c
+index cb35bb4873..98f5dc4f37 100644
+--- a/bin/varnishd/http2/cache_http2_proto.c
++++ b/bin/varnishd/http2/cache_http2_proto.c
+@@ -546,6 +546,7 @@ h2_end_headers(struct worker *wrk, struct h2_sess *h2,
+     struct req *req, struct h2_req *r2)
+ {
+ 	h2_error h2e;
++	ssize_t cl;
+ 
+ 	ASSERT_RXTHR(h2);
+ 	assert(r2->state == H2_S_OPEN);
+@@ -572,14 +572,24 @@ h2_end_headers(struct worker *wrk, struct h2_sess *h2,
+ 	// XXX: Have I mentioned H/2 Is hodge-podge ?
+ 	http_CollectHdrSep(req->http, H_Cookie, "; ");	// rfc7540,l,3114,3120
+ 
++	cl = http_GetContentLength(req->http);
++	assert(cl >= -2);
++	if (cl == -2) {
++		VSLb(h2->vsl, SLT_Debug, "Non-parseable Content-Length");
++		return (H2SE_PROTOCOL_ERROR);
++	}
++
+ 	if (req->req_body_status == REQ_BODY_INIT) {
+-		if (!http_GetHdr(req->http, H_Content_Length, NULL))
++		if (cl == -1)
+ 			req->req_body_status = REQ_BODY_WITHOUT_LEN;
+ 		else
+ 			req->req_body_status = REQ_BODY_WITH_LEN;
++		req->htc->content_length = cl;
+ 	} else {
++		/* A HEADER frame contained END_STREAM */
+ 		assert (req->req_body_status == REQ_BODY_NONE);
+-		if (http_GetContentLength(req->http) > 0)
++		r2->state = H2_S_CLOS_REM;
++		if (cl > 0)
+ 			return (H2CE_PROTOCOL_ERROR); //rfc7540,l,1838,1840
+ 	}
+ 
+@@ -736,6 +746,7 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
+ 	int w1 = 0, w2 = 0;
+ 	char buf[4];
+ 	unsigned wi;
++	ssize_t cl;
+ 
+ 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+ 	ASSERT_RXTHR(h2);
+@@ -754,6 +765,23 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
+ 	}
+ 	Lck_Lock(&h2->sess->mtx);
+ 	while (h2->mailcall != NULL && h2->error == 0 && r2->error == 0)
+ 		AZ(Lck_CondWait(h2->cond, &h2->sess->mtx, 0));
++
++	r2->reqbody_bytes += h2->rxf_len;
++	if (h2->rxf_flags & H2FF_DATA_END_STREAM)
++		r2->state = H2_S_CLOS_REM;
++	cl = r2->req->htc->content_length;
++	if (cl >= 0 && (r2->reqbody_bytes > cl ||
++	      (r2->state >= H2_S_CLOS_REM && r2->reqbody_bytes != cl))) {
++		VSLb(h2->vsl, SLT_Debug,
++		    "H2: stream %u: Received data and Content-Length"
++		    " mismatch", h2->rxf_stream);
++		r2->error = H2SE_PROTOCOL_ERROR; // rfc7540,l,3150,3163
++		if (r2->cond)
++			AZ(pthread_cond_signal(r2->cond));
++		Lck_Unlock(&h2->sess->mtx);
++		return (H2SE_PROTOCOL_ERROR);
++	}
++
+ 	AZ(h2->mailcall);
+ 	h2->mailcall = r2;
+ 	h2->req0->r_window -= h2->rxf_len;
+@@ -772,6 +800,8 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
+ 		r2->r_window += wi;
+ 		w2 = 1;
+ 	}
++
++
+ 	Lck_Unlock(&h2->sess->mtx);
+ 
+ 	if (w1 || w2) {
+@@ -794,7 +824,7 @@ h2_vfp_body(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr, ssize_t *lp)
+ 	struct h2_req *r2;
+ 	struct h2_sess *h2;
+ 	unsigned l;
+-	enum vfp_status retval = VFP_OK;
++	enum vfp_status retval;
+ 
+ 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
+ 	CHECK_OBJ_NOTNULL(vfe, VFP_ENTRY_MAGIC);
+@@ -807,7 +837,6 @@ h2_vfp_body(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr, ssize_t *lp)
+ 	*lp = 0;
+ 
+ 	Lck_Lock(&h2->sess->mtx);
+-	assert (r2->state == H2_S_OPEN);
+ 	r2->cond = &vc->wrk->cond;
+ 	while (h2->mailcall != r2 && h2->error == 0 && r2->error == 0)
+ 		AZ(Lck_CondWait(r2->cond, &h2->sess->mtx, 0));
+@@ -830,12 +859,10 @@ h2_vfp_body(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr, ssize_t *lp)
+ 			Lck_Unlock(&h2->sess->mtx);
+ 			return (VFP_OK);
+ 		}
+-		if (h2->rxf_len == 0) {
+-			if (h2->rxf_flags & H2FF_DATA_END_STREAM) {
+-				retval = VFP_END;
+-				r2->state = H2_S_CLOS_REM;
+-			}
+-		}
++		if (h2->rxf_len == 0 && r2->state >= H2_S_CLOS_REM)
++			retval = VFP_END;
++		else
++			retval = VFP_OK;
+ 		h2->mailcall = NULL;
+ 		AZ(pthread_cond_signal(h2->cond));
+ 	}

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -41,8 +41,8 @@ let
 in
 {
   varnish60 = common {
-    version = "6.0.7";
-    sha256 = "0njs6xpc30nc4chjdm4d4g63bigbxhi4dc46f4az3qcz51r8zl2a";
+    version = "6.0.8";
+    sha256 = "1zk83hfxgjq1d0n4zx86q3f05y9f2zc6a1miz1zcvfa052q4bljx";
   };
   varnish62 = common {
     version = "6.2.3";

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -2,7 +2,7 @@
 , python3, makeWrapper }:
 
 let
-  common = { version, sha256, extraNativeBuildInputs ? [] }:
+  common = { version, sha256, extraNativeBuildInputs ? [], extraPatches ? [] }:
     stdenv.mkDerivation rec {
       pname = "varnish";
       inherit version;
@@ -11,6 +11,8 @@ let
         url = "https://varnish-cache.org/_downloads/${pname}-${version}.tgz";
         inherit sha256;
       };
+
+      patches = extraPatches;
 
       passthru.python = python3;
 
@@ -47,9 +49,15 @@ in
   varnish62 = common {
     version = "6.2.3";
     sha256 = "02b6pqh5j1d4n362n42q42bfjzjrngd6x49b13q7wzsy6igd1jsy";
+    extraPatches = [
+      ./6.2-6.3-CVE-2021-36740.patch
+    ];
   };
   varnish63 = common {
     version = "6.3.2";
     sha256 = "1f5ahzdh3am6fij5jhiybv3knwl11rhc5r3ig1ybzw55ai7788q8";
+    extraPatches = [
+      ./6.2-6.3-CVE-2021-36740.patch
+    ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-36740

Annoyingly, updates are only available for the 6.0 (LTS) and 6.5 branches. And we have 6.0, 6.2 and 6.3. I've bumped `varnish60` to 6.0.8, but for 6.2 and 6.3 we're on our own.

Fortunately I noticed how similar the fixes for 6.2 and 6.3 were and was able to quite easily interpolate between the two a bit to put together a patch that would work for both.

~Would be nice if someone would bring us up to e.g. 6.5 so we can reasonably justify chucking 6.2 and 6.3 (maybe even 6.0).~ See #131537

~Tested `nixosTests.prometheus-exporters.varnish` as we don't have any real varnish nixos tests.~ Not re-tested yet

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
