### PR TITLE
fulcio: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/security/fulcio/default.nix
+++ b/pkgs/tools/security/fulcio/default.nix
@@ -2,15 +2,15 @@
 
 buildGoModule rec {
   pname = "fulcio";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "sigstore";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-+HWzhg+LTKpr9VJ9mzQghwOuGgp3EBb4/zltaqp0zHw=";
+    rev = "v${version}";
+    sha256 = "sha256-MvLQMGPyJYqYUljLqsr+qJeeYnxdH9aNGkWpDRvOeh8=";
   };
-  vendorSha256 = "sha256-1tR1vUm5eFBS93kELQoKWEyFlfMF28GBI8VEHxTyeM4=";
+  vendorSha256 = "sha256-pRL0et+UOi/tzuQz/Q7UmSA+pVhLJYR8lG8NAbPN9PU=";
 
   ldflags = [ "-s" "-w" ];
 
@@ -18,22 +18,23 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    installShellCompletion --cmd fulcio \
-      --bash <($out/bin/fulcio completion bash) \
-      --fish <($out/bin/fulcio completion fish) \
-      --zsh <($out/bin/fulcio completion zsh)
+    mv $out/bin/fulcio $out/bin/fulcio-server
+    installShellCompletion --cmd fulcio-server \
+      --bash <($out/bin/fulcio-server completion bash) \
+      --fish <($out/bin/fulcio-server completion fish) \
+      --zsh <($out/bin/fulcio-server completion zsh)
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck
-    $out/bin/fulcio --help
+    $out/bin/fulcio-server --help
     runHook postInstallCheck
   '';
 
   meta = with lib; {
     homepage = "https://github.com/sigstore/fulcio";
-    changelog = "https://github.com/sigstore/fulcio/releases/tag/${version}";
+    changelog = "https://github.com/sigstore/fulcio/releases/tag/v${version}";
     description = "A Root-CA for code signing certs - issuing certificates based on an OIDC email address";
     license = licenses.asl20;
     maintainers = with maintainers; [ lesuisse jk ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/sigstore/fulcio/releases/tag/v0.1.1

The binary has been renamed from `fulcio` to `fulcio-server` to match what's given in the `--help` page.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
