### PR TITLE
roon-{bridge,server}: 1.8-806 -> 1.8-814

### DIFF
--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -10,15 +10,15 @@
 
 stdenv.mkDerivation rec {
   pname = "roon-bridge";
-  version = "1.8-795";
+  version = "1.8-814";
 
   # N.B. The URL is unstable. I've asked for them to provide a stable URL but
   # they have ignored me. If this package fails to build for you, you may need
   # to update the version and sha256.
   # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
   src = fetchurl {
-    url = "https://web.archive.org/web/20210610172810/http://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2";
-    sha256 = "sha256-ahdy0/TBOyMfCt4VTkcDTZGAFmwQJT2KvZuMtFcAY3w=";
+    url = "https://web.archive.org/web/20210729154257/http://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2";
+    sha256 = "sha256-dersaP/8qkl9k81FrgMieB0P4nKmDwjLW5poqKhEn7A=";
   };
 
   buildInputs = [

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -11,15 +11,15 @@
 , zlib
 }: stdenv.mkDerivation rec {
   pname = "roon-server";
-  version = "1.8-806";
+  version = "1.8-814";
 
   # N.B. The URL is unstable. I've asked for them to provide a stable URL but
   # they have ignored me. If this package fails to build for you, you may need
   # to update the version and sha256.
   # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
   src = fetchurl {
-    url = "https://web.archive.org/web/20210707070319/http://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
-    sha256 = "sha256-TRgsHR71wNz2MoH+RZrIaWEzQSAbo+q8ICKfmmCFy5Y=";
+    url = "https://web.archive.org/web/20210729154130/http://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
+    sha256 = "sha256-GbWcgNq+dmzoHNFZyB/QFCvJ7Hh48v8IuGS4WMNlKgI=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- roon-bridge: 1.8-795 -> 1.8-814
- roon-server: 1.8-795 -> 1.8-814

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
