### PR TITLE
ocamlPackages.pecu: 0.5 -> 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/pecu/default.nix
+++ b/pkgs/development/ocaml-modules/pecu/default.nix
@@ -1,21 +1,21 @@
-{ lib, buildDunePackage, ocaml, fetchurl, fmt, alcotest }:
+{ lib, buildDunePackage, ocaml, fetchurl, fmt, alcotest, crowbar, astring }:
 
 buildDunePackage rec {
   pname = "pecu";
-  version = "0.5";
+  version = "0.6";
 
   useDune2 = true;
 
   minimumOCamlVersion = "4.03";
 
   src = fetchurl {
-    url = "https://github.com/mirage/pecu/releases/download/v0.5/pecu-v0.5.tbz";
-    sha256 = "713753cd6ba3f4609a26d94576484e83ffef7de5f2208a2993576a1b22f0e0e7";
+    url = "https://github.com/mirage/pecu/releases/download/v${version}/pecu-v${version}.tbz";
+    sha256 = "a9d2b7da444c83b20f879f6c3b7fc911d08ac1e6245ad7105437504f9394e5c7";
   };
 
-  # fmt availability
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
-  checkInputs = [ fmt alcotest ];
+  # crowbar availability
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  checkInputs = [ fmt alcotest crowbar astring ];
 
   meta = with lib; {
     description = "Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)";


### PR DESCRIPTION
https://github.com/mirage/pecu/releases/tag/v0.6

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
