### PR TITLE
srtrelay: init at 2021-07-28

### DIFF
--- a/pkgs/applications/video/srtrelay/default.nix
+++ b/pkgs/applications/video/srtrelay/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub, srt, ffmpeg }:
+
+buildGoModule rec {
+  pname = "srtrelay-unstable";
+  version = "2021-07-28";
+
+  src = fetchFromGitHub {
+    owner = "voc";
+    repo = "srtrelay";
+    rev = "c4f02ff2e9637b01a0679b29e5a76f4521eeeef3";
+    sha256 = "06zbl97bjjyv51zp27qk37ffpbh1ylm9bsr0s5qlyd73pyavcj1g";
+  };
+
+  vendorSha256 = "1pdpb0my7gdvjjkka6jhj19b9nx575k6117hg536b106ij2n4zd2";
+
+  buildInputs = [ srt ];
+  checkInputs = [ ffmpeg ];
+
+  meta = with lib; {
+    description = "Streaming-Relay for the SRT-protocol";
+    homepage = "https://github.com/voc/srtrelay";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fpletz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9048,6 +9048,8 @@ in
 
   srt-to-vtt-cl = callPackage ../tools/cd-dvd/srt-to-vtt-cl { };
 
+  srtrelay = callPackage ../applications/video/srtrelay { };
+
   sourcehut = callPackage ../applications/version-management/sourcehut { };
 
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
