### PR TITLE
python3Packages.palace: init at 0.2.5

### DIFF
--- a/pkgs/development/python-modules/palace/default.nix
+++ b/pkgs/development/python-modules/palace/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildPythonPackage, fetchFromSourcehut, pythonOlder
+, cmake, cython, alure2, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "palace";
+  version = "0.2.5";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "1z0m35y4v1bg6vz680pwdicm9ssryl0q6dm9hfpb8hnifmridpcj";
+  };
+
+  # Nix uses Release CMake configuration instead of what is assumed by palace.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace IMPORTED_LOCATION_NOCONFIG IMPORTED_LOCATION_RELEASE
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ cython ];
+  propagatedBuildInputs = [ alure2 ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+  ];
+
+  doCheck = false; # FIXME: tests need an audio device
+  pythonImportsCheck = [ "palace" ];
+
+  meta = with lib; {
+    description = "Pythonic Audio Library and Codecs Environment";
+    homepage = "https://mcsinyx.gitlab.io/palace";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5083,6 +5083,8 @@ in {
 
   paho-mqtt = callPackage ../development/python-modules/paho-mqtt { };
 
+  palace = callPackage ../development/python-modules/palace { };
+
   palettable = callPackage ../development/python-modules/palettable { };
 
   # Alias. Added 2020-09-07.


### PR DESCRIPTION
###### Motivation for this change

Palace is used in a game of mine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
