### PR TITLE
chez-racket: init at 2021-12-11

### DIFF
--- a/pkgs/development/compilers/chez-racket/default.nix
+++ b/pkgs/development/compilers/chez-racket/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, buildPackages, callPackage }:
+
+let
+  chezSystemMap = {
+    # See `/workarea` of source code for list of systems
+    "aarch64-darwin" = "tarm64osx";
+    "aarch64-linux" = "tarm64le";
+    "armv7l-linux" = "tarm32le";
+    "x86_64-darwin" = "ta6osx";
+    "x86_64-linux" = "ta6le";
+  };
+  inherit (stdenv.hostPlatform) system;
+  chezSystem = chezSystemMap.${system} or (throw "Add ${system} to chezSystemMap to enable building chez-racket");
+  # Chez Scheme uses an ad-hoc `configure`, hence we don't use the usual
+  # stdenv abstractions.
+  forBoot = {
+    pname = "chez-scheme-racket-boot";
+    configurePhase = ''
+      runHook preConfigure
+      ./configure --pb ZLIB=$ZLIB LZ4=$LZ4
+      runHook postConfigure
+    '';
+    makeFlags = [ "${chezSystem}.bootquick" ];
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      pushd boot
+      mv $(ls -1 | grep -v "^pb$") -t $out
+      popd
+      runHook postInstall
+    '';
+  };
+  boot = buildPackages.callPackage (import ./shared.nix forBoot) {};
+  forFinal = {
+    pname = "chez-scheme-racket";
+    configurePhase = ''
+      runHook preConfigure
+      cp -r ${boot}/* -t ./boot
+      ./configure -m=${chezSystem} --installprefix=$out --installman=$out/share/man ZLIB=$ZLIB LZ4=$LZ4
+      runHook postConfigure
+    '';
+    preBuild = ''
+      pushd ${chezSystem}/c
+    '';
+    postBuild = ''
+      popd
+    '';
+    setupHook = ./setup-hook.sh;
+  };
+  final = callPackage (import ./shared.nix forFinal) {};
+in
+final

--- a/pkgs/development/compilers/chez-racket/setup-hook.sh
+++ b/pkgs/development/compilers/chez-racket/setup-hook.sh
@@ -1,0 +1,5 @@
+addChezLibraryPath() {
+  addToSearchPath CHEZSCHEMELIBDIRS "$1/lib/csv-site"
+}
+
+addEnvHooks "$targetOffset" addChezLibraryPath

--- a/pkgs/development/compilers/chez-racket/shared.nix
+++ b/pkgs/development/compilers/chez-racket/shared.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (args // {
     export LZ4="$(find ${lz4.out}/lib -type f | sort | head -n1)"
   '';
 
-  nativeBuildInputs = lib.optional stdenv.isDarwin darwin.cctools;
+  nativeBuildInputs = lib.optionals stdenv.isDarwin (with darwin; [ cctools autoSignDarwinBinariesHook ]);
   buildInputs = [ ncurses libX11 zlib lz4 ]
     ++ lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/development/compilers/chez-racket/shared.nix
+++ b/pkgs/development/compilers/chez-racket/shared.nix
@@ -1,0 +1,41 @@
+args:
+{ stdenv, lib, fetchFromGitHub, coreutils, darwin
+, ncurses, libiconv, libX11, zlib, lz4
+}:
+
+stdenv.mkDerivation (args // {
+  version = "unstable-2021-12-11";
+
+  src = fetchFromGitHub {
+    owner  = "racket";
+    repo   = "ChezScheme";
+    rev    = "8846c96b08561f05a937d5ecfe4edc96cc99be39";
+    sha256 = "IYJQzT88T8kFahx2BusDOyzz6lQDCbZIfSz9rZoNF7A=";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    rm -rf zlib/*.c lz4/lib/*.c
+  '';
+
+  postPatch = ''
+    export ZLIB="$(find ${zlib.out}/lib -type f | sort | head -n1)"
+    export LZ4="$(find ${lz4.out}/lib -type f | sort | head -n1)"
+  '';
+
+  nativeBuildInputs = lib.optional stdenv.isDarwin darwin.cctools;
+  buildInputs = [ ncurses libX11 zlib lz4 ]
+    ++ lib.optional stdenv.isDarwin libiconv;
+
+  enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-error=format-truncation";
+
+  meta = {
+    description  = "Fork of Chez Scheme for Racket";
+    homepage     = "https://github.com/racket/ChezScheme";
+    license      = lib.licenses.asl20;
+    maintainers  = with lib.maintainers; [ l-as ];
+    platforms    = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11599,6 +11599,8 @@ with pkgs;
     inherit (darwin) cctools;
   };
 
+  chez-racket = callPackage ../development/compilers/chez-racket {};
+
   chez-srfi = callPackage ../development/chez-modules/chez-srfi { };
 
   chez-mit = callPackage ../development/chez-modules/chez-mit { };


### PR DESCRIPTION
###### Motivation for this change

This is basically Chez Scheme but better, notably it supports aarch64-linux (and likely aarch64-darwin too!).
This can be used to make Idris 2 work on more platforms with its Chez Scheme backend, albeit it is not done in this PR.

###### Things done

I've added `chez-racket` as a separate directory with its own files, since it's a permanent fork.
The only common part is the setup hook.

It would be great if someone on `aarch64-darwin` could test this.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
