### PR TITLE
Elixir update

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -42,6 +42,14 @@ let
     nativeBuildInputs = nativeBuildInputs ++ [ elixir hex ];
     propagatedBuildInputs = propagatedBuildInputs ++ beamDeps;
 
+    configurePhase = attrs.configurePhase or ''
+      runHook preConfigure
+
+      ${./mix-configure-hook.sh}
+
+      runHook postConfigure
+    '';
+
     buildPhase = attrs.buildPhase or ''
       runHook preBuild
       export HEX_HOME="$TEMPDIR/hex"
@@ -83,3 +91,4 @@ let
   });
 in
 fix pkg
+

--- a/pkgs/development/beam-modules/mix-configure-hook.sh
+++ b/pkgs/development/beam-modules/mix-configure-hook.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+# this hook will symlink all dependencies found in ERL_LIBS
+# since Elixir 1.12.2 elixir does not look into ERL_LIBS for
+# elixir depencencies anymore, so those have to be symlinked to the _build directory
+mkdir -p _build/"$MIX_ENV"/lib
+while read -r -d ':' lib; do
+    for dir in "$lib"/*; do
+    # Strip version number for directory name if it exists, so naming of
+    # all libs matches what mix's expectation.
+    dest=$(basename "$dir" | cut -d '-' -f1)
+    build_dir="_build/$MIX_ENV/lib/$dest"
+    ((MIX_DEBUG == 1)) && echo "Linking $dir to $build_dir"
+    # Symlink libs to _build so that mix can find them when compiling.
+    # This is what allows mix to compile the package without searching
+    # for dependencies over the network.
+    ln -s "$dir" "$build_dir"
+    done
+done <<< "$ERL_LIBS:"

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -58,20 +58,7 @@ stdenv.mkDerivation (overridable // {
   configurePhase = attrs.configurePhase or ''
     runHook preConfigure
 
-    mkdir -p _build/$MIX_ENV/lib
-    while read -d ':' lib; do
-      for dir in $lib/*; do
-        # Strip version number for directory name if it exists, so naming of
-        # all libs matches what mix's expectation.
-        dest=$(basename $dir | cut -d '-' -f1)
-        echo "Linking $dir to _build/$MIX_ENV/lib/$dest"
-        # Symlink libs to _build so that mix can find them when compiling.
-        # This is what allows mix to compile the package without searching
-        # for dependencies over the network.
-        ln -s $dir _build/$MIX_ENV/lib/$dest
-      done
-    done <<< "$ERL_LIBS:"
-
+    ${./mix-configure-hook.sh}
     # this is needed for projects that have a specific compile step
     # the dependency needs to be compiled in order for the task
     # to be available

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -58,6 +58,20 @@ stdenv.mkDerivation (overridable // {
   configurePhase = attrs.configurePhase or ''
     runHook preConfigure
 
+    mkdir -p _build/$MIX_ENV/lib
+    while read -d ':' lib; do
+      for dir in $lib/*; do
+        # Strip version number for directory name if it exists, so naming of
+        # all libs matches what mix's expectation.
+        dest=$(basename $dir | cut -d '-' -f1)
+        echo "Linking $dir to _build/$MIX_ENV/lib/$dest"
+        # Symlink libs to _build so that mix can find them when compiling.
+        # This is what allows mix to compile the package without searching
+        # for dependencies over the network.
+        ln -s $dir _build/$MIX_ENV/lib/$dest
+      done
+    done <<< "$ERL_LIBS:"
+
     # this is needed for projects that have a specific compile step
     # the dependency needs to be compiled in order for the task
     # to be available

--- a/pkgs/development/interpreters/elixir/1.12.nix
+++ b/pkgs/development/interpreters/elixir/1.12.nix
@@ -3,7 +3,7 @@
 # How to obtain `sha256`:
 # nix-prefetch-url --unpack https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz
 mkDerivation {
-  version = "1.12.1";
-  sha256 = "sha256-gRgGXb4btMriQwT/pRIYOJt+NM7rtYBd+A3SKfowC7k=";
+  version = "1.12.2";
+  sha256 = "sha256-PQkvBaQQljATt+LA3hWJOFyQessqqR1t6o1J2LHllec=";
   minimumOTPVersion = "22";
 }


### PR DESCRIPTION
###### Motivation for this change

Following a discussion from https://github.com/NixOS/nixpkgs/pull/129094

There was a breaking change in elixir 1.12.2 in the way libraries are loaded when building.
Before 1.12.2 adding a library path to ERL_LIBS was sufficient for mix to find the library
Now the library needs to be present in the build directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
