### PR TITLE
stdenv: switch shell to oil

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -576,6 +576,8 @@ rec {
           xz.bin
           xz.out
           bash
+          burning-oil
+          oil-uninteractive
           zlib
           libxml2.out
           curl.out

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -590,6 +590,7 @@ rec {
           gmp
           libiconv
           brotli.lib
+          ncurses6
         ] ++ lib.optional haveKRB5 libkrb5) ++
         (with pkgs."${finalLlvmPackages}"; [
           libcxx
@@ -748,6 +749,8 @@ rec {
         ncurses.man
         gnused
         bash
+        burning-oil
+        oil
         gawk
         gnugrep
         patch
@@ -763,6 +766,7 @@ rec {
         brotli.lib
         cc.expand-response-params
         libxml2.out
+        ncurses6
       ] ++ lib.optional haveKRB5 libkrb5
       ++ lib.optionals localSystem.isAarch64 [
         pkgs.updateAutotoolsGnuConfigScriptsHook

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -295,6 +295,14 @@ if [ -z "${SHELL:-}" ]; then echo "SHELL not set"; exit 1; fi
 BASH="$SHELL"
 export CONFIG_SHELL="$SHELL"
 
+# those variables are declared here, since where and if they are used varies
+# shellcheck disable=SC2034
+declare -a failureHooks addInputsHooks userHooks unpackCmdHooks fixupOutputHooks
+declare -a preHooks prePatchHooks preUnpackHooks preConfigureHooks preBuildHooks preInstallHooks preInstallCheckHooks preCheckHooks preFixupHooks preDistHooks
+declare -a postHooks postPathHooks postUnpackHooks postConfigureHooks postBuildHooks postInstallHooks postInstallCheckHooks postCheckHooks postFixupHooks postDistHooks
+declare failureHook addInputsHook userHook unpackCmdHook fixupOutputHook
+declare preHook prePatch preUnpack preConfigure preBuild preInstall preInstallCheck preCheck preFixup preDist
+declare postHook postPatch postUnpack postConfigure postBuild postInstall postInstallCheck postCheck postFixup postDist
 
 # Execute the pre-hook.
 if [ -z "${shell:-}" ]; then export shell="$SHELL"; fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,6 +1,7 @@
 set -eu
 set -o pipefail
 shopt -s inherit_errexit
+shopt -s eval_unsafe_arith || true 2>/dev/null
 
 if [[ -n "${BASH_VERSINFO-}" && "${BASH_VERSINFO-}" -lt 4 ]]; then
     echo "Detected Bash version that isn't supported by Nixpkgs (${BASH_VERSION})"

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -4,40 +4,46 @@
 # compiler and linker that do not search in default locations,
 # ensuring purity of components produced by it.
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
-
-, bootstrapFiles ?
-  let table = {
-    glibc = {
-      i686-linux = import ./bootstrap-files/i686.nix;
-      x86_64-linux = import ./bootstrap-files/x86_64.nix;
-      armv5tel-linux = import ./bootstrap-files/armv5tel.nix;
-      armv6l-linux = import ./bootstrap-files/armv6l.nix;
-      armv7l-linux = import ./bootstrap-files/armv7l.nix;
-      aarch64-linux = import ./bootstrap-files/aarch64.nix;
-      mipsel-linux = import ./bootstrap-files/loongson2f.nix;
-      riscv64-linux = import ./bootstrap-files/riscv64.nix;
+, localSystem
+, crossSystem
+, config
+, overlays
+, crossOverlays ? [ ]
+, bootstrapFiles ? let
+    table = {
+      glibc = {
+        i686-linux = import ./bootstrap-files/i686.nix;
+        x86_64-linux = import ./bootstrap-files/x86_64.nix;
+        armv5tel-linux = import ./bootstrap-files/armv5tel.nix;
+        armv6l-linux = import ./bootstrap-files/armv6l.nix;
+        armv7l-linux = import ./bootstrap-files/armv7l.nix;
+        aarch64-linux = import ./bootstrap-files/aarch64.nix;
+        mipsel-linux = import ./bootstrap-files/loongson2f.nix;
+      };
+      musl = {
+        aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;
+        armv6l-linux = import ./bootstrap-files/armv6l-musl.nix;
+        x86_64-linux = import ./bootstrap-files/x86_64-musl.nix;
+      };
     };
-    musl = {
-      aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;
-      armv6l-linux  = import ./bootstrap-files/armv6l-musl.nix;
-      x86_64-linux  = import ./bootstrap-files/x86_64-musl.nix;
-    };
-  };
 
-  # Try to find an architecture compatible with our current system. We
-  # just try every bootstrap we’ve got and test to see if it is
-  # compatible with or current architecture.
-  getCompatibleTools = lib.foldl (v: system:
-    if v != null then v
-    else if localSystem.isCompatible (lib.systems.elaborate { inherit system; }) then archLookupTable.${system}
-    else null) null (lib.attrNames archLookupTable);
+    # Try to find an architecture compatible with our current system. We
+    # just try every bootstrap we’ve got and test to see if it is
+    # compatible with or current architecture.
+    getCompatibleTools = lib.foldl
+      (v: system:
+        if v != null then v
+        else if localSystem.isCompatible (lib.systems.elaborate { inherit system; }) then archLookupTable.${system}
+        else null)
+      null
+      (lib.attrNames archLookupTable);
 
-  archLookupTable = table.${localSystem.libc}
-    or (abort "unsupported libc for the pure Linux stdenv");
-  files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
+    archLookupTable = table.${localSystem.libc}
+      or (abort "unsupported libc for the pure Linux stdenv");
+    files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
     else (abort "unsupported platform for the pure Linux stdenv"));
-  in files
+  in
+  files
 }:
 
 assert crossSystem == localSystem;
@@ -80,7 +86,7 @@ let
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun = prevStage:
-    { name, overrides ? (self: super: {}), extraNativeBuildInputs ? [] }:
+    { name, overrides ? (self: super: { }), extraNativeBuildInputs ? [ ] }:
 
     let
 
@@ -98,34 +104,37 @@ let
             ${commonPreHook}
           '';
         shell = "${bootstrapTools}/bin/bash";
-        initialPath = [bootstrapTools];
+        initialPath = [ bootstrapTools ];
 
         fetchurlBoot = import ../../build-support/fetchurl/boot.nix {
           inherit system;
         };
 
-        cc = if prevStage.gcc-unwrapped == null
-             then null
-             else lib.makeOverridable (import ../../build-support/cc-wrapper) {
-          name = "${name}-gcc-wrapper";
-          nativeTools = false;
-          nativeLibc = false;
-          buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
-            inherit (prevStage) stdenv;
-          };
-          cc = prevStage.gcc-unwrapped;
-          bintools = prevStage.binutils;
-          isGNU = true;
-          libc = getLibc prevStage;
-          inherit lib;
-          inherit (prevStage) coreutils gnugrep;
-          stdenvNoCC = prevStage.ccWrapperStdenv;
-        };
+        cc =
+          if prevStage.gcc-unwrapped == null
+          then null
+          else
+            lib.makeOverridable (import ../../build-support/cc-wrapper) {
+              name = "${name}-gcc-wrapper";
+              nativeTools = false;
+              nativeLibc = false;
+              buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
+                inherit (prevStage) stdenv;
+              };
+              cc = prevStage.gcc-unwrapped;
+              bintools = prevStage.binutils;
+              isGNU = true;
+              libc = getLibc prevStage;
+              inherit lib;
+              inherit (prevStage) coreutils gnugrep;
+              stdenvNoCC = prevStage.ccWrapperStdenv;
+            };
 
         overrides = self: super: (overrides self super) // { fetchurl = thisStdenv.fetchurlBoot; };
       };
 
