### PR TITLE
openafs: 1.8.7 -> 1.8.8

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -18,49 +18,6 @@ in stdenv.mkDerivation {
 
   buildInputs = [ libkrb5 ];
 
-  patches = [
-    # LINUX 5.8: Replace kernel_setsockopt with new funcs
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/d7fc5bf9bf031089d80703c48daf30d5b15a80ca.patch";
-      sha256 = "0469ydzgvyvrl1b2s1qbl9cd8c5c1nb99c3z52z5i685da5z6pab";
-    })
-    # LINUX 5.8: do not set name field in backing_dev_info
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/335f37be13d2ff954e4aeea617ee66502170805e.patch";
-      sha256 = "0jr6cgplnip61cjlcd3fvgsc6n3jhfk93mm9m7ak04w1vc26dk9x";
-    })
-    # LINUX 5.8: use lru_cache_add
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/facff58b840a47853592510617ba7a1da2e3eaa9.patch";
-      sha256 = "0izafg6bi5iaigq3jjx0zlg1cxwaddz3238hk0s08fcb6nyhkvx1";
-    })
-    # LINUX 5.9: Remove HAVE_UNLOCKED_IOCTL/COMPAT_IOCTL
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/e7902252f15acfc28453c531f6fa3b29c9c91b92.patch";
-      sha256 = "1jy4v8yx8p6mhma6b3h3g94mb38bw7hg7q6lnyc8bijkbnl0d1rl";
-    })
-    # Linux: Refactor test for 32bit compat
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/4ad1057ab8fd206c9fa8d5e3bdde4f1a8417afdb.patch";
-      sha256 = "0v2537wkav78yi8lv6fkd1n6rf2g17igf44rpa3kd0kkidxv5lqr";
-    })
-    # Linux 5.11: Test 32bit compat with in_compat_syscall
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/ee53dd3bc087a05e22fc4111297a51ddb30013f0.patch";
-      sha256 = "0dfab3zk0dmf6iksna5n09lf5dn4f8w43q4irl2yf5dgqm35shkr";
-    })
-    # Linux: Create wrapper for setattr_prepare
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/5a5d358b02b88d6d2c7a27a75149e35b1de7db38.patch";
-      sha256 = "07gywsg41cz5h6iafr4pb0gb9jnsb58xkwn479lw46b3y5jgz7ki";
-    })
-    # Linux 5.12: Add user_namespace param to inode ops
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/c747b15dd2877e6d17e3e6b940ae78c1e1ccd3ea.patch";
-      sha256 = "0bbqmx4nkmfkapk25zrv9ivhhs91rn9dizb1lkfs7a6937q1kaqh";
-    })
-  ];
-
   hardeningDisable = [ "pic" ];
 
   configureFlags = [

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.8.7";
+  version = "1.8.8";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "0ygsrf65w9sqji2x3jbx3h31vk6513s6nalzxi7p2ryf3xb3lm2k";
+    sha256 = "sha256-2qjvhqdyf6z83jvJemrRQxKcHCXuNfM0cIDsfp0oTaA=";
   };
 
   srcs = [ src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "0zri99pxmp4klh8ki5ycnjpf1h21lynn4049s6ywmap1vkpq84yn";
+      sha256 = "sha256-3cxODH1KvOTxrGB+acEudxGCX1iBPjZcTfjpfraOm+U=";
     })];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This still needs some testing.

###### Motivation for this change

https://openafs.org/dl/openafs/1.8.8/RELNOTES-1.8.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
