### PR TITLE
vault-bin: correct wrapping arguments

### DIFF
--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -42,8 +42,8 @@ in stdenv.mkDerivation {
     echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
   '' + lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/vault \
-      --prefix PATH ${lib.makeBinPath [ gawk glibc ]}
-  '' + ''
+      --prefix PATH : ${lib.makeBinPath [ gawk glibc ]}
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change
`--prefix` was missing a separator

before:
```
$ cat ./result/bin/vault
#! /nix/store/b45zavallnsvqwjs9wg9xw167jcs0935-bash-4.4-p23/bin/bash -e
exec -a "$0" "/nix/store/w1i5429rpm1zfkgmm4impy183mh6zi2i-vault-bin-1.7.3/bin/.vault-wrapped"  "$@"
```

after:
```
$ cat ./result/bin/vault
#! /nix/store/b45zavallnsvqwjs9wg9xw167jcs0935-bash-4.4-p23/bin/bash -e
export PATH='/nix/store/b27wld0aqcdspznhxwgmr6cs67kg9lk3-gawk-5.1.0/bin:/nix/store/yj1ynwa7dr25fljf5z18rvks7xjxvpbh-glibc-2.33-47-bin/bin'${PATH:+':'}$PATH
exec -a "$0" "/nix/store/5p5mj0qdlghqm561cdvcqq2d8hq7k700-vault-bin-1.7.3/bin/.vault-wrapped"  "$@"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
