### PR TITLE
rsmixer: init at 0.5.5

### DIFF
--- a/pkgs/applications/audio/rsmixer/default.nix
+++ b/pkgs/applications/audio/rsmixer/default.nix
@@ -1,0 +1,35 @@
+{ lib, rustPlatform, fetchFromGitHub, libpulseaudio, makeWrapper }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rsmixer";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "jantap";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "HvmX3GCMExkQ74OGiYsDlsNfJk+i258A5seNy3e+wCw=";
+  };
+
+  cargoLock.lockFile = "${src}/Cargo.lock";
+
+  buildInputs = [ libpulseaudio ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  preFixup = ''
+    wrapProgram $out/bin/rsmixer --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libpulseaudio ]}"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/rsmixer --help
+  '';
+
+  meta = with lib; {
+    description = "A PulseAudio volume mixer written in rust";
+    homepage = "https://github.com/jantap/rsmixer";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nkje ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8565,6 +8565,8 @@ in
 
   rsibreak = libsForQt5.callPackage ../applications/misc/rsibreak { };
 
+  rsmixer = callPackage ../applications/audio/rsmixer { };
+
   rss-bridge-cli = callPackage ../applications/misc/rss-bridge-cli { };
 
   rss2email = callPackage ../applications/networking/feedreaders/rss2email {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add rsmixer which is a PulseAudio volume mixer written in rust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
