### PR TITLE
ocamlPackages.lens: 1.2.4 → 1.2.5

### DIFF
--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -1,18 +1,20 @@
-{ lib, fetchzip, ppx_deriving, ppxfind, buildDunePackage, ounit }:
+{ lib, fetchFromGitHub, ppx_deriving, ppxlib, buildDunePackage, ounit }:
 
 buildDunePackage rec {
   pname = "lens";
-  version = "1.2.4";
+  version = "1.2.5";
 
   useDune2 = true;
 
-  src = fetchzip {
-    url = "https://github.com/pdonadeo/ocaml-lens/archive/v${version}.tar.gz";
-    sha256 = "18mv7n5rcix3545mc2qa2f9xngks4g4kqj2g878qj7r3cy96kklv";
+  src = fetchFromGitHub {
+    owner = "pdonadeo";
+    repo = "ocaml-lens";
+    rev = "v${version}";
+    sha256 = "1k23n7pa945fk6nbaq6nlkag5kg97wsw045ghz4gqp8b9i2im3vn";
   };
 
-  minimumOCamlVersion = "4.10";
-  buildInputs = [ ppx_deriving ppxfind ];
+  minimalOCamlVersion = "4.10";
+  buildInputs = [ ppx_deriving ppxlib ];
 
   doCheck = true;
   checkInputs = [ ounit ];
@@ -24,6 +26,5 @@ buildDunePackage rec {
     maintainers = with maintainers; [
       kazcw
     ];
-    broken = true; # Not compatible with ppx_deriving ≥ 5.0
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix broken package.

cc maintainer @kazcw.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
