### PR TITLE
nixos/virtualisation/containerd: do not wipe runtime directory on restart or stop

### DIFF
--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -86,6 +86,7 @@ in
 
         StateDirectory = "containerd";
         RuntimeDirectory = "containerd";
+        RuntimeDirectoryPreserve = "yes";
       };
       unitConfig = {
         StartLimitBurst = "16";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Due to the lack of `RuntimeDirectoryPreserve` in the containerd systemd service, `/run/containerd` will be wiped when the service is restarted or stopped. This is illegal behaviour, as this causes containerd to lose knowledge of every shim process it owns; they remain in the background, unkillable until a system restart.

This series of commands can be used to reproduce the issue:
```
image="docker.io/library/busybox:latest"
ctr image pull "$image"
ctr run --detach "$image" test5 sleep infinity

# task running
ctr t ls

systemctl restart containerd

# task no longer running
ctr t ls

# shim process is still there
ps -aux | grep shim
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