-    in {
+    in
+    {
       inherit config overlays;
       stdenv = thisStdenv;
     };
@@ -232,7 +241,7 @@ in
         ccWrapperStdenv
         gcc-unwrapped coreutils gnugrep
         perl gnum4 bison;
-      dejagnu = super.dejagnu.overrideAttrs (a: { doCheck = false; } );
+      dejagnu = super.dejagnu.overrideAttrs (a: { doCheck = false; });
 
       # We need libidn2 and its dependency libunistring as glibc dependency.
       # To avoid the cycle, we build against bootstrap libc, nuke references,
@@ -317,7 +326,7 @@ in
     extraNativeBuildInputs = [ prevStage.patchelf ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (!localSystem.isx86 || localSystem.libc == "musl")
-                   prevStage.updateAutotoolsGnuConfigScriptsHook;
+        prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
 
@@ -360,7 +369,7 @@ in
     extraNativeBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (!localSystem.isx86 || localSystem.libc == "musl")
-                   prevStage.updateAutotoolsGnuConfigScriptsHook;
+        prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
   # Construct the final stdenv.  It uses the Glibc and GCC, and adds
@@ -383,12 +392,12 @@ in
       preHook = commonPreHook;
 
       initialPath =
-        ((import ../common-path.nix) {pkgs = prevStage;});
+        ((import ../common-path.nix) { pkgs = prevStage; });
 
       extraNativeBuildInputs = [ prevStage.patchelf ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
         lib.optional (!localSystem.isx86 || localSystem.libc == "musl")
-        prevStage.updateAutotoolsGnuConfigScriptsHook;
+          prevStage.updateAutotoolsGnuConfigScriptsHook;
 
       cc = prevStage.gcc;
 
@@ -408,21 +417,41 @@ in
       allowedRequisites = with prevStage; with lib;
         # Simple executable tools
         concatMap (p: [ (getBin p) (getLib p) ]) [
-            gzip bzip2 xz bash binutils.bintools coreutils diffutils findutils
-            gawk gnumake gnused gnutar gnugrep gnupatch patchelf ed
-          ]
+          gzip
+          bzip2
+          xz
+          bash
+          binutils.bintools
+          coreutils
+          diffutils
+          findutils
+          gawk
+          gnumake
+          gnused
+          gnutar
+          gnugrep
+          gnupatch
+          patchelf
+          ed
+        ]
         # Library dependencies
         ++ map getLib (
-            [ attr acl zlib pcre libidn2 libunistring ]
-            ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
-          )
+          [ attr acl zlib pcre libidn2 libunistring ]
+          ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
+        )
         # More complicated cases
-        ++ (map (x: getOutput x (getLibc prevStage)) [ "out" "dev" "bin" ] )
-        ++  [ /*propagated from .dev*/ linuxHeaders
-            binutils gcc gcc.cc gcc.cc.lib gcc.expand-response-params
-          ]
-          ++ lib.optionals (!localSystem.isx86 || localSystem.libc == "musl")
-            [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
+        ++ (map (x: getOutput x (getLibc prevStage)) [ "out" "dev" "bin" ])
+        ++ [
+          /*propagated from .dev*/
+          linuxHeaders
+          binutils
+          gcc
+          gcc.cc
+          gcc.cc.lib
+          gcc.expand-response-params
+        ]
+        ++ lib.optionals (!localSystem.isx86 || localSystem.libc == "musl")
+          [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
 
       overrides = self: super: {
         inherit (prevStage)

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -421,6 +421,9 @@ in
           bzip2
           xz
           bash
+          burning-oil
+          oil-uninteractive
+          ncurses6
           binutils.bintools
           coreutils
           diffutils

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11373,15 +11373,42 @@ with pkgs;
   bash_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
     binutils = stdenv.cc.bintools;
   });
-  bash = lowPrio (callPackage ../shells/bash/5.1.nix {
-    binutils = stdenv.cc.bintools;
-  });
+  # bash = lowPrio (callPackage ../shells/bash/5.1.nix {
+  #   binutils = stdenv.cc.bintools;
+  # });
+  bash = lowPrio (burning-oil);
+  burning-oil = pkgs.runCommand "bash-oil" {
+    passthru.shellPath = "/bin/bash";
+    meta.platforms = lib.platforms.all;
+  } ''
+    mkdir -p $out/bin
+    cat <<PROG > $out/bin/bash
+    #!${oil-uninteractive}/bin/osh
+    exec ${oil-uninteractive}/bin/osh -x "\$@"
+    PROG
+    chmod +x "$out/bin/bash"
+    ln -s ${oil-uninteractive}/bin/osh $out/bin/sh
+  '';
+
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = callPackage ../shells/bash/5.1.nix {
-    binutils = stdenv.cc.bintools;
-    interactive = true;
-    withDocs = true;
-  };
+  # bashInteractive = callPackage ../shells/bash/5.1.nix {
+  #   binutils = stdenv.cc.bintools;
+  #   interactive = true;
+  #   withDocs = true;
+  # };
+  bashInteractive = burning-interactive-oil;
+  
+  burning-interactive-oil = pkgs.runCommand "bash-oil" {
+    passthru.shellPath = "/bin/bash";
+  } ''
+    mkdir -p $out/bin
+    cat <<PROG > $out/bin/bash
+    #!${oil}/bin/osh
+    exec ${oil}/bin/osh -x "\$@"
+    PROG
+    chmod +x "$out/bin/bash"
+    ln -s ${oil}/bin/osh $out/bin/sh
+  '';
 
   bashInteractive_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
     binutils = stdenv.cc.bintools;
@@ -11430,6 +11457,7 @@ with pkgs;
   oh = callPackage ../shells/oh { };
 
   oil = callPackage ../shells/oil { };
+  oil-uninteractive = callPackage ../shells/oil { withReadline=false; };
 
   oksh = callPackage ../shells/oksh { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11397,7 +11397,7 @@ with pkgs;
   #   withDocs = true;
   # };
   bashInteractive = burning-interactive-oil;
-  
+
   burning-interactive-oil = pkgs.runCommand "bash-oil" {
     passthru.shellPath = "/bin/bash";
   } ''


### PR DESCRIPTION
###### Motivation for this change

This is a draft PR to test switching the shell to oil shell.
My first try involved setting strict execution options for the shell which are not necessary. (oil:strict_all is like enabling the `e` and `u` flag).
This PR is not meant to be merged as is, it's just a way to test the potential failures.
I've successfully built bash, I'm not sure what to test next.

@zimbatm this is basically your code. Thanks again for initiating this!
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
