### PR TITLE
python3Packages.sphinxext-opengraph: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/sphinxext-opengraph/default.nix
+++ b/pkgs/development/python-modules/sphinxext-opengraph/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxext-opengraph";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "wpilibsuite";
+    repo = "sphinxext-opengraph";
+    rev = "v${version}";
+    sha256 = "sha256-978aPtaqUDHcswDdFynzi+IjDYaBmCZDZk+dmDkhajY=";
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "sphinxext.opengraph" ];
+
+  meta = with lib; {
+    description = "Sphinx extension to generate unique OpenGraph metadata";
+    homepage = "https://github.com/wpilibsuite/sphinxext-opengraph";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8286,6 +8286,8 @@ in {
 
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
 
+  sphinxext-opengraph = callPackage ../development/python-modules/sphinxext-opengraph { };
+
   spidev = callPackage ../development/python-modules/spidev { };
 
   splinter = callPackage ../development/python-modules/splinter { };


### PR DESCRIPTION
###### Motivation for this change
This sphinx extension is required to build the documentation of the next kitty version (#131559).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).