### PR TITLE
fldigi: 4.1.18 -> 4.1.19

### DIFF
--- a/pkgs/applications/radio/fldigi/default.nix
+++ b/pkgs/applications/radio/fldigi/default.nix
@@ -13,16 +13,19 @@
 , gettext
 , pkg-config
 , alsa-lib
+, udev
 }:
 
 stdenv.mkDerivation rec {
   pname = "fldigi";
-  version = "4.1.18";
+  version = "4.1.19";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-PH/YSrOoS6RSWyUenVYSDa7mJqODFoSpdP2tR2+QJw0=";
+    sha256 = "0zvfkmvxi31ccbpxvimkcrqrkf3wzr1pgja2ny04srrakl8ff5c7";
   };
+
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     libXinerama
@@ -34,16 +37,13 @@ stdenv.mkDerivation rec {
     portaudio
     libsndfile
     libsamplerate
-    libpulseaudio
-    pkg-config
-    alsa-lib
-  ];
+  ] ++ lib.optionals (stdenv.isLinux) [ libpulseaudio alsa-lib udev ];
 
   meta = with lib; {
     description = "Digital modem program";
     homepage = "https://sourceforge.net/projects/fldigi/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ relrod ftrvxmtrx ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Also fix the build of fldigi on darwin machines.

###### Things done
Built and tested on arm64 darwin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (arm64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
