### PR TITLE
pythonPackages.inotify-simple: 1.2.1 -> 1.3.5

### DIFF
--- a/pkgs/development/python-modules/inotify-simple/default.nix
+++ b/pkgs/development/python-modules/inotify-simple/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "inotify-simple";
-  version = "1.2.1";
+  version = "1.3.5";
 
   src = fetchPypi {
     pname = "inotify_simple";
     inherit version;
-    sha256 = "132craajflksgxxwjawj73nn1ssv8jn58j3k5vvyiq03avbz4sfv";
+    sha256 = "0a61bh087cq5wfrvz680hg5pmykb9gmy26kwyn6ims2akkjgyh44";
   };
 
   # The package has no tests

--- a/pkgs/development/python-modules/inotify-simple/default.nix
+++ b/pkgs/development/python-modules/inotify-simple/default.nix
@@ -13,6 +13,8 @@ buildPythonPackage rec {
   # The package has no tests
   doCheck = false;
 
+  pythonImportsCheck = [ "inotify_simple" ];
+
   meta = with lib; {
     description = "A simple Python wrapper around inotify";
     homepage = "https://github.com/chrisjbillington/inotify_simple";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I fell into the GitHub Online edit trap -> Fixes my mess in https://github.com/NixOS/nixpkgs/pull/131631

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
