### PR TITLE
tracker-miners: drop libgrss

### DIFF
--- a/pkgs/development/libraries/tracker-miners/default.nix
+++ b/pkgs/development/libraries/tracker-miners/default.nix
@@ -26,7 +26,6 @@
 , json-glib
 , libcue
 , libexif
-, libgrss
 , libgsf
 , libgxps
 , libiptcdata
@@ -86,7 +85,6 @@ stdenv.mkDerivation rec {
     json-glib
     libcue
     libexif
-    libgrss
     libgsf
     libgxps
     libiptcdata
@@ -108,6 +106,11 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     # TODO: tests do not like our sandbox
     "-Dfunctional_tests=false"
+
+    # libgrss is unmaintained and has no new releases since 2015, and an open
+    # security issue since then. Despite a patch now being availab, we're opting
+    # to be safe due to the general state of the project
+    "-Dminer_rss=false"
   ];
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`libgrss` hasn't seen activity in years (last commit 2 years ago, last release 6 years ago), and (afaik) the only application that uses it, `gnome-news`, is similarly unmaintained and not part of `nixpkgs` anyway.

As a reported security bug was present since 2016 (only getting a CVE assigned to it this year), it doesn't seem to be a great idea to keep depending on it, as `tracker-miners` is a core part of GNOME.

This drops the dependency completely. I don't think this should be backported to 21.05.

This PR is a follow-on from #131478.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
