### PR TITLE
Various crystal improvements

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/thicket/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/thicket/default.nix
@@ -1,10 +1,10 @@
 { lib
 , fetchFromGitHub
-, crystal_0_33
+, crystal_1_0
 }:
 
 let
-  crystal = crystal_0_33;
+  crystal = crystal_1_0;
 
 in crystal.buildCrystalPackage rec {
   pname = "thicket";

--- a/pkgs/applications/version-management/git-and-tools/thicket/shards.nix
+++ b/pkgs/applications/version-management/git-and-tools/thicket/shards.nix
@@ -2,7 +2,7 @@
   ameba = {
     owner = "veelenga";
     repo = "ameba";
-    rev = "v0.10.0";
-    sha256 = "1yjxzwdhigsyjn0qp362jkj85qvg4dsyzal00pgr1srnh2xry912";
+    rev = "v0.14.3";
+    sha256 = "1cfr95xi6hsyxw1wlrh571hc775xhwmssk3k14i8b7dgbwfmm5x1";
   };
 }

--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation (mkDerivationArgs // {
 
   installCheckPhase = args.installCheckPhase or ''
     for f in $out/bin/*; do
-      $f --help
+      $f --help > /dev/null
     done
   '';
 

--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -10,7 +10,7 @@
 , format ? "make"
 , installManPages ? true
   # Specify binaries to build in the form { foo.src = "src/foo.cr"; }
-  # The default `crystal build` options can be overridden with { foo.options = [ "--no-debug" ]; }
+  # The default `crystal build` options can be overridden with { foo.options = [ "--optionname" ]; }
 , crystalBinaries ? { }
 , ...
 }@args:
@@ -32,8 +32,7 @@ let
     })
     (import shardsFile));
 
-  # we previously had --no-debug here but that is not recommended by upstream
-  defaultOptions = [ "--release" "--progress" "--verbose" ];
+  defaultOptions = [ "--release" "--progress" "--verbose" "--no-debug" ];
 
   buildDirectly = shardsFile == null || crystalBinaries != { };
 

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -219,48 +219,6 @@ let
 
 in
 rec {
-  binaryCrystal_0_31 = genericBinary {
-    version = "0.31.1";
-    sha256s = {
-      x86_64-linux = "0r8salf572xrnr4m6ll9q5hz6jj8q7ff1rljlhmqb1r26a8mi2ih";
-      i686-linux = "0hridnis5vvrswflx0q67xfg5hryhz6ivlwrb9n4pryj5d1gwjrr";
-      x86_64-darwin = "1dgxgv0s3swkc5cwawzgpbc6bcd2nx4hjxc7iw2h907y1vgmbipz";
-    };
-  };
-
-  crystal_0_31 = generic {
-    version = "0.31.1";
-    sha256 = "1dswxa32w16gnc6yjym12xj7ibg0g6zk3ngvl76lwdjqb1h6lwz8";
-    doCheck = false; # 5 checks are failing now
-    binary = binaryCrystal_0_31;
-  };
-
-  crystal_0_32 = generic {
-    version = "0.32.1";
-    sha256 = "120ndi3nhh2r52hjvhwfb49cdggr1bzdq6b8xg7irzavhjinfza6";
-    binary = crystal_0_31;
-  };
-
-  crystal_0_33 = generic {
-    version = "0.33.0";
-    sha256 = "1zg0qixcws81s083wrh54hp83ng2pa8iyyafaha55mzrh8293jbi";
-    binary = crystal_0_32;
-  };
-
-  crystal_0_34 = generic {
-    version = "0.34.0";
-    sha256 = "110lfpxk9jnqyznbfnilys65ixj5sdmy8pvvnlhqhc3ccvrlnmq4";
-    binary = crystal_0_33;
-  };
-
-  crystal_0_35 = generic {
-    version = "0.35.1";
-    sha256 = "0p51bjl1nsvwsm64lqq421dcsxa201w7wwq8plw4r8wqarpq0g69";
-    binary = crystal_0_34;
-    # Needs git to build as per https://github.com/crystal-lang/crystal/issues/9789
-    extraBuildInputs = [ git ];
-  };
-
   binaryCrystal_0_36 = genericBinary {
     version = "0.36.1";
     sha256s = {

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -214,8 +214,7 @@ let
         license = licenses.asl20;
         maintainers = with maintainers; [ david50407 fabianhjr manveru peterhoeg ];
         platforms = builtins.attrNames archs;
-        # Error running at_exit handler: Nil assertion failed
-        broken = lib.versions.minor version == "32" && stdenv.isDarwin;
+        broken = lib.versionOlder version "0.36.1" && stdenv.isDarwin;
       };
     })
   );
@@ -264,10 +263,19 @@ rec {
     extraBuildInputs = [ git ];
   };
 
+  binaryCrystal_0_36 = genericBinary {
+    version = "0.36.1";
+    sha256s = {
+      x86_64-linux = "065vzq34g7hgzl2mrzy9gwwsfikc78nj7xxsbrk67r6rz0a7bk1q";
+      i686-linux = "18m4b1lnd682i5ygbg6cljqjny60nn2mlrzrk765h2ip6fljqbm1";
+      x86_64-darwin = "0xggayk92zh64pb5sz77n12hkcd1hg8kw90z7gb18594q551sf1v";
+    };
+  };
+
   crystal_0_36 = generic {
     version = "0.36.1";
     sha256 = "sha256-5rjrvwZKM4lHpmxLyUVbi0Zw98xT+iJKonxwfUwS/Wk=";
-    binary = crystal_0_35;
+    binary = binaryCrystal_0_36;
   };
 
   crystal_1_0 = generic {

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , crystal_0_34
 , crystal_0_36
+, crystal_1_0
 }:
 let
   generic =
@@ -49,5 +50,11 @@ rec {
     crystal = crystal_0_36;
   };
 
-  shards = shards_0_14;
+  shards_0_15 = generic {
+    version = "0.15.0";
+    sha256 = "sha256-/C6whh5RbTBkFWqpn0GqyVe0opbrklm8xPv5MIG99VU=";
+    crystal = crystal_1_0;
+  };
+
+  shards = shards_0_15;
 }

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -1,7 +1,5 @@
 { lib
 , fetchFromGitHub
-, crystal_0_34
-, crystal_0_36
 , crystal_1_0
 }:
 let
@@ -37,18 +35,6 @@ let
 
 in
 rec {
-  # needed for anything that requires the old v1 shards format
-  shards_0_11 = generic {
-    version = "0.11.1";
-    sha256 = "05qnhc23xbmicdl4fwyxfpcvd8jq4inzh6v7jsjjw4n76vzb1f71";
-    crystal = crystal_0_34;
-  };
-
-  shards_0_14 = generic {
-    version = "0.14.1";
-    sha256 = "sha256-/C6whh5RbTBkFWqpn0GqyVe0opbrklm8xPv5MIG99VU=";
-    crystal = crystal_0_36;
-  };
 
   shards_0_15 = generic {
     version = "0.15.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11118,9 +11118,6 @@ with pkgs;
   inherit (callPackages ../development/compilers/crystal {
     llvmPackages = llvmPackages_10;
   })
-    crystal_0_33
-    crystal_0_34
-    crystal_0_35
     crystal_0_36
     crystal_1_0
     crystal;
@@ -14721,8 +14718,6 @@ with pkgs;
   shallot = callPackage ../tools/misc/shallot { };
 
   inherit (callPackage ../development/tools/build-managers/shards { })
-    shards_0_11
-    shards_0_14
     shards_0_15
     shards;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14723,6 +14723,7 @@ with pkgs;
   inherit (callPackage ../development/tools/build-managers/shards { })
     shards_0_11
     shards_0_14
+    shards_0_15
     shards;
 
   shellcheck = callPackage ../development/tools/shellcheck {};


### PR DESCRIPTION
###### Motivation for this change

darwin builds were broken for all above 0_32
because 0_32 was marked broken and thus broke the dependency chain
Should close #131268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
