### PR TITLE
fmpy: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1044,6 +1044,12 @@
     email = "sivaraman.balaji@gmail.com";
     name = "Balaji Sivaraman";
   };
+  balodja = {
+    email = "balodja@gmail.com";
+    github = "balodja";
+    githubId = 294444;
+    name = "Vladimir Korolev";
+  };
   baloo = {
     email = "nixpkgs@superbaloo.net";
     github = "baloo";

--- a/pkgs/development/libraries/rpclib/default.nix
+++ b/pkgs/development/libraries/rpclib/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+stdenv.mkDerivation rec {
+  pname = "rpclib";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "rpclib";
+    repo = "rpclib";
+    rev = "v${version}";
+    sha256 = "0dlbkl47zd2fkxwbn93w51wmvfr8ssp4zribn5wi4cpiky44a4g9";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "RPC library for C++, providing both a client and server implementation";
+    homepage = "https://github.com/rpclib/rpclib/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ balodja ];
+  };
+}

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , cmake
 , fetchurl
 , python
@@ -8,6 +9,12 @@
 , suitesparse
 , lapackSupport ? true
 , kluSupport ? true
+, enableCvode ? true
+, enableCvodes ? true
+, enableArkode ? true
+, enableIda ? true
+, enableIdas ? true
+, enableKinsol ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -26,13 +33,15 @@ stdenv.mkDerivation rec {
   buildInputs = [
     python
   ]
-    ++ lib.optionals (lapackSupport)
+  ++ lib.optionals (lapackSupport)
     # Check that the same index size is used for both libraries
-    (assert (blas.isILP64 == lapack.isILP64); [
-      gfortran
-      blas
-      lapack
-    ])
+    (
+      assert (blas.isILP64 == lapack.isILP64); [
+        gfortran
+        blas
+        lapack
+      ]
+    )
   # KLU support is based on Suitesparse.
   # It is tested upstream according to the section 1.1.4 of
   # [INSTALL_GUIDE.pdf](https://raw.githubusercontent.com/LLNL/sundials/master/INSTALL_GUIDE.pdf)
@@ -49,15 +58,22 @@ stdenv.mkDerivation rec {
     "-DENABLE_KLU=ON"
     "-DKLU_INCLUDE_DIR=${suitesparse.dev}/include"
     "-DKLU_LIBRARY_DIR=${suitesparse}/lib"
-  ] ++ [(
-    # Use the correct index type according to lapack and blas used. They are
-    # already supposed to be compatible but we check both for extra safety. 64
-    # should be the default but we prefer to be explicit, for extra safety.
-    if blas.isILP64 then
-      "-DSUNDIALS_INDEX_SIZE=64"
-    else
-      "-DSUNDIALS_INDEX_SIZE=32"
-  )]
+  ] ++ [
+    (
+      # Use the correct index type according to lapack and blas used. They are
+      # already supposed to be compatible but we check both for extra safety. 64
+      # should be the default but we prefer to be explicit, for extra safety.
+      if blas.isILP64 then
+        "-DSUNDIALS_INDEX_SIZE=64"
+      else
+        "-DSUNDIALS_INDEX_SIZE=32"
+    )
+  ] ++ lib.optional (!enableCvode) "-DBUILD_CVODE=OFF"
+  ++ lib.optional (!enableCvodes) "-DBUILD_CVODES=OFF"
+  ++ lib.optional (!enableArkode) "-DBUILD_ARKODE=OFF"
+  ++ lib.optional (!enableIda) "-DBUILD_IDA=OFF"
+  ++ lib.optional (!enableIdas) "-DBUILD_IDAS=OFF"
+  ++ lib.optional (!enableKinsol) "-DBUILD_KINSOL=OFF"
   ;
 
   doCheck = true;
@@ -65,9 +81,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Suite of nonlinear differential/algebraic equation solvers";
-    homepage    = "https://computation.llnl.gov/projects/sundials";
-    platforms   = platforms.all;
+    homepage = "https://computation.llnl.gov/projects/sundials";
+    platforms = platforms.all;
     maintainers = with maintainers; [ idontgetoutmuch ];
