### PR TITLE
protoc-gen-grpc-web: init at 1.2.1

### DIFF
--- a/pkgs/development/tools/protoc-gen-grpc-web/default.nix
+++ b/pkgs/development/tools/protoc-gen-grpc-web/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, protobuf }:
+
+stdenv.mkDerivation rec {
+  pname = "protoc-gen-grpc-web";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "grpc";
+    repo = "grpc-web";
+    rev = version;
+    sha256 = "sha256-NBENyc01O8NPo84z1CeZ7YvFvVGY2GSlcdxacRrQALw=";
+  };
+
+  sourceRoot = "source/javascript/net/grpc/web";
+
+  # remove once PR merged
+  # https://github.com/grpc/grpc-web/pull/1107
+  patches = [
+    (fetchpatch {
+      name = "add-prefix.patch";
+      url = "https://github.com/06kellyjac/grpc-web/commit/b0803be1080fc635a8d5b88da971835a888a0c77.patch";
+      stripLen = 4;
+      sha256 = "sha256-Rw9Z7F8cYrc/UIGUN6yXOus4v+Qn9Yf1Nc301TFx85A=";
+    })
+  ];
+
+  strictDeps = true;
+  nativeBuildInputs = [ protobuf ];
+  buildInputs = [ protobuf ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/grpc/grpc-web";
+    changelog = "https://github.com/grpc/grpc-web/blob/${version}/CHANGELOG.md";
+    description = "gRPC web support for Google's protocol buffers";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -317,6 +317,8 @@ in
 
   protoc-gen-go-grpc = callPackage ../development/tools/protoc-gen-go-grpc { };
 
+  protoc-gen-grpc-web = callPackage ../development/tools/protoc-gen-grpc-web { };
+
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
 
   protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Init `protoc-gen-grpc-web` at `1.2.1`

Using a patch from https://github.com/grpc/grpc-web/pull/1107

Is there a better way to change dir or to fetchFromGithub and only keep the `./javascript/net/grpc/web/` subdir? thanks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
