### PR TITLE
Luarocks nix bump

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -78,10 +78,11 @@ mpack,,,,,
 moonscript,,,,,arobyn
 nvim-client,,,,,
 penlight,,,,,
+plenary.nvim,,,,lua5_1,
 rapidjson,,,,,
 readline,,,,,
 say,,,,,
-std__debug,std._debug,,,,
+std-_debug,std._debug,,,,
 std_normalize,std.normalize,,,,
 stdlib,,,,,vyp
 vstruct,,,,,

--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -89,6 +89,10 @@ function convert_pkg() {
         echo "Skipping comment ${*}" >&2
         return
     fi
+
+    # Normalize package name
+    nix_pkg_name_normalized=$(sed 's/\./-/' <(echo "$nix_pkg_name"))
+
     if [ -z "$lua_pkg_name" ]; then
         echo "Using nix_name as lua_pkg_name for '$nix_pkg_name'" >&2
         lua_pkg_name="$nix_pkg_name"
@@ -111,7 +115,7 @@ function convert_pkg() {
         luarocks_args+=("$pkg_version")
     fi
     echo "Running 'luarocks ${luarocks_args[*]}'" >&2
-    if drv="$nix_pkg_name = $(luarocks "${luarocks_args[@]}")"; then
+    if drv="$nix_pkg_name_normalized = $(luarocks "${luarocks_args[@]}")"; then
         echo "$drv"
     else
         echo "Failed to convert $nix_pkg_name" >&2

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1479,6 +1479,36 @@ penlight = buildLuarocksPackage {
     license.fullName = "MIT/X11";
   };
 };
+plenary-nvim = buildLuarocksPackage {
+  pname = "plenary.nvim";
+  version = "scm-1";
+
+  knownRockspec = (fetchurl {
+    url    = "mirror://luarocks/plenary.nvim-scm-1.rockspec";
+    sha256 = "1cp2dzf3010q85h300aa7zphyz75qn67lrwf9v6b0p534nzvmash";
+  }).outPath;
+
+  src = fetchgit ( removeAttrs (builtins.fromJSON ''{
+  "url": "git://github.com/nvim-lua/plenary.nvim",
+  "rev": "8bae2c1fadc9ed5bfcfb5ecbd0c0c4d7d40cb974",
+  "date": "2021-07-12T11:07:18-04:00",
+  "path": "/nix/store/djp9yacizsxs9hiz786fb900fri0m2l8-plenary.nvim",
+  "sha256": "1axvjv6n77afkjqk914dpc020kxd7mig6m5sr916k1n1q35jc4ny",
+  "fetchSubmodules": true,
+  "deepClone": false,
+  "leaveDotGit": false
+}
+ '') ["date" "path"]) ;
+
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  propagatedBuildInputs = [ lua luassert ];
+
+  meta = with lib; {
+    homepage = "http://github.com/nvim-lua/plenary.nvim";
+    description = "lua functions you don't want to write ";
+    license.fullName = "MIT/X11";
+  };
+};
 rapidjson = buildLuarocksPackage {
   pname = "rapidjson";
   version = "0.6.1-1";

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -5,7 +5,7 @@ luarocks.overrideAttrs(old: {
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "luarocks-nix";
-    rev = "v3.5.0_nix";
-    sha256 = "sha256-Ea3PVkCaUPO/mvVZtHtD1G9T/Yom28M9oN6duY4ovHk=";
+    rev = "nix_v3.5.0-1";
+    sha256 = "sha256-jcgshxAuuc8QizpYL/2K3PKYWiKsnF/8BJAUaryvEvQ=";
   };
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

less controversial changes I made while working on https://github.com/NixOS/nixpkgs/pull/131499
- normalize lua package names like vim plugins aka replace dot by a dash
- added plenary.nvim, an important package in the neovim ecosystem
-
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
