### PR TITLE
python3Packages.dbus-next: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/development/python-modules/dbus-next/default.nix
+++ b/pkgs/development/python-modules/dbus-next/default.nix
@@ -2,23 +2,22 @@
 , buildPythonPackage
 , fetchFromGitHub
 , python
-, dbus, dbus-python, pytest, pytest-cov, pytest-asyncio, pytest-timeout
+, dbus, pytest, pytest-cov, pytest-asyncio, pytest-timeout
 }:
 
 buildPythonPackage rec {
   pname = "dbus-next";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "altdesktop";
     repo = "python-dbus-next";
     rev = "v${version}";
-    sha256 = "0x78ghkci4las13gwbrm8fzg671lx1q2cn8h0f64ki8yag1myia1";
+    sha256 = "sha256-EKEQZFRUe+E65Z6DNCJFL5uCI5kbXrN7Tzd4O0X5Cqo=";
   };
 
   checkInputs = [
     dbus
-    dbus-python
     pytest
     pytest-cov
     pytest-asyncio


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
