### PR TITLE
google-compute-engine: use boto3 with python >= 3.9

### DIFF
--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -5,7 +5,6 @@
 , bashInteractive
 , systemd
 , util-linux
-, boto
 , boto3
 , setuptools
 , distro
@@ -24,12 +23,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ bash ];
-  propagatedBuildInputs = [
-    setuptools
-    distro
-    # boto isn't compatible with python3.9, but boto3 is
-    (if pythonOlder "3.9" then boto else boto3)
-  ];
+  propagatedBuildInputs = [ boto3 setuptools distro ];
 
   postPatch = ''
     for file in $(find google_compute_engine -type f); do

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -6,8 +6,10 @@
 , systemd
 , util-linux
 , boto
+, boto3
 , setuptools
 , distro
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -22,7 +24,12 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ bash ];
-  propagatedBuildInputs = [ boto setuptools distro ];
+  propagatedBuildInputs = [
+    setuptools
+    distro
+    # boto isn't compatible with python3.9, but boto3 is
+    (if pythonOlder "3.9" then boto else boto3)
+  ];
 
   postPatch = ''
     for file in $(find google_compute_engine -type f); do

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -14,6 +14,7 @@
 buildPythonPackage rec {
   pname = "google-compute-engine";
   version = "20190124";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GCE images weren't building because the `boto` package isn't compatible
with Python >= 3.9.

`boto3` supports Python 3.9, so we branch using `pythonOlder` at build time
to determine which version of boto to depend on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
