### PR TITLE
streamlink: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -7,13 +7,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "streamlink";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "streamlink";
     repo = "streamlink";
     rev = version;
-    sha256 = "1323v1pavmbb2vk3djdkxd8j6i3yrcgrkyl2d7xwkb7nwlla1x1v";
+    sha256 = "sha256-lsurDFvVHn1rxR3bgG7BY512ISavpja36/UaKXauf+g=";
   };
 
   checkInputs = with python3.pkgs; [
@@ -35,9 +35,11 @@ python3.pkgs.buildPythonApplication rec {
     ffmpeg
   ];
 
-  disabledTests = [
-    "test_plugin_not_in_removed_list"
-  ];
+  # note that upstream currently uses requests 2.25.1 in Windows builds
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'requests>=2.26.0,<3.0' 'requests>=2.25.1,<3.0'
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/streamlink/streamlink";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/streamlink/streamlink/releases/tag/2.3.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Upstream currently forces requests 2.25.1 on Windows (because of an issue with tests they have on the platform), and it's what's currently in nixpkgs, so it should be safe to patch the requirement to that
