### PR TITLE
freeplane: 1.8.11 -> 1.9.5

### DIFF
--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "freeplane";
-  version = "1.8.11";
+  version = "1.9.5";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "release-${version}";
-    sha256 = "07xjx9pf62dvy8lx6vnbwwcn1zqy89cmdmwy792k7gb12wz81nnc";
+    sha256 = "qfhhmF3mePxcL4U8izkEmWaiaOLi4slsaymVnDoO3sY=";
   };
 
   deps = stdenv.mkDerivation {
@@ -31,7 +31,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0r7f6713m0whh5hlk1id7z9j5v9494r41sivn9fzl63q70kzz92g";
+    outputHash = "xphTzaSXTGpP7vI/t4oIiv1ZpbekG2dFRzyl3ub6qnA=";
   };
 
   # Point to our local deps repo


### PR DESCRIPTION
version bump of freeplane, see https://github.com/freeplane/freeplane/releases/tag/release-1.9.5

###### Motivation for this change

this fixes an significant and annoying bug: https://sourceforge.net/p/freeplane/discussion/758437/thread/2d9738085a/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
