### PR TITLE
libvarlink: init at 22

### DIFF
--- a/pkgs/development/libraries/libvarlink/default.nix
+++ b/pkgs/development/libraries/libvarlink/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libvarlink";
+  version = "22";
+
+  src = fetchFromGitHub {
+    owner = "varlink";
+    repo = pname;
+    rev = version;
+    sha256 = "1i15227vlc9k4276r833ndhxrcys9305pf6dga1j0alx2vj85yz2";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+
+  postPatch = ''
+    substituteInPlace varlink-wrapper.py \
+      --replace "/usr/bin/env python3" "${python3}/bin/python3"
+
+    # test-object: ../lib/test-object.c:129: main: Assertion `setlocale(LC_NUMERIC, "de_DE.UTF-8") != 0' failed.
+    # PR that added it https://github.com/varlink/libvarlink/pull/27
+    substituteInPlace lib/test-object.c \
+      --replace 'assert(setlocale(LC_NUMERIC, "de_DE.UTF-8") != 0);' ""
+
+    patchShebangs lib/test-symbols.sh
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "C implementation of the Varlink protocol and command line tool";
+    homepage = "https://github.com/varlink/libvarlink";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ artturin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17283,6 +17283,8 @@ in
   libva1 = callPackage ../development/libraries/libva/1.0.0.nix { };
   libva1-minimal = libva1.override { minimal = true; };
 
+  libvarlink = callPackage ../development/libraries/libvarlink { };
+
   libvdpau = callPackage ../development/libraries/libvdpau { };
 
   libmodulemd = callPackage ../development/libraries/libmodulemd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #131750


###### Things done

Should i mess with `outputs`? 
Package structure
```tree
 tree result
result
├── bin
│   └── varlink
├── include
│   └── varlink.h
├── lib
│   ├── libvarlink.so -> libvarlink.so.0
│   ├── libvarlink.so.0
│   └── pkgconfig
│       └── libvarlink.pc
└── share
    ├── bash-completion
    │   └── completions
    │       └── varlink
    └── vim
        └── vimfiles
            └── after
                ├── ftdetect
                │   └── varlink.vim
                ├── ftplugin
                │   └── varlink.vim
                └── syntax
                    └── varlink.vim
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
