### PR TITLE
{lib,}fprint: version bumps

### DIFF
--- a/pkgs/development/libraries/libfprint/default.nix
+++ b/pkgs/development/libraries/libfprint/default.nix
@@ -10,6 +10,8 @@
 , nss
 , gobject-introspection
 , coreutils
+, cairo
+, libgudev
 , gtk-doc
 , docbook-xsl-nons
 , docbook_xml_dtd_43
@@ -17,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libfprint";
-  version = "1.90.7";
+  version = "1.92.1";
   outputs = [ "out" "devdoc" ];
 
   src = fetchFromGitLab {
@@ -25,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "libfprint";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-g/yczzCZEzUKV2uFl1MAPL1H/R2QJSwxgppI2ftt9QI=";
+    sha256 = "0dpwzmwl9jjpaz44znvy3v8s9sln0c71b756rs1knk0zx8sa1qbc";
   };
 
   nativeBuildInputs = [
@@ -43,6 +45,8 @@ stdenv.mkDerivation rec {
     pixman
     glib
     nss
+    cairo
+    libgudev
   ];
 
   checkInputs = [
@@ -53,6 +57,7 @@ stdenv.mkDerivation rec {
     "-Dudev_rules_dir=${placeholder "out"}/lib/udev/rules.d"
     # Include virtual drivers for fprintd tests
     "-Ddrivers=all"
+    "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
   ];
 
   doCheck = true;
@@ -61,7 +66,9 @@ stdenv.mkDerivation rec {
     patchShebangs \
       tests/test-runner.sh \
       tests/unittest_inspector.py \
-      tests/virtual-image.py
+      tests/virtual-image.py \
+      tests/umockdev-test.py \
+      tests/test-generated-hwdb.sh
   '';
 
   meta = with lib; {

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation rec {
   pname = "fprintd";
-  version = "1.90.9";
+  version = "1.92.0";
   outputs = [ "out" "devdoc" ];
 
   src = fetchFromGitLab {
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     owner = "libfprint";
     repo = pname;
     rev = "v${version}";
-    sha256 = "rOTVThHOY/Q2IIu2RGiv26UE2V/JFfWWnfKZQfKl5Mg=";
+    sha256 = "0bqzxxb5iq3pdwdv1k8wsx3alirbjla6zgcki55b5p6mzrvk781x";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Brings support for more fingerprint sensors, in particular the Framework laptop uses a 27c6:609c Goodix sensor.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
