### PR TITLE
chataigne: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6188,6 +6188,12 @@
     githubId = 591860;
     name = "Lionello Lunesu";
   };
+  llelievr = {
+    name = "Lucas Lelievre";
+    email = "llelievr2@gmail.com";
+    github = "loucass003";
+    githubId = 3948904;
+  };
   lluchs = {
     email = "lukas.werling@gmail.com";
     github = "lluchs";

--- a/pkgs/applications/misc/chataigne/default.nix
+++ b/pkgs/applications/misc/chataigne/default.nix
@@ -27,7 +27,7 @@ appimageTools.wrapType2 {
   meta = with lib; {
     description = "Artist-friendly Modular Machine for Art and Technology";
     homepage = "https://benjamin.kuperberg.fr/chataigne";
-    license = licenses.gpl2;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ llelievr ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/applications/misc/chataigne/default.nix
+++ b/pkgs/applications/misc/chataigne/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchurl, appimageTools, pkgs }:
+
+let
+  pname = "chataigne";
+  version = "1.8.0";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://benjamin.kuperberg.fr/chataigne/user/data/Chataigne-linux-x64-1.8.0.AppImage";
+    name="${pname}-${version}.AppImage";
+    sha512 = "aHo+8U0jRczJHQwMMmvNYpWdamensO5hpIIHgaayvvI+NFoN4Hb9VhVY9vJgv5OkzktjhfTs4WsB+SHUDjQF2Q==";
+  };
+  curlWithGnutls = pkgs.curl.override { gnutlsSupport = true; sslSupport = false; };
+in
+appimageTools.wrapType2 {
+  inherit name src;
+
+  extraPkgs = pkgs: with pkgs; [
+    bluez avahi curlWithGnutls libjack2 gtk3 SDL2 fuse libusb1 hidapi
+    xorg.libX11 xorg.libXinerama xorg.xrandr xorg.libXcursor xorg.libXcomposite
+    mesa alsaLib
+  ];
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${pname}}
+  '';
+
+  meta = with lib; {
+    description = "Artist-friendly Modular Machine for Art and Technology";
+    homepage = "https://benjamin.kuperberg.fr/chataigne";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ llelievr ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1289,6 +1289,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  chataigne = callPackage ../applications/misc/chataigne { };
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want to use chataigne
So i make a package for it at the same time

###### Things done

I added a package called chataigne.
Chataigne is a VJ software.


I never made packages before, i plan to do more in the future so please, feel free to tell me stuff i got wrong.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
