### PR TITLE
fetchmail: 6.4.16 -> 6.4.20

### DIFF
--- a/pkgs/applications/misc/fetchmail/default.nix
+++ b/pkgs/applications/misc/fetchmail/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, openssl }:
 
 let
-  version = "6.4.16";
+  version = "6.4.20";
 in
 stdenv.mkDerivation {
   pname = "fetchmail";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/fetchmail/fetchmail-${version}.tar.xz";
-    sha256 = "sha256-BEuaCsA6+653RJed7+Pi4y45FBvKaP0Mje2i7UCIT7k=";
+    sha256 = "0xk171sbxcwjh1ibpipryw5sv4sy7jjfvhn5n373j04g5sp428f8";
   };
 
   buildInputs = [ openssl ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://www.openwall.com/lists/oss-security/2021/07/28/5

Fixes: CVE-2021-36386

> Fetchmail has long had support to assemble log/error messages that are 
> generated piecemeal, and takes care to reallocate the output buffer as needed.  
> In the reallocation case, i. e. when long log messages are assembled that can 
> stem from very long headers, and on systems that have a varargs.h/stdarg.h 
> interface (all modern systems), fetchmail's code would fail to reinitialize 
> the va_list argument to vsnprintf. 
> 
> The exact effects depend on the verbose mode (how many -v are given) of 
> fetchmail, computer architecture, compiler, operating system and 
> configuration.  On some systems, the code just works without ill effects, some 
> systems log a garbage message (potentially disclosing sensitive information), 
> some systems log literally "(null)", some systems trigger SIGSEGV (signal 
> #11), which crashes fetchmail, causing a denial of service on fetchmail's end.

Qualifies for a direct backport

> Distributors are encouraged to review the NEWS file and move forward to 
> 6.4.20, rather than backport individual security fixes, because doing so 
> routinely misses other fixes crucial to fetchmail's proper operation, 
> for which no security announcements are issued, or documentation,
> or translation updates.
>
> Fetchmail 6.4.X releases have been made with a focus on unchanged user and 
> program interfaces so as to avoid disruptions when upgrading from 6.3.Z or 
> 6.4.X to 6.4.Y with Y > X.  Care was taken to not change the interface 
> incompatibly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