-    license     = licenses.bsd3;
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/fmpy/default.nix
+++ b/pkgs/development/python-modules/fmpy/default.nix
@@ -1,0 +1,119 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, cvode
+, cmake
+, attrs
+, lark-parser
+, lxml
+, rpclib
+, msgpack
+, numpy
+, scipy
+, pytz
+, dask
+, requests
+, matplotlib
+, pyqt5
+, pyqtgraph
+, notebook
+, plotly
+}:
+
+buildPythonPackage rec {
+  pname = "FMPy";
+  version = "0.3.1";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "CATIA-Systems";
+    repo = "FMPy";
+    rev = "v${version}";
+    sha256 = "0ig08323id84nd9y272hyccky33my2nlhl44m41fxnkrg6xq7z3m";
+  };
+
+  nativeBuildInputs = [ cmake pyqt5 ];
+
+  propagatedBuildInputs = [
+    attrs
+    lark-parser
+    lxml
+    msgpack
+    numpy
+    scipy
+    pytz
+    dask
+    requests
+    matplotlib
+    pyqt5
+    pyqtgraph
+    notebook
+    plotly
+    rpclib
+    cvode
+  ];
+
+  dontUseCmakeConfigure = true;
+  dontUseCmakeBuildDir = true;
+
+  postPatch = ''
+    substitute ${./libraries.py} ./fmpy/sundials/libraries.py \
+        --subst-var-by cvode ${cvode}
+  '';
+
+  # Don't run upstream build scripts as they are too specialized.
+  # And don't build sundials because it is already built.
+  preBuild =
+    let
+      platform = if stdenv.isDarwin then "darwin" else "linux";
+    in
+    ''
+      # Don't reproduce the full build_cvode.py, just two items:
+      # 1. The cswrapper (Model Exchange -> Co-Simulation wrapper).
+      cmakeFlags="-DCVODE_INSTALL_DIR=${cvode} -S cswrapper -B cswrapper/build"
+      cmakeConfigurePhase
+      cmake --build cswrapper/build --config Release
+
+      # 2. fmpy logger.
+      cmakeFlags="-S fmpy/logging -B fmpy/logging/build"
+      cmakeConfigurePhase
+      cmake --build fmpy/logging/build --config Release
+
+      # The reproduction of build_fmucontainer.py:
+      cmakeFlags="-S fmpy/fmucontainer -B fmpy/fmucontainer/${platform}"
+      cmakeConfigurePhase
+      cmake --build fmpy/fmucontainer/${platform} --config Release
+    '' + lib.optionalString stdenv.isLinux ''
+      # The reproduction of build_remoting.py
+      cmakeFlags="-S remoting -B remoting/linux64 -D RPCLIB=${rpclib}"
+      cmakeConfigurePhase
+      cmake --build remoting/linux64 --config Release
+    '';
+
+  # Some of tests are supposed to be failing in upstream, so we don't use
+  # them for package verification at the moment.
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "fmpy"
+    "fmpy.cross_check"
+    "fmpy.cswrapper"
+    "fmpy.examples"
+    "fmpy.fmucontainer"
+    "fmpy.logging"
+    "fmpy.gui"
+    "fmpy.gui.generated"
+    "fmpy.ssp"
+    "fmpy.sundials"
+  ];
+
+  meta = with lib; {
+    description = "A free Python library to simulate Functional Mock-up Units (FMUs)";
+    homepage = "https://github.com/CATIA-Systems/FMPy";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ balodja ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/development/python-modules/fmpy/libraries.py
+++ b/pkgs/development/python-modules/fmpy/libraries.py
@@ -1,0 +1,11 @@
+from ctypes import cdll
+import os
+from fmpy import sharedLibraryExtension
+
+library_dir = '@cvode@'
+
+# load SUNDIALS shared libraries
+sundials_nvecserial     = cdll.LoadLibrary(os.path.join(library_dir, 'lib', 'libsundials_nvecserial'     + sharedLibraryExtension))
+sundials_sunmatrixdense = cdll.LoadLibrary(os.path.join(library_dir, 'lib', 'libsundials_sunmatrixdense' + sharedLibraryExtension))
+sundials_sunlinsoldense = cdll.LoadLibrary(os.path.join(library_dir, 'lib', 'libsundials_sunlinsoldense' + sharedLibraryExtension))
+sundials_cvode          = cdll.LoadLibrary(os.path.join(library_dir, 'lib', 'libsundials_cvode'          + sharedLibraryExtension))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17284,6 +17284,8 @@ in
 
   ronn = callPackage ../development/tools/ronn { };
 
+  rpclib = callPackage ../development/libraries/rpclib { };
+
   rshell = python3.pkgs.callPackage ../development/tools/rshell { };
 
   rttr = callPackage ../development/libraries/rttr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2559,6 +2559,20 @@ in {
 
   flux-led = callPackage ../development/python-modules/flux-led { };
 
+  fmpy = callPackage ../development/python-modules/fmpy {
+    cvode = callPackage ../development/libraries/sundials rec {
+      lapackSupport = false;
+      lapack = { isILP64 = stdenv.hostPlatform.is64bit; };
+      blas = lapack;
+      kluSupport = false;
+      enableCvodes = false;
+      enableArkode = false;
+      enableIda = false;
+      enableIdas = false;
+      enableKinsol = false;
+    };
+  };
+
   fn = callPackage ../development/python-modules/fn { };
 
   fnvhash = callPackage ../development/python-modules/fnvhash { };


### PR DESCRIPTION
###### Motivation for this change
Useful library for dealing with Functional Mock-up Units (see [FMI](https://fmi-standard.org/)) in Python. This is continuation of work in #122828 and #131504

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).