### PR TITLE
fluent-bit: 1.8.9 -> 1.8.11

### DIFF
--- a/pkgs/tools/misc/fluent-bit/default.nix
+++ b/pkgs/tools/misc/fluent-bit/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, flex, bison, systemd }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, flex, bison, systemd, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "fluent-bit";
-  version = "1.8.9";
+  version = "1.8.11";
 
   src = fetchFromGitHub {
     owner = "fluent";
     repo = "fluent-bit";
     rev = "v${version}";
-    sha256 = "sha256-b+MZuZQB/sl0HcioU1KCxH3TNiXYSPBfC9dBKqCVeXk=";
+    sha256 = "sha256-DULXfkddBdCvTWkuWXjSTEujRZ3mVVzy//qeB3j0Vz8=";
   };
 
   patches = lib.optionals stdenv.isDarwin [
@@ -32,7 +32,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake flex bison ];
 
-  buildInputs = lib.optionals stdenv.isLinux [ systemd ];
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isLinux [ systemd ];
 
   cmakeFlags = [ "-DFLB_METRICS=ON" "-DFLB_HTTP_SERVER=ON" ];
 


### PR DESCRIPTION
Added openssl to deps since it yields better performance. Unfortunately
mbedtls is still being built (but that's apparently intended).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
