### PR TITLE
aften: apple silicon support

### DIFF
--- a/pkgs/development/libraries/aften/default.nix
+++ b/pkgs/development/libraries/aften/default.nix
@@ -8,14 +8,21 @@ stdenv.mkDerivation rec {
     sha256 = "02hc5x9vkgng1v9bzvza9985ifrjd7fjr7nlpvazp4mv6dr89k47";
   };
 
+  patches = [
+    # Add fallback for missing SIMD functions on ARM
+    # Source https://github.com/Homebrew/homebrew-core/blob/cad412c7fb4b64925f821fcc9ac5f16a2c40f32d/Formula/aften.rb
+    ./simd-fallback.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DSHARED=ON" ];
 
-  meta = {
+  meta = with lib; {
     description = "An audio encoder which generates compressed audio streams based on ATSC A/52 specification";
     homepage = "http://aften.sourceforge.net/";
-    license = lib.licenses.lgpl2;
-    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+    license = licenses.lgpl21Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ angustrau ];
   };
 }

--- a/pkgs/development/libraries/aften/simd-fallback.patch
+++ b/pkgs/development/libraries/aften/simd-fallback.patch
@@ -1,0 +1,25 @@
+From dca9c03930d669233258c114e914a01f7c0aeb05 Mon Sep 17 00:00:00 2001
+From: jbr79 <jbr79@ef0d8562-5c19-0410-972e-841db63a069c>
+Date: Wed, 24 Sep 2008 22:02:59 +0000
+Subject: [PATCH] add fallback function for apply_simd_restrictions() on
+ non-x86/ppc
+
+git-svn-id: https://aften.svn.sourceforge.net/svnroot/aften@766 ef0d8562-5c19-0410-972e-841db63a069c
+---
+ libaften/cpu_caps.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libaften/cpu_caps.h b/libaften/cpu_caps.h
+index b7c6159..4db11f7 100644
+--- a/libaften/cpu_caps.h
++++ b/libaften/cpu_caps.h
+@@ -26,6 +26,7 @@
+ #include "ppc_cpu_caps.h"
+ #else
+ static inline void cpu_caps_detect(void){}
++static inline void apply_simd_restrictions(AftenSimdInstructions *simd_instructions){}
+ #endif
+
+ #endif /* CPU_CAPS_H */
+--
+2.24.3 (Apple Git-128)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Patches aften for Apple Silicon. aften is a dependency of jack2, and this allows jack to build on aarch64-darwin as well.

This patch was found in [Homebrew](https://github.com/Homebrew/homebrew-core/blob/cad412c7fb4b64925f821fcc9ac5f16a2c40f32d/Formula/aften.rb)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
