### PR TITLE
c3c: init at unstable-2021-07-30

### DIFF
--- a/pkgs/development/compilers/c3c/default.nix
+++ b/pkgs/development/compilers/c3c/default.nix
@@ -1,0 +1,47 @@
+{ llvmPackages
+, lib
+, fetchFromGitHub
+, cmake
+, python3
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+  pname = "c3c";
+  version = "unstable-2021-07-30";
+
+  src = fetchFromGitHub {
+    owner = "c3lang";
+    repo = pname;
+    rev = "2246b641b16e581aec9059c8358858e10a548d94";
+    sha256 = "VdMKdQsedDQCnsmTxO4HnBj5GH/EThspnotvrAscSqE=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.lld
+  ];
+
+  checkInputs = [ python3 ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    ( cd ../resources/testproject; ../../build/c3c build )
+    ( cd ../test; python src/tester.py ../build/c3c test_suite )
+  '';
+
+  installPhase = ''
+    install -Dm755 c3c $out/bin/c3c
+    cp -r lib $out
+  '';
+
+  meta = with lib; {
+    description = "Compiler for the C3 language";
+    homepage = "https://github.com/c3lang/c3c";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14337,6 +14337,10 @@ in
 
   c2ffi = callPackage ../development/tools/misc/c2ffi { };
 
+  c3c = callPackage ../development/compilers/c3c {
+    llvmPackages = llvmPackages_11;
+  };
+
   swfmill = callPackage ../tools/video/swfmill { };
 
   swftools = callPackage ../tools/video/swftools {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
