### PR TITLE
pkgsMusl.python*: disable LTO

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -45,7 +45,9 @@
 # enableLTO is a subset of the enableOptimizations flag that doesn't harm reproducibility.
 # enabling LTO on 32bit arch causes downstream packages to fail when linking
 # enabling LTO on *-darwin causes python3 to fail when linking.
-, enableLTO ? stdenv.is64bit && stdenv.isLinux
+# enabling LTO with musl and dynamic linking fails with a linker error although it should
+# be possible as alpine is doing it: https://github.com/alpinelinux/aports/blob/a8ccb04668c7729e0f0db6c6ff5f25d7519e779b/main/python3/APKBUILD#L82
+, enableLTO ? stdenv.is64bit && stdenv.isLinux && !(stdenv.hostPlatform.isMusl && !stdenv.hostPlatform.isStatic)
 , reproducibleBuild ? true
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:


### PR DESCRIPTION
LTO fails to build with musl with the following linker error:

<details>

```
rm -f libpython3.9.a
if test libpython3.9.so.1.0 != libpython3.9.so; then \
        gcc -shared -L/nix/store/1dlhc7w4dlacgmkjbcx9454givv4kdqj-zlib-1.2.11/lib -L/nix/store/6fdwln0ac2p100dhifk2picm0c2d0bw3-bzip2-1.0.6.0.2/lib -L/nix/store/540aidi6ppgnjdd60ky4m6sm6ml824sp-expat-2.4.1/lib -L/nix/store/b493yxrr0glvv3988mkagqlq5k8rg5g1-xz-5.2.5/lib -L/nix/store/2145y7j63691khrjqhn66gc3srb52af8-libffi-3.3/lib -L/nix/store/4h0qimk9kkkrd1v9j6j0v3r3gqg6w22a-gdbm-1.20/lib -L/nix/store/b8n0k1vhjdg0r95x8d2ybgrmbdlhw738-sqlite-3.35.5/lib -L/nix/store/f4y7v8k7ar3n05h3446k6z4aa1c77n22-readline-6.3p08/lib -L/nix/store/j79lxjyfin611lz3rm0mzc26afxm3dgm-ncurses-6.2/lib -L/nix/store/mqs20xckz2gj0asgy2hv60h5dg1i3ci5-openssl-1.1.1k/lib -L/nix/store/hbfls4hgbjn8cb0d4m0kgz4a4cwlcbx5-tzdata-2021a/lib -L/nix/store/1dlhc7w4dlacgmkjbcx9454givv4kdqj-zlib-1.2.11/lib -L/nix/store/6fdwln0ac2p100dhifk2picm0c2d0bw3-bzip2-1.0.6.0.2/lib -L/nix/store/540aidi6ppgnjdd60ky4m6sm6ml824sp-expat-2.4.1/lib -L/nix/store/b493yxrr0glvv3988mkagqlq5k8rg5g1-xz-5.2.5/lib -L/nix/store/2145y7j63691khrjqhn66gc3srb52af8-libffi-3.3/lib -L/nix/store/4h0qimk9kkkrd1v9j6j0v3r3gqg6w22a-gdbm-1.20/lib -L/nix/store/b8n0k1vhjdg0r95x8d2ybgrmbdlhw738-sqlite-3.35.5/lib -L/nix/store/f4y7v8k7ar3n05h3446k6z4aa1c77n22-readline-6.3p08/lib -L/nix/store/j79lxjyfin611lz3rm0mzc26afxm3dgm-ncurses-6.2/lib -L/nix/store/mqs20xckz2gj0asgy2hv60h5dg1i3ci5-openssl-1.1.1k/lib -L/nix/store/hbfls4hgbjn8cb0d4m0kgz4a4cwlcbx5-tzdata-2021a/lib -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -g  -Wl,-hlibpython3.9.so.1.0 -o libpython3.9.so.1.0 Modules/getbuildinfo.o Parser/acceler.o Parser/grammar1.o Parser/listnode.o Parser/node.o Parser/parser.o Parser/token.o  Parser/pegen/pegen.o Parser/pegen/parse.o Parser/pegen/parse_string.o Parser/pegen/peg_api.o Parser/myreadline.o Parser/parsetok.o Parser/tokenizer.o Objects/abstract.o Objects/accu.o Objects/boolobject.o Objects/bytes_methods.o Objects/bytearrayobject.o Objects/bytesobject.o Objects/call.o Objects/capsule.o Objects/cellobject.o Objects/classobject.o Objects/codeobject.o Objects/complexobject.o Objects/descrobject.o Objects/enumobject.o Objects/exceptions.o Objects/genericaliasobject.o Objects/genobject.o Objects/fileobject.o Objects/floatobject.o Objects/frameobject.o Objects/funcobject.o Objects/interpreteridobject.o Objects/iterobject.o Objects/listobject.o Objects/longobject.o Objects/dictobject.o Objects/odictobject.o Objects/memoryobject.o Objects/methodobject.o Objects/moduleobject.o Objects/namespaceobject.o Objects/object.o Objects/obmalloc.o Objects/picklebufobject.o Objects/rangeobject.o Objects/setobject.o Objects/sliceobject.o Objects/structseq.o Objects/tupleobject.o Objects/typeobject.o Objects/unicodeobject.o Objects/unicodectype.o Objects/weakrefobject.o Python/_warnings.o Python/Python-ast.o Python/asdl.o Python/ast.o Python/ast_opt.o Python/ast_unparse.o Python/bltinmodule.o Python/ceval.o Python/codecs.o Python/compile.o Python/context.o Python/dynamic_annotations.o Python/errors.o Python/frozenmain.o Python/future.o Python/getargs.o Python/getcompiler.o Python/getcopyright.o Python/getplatform.o Python/getversion.o Python/graminit.o Python/hamt.o Python/hashtable.o Python/import.o Python/importdl.o Python/initconfig.o Python/marshal.o Python/modsupport.o Python/mysnprintf.o Python/mystrtoul.o Python/pathconfig.o Python/peephole.o Python/preconfig.o Python/pyarena.o Python/pyctype.o Python/pyfpe.o Python/pyhash.o Python/pylifecycle.o Python/pymath.o Python/pystate.o Python/pythonrun.o Python/pytime.o Python/bootstrap_hash.o Python/structmember.o Python/symtable.o Python/sysmodule.o Python/thread.o Python/traceback.o Python/getopt.o Python/pystrcmp.o Python/pystrtod.o Python/pystrhex.o Python/dtoa.o Python/formatter_unicode.o Python/fileutils.o Python/dynload_shlib.o    Modules/config.o Modules/getpath.o Modules/main.o Modules/gcmodule.o Modules/posixmodule.o  Modules/errnomodule.o  Modules/pwdmodule.o  Modules/_sre.o  Modules/_codecsmodule.o  Modules/_weakref.o  Modules/_functoolsmodule.o  Modules/_operator.o  Modules/_collectionsmodule.o  Modules/_abc.o  Modules/itertoolsmodule.o  Modules/atexitmodule.o  Modules/signalmodule.o  Modules/_stat.o  Modules/timemodule.o  Modules/_threadmodule.o  Modules/_localemodule.o  Modules/_iomodule.o Modules/iobase.o Modules/fileio.o Modules/bytesio.o Modules/bufferedio.o Modules/textio.o Modules/stringio.o  Modules/faulthandler.o  Modules/_tracemalloc.o  Modules/_peg_parser.o  Modules/symtablemodule.o  Modules/xxsubtype.o Python/frozen.o   -ldl -lcrypt -lncurses -lm  -lm; \
        ln -f libpython3.9.so.1.0 libpython3.9.so; \
else \
        gcc -shared -L/nix/store/1dlhc7w4dlacgmkjbcx9454givv4kdqj-zlib-1.2.11/lib -L/nix/store/6fdwln0ac2p100dhifk2picm0c2d0bw3-bzip2-1.0.6.0.2/lib -L/nix/store/540aidi6ppgnjdd60ky4m6sm6ml824sp-expat-2.4.1/lib -L/nix/store/b493yxrr0glvv3988mkagqlq5k8rg5g1-xz-5.2.5/lib -L/nix/store/2145y7j63691khrjqhn66gc3srb52af8-libffi-3.3/lib -L/nix/store/4h0qimk9kkkrd1v9j6j0v3r3gqg6w22a-gdbm-1.20/lib -L/nix/store/b8n0k1vhjdg0r95x8d2ybgrmbdlhw738-sqlite-3.35.5/lib -L/nix/store/f4y7v8k7ar3n05h3446k6z4aa1c77n22-readline-6.3p08/lib -L/nix/store/j79lxjyfin611lz3rm0mzc26afxm3dgm-ncurses-6.2/lib -L/nix/store/mqs20xckz2gj0asgy2hv60h5dg1i3ci5-openssl-1.1.1k/lib -L/nix/store/hbfls4hgbjn8cb0d4m0kgz4a4cwlcbx5-tzdata-2021a/lib -L/nix/store/1dlhc7w4dlacgmkjbcx9454givv4kdqj-zlib-1.2.11/lib -L/nix/store/6fdwln0ac2p100dhifk2picm0c2d0bw3-bzip2-1.0.6.0.2/lib -L/nix/store/540aidi6ppgnjdd60ky4m6sm6ml824sp-expat-2.4.1/lib -L/nix/store/b493yxrr0glvv3988mkagqlq5k8rg5g1-xz-5.2.5/lib -L/nix/store/2145y7j63691khrjqhn66gc3srb52af8-libffi-3.3/lib -L/nix/store/4h0qimk9kkkrd1v9j6j0v3r3gqg6w22a-gdbm-1.20/lib -L/nix/store/b8n0k1vhjdg0r95x8d2ybgrmbdlhw738-sqlite-3.35.5/lib -L/nix/store/f4y7v8k7ar3n05h3446k6z4aa1c77n22-readline-6.3p08/lib -L/nix/store/j79lxjyfin611lz3rm0mzc26afxm3dgm-ncurses-6.2/lib -L/nix/store/mqs20xckz2gj0asgy2hv60h5dg1i3ci5-openssl-1.1.1k/lib -L/nix/store/hbfls4hgbjn8cb0d4m0kgz4a4cwlcbx5-tzdata-2021a/lib -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -g  -o libpython3.9.so Modules/getbuildinfo.o Parser/acceler.o Parser/grammar1.o Parser/listnode.o Parser/node.o Parser/parser.o Parser/token.o  Parser/pegen/pegen.o Parser/pegen/parse.o Parser/pegen/parse_string.o Parser/pegen/peg_api.o Parser/myreadline.o Parser/parsetok.o Parser/tokenizer.o Objects/abstract.o Objects/accu.o Objects/boolobject.o Objects/bytes_methods.o Objects/bytearrayobject.o Objects/bytesobject.o Objects/call.o Objects/capsule.o Objects/cellobject.o Objects/classobject.o Objects/codeobject.o Objects/complexobject.o Objects/descrobject.o Objects/enumobject.o Objects/exceptions.o Objects/genericaliasobject.o Objects/genobject.o Objects/fileobject.o Objects/floatobject.o Objects/frameobject.o Objects/funcobject.o Objects/interpreteridobject.o Objects/iterobject.o Objects/listobject.o Objects/longobject.o Objects/dictobject.o Objects/odictobject.o Objects/memoryobject.o Objects/methodobject.o Objects/moduleobject.o Objects/namespaceobject.o Objects/object.o Objects/obmalloc.o Objects/picklebufobject.o Objects/rangeobject.o Objects/setobject.o Objects/sliceobject.o Objects/structseq.o Objects/tupleobject.o Objects/typeobject.o Objects/unicodeobject.o Objects/unicodectype.o Objects/weakrefobject.o Python/_warnings.o Python/Python-ast.o Python/asdl.o Python/ast.o Python/ast_opt.o Python/ast_unparse.o Python/bltinmodule.o Python/ceval.o Python/codecs.o Python/compile.o Python/context.o Python/dynamic_annotations.o Python/errors.o Python/frozenmain.o Python/future.o Python/getargs.o Python/getcompiler.o Python/getcopyright.o Python/getplatform.o Python/getversion.o Python/graminit.o Python/hamt.o Python/hashtable.o Python/import.o Python/importdl.o Python/initconfig.o Python/marshal.o Python/modsupport.o Python/mysnprintf.o Python/mystrtoul.o Python/pathconfig.o Python/peephole.o Python/preconfig.o Python/pyarena.o Python/pyctype.o Python/pyfpe.o Python/pyhash.o Python/pylifecycle.o Python/pymath.o Python/pystate.o Python/pythonrun.o Python/pytime.o Python/bootstrap_hash.o Python/structmember.o Python/symtable.o Python/sysmodule.o Python/thread.o Python/traceback.o Python/getopt.o Python/pystrcmp.o Python/pystrtod.o Python/pystrhex.o Python/dtoa.o Python/formatter_unicode.o Python/fileutils.o Python/dynload_shlib.o    Modules/config.o Modules/getpath.o Modules/main.o Modules/gcmodule.o Modules/posixmodule.o  Modules/errnomodule.o  Modules/pwdmodule.o  Modules/_sre.o  Modules/_codecsmodule.o  Modules/_weakref.o  Modules/_functoolsmodule.o  Modules/_operator.o  Modules/_collectionsmodule.o  Modules/_abc.o  Modules/itertoolsmodule.o  Modules/atexitmodule.o  Modules/signalmodule.o  Modules/_stat.o  Modules/timemodule.o  Modules/_threadmodule.o  Modules/_localemodule.o  Modules/_iomodule.o Modules/iobase.o Modules/fileio.o Modules/bytesio.o Modules/bufferedio.o Modules/textio.o Modules/stringio.o  Modules/faulthandler.o  Modules/_tracemalloc.o  Modules/_peg_parser.o  Modules/symtablemodule.o  Modules/xxsubtype.o Python/frozen.o   -ldl -lcrypt -lncurses -lm  -lm; \
fi
ar rcs libpython3.9.a Modules/getbuildinfo.o Parser/acceler.o Parser/grammar1.o Parser/listnode.o Parser/node.o Parser/parser.o Parser/token.o  Parser/pegen/pegen.o Parser/pegen/parse.o Parser/pegen/parse_string.o Parser/pegen/peg_api.o Parser/myreadline.o Parser/parsetok.o Parser/tokenizer.o Objects/abstract.o Objects/accu.o Objects/boolobject.o Objects/bytes_methods.o Objects/bytearrayobject.o Objects/bytesobject.o Objects/call.o Objects/capsule.o Objects/cellobject.o Objects/classobject.o Objects/codeobject.o Objects/complexobject.o Objects/descrobject.o Objects/enumobject.o Objects/exceptions.o Objects/genericaliasobject.o Objects/genobject.o Objects/fileobject.o Objects/floatobject.o Objects/frameobject.o Objects/funcobject.o Objects/interpreteridobject.o Objects/iterobject.o Objects/listobject.o Objects/longobject.o Objects/dictobject.o Objects/odictobject.o Objects/memoryobject.o Objects/methodobject.o Objects/moduleobject.o Objects/namespaceobject.o Objects/object.o Objects/obmalloc.o Objects/picklebufobject.o Objects/rangeobject.o Objects/setobject.o Objects/sliceobject.o Objects/structseq.o Objects/tupleobject.o Objects/typeobject.o Objects/unicodeobject.o Objects/unicodectype.o Objects/weakrefobject.o Python/_warnings.o Python/Python-ast.o Python/asdl.o Python/ast.o Python/ast_opt.o Python/ast_unparse.o Python/bltinmodule.o Python/ceval.o Python/codecs.o Python/compile.o Python/context.o Python/dynamic_annotations.o Python/errors.o Python/frozenmain.o Python/future.o Python/getargs.o Python/getcompiler.o Python/getcopyright.o Python/getplatform.o Python/getversion.o Python/graminit.o Python/hamt.o Python/hashtable.o Python/import.o Python/importdl.o Python/initconfig.o Python/marshal.o Python/modsupport.o Python/mysnprintf.o Python/mystrtoul.o Python/pathconfig.o Python/peephole.o Python/preconfig.o Python/pyarena.o Python/pyctype.o Python/pyfpe.o Python/pyhash.o Python/pylifecycle.o Python/pymath.o Python/pystate.o Python/pythonrun.o Python/pytime.o Python/bootstrap_hash.o Python/structmember.o Python/symtable.o Python/sysmodule.o Python/thread.o Python/traceback.o Python/getopt.o Python/pystrcmp.o Python/pystrtod.o Python/pystrhex.o Python/dtoa.o Python/formatter_unicode.o Python/fileutils.o Python/dynload_shlib.o    Modules/config.o Modules/getpath.o Modules/main.o Modules/gcmodule.o Modules/posixmodule.o  Modules/errnomodule.o  Modules/pwdmodule.o  Modules/_sre.o  Modules/_codecsmodule.o  Modules/_weakref.o  Modules/_functoolsmodule.o  Modules/_operator.o  Modules/_collectionsmodule.o  Modules/_abc.o  Modules/itertoolsmodule.o  Modules/atexitmodule.o  Modules/signalmodule.o  Modules/_stat.o  Modules/timemodule.o  Modules/_threadmodule.o  Modules/_localemodule.o  Modules/_iomodule.o Modules/iobase.o Modules/fileio.o Modules/bytesio.o Modules/bufferedio.o Modules/textio.o Modules/stringio.o  Modules/faulthandler.o  Modules/_tracemalloc.o  Modules/_peg_parser.o  Modules/symtablemodule.o  Modules/xxsubtype.o Python/frozen.o
In function ‘assemble_lnotab’,
    inlined from ‘assemble_emit’ at Python/compile.c:5717:0,
    inlined from ‘assemble’ at Python/compile.c:6056:0:
Python/compile.c:5671: warning: writing 1 byte into a region of size 0 [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow=-Wstringop-overflow=8;;]
 5671 |         *lnotab++ = k;
      |
/nix/store/vf20zcyqr3qzcjhdidzk377qankcqsqa-binutils-2.35.1/bin/ld: libpython3.9.so.1.0.lto.o: warning: relocation against `PyDictValues_Type' in read-only section `.text'
/nix/store/vf20zcyqr3qzcjhdidzk377qankcqsqa-binutils-2.35.1/bin/ld: libpython3.9.so.1.0.lto.o: relocation R_X86_64_PC32 against symbol `PyBool_Type' can not be used when making a shared object; recompile with -fPIC
/nix/store/vf20zcyqr3qzcjhdidzk377qankcqsqa-binutils-2.35.1/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
ln: failed to access 'libpython3.9.so.1.0': No such file or directory
```

</details>

This should be investigated (since it should be possible), but disabling it for
now seems better than having a significant percentage of pkgsMusl broken.

Ref https://github.com/NixOS/nixpkgs/issues/131557.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
