### PR TITLE
.github/labeler.yml: Label nixos-rebuild changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -70,6 +70,7 @@
 
 "6.topic: nixos":
   - nixos/**/*
+  - pkgs/os-specific/linux/nixos-rebuild/**/*
 
 "6.topic: ocaml":
   - doc/languages-frameworks/ocaml.section.md


### PR DESCRIPTION
I noticed in #131831 that the `nixos` label gets removed from PRs that modify `nixos-rebuild`. This rectifies that.