### PR TITLE
[21.05] Backport flameshot update from 0.9.0 -> 0.10.1

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "flameshot";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
     rev = "v${version}";
-    sha256 = "sha256-E5J61k1tVpbwlzYHbCY1rf9+GODcJRRAQwb0jR4s7BU=";
+    sha256 = "1m0mx8qhy9ycsqh5dj6c7mwwpbhqxlds31dqdxxk0krwl750smi2";
   };
 
   nativeBuildInputs = [ cmake qttools qtsvg ];
@@ -17,8 +17,8 @@ mkDerivation rec {
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";
     homepage = "https://github.com/flameshot-org/flameshot";
-    maintainers = [ maintainers.scode ];
-    license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.linux;
+    maintainers = with maintainers; [ scode ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "flameshot";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
     rev = "v${version}";
-    sha256 = "1m0mx8qhy9ycsqh5dj6c7mwwpbhqxlds31dqdxxk0krwl750smi2";
+    sha256 = "1ncknjayl6am740f49g0lc28z1zsifbicxz1j1kwps3ksj15nl7a";
   };
 
   nativeBuildInputs = [ cmake qttools qtsvg ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update flameshot from 0.9.0 to 0.10.1. Currently 0.9.0 in nixos-21.05 segfaults under specific (but not uncommon) conditions—see https://github.com/flameshot-org/flameshot/issues/1730 and https://bugs.debian.org/991320. The fixes are in 0.10.1 but not in 0.10.0.

Backports #130631 and #131536, cherry-picking 7937fef and 8963fb9 respectively.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
