### PR TITLE
nixos-rebuild: Set inherit_errexit

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -4,6 +4,7 @@ if [ -x "@runtimeShell@" ]; then export SHELL="@runtimeShell@"; fi;
 
 set -e
 set -o pipefail
+shopt -s inherit_errexit
 
 export PATH=@path@:$PATH
 


### PR DESCRIPTION
Without this, failure of `nixBuild()` and `nixFlakeBuild()` was ignored (since bash doesn't inherit `set -e` in subshells by default), so the script would proceed with a bogus `./result` link, e.g. 

```
++ readlink -f /tmp/nixos-rebuild.NfHKxx/result
+ pathToConfig='/nix/store/m7dvk6an18cpr95qn5wnig2600qhv6w7-nix-2.4pre20210727_706777a/bin/nix
/tmp/nixos-rebuild.NfHKxx/result'
+ '[' test = switch -o test = boot ']'
+ copyToTarget '/nix/store/m7dvk6an18cpr95qn5wnig2600qhv6w7-nix-2.4pre20210727_706777a/bin/nix
/tmp/nixos-rebuild.NfHKxx/result'
+ '[' '' = '' ']'
+ '[' test = switch -o test = boot -o test = test -o test = dry-activate ']'
+ targetHostCmd /nix/store/m7dvk6an18cpr95qn5wnig2600qhv6w7-nix-2.4pre20210727_706777a/bin/nix /tmp/nixos-rebuild.NfHKxx/result/bin/switch-to-configuration test
+ '[' -z '' ']'
+ sudo -- /nix/store/m7dvk6an18cpr95qn5wnig2600qhv6w7-nix-2.4pre20210727_706777a/bin/nix /tmp/nixos-rebuild.NfHKxx/result/bin/switch-to-configuration test
error: '/tmp/nixos-rebuild.NfHKxx/result/bin/switch-to-configuration' is not a recognised command
Try '/nix/store/m7dvk6an18cpr95qn5wnig2600qhv6w7-nix-2.4pre20210727_706777a/bin/nix --help' for more information.
+ echo 'warning: error(s) occurred while switching to the new configuration'
warning: error(s) occurred while switching to the new configuration
```
