### PR TITLE
notmuch-bower: 0.12 -> 0.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4801,6 +4801,12 @@
       fingerprint = "7EB1 C02A B62B B464 6D7C  E4AE D1D0 9DE1 69EA 19A0";
     }];
   };
+  jgart = {
+    email = "jgart@dismail.de";
+    github = "jgarte";
+    githubId = 47760695;
+    name = "Jorge Gomez";
+  };
   jgeerds = {
     email = "jascha@geerds.org";
     github = "jgeerds";

--- a/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "notmuch-bower";
-  version = "0.12";
+  version = "0.13";
 
   src = fetchFromGitHub {
     owner = "wangp";
     repo = "bower";
     rev = version;
-    sha256 = "0hvvlbvad6h73iiyn9xshlj073p2ddchgh0pyizh9gi8niir4fn5";
+    sha256 = "0r5s16pc3ym5nd33lv9ljv1p1gpb7yysrdni4g7w7yvjrnwk35l6";
   };
 
   nativeBuildInputs = [ gawk mercury pandoc ];
@@ -18,10 +18,12 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PARALLEL=-j$(NIX_BUILD_CORES)" "bower" "man" ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     mv bower $out/bin/
     mkdir -p $out/share/man/man1
     mv bower.1 $out/share/man/man1/
+    runHook postInstall
   '';
 
   enableParallelBuilding = true;
@@ -30,7 +32,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/wangp/bower";
     description = "A curses terminal client for the Notmuch email system";
     maintainers = with maintainers; [ erictapen ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/wangp/bower";
     description = "A curses terminal client for the Notmuch email system";
-    maintainers = with maintainers; [ erictapen ];
+    maintainers = with maintainers; [ jgart ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Things done

- [x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



Bower 0.13 (2021-07-24)
=======================
Please note there are a few key binding changes.

* Support composing messages with text/html alternative;
  see alt_html_filter config option. (Frank Seifferth)
* Add compose.signature_file config option.
* Support Alt+Key bindings for fast alias expansion in index. (Frank Seifferth)
* Use 'U' to toggle unread instead of 'N'. (Frank Seifferth)
* Add 'N' to search in opposite direction. (Frank Seifferth)
* Add 'w' as an alias to save parts. (Frank Seifferth)
* Add '$' to mark threads or messages as spam. (Sean E. Russell)
* compose: Use 'B' for "edit Bcc". (Frank Seifferth)
* Add thread_ordering config option. (Frank Seifferth)
* Increase thread pane size for long threads. (Frank Seifferth)
* Auto-refresh index view after a period of inactivity (off by default).
* Drop "Non-text part" and "Attachment" lines in reply templates.
* Minor improvements.