### PR TITLE
newt: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -12,16 +12,21 @@ stdenv.mkDerivation rec {
     sha256 = "0cdvbancr7y4nrj8257y5n45hmhizr8isynagy4fpsnpammv8pi6";
   };
 
-  patchPhase = ''
+  postPatch = ''
     sed -i -e s,/usr/bin/install,install, -e s,-I/usr/include/slang,, Makefile.in po/Makefile
 
     substituteInPlace configure \
       --replace "/usr/include/python" "${pythonIncludePath}"
     substituteInPlace configure.ac \
       --replace "/usr/include/python" "${pythonIncludePath}"
+
+    substituteInPlace Makefile.in \
+      --replace "ar rv" "${stdenv.cc.targetPrefix}ar rv"
   '';
 
-  buildInputs = [ slang popt python ];
+  strictDeps = true;
+  nativeBuildInputs = [ python ];
+  buildInputs = [ slang popt ];
 
   NIX_LDFLAGS = "-lncurses";
 


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for newt, a dependency of e.g. networkmanager.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
