### PR TITLE
coqPackages.VST: also build and install floyd.io_events

### DIFF
--- a/pkgs/development/coq-modules/VST/default.nix
+++ b/pkgs/development/coq-modules/VST/default.nix
@@ -1,4 +1,16 @@
-{ lib, mkCoqDerivation, coq, compcert, version ? null }:
+{ lib, mkCoqDerivation, coq, compcert, ITree, version ? null }:
+
+# A few modules that are not built and installed by default
+#  but that may be useful to some users.
+# They depend on ITree.
+let extra_floyd_files = [
+  "ASTsize.v"
+  "io_events.v"
+  "powerlater.v"
+  "printf.v"
+  "quickprogram.v"
+  ];
+in
 
 with lib; mkCoqDerivation {
   pname = "coq${coq.coq-version}-VST";
@@ -12,9 +24,14 @@ with lib; mkCoqDerivation {
   ] null;
   release."2.8".sha256 = "sha256-cyK88uzorRfjapNQ6XgQEmlbWnDsiyLve5po1VG52q0=";
   releaseRev = v: "v${v}";
+  extraBuildInputs = [ ITree ];
   propagatedBuildInputs = [ compcert ];
 
-  preConfigure = "patchShebangs util";
+  preConfigure = ''
+    patchShebangs util
+    substituteInPlace Makefile \
+      --replace 'FLOYD_FILES=' 'FLOYD_FILES= ${toString extra_floyd_files}'
+  '';
 
   makeFlags = [
     "BITSIZE=64"


### PR DESCRIPTION
###### Motivation for this change

Fixes #131203

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
