### PR TITLE
mergerfs: 2.32.4 -> 2.32.6

### DIFF
--- a/pkgs/tools/filesystems/mergerfs/default.nix
+++ b/pkgs/tools/filesystems/mergerfs/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mergerfs";
-  version = "2.32.4";
+  version = "2.32.6";
 
   src = fetchFromGitHub {
     owner = "trapexit";
     repo = pname;
     rev = version;
-    sha256 = "sha256-VTnAAJWya1JLZA0gjzpUsdnO5XQP8sJzEP8qHBH+t5k=";
+    sha256 = "sha256-45KZbQuYnPbrcct5Uxo9WW3iwq5+bQKSynMarb5lkyY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/filesystems/mergerfs/tools.nix
+++ b/pkgs/tools/filesystems/mergerfs/tools.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mergerfs-tools";
-  version = "20190411";
+  version = "20210502";
 
   src = fetchFromGitHub {
     owner = "trapexit";
     repo = pname;
-    rev = "6e41fc5848c7cc4408caea86f3991c8cc2ac85a1";
-    sha256 = "0izswg6bya13scvb37l3gkl7mvi8q7l11p4hp4phdlcwh9jvdzcj";
+    rev = "3b6fe008517aeda715c306eaf4914f6f537da88d";
+    sha256 = "sha256-TQGlvFBYoVO8Qa8rAfIbTgTIsW1I3MfYKT5uwkz175Y=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -20,11 +20,17 @@ stdenv.mkDerivation rec {
     "PREFIX=${placeholder "out"}"
   ];
 
-  postInstall = with lib; ''
-    wrapProgram $out/bin/mergerfs.balance --prefix PATH : ${makeBinPath [ rsync ]}
-    wrapProgram $out/bin/mergerfs.dup --prefix PATH : ${makeBinPath [ rsync ]}
-    wrapProgram $out/bin/mergerfs.mktrash --prefix PATH : ${makeBinPath [ python3.pkgs.xattr ]}
-  '';
+  postInstall =
+    let
+      binPath = lib.makeBinPath [
+        rsync
+        python3.pkgs.xattr
+      ];
+    in ''
+      for program in $out/bin/mergerfs.*; do
+        wrapProgram "$program" --prefix PATH : ${binPath}
+      done
+    '';
 
   meta = with lib; {
     description = "Optional tools to help manage data in a mergerfs pool";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Have been running `mergerfs` for the past few days. Anything from `mergerfs-tools` though not really.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
