### PR TITLE
ddd: fix desktop icon

### DIFF
--- a/pkgs/development/tools/misc/ddd/default.nix
+++ b/pkgs/development/tools/misc/ddd/default.nix
@@ -10,14 +10,22 @@ stdenv.mkDerivation rec {
   buildInputs = [motif ncurses libX11 libXt];
   configureFlags = [ "--with-x" ];
 
-  patches = [ ./gcc44.patch ];
+  patches = [
+    # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=504868
+    ./gcc44.patch
+  ];
 
   NIX_CFLAGS_COMPILE = "-fpermissive";
+
+  postInstall = ''
+    install -D icons/ddd.xpm $out/share/pixmaps/ddd.xpm
+  '';
 
   meta = {
     homepage = "https://www.gnu.org/software/ddd";
     description = "Graphical front-end for command-line debuggers";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ angustrau ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes missing desktop icon for DDD

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
