### PR TITLE
nixos/nix-daemon: fix registry flake type

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -458,7 +458,7 @@ in
                 description = "The flake reference to which <option>from></option> is to be rewritten.";
               };
               flake = mkOption {
-                type = types.unspecified;
+                type = types.nullOr types.attrs;
                 default = null;
                 example = literalExample "nixpkgs";
                 description = ''


### PR DESCRIPTION
Before this commit, the `flake` option was typed with `types.unspecified`.

This type get's merged via [`mergeDefaultOption`](https://github.com/NixOS/nixpkgs/blob/ebb592a04c5282f316d60cd4aba066f6e5d74b65/lib/options.nix#L119-L128), which has a line
```nix
else if all isFunction list then x: mergeDefaultOption loc (map (f: f x) list)
```

`lib.isFunction` detects an attrs in the shape of `{__functor = ...}` as
a function and hence this line substitutes such attrs with a function
(`f: f x`).

If now, a flake input has a `__functor` as it's output, this will
coerce the once attrs to a function. This breaks a lot of things later
in the stack, for example a later `lib.filterAttrs seive <LAMBDA>` will
fail for obious reasons.

According to @infinisil, `types.unspecified` is due to deprecation. In
the meantime this PR provides a specific fix for the specific problem
discovered.

EDIT: this needs quite some back-porting, please someone can add the respective labels?
