### PR TITLE
signal-desktop: preload sqlcipher library from nixpkgs

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -10,6 +10,7 @@
 , hunspellDicts, spellcheckerLanguage ? null # E.g. "de_DE"
 # For a full list of available languages:
 # $ cat pkgs/development/libraries/hunspell/dictionaries.nix | grep "dictFileName =" | awk '{ print $3 }'
+, sqlcipher
 }:
 
 let
@@ -21,6 +22,40 @@ let
     in lib.optionalString (spellcheckerLanguage != null) ''
       --set HUNSPELL_DICTIONARIES "${hunspellDicts.${hunspellDict}}/share/hunspell" \
       --set LC_MESSAGES "${spellcheckerLanguage}"'');
+
+  sqlcipher-signal = sqlcipher.overrideAttrs (_: {
+    # Using the same features as the upstream signal sqlcipher build
+    # https://github.com/signalapp/better-sqlite3/blob/2fa02d2484e9f9a10df5ac7ea4617fb2dff30006/deps/defines.gypi
+    CFLAGS = [
+      "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS"
+      "-DSQLITE_THREADSAFE=2"
+      "-DSQLITE_USE_URI=0"
+      "-DSQLITE_DEFAULT_MEMSTATUS=0"
+      "-DSQLITE_OMIT_DEPRECATED"
+      "-DSQLITE_OMIT_GET_TABLE"
+      "-DSQLITE_OMIT_TCL_VARIABLE"
+      "-DSQLITE_OMIT_PROGRESS_CALLBACK"
+      "-DSQLITE_OMIT_SHARED_CACHE"
+      "-DSQLITE_TRACE_SIZE_LIMIT=32"
+      "-DSQLITE_DEFAULT_CACHE_SIZE=-16000"
+      "-DSQLITE_DEFAULT_FOREIGN_KEYS=1"
+      "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1"
+      "-DSQLITE_ENABLE_COLUMN_METADATA"
+      "-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT"
+      "-DSQLITE_ENABLE_STAT4"
+      "-DSQLITE_ENABLE_FTS5"
+      "-DSQLITE_ENABLE_JSON1"
+      "-DSQLITE_ENABLE_RTREE"
+      "-DSQLITE_INTROSPECTION_PRAGMAS"
+
+      # SQLCipher-specific options
+      "-DSQLITE_HAS_CODEC"
+      "-DSQLITE_TEMP_STORE=2"
+      "-DSQLITE_SECURE_DELETE"
+    ];
+
+    LDFLAGS = [ "-lm" ];
+  });
 in stdenv.mkDerivation rec {
   pname = "signal-desktop";
   version = "5.19.0"; # Please backport all updates to the stable channel.
@@ -115,15 +150,10 @@ in stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  # Required for $SQLCIPHER_LIB which contains "/build/" inside the path:
-  noAuditTmpdir = true;
-
   preFixup = ''
-    export SQLCIPHER_LIB="$out/lib/Signal/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
-    test -x "$SQLCIPHER_LIB" # To ensure the location hasn't changed
     gappsWrapperArgs+=(
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ] }"
-      --prefix LD_PRELOAD : "$SQLCIPHER_LIB"
+      --prefix LD_PRELOAD : "${sqlcipher-signal}/lib/libsqlcipher.so"
       ${customLanguageWrapperArgs}
     )
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #124901.

Preloading the packaged node sqlcipher lib was leading to errors like:

 `/bin/sh: symbol lookup error: /nix/store/igb91vpsqwpiw9kpppjhxhhlk4q4b4s5-signal-desktop-5.10.0/lib/Signal/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node: undefined symbol: node_module_register` 

which prevented xdg-open calls to work and in turn having links fail to open in the browser. Preloading instead the sqlcipher library from the nixpkgs repo fixes the issue, and I could still open my existing database so I presume encryption is working.

I also needed to add json and fts5 feature support to the sqlcipher library since Signal uses these (these and more are included with the vanilla sqlite package).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
