### PR TITLE
ccextractor: enable ocr and hardsub support

### DIFF
--- a/pkgs/applications/video/ccextractor/default.nix
+++ b/pkgs/applications/video/ccextractor/default.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!stdenv.isLinux) libiconv
     ++ lib.optionals enableOcr [ leptonica tesseract4 ffmpeg ];
 
-
   cmakeFlags = lib.optionals enableOcr [ "-DWITH_OCR=on" "-DWITH_HARDSUBX=on" ];
 
   postInstall = lib.optionalString enableOcr ''

--- a/pkgs/applications/video/ccextractor/default.nix
+++ b/pkgs/applications/video/ccextractor/default.nix
@@ -1,7 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake
-, glew, glfw3, leptonica, libiconv, tesseract3, zlib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, glew
+, glfw3
+, leptonica
+, libiconv
+, tesseract3
+, zlib
+}:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "ccextractor";
   version = "0.91";
@@ -17,9 +26,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config cmake ];
 
-  buildInputs = [ glew glfw3 leptonica tesseract3 zlib ] ++ lib.optional (!stdenv.isLinux) libiconv;
+  buildInputs = [ 
+    glew
+    glfw3
+    leptonica
+    tesseract3 
+    zlib
+  ] ++ lib.optional (!stdenv.isLinux) libiconv;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.ccextractor.org";
     description = "Tool that produces subtitles from closed caption data in videos";
     longDescription = ''


### PR DESCRIPTION

###### Motivation for this change
Supersedes #76534

###### Things done
i put the hardsub support behind ocrSupport because it was kind of useless to just have a option for only 1 dependency ffmpeg

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
