### PR TITLE
rott: init at 1.1.2

### DIFF
--- a/pkgs/games/rott/default.nix
+++ b/pkgs/games/rott/default.nix
@@ -1,0 +1,54 @@
+{stdenv, lib, fetchurl, SDL, SDL_mixer, makeDesktopItem, copyDesktopItems, runtimeShell, buildShareware ? false}:
+
+stdenv.mkDerivation rec {
+  pname = "rott";
+  version = "1.1.2";
+
+  src = fetchurl {
+    url = "https://icculus.org/rott/releases/${pname}-${version}.tar.gz";
+    sha256 = "1zr7v5dv2iqx40gzxbg8mhac7fxz3kqf28y6ysxv1xhjqgl1c98h";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems ];
+  buildInputs = [ SDL SDL_mixer ];
+
+  preBuild = ''
+    cd rott
+    make clean
+    make SHAREWARE=${if buildShareware then "1" else "0"}
+  '';
+
+  # Include a wrapper script to allow the game to be launched from a user's PATH and load the game data from the user's home directory.
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp rott $out/bin
+
+    cat > $out/bin/launch-rott <<EOF
+    #! ${runtimeShell} -e
+    cd ~/.rott/data
+    exec $out/bin/rott
+    EOF
+
+    chmod +x $out/bin/launch-rott
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "rott";
+      exec = "launch-rott";
+      desktopName = "Rise of the Triad: ${if buildShareware then "The HUNT Begins" else "Dark War"}";
+      categories = "Game;";
+    })
+  ];
+
+  meta = with lib; {
+    description = "SDL port of Rise of the Triad";
+    homepage = "https://icculus.org/rott/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sander ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29471,6 +29471,12 @@ in
 
   rocksndiamonds = callPackage ../games/rocksndiamonds { };
 
+  rott = callPackage ../games/rott { };
+
+  rott-shareware = rott.override {
+    buildShareware = true;
+  };
+
   rrootage = callPackage ../games/rrootage { };
 
   saga = libsForQt5.callPackage ../applications/gis/saga {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds an SDL port of the Rise of the Triad: The HUNT begins (shareware episode) and Rise of The Triad: Dark War (full version) games

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
