### PR TITLE
cgit: support cross-compilation

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
     sha256 = "09lzwa183nblr6l8ib35g2xrjf9wm9yhk3szfvyzkwivdv69c9r2";
   };
 
-  nativeBuildInputs = [ pkg-config ] ++ [ python wrapPython ];
+  nativeBuildInputs = [ pkg-config asciidoc ] ++ [ python wrapPython ];
   buildInputs = [
-    openssl zlib asciidoc libxml2 libxslt docbook_xsl luajit
+    openssl zlib libxml2 libxslt docbook_xsl luajit
   ];
   pythonPath = [ pygments markdown ];
 
@@ -48,9 +48,14 @@ stdenv.mkDerivation rec {
   preBuild = ''
     mkdir -p git
     tar --strip-components=1 -xf "$gitSrc" -C git
-
-    makeFlagsArray+=(prefix="$out" CGIT_SCRIPT_PATH="$out/cgit/")
   '';
+
+  makeFlags = [
+    "prefix=$(out)"
+    "CGIT_SCRIPT_PATH=$out/cgit/"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "AR=${stdenv.cc.targetPrefix}ar"
+  ];
 
   # Install manpage.
   postInstall = ''


### PR DESCRIPTION
asciidoc was in the incorrect location, and CC and AR must be set explictly.

###### Motivation for this change

Support cross-compilation for more packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (on staging)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Building on master is broken due to zstd being broken, but it should work on staging or staging-next (tested on staging). Changes are simple so I don't know if this should target staging anyway or what is best practice.
