### PR TITLE
nixos/networkd: add DNSOverTLS option

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -118,6 +118,48 @@ in
       '';
     };
 
+    services.resolved.dnsovertls = mkOption {
+      default = "false";
+      example = "true";
+      type = types.enum [ "true" "opportunistic" "false" ];
+      description = ''
+        If set to
+        <variablelist>
+        <varlistentry>
+          <term><literal>"true"</literal></term>
+          <listitem><para>
+            all connections to the server will be encrypted.
+            Note that this mode requires a DNS server that supports
+            DNS-over-TLS and has a valid certificate. If the hostname
+            was specified using the format "address#server_name"
+            it is used to validate its certificate and also to enable
+            Server Name Indication (SNI) when opening a TLS connection.
+            Otherwise the certificate is checked against the server's
+            IP. If the DNS server does not support DNS-over-TLS all
+            DNS requests will fail.
+          </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>"opportunistic"</literal></term>
+          <listitem><para>
+            DNS request are attempted to send encrypted with DNS-over-TLS.
+            If the DNS server does not support TLS, DNS-over-TLS is disabled.
+            Note that this mode makes DNS-over-TLS vulnerable to "downgrade"
+            attacks, where an attacker might be able to trigger a downgrade
+            to non-encrypted mode by synthesizing a response that suggests
+            DNS-over-TLS was not supported.
+            </para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>"false"</literal></term>
+          <listitem><para>
+            DNS lookups are send over UDP.
+          </para></listitem>
+        </varlistentry>
+        </variablelist>
+      '';
+    };
+
     services.resolved.extraConfig = mkOption {
       default = "";
       type = types.lines;
@@ -164,6 +206,7 @@ in
           "Domains=${concatStringsSep " " cfg.domains}"}
         LLMNR=${cfg.llmnr}
         DNSSEC=${cfg.dnssec}
+        DNSOverTLS=${cfg.dnsovertls}
         ${config.services.resolved.extraConfig}
       '';
 


### PR DESCRIPTION
###### Things done

Added new option to enable DNSOverTLS

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
