### PR TITLE
chromiumDev: Fix the build

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -75,15 +75,16 @@ let
     in attrs: concatStringsSep " " (attrValues (mapAttrs toFlag attrs));
 
   # https://source.chromium.org/chromium/chromium/src/+/master:build/linux/unbundle/replace_gn_files.py
-  gnSystemLibraries = [
+  gnSystemLibraries = lib.optionals (!chromiumVersionAtLeast "93") [
     "ffmpeg"
+    "snappy"
+  ] ++ [
     "flac"
     "libjpeg"
     "libpng"
     "libwebp"
     "libxslt"
     "opus"
-    "snappy"
     "zlib"
   ];
 


### PR DESCRIPTION
Our system FFmpeg version is too outdated and Snappy causes a linking
failure (I didn't have time to investigate yet). Hopefully we can revert
this before the stable release of M93.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

FFmpeg failure (4.5 isn't out yet):
```
[33110/47422] CXX obj/media/filters/filters/ffmpeg_demuxer.om_converter.onner.oo-utils.o-utils.oavascript_dialog_extension_client_impl.ohrome/browser/ui/webui/history_clusters/history_clusters.mojom-webui.js
FAILED: obj/media/filters/filters/ffmpeg_demuxer.o
clang++ -MMD -MF obj/media/filters/filters/ffmpeg_demuxer.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DUSE_X11=1 -DOFFICIAL_BUILD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D_GNU_SOURCE -DCR_CLANG_REVISION=\"llvmorg-13-init-15163-g98033fdc-1\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_ABI_UNSTABLE -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_NODISCARD -DCR_LIBCXX_REVISION=79a2e924d96e2fc1e4b937c42efd08898fa472d7 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DIS_MEDIA_IMPL -DUSE_PULSEAUDIO -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_40 -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 -DGL_GLEXT_PROTOTYPES -DUSE_GLX -DUSE_EGL -DVK_USE_PLATFORM_XCB_KHR -DSK_UNTIL_CRBUG_1187654_IS_FIXED -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_WEBP -DSK_ENCODE_PNG -DSK_ENCODE_WEBP -DSK_USER_CONFIG_HEADER=\"../../skia/config/SkUserConfig.h\" -DSK_GL -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_HAS_WUFFS_LIBRARY -DSK_VULKAN_HEADER=\"../../skia/config/SkVulkanConfig.h\" -DSK_VULKAN=1 -DSK_SUPPORT_GPU=1 -DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\" -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DCONFIG_LOG=0 -DDAV1D_API= -I../.. -Igen -I../../buildtools/third_party/libc++ -I../../third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -Igen/shim_headers/zlib_shim -Igen/shim_headers/libpng_shim -Igen/shim_headers/libwebp_shim -I../../third_party/vulkan-deps/vulkan-headers/src/include -I../../third_party/khronos -I../../gpu -I../../third_party/libyuv/include -Igen/shim_headers/ffmpeg_shim -Igen/shim_headers/opus_shim -I../../third_party/abseil-cpp -I../../third_party/boringssl/src/include -I../../third_party/protobuf/src -Igen/protoc_out -I../../third_party/skia -I../../third_party/wuffs/src/release/c -I../../third_party/vulkan/include -I../../third_party/mesa_headers -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/libvpx/source/libvpx -I../../third_party/dav1d/version -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -fcrash-diagnostics-dir=../../tools/clang/crashreports -mllvm -instcombine-lower-dbg-declare=0 -flto=thin -fsplit-lto-unit -fwhole-program-vtables -fcomplete-member-pointers -m64 -march=x86-64 -msse3 -Xclang -fdebug-compilation-dir -Xclang . -no-canonical-prefixes -Wall -Wextra -Wimplicit-fallthrough -Wunreachable-code -Wthread-safety -Wextra-semi -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wenum-compare-conditional -Wno-psabi -Wno-ignored-pragma-optimize -Wno-final-dtor-non-final-class -Wno-builtin-assume-aligned-alignment -Wno-deprecated-copy -Wno-non-c-typedef-for-linkage -Wno-unused-but-set-parameter -Wno-unused-but-set-variable -O2 -fdata-sections -ffunction-sections -fno-unique-section-names -fno-omit-frame-pointer -g0 -ftrivial-auto-var-init=pattern -fsanitize=cfi-vcall -fsanitize-blacklist=../../tools/cfi/ignores.txt -fsanitize=cfi-icall -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wno-shorten-64-to-32 -Wexit-time-destructors -I/nix/store/6l8vy0rpikcw0j1xw67qf983sqpxcfzp-glib-2.68.3-dev/include -I/nix/store/6l8vy0rpikcw0j1xw67qf983sqpxcfzp-glib-2.68.3-dev/include/glib-2.0 -I/nix/store/i6z36ml0nm0vl93q9jn40bwjbi5b6r8g-glib-2.68.3/lib/glib-2.0/include -DPROTOBUF_ALLOW_DEPRECATED=1 -I/nix/store/c35wmlbm5z5qlfz6yazx5vs669x1absf-ffmpeg-4.4-dev/include -I/nix/store/h6mgkjh58f704xp6ra2fvij11sg2xz63-libopus-1.3.1-dev/include/opus -std=c++14 -fno-trigraphs -Wno-trigraphs -fno-exceptions -fno-rtti -nostdinc++ -isystem../../buildtools/third_party/libc++/trunk/include -isystem../../buildtools/third_party/libc++abi/trunk/include -fvisibility-inlines-hidden -c ../../media/filters/ffmpeg_demuxer.cc -o obj/media/filters/filters/ffmpeg_demuxer.o
../../media/filters/ffmpeg_demuxer.cc:431:24: error: no matching function for call to 'av_packet_get_side_data'
    uint8_t* id_data = av_packet_get_side_data(
                       ^~~~~~~~~~~~~~~~~~~~~~~
/nix/store/c35wmlbm5z5qlfz6yazx5vs669x1absf-ffmpeg-4.4-dev/include/libavcodec/packet.h:626:10: note: candidate function not viable: no known conversion from 'size_t *' (aka 'unsigned long *') to 'int *' for 3rd argument
uint8_t* av_packet_get_side_data(const AVPacket *pkt, enum AVPacketSideDataType type,
         ^
../../media/filters/ffmpeg_demuxer.cc:435:30: error: no matching function for call to 'av_packet_get_side_data'
    uint8_t* settings_data = av_packet_get_side_data(
                             ^~~~~~~~~~~~~~~~~~~~~~~
/nix/store/c35wmlbm5z5qlfz6yazx5vs669x1absf-ffmpeg-4.4-dev/include/libavcodec/packet.h:626:10: note: candidate function not viable: no known conversion from 'size_t *' (aka 'unsigned long *') to 'int *' for 3rd argument
uint8_t* av_packet_get_side_data(const AVPacket *pkt, enum AVPacketSideDataType type,
         ^
../../media/filters/ffmpeg_demuxer.cc:447:26: error: no matching function for call to 'av_packet_get_side_data'
    uint8_t* side_data = av_packet_get_side_data(
                         ^~~~~~~~~~~~~~~~~~~~~~~
/nix/store/c35wmlbm5z5qlfz6yazx5vs669x1absf-ffmpeg-4.4-dev/include/libavcodec/packet.h:626:10: note: candidate function not viable: no known conversion from 'size_t *' (aka 'unsigned long *') to 'int *' for 3rd argument
uint8_t* av_packet_get_side_data(const AVPacket *pkt, enum AVPacketSideDataType type,
         ^
../../media/filters/ffmpeg_demuxer.cc:509:43: error: no matching function for call to 'av_packet_get_side_data'
        reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
                                          ^~~~~~~~~~~~~~~~~~~~~~~
/nix/store/c35wmlbm5z5qlfz6yazx5vs669x1absf-ffmpeg-4.4-dev/include/libavcodec/packet.h:626:10: note: candidate function not viable: no known conversion from 'size_t *' (aka 'unsigned long *') to 'int *' for 3rd argument
uint8_t* av_packet_get_side_data(const AVPacket *pkt, enum AVPacketSideDataType type,
         ^
4 errors generated.
[33113/47422] CXX obj/media/filters/filters/vpx_video_decoder.o[Kverter.o
ninja: build stopped: subcommand failed.
```

Snappy (`-L${snappy}/lib` seems to be missing, might be difficult to fix because they deliberately don't even provide a pkg-config file... - likely a problem since https://github.com/chromium/chromium/commit/8dfa5e740cc3628f20c7615636856896caca02e7):
```
[47707/47707] LINK ./chrome/child_dependencies.stampKt_snapshot.stamp.stampoolchain/linux/unbundle:default)[Kion.oKry.oK[Kringcontext2d_webgl2renderingcontext_webglrenderingcontext.olusters.mojom-webui.js
FAILED: chrome
python3 "../../build/toolchain/gcc_link_wrapper.py" --output="./chrome" -- clang++ -Wl,--version-script=../../build/linux/chrome.map -fuse-ld=lld -Wl,--fatal-warnings -Wl,--build-id=sha1 -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--icf=all -Wl,--color-diagnostics -Wl,-mllvm,-instcombine-lower-dbg-declare=0 -flto=thin -Wl,--thinlto-jobs=all -Wl,--thinlto-cache-dir=thinlto-cache -Wl,--thinlto-cache-policy,cache_size=10\%:cache_size_bytes=40g:cache_size_files=100000 -Wl,-mllvm,-import-instr-limit=5 -fwhole-program-vtables -Wl,--no-call-graph-profile-sort -m64 -Wl,-O2 -Wl,--gc-sections -rdynamic -nostdlib++ -Wl,-z,defs -Wl,--as-needed -fsanitize=cfi-vcall -fsanitize=cfi-icall -pie -Wl,--disable-new-dtags -Wl,--lto-O2 -L/nix/store/i6z36ml0nm0vl93q9jn40bwjbi5b6r8g-glib-2.68.3/lib -L/nix/store/pwhfsd9ib89npyh9xrpail4vnbcljyg0-nspr-4.31/lib -L/nix/store/vlddb27vzcxa2fic6w7glir0gq0vwdfp-nss-3.67/lib64 -L/nix/store/dc5s8gxzdh98q614xqhcihfaghnbjz03-at-spi2-atk-2.38.0/lib -L/nix/store/7i229qci6zb9q9pyil82k484dr79x5z3-atk-2.36.0/lib -L/nix/store/djrq4xc4lgx33gdycngv4zhy9f9p5194-libdrm-2.4.107/lib -L/nix/store/ssrk8l0npd2y1s7nx11ffyghiyw42lvi-dbus-1.12.20-lib/lib -L/nix/store/qp16k48xy3ic4armrkgq099ch3vv0lkc-libpng-1.6.37/lib -L/nix/store/zg4jsb0s6l9wnzlz8a20hwni9g67ynlc-zlib-1.2.11/lib -L/nix/store/sq5xwqxisd0favjpvr5crni7zwvarilg-libwebp-1.1.0/lib -L/nix/store/cfa6sbmqkhzhbd8axch4cm65cl1kag67-libxkbcommon-1.3.0/lib -L/nix/store/skphad9mldwxzcmfjvgjvgjz66qqabw8-libopus-1.3.1/lib -L/nix/store/w41vgk36x35vvylwqnnmy6pk0r6y9m49-mesa-21.1.5/lib -L/nix/store/fkr400yicwmw14cbb6jw44js87nb55d2-wayland-1.19.0/lib -L/nix/store/0yi33y4gsn5v68cwfpvm07sjqnr96m3p-cairo-1.16.0/lib -L/nix/store/dnbrvn0syfq66haqidh70y205mj2v1bk-pango-1.48.5/lib -L/nix/store/mfk76q6khi31iwylzj3dld5xza9jlc8q-harfbuzz-2.8.1/lib -L/nix/store/0h4gs3dy0sjc95003142wal55x8c20r2-libpulseaudio-14.2/lib -L/nix/store/ad84nckkmmilnv524ljxzk8qyjwl9m74-at-spi2-core-2.40.2/lib -L/nix/store/3wwsgr5s559ln1bwmdjwy2qhs51a1fql-flac-1.3.3/lib -L/nix/store/ygczqxr27k63jz0lbdp9mgph9rjfszib-gtk+3-3.24.27/lib -L/nix/store/zx504rcla5xd7avq43ilv2c410v1sar1-gdk-pixbuf-2.42.6/lib -L/nix/store/1iihbckplvw2qw8878f4x2bfwqdnhwvm-libxslt-1.1.34/lib -L/nix/store/8di76dfd4zrw3bx1wkgcrqb0qi1nm012-libxml2-2.9.12/lib -o "./chrome" -Wl,--start-group @"./chrome.rsp"  -Wl,--end-group  -ldl -lpthread -lrt -lgmodule-2.0 -lgobject-2.0 -lgthread-2.0 -lglib-2.0 -lsmime3 -lnss3 -lnssutil3 -lplds4 -lplc4 -lnspr4 -latk-1.0 -latk-bridge-2.0 -lcups -ldrm -ldbus-1 -latomic -lz -lresolv -lpng16 -lwebpdemux -lwebpmux -lwebp -ljpeg -lexpat -luuid -lxcb -lxkbcommon -lm -lopus -lX11 -lXcomposite -lXdamage -lXext -lXfixes -lXrender -lXrandr -lXtst -lgio-2.0 -lgbm -lwayland-client -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -lcairo -lXi -lpci -lasound -lpulse -lsnappy -latspi -lminizip -lFLAC -lgtk-3 -lgdk-3 -lcairo-gobject -lgdk_pixbuf-2.0 -lxshmfence -lxslt -lxml2
ld.lld: error: undefined symbol: snappy::Compress(char const*, unsigned long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)
>>> referenced by compression_module.cc
>>>               thinlto-cache/Thin-a3101c.tmp.o:(reporting::CompressionModule::CompressRecord(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, base::OnceCallback<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, absl::optional<reporting::CompressionInformation>)>) const)
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

References:
- https://source.chromium.org/chromium/chromium/src/+/8dfa5e740cc3628f20c7615636856896caca02e7:components/reporting/compression/BUILD.gn
- https://source.chromium.org/chromium/chromium/src/+/main:build/linux/unbundle/snappy.gn;drc=fd2865f3febcd8ba43cc3f4f10e47736dfff1b66
- https://source.chromium.org/chromium/chromium/src/+/main:components/reporting/compression/compression_module.cc;drc=4eac52c693ad07697c6e21b6e12edcb495099544

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
