### PR TITLE
cgit: fix regression where cgi script was not installed anymore

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "prefix=$(out)"
-    "CGIT_SCRIPT_PATH=$out/cgit/"
+    "CGIT_SCRIPT_PATH=$(out)/cgit/"
     "CC=${stdenv.cc.targetPrefix}cc"
     "AR=${stdenv.cc.targetPrefix}ar"
   ];


### PR DESCRIPTION
Related to https://github.com/NixOS/nixpkgs/pull/131705.

###### Motivation for this change

The package regressed due to incorrect escaping. This solves it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> tested cgit/cgit.cgi
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @bjornfor 