### PR TITLE
python3Packages.amcrest: 1.7.2 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/amcrest/default.nix
+++ b/pkgs/development/python-modules/amcrest/default.nix
@@ -4,26 +4,30 @@
 , fetchFromGitHub
 , mock
 , pytestCheckHook
+, pythonOlder
 , requests
 , responses
 , urllib3
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "amcrest";
-  version = "1.7.2";
+  version = "1.8.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "tchellomello";
     repo = "python-amcrest";
     rev = version;
-    sha256 = "06gbrshf6vqvq3k813d1w37k2kmps0g6msa4lp2f9xvzw3iczshy";
+    sha256 = "180c0g840vh8dg4f08j0r29pdnhisav93d3axfvicd8fsb2cn36g";
   };
 
   propagatedBuildInputs = [
     argcomplete
     requests
     urllib3
+    typing-extensions
   ];
 
   checkInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.8.0

Change log: https://github.com/tchellomello/python-amcrest/releases/tag/1.8.0

- Related Home Assistant change: https://github.com/home-assistant/core/pull/53784

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
