### PR TITLE
octoprint: 1.5.3 -> 1.6.1

### DIFF
--- a/pkgs/development/python-modules/immutabledict/default.nix
+++ b/pkgs/development/python-modules/immutabledict/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "immutabledict";
+  version = "2.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ylnddj3x1zvak4fp69bk2c56k3zbfgrf2q5jk9kvlj61zrvhgv7";
+  };
+
+  # No tests in PyPI archive
+  doCheck = false;
+
+  pythonImportsCheck = [ "immutabledict" ];
+
+  meta = with lib; {
+    description = "A fork of frozendict, an immutable wrapper around dictionaries.";
+    homepage = "https://github.com/corenting/immutabledict";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/development/python-modules/zipstream-new/default.nix
+++ b/pkgs/development/python-modules/zipstream-new/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "zipstream-new";
+  version = "1.1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xhw24zhibmyypcdbmvql02jcf3npisb29lx71w1drcl3ccgwcdh";
+  };
+
+  # No tests in PyPI archive
+  doCheck = false;
+
+  pythonImportsCheck = [ "zipstream" ];
+
+  meta = with lib; {
+    description = "A zip archive generator";
+    homepage = "https://github.com/arjan-s/python-zipstream";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9550,6 +9550,8 @@ in {
 
   zipstream = callPackage ../development/python-modules/zipstream { };
 
+  zipstream-new = callPackage ../development/python-modules/zipstream-new { };
+
   zm-py = callPackage ../development/python-modules/zm-py { };
 
   zodb = callPackage ../development/python-modules/zodb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3513,6 +3513,8 @@ in {
 
   immutables = callPackage ../development/python-modules/immutables { };
 
+  immutabledict = callPackage ../development/python-modules/immutabledict { };
+
   impacket = callPackage ../development/python-modules/impacket { };
 
   importlib-metadata = callPackage ../development/python-modules/importlib-metadata { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates OctoPrint to the latest version.

OctoPrints pins a lot of its dependencies to older versions, causing it to often fail to build when packages are updated in nixpkgs. Recently, the Pallets Projects (Flask, Werkzeug, Click, etc.) all released new major versions, which are not officially supported by OctoPrint. Most of the version restrictions appear to exist not for any specific reason, but just to avoid any potential breakages that might occur when upgrading to an new major version. A few other dependencies are pinned to keep support for Python 2, which is not relevant to us.

In this PR, I chose to be fairly aggressive about removing the version pinning and have not run into any problems as a result. All the unit tests pass, and I've printed with it without issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @abbradar @gebner @WhittlesJr @lovesegfault 