### PR TITLE
qtscrcpy: init at 1.7.0

### DIFF
--- a/pkgs/misc/qtscrcpy/default.nix
+++ b/pkgs/misc/qtscrcpy/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, qttools
+, qtx11extras
+, ffmpeg
+, wrapQtAppsHook
+, copyDesktopItems
+, android-tools
+, makeDesktopItem
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtscrcpy";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "barry-ran";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-2d7AIUra7Uc/N0Ako8JYo07GUTPNgorxl2hmeDJOGPU=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook copyDesktopItems ];
+  buildInputs = [ qttools qtx11extras ffmpeg ];
+
+  postPatch = ''
+    substituteInPlace ./QtScrcpy/main.cpp \
+      --replace "../../../third_party/adb/linux/adb" "${android-tools.out}/bin/adb" \
+      --replace "../../../third_party/scrcpy-server" "$out/scrcpy-server"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp ../output/linux/release/QtScrcpy $out/bin/
+    cp ${src}/third_party/scrcpy-server $out/
+    mkdir -p $out/share/pixmaps/
+    cp ${src}/backup/logo.png $out/share/pixmaps/${pname}.png
+    runHook postInstall
+  '';
+
+  # https://aur.archlinux.org/cgit/aur.git/tree/qtscrcpy.desktop?h=qtscrcpy
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      type = "Application";
+      icon = pname;
+      desktopName = "QtScrcpy";
+      exec = "QtScrcpy";
+      terminal = false;
+      categories = "Development;Utility";
+      comment = "Android real-time screencast control tool";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Android real-time display control software";
+    homepage = "https://github.com/barry-ran/QtScrcpy";
+    license = licenses.asl20;
+    maintainers = [ maintainers.vanilla ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26052,6 +26052,8 @@ in
 
   qemacs = callPackage ../applications/editors/qemacs { };
 
+  qtscrcpy = libsForQt5.callPackage ../misc/qtscrcpy { };
+
   rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };


### PR DESCRIPTION
###### Motivation for this change
Android real-time display control software.
(GUI front end of [scrcpy](https://github.com/NixOS/nixpkgs/blob/nixos-21.05/pkgs/misc/scrcpy/default.nix#L58))

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
