### PR TITLE
libcanberra: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, fetchpatch, pkg-config, libtool
 , gtk ? null
 , libpulseaudio, gst_all_1, libvorbis, libcap
-, CoreServices
+, Carbon, CoreServices
 , withAlsa ? stdenv.isLinux, alsa-lib }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libpulseaudio libvorbis gtk
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base ])
-    ++ lib.optional stdenv.isDarwin CoreServices
+    ++ lib.optionals stdenv.isDarwin [Carbon CoreServices]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional withAlsa alsa-lib;
 
@@ -60,8 +60,5 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     maintainers = [ ];
     platforms = platforms.unix;
-    # canberra-gtk-module.c:28:10: fatal error: 'gdk/gdkx.h' file not found
-    # #include <gdk/gdkx.h>
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16283,7 +16283,7 @@ in
   libcacard = callPackage ../development/libraries/libcacard { };
 
   libcanberra = callPackage ../development/libraries/libcanberra {
-    inherit (darwin.apple_sdk.frameworks) CoreServices;
+    inherit (darwin.apple_sdk.frameworks) Carbon CoreServices;
   };
   libcanberra-gtk2 = pkgs.libcanberra.override {
     gtk = gtk2-x11;


### PR DESCRIPTION
libcanberra was marked as broken on commit 806d814516c, but the error doesn't appear with current nixpkgs `master`.

It is the linking which is failing now with:

    ld: file not found: /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon for architecture x86_64
    clang-7: error: linker command failed with exit code 1 (use -v to see invocation)

But it was easily fixed by adding `Carbon` to the derivation inputs.

I just found this broken package because I am trying to fix pympress, which doesn't build on Darwin because of it (and a few other packages). I can see it building, but I cannot run it to see that it is running properly, since it is a library.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

libcanberra not building on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
