### PR TITLE
python3Packages.sphinx-inline-tabs: init at 2021.04.11.beta9

### DIFF
--- a/pkgs/development/python-modules/sphinx-inline-tabs/default.nix
+++ b/pkgs/development/python-modules/sphinx-inline-tabs/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-inline-tabs";
+  version = "2021.04.11.beta9";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "pradyunsg";
+    repo = "sphinx-inline-tabs";
+    rev = version;
+    sha256 = "sha256-UYrLQAXPProjpGPQNkju6+DmzjPG+jbjdKveoeViVTY=";
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+  # no tests, see https://github.com/pradyunsg/sphinx-inline-tabs/issues/6
+  doCheck = false;
+
+  pythonImportsCheck = [ "sphinx_inline_tabs" ];
+
+  meta = with lib; {
+    description = "Add inline tabbed content to your Sphinx documentation";
+    homepage = "https://github.com/pradyunsg/sphinx-inline-tabs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8262,6 +8262,8 @@ in {
 
   sphinx-copybutton = callPackage ../development/python-modules/sphinx-copybutton { };
 
+  sphinx-inline-tabs = callPackage ../development/python-modules/sphinx-inline-tabs { };
+
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
   sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };


### PR DESCRIPTION
###### Motivation for this change
Add sphinx-inline-tabs, which will be useful to build the documentation of the next kitty version using Nix.
I plan to update kitty in #131559 when I finished packaging all new required dependencies.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).