### PR TITLE
xonsh: add PYTHONPATH

### DIFF
--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -29,6 +29,19 @@ python3Packages.buildPythonApplication rec {
     find scripts -name 'xonsh*' -exec sed -i -e "s|env -S|env|" {} \;
     find -name "*.xsh" | xargs sed -ie 's|/usr/bin/env|${coreutils}/bin/env|'
     patchShebangs .
+
+    substituteInPlace scripts/xon.sh \
+      --replace 'python' "${python3Packages.python}/bin/python"
+
+  '';
+
+  makeWrapperArgs = [
+    "--prefix PYTHONPATH : ${placeholder "out"}/lib/${python3Packages.python.libPrefix}/site-packages"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/xon.sh \
+      $makeWrapperArgs
   '';
 
   disabledTests = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #104745

before

```
xonfig web
/nix/store/81lwy2hfqj4c1943b1x8a0qsivjhdhw9-python3-3.9.6/bin/python3.9: Error while finding module specification for 'xonsh.webconfig' (ModuleNotFoundError: No module named 'xonsh')

./result/bin/xon.sh
/result/bin/xon.sh
/nix/store/v9v98vxswg629l9hxpnyn65ma6l2ia4x-python3-3.9.5-env/bin/python3.9: No module named xonsh
```

after

```
xonfig web
Web config started at 'http://localhost:8421'. Hit Crtl+C to stop.

./result/bin/xon.sh
opens normally in readline backend
```

for some reason

```
  makeWrapperArgs = [
    "--prefix PYTHONPATH : $out/lib/${python3Packages.python.libPrefix}/site-packages"
  ];
```

causes this
```
=============================== warnings summary ===============================
tests/test_shell.py::test_shell_with_dummy_history_in_not_interactive
  /nix/store/115c8s7bvnqyj3vwws5kz1pad0dsnf0d-python3.9-pytest-6.2.4/lib/python3.9/site-packages/_pytest/threadexception.py:75: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-2950

  Traceback (most recent call last):
    File "/nix/store/81lwy2hfqj4c1943b1x8a0qsivjhdhw9-python3-3.9.6/lib/python3.9/threading.py", line 973, in _bootstrap_inner
      self.run()
    File "/build/source/xonsh/history/__amalgam__.py", line 1088, in run
      hsize, units = envs.get("XONSH_HISTORY_SIZE")
  TypeError: cannot unpack non-iterable NoneType object

    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
