### PR TITLE
kubernetes: fix flaky test and run tests as group

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/addon-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/addon-manager.nix
@@ -84,6 +84,9 @@ in
         Restart = "on-failure";
         RestartSec = 10;
       };
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+      };
     };
 
     services.kubernetes.addonManager.bootstrapAddons = mkIf isRBACEnabled

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -398,6 +398,10 @@ in
             Restart = "on-failure";
             RestartSec = 5;
           };
+
+          unitConfig = {
+            StartLimitIntervalSec = 0;
+          };
         };
 
         services.etcd = {

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -146,6 +146,9 @@ in
         User = "kubernetes";
         Group = "kubernetes";
       };
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+      };
       path = top.path;
     };
 

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -337,6 +337,9 @@ in
           '';
           WorkingDirectory = top.dataDir;
         };
+        unitConfig = {
+          StartLimitIntervalSec = 0;
+        };
       };
 
       # Allways include cni plugins

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -77,6 +77,9 @@ in
         Restart = "on-failure";
         RestartSec = 5;
       };
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+      };
     };
 
     services.kubernetes.proxy.hostname = with config.networking; mkDefault hostName;

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -79,6 +79,9 @@ in
         Restart = "on-failure";
         RestartSec = 5;
       };
+      unitConfig = {
+        StartLimitIntervalSec = 0;
+      };
     };
 
     services.kubernetes.pki.certs = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -220,10 +220,7 @@ in
   knot = handleTest ./knot.nix {};
   krb5 = discoverTests (import ./krb5 {});
   ksm = handleTest ./ksm.nix {};
-  kubernetes.dns = handleTestOn ["x86_64-linux"] ./kubernetes/dns.nix {};
-  # kubernetes.e2e should eventually replace kubernetes.rbac when it works
-  #kubernetes.e2e = handleTestOn ["x86_64-linux"] ./kubernetes/e2e.nix {};
-  kubernetes.rbac = handleTestOn ["x86_64-linux"] ./kubernetes/rbac.nix {};
+  kubernetes = handleTestOn ["x86_64-linux"] ./kubernetes {};
   latestKernel.hardened = handleTest ./hardened.nix { latestKernel = true; };
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   leaps = handleTest ./leaps.nix {};

--- a/nixos/tests/kubernetes/default.nix
+++ b/nixos/tests/kubernetes/default.nix
@@ -1,7 +1,15 @@
-{ system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem
+, pkgs ? import <nixpkgs> { inherit system; }
+}:
+let
+  dns = import ./dns.nix { inherit system pkgs; };
+  rbac = import ./rbac.nix { inherit system pkgs; };
+  # TODO kubernetes.e2e should eventually replace kubernetes.rbac when it works
+  # e2e = import ./e2e.nix { inherit system pkgs; };
+in
 {
-  dns = import ./dns.nix { inherit system; };
-  # e2e = import ./e2e.nix { inherit system; };  # TODO: make it pass
-  # the following test(s) can be removed when e2e is working:
-  rbac = import ./rbac.nix { inherit system; };
+  dns-single-node = dns.singlenode.test;
+  dns-multi-node = dns.multinode.test;
+  rbac-single-node = rbac.singlenode.test;
+  rbac-multi-node = rbac.multinode.test;
 }

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -97,10 +97,5 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 
-  passthru.tests = with nixosTests.kubernetes; {
-    dns-single-node = dns.singlenode;
-    dns-multi-node = dns.multinode;
-    rbac-single-node = rbac.singlenode;
-    rbac-multi-node = rbac.multinode;
-  };
+  passthru.tests = nixosTests.kubernetes;
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

#### Motivation for this change

Fixes the flakiness in the kubernetes tests and makes it possible to run the tests as a group in all circumstances.

##### Fixing the flakyness

All of the kubernetes tests would sometimes fail after spamming the logs with messages like this:

```
...
machine1 # [  232.393093] kubelet[1402]: E0730 10:42:42.228320    1402 kubelet.go:2291] "Error getting node" err="node \"machine1.my.zyx\" not found"
```

The underlying cause was that `kube-apiserver` failed to start because it ran out of restarts while waiting for the certificates to appear:

```
machine1 # [   15.805215] kube-apiserver[876]: Error: failed to parse service-account-issuer-key-file: open /var/lib/kubernetes/secrets/service-account-key.pem: no such file or directory
machine1 # [   15.809382] systemd[1]: kube-apiserver.service: Main process exited, code=exited, status=1/FAILURE
machine1 # [   15.812195] systemd[1]: kube-apiserver.service: Failed with result 'exit-code'.
...
machine1 # [   21.243087] kube-apiserver[1111]: Error: failed to parse service-account-issuer-key-file: open /var/lib/kubernetes/secrets/service-account-key.pem: no such file or directory
machine1 # [   21.249561] systemd[1]: kube-apiserver.service: Main process exited, code=exited, status=1/FAILURE
machine1 # [   21.251559] systemd[1]: kube-apiserver.service: Failed with result 'exit-code'.
...
machine1 # [   27.410962] kube-apiserver[1248]: Error: failed to parse service-account-issuer-key-file: open /var/lib/kubernetes/secrets/service-account-key.pem: no such file or directory
machine1 # [   27.455427] systemd[1]: kube-apiserver.service: Main process exited, code=exited, status=1/FAILURE
machine1 # [   27.468722] systemd[1]: kube-apiserver.service: Failed with result 'exit-code'.
...
machine1 # [   28.062371] systemd[1]: kube-apiserver.service: Start request repeated too quickly.
machine1 # [   28.069502] systemd[1]: kube-apiserver.service: Failed with result 'start-limit-hit'.
```

By default, a service is only permitted to restart some amount of times in an interval  (see `DefaultStartLimitIntervalSec` in [`systemd-system.conf(5)`](https://manpages.debian.org/buster/systemd/systemd-system.conf.5.en.html)), and `kube-apiserver` was hitting this.  According to the docs, the default limit was supposed to be 5 restarts in 10s, but systemd in the tests seems to give up after 3 restarts in 10s.  I couldn't find where this is configured.

I think the solution to this is to remove the restart limit on `kube-apiserver` by setting `StartLimitIntervalSec` to 0 (according to [`systemd.unit(5)`](https://manpages.debian.org/buster/systemd/systemd.unit.5.en.html).  Although I've never seen them fail in tests, the other kubernetes processes also have similar failures due to missing certificates.  So, let's make them restart forever too.

The change affects live deployments too and not just tests.  I'd say this is desirable since kubernetes components are supposed to self-heal automatically, so restarting them forever should be fine.

##### Running the tests as a group

This PR reorganizes the tests a bit so that all of the following work:

```
# ofborg running passthrough tests
$ nix-build --no-out-link -A kubernetes.passthru.tests

# ofborg running tests because of an issue comment like `@ofborg test kubernetes`
$ nix-build --no-out-link ./nixos/release.nix -A tests.kubernetes

# ofborg running individual test because of an issue comment like `@ofborg test kubernetes.dns-single-node`
$ nix-build --no-out-link ./nixos/release.nix -A tests.kubernetes.dns-single-node

# human runs individual tests
$ nix-build --no-out-link ./nixos/release.nix -A tests.kubernetes.dns-single-node
$ nix-build --no-out-link ./nixos/tests/kubernetes/dns.nix
```

The weird thing here is that I couldn't find any other examples of groups of tests that work like this.  Everybody else seems to just be running tests only individually.

#### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
