### PR TITLE
rebar3: apply tmpdir patch from upstream

### DIFF
--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub,
+{ lib, stdenv, fetchFromGitHub, fetchpatch,
   fetchHex, erlang, makeWrapper,
   writeScript, common-updater-scripts, coreutils, git, gnused, nix, rebar3-nix }:
 
@@ -40,12 +40,14 @@ let
     '';
 
 
-    patches = []
-      # Skips test that can write outside the designated tmp directory, potentially resulting in build failures
-      # due to file ownership issues if ran without sandbox (eg. Mac M1 default). This patch can be Removed when
-      # rebar3 releases with the following commit:
-      # https://github.com/erlang/rebar3/commit/11055384dbd5bf7d181bca83a33b0e100275ff21
-      ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ ./tmp-tests-skip.patch ];
+    patches = [
+      # TODO: remove this on next rebar3 release
+      (fetchpatch {
+        name = "escriptize-erl-libs";
+        url = "https://github.com/erlang/rebar3/commit/11055384dbd5bf7d181bca83a33b0e100275ff21.patch";
+        sha256 = "01xjaqnhmjlxqdgb8ph15wssjq5crdhjslxnndbs5f0kscqpq14c";
+      })
+    ];
 
     checkPhase = ''
       HOME=. escript ./rebar3 ct


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should help with some build issues on darwin, see #131175. @happysalada FYI :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
