### PR TITLE
[staging-next] cmake: Fix embedded curl on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/application-services.patch
@@ -1,8 +1,8 @@
 diff --git a/Source/CMakeLists.txt b/Source/CMakeLists.txt
-index 1b6bb00d4c..487114daa8 100644
+index 9a18184fd3..278d146dd1 100644
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -893,7 +893,6 @@ endif()
+@@ -933,7 +933,6 @@ endif()
  # On Apple we need CoreFoundation and CoreServices
  if(APPLE)
    target_link_libraries(CMakeLib "-framework CoreFoundation")
@@ -11,27 +11,25 @@ index 1b6bb00d4c..487114daa8 100644
  
  if(WIN32 AND NOT UNIX)
 diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.cxx
-index a5ce5d18f4..3d6838ce82 100644
+index 77403b076a..d5aac95e1e 100644
 --- a/Source/cmGlobalXCodeGenerator.cxx
 +++ b/Source/cmGlobalXCodeGenerator.cxx
-@@ -43,11 +43,10 @@
- 
- struct cmLinkImplementation;
+@@ -49,10 +49,6 @@ struct cmLinkImplementation;
  
  #if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
--#  define HAVE_APPLICATION_SERVICES
--#  include <ApplicationServices/ApplicationServices.h>
-+#  include <CoreFoundation/CoreFoundation.h>
+ #  include <CoreFoundation/CoreFoundation.h>
+-#  if !TARGET_OS_IPHONE
+-#    define HAVE_APPLICATION_SERVICES
+-#    include <ApplicationServices/ApplicationServices.h>
+-#  endif
  #endif
-
- #if !defined(CMAKE_BOOTSTRAP)
- #  include "cmXMLParser.h"
  
+ #if !defined(CMAKE_BOOTSTRAP)
 diff --git a/Utilities/cmlibarchive/CMakeLists.txt b/Utilities/cmlibarchive/CMakeLists.txt
