### PR TITLE
libcprime: fix application dirs

### DIFF
--- a/pkgs/development/libraries/libcprime/0001-fix-application-dirs.patch
+++ b/pkgs/development/libraries/libcprime/0001-fix-application-dirs.patch
@@ -1,0 +1,29 @@
+From 8e6328e932ab2739f075e8e8d602c2370a2a8ce8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mustafa=20=C3=87al=C4=B1=C5=9Fkan?= <musfay@protonmail.com>
+Date: Wed, 28 Jul 2021 02:26:39 +0300
+Subject: [PATCH] fix application dirs
+
+---
+ cprime/systemxdg.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/cprime/systemxdg.cpp b/cprime/systemxdg.cpp
+index f9eee66..ea0553d 100644
+--- a/cprime/systemxdg.cpp
++++ b/cprime/systemxdg.cpp
+@@ -233,8 +233,10 @@ void SystemXdgMime::setApplicationAsDefault( QString appFileName, QString mimety
+ SystemXdgMime::SystemXdgMime() {
+ 
+ 	appsDirs << QDir::home().filePath( ".local/share/applications/" );
+-	appsDirs << "/usr/local/share/applications/" << "/usr/share/applications/";
+-	appsDirs << "/usr/share/applications/kde4/" << "/usr/share/gnome/applications/";
++	appsDirs << QDir::home().filePath( ".nix-profile/share/applications/" );
++	appsDirs << "/run/current-system/sw/share/applications/";
++	appsDirs << "/run/current-system/sw/share/applications/kde4/";
++	appsDirs << "/run/current-system/sw/share/gnome/applications/";
+ };
+ 
+ DesktopFile SystemXdgMime::xdgDefaultApp( QMimeType mimeType ) {
+-- 
+2.32.0
+

--- a/pkgs/development/libraries/libcprime/default.nix
+++ b/pkgs/development/libraries/libcprime/default.nix
@@ -19,6 +19,8 @@ mkDerivation rec {
     sha256 = "sha256-RywvFATA/+fDP/TR5QRWaJlDgy3EID//iVmrJcj3GXI=";
   };
 
+  patches = [ ./0001-fix-application-dirs.patch ];
+
   nativeBuildInputs = [
     cmake
     ninja


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`libcprime` provides an application picker dialog which being used in most of `coreapps`. This PR fixes paths. Otherwise dialog only shows applications at `~/.local/share/applications`

Tested with [corepdf](https://github.com/NixOS/nixpkgs/pull/131724)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
