### PR TITLE
iwd: Make predictable link naming policy disabling configurable

### DIFF
--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -10,6 +10,14 @@ in {
   options.networking.wireless.iwd = {
     enable = mkEnableOption "iwd";
 
+    # https://github.com/NixOS/nixpkgs/issues/110898
+    enableLinkPolicy = mkOption {
+      default = true;
+      description = "Whether to enable iwd's link policy to disable predictable interface naming scheme";
+      example = true;
+      type = types.bool;
+    };
+
     settings = mkOption {
       type = ini.type;
       default = { };
@@ -30,7 +38,7 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf cfg.enable ({
     assertions = [{
       assertion = !config.networking.wireless.enable;
       message = ''
@@ -47,16 +55,16 @@ in {
 
     systemd.packages = [ pkgs.iwd ];
 
-    systemd.network.links."80-iwd" = {
-      matchConfig.Type = "wlan";
-      linkConfig.NamePolicy = "keep kernel";
-    };
-
     systemd.services.iwd = {
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ configFile ];
     };
-  };
+  } // optionalAttrs cfg.enableLinkPolicy {
+    systemd.network.links."80-iwd" = {
+      matchConfig.Type = "wlan";
+      linkConfig.NamePolicy = "keep kernel";
+    };
+  });
 
   meta.maintainers = with lib.maintainers; [ mic92 dtzWill ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/110898

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
