### PR TITLE
multimon-ng: fix for darwin

### DIFF
--- a/pkgs/applications/radio/multimon-ng/default.nix
+++ b/pkgs/applications/radio/multimon-ng/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "01716cfhxfzsab9zjply9giaa4nn4b7rm3p3vizrwi7n253yiwm2";
   };
 
-  buildInputs = lib.optionals (stdenv.isLinux) [ libpulseaudio libX11 ];
+  buildInputs = lib.optionals stdenv.isLinux [ libpulseaudio libX11 ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/applications/radio/multimon-ng/default.nix
+++ b/pkgs/applications/radio/multimon-ng/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "01716cfhxfzsab9zjply9giaa4nn4b7rm3p3vizrwi7n253yiwm2";
   };
 
-  buildInputs = [ libpulseaudio libX11 ];
+  buildInputs = lib.optionals (stdenv.isLinux) [ libpulseaudio libX11 ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/EliasOenal/multimon-ng";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ markuskowa ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix the multimon-ng package for darwin systems.

###### Things done
Built and tested on arm64 darwin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (arm64)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
