### PR TITLE
gast: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/gast/default.nix
+++ b/pkgs/development/python-modules/gast/default.nix
@@ -7,22 +7,13 @@
 
 buildPythonPackage rec {
   pname = "gast";
-  version = "0.5.0";
-
-  # TODO: remove this patch on the next release, this fixes a bug with parsing
-  # assignment expressions e.g., `x := 1`.
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/serge-sans-paille/gast/commit/3cc9b4d05a80e4bb42882de00df314aaa1e6e591.patch";
-      sha256 = "0ylpn0x0a4y6139vd048blsh77yd08npjcn4b5ydf89xnji5mlm1";
-    })
-  ];
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "serge-sans-paille";
     repo = "gast";
     rev = version;
-    sha256 = "0qsg36knv0k2ppzbr5m4w6spxxw7a77lw88y8vjx7m176bajnsbw";
+    sha256 = "1gph45frnj47lfr6idiyxrb3gk7vzc9rni9cijmcyz10dyx5kgwa";
   };
 
   checkInputs = [ astunparse ];

--- a/pkgs/development/python-modules/gast/default.nix
+++ b/pkgs/development/python-modules/gast/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , buildPythonPackage
 , astunparse
 }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR bumps the gast Python package from 0.5.0 to 0.5.1 to pick up a bug fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
