### PR TITLE
transifex-client: 0.13.9 → 0.14.3, fix build

### DIFF
--- a/pkgs/tools/text/transifex-client/default.nix
+++ b/pkgs/tools/text/transifex-client/default.nix
@@ -1,23 +1,23 @@
 { lib, buildPythonApplication, fetchPypi
-, python-slugify, requests, urllib3, six, setuptools }:
+, python-slugify, requests, urllib3, six, setuptools, GitPython }:
 
 buildPythonApplication rec {
   pname = "transifex-client";
-  version = "0.13.9";
+  version = "0.14.3";
 
   propagatedBuildInputs = [
-    urllib3 requests python-slugify six setuptools
+    urllib3 requests python-slugify six setuptools GitPython
   ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0lgd77vrddvyn8afkxr7a7hblmp4k5sr0i9i1032xdih2bipdd9f";
+    sha256 = "sha256-sKol67lRaYPFa7Bg9KNa1rDrNoT9DtUd48NY8jqK1iw=";
   };
 
+  # https://github.com/transifex/transifex-client/issues/323
   prePatch = ''
-    substituteInPlace requirements.txt --replace "urllib3<1.24" "urllib3>=1.24" \
-      --replace "six==1.11.0" "six>=1.11.0" \
-      --replace "python-slugify<2.0.0" "python-slugify>2.0.0"
+    substituteInPlace requirements.txt \
+      --replace "python-slugify<5.0.0" "python-slugify"
   '';
 
   # Requires external resources
@@ -25,8 +25,8 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://www.transifex.com/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     description = "Transifex translation service client";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ sikmir ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
We have [updated python-slugify to 5.0.2](https://github.com/NixOS/nixpkgs/pull/126255) which [broke the build](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.transifex-client.x86_64-linux). Using  python-slugify 5.0.2 doesn't actually
break the software.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