-index bfcaf30bb7..1da540aee5 100644
+index 79452ffff6..a848731b7e 100644
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -2007,11 +2007,6 @@ IF(ENABLE_TEST)
+@@ -2013,11 +2013,6 @@ IF(ENABLE_TEST)
  ENDIF(ENABLE_TEST)
  ENDIF()
  

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -16,12 +16,11 @@ stdenv.mkDerivation rec {
           + lib.optionalString isBootstrap "-boot"
           + lib.optionalString useNcurses "-cursesUI"
           + lib.optionalString withQt5 "-qt5UI";
-  version = "3.19.7";
+  version = "3.21.0";
 
   src = fetchurl {
     url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
-    # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
-    sha256 = "sha256-WKFfDVagr8zDzFNxI0/Oc/zGyPnb13XYmOUQuDF1WI4=";
+    sha256 = "sha256-SkLVZEmlH004CatNO2H9SpakaeViZuiWzhAJtXaL0qs=";
   };
 
   patches = [

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -2,6 +2,7 @@
 , bzip2, curlMinimal, expat, libarchive, xz, zlib, libuv, rhash
 , buildPackages
 # darwin attributes
+, SystemConfiguration
 , ps
 , isBootstrap ? false
 , useSharedLibraries ? (!isBootstrap && !stdenv.isCygwin)
@@ -33,7 +34,9 @@ stdenv.mkDerivation rec {
     # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
     ./libuv-application-services.patch
 
-  ] ++ lib.optional stdenv.isCygwin ./3.2.2-cygwin.patch;
+  ] ++ lib.optional stdenv.isCygwin ./3.2.2-cygwin.patch
+  # Derived from https://github.com/curl/curl/commit/31f631a142d855f069242f3e0c643beec25d1b51
+  ++ lib.optional (stdenv.isDarwin && isBootstrap) ./remove-systemconfiguration-dep.patch;
 
   outputs = [ "out" ]
     ++ lib.optionals buildDocs [ "man" "info" ];
@@ -51,7 +54,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals useSharedLibraries [ bzip2 curlMinimal expat libarchive xz zlib libuv rhash ]
     ++ lib.optional useOpenSSL openssl
     ++ lib.optional useNcurses ncurses
-    ++ lib.optional withQt5 qtbase;
+    ++ lib.optional withQt5 qtbase
+    ++ lib.optional (stdenv.isDarwin && !isBootstrap) SystemConfiguration;
 
   propagatedBuildInputs = lib.optional stdenv.isDarwin ps;
 

--- a/pkgs/development/tools/build-managers/cmake/remove-systemconfiguration-dep.patch
+++ b/pkgs/development/tools/build-managers/cmake/remove-systemconfiguration-dep.patch
@@ -1,0 +1,89 @@
+From 76523ca5b2227085bb65253900e866b08a2b5efb Mon Sep 17 00:00:00 2001
+From: Tobias Mayer <tobim@fastmail.fm>
+Date: Fri, 30 Jul 2021 10:50:16 +0200
+Subject: [PATCH] Disable NAT64 address synthesis on darwin
+
+This intentionally breaks the feature by partially reverting
+https://github.com/curl/curl/commit/31f631a142d855f069242f3e0c643beec25d1b51
+
+This is a stop-gap to get CMake to build without the SystemConfiguration
+framework.
+---
+ Utilities/cmcurl/CMakeLists.txt   |  8 --------
+ Utilities/cmcurl/lib/curl_setup.h |  4 ----
+ Utilities/cmcurl/lib/hostip.c     | 17 -----------------
+ 3 files changed, 29 deletions(-)
+
+diff --git a/Utilities/cmcurl/CMakeLists.txt b/Utilities/cmcurl/CMakeLists.txt
+index 16ef037ccc..17564bbb69 100644
+--- a/Utilities/cmcurl/CMakeLists.txt
++++ b/Utilities/cmcurl/CMakeLists.txt
+@@ -511,14 +511,6 @@ if(CMAKE_USE_SECTRANSP)
+   list(APPEND CURL_LIBS "${COREFOUNDATION_FRAMEWORK}" "${SECURITY_FRAMEWORK}")
+ endif()
+ 
+-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-  find_library(SYSTEMCONFIGURATION_FRAMEWORK "SystemConfiguration")
+-  if(NOT SYSTEMCONFIGURATION_FRAMEWORK)
+-     message(FATAL_ERROR "SystemConfiguration framework not found")
+-  endif()
+-  list(APPEND CURL_LIBS "${SYSTEMCONFIGURATION_FRAMEWORK}")
+-endif()
+-
+ if(CMAKE_USE_OPENSSL)
+   find_package(OpenSSL)
+   if(NOT OpenSSL_FOUND)
+diff --git a/Utilities/cmcurl/lib/curl_setup.h b/Utilities/cmcurl/lib/curl_setup.h
+index 2d13a40a55..35160bc0f5 100644
+--- a/Utilities/cmcurl/lib/curl_setup.h
++++ b/Utilities/cmcurl/lib/curl_setup.h
+@@ -251,11 +251,7 @@
+  * performing this task will result in a synthesized IPv6 address.
+  */
+ #if defined(__APPLE__) && !defined(USE_ARES)
+-#include <TargetConditionals.h>
+ #define USE_RESOLVE_ON_IPS 1
+-#  if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+-#    define CURL_OSX_CALL_COPYPROXIES 1
+-#  endif
+ #endif
+ 
+ #ifdef USE_LWIPSOCK
+diff --git a/Utilities/cmcurl/lib/hostip.c b/Utilities/cmcurl/lib/hostip.c
+index e0e3cfc2cb..45190a100b 100644
+--- a/Utilities/cmcurl/lib/hostip.c
++++ b/Utilities/cmcurl/lib/hostip.c
+@@ -68,10 +68,6 @@
+ #include "curl_memory.h"
+ #include "memdebug.h"
+ 
+-#if defined(ENABLE_IPV6) && defined(CURL_OSX_CALL_COPYPROXIES)
+-#include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
+-#endif
+-
+ #if defined(CURLRES_SYNCH) && \
+     defined(HAVE_ALARM) && defined(SIGALRM) && defined(HAVE_SIGSETJMP)
+ /* alarm-based timeouts can only be used with all the dependencies satisfied */
+@@ -533,19 +529,6 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
+         return CURLRESOLV_ERROR;
+     }
+ 
+-#if defined(ENABLE_IPV6) && defined(CURL_OSX_CALL_COPYPROXIES)
+-    /*
+-     * The automagic conversion from IPv4 literals to IPv6 literals only works
+-     * if the SCDynamicStoreCopyProxies system function gets called first. As
+-     * Curl currently doesn't support system-wide HTTP proxies, we therefore
+-     * don't use any value this function might return.
+-     *
+-     * This function is only available on a macOS and is not needed for
+-     * IPv4-only builds, hence the conditions above.
+-     */
+-    SCDynamicStoreCopyProxies(NULL);
+-#endif
+-
+ #ifndef USE_RESOLVE_ON_IPS
+     /* First check if this is an IPv4 address string */
+     if(Curl_inet_pton(AF_INET, hostname, &in) > 0)
+-- 
+2.32.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13436,10 +13436,15 @@ in
 
   cmake_2_8 = callPackage ../development/tools/build-managers/cmake/2.8.nix { };
 
-  cmake = libsForQt5.callPackage ../development/tools/build-managers/cmake { };
+  cmake = libsForQt5.callPackage ../development/tools/build-managers/cmake {
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
+  };
 
   cmakeMinimal = libsForQt5.callPackage ../development/tools/build-managers/cmake {
     isBootstrap = true;
+    # There is no SystemConfiguration in bootstrapTools, so this version gets
+    # patched to remove that dependency.
+    SystemConfiguration = null;
   };
 
   cmakeCurses = cmake.override { useNcurses = true; };


### PR DESCRIPTION
Add SystemConfiguration framework to buildInputs.

This is a naive attempt that I can't test at the moment.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
