### PR TITLE
nextpnr: update

### DIFF
--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -14,21 +14,21 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nextpnr";
-  version = "2021.01.02";
+  version = "2021.07.28";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "YosysHQ";
       repo   = "nextpnr";
-      rev    = "9b9628047c01a970cfe20f83f2b7129ed109440d";
-      sha256 = "0pcv96d0n40h2ipywi909hpzlys5b6r4pamc320qk1xxhppmgkmm";
+      rev    = "39a7381928359934788aefd670c835dedbbf2cd7";
+      sha256 = "1rs95vp5m3fdvhmjilj2r2g54xlabd3vy8wii1ammajqkyamy8x3";
       name   = "nextpnr";
     })
     (fetchFromGitHub {
       owner  = "YosysHQ";
       repo   = "nextpnr-tests";
-      rev    = "8f93e7e0f897b1b5da469919c9a43ba28b623b2a";
-      sha256 = "0zpd0w49k9l7rs3wmi2v8z5s4l4lad5rprs5l83w13667himpzyc";
+      rev    = "ccc61e5ec7cc04410462ec3196ad467354787afb";
+      sha256 = "09a0bhrphr3rsppryrfak4rhziyj8k3s17kgb0vgm0abjiz0jgam";
       name   = "nextpnr-tests";
     })
   ];

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "trellis";
-  version = "2021.01.02";
+  version = "2021.07.06";
 
   # git describe --tags
   realVersion = with lib; with builtins;
@@ -15,16 +15,16 @@ stdenv.mkDerivation rec {
     (fetchFromGitHub {
        owner  = "YosysHQ";
        repo   = "prjtrellis";
-       rev    = "60c05b3f4e71fd78d4fba5c31f9974694245199e";
-       sha256 = "1k37mxwxv9fpm6xnrxlqqap7zqh2dvgqncphj3asi2rz0kh07ppf";
+       rev    = "dff1cbcb1bd30de7e96f8a059f2e19be1bb2e44d";
+       sha256 = "1gbrka9gqn124shx448aivbgywyp30zyjwfazr7v49lhrl7d46lb";
        name   = "trellis";
      })
 
     (fetchFromGitHub {
       owner  = "YosysHQ";
       repo   = "prjtrellis-db";
-      rev    = "2cf058e7a3ba36134d21e34823e9b2ecaaceac2c";
-      sha256 = "1hjaw5jkwiaiznm2z0smy88m2cdz63cd51z4nibajfih7ikvkj6g";
+      rev    = "0ee729d20eaf9f1e0f1d657bc6452e3ffe6a0d63";
+      sha256 = "0069c98bb4wilxz21snwc39yy0rm7ffma179djyz57d99p0vcfkq";
       name   = "trellis-database";
     })
   ];


### PR DESCRIPTION
This also includes an accompanying update to `trellis`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
