### PR TITLE
grafanaPlugins: add grafadruid-druid-datasource plugin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7832,6 +7832,12 @@
     githubId = 1839979;
     name = "Niklas Thörne";
   };
+  nukaduka = {
+    email = "ksgokte@gmail.com";
+    github = "NukaDuka";
+    githubId = 22592293;
+    name = "Kartik Gokte";
+  };
   nullx76 = {
     email = "nix@xirion.net";
     github = "NULLx76";

--- a/pkgs/servers/monitoring/grafana/plugins/grafadruid-druid-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafadruid-druid-datasource/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin rec {
+  pname = "grafadruid-druid-datasource";
+  version = "1.2.0";
+  zipHash = "sha256-DPeyV2jZquSQcSE+HzvxArWEefs9bFNPjZwDFp+dIjg=";
+  meta = with lib; {
+    description = "Connects Grafana to Druid";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nukaduka ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -5,6 +5,7 @@
   grafanaPlugin = callPackage ./grafana-plugin.nix { };
 
   doitintl-bigquery-datasource = callPackage ./doitintl-bigquery-datasource { };
+  grafadruid-druid-datasource = callPackage ./grafadruid-druid-datasource { };
   grafana-clock-panel = callPackage ./grafana-clock-panel { };
   grafana-piechart-panel = callPackage ./grafana-piechart-panel { };
   grafana-polystat-panel = callPackage ./grafana-polystat-panel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding the [grafadruid-druid-datasource](https://grafana.com/grafana/plugins/grafadruid-druid-datasource) Grafana plugin to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
