### PR TITLE
libsigrok: fix c++ bindings

### DIFF
--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, libzip, glib, libusb1, libftdi1, check
-, libserialport, librevisa, doxygen, glibmm
+, libserialport, librevisa, doxygen, glibmm, python3
 , version ? "0.5.1", sha256 ? "171b553dir5gn6w4f7n37waqk62nq2kf1jykx4ifjacdz5xdw3z4"
 }:
 
@@ -17,10 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "14sd8xqph4kb109g073daiavpadb20fcz7ch1ipn0waz7nlly4sw";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libzip glib libusb1 libftdi1 check libserialport
-    librevisa doxygen glibmm
-  ];
+  nativeBuildInputs = [ doxygen pkg-config python3 ];
+  buildInputs = [ libzip glib libusb1 libftdi1 check libserialport librevisa glibmm ];
 
   strictDeps = true;
 
@@ -29,11 +27,18 @@ stdenv.mkDerivation rec {
     tar --strip-components=1 -xvf "${firmware}" -C "$out/share/sigrok-firmware/"
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # assert that c++ bindings are included
+    [[ -f $out/include/libsigrokcxx/libsigrokcxx.hpp ]] \
+      || { echo 'C++ bindings were not generated; check configure output'; false; }
+  '';
+
   meta = with lib; {
     description = "Core library of the sigrok signal analysis software suite";
     homepage = "https://sigrok.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
Doxygen and Python are needed as `nativeBuildInputs` (according to this project's `configure`).

Add a tiny `installCheck` for this.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`pulseview` is broken because of missing C++ headers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
