### PR TITLE
mc: move signature breaking sed from post to pre fixup

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -57,10 +57,12 @@ stdenv.mkDerivation rec {
       --replace /bin/rm ${coreutils}/bin/rm
   '';
 
-  postFixup = ''
+  preFixup = ''
     # remove unwanted build-dependency references
     sed -i -e "s!PKG_CONFIG_PATH=''${PKG_CONFIG_PATH}!PKG_CONFIG_PATH=$(echo "$PKG_CONFIG_PATH" | sed -e 's/./0/g')!" $out/bin/mc
-  '' + lib.optionalString (!stdenv.isDarwin) ''
+  '';
+
+  postFixup = lib.optionalString (!stdenv.isDarwin) ''
     # libX11.so is loaded dynamically so autopatch doesn't detect it
     patchelf \
       --add-needed ${libX11}/lib/libX11.so \


### PR DESCRIPTION
###### Motivation for this change

Commit cb0e81b5b6c6 reverted changes from a7f0bf791608, which are required to have mc working on aarch64-darwin, where binary signatures are enforced.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x]  Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64-darwin)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
