### PR TITLE
unixcw: fix qt wrapping

### DIFF
--- a/pkgs/applications/radio/unixcw/default.nix
+++ b/pkgs/applications/radio/unixcw/default.nix
@@ -1,5 +1,5 @@
-{lib, stdenv, fetchurl, libpulseaudio, alsa-lib , pkg-config, qt5}:
-stdenv.mkDerivation rec {
+{lib, mkDerivation, fetchurl, libpulseaudio, alsa-lib , pkg-config, qt5}:
+mkDerivation rec {
   pname = "unixcw";
   version = "3.5.1";
   src = fetchurl {
@@ -11,8 +11,6 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [libpulseaudio alsa-lib pkg-config qt5.qtbase];
   CFLAGS   ="-lasound -lpulse-simple";
-
-  dontWrapQtApps = true;
 
   meta = with lib; {
     description = "sound characters as Morse code on the soundcard or console speaker";

--- a/pkgs/applications/radio/unixcw/default.nix
+++ b/pkgs/applications/radio/unixcw/default.nix
@@ -9,7 +9,7 @@ mkDerivation rec {
   patches = [
     ./remove-use-of-dlopen.patch
   ];
-  buildInputs = [libpulseaudio alsa-lib pkg-config qt5.qtbase];
+  buildInputs = [ libpulseaudio alsa-lib pkg-config qtbase ];
   CFLAGS   ="-lasound -lpulse-simple";
 
   meta = with lib; {

--- a/pkgs/applications/radio/unixcw/default.nix
+++ b/pkgs/applications/radio/unixcw/default.nix
@@ -1,4 +1,5 @@
-{lib, mkDerivation, fetchurl, libpulseaudio, alsa-lib , pkg-config, qt5}:
+{ lib, mkDerivation, fetchurl, libpulseaudio, alsa-lib , pkg-config, qtbase }:
+
 mkDerivation rec {
   pname = "unixcw";
   version = "3.5.1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31901,7 +31901,7 @@ in
 
   unicode-paracode = callPackage ../tools/misc/unicode { };
 
-  unixcw = callPackage ../applications/radio/unixcw { };
+  unixcw = libsForQt5.callPackage ../applications/radio/unixcw { };
 
   vault = callPackage ../tools/security/vault { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
xcwcp gave a qt error and failed to start.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
