### PR TITLE
nvchecker: 2.3 -> 2.4

### DIFF
--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pythonOlder
 , pytestCheckHook
 , setuptools
@@ -21,23 +20,15 @@
 
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "2.3";
+  version = "2.4";
 
   # Tests not included in PyPI tarball
   src = fetchFromGitHub {
     owner = "lilydjwg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0ikqjlw6v7va69i8qskj1lf07ik84q4n3qgsb7khk520gv2ks3sx";
+    sha256 = "0ys4shp7gz6aaxrbflwcz7yjbvdv2v8pgj047p4rnp8ascpxg044";
   };
-
-  patches = [
-    # Fix test that fail in sandbox build. See https://github.com/lilydjwg/nvchecker/pull/179
-    (fetchpatch {
-      url = "https://github.com/lilydjwg/nvchecker/commit/7366d82bfc3dcf231f7908e259bf2437cf7dafd5.patch";
-      sha256 = "0pwrwa2wyy4i668lk2mqzzy6y3xi08mq3w520b4954kfm07g75a9";
-    })
-  ];
 
   nativeBuildInputs = [ installShellFiles docutils ];
   propagatedBuildInputs = [ setuptools packaging toml structlog appdirs tornado pycurl aiohttp ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
