### PR TITLE
wine{Unstable,Staging}: 6.12 -> 6.13

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.12";
+    version = "6.13";
     url = "https://dl.winehq.org/wine/source/6.x/wine-${version}.tar.xz";
-    sha256 = "1a6fnxb4rci310m0wjcs9cnmpj88775q70qk7xi3k06z1qqbx4pv";
+    sha256 = "sha256-4DohoBHUXSrp8iIED7dpC5cVY3bnQx+GHyAHPq8k8oo=";
     inherit (stable) gecko32 gecko64;
 
     ## see http://wiki.winehq.org/Mono
@@ -65,11 +65,10 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "1mg5yrw5jk2nbdp9mcqc3iar01lr76lmm1py95wify9p2bqzavpp";
+    sha256 = "sha256-3IpO+eQ/+DiQZH6en5Q/p+j441LDvjn4i9Ex7PY8KCk=";
     owner = "wine-staging";
     repo = "wine-staging";
-    # Replace back on next release: rev = "v${version}";
-    rev = "v6.12.1";
+    rev = "v${version}";
 
     disabledPatchsets = [ ];
   };

--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -21,7 +21,10 @@ in stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
 
-  patches = [ ./pipelight.patch ];
+  patches = [
+    ./pipelight.patch
+    ./wine-6.13-new-args.patch
+  ];
 
   configurePhase = ''
     patchShebangs .

--- a/pkgs/tools/misc/pipelight/wine-6.13-new-args.patch
+++ b/pkgs/tools/misc/pipelight/wine-6.13-new-args.patch
@@ -1,0 +1,42 @@
+diff --git a/src/windows/pluginloader/apihook.c b/src/windows/pluginloader/apihook.c
+index 80bf726..6b80f70 100644
+--- a/src/windows/pluginloader/apihook.c
++++ b/src/windows/pluginloader/apihook.c
+@@ -42,7 +42,9 @@
+ #include "common/common.h"
+ #include "pluginloader.h"
+ 
++#define new cnew
+ #include <windows.h>							// for PVOID and other types
++#undef new
+ #include <string.h>								// for memset
+ 
+ void* patchDLLExport(PVOID ModuleBase, const char* functionName, void* newFunctionPtr){
+diff --git a/src/windows/pluginloader/npnfunctions.c b/src/windows/pluginloader/npnfunctions.c
+index e4e38aa..19f29d5 100644
+--- a/src/windows/pluginloader/npnfunctions.c
++++ b/src/windows/pluginloader/npnfunctions.c
+@@ -41,7 +41,9 @@
+ #include "common/common.h"
+ #include "pluginloader.h"
+ 
++#define new cnew
+ #include <windows.h>
++#undef new
+ 
+ /* Shockwave sometimes calls the function with a wrong instance? Is this a wine bug? */
+ NPP shockwaveInstanceBug = NULL;
+diff --git a/src/windows/pluginloader/pluginloader.c b/src/windows/pluginloader/pluginloader.c
+index 8f1170a..99dbceb 100644
+--- a/src/windows/pluginloader/pluginloader.c
++++ b/src/windows/pluginloader/pluginloader.c
+@@ -50,7 +50,9 @@
+ #include "pluginloader.h"
+ #include "apihook.h"
+ 
++#define new cnew
+ #include <windows.h>
++#undef new
+ #include <objbase.h>							// for CoInitializeEx
+ #include <GL/gl.h>
+ 


### PR DESCRIPTION
###### Motivation for this change

Upstream update, @avnik 

@svenkeidel for ugly hack on pipelight

###### Things done

```
$ NIXPKGS_ALLOW_UNFREE=1 nixpkgs-review rev wine-6.13
[...]
14 packages updated:
grapejuice lutris lutris lutris-original pipelight wineUnstable (6.12 → 6.13) winePackages.unstable (6.12 → 6.13) wine-staging (6.12-staging → 6.13-staging) wineStaging (6.12-staging → 6.13-staging) winePackages.staging (6.12-staging → 6.13-staging) wineWowPackages.unstable (6.12 → 6.13) wineWowPackages.staging (6.12-staging → 6.13-staging) yabridge yabridgectl
[...]
12 packages built:
grapejuice lutris lutris-free lutris-unwrapped pipelight wineStaging winePackages.staging wineUnstable wineWowPackages.staging wineWowPackages.unstable yabridge yabridgectl
```

My Windows software still works (although one application required re-installation).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
