### PR TITLE
brutalmaze: init at 1.1.1

### DIFF
--- a/pkgs/games/brutalmaze/default.nix
+++ b/pkgs/games/brutalmaze/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromSourcehut, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "brutalmaze";
+  version = "1.1.1";
+  format = "flit";
+  disabled = python3Packages.pythonOlder "3.7";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "1m105iq378mypj64syw59aldbm6bj4ma4ynhc50gafl656fabg4y";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    loca
+    palace
+    pygame
+  ];
+
+  doCheck = false; # there's no test
+
+  meta = with lib; {
+    description = "Minimalist thrilling shoot 'em up game";
+    homepage = "https://brutalmaze.rtfd.io";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29059,6 +29059,8 @@ with pkgs;
 
   brogue = callPackage ../games/brogue { };
 
+  brutalmaze = callPackage ../games/brutalmaze { };
+
   bsdgames = callPackage ../games/bsdgames { };
 
   btanks = callPackage ../games/btanks { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).