### PR TITLE
exiv2: Add lib/static outputs, remove reference to gcc

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -11,13 +11,14 @@
 , graphviz
 , libxslt
 , libiconv
+, removeReferencesTo
 }:
 
 stdenv.mkDerivation rec {
   pname = "exiv2";
   version = "0.27.4";
 
-  outputs = [ "out" "dev" "doc" "man" ];
+  outputs = [ "out" "lib" "dev" "doc" "man" "static" ];
 
   src = fetchFromGitHub {
     owner = "exiv2";
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
     gettext
     graphviz
     libxslt
+    removeReferencesTo
   ];
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
@@ -90,7 +92,14 @@ stdenv.mkDerivation rec {
       rm *
       mv .exiv2 exiv2
     )
+
+    mkdir -p $static/lib
+    mv $lib/lib/*.a $static/lib/
+
+    remove-references-to -t ${stdenv.cc.cc} $lib/lib/*.so.*.*.* $out/bin/exiv2 $static/lib/*.a
   '';
+
+  disallowedReferences = [ stdenv.cc.cc ];
 
   meta = with lib; {
     homepage = "https://www.exiv2.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This reduces the closure size of packages that depend on exiv2 (like geeqie) by removing a dependency on stdenv.cc.cc, and moving a static library into its own output.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
