### PR TITLE
seahorse: add glib-networking for sync

### DIFF
--- a/pkgs/desktops/gnome/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome/apps/seahorse/default.nix
@@ -7,6 +7,7 @@
 , pkg-config
 , gtk3
 , glib
+, glib-networking
 , wrapGAppsHook
 , itstool
 , gnupg
@@ -48,6 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     glib
+    glib-networking
     gcr
     gsettings-desktop-schemas
     gnupg


### PR DESCRIPTION
###### Motivation for this change
While syncing with a hkps-server (https) I got a warning that glib-networking is missing for this.

###### Things done
Added glib-networking

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
