### PR TITLE
multimc: don't re-distribute package

### DIFF
--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -43,7 +43,7 @@ in mkDerivation rec {
       Allows you to have multiple, separate instances of Minecraft (each with their own mods, texture packs, saves, etc) and helps you manage them and their associated options with a simple interface.
     '';
     platforms = platforms.linux;
-    license = licenses.lgpl21Plus;
+    license = licenses.asl20;
     maintainers = with maintainers; [ cleverca22 starcraft66 ];
   };
 }

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -44,6 +44,9 @@ in mkDerivation rec {
     '';
     platforms = platforms.linux;
     license = licenses.asl20;
+    # upstream don't want us to re-distribute this application:
+    # https://github.com/NixOS/nixpkgs/issues/131983
+    hydraPlatforms = [];
     maintainers = with maintainers; [ cleverca22 starcraft66 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[MultiMC's licensing terms](https://github.com/peterix/multimc5#forkingredistributing) forbid the redistribution of binaries without branding changes. Since we don't want to maintain the patch set associated with a branding change, we will stop distributing the package in binary form.

This also changes the license to Apache 2.0 because it was mistakenly set to something else.

Closes #131983 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
