### PR TITLE
cairo: apply patch for CVE-2020-35492

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -42,6 +42,16 @@ in stdenv.mkDerivation rec {
       url = "https://gitlab.freedesktop.org/cairo/cairo/commit/5e34c5a9640e49dcc29e6b954c4187cfc838dbd1.patch";
       sha256 = "yCwsDUY7efVvOZkA6a0bPS+RrVc8Yk9bfPwWHeOjq5o=";
     })
+
+    # Fixes CVE-2020-35492; see https://github.com/NixOS/nixpkgs/issues/120364.
+    # CVE information: https://nvd.nist.gov/vuln/detail/CVE-2020-35492
+    # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/merge_requests/85
+    (fetchpatch {
+      name = "CVE-2020-35492.patch";
+      includes = [ "src/cairo-image-compositor.c" ];
+      url = "https://github.com/freedesktop/cairo/commit/78266cc8c0f7a595cfe8f3b694bfb9bcc3700b38.patch";
+      sha256 = "048nzfz7rkgqb9xs0dfs56qdw7ckkxr87nbj3p0qziqdq4nb6wki";
+    })
   ] ++ optionals stdenv.hostPlatform.isDarwin [
     # Workaround https://gitlab.freedesktop.org/cairo/cairo/-/issues/121
     ./skip-configure-stderr-check.patch


### PR DESCRIPTION
Fixes CVE-2020-35492; see https://github.com/NixOS/nixpkgs/issues/120364.
CVE information: https://nvd.nist.gov/vuln/detail/CVE-2020-35492
Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/merge_requests/85

Note that `fetchpatch` messes up the full patch (which also adds a new file containing a regression test), which I worked around by only including the actual bugfix to `src/cairo-image-compositor.c`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
