### PR TITLE
[21.05] grub2: 2.06-rc1 -> 2.06

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -39,7 +39,7 @@ let
   canEfi = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) efiSystemsBuild);
   inPCSystems = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) pcSystems);
 
-  version = "2.06-rc1";
+  version = "2.06";
 
 in (
 
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.savannah.gnu.org/grub.git";
     rev = "${pname}-${version}";
-    sha256 = "1ngc960g4w91rg13l724v6nlj6fq1adxp6is2mrq4bnp7sm9mysa";
+    sha256 = "1vkxr6b4p7h259vayjw8bfgqj57x68byy939y4bmyaz6g7fgrv0f";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
backport #126585

* GCC 10 support.
* clang 10 support.
* SBAT support.
* LUKS2 support.
* Drop small MBR gap support.
* Xen Security Modules (XSM/FLASK) support.
* The lockdown mechanism similar to the Linux kernel one.
* Disable the os-prober by default.
* Many backports of GRUB distros specific patches.
* BootHole and BootHole2 fixes.
* XFS bigtime support.
* ...and tons of other fixes and cleanups...

(cherry picked from commit 963b0a1dbf32b80eb6375973bff48af313c2a7c5)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
