### PR TITLE
Mold: 0.9.2 -> 0.9.3, apply patch: "Intercept all invocations of ld, ld.gold or ld.lld"

### DIFF
--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , lib
 , autoPatchelfHook
 , cmake
@@ -19,6 +20,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256:1z9i8nvdl9h0zydh1gd9244q96n9x1gh5y90m71bghnh7nws0zmd";
   };
+
+  patches = [
+    # Intercept all invocations of ld, ld.gold or ld.lld
+    (fetchpatch {
+      url = "https://github.com/rui314/mold/commit/d25c2553ad3cfa39d99043927db1af2c028b5acf.patch";
+      sha256 = "1ic1dyvjcrj6834n6mw9id50l6nymrfn6hws6pjpy8gjk6mqfvnk";
+    })
+  ];
 
   buildInputs = [ zlib openssl ];
   nativeBuildInputs = [ autoPatchelfHook cmake xxHash ];

--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -3,7 +3,6 @@
 , lib
 , autoPatchelfHook
 , cmake
-, tbb
 , llvmPackages_latest
 , xxHash
 , zlib
@@ -12,16 +11,16 @@
 
 stdenv.mkDerivation rec {
   pname = "mold";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "rui314";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2LXOPirhjAifKYPgngUJwEdGrKMYsRySr5TL2x2p8J0=";
+    sha256 = "sha256:1z9i8nvdl9h0zydh1gd9244q96n9x1gh5y90m71bghnh7nws0zmd";
   };
 
-  buildInputs = [ tbb zlib openssl ];
+  buildInputs = [ zlib openssl ];
   nativeBuildInputs = [ autoPatchelfHook cmake xxHash ];
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/rui314/mold/issues/101, https://github.com/NixOS/nixpkgs/pull/128889#issuecomment-887736966

###### Things done

I've confirmed that `mold --run cargo build` uses mold as the linker.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
