### PR TITLE
usbsdmux: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/development/tools/misc/usbsdmux/default.nix
+++ b/pkgs/development/tools/misc/usbsdmux/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "usbsdmux";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-ydDUSqBTY62iOtWdgrFh2qrO9LMi+OCYIw5reh6uoIA=";
+    sha256 = "sha256-gCxwR5jxzkH22B6nxBwAd0HpwWMIj/zp5VROJ0IWq7c=";
   };
 
   # usbsdmux is not meant to be used as an importable module and has no tests


### PR DESCRIPTION
###### Motivation for this change
New upstream release:
- The get command now respects the hardware signal priority. Until now
  this command returned the wrong value if the USB-SD-Mux was switched
  to off.
- An error leading to creation of files in /dev/ when using the tool as
  root and if the device-node does not exist was fixed.  This error lead
  to errors like OSError: [Errno 25] Inappropriate ioctl for device. Now
  the actual error File not found will be raised instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
