### PR TITLE
cone: init at unstable-2021-07-25

### DIFF
--- a/pkgs/development/compilers/cone/default.nix
+++ b/pkgs/development/compilers/cone/default.nix
@@ -1,0 +1,42 @@
+{ llvmPackages
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+  pname = "cone";
+  version = "unstable-2021-07-25";
+
+  src = fetchFromGitHub {
+    owner = "jondgoodwin";
+    repo = pname;
+    rev = "5feaabc342bcff3755f638a7e25155cd12127592";
+    sha256 = "CTDS83AWtuDY5g6NDn7O2awrYsKFf3Kp35FkMEjfbVw=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    llvmPackages.llvm
+  ];
+
+  postPatch = ''
+    sed -i CMakeLists.txt \
+        -e 's/LLVM 7/LLVM/' \
+        -e '/AVR/d'
+  '';
+
+  installPhase = ''
+    install -Dm755 conec $out/bin/conec
+    install -Dm644 libconestd.a $out/lib/libconestd.a
+  '';
+
+  meta = with lib; {
+    description = "Cone Programming Language";
+    homepage = "https://cone.jondgoodwin.com";
+    license = licenses.mit;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3958,6 +3958,10 @@ in
 
   compass = callPackage ../development/tools/compass { };
 
+  cone = callPackage ../development/compilers/cone {
+    llvmPackages = llvmPackages_7;
+  };
+
   conda = callPackage ../tools/package-management/conda { };
 
   console-bridge = callPackage ../development/libraries/console-bridge { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
