### PR TITLE
apio: 0.7.5 -> 0.7.6

### DIFF
--- a/pkgs/development/tools/misc/apio/default.nix
+++ b/pkgs/development/tools/misc/apio/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonApplication rec {
   pname = "apio";
-  version = "0.7.5";
+  version = "0.7.6";
   format = "flit";
 
   src = fetchFromGitHub {
     owner = "FPGAwars";
     repo = "apio";
     rev = "v${version}";
-    sha256 = "sha256-9f0q6tELUDo6FdjPG708d7BY3O5ZiZ0FwNFzBBiLQp4=";
+    sha256 = "sha256-KmqxwYKsvcTSuUSVXgegR47y9VeU/vICbYWD7z3aDRM=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/FPGAwars/apio/releases/tag/v0.7.6

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).