### PR TITLE
spruce: init at 1.28.0

### DIFF
--- a/pkgs/development/tools/misc/spruce/default.nix
+++ b/pkgs/development/tools/misc/spruce/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "spruce";
+  version = "1.28.0";
+
+  src = fetchFromGitHub {
+    owner = "geofffranks";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-cNO+6rMQPO1e4Hen8vcFU1FRnnCv2+fDYtXXbuR2UCU=";
+  };
+
+  deleteVendor = true;
+  vendorSha256 = "sha256-5EM4Z9AN1Mjy7DayII0Iu+XrjM9lyUqrScMT/fe43dw=";
+
+  meta = with lib; {
+    description = "A BOSH template merge tool";
+    homepage = "https://github.com/geofffranks/spruce";
+    license = licenses.mit;
+    maintainers = with maintainers; [ risson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14345,6 +14345,8 @@ in
 
   spooles = callPackage ../development/libraries/science/math/spooles {};
 
+  spruce = callPackage ../development/tools/misc/spruce { };
+
   sqlcheck = callPackage ../development/tools/database/sqlcheck { };
 
   sqlitebrowser = libsForQt5.callPackage ../development/tools/database/sqlitebrowser { };


### PR DESCRIPTION
###### Motivation for this change

Add https://github.com/geofffranks/spruce to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
