### PR TITLE
lsirec: init at unstable-2019-03-03

### DIFF
--- a/pkgs/os-specific/linux/lsirec/default.nix
+++ b/pkgs/os-specific/linux/lsirec/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lsirec";
+  version = "unstable-2019-03-03";
+
+  src = fetchFromGitHub {
+    owner = "marcan";
+    repo = "lsirec";
+    rev = "2dfb6dc92649feb01a3ddcfd117d4a99098084f2";
+    sha256 = "sha256-8v+KKjAJlJNpUT0poedRTQfPiDiwahrosXD35Bmh3jM=";
+  };
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 'lsirec' "$out/bin/lsirec"
+    install -Dm755 'sbrtool.py' "$out/bin/sbrtool"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "LSI SAS2008/SAS2108 low-level recovery tool for Linux";
+    homepage = "https://github.com/marcan/lsirec";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22605,6 +22605,8 @@ with pkgs;
 
   lockdep = callPackage ../os-specific/linux/lockdep { };
 
+  lsirec = callPackage ../os-specific/linux/lsirec { };
+
   lsiutil = callPackage ../os-specific/linux/lsiutil { };
 
   kaitai-struct-compiler = callPackage ../development/compilers/kaitai-struct-compiler { };


### PR DESCRIPTION
###### Motivation for this change
This adds lsirec, a utility that can be used to modify and recover certain LSI HBA PCIe cards.
My Dell R610 Server has an anti-feature that prevents the machine from booting, if any PCIe card not blessed by Dell for such usage is installed in the "storage slot" of the server. I used lsiutil to flash a different firmware to my "Dell PERC H310" to convert it into a "Dell 6Gbps SAS HBA Adapter". I was then able to use lsirec and the included sbrtool python script to modify my "Dell 6Gbps SAS HBA Adapter" card into pretending to be a "Dell PERC H200 Integrated" card, finally making it work in the storage slot and circumventing the stupid firmware check.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).