### PR TITLE
yabar: support cross-compilation, format

### DIFF
--- a/pkgs/applications/window-managers/yabar/build.nix
+++ b/pkgs/applications/window-managers/yabar/build.nix
@@ -19,16 +19,33 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  nativeBuildInputs = [ pkg-config ];
+  strictDeps = true;
+  depsBuildBuild = [
+    pkg-config
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    asciidoc
+    docbook_xsl
+    libxslt
+    makeWrapper
+    libconfig
+    pango
+  ];
   buildInputs = [
-    cairo gdk-pixbuf libconfig pango xcbutilwm docbook_xsl
-    alsa-lib wirelesstools asciidoc libxslt makeWrapper
+    cairo
+    gdk-pixbuf
+    libconfig
+    pango
+    xcbutilwm
+    alsa-lib
+    wirelesstools
   ];
 
   postPatch = ''
     substituteInPlace ./Makefile \
       --replace "\$(shell git describe)" "${version}" \
-      --replace "a2x" "${asciidoc}/bin/a2x --no-xmllint"
+      --replace "a2x" "a2x --no-xmllint"
   '';
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=/" ];


### PR DESCRIPTION
###### Motivation for this change

More cross-compilation support!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've also diffed the output for native using diffoscope (before and after this change), the only difference is the order of paths embedded in the executable.

Note: targeting staging due to zstd cross-compilation being broken in master (https://github.com/NixOS/nixpkgs/pull/129873 fixes this). It's impossible to check compilation on master, on staging it's at least _possible_.