### PR TITLE
[Backport release-21.05] eduke32: 20200907 -> 20210722

### DIFF
--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -3,10 +3,6 @@
 , SDL2, SDL2_mixer }:
 
 let
-  version = "20200907";
-  rev = "9257";
-  revExtra = "93f62bbad";
-
   desktopItem = makeDesktopItem {
     name = "eduke32";
     exec = "@out@/bin/${wrapper}";
@@ -18,13 +14,15 @@ let
 
   wrapper = "eduke32-wrapper";
 
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
   pname = "eduke32";
-  inherit version;
+  version = "20210722";
+  rev = "9484";
+  revExtra = "f3fea8c15";
 
   src = fetchurl {
-    url = "http://dukeworld.duke4.net/eduke32/synthesis/latest/eduke32_src_${version}-${rev}-${revExtra}.tar.xz";
-    sha256 = "972630059be61ef9564a241b84ef2ee4f69fc85c19ee36ce46052ff2f1ce3bf9";
+    url = "http://dukeworld.duke4.net/eduke32/synthesis/${version}-${rev}-${revExtra}/eduke32_src_${version}-${rev}-${revExtra}.tar.xz";
+    sha256 = "0fdl2i465cl5x7129772ksx97lvim98m9009q5cfmf6scagj9pvz";
   };
 
   buildInputs = [ alsaLib flac gtk2 libvorbis libvpx libGL libGLU SDL2 SDL2_mixer ];


### PR DESCRIPTION
(cherry picked from commit 94ac68c879f4b172ade9cd7fabca1b9ed85bcdd1)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of: https://github.com/NixOS/nixpkgs/pull/131513

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
