### PR TITLE
android-tools: use system fmt

### DIFF
--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl
+{ lib, stdenv, fetchurl, fetchpatch
 , cmake, perl, go
-, protobuf, zlib, gtest, brotli, lz4, zstd, libusb1, pcre2
+, protobuf, zlib, gtest, brotli, lz4, zstd, libusb1, pcre2, fmt_7
 }:
 
 stdenv.mkDerivation rec {
@@ -12,8 +12,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YbO/bCQMsLTQzP72lsVZhuBmV4Q2J9+VD9z2iBrw+NQ=";
   };
 
+  patches = [
+    # fmt 8 breaks the build but we can use fmt 7 from Nixpkgs:
+    (fetchpatch {
+      # Vendor google's version of fmtlib
+      url = "https://github.com/nmeum/android-tools/commit/21061c1dfb006c22304053c1f6f9e48ae4cbe25a.patch";
+      sha256 = "17mcsgfc3i8xq4hck0ppnzafh15aljxy7j2q4djcmwnvrkv9kx3s";
+      revert = true;
+      excludes = [ "vendor/fmtlib" ];
+    })
+  ];
+
   nativeBuildInputs = [ cmake perl go ];
-  buildInputs = [ protobuf zlib gtest brotli lz4 zstd libusb1 pcre2 ];
+  buildInputs = [ protobuf zlib gtest brotli lz4 zstd libusb1 pcre2 fmt_7 ];
 
   # Don't try to fetch any Go modules via the network:
   GOFLAGS = [ "-mod=vendor" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fmt 8.x releases doesn't supported by `platform-tools`. Upstream vendorized fmt 7.x so it can be compiled on distros which bumped fmt to 8.x. `nixpkgs` have both of them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
